### PR TITLE
exclude EMACS support in a2ps because of build failures

### DIFF
--- a/easybuild/easyconfigs/a/a2ps/a2ps-4.14-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/a/a2ps/a2ps-4.14-goalf-1.1.0-no-OFED.eb
@@ -23,6 +23,7 @@ dependencies = [
     ('gperf', '3.0.4'),
 ]
 
+preconfigopts = 'EMACS=no'
 configopts = '--with-gnu-gettext'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/a2ps/a2ps-4.14-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/a/a2ps/a2ps-4.14-goolf-1.4.10.eb
@@ -23,6 +23,7 @@ dependencies = [
     ('gperf', '3.0.4'),
 ]
 
+preconfigopts = 'EMACS=no'
 configopts = '--with-gnu-gettext'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/a2ps/a2ps-4.14-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/a/a2ps/a2ps-4.14-ictce-4.0.6.eb
@@ -23,6 +23,7 @@ dependencies = [
     ('gperf', '3.0.4'),
 ]
 
+preconfigopts = 'EMACS=no'
 configopts = '--with-gnu-gettext'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/a2ps/a2ps-4.14-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/a/a2ps/a2ps-4.14-ictce-5.3.0.eb
@@ -24,6 +24,7 @@ dependencies = [
     ('gperf', '3.0.4'),
 ]
 
+preconfigopts = 'EMACS=no'
 configopts = '--with-gnu-gettext'
 
 sanity_check_paths = {


### PR DESCRIPTION
merging in ater verifying this fixes problems like:

```
2922 make[3]: Entering directory `/tmp/easybuild_build/a2ps/4.14/goalf-1.1.0-no-OFED/a2ps-4.14/contrib/emacs'
2923 WARNING: Warnings can be ignored. :-)
2924 if test "emacs" != no; then \
2925       set x; \
2926       list='a2ps.el a2ps-print.el'; for p in $list; do \
2927         if test -f "$p"; then d=; else d="./"; fi; \
2928         set x "$@" "$d$p"; shift; \
2929       done; \
2930       shift; \
2931       EMACS="emacs" /bin/sh ../../auxdir/elisp-comp "$@" || exit 1; \
2932     else : ; fi
2933 Loading /usr/share/emacs/site-lisp/site-start.d/igrep-init.el (source)...
2934 Loading /usr/share/emacs/site-lisp/site-start.d/lang-coding-systems-init.el (source)...
2935 Wrong type argument: stringp, nil
```

Note: the problem only manifested itself when the `a2ps` builds were submitted as a job, not when the build is performed via an interactive shell...
