### PR TITLE
Updating MTL4 version, old version no longer on website

### DIFF
--- a/easybuild/easyconfigs/d/DOLFIN/DOLFIN-1.0.0-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/d/DOLFIN/DOLFIN-1.0.0-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -45,7 +45,7 @@ dependencies = [
                 ('CGAL', '4.0', versionsuffix),
                 ('PETSc', '3.3-p2', versionsuffix),
                 ('SLEPc', '3.3-p1', versionsuffix),
-                ('MTL4', '4.0.8878', '', True),
+                ('MTL4', '4.0.9150', '', True),
                 ('Trilinos', '10.12.2', versionsuffix),
                 ('Sphinx', '1.1.3', versionsuffix),
                 ('zlib', '1.2.7'),

--- a/easybuild/easyconfigs/d/DOLFIN/DOLFIN-1.0.0-ictce-4.0.6-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/d/DOLFIN/DOLFIN-1.0.0-ictce-4.0.6-Python-2.7.3.eb
@@ -45,7 +45,7 @@ dependencies = [
                 ('CGAL', '4.0', versionsuffix),
                 ('PETSc', '3.3-p2', versionsuffix),
                 ('SLEPc', '3.3-p1', versionsuffix),
-                ('MTL4', '4.0.8878', '', True),
+                ('MTL4', '4.0.9150', '', True),
                 ('Trilinos', '10.12.2', versionsuffix),
                 ('Sphinx', '1.1.3', versionsuffix),
                 ('zlib', '1.2.7'),

--- a/easybuild/easyconfigs/m/MTL4/MTL4-4.0.9150.eb
+++ b/easybuild/easyconfigs/m/MTL4/MTL4-4.0.9150.eb
@@ -1,0 +1,13 @@
+name = "MTL4"
+version = "4.0.9150"
+
+homepage = "http://www.simunova.com/mtl4"
+description = """The Matrix Template Library 4 incorporates the most modern programming techniques
+to provide an easy and intuitive interface to users while enabling optimal performance. The natural
+mathematical notation in MTL4 empowers all engineers and scientists to implement their algorithms and
+models in minimal time. All technical aspects are encapsulated in the library."""
+
+toolchain = {'name': "dummy", 'version': "dummy"}
+
+source_urls = ['http://www.simunova.com/downloads/mtl4']
+sources = ["MTL-all-%s-Linux.tar.gz" % version]


### PR DESCRIPTION
The MTL4 that is pointed to results in a 404 error.  Here is one that is available (today at least)
