### PR TITLE
Add protobuf (Google 'Protocol Buffers')

### DIFF
--- a/easybuild/easyconfigs/p/protobuf/protobuf-2.4.0a-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/protobuf/protobuf-2.4.0a-goolf-1.4.10.eb
@@ -1,0 +1,16 @@
+name = 'protobuf'
+version = '2.4.0a'
+
+homepage = 'https://code.google.com/p/protobuf/'
+description = """Google Protocol Buffers"""
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['https://protobuf.googlecode.com/files/']
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+sanity_check_paths = {
+                      'files': ['bin/protoc'],
+                      'dirs': []
+                     }
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/protobuf/protobuf-2.5.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/protobuf/protobuf-2.5.0-goolf-1.4.10.eb
@@ -1,0 +1,16 @@
+name = 'protobuf'
+version = '2.5.0'
+
+homepage = 'https://code.google.com/p/protobuf/'
+description = """Google Protocol Buffers"""
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['https://protobuf.googlecode.com/files/']
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+sanity_check_paths = {
+                      'files': ['bin/protoc'],
+                      'dirs': []
+                     }
+
+moduleclass = 'devel'


### PR DESCRIPTION
2.4.0a is required for Hadoop.
2.5.0 is the latest version.
