### PR TITLE
added missing toolchainopts (pic) to goolf-1.4.10

### DIFF
--- a/easybuild/easyconfigs/p/Perl/Perl-5.16.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.16.3-goolf-1.4.10.eb
@@ -5,6 +5,7 @@ homepage = 'http://www.perl.org/'
 description = """Larry Wall's Practical Extraction and Report Language"""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchainopts = {'optarch': True, 'pic': True}
 
 source_urls = ['http://www.cpan.org/src/5.0']
 sources = [SOURCELOWER_TAR_GZ]


### PR DESCRIPTION
toolchainopts were available for both toolchains (both versions {,-bare})),
but missing in this one. PIC is needed for language bindings (e.g. SWIG).
