### PR TITLE
remove the dependency to libib* libraries, as a default choice

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3.eb
@@ -11,13 +11,6 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%s/downloads' % '.'.join(
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-threads --with-openib --with-udapl '
 
-# OFED support
-dependencies = [
-                ('libibverbs', '1.1.4'),
-                ('libibmad', '1.3.9'),
-                ('libibumad', '1.3.8')
-               ]
-
 # required for uDAPL support
 osdependencies = ['dapl-devel']
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.3-iccifort-2011.13.367.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.3-iccifort-2011.13.367.eb
@@ -9,12 +9,6 @@ toolchain = {'name': 'iccifort', 'version': '2011.13.367'}
 sources = ['%s-%s.tar.gz' % (name.lower(), version)]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%s/downloads' % '.'.join(version.split('.')[0:2])]
 
-osdependencies = [
-                  'libibverbs-devel',  # required for OFED support
-                  'dapl-devel',  # required for uDAPL support
-                  'libibumad-devel',  # required for OFED support
-                 ]
-
 configopts = '--with-threads=posix --enable-shared --enable-mpi-threads --with-openib --with-udapl '
 
 # hwloc support


### PR DESCRIPTION
This may require a bit of discussion, because in some cases it may actually be useful to indeed build your own libib\* deps...

Signed-off-by: Fotis Georgatos fotis.georgatos@uni.lu
