### PR TITLE
Fix OpenMPI OS dependencies for Debian and Ubuntu

### DIFF
--- a/easybuild/easyconfigs/i/iqacml/iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/i/iqacml/iqacml-3.7.3.eb
@@ -1,4 +1,4 @@
-easyblock  =  'Toolchain'
+easyblock = 'Toolchain'
 
 name = 'iqacml'
 version = '3.7.3'

--- a/easybuild/easyconfigs/i/iqacml/iqacml-4.4.13.eb
+++ b/easybuild/easyconfigs/i/iqacml/iqacml-4.4.13.eb
@@ -1,4 +1,4 @@
-easyblock  =  'Toolchain'
+easyblock = 'Toolchain'
 
 name = 'iqacml'
 version = '4.4.13'

--- a/easybuild/easyconfigs/m/MPICH/MPICH-3.0.3-ClangGCC-1.1.3.eb
+++ b/easybuild/easyconfigs/m/MPICH/MPICH-3.0.3-ClangGCC-1.1.3.eb
@@ -13,7 +13,7 @@ source_urls = ['http://www.mpich.org/static/tarballs/%s' % version]
 # MPICH configure wants F90/F90FLAGS to be renamed to FC/FCFLAGS.
 preconfigopts = 'export FC="$F90"; export FCFLAGS="$F90FLAGS"; unset F90; unset F90FLAGS; '
 
-sanity_check_paths  =  {
+sanity_check_paths = {
     'files': ['bin/mpicc', 'bin/mpicxx', 'bin/mpic++', 'bin/mpif77', 'bin/mpif90',
               'bin/mpiexec', 'bin/mpirun',
               'include/mpi.h', 'include/mpi.mod', 'include/mpif.h'],

--- a/easybuild/easyconfigs/n/NCL/NCL-6.0.0-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.0.0-goalf-1.1.0-no-OFED.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('ESMF', '5.3.0'),
     ('cairo', '1.12.14'),
 ]
-builddependencies  =  [('makedepend', '1.0.4')]
+builddependencies = [('makedepend', '1.0.4')]
 
 sources = ['%s_ncarg-%s.tar.gz' % (name.lower(), version)]
 

--- a/easybuild/easyconfigs/n/NCL/NCL-6.0.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.0.0-goolf-1.4.10.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('ESMF', '5.3.0'),
     ('cairo', '1.12.14'),
 ]
-builddependencies  =  [('makedepend', '1.0.4')]
+builddependencies = [('makedepend', '1.0.4')]
 
 sources = ['%s_ncarg-%s.tar.gz' % (name.lower(), version)]
 

--- a/easybuild/easyconfigs/n/NCL/NCL-6.0.0-ictce-3.2.2.u3.eb
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.0.0-ictce-3.2.2.u3.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('ESMF', '5.3.0'),
     ('cairo', '1.12.14'),
 ]
-builddependencies  =  [('makedepend', '1.0.4')]
+builddependencies = [('makedepend', '1.0.4')]
 
 sources = ['%s_ncarg-%s.tar.gz' % (name.lower(), version)]
 

--- a/easybuild/easyconfigs/n/NCL/NCL-6.1.0-iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.1.0-iqacml-3.7.3.eb
@@ -30,7 +30,7 @@ dependencies = [
     ('ESMF', '6.1.1'),
     ('bzip2', '1.0.6'),
 ]
-builddependencies  =  [('makedepend', '1.0.4')]
+builddependencies = [('makedepend', '1.0.4')]
 
 osdependencies = ['cairo-devel']
 

--- a/easybuild/easyconfigs/n/NCL/NCL-6.1.2-iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.1.2-iqacml-3.7.3.eb
@@ -30,7 +30,7 @@ dependencies = [
     ('ESMF', '6.1.1'),
     ('bzip2', '1.0.6'),
 ]
-builddependencies  =  [('makedepend', '1.0.4')]
+builddependencies = [('makedepend', '1.0.4')]
 
 osdependencies = ['cairo-devel']
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3-no-OFED.eb
@@ -15,12 +15,12 @@ configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in 
 
 patches = ['pax_disable.patch']
 
