### PR TITLE
Remove the dependency to libib* libraries, as a default choice

### DIFF
--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3-hwloc-chkpt.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3-hwloc-chkpt.eb
@@ -12,13 +12,6 @@ sources = ['%s-%s.tgz' % (name.lower(), version)]
 # note: this URL will only work for the most recent version (previous versions no longer available?)
 source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2']
 
-# OFED support
-dependencies = [
-                ('libibverbs', '1.1.4'),
-                ('libibmad', '1.3.9'),
-                ('libibumad', '1.3.8')
-               ]
-
 rdma_type = "gen2"  # 'gen2' or 'udapl'
 
 # enable building of MPE routines

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3.eb
@@ -11,13 +11,6 @@ sources = ['%s-%s.tgz' % (name.lower(), version)]
 # note: this URL will only work for the most recent version (previous versions no longer available?)
 source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2']
 
-# OFED support
-dependencies = [
-                ('libibverbs', '1.1.4'),
-                ('libibmad', '1.3.9'),
-                ('libibumad', '1.3.8')
-               ]
-
 rdma_type = "gen2" # 'gen2' or 'udapl'
 
 ## enable building of MPE routines

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.8.1-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.8.1-GCC-4.7.2.eb
@@ -12,11 +12,4 @@ sources = ['mvapich2-%s.tgz' % version]
 # parallel build doesn't work
 parallel = 1
 
-# OFED support
-dependencies = [
-                ('libibverbs', '1.1.4'),
-                ('libibmad', '1.3.9'),
-                ('libibumad', '1.3.8')
-               ]
-
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.9a2-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.9a2-GCC-4.7.2.eb
@@ -9,11 +9,4 @@ toolchain = {'name': 'GCC', 'version': '4.7.2'}
 source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2/']
 sources = ['mvapich2-%s.tgz' % version]
 
-# OFED support
-dependencies = [
-                ('libibverbs', '1.1.4'),
-                ('libibmad', '1.3.9'),
-                ('libibumad', '1.3.8')
-               ]
-
 moduleclass = 'mpi'


### PR DESCRIPTION
This is the MVAPICH2 part of fixing #172.
