### PR TITLE
Fix website and description for scipy easyconfigs

### DIFF
--- a/easybuild/easyconfigs/s/scipy/scipy-0.11.0-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/s/scipy/scipy-0.11.0-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -2,12 +2,9 @@ name = 'scipy'
 version = '0.11.0'
 versionsuffix = '-Python-2.7.3'
 
-homepage = 'http://www.numpy.org'
-description = """SciPy is the fundamental package for scientific computing with Python. It contains among other things:
- a powerful N-dimensional array object, sophisticated (broadcasting) functions, tools for integrating C/C++ and Fortran
- code, useful linear algebra, Fourier transform, and random number capabilities. Besides its obvious scientific uses,
- SciPy can also be used as an efficient multi-dimensional container of generic data. Arbitrary data-types can be 
- defined. This allows SciPy to seamlessly and speedily integrate with a wide variety of databases."""
+homepage = 'http://www.scipy.org'
+description = """SciPy is a collection of mathematical algorithms and convenience 
+ functions built on the Numpy extension for Python."""
 
 toolchain = {'name': 'goalf', 'version': '1.1.0-no-OFED'}
 toolchainopts = {'pic': True}

--- a/easybuild/easyconfigs/s/scipy/scipy-0.11.0-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/s/scipy/scipy-0.11.0-goolf-1.4.10-Python-2.7.3.eb
@@ -2,12 +2,9 @@ name = 'scipy'
 version = '0.11.0'
 versionsuffix = '-Python-2.7.3'
 
-homepage = 'http://www.numpy.org'
-description = """NumPy is the fundamental package for scientific computing with Python. It contains among other things:
-a powerful N-dimensional array object, sophisticated (broadcasting) functions, tools for integrating C/C++ and Fortran
-code, useful linear algebra, Fourier transform, and random number capabilities. Besides its obvious scientific uses,
-NumPy can also be used as an efficient multi-dimensional container of generic data. Arbitrary data-types can be 
-defined. This allows NumPy to seamlessly and speedily integrate with a wide variety of databases."""
+homepage = 'http://www.scipy.org'
+description = """SciPy is a collection of mathematical algorithms and convenience
+ functions built on the Numpy extension for Python."""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 toolchainopts = {'pic': True}

--- a/easybuild/easyconfigs/s/scipy/scipy-0.11.0-ictce-4.0.6-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/s/scipy/scipy-0.11.0-ictce-4.0.6-Python-2.7.3.eb
@@ -2,12 +2,9 @@ name = 'scipy'
 version = '0.11.0'
 versionsuffix = '-Python-2.7.3'
 
-homepage = 'http://www.numpy.org'
-description = """SciPy is the fundamental package for scientific computing with Python. It contains among other things:
- a powerful N-dimensional array object, sophisticated (broadcasting) functions, tools for integrating C/C++ and Fortran
- code, useful linear algebra, Fourier transform, and random number capabilities. Besides its obvious scientific uses,
- SciPy can also be used as an efficient multi-dimensional container of generic data. Arbitrary data-types can be 
- defined. This allows SciPy to seamlessly and speedily integrate with a wide variety of databases."""
+homepage = 'http://www.scipy.org'
+description = """SciPy is a collection of mathematical algorithms and convenience 
+ functions built on the Numpy extension for Python."""
 
 toolchain = {'name': 'ictce', 'version': '4.0.6'}
 toolchainopts = {'pic': True}

--- a/easybuild/easyconfigs/s/scipy/scipy-0.11.0-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/s/scipy/scipy-0.11.0-ictce-5.3.0-Python-2.7.3.eb
@@ -2,13 +2,9 @@ name = 'scipy'
 version = '0.11.0'
 versionsuffix = '-Python-2.7.3'
 
-homepage = 'http://www.numpy.org'
-description = """SciPy is the fundamental package for scientific computing with Python. It contains among other things:
- a powerful N-dimensional array object, sophisticated (broadcasting) functions, tools for integrating C/C++ and Fortran
- code, useful linear algebra, Fourier transform, and random number capabilities. Besides its obvious scientific uses,
- SciPy can also be used as an efficient multi-dimensional container of generic data. Arbitrary data-types can be 
- defined. This allows SciPy to seamlessly and speedily integrate with a wide variety of databases."""
-
+homepage = 'http://www.scipy.org'
+description = """SciPy is a collection of mathematical algorithms and convenience 
+ functions built on the Numpy extension for Python."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'pic': True}


### PR DESCRIPTION
Previously, all the scipy easyconfigs listed numpy.org as the homepage
and used a copy-pasted numpy description with "Numpy" replaced with
"Scipy".

This commit changes the homepage to point to scipy.org and changes the
description to that used at the beginning of the SciPy reference manual:

"SciPy is a collection of mathematical algorithms and convenience
functions built on the Numpy extension for Python."
