### PR TITLE
adding ipython-1.0.0 with goolf

### DIFF
--- a/easybuild/easyconfigs/i/IPython/IPython-1.1.0-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-1.1.0-goolf-1.4.10-Python-2.7.3.eb
@@ -1,0 +1,49 @@
+easyblock = "PythonPackage"
+
+name = 'IPython'
+version = '1.1.0'
+
+homepage = 'http://ipython.org/index.html'
+description = """IPython provides a rich architecture for interactive computing with:
+Powerful interactive shells (terminal and Qt-based).
+A browser-based notebook with support for code, text, mathematical expressions, inline plots and other rich media.
+Support for interactive data visualization and use of GUI toolkits.
+Flexible, embeddable interpreters to load into your own projects.
+Easy to use, high performance tools for parallel computing."""
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+#source_urls = [('http://archive.ipython.org/release/%s' % version, 'download')]
+#sources = [SOURCE_TAR_GZ]
+
+sources = ['%s-%s.tar.gz' % (name.lower(), version)]
+source_urls = ['http://archive.ipython.org/release/%s/' %(version)]
+
+
+python = 'Python'
+pyver = '2.7.3'
+pyshortver = '2.7'
+versionsuffix = '-%s-%s' % (python, pyver)
+
+
+dependencies = [
+    (python, pyver),
+]
+
+# we're giving the sanity check just a method to replace the EXTS_FILTER_PYTHON_PACKAGES default value (mentioned below)  with something that will tell use that i[ython exists but not a test, and will work
+# EXTS_FILTER_PYTHON_PACKAGES = ('python -c "import %(ext_name)s"', "")
+
+exts_filter = ('ipython -h', "")
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/IPython' % pyshortver],
+}
+
+#sanity_check_commands = [('/bin/touch', ' /tmp/run_yossi')]
+sanity_check_commands = [('iptest','')]
+
+# IPython is tested using iptest
+#tests = [iptest]#
+
+moduleclass = 'tools'


### PR DESCRIPTION
this relates to
issue https://github.com/hpcugent/easybuild-framework/issues/737 - probably a bug in sanity_check_commands
issue #35 - scipy stack, as IPython is part of that stack

also, thinking about adding pylab, that will need the scipy stack (maybe not all of it)
