### PR TITLE
Add easyconfig for CUDA 5.5.22

### DIFF
--- a/easybuild/easyconfigs/c/CUDA/CUDA-5.0.35-1.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-5.0.35-1.eb
@@ -45,6 +45,6 @@ elif OS_NAME in ["suse", "SLES"] and OS_VERSION.startswith('11_SP'):
 else:
     system = 'UNKNOWN'
 
-sources = ['%s_%s_linux_64_%s%s.run' % (name.lower(), version, system, versionsuffix)]
+sources = ['%%(namelower)s_%%(version)s_linux_64_%s%%(versionsuffix)s.run' % system]
 
 moduleclass = 'system'

--- a/easybuild/easyconfigs/c/CUDA/CUDA-5.5.22.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-5.5.22.eb
@@ -24,6 +24,6 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 # eg. http://developer.download.nvidia.com/compute/cuda/5_5/rel/installers/cuda_5.5.22_linux_64.run
 source_urls = ['http://developer.download.nvidia.com/compute/cuda/5_5/rel/installers/']
 
-sources = ['%s_%s_linux_64.run' % (name.lower(), version)]
+sources = ['%(namelower)s_%(version)s_linux_64.run']
 
 moduleclass = 'system'


### PR DESCRIPTION
CUDA 5.5.x adds support for a unified Linux installer, instead of using different installers for each distro.

edit: depends on https://github.com/hpcugent/easybuild-easyblocks/pull/238
