### PR TITLE
add a template sanity_check_paths as MUST in TEMPLATE.eb

### DIFF
--- a/easybuild/easyconfigs/TEMPLATE.eb
+++ b/easybuild/easyconfigs/TEMPLATE.eb
@@ -12,16 +12,19 @@ description = """TEMPLATE DESCRIPTION"""
 toolchain = {'name': 'TEMPLATE', 'version': 'TK_VERSION'}
 toolchainopts = {}  # toolchain options, e.g. opt, pic, usempi, optarch, ...
 
-source_urls = ['http://www.example.com']
 # For sources line to work correctly with --try-software-version, you MUST employ %s OR use a construct like SOURCE_TAR_GZ
-sources = ['%s-%s.tar.gz' % (name, version)]
+sources = ['%(name)s-%(version)s.tar.gz']
+source_urls = ['http://www.example.com']
 
 patches = []
 
 dependencies = []
 
+# The sanity test MUST be tuned before going production and submitting your contribution to upstream git repositories
 sanity_check_paths = {
-    # This and the next line MUST be tuned before going production and submitting your contribution to upstream git repo
     'files': [],
     'dirs': ["."]
 }
+
+# You SHOULD change the following line; Kindly consult other easyconfigs for possible options
+moduleclass = 'base'


### PR DESCRIPTION
This helps in two ways:
- Less keystrokes for newcomers in easybuild, before arriving to first success AND request a quality standard
- Permits https://github.com/hpcugent/easybuild-framework/issues/602 to actually finish gracefully

Signed-off-by: Fotis Georgatos fotis.georgatos@uni.lu
