### PR TITLE
Add support for SPM - needs work

### DIFF
--- a/easybuild/easyconfigs/s/SPM/SPM-12b.5852.eb
+++ b/easybuild/easyconfigs/s/SPM/SPM-12b.5852.eb
@@ -27,12 +27,21 @@ source_urls = [
 
 sources = [ 'spm%(version_major)s.zip' ]
 
+mexfiles = [
+    'spm_add', 'spm_bias_mex', 'spm_brainwarp', 'spm_bsplinc', 'spm_bsplins',
+    'spm_bwlabel', 'spm_conv_vol', 'spm_dilate_erode', 'spm_existfile', 'spm_gamrnd',
+    'spm_get_lm', 'spm_global', 'spm_hist2', 'spm_hist', 'spm_invdef', 'spm_krutil',
+    'spm_project', 'spm_render_vol', 'spm_resels_vol', 'spm_sample_vol', 'spm_slice_vol',
+    'spm_unlink', 'spm_voronoi', '@file_array/private/file2mat', '@file_array/private/mat2file',
+]  
+
 dependencies = [
     (matlab, matlab_ver),
 ]
 
 builddependencies = [
-    ('GCC', '4.8.2')
+    ('GCC', '4.8.2'),
+    (matlab, matlab_ver)
 ]
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/s/SPM/SPM-8.5236.eb
+++ b/easybuild/easyconfigs/s/SPM/SPM-8.5236.eb
@@ -27,12 +27,21 @@ source_urls = [
 
 sources = [ 'spm%(version_major)s.zip' ]
 
+mexfiles = [
+    'spm_add', 'spm_bias_mex', 'spm_brainwarp', 'spm_bsplinc', 'spm_bsplins',
+    'spm_bwlabel', 'spm_conv_vol', 'spm_dilate_erode', 'spm_existfile', 'spm_gamrnd',
+    'spm_get_lm', 'spm_global', 'spm_hist2', 'spm_hist', 'spm_invdef', 'spm_krutil',
+    'spm_project', 'spm_render_vol', 'spm_resels_vol', 'spm_sample_vol', 'spm_slice_vol',
+    'spm_unlink', 'spm_voronoi', '@file_array/private/file2mat', '@file_array/private/mat2file',
+]
+
 dependencies = [
     (matlab, matlab_ver),
 ]
 
 builddependencies = [
-    ('GCC', '4.8.2')
+    ('GCC', '4.8.2'),
+    (matlab, matlab_ver)
 ]
 
 moduleclass = 'bio'


### PR DESCRIPTION
These configs need the spm easyblock in this PR: https://github.com/hpcugent/easybuild-easyblocks/pull/358 .

SPM is a MATLAB script, where the "performance-critical" parts have been compiled using the MATLAB-Compiler mcc. mcc needs a loaded GCC (4.4.x is supported, but it seems that 4.8.2. works fine).
This config/block uses the system GCC, which kinda sucks. What I would do is add MATLAB to the GCC toolchain (dummy right now) and solve the problem that way, but I am not sure if this is the right approach. Would be glad if someone who actually knows what they are doing could comment on this.

Stuff to do:
- Fix this dependency problem
- Do some testing (right now this builds and loads fine in MATLAB, but these are the only things I checked.)
- Fill in the right description
