### PR TITLE
add GROMACS v4.6 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/c/CMake/CMake-2.8.4-goolfc-1.3.12.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-2.8.4-goolfc-1.3.12.eb
@@ -1,0 +1,21 @@
+name = 'CMake'
+version = '2.8.4'
+
+homepage = 'http://www.cmake.org'
+description = """CMake, the cross-platform, open-source build system.
+CMake is a family of tools designed to build, test and package software."""
+
+toolchain = {'name': 'goolfc', 'version': '1.3.12'}
+
+source_urls = ["http://www.cmake.org/files/v%s/" % '.'.join(version.split('.')[0:2])]
+sources = ['%s-%s.tar.gz' % (name.lower(), version)]
+
+majorversion = ".".join(version.split('.')[:-1])
+source_urls = ['http://www.cmake.org/files/v%s' % majorversion]
+
+sanity_check_paths = {
+                      'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+                      'dirs': []
+                     }
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.1-goolf-1.4.10.eb
@@ -14,8 +14,7 @@
 easyblock = 'CMakeMake'
 
 name = 'GROMACS'
-version = '4.6'
-versionsuffix ='-CUDA-5.0.35-1'
+version = '4.6.1'
 
 homepage = 'http://www.gromacs.org'
 description = """GROMACS is a versatile package to perform molecular dynamics,
@@ -24,9 +23,22 @@ description = """GROMACS is a versatile package to perform molecular dynamics,
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 # eg. ftp://ftp.gromacs.org/pub/gromacs/gromacs-4.6.tar.gz
-sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
+sources = [
+    SOURCELOWER_TAR_GZ,
+    'regressiontests-%(version)s.tar.gz',
+]
+source_urls = [
+    'ftp://ftp.gromacs.org/pub/gromacs/',  # GROMACS sources
+    'http://gerrit.gromacs.org/download/',  # regression tests sources
+]
 
-dependencies = [('CUDA', '5.0.35-1', '', True)]
+builddependencies = [('CMake', '2.8.4')]
+
+configopts = "-DREGRESSIONTEST_PATH='%(builddir)s/regressiontests-%(version)s'"
+runtest = 'check'
+
+# explicitely disable CUDA support, i.e. avoid that GROMACS find and uses a system-wide CUDA compiler
+# CUDA and GCC v4.7 don't play well together
+configopts += ' -DGMX_GPU=OFF'
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.1-goolfc-1.3.12.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.1-goolfc-1.3.12.eb
@@ -14,16 +14,27 @@
 easyblock = 'CMakeMake'
 
 name = 'GROMACS'
-version = '4.6'
+version = '4.6.1'
 
 homepage = 'http://www.gromacs.org'
 description = """GROMACS is a versatile package to perform molecular dynamics,
   i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles."""
 
-toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchain = {'name': 'goolfc', 'version': '1.3.12'}
 
 # eg. ftp://ftp.gromacs.org/pub/gromacs/gromacs-4.6.tar.gz
-sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
+sources = [
+    SOURCELOWER_TAR_GZ,
+    'regressiontests-%(version)s.tar.gz',
+]
+source_urls = [
+    'ftp://ftp.gromacs.org/pub/gromacs/',  # GROMACS sources
+    'http://gerrit.gromacs.org/download/',  # regression tests sources
+]
+
+builddependencies = [('CMake', '2.8.4')]
+
+configopts = "-DREGRESSIONTEST_PATH='%(builddir)s/regressiontests-%(version)s'"
+runtest = 'check'
 
 moduleclass = 'bio'


### PR DESCRIPTION
highlights:
- 2 versions supplied, one with CUDA, one without
- FFTWsp dependency exists, but not included, since we may opt for an FFT-jumbo build
- easyblock must also be provided later, otherwise there we have no sanity_checks etc.

Ref:
- 1.3.2.1. 3.2.1. Running in parallel: http://www.gromacs.org/Documentation/Installation_Instructions#3.2.1._Running_in_parallel
- 1.3.4.1. 3.4.1. FFTW: http://www.gromacs.org/Documentation/Installation_Instructions#3.4.1._FFTW
  (generally the installation instructions are a must-read and things can be tuned more).

fyi. the current initial code is a synthesis of all these bits (reflected in "authors"):
https://github.com/fgeorgatos/easybuild.experimental/tree/master/users/georgets/g/GROMACS
https://github.com/fgeorgatos/easybuild.experimental/tree/master/users/wiktor/GROMACS
https://github.com/fgeorgatos/easybuild.experimental/blob/master/contrib/pkgsrc/20121109/g/gromacs-4.5.5.eb
I took the freedom to add Kenneth, since I know his magic hand will touch this...

Progress is pending now on the FFT/CUDA business.

Signed-off-by: Fotis Georgatos fotis.georgatos@uni.lu
