### PR TITLE
Fix make install step when USE_THREAD=0

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-cgmpich-1.1.6-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-cgmpich-1.1.6-LAPACK-3.4.2.eb
@@ -33,8 +33,10 @@ patches = [
 ]
 
 skipsteps = ['configure']
-makeopts = 'BINARY=64 USE_THREAD=1 CC="$CC" FC="$F77"'
-installopts = "PREFIX=%(installdir)s"
+
+threading = 'USE_THREAD=1'
+makeopts = 'BINARY=64 '+threading+' CC="$CC" FC="$F77"'
+installopts = threading+" PREFIX=%(installdir)s"
 
 # extensive testing can be enabled by uncommenting the line below
 #runtest = 'PATH=.:$PATH lapack-timing'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-cgmvapich2-1.1.12rc1-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-cgmvapich2-1.1.12rc1-LAPACK-3.4.2.eb
@@ -33,8 +33,9 @@ patches = [
 ]
 
 skipsteps = ['configure']
-makeopts = 'BINARY=64 USE_THREAD=1 CC="$CC" FC="$F77"'
-installopts = "PREFIX=%(installdir)s"
+threading = 'USE_THREAD=1'
+makeopts = 'BINARY=64 '+threading+' CC="$CC" FC="$F77"'
+installopts = threading+" PREFIX=%(installdir)s"
 
 # extensive testing can be enabled by uncommenting the line below
 #runtest = 'PATH=.:$PATH lapack-timing'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-cgompi-1.1.7-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-cgompi-1.1.7-LAPACK-3.4.2.eb
@@ -33,8 +33,9 @@ patches = [
 ]
 
 skipsteps = ['configure']
-makeopts = 'BINARY=64 USE_THREAD=1 CC="$CC" FC="$F77"'
-installopts = "PREFIX=%(installdir)s"
+threading = 'USE_THREAD=1'
+makeopts = 'BINARY=64 '+threading+' CC="$CC" FC="$F77"'
+installopts = threading+" PREFIX=%(installdir)s"
 
 # extensive testing can be enabled by uncommenting the line below
 #runtest = 'PATH=.:$PATH lapack-timing'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-gmvapich2-1.7.12rc1-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-gmvapich2-1.7.12rc1-LAPACK-3.4.2.eb
@@ -33,8 +33,9 @@ patches = [
           ]
 
 skipsteps = ['configure']
-makeopts = 'BINARY=64 USE_THREAD=1 CC="$CC" FC="$F77"'
-installopts = "PREFIX=%(installdir)s"
+threading = 'USE_THREAD=1'
+makeopts = 'BINARY=64 '+threading+' CC="$CC" FC="$F77"'
+installopts = threading+" PREFIX=%(installdir)s"
 
 # extensive testing can be enabled by uncommenting the line below
 #runtest = 'PATH=.:$PATH lapack-timing'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-gompi-1.3.12-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-gompi-1.3.12-LAPACK-3.4.2.eb
@@ -33,8 +33,9 @@ patches = [
           ]
 
 skipsteps = ['configure']
-makeopts = 'BINARY=64 USE_THREAD=1 CC="$CC" FC="$F77"'
-installopts = "PREFIX=%(installdir)s"
+threading = 'USE_THREAD=1'
+makeopts = 'BINARY=64 '+threading+' CC="$CC" FC="$F77"'
+installopts = threading+" PREFIX=%(installdir)s"
 
 # extensive testing can be enabled by uncommenting the line below
 #runtest = 'PATH=.:$PATH lapack-timing'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-gompi-1.4.10-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-gompi-1.4.10-LAPACK-3.4.2.eb
@@ -33,8 +33,9 @@ patches = [
 ]
 
 skipsteps = ['configure']
-makeopts = 'BINARY=64 USE_THREAD=1 CC="$CC" FC="$F77"'
-installopts = "PREFIX=%(installdir)s"
+threading = 'USE_THREAD=1'
+makeopts = 'BINARY=64 '+threading+' CC="$CC" FC="$F77"'
+installopts = threading+" PREFIX=%(installdir)s"
 
 # extensive testing can be enabled by uncommenting the line below
 #runtest = 'PATH=.:$PATH lapack-timing'


### PR DESCRIPTION
The OpenBLAS easyconfig potentially allows setting USE_THREAD=0 causing the "make install" step to fail if this is not passed to "make install". "make install" probably assumes USE_THREAD=1 regardless of what was specified in the "make" step. 

The generated library names are different: e.g. 
libopenblas_nehalemp.so
libopenblas_nehalem.so
