### PR TITLE
84 contrib binutils-2.22-goalf-1.1.0-no-OFED.eb

### DIFF
--- a/easybuild/easyconfigs/b/binutils/binutils-2.22-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.22-goalf-1.1.0-no-OFED.eb
@@ -1,11 +1,14 @@
+##
 # This file is an EasyBuild recipy as per https://github.com/hpcugent/easybuild
 #
-# Copyright:: Copyright (c) 2012 University of Luxembourg / LCSB
-# Author::    Fotis Georgatos <fotis.georgatos@uni.lu>
+# Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
+# Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>
 # License::   MIT/GPL
+# $Id$
 #
-# File::      binutils-2.22.eb
-# Date::      Wed Dec 26 17:08:19 CET 2012
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_07-02.html
+##
 
 name = 'binutils'
 version = '2.22'


### PR DESCRIPTION
Provides gprof and a few other items;

It also relates to the following, but no easyblocks are really need for it:
https://github.com/hpcugent/easybuild-easyblocks/issues/84

Signed-off-by: Fotis Georgatos fotis.georgatos@uni.lu
