### PR TITLE
Build shared libraries with MPICH

### DIFF
--- a/easybuild/easyconfigs/m/MPICH/MPICH-3.0.3-ClangGCC-1.1.3.eb
+++ b/easybuild/easyconfigs/m/MPICH/MPICH-3.0.3-ClangGCC-1.1.3.eb
@@ -13,6 +13,9 @@ source_urls = ['http://www.mpich.org/static/tarballs/%s' % version]
 # MPICH configure wants F90/F90FLAGS to be renamed to FC/FCFLAGS.
 preconfigopts = 'export FC="$F90"; export FCFLAGS="$F90FLAGS"; unset F90; unset F90FLAGS; '
 
+# Build shared libraries
+configopts = '--enable-shared'
+
 sanity_check_paths = {
     'files': ['bin/mpicc', 'bin/mpicxx', 'bin/mpic++', 'bin/mpif77', 'bin/mpif90',
               'bin/mpiexec', 'bin/mpirun',

--- a/easybuild/easyconfigs/m/MPICH2/MPICH2-3.0.4-GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/m/MPICH2/MPICH2-3.0.4-GCC-4.8.1.eb
@@ -13,6 +13,9 @@ source_urls = ['http://www.mpich.org/static/tarballs/%(version)s']
 # MPICH configure wants F90/F90FLAGS to be renamed to FC/FCFLAGS.
 preconfigopts = 'export FC="$F90"; export FCFLAGS="$F90FLAGS"; unset F90; unset F90FLAGS; '
 
+# Build shared libraries
+configopts = '--enable-shared'
+
 sanity_check_paths = {
     'files': ['bin/mpicc', 'bin/mpicxx', 'bin/mpic++', 'bin/mpif77', 'bin/mpif90',
               'bin/mpiexec', 'bin/mpirun', 'include/mpi.h', 'include/mpi.mod', 'include/mpif.h'],


### PR DESCRIPTION
I believe this is required. Without this, I cannot build Boost with MPICH and I get the following error:

```
gcc.link.dll bin.v2/libs/mpi/build/gcc-4.8.1/release/threading-multi/libboost_mpi.so.1.53.0
/usr/bin/ld: /home/users/xbesseron/.local/easybuild/software/MPICH2/3.0.4-GCC-4.8.1/lib/libmpich.a(attr_get.o): relocation R_X86_64_32 against `MPIR_ThreadInfo' can not be used when making a shared object; recompile with -fPIC
/home/users/xbesseron/.local/easybuild/software/MPICH2/3.0.4-GCC-4.8.1/lib/libmpich.a: could not read symbols: Bad value
collect2: error: ld returned 1 exit status
```
