### PR TITLE
Support protobuf ("Google Protocol Buffers")

### DIFF
--- a/easybuild/easyconfigs/p/protobuf/protobuf-2.4.0a-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/protobuf/protobuf-2.4.0a-goolf-1.4.10.eb
@@ -7,11 +7,11 @@ description = """Google Protocol Buffers"""
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['https://protobuf.googlecode.com/files/']
+source_urls = [GOOGLECODE_SOURCE]
 
 sanity_check_paths = {
     'files': ['bin/protoc'],
-    'dirs': []
+    'dirs': [],
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/protobuf/protobuf-2.5.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/protobuf/protobuf-2.5.0-goolf-1.4.10.eb
@@ -7,11 +7,11 @@ description = """Google Protocol Buffers"""
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['https://protobuf.googlecode.com/files/']
+source_urls = [GOOGLECODE_SOURCE]
 
 sanity_check_paths = {
     'files': ['bin/protoc'],
-    'dirs': []
+    'dirs': [],
 }
 
 moduleclass = 'devel'


### PR DESCRIPTION
2.5.0 is the latest version.
2.4.0a is required by Hadoop-2.0.0-cdh4.5.0.
