### PR TITLE
OpenBUGS-3.2.3.eb

### DIFF
--- a/easybuild/easyconfigs/o/OpenBUGS/OpenBUGS-3.2.3.eb
+++ b/easybuild/easyconfigs/o/OpenBUGS/OpenBUGS-3.2.3.eb
@@ -23,7 +23,7 @@ source_urls = ['http://www.openbugs.net/w/OpenBUGS_3_2_3?action=AttachFile&do=ge
 sources = [SOURCE_TAR_GZ]
 
 # as OpenBUGS requires 32bit support we have to be sure
-# that RPM glibc-devel.i386 is installed
+# that RPM glibc-devel.i686 is installed
 osdependencies = ['glibc-devel.i686']
 
 moduleclass = 'math'


### PR DESCRIPTION
As this app requires 32bit support, this easyconfig is forced to use the system compiler instead of an EB toolchain and verifies that glibc-devel.i686 is installed
