### PR TITLE
add Tesla Deployment Kit from Nvidia

### DIFF
--- a/easybuild/easyconfigs/t/Tesla-Deployment-Kit/Tesla-Deployment-Kit-5.319.43.eb
+++ b/easybuild/easyconfigs/t/Tesla-Deployment-Kit/Tesla-Deployment-Kit-5.319.43.eb
@@ -1,7 +1,7 @@
 ##
 # This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
 #
-# Copyright:: University of Luxembourg / LCSB
+# Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>
 # License::   MIT/GPL
 # $Id$
@@ -26,13 +26,14 @@ source_urls = ['http://developer.download.nvidia.com/compute/cuda/5_5/rel/nvml']
 
 sanity_check_paths = {
     'files': ["nvidia-healthmon/nvidia-healthmon", "nvidia-healthmon/nvidia-healthmon_x86"],
-    'dirs': []
+    'dirs': ["nvml/lib", "nvml/lib64"]
 }
 
 modextrapaths = {
     'PATH': ['nvidia-healthmon'],
     'CPATH': ['nvml/include'],
     'MANPATH': ['nvml/doc/man'],
+    'LD_LIBRARY_PATH': ['nvml/lib', 'nvml/lib64'],
 }
 
 moduleclass = 'system'


### PR DESCRIPTION
Hi,

this one is now  implementable in easyconfig, after squashing a modextrapaths bug.

ie. https://github.com/hpcugent/easybuild-easyblocks/issues/189 case is now mute.

Signed-off-by: Fotis Georgatos fotis.georgatos@uni.lu
