### PR TITLE
176 bugfix contrib matlab 2013a

### DIFF
--- a/easybuild/easyconfigs/m/MATLAB/MATLAB-2013a.eb
+++ b/easybuild/easyconfigs/m/MATLAB/MATLAB-2013a.eb
@@ -18,16 +18,16 @@ description = """MATLAB is a high-level language and interactive environment
  that enables you to perform computationally intensive tasks faster than with
  traditional programming languages such as C, C++, and Fortran."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
-sources = [
-    'p7zip_9.20.1_x86_linux_bin.tar.bz2', # 7z is able to extract from the .iso directly
-    ('R%s_UNIX_MAC.iso' % version, './p7zip_9.20.1/bin/7z x %s && chmod -R u+rx . && ln -s . 2013a'),
-    ]
+builddependencies = [('p7zip', '9.20.1')] # 7z is able to extract from the .iso directly
+
+#sources = [('R%s_UNIX_MAC.iso' % version, '$EBROOTP7ZIP/bin/7z x %s && chmod -R u+rx . && ln -s . 2013a')]
+sources = [('R%s_UNIX_MAC.iso' % version, '7z x %s && chmod -R u+rx . && ln -s . 2013a')]
 source_urls = ['http://downloads.sourceforge.net/project/p7zip/p7zip/9.20.1']
 
-start_dir = '..' # this is needed because otherwise the called ./install is the one from the 1st package (p7zip)
-preinstallopts = 'export _JAVA_OPTIONS="${EB_MATLAB_JAVA_XMX:--Xmx512m}" ;' # this is very important to prevent subtle failures
+#start_dir = '..' # this is needed because otherwise the called ./install is the one from the 1st package (p7zip)
+#preinstallopts = 'export _JAVA_OPTIONS="${EB_MATLAB_JAVA_XMX:--Xmx512m}" ;' # this is very important to prevent subtle failures
  
 sanity_check_paths = {
     'files': ["bin/matlab", "bin/mcc", "bin/glnxa64/MATLAB", "bin/glnxa64/mcc",

--- a/easybuild/easyconfigs/p/p7zip/p7zip-9.20.1.eb
+++ b/easybuild/easyconfigs/p/p7zip/p7zip-9.20.1.eb
@@ -1,0 +1,36 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
+# Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>, Kenneth Hoste
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-97.html
+##
+
+name = 'p7zip'
+version = '9.20.1'
+
+homepage = 'http://p7zip.sourceforge.net/'
+description = """p7zip is a port of 7za.exe for POSIX systems like Unix"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'} # this is so that it can be combined with many toolchains
+
+# eg. http://downloads.sourceforge.net/project/p7zip/p7zip/9.20.1/p7zip_9.20.1_src_all.tar.bz2 (3.8 MB)
+sources = ['p7zip_%s_src_all.tar.bz2' % version]
+source_urls = ['SOURCEFORGE_SOURCE'] # http://downloads.sourceforge.net/project/p7zip/p7zip/9.20.1']
+
+skipsteps = ['configure']
+
+makeopts = 'all3'
+
+preinstallopts = './install.sh %(installdir)s/bin %(installdir)s/lib/p7zip %(installdir)s/man %(installdir)s/share/doc/p7zip && /bin/true '
+
+runtest = 'all_test'
+
+sanity_check_paths = {
+    'files': ["bin/7z", "bin/7za", "bin/7zr"],
+    'dirs': [],
+    }

--- a/easybuild/easyconfigs/p/p7zip/p7zip-9.20.1_x86_linux_bin.eb
+++ b/easybuild/easyconfigs/p/p7zip/p7zip-9.20.1_x86_linux_bin.eb
@@ -1,0 +1,30 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
+# Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>, Kenneth Hoste
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-97.html
+##
+
+easyblock = 'Tarball'
+
+name = 'p7zip'
+version = '9.20.1'
+versionsuffix = '_x86_linux_bin'
+
+homepage = 'http://p7zip.sourceforge.net/'
+description = """p7zip is a port of 7za.exe for POSIX systems like Unix"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = ['p7zip_%s%s.tar.bz2' % (version, versionsuffix)]
+source_urls = ['http://downloads.sourceforge.net/project/p7zip/p7zip/9.20.1']
+
+sanity_check_paths = {
+    'files': ["bin/7z", "bin/7za", "bin/7zr"],
+    'dirs': [],
+    }


### PR DESCRIPTION
summary:

v2012b:
- pull out Java as dependency; MATLAB's JRE appears more robust solution
- employ preinstallopts/installopts construct
- quadraple heap: `_JAVA_OPTIONS="-Xmx512m"`; important to prevent subtle failures
- add `toolbox/local/classpath.txt` to fail-hard, when build is not finishing properly
- modextravars defines `_JAVA_OPTIONS`

v2013a:
- all of v2012b conveniences, as described above
- use 7z to extract directly from the .iso, no man-in-the-middle needed any more
- added hpcbios banner, since this implements the solution for climate scientists' needs