-moduleclass = 'mpi'
-
 sanity_check_paths = {
-                      'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
-                               ["lib/lib%s.%s" % (libfile, shared_lib_ext) for libfile in ["mca_common_sm", "mpi_cxx",
-                                                                                          "mpi_f77", "mpi_f90", "mpi",
-                                                                                          "open-pal", "open-rte"]],
-                      'dirs': ["include/openmpi/ompi/mpi/cxx"]
-                     }
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, shared_lib_ext) for libfile in ["mca_common_sm", "mpi_cxx",
+                                                                         "mpi_f77", "mpi_f90", "mpi",
+                                                                         "open-pal", "open-rte"]],
+    'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3.eb
@@ -12,15 +12,19 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%s/downloads' % '.'.join(
 configopts = '--with-threads=posix --enable-shared --enable-mpi-threads --with-openib '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 
-# required for uDAPL support
-osdependencies = ['dapl-devel']
-
-moduleclass = 'mpi'
+# needed for --with-openib
+if OS_NAME in ['debian', 'ubuntu']:
+    osdependencies = ['libibverbs-dev']
+else:
+    # OK for OS_NAME == redhat, fedora, RHEL, SL, centos
+    osdependencies = ['libibverbs-devel']
 
 sanity_check_paths = {
-                      'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
-                               ["lib/lib%s.%s" % (libfile, shared_lib_ext) for libfile in ["mca_common_sm", "mpi_cxx",
-                                                                                          "mpi_f77", "mpi_f90", "mpi",
-                                                                                          "open-pal", "open-rte"]],
-                      'dirs': ["include/openmpi/ompi/mpi/cxx"]
-                     }
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, shared_lib_ext) for libfile in ["mca_common_sm", "mpi_cxx",
+                                                                         "mpi_f77", "mpi_f90", "mpi",
+                                                                         "open-pal", "open-rte"]],
+    'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.3-iccifort-2011.13.367.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.3-iccifort-2011.13.367.eb
@@ -15,17 +15,24 @@ configopts += '--with-hwloc '  # hwloc support
 
 dependencies = [('hwloc', '1.6')]
 
-sanity_check_paths  =  {
-                        'files':["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
-                                ["lib/lib%s.%s" % (libfile, shared_lib_ext) for libfile in ["mca_common_sm", "mpi_cxx",
-                                                                                            "mpi_f77" ,"mpi_f90", "mpi",
-                                                                                            "ompitrace", "open-pal",
-                                                                                            "open-rte", "otfaux", "otf",
-                                                                                            "vt", "vt-hyb", "vt-mpi",
-                                                                                            "vt-mpi-unify"]] +
-                                ["include/%s.h" % x for x in ["mpi-ext", "mpif-common", "mpif-config", "mpif",
-                                                              "mpif-mpi-io", "mpi", "mpi_portable_platform"]],
-                        'dirs':["include/openmpi/ompi/mpi/cxx"]
-                       }
+# needed for --with-openib
+if OS_NAME in ['debian', 'ubuntu']:
+    osdependencies = ['libibverbs-dev']
+else:
+    # OK for OS_NAME == redhat, fedora, RHEL, SL, centos
+    osdependencies = ['libibverbs-devel']
+
+sanity_check_paths = {
+    'files':["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+            ["lib/lib%s.%s" % (libfile, shared_lib_ext) for libfile in ["mca_common_sm", "mpi_cxx",
+                                                                        "mpi_f77" ,"mpi_f90", "mpi",
+                                                                        "ompitrace", "open-pal",
+                                                                        "open-rte", "otfaux", "otf",
+                                                                        "vt", "vt-hyb", "vt-mpi",
+                                                                        "vt-mpi-unify"]] +
+            ["include/%s.h" % x for x in ["mpi-ext", "mpif-common", "mpif-config", "mpif",
+                                          "mpif-mpi-io", "mpi", "mpi_portable_platform"]],
+     'dirs':["include/openmpi/ompi/mpi/cxx"],
+}
 
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-ClangGCC-1.1.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-ClangGCC-1.1.3.eb
@@ -16,16 +16,22 @@ configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in 
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
-sanity_check_paths  =  {
-                        'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
-                                 ["lib/lib%s.%s" % (libfile, shared_lib_ext) for libfile in ["mpi_cxx", "mpi_f77" ,"mpi_f90",
-                                                                                             "mpi", "ompitrace", "open-pal",
-                                                                                             "open-rte", "vt", "vt-hyb",
-                                                                                             "vt-mpi", "vt-mpi-unify"]] +
-                                 ["include/%s.h" % x for x in ["mpi-ext", "mpif-common", "mpif-config", "mpif",
-                                                               "mpif-mpi-io",
-                                                               "mpi", "mpi_portable_platform"]],
-                        'dirs': ["include/openmpi/ompi/mpi/cxx"]
-                       }
+# needed for --with-openib
+if OS_NAME in ['debian', 'ubuntu']:
+    osdependencies = ['libibverbs-dev']
+else:
+    # OK for OS_NAME == redhat, fedora, RHEL, SL, centos
+    osdependencies = ['libibverbs-devel']
+
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, shared_lib_ext) for libfile in ["mpi_cxx", "mpi_f77" ,"mpi_f90",
+                                                                         "mpi", "ompitrace", "open-pal",
+                                                                         "open-rte", "vt", "vt-hyb",
+                                                                         "vt-mpi", "vt-mpi-unify"]] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-common", "mpif-config", "mpif",
+                                           "mpif-mpi-io", "mpi", "mpi_portable_platform"]],
+     'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
 
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.6.4.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.6.4.eb
@@ -17,21 +17,21 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-openib
-if OS_NAME in ['redhat', 'fedora', 'RHEL', 'SL', 'centos']:
-    osdependencies = ['libibverbs-devel']
-elif OS_NAME in ['debian', 'ubuntu']:
+if OS_NAME in ['debian', 'ubuntu']:
     osdependencies = ['libibverbs-dev']
