### PR TITLE
bugfix VTune & Inspector licensefile

### DIFF
--- a/easybuild/easyconfigs/i/Inspector/Inspector-2013_update6.eb
+++ b/easybuild/easyconfigs/i/Inspector/Inspector-2013_update6.eb
@@ -10,8 +10,9 @@ sources = ['inspector_xe_%s.tar.gz' % version]
 
 dontcreateinstalldir = 'True'
 
-# licensepath
-license = "/apps/gent/licenses/intel"
+# license file
+import os
+license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
 
 # hackish sanity check paths
 sanity_check_paths = {

--- a/easybuild/easyconfigs/v/VTune/VTune-2013_update6.eb
+++ b/easybuild/easyconfigs/v/VTune/VTune-2013_update6.eb
@@ -10,8 +10,9 @@ sources = ['vtune_amplifier_xe_%s.tar.gz' % version]
 
 dontcreateinstalldir = 'True'
 
-# licensepath
-license = "/apps/gent/licenses/intel"
+# license file
+import os
+license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
 
 # hackish sanity check paths
 sanity_check_paths = {


### PR DESCRIPTION
I got the following error which was resolved with the attached commit;

```
sw@gaia-63:~$ time eb /opt/apps/HPCBIOS.20130501/software/EasyBuild/1.4.0/lib/python2.6/site-packages/easybuild_easyconfigs-1.4.0.0-py2.6.egg/easybuild/easyconfigs/v/VTune/VTune-2013_update6.eb
== temporary log file in case of crash /tmp/easybuild-quMs4n.log
/opt/apps/HPCBIOS.20130501/software/EasyBuild/1.4.0/lib/python2.6/site-packages/easybuild_framework-1.4.0-py2.6.egg/easybuild/framework/easyconfig/easyconfig.py:159: DeprecationWarning: object.__init__() takes no parameters
  typ_lic.__init__(self, args[0])
== resolving dependencies ...
== processing EasyBuild easyconfig /opt/apps/HPCBIOS.20130501/software/EasyBuild/1.4.0/lib/python2.6/site-packages/easybuild_easyconfigs-1.4.0.0-py2.6.egg/easybuild/easyconfigs/v/VTune/VTune-2013_update6.eb
== building and installing VTune-2013_update6...
== fetching files...
== creating build dir, resetting environment...
== unpacking...
== patching...
== preparing...
== configuring...
ERROR: EasyBuild encountered an exception (at easybuild/main.py:817 in build_and_install_software): autoBuild Failed (last 300 chars): EasyBuild crashed with an error (at easybuild/easyblocks/generic/intelbase.py:163 in configure_step): Can't find license at /apps/gent/licenses/intel

real    0m3.485s
user    0m2.440s
sys     0m0.688s
```

N.B. didn't really get what the DeprecationWarning is really about, but I didn't see it a second time either, so I ignored it.

Signed-off-by: Fotis Georgatos fotis.georgatos@uni.lu
