### PR TITLE
init PRACE Common Production Environment (CPE)

### DIFF
--- a/easybuild/easyconfigs/p/PRACE/PRACE-20130605-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/PRACE/PRACE-20130605-goolf-1.4.10.eb
@@ -1,0 +1,36 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
+# Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of HPCBIOS project:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = "Toolchain"
+
+name = 'PRACE'
+version = '20130605'
+
+homepage = 'http://www.prace-ri.eu/PRACE-Common-Production'
+description = """The PRACE Common Production Environment (PCPE) is a set of software tools and libraries
+ that are planned to be available on all PRACE execution sites. The PCPE also defines a set of environment
+ variables that try to make compilation on all sites as homogeneous and simple as possible."""
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+dependencies = [
+    ('make', '3.82'),
+    ('Java', '1.7.0_10', '', True),
+    ('Bash', '4.2'),
+    ('tcsh', '6.18.01'),
+    ('Tcl', '8.5.12'),
+    ('Tk', '8.5.12'),
+    ('netCDF', '4.1.3'), # this one will also bring in HDF5
+    ('Perl', '5.16.3'),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/p/PRACE/PRACE-20130605-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/PRACE/PRACE-20130605-ictce-5.3.0.eb
@@ -1,0 +1,36 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
+# Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of HPCBIOS project:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = "Toolchain"
+
+name = 'PRACE'
+version = '20130605'
+
+homepage = 'http://www.prace-ri.eu/PRACE-Common-Production'
+description = """The PRACE Common Production Environment (PCPE) is a set of software tools and libraries
+ that are planned to be available on all PRACE execution sites. The PCPE also defines a set of environment
+ variables that try to make compilation on all sites as homogeneous and simple as possible."""
+
+toolchain = {'name': 'ictce', 'version': '5.3.0'}
+
+dependencies = [
+    ('make', '3.82'),
+    ('Java', '1.7.0_10', '', True),
+    ('Bash', '4.2'),
+    ('tcsh', '6.18.01'),
+    ('Tcl', '8.5.12'),
+    ('Tk', '8.5.12'),
+    ('netCDF', '4.1.3'), # this one will also bring in HDF5
+    ('Perl', '5.16.3'),
+]
+
+moduleclass = 'toolchain'


### PR DESCRIPTION
Summary: PRACE modulefiles have been working for a few months, on .lu side, w. mild usage.

PR does not implement the variables visible at http://www.prace-ri.eu/PRACE-Common-Production;
these should be provided via an alternative mechanism, possibly via Lmod sorcery.
Also, current code does not define `ftn` as spec'd in original PRACE/DEISA guidelines. TBD.

Ref: https://github.com/hpcugent/easybuild-easyblocks/issues/82#issuecomment-14033797 (largely covered)

Signed-off-by: Fotis Georgatos fotis.georgatos@uni.lu
