### PR TITLE
Add an easyconfig for Node.js 0.10.24

### DIFF
--- a/easybuild/easyconfigs/n/nodejs/nodejs-0.10.24-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/n/nodejs/nodejs-0.10.24-goolf-1.4.10.eb
@@ -1,29 +1,24 @@
-# Note:
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
-# It was auto-generated based on a template easyconfig, so it should be used with care.
-
 name = 'nodejs'
 version = '0.10.24'
 
 homepage = 'http://nodejs.org'
+
 description = """Node.js is a platform built on Chrome's JavaScript runtime 
-    for easily building fast, scalable network applications. Node.js uses an 
-    event-driven, non-blocking I/O model that makes it lightweight and efficient, 
-    perfect for data-intensive real-time applications that run across distributed devices."""
+ for easily building fast, scalable network applications. Node.js uses an 
+ event-driven, non-blocking I/O model that makes it lightweight and efficient, 
+ perfect for data-intensive real-time applications that run across distributed devices."""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 sources = ['node-v%(version)s.tar.gz']
+
 source_urls = ['http://nodejs.org/dist/v%(version)s/']
 
 dependencies = [('Python','2.7.5')]
-builddependencies = [('Python','2.7.5')]
 
-# The sanity test MUST be tuned before going production and submitting your contribution to upstream git repositories
 sanity_check_paths = {
     'files': ["bin/node", "bin/npm", ],
     'dirs': ["lib/node_modules", "lib/dtrace", "include/node"]
 }
 
-# You SHOULD change the following line; Kindly consult other easyconfigs for possible options
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/v/vsc-mympirun/vsc-mympirun-3.2.1.eb
+++ b/easybuild/easyconfigs/v/vsc-mympirun/vsc-mympirun-3.2.1.eb
@@ -2,7 +2,7 @@ easyblock = 'VersionIndependendPythonPackage'
 name = 'vsc-mympirun'
 version = '3.2.1'
 
-homepage = 'http://hpcugent.github.com/vsc-mympirun/'
+homepage = 'http://github.com/hpcugent/vsc-mympirun/'
 description = """VSC-tools is a set of Python libraries and scripts that are commonly used within HPC-UGent."""
 
 # we build this to work with every python version


### PR DESCRIPTION
Yes, Node.js. :) I use EasyBuild to manage my personal dev environment, and I'm working on the Stripe CTF. Node.js is required for level 2.

I have actually had requests for Node.js on one of my clusters, but I expect it's an edge case on most HPC clusters...