+else:
+    # OK for OS_NAME == redhat, fedora, RHEL, SL, centos
+    osdependencies = ['libibverbs-devel']
 
-sanity_check_paths  =  {
-                        'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
-                                 ["lib/lib%s.%s" % (libfile, shared_lib_ext) for libfile in ["mpi_cxx", "mpi_f77" ,"mpi_f90",
-                                                                                             "mpi", "ompitrace", "open-pal",
-                                                                                             "open-rte", "vt", "vt-hyb",
-                                                                                             "vt-mpi", "vt-mpi-unify"]] +
-                                 ["include/%s.h" % x for x in ["mpi-ext", "mpif-common", "mpif-config", "mpif",
-                                                               "mpif-mpi-io",
-                                                               "mpi", "mpi_portable_platform"]],
-                        'dirs': ["include/openmpi/ompi/mpi/cxx"]
-                       }
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, shared_lib_ext) for libfile in ["mpi_cxx", "mpi_f77" ,"mpi_f90",
+                                                                         "mpi", "ompitrace", "open-pal",
+                                                                         "open-rte", "vt", "vt-hyb",
+                                                                         "vt-mpi", "vt-mpi-unify"]] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-common", "mpif-config", "mpif",
+                                           "mpif-mpi-io", "mpi", "mpi_portable_platform"]],
+     'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
 
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2.eb
@@ -17,18 +17,21 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-openib
-if OS_NAME in ['redhat', 'fedora', 'RHEL', 'SL', 'centos']:
-    osdependencies = ['libibverbs-devel']
-elif OS_NAME in ['debian', 'ubuntu']:
+if OS_NAME in ['debian', 'ubuntu']:
     osdependencies = ['libibverbs-dev']
+else:
+    # OK for OS_NAME == redhat, fedora, RHEL, SL, centos
+    osdependencies = ['libibverbs-devel']
 
 sanity_check_paths = {
     'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
-             ["lib/lib%s.so" % (libfile) for libfile in ["mpi_cxx", "mpi_f77", "mpi_f90",
-              "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]] +
+             ["lib/lib%s.%s" % (libfile, shared_lib_ext) for libfile in ["mpi_cxx", "mpi_f77" ,"mpi_f90",
+                                                                         "mpi", "ompitrace", "open-pal",
+                                                                         "open-rte", "vt", "vt-hyb",
+                                                                         "vt-mpi", "vt-mpi-unify"]] +
              ["include/%s.h" % x for x in ["mpi-ext", "mpif-common", "mpif-config", "mpif",
-              "mpif-mpi-io", "mpi", "mpi_portable_platform"]],
-    'dirs': ["include/openmpi/ompi/mpi/cxx"]
+                                           "mpif-mpi-io", "mpi", "mpi_portable_platform"]],
+     'dirs': ["include/openmpi/ompi/mpi/cxx"],
 }
 
 moduleclass = 'mpi'


### PR DESCRIPTION
OpenMPI-1.6.4-GCC-4.7.2.eb had an OS dependency on libibverbs-devel,
which is a package found in RHEL-based distros and Fedora. In Debian
and Ubuntu, this package is called libibverbs-dev. In this commit I
added an OS_NAME check to make the libibverbs-devel check conditional
on running RHEL, etc. and added a check for the correct package name
on Debian.

I also added the same check into OpenMPI-1.6.4-GCC-4.6.4.eb because
it has the same dependency, and this easyconfig is used for the
goolfc-1.3.12 toolchain.
