### PR TITLE
remove --with-udapl within OpenMPI modules

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3-no-OFED.eb
@@ -10,7 +10,7 @@ toolchain = {'name': 'GCC', 'version': '4.6.3'}
 sources = ['%s-%s.tar.gz' % (name.lower(), version)]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%s/downloads' % '.'.join(version.split('.')[0:2])]
 
-configopts = '--with-threads=posix --enable-shared --enable-mpi-threads --without-openib --without-udapl'
+configopts = '--with-threads=posix --enable-shared --enable-mpi-threads --without-openib '
 
 patches = ['pax_disable.patch']
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3.eb
@@ -9,7 +9,7 @@ toolchain = {'name': 'GCC', 'version': '4.6.3'}
 sources = ['%s-%s.tar.gz' % (name.lower(), version)]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%s/downloads' % '.'.join(version.split('.')[0:2])]
 
-configopts = '--with-threads=posix --enable-shared --enable-mpi-threads --with-openib --with-udapl '
+configopts = '--with-threads=posix --enable-shared --enable-mpi-threads --with-openib '
 
 # required for uDAPL support
 osdependencies = ['dapl-devel']

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.3-iccifort-2011.13.367.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.3-iccifort-2011.13.367.eb
@@ -9,7 +9,7 @@ toolchain = {'name': 'iccifort', 'version': '2011.13.367'}
 sources = ['%s-%s.tar.gz' % (name.lower(), version)]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%s/downloads' % '.'.join(version.split('.')[0:2])]
 
-configopts = '--with-threads=posix --enable-shared --enable-mpi-threads --with-openib --with-udapl '
+configopts = '--with-threads=posix --enable-shared --enable-mpi-threads --with-openib '
 
 # hwloc support
 configopts += '--with-hwloc '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2.eb
@@ -11,7 +11,7 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%s/downloads' % '.'.join(
 
 dependencies = [ ('hwloc', '1.6.2') ]
 
-configopts = '--with-threads=posix --enable-shared --enable-mpi-threads --with-openib --with-udapl'
+configopts = '--with-threads=posix --enable-shared --enable-mpi-threads --with-openib '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 


### PR DESCRIPTION
Hi,

You may prefer skip this for a post v1.3 discussion; the arguments against have been:
- http://www.open-mpi.org/community/lists/users/2013/02/21452.php
- http://thegeekinthecorner.wordpress.com/2010/08/14/on-dapl/
- spits errors on a default debian squeeze setup (can't recall, need to investigate again)

In short, in the name of "principle of least surprise" I'd suggest to drop it from the default bundle of easyconfigs and let local sysadmins add it in, if/when needed.

Signed-off-by: Fotis Georgatos fotis.georgatos@uni.lu
