### PR TITLE
Contribute new easyconfig for Libint with ictce-4.1.13 needed for CP2K

### DIFF
--- a/easybuild/easyconfigs/l/Libint/Libint-1.1.4-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/l/Libint/Libint-1.1.4-ictce-4.1.13.eb
@@ -1,0 +1,24 @@
+name = 'Libint'
+version = '1.1.4'
+
+homepage = 'http://www.files.chem.vt.edu/chem-dept/valeev/software/libint/libint.html'
+description = """Libint library is used to evaluate the traditional (electron repulsion) and certain novel two-body
+ matrix elements (integrals) over Cartesian Gaussian functions used in modern atomic and molecular theory."""
+
+
+toolchain = {'name': 'ictce', 'version': '4.1.13'}
+toolchainopts = {'opt': True, 'optarch': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ('http://sourceforge.net/projects/libint/files/v1-releases/', 'download')
+
+configopts = "--with-pic --enable-deriv --enable-r12"
+
+sanity_check_paths = {
+                      'files': ["include/lib%(x)s/lib%(x)s.h" % {'x': x} for x in ["deriv", "int", "r12"]] + 
+                               ["include/libint/hrr_header.h", "include/libint/vrr_header.h"] +
+                               ["lib/lib%s.a" % x for x in ["deriv", "int", "r12"]],
+                      'dirs':[]
+                     }
+
+moduleclass = 'chem'


### PR DESCRIPTION
To be included in the following versions of Easybuild.
