### PR TITLE
Add MVAPICH2 1.9b easyconfig

### DIFF
--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.9b-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.9b-GCC-4.7.2.eb
@@ -1,0 +1,12 @@
+name = 'MVAPICH2'
+version = '1.9b'
+
+homepage = 'http://mvapich.cse.ohio-state.edu/overview/mvapich2/'
+description = "This is an MPI 3.0 implementation.  It is based on MPICH2 and MVICH."
+
+toolchain = {'name': 'GCC', 'version': '4.7.2'}
+
+source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2/']
+sources = ['mvapich2-%s.tgz' % version]
+
+moduleclass = 'mpi'


### PR DESCRIPTION
I know we are late in the release cycle, but previous 1.9 tarballs are no longer available for download.  So MVAPICH2 easyconfigs will not work for new users because they don't have old sources cached.
