### PR TITLE
ictce-6.2.6

### DIFF
--- a/easybuild/easyconfigs/i/ictce/ictce-6.2.6.eb
+++ b/easybuild/easyconfigs/i/ictce/ictce-6.2.6.eb
@@ -1,0 +1,21 @@
+easyblock = "Toolchain"
+
+name = 'ictce'
+version = '6.2.6'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MPI & Intel MKL."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+suff = '2.144'
+compver = '2013_sp1.%s' % suff
+
+dependencies = [
+    ('icc', compver),
+    ('ifort', compver),
+    ('impi', '4.1.3.049'),
+    ('imkl', '11.1.%s' % suff),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.1.2.144.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.1.2.144.eb
@@ -1,0 +1,30 @@
+name = 'imkl'
+version = '11.1.2.144'
+
+homepage = 'http://software.intel.com/en-us/intel-mkl/'
+description = """Intel Math Kernel Library is a library of highly optimized,
+ extensively threaded math routines for science, engineering, and financial
+ applications that require maximum performance. Core math functions include
+ BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = ['l_mkl_%(version)s.tgz']
+
+# deps for interface build
+compver = '2013_sp1.2.144'
+dependencies = [
+    ('icc', compver),
+    ('ifort', compver),
+    ('impi', '4.1.3.049')
+]
+
+dontcreateinstalldir = 'True'
+
+# license file
+import os
+license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+
+interfaces = True
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/i/impi/impi-4.1.3.049.eb
+++ b/easybuild/easyconfigs/i/impi/impi-4.1.3.049.eb
@@ -1,0 +1,19 @@
+name = 'impi'
+version = '4.1.3.049'
+
+homepage = 'http://software.intel.com/en-us/intel-mpi-library/'
+description = """The Intel(R) MPI Library for Linux* OS is a multi-fabric message
+ passing library based on ANL MPICH2 and OSU MVAPICH2. The Intel MPI Library for
+ Linux OS implements the Message Passing Interface, version 2 (MPI-2) specification."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = ['l_mpi_p_%(version)s.tgz']
+
+dontcreateinstalldir = 'True'
+
+# license file
+import os
+license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+
+moduleclass = 'mpi'


### PR DESCRIPTION
newer version of ictce using the latest intel-mpi release impi-4.1.3.049

This PR depends on this other: https://github.com/hpcugent/easybuild-easyconfigs/pull/726

Please notice that the file name "imkl-11.1.2.144.eb" is the same in both PR.  The only change is in the dependencies to add the newer intel-mpi version as dependency for imkl-11.1.2.144
