### PR TITLE
bugfix R: convert major_version to version_major for R - bugfix

### DIFF
--- a/easybuild/easyconfigs/r/R/R-2.15.2-goalf-1.1.0-no-OFED-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-goalf-1.1.0-no-OFED-bare.eb
@@ -8,7 +8,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'goalf', 'version': '1.1.0-no-OFED'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-2.15.2-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-goalf-1.1.0-no-OFED.eb
@@ -7,7 +7,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'goalf', 'version': '1.1.0-no-OFED'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10-bare.eb
@@ -8,7 +8,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10.eb
@@ -7,7 +7,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.10.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.10.eb
@@ -7,7 +7,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'ictce', 'version': '4.0.10'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.6-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.6-bare.eb
@@ -8,7 +8,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'ictce', 'version': '4.0.6'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.6.eb
@@ -7,7 +7,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'ictce', 'version': '4.0.6'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0-bare.eb
@@ -8,7 +8,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0.eb
@@ -7,7 +7,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-2.15.3-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-goalf-1.1.0-no-OFED.eb
@@ -7,7 +7,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'goalf', 'version': '1.1.0-no-OFED'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-2.15.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-goolf-1.4.10.eb
@@ -7,7 +7,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-2.15.3-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-ictce-4.1.13.eb
@@ -7,7 +7,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'ictce', 'version': '4.1.13'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-2.15.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-ictce-5.3.0.eb
@@ -7,7 +7,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-3.0.1-goalf-1.1.0-no-OFED-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.1-goalf-1.1.0-no-OFED-bare.eb
@@ -8,7 +8,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'goalf', 'version': '1.1.0-no-OFED'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-3.0.1-goolf-1.4.10-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.1-goolf-1.4.10-bare.eb
@@ -8,7 +8,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-3.0.1-ictce-4.0.6-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.1-ictce-4.0.6-bare.eb
@@ -8,7 +8,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'ictce', 'version': '4.0.6'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-3.0.1-ictce-4.1.13-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.1-ictce-4.1.13-bare.eb
@@ -8,7 +8,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'ictce', 'version': '4.1.13'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"

--- a/easybuild/easyconfigs/r/R/R-3.0.1-ictce-5.3.0-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.1-ictce-5.3.0-bare.eb
@@ -8,7 +8,7 @@ description = """R is a free software environment for statistical computing and 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(major_version)s']
+source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
 configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"


### PR DESCRIPTION
the v2.15.3 was tested and seems to be doing the job right now. The bug was introduced via last commit of #279 

Signed-off-by: Fotis Georgatos fotis.georgatos@uni.lu
