### PR TITLE
add easyconfigs for MUMPS and OpenFOAM 1.6-ext dependencies

### DIFF
--- a/easybuild/easyconfigs/m/METIS/METIS-4.0.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/METIS/METIS-4.0.3-goolf-1.4.10.eb
@@ -1,0 +1,18 @@
+name = 'METIS'
+version = '4.0.3'
+
+homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/metis/overview'
+description = """METIS is a set of serial programs for partitioning graphs, partitioning finite element meshes,
+ and producing fill reducing orderings for sparse matrices. The algorithms implemented in METIS are based on the
+ multilevel recursive-bisection, multilevel k-way, and multi-constraint partitioning schemes."""
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis',
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD',
+]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/METIS/METIS-4.0.3-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/m/METIS/METIS-4.0.3-ictce-4.1.13.eb
@@ -1,0 +1,18 @@
+name = 'METIS'
+version = '4.0.3'
+
+homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/metis/overview'
+description = """METIS is a set of serial programs for partitioning graphs, partitioning finite element meshes,
+ and producing fill reducing orderings for sparse matrices. The algorithms implemented in METIS are based on the
+ multilevel recursive-bisection, multilevel k-way, and multi-constraint partitioning schemes."""
+
+toolchain = {'name': 'ictce', 'version': '4.1.13'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis',
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD',
+]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/METIS/METIS-5.0.2-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/m/METIS/METIS-5.0.2-ictce-4.1.13.eb
@@ -1,0 +1,20 @@
+name = 'METIS'
+version = '5.0.2'
+
+homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/metis/overview'
+description = """METIS is a set of serial programs for partitioning graphs, partitioning finite element meshes,
+ and producing fill reducing orderings for sparse matrices. The algorithms implemented in METIS are based on the
+ multilevel recursive-bisection, multilevel k-way, and multi-constraint partitioning schemes."""
+
+toolchain = {'name': 'ictce', 'version': '4.1.13'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis',
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD',
+]
+
+dependencies = [('CMake', '2.8.4')]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/METIS/METIS-5.1.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/METIS/METIS-5.1.0-goolf-1.4.10.eb
@@ -1,0 +1,20 @@
+name = 'METIS'
+version = '5.1.0'
+
+homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/metis/overview'
+description = """METIS is a set of serial programs for partitioning graphs, partitioning finite element meshes,
+ and producing fill reducing orderings for sparse matrices. The algorithms implemented in METIS are based on the
+ multilevel recursive-bisection, multilevel k-way, and multi-constraint partitioning schemes."""
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis',
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD',
+]
+
+builddependencies = [('CMake', '2.8.4')]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/METIS/METIS-5.1.0-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/m/METIS/METIS-5.1.0-ictce-4.1.13.eb
@@ -1,0 +1,20 @@
+name = 'METIS'
+version = '5.1.0'
+
+homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/metis/overview'
+description = """METIS is a set of serial programs for partitioning graphs, partitioning finite element meshes,
+ and producing fill reducing orderings for sparse matrices. The algorithms implemented in METIS are based on the
+ multilevel recursive-bisection, multilevel k-way, and multi-constraint partitioning schemes."""
+
+toolchain = {'name': 'ictce', 'version': '4.1.13'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis',
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD',
+]
+
+builddependencies = [('CMake', '2.8.4')]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MUMPS/MUMPS-4.10.0-goolf-1.4.10-metis.eb
+++ b/easybuild/easyconfigs/m/MUMPS/MUMPS-4.10.0-goolf-1.4.10-metis.eb
@@ -1,0 +1,22 @@
+name = 'MUMPS'
+version = '4.10.0'
+versionsuffix = '-metis'
+
+homepage = 'http://graal.ens-lyon.fr/MUMPS/'
+description = "A parallel sparse direct solver"
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['http://mumps.enseeiht.fr/']
+sources = ['%(name)s_%(version)s.tar.gz']
+
+dependencies = [
+    ('SCOTCH', '6.0.0_esmumps'),
+    ('METIS', '4.0.3'),
+]
+
+parallel = 1
+makeopts = 'all'
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MUMPS/MUMPS-4.10.0-goolf-1.4.10-parmetis.eb
+++ b/easybuild/easyconfigs/m/MUMPS/MUMPS-4.10.0-goolf-1.4.10-parmetis.eb
@@ -1,0 +1,22 @@
+name = 'MUMPS'
+version = '4.10.0'
+versionsuffix = '-parmetis'
+
+homepage = 'http://graal.ens-lyon.fr/MUMPS/'
+description = "A parallel sparse direct solver"
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['http://mumps.enseeiht.fr/']
+sources = ['%(name)s_%(version)s.tar.gz']
+
+dependencies = [
+    ('SCOTCH', '6.0.0_esmumps'),
+    ('ParMETIS', '3.2.0'),
+]
+
+parallel = 1
+makeopts = 'all'
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MUMPS/MUMPS-4.10.0-ictce-4.1.13-metis.eb
+++ b/easybuild/easyconfigs/m/MUMPS/MUMPS-4.10.0-ictce-4.1.13-metis.eb
@@ -1,0 +1,22 @@
+name = 'MUMPS'
+version = '4.10.0'
+versionsuffix = '-metis'
+
+homepage = 'http://graal.ens-lyon.fr/MUMPS/'
+description = "A parallel sparse direct solver"
+
+toolchain = {'name': 'ictce', 'version': '4.1.13'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['http://mumps.enseeiht.fr/']
+sources = ['%(name)s_%(version)s.tar.gz']
+
+dependencies = [
+    ('SCOTCH', '6.0.0_esmumps'),
+    ('METIS', '4.0.3'),
+]
+
+parallel = 1
+makeopts = 'all'
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MUMPS/MUMPS-4.10.0-ictce-4.1.13-parmetis.eb
+++ b/easybuild/easyconfigs/m/MUMPS/MUMPS-4.10.0-ictce-4.1.13-parmetis.eb
@@ -1,0 +1,22 @@
+name = 'MUMPS'
+version = '4.10.0'
+versionsuffix = '-parmetis'
+
+homepage = 'http://graal.ens-lyon.fr/MUMPS/'
+description = "A parallel sparse direct solver"
+
+toolchain = {'name': 'ictce', 'version': '4.1.13'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['http://mumps.enseeiht.fr/']
+sources = ['%(name)s_%(version)s.tar.gz']
+
+dependencies = [
+    ('SCOTCH', '6.0.0_esmumps'),
+    ('ParMETIS', '3.2.0'),
+]
+
+parallel = 1
+makeopts = 'all'
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/Mesquite/Mesquite-2.3.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/Mesquite/Mesquite-2.3.0-goolf-1.4.10.eb
@@ -1,0 +1,13 @@
+name = 'Mesquite'
+version = '2.3.0'
+
+homepage = 'http://software.sandia.gov/~bktidwe/mesquite.html'
+description = """Mesh-Quality Improvement Library"""
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://software.sandia.gov/~bktidwe/']
+sources = [SOURCELOWER_TAR_GZ]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/Mesquite/Mesquite-2.3.0-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/m/Mesquite/Mesquite-2.3.0-ictce-4.1.13.eb
@@ -1,0 +1,13 @@
+name = 'Mesquite'
+version = '2.3.0'
+
+homepage = 'http://software.sandia.gov/~bktidwe/mesquite.html'
+description = """Mesh-Quality Improvement Library"""
+
+toolchain = {'name': 'ictce', 'version': '4.1.13'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://software.sandia.gov/~bktidwe/']
+sources = [SOURCELOWER_TAR_GZ]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/ParMETIS/ParMETIS-3.2.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/ParMETIS/ParMETIS-3.2.0-goolf-1.4.10.eb
@@ -1,0 +1,22 @@
+name = 'ParMETIS'
+version = '3.2.0'
+
+homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview'
+description = """ParMETIS is an MPI-based parallel library that implements a variety of algorithms for partitioning unstructured graphs,
+ meshes, and for computing fill-reducing orderings of sparse matrices. ParMETIS extends the functionality provided by METIS and includes
+ routines that are especially suited for parallel AMR computations and large scale numerical simulations. The algorithms implemented in
+ ParMETIS are based on the parallel multilevel k-way graph-partitioning, adaptive repartitioning, and parallel multi-constrained partitioning
+ schemes."""
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
+
+source_urls = [
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis',
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/OLD',
+]
+sources = ['ParMetis-%(version)s.tar.gz']
+
+builddependencies = [('CMake', '2.8.4')]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/ParMETIS/ParMETIS-3.2.0-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/ParMETIS/ParMETIS-3.2.0-ictce-4.1.13.eb
@@ -1,0 +1,22 @@
+name = 'ParMETIS'
+version = '3.2.0'
+
+homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview'
+description = """ParMETIS is an MPI-based parallel library that implements a variety of algorithms for partitioning unstructured graphs,
+ meshes, and for computing fill-reducing orderings of sparse matrices. ParMETIS extends the functionality provided by METIS and includes
+ routines that are especially suited for parallel AMR computations and large scale numerical simulations. The algorithms implemented in
+ ParMETIS are based on the parallel multilevel k-way graph-partitioning, adaptive repartitioning, and parallel multi-constrained partitioning
+ schemes."""
+
+toolchain = {'name': 'ictce', 'version': '4.1.13'}
+toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
+
+source_urls = [
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis',
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/OLD',
+]
+sources = ['ParMetis-%(version)s.tar.gz']
+
+builddependencies = [('CMake', '2.8.4')]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/ParMGridGen/ParMGridGen-1.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/ParMGridGen/ParMGridGen-1.0-goolf-1.4.10.eb
@@ -1,0 +1,26 @@
+easyblock = 'MakeCp'
+
+name = 'ParMGridGen'
+version = '1.0'
+
+homepage = 'http://www-users.cs.umn.edu/~moulitsa/software.html'
+description = """ParMGridGen is an MPI-based parallel library that is based on the serial package MGridGen,
+ that implements (serial) algorithms for obtaining a sequence of successive coarse grids that are well-suited
+ for geometric multigrid methods."""
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = ['http://www-users.cs.umn.edu/~moulitsa/download/']
+sources = [SOURCE_TAR_GZ]
+
+patches = ['ParMGridGen-1.0_malloc_include.patch']
+
+makeopts = 'parallel CC="$CC" PARCC="$CC" PARLD="$CC" BINDIR="."'
+
+files_to_copy = [
+    (['MGridGen/Programs/mgridgen', 'ParMGridGen/Programs/parmgridgen'], 'bin'),
+    (['mgridgen.h', 'parmgridgen.h'], 'include'),
+    (['libmgrid.a', 'libparmgrid.a'], 'lib'),
+]
+

--- a/easybuild/easyconfigs/p/ParMGridGen/ParMGridGen-1.0-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/ParMGridGen/ParMGridGen-1.0-ictce-4.1.13.eb
@@ -1,0 +1,26 @@
+easyblock = 'MakeCp'
+
+name = 'ParMGridGen'
+version = '1.0'
+
+homepage = 'http://www-users.cs.umn.edu/~moulitsa/software.html'
+description = """ParMGridGen is an MPI-based parallel library that is based on the serial package MGridGen,
+ that implements (serial) algorithms for obtaining a sequence of successive coarse grids that are well-suited
+ for geometric multigrid methods."""
+
+toolchain = {'name': 'ictce', 'version': '4.1.13'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = ['http://www-users.cs.umn.edu/~moulitsa/download/']
+sources = [SOURCE_TAR_GZ]
+
+patches = ['ParMGridGen-1.0_malloc_include.patch']
+
+makeopts = 'parallel CC="$CC" PARCC="$CC" PARLD="$CC" BINDIR="."'
+
+files_to_copy = [
+    (['MGridGen/Programs/mgridgen', 'ParMGridGen/Programs/parmgridgen'], 'bin'),
+    (['mgridgen.h', 'parmgridgen.h'], 'include'),
+    (['libmgrid.a', 'libparmgrid.a'], 'lib'),
+]
+

--- a/easybuild/easyconfigs/p/ParMGridGen/ParMGridGen-1.0_malloc_include.patch
+++ b/easybuild/easyconfigs/p/ParMGridGen/ParMGridGen-1.0_malloc_include.patch
@@ -1,0 +1,48 @@
+diff -ru ParMGridGen-1.0.orig/MGridGen/IMlib/IMlib.h ParMGridGen-1.0/MGridGen/IMlib/IMlib.h
+--- ParMGridGen-1.0.orig/MGridGen/IMlib/IMlib.h	2013-09-18 21:51:04.000000000 +0200
++++ ParMGridGen-1.0/MGridGen/IMlib/IMlib.h	2013-09-18 21:51:14.000000000 +0200
+@@ -43,7 +43,7 @@
+ #ifdef DMALLOC
+ #include <dmalloc.h>
+ #else
+-#include <malloc.h>
++//#include <malloc.h>
+ #endif
+ 
+ /*************************************************************************
+diff -ru ParMGridGen-1.0.orig/MGridGen/Lib/mgridgen.h ParMGridGen-1.0/MGridGen/Lib/mgridgen.h
+--- ParMGridGen-1.0.orig/MGridGen/Lib/mgridgen.h	2013-09-18 21:52:14.000000000 +0200
++++ ParMGridGen-1.0/MGridGen/Lib/mgridgen.h	2013-09-18 21:52:00.000000000 +0200
+@@ -26,7 +26,7 @@
+ #ifdef DMALLOC
+ #include <dmalloc.h>
+ #else
+-#include <malloc.h>
++//#include <malloc.h>
+ #endif
+ 
+ #include "defs.h"
+diff -ru ParMGridGen-1.0.orig/ParMGridGen/IMParMetis-2.0/ParMETISLib/parmetis.h ParMGridGen-1.0/ParMGridGen/IMParMetis-2.0/ParMETISLib/parmetis.h
+--- ParMGridGen-1.0.orig/ParMGridGen/IMParMetis-2.0/ParMETISLib/parmetis.h	2013-09-18 21:57:20.000000000 +0200
++++ ParMGridGen-1.0/ParMGridGen/IMParMetis-2.0/ParMETISLib/parmetis.h	2013-09-18 21:57:30.000000000 +0200
+@@ -21,7 +21,7 @@
+ #ifdef DMALLOC
+ #include <dmalloc.h>
+ #else
+-#include <malloc.h>
++//#include <malloc.h>
+ #endif
+ 
+ #include "rename.h"
+diff -ru ParMGridGen-1.0.orig/ParMGridGen/ParLib/parmgridgen.h ParMGridGen-1.0/ParMGridGen/ParLib/parmgridgen.h
+--- ParMGridGen-1.0.orig/ParMGridGen/ParLib/parmgridgen.h	2013-09-18 21:57:57.000000000 +0200
++++ ParMGridGen-1.0/ParMGridGen/ParLib/parmgridgen.h	2013-09-18 21:58:06.000000000 +0200
+@@ -21,7 +21,7 @@
+ #ifdef DMALLOC
+ #include <dmalloc.h>
+ #else
+-#include <malloc.h>
++//#include <malloc.h>
+ #endif
+ 
+ #include "IMlib.h"

--- a/easybuild/easyconfigs/s/SCOTCH/SCOTCH-5.1.12b_esmumps-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/s/SCOTCH/SCOTCH-5.1.12b_esmumps-ictce-4.1.13.eb
@@ -1,0 +1,14 @@
+name = 'SCOTCH'
+version = '5.1.12b_esmumps'
+
+homepage = 'http://www.labri.fr/perso/pelegrin/scotch/'
+description = """Software package and libraries for sequential and parallel graph partitioning,
+ static mapping, and sparse matrix block ordering, and sequential mesh and hypergraph partitioning."""
+
+toolchain = {'name': 'ictce', 'version': '4.1.13'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://gforge.inria.fr/frs/download.php/28978/']
+sources = ['%(namelower)s_%(version)s.tar.gz']
+
+moduleclass = 'math'


### PR DESCRIPTION
follow-up for #437, includes everything but the OpenFOAM easyconfigs because some problems remain there (see also https://github.com/hpcugent/easybuild-easyblocks/pull/253)
