### PR TITLE
add latest GCC versions 4.8.0 & 4.8.1

### DIFF
--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.1.eb
@@ -3,13 +3,13 @@ version = '4.8.1'
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
-    as well as libraries for these languages (libstdc++, libgcj,...)."""
+ as well as libraries for these languages (libstdc++, libgcj,...)."""
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 sources = [
     SOURCELOWER_TAR_GZ,
-    'gmp-5.1.1.tar.bz2',
+    'gmp-5.1.2.tar.bz2',
     'mpfr-3.1.2.tar.gz',
     'mpc-1.0.1.tar.gz',
 ]


### PR DESCRIPTION
Fresh from the press; fiddle with the header & commented patch line, as needed.

Signed-off-by: Fotis Georgatos fotis.georgatos@uni.lu
