### PR TITLE
fixed URL of ligtextutils from toolchain to toolkit

### DIFF
--- a/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.6.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.6.1-goalf-1.1.0-no-OFED.eb
@@ -10,14 +10,14 @@
 name = 'libgtextutils'
 version = '0.6.1'
 
-homepage = 'http://hannonlab.cshl.edu/fastx_toolchain/'
-description = """ligtextutils is a dependency of fastx-toolchain and is provided via the same upstream"""
+homepage = 'http://hannonlab.cshl.edu/fastx_toolkit/'
+description = """ligtextutils is a dependency of fastx-toolkit and is provided via the same upstream"""
 
 toolchain = {'name': 'goalf', 'version': '1.1.0-no-OFED'}
 toolchainopts = {'optarch': True, 'pic': True}
 
 sources = ['%s-%s.tar.bz2' % (name, version)]
-source_urls = ['http://hannonlab.cshl.edu/fastx_toolchain']
+source_urls = ['http://hannonlab.cshl.edu/fastx_toolkit']
 
 sanity_check_paths = {
                       'files': ['lib/libgtextutils.so', 'lib/libgtextutils.a'],

--- a/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.6.1-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.6.1-ictce-4.0.6.eb
@@ -10,14 +10,14 @@
 name = 'libgtextutils'
 version = '0.6.1'
 
-homepage = 'http://hannonlab.cshl.edu/fastx_toolchain/'
-description = """ligtextutils is a dependency of fastx-toolchain and is provided via the same upstream"""
+homepage = 'http://hannonlab.cshl.edu/fastx_toolkit/'
+description = """ligtextutils is a dependency of fastx-toolkit and is provided via the same upstream"""
 
 toolchain = {'name': 'ictce', 'version': '4.0.6'}
 toolchainopts = {'optarch': True, 'pic': True}
 
 sources = ['%s-%s.tar.bz2' % (name, version)]
-source_urls = ['http://hannonlab.cshl.edu/fastx_toolchain']
+source_urls = ['http://hannonlab.cshl.edu/fastx_toolkit']
 
 sanity_check_paths = {
                       'files': ['lib/libgtextutils.so', 'lib/libgtextutils.a'],


### PR DESCRIPTION
Hi there,

this is a bugfix; I guess the issue was introduced while converting from toolkit to toolchain and passed unnoticed since at the hpcugent you already had a working build of this lib since earlier times.

Signed-off-by: Fotis Georgatos fotis.georgatos@uni.lu
