### PR TITLE
enable -fPIC for libreadline, so it can be linked into shared libs (e.g. libpython2.x.so)

### DIFF
--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmpolf-1.1.6.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmpolf-1.1.6.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'cgmpolf', 'version': '1.1.6'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmvolf-1.1.12rc1.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmvolf-1.1.12rc1.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'cgmvolf', 'version': '1.1.12rc1'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmvolf-1.2.7.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmvolf-1.2.7.eb
@@ -8,6 +8,7 @@ additional functions to maintain a list of previously-entered command lines, to 
 and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'cgmvolf', 'version': '1.2.7'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgoolf-1.1.7.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgoolf-1.1.7.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'cgoolf', 'version': '1.1.7'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmpolf-1.4.8.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmpolf-1.4.8.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'gmpolf', 'version': '1.4.8'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmvolf-1.7.12.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmvolf-1.7.12.eb
@@ -8,6 +8,7 @@ additional functions to maintain a list of previously-entered command lines, to 
 and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'gmvolf', 'version': '1.7.12'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmvolf-1.7.12rc1.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmvolf-1.7.12rc1.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'gmvolf', 'version': '1.7.12rc1'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goalf-1.1.0-no-OFED.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'goalf', 'version': '1.1.0-no-OFED'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goalf-1.5.12-no-OFED.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goalf-1.5.12-no-OFED.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'goalf', 'version': '1.5.12-no-OFED'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gompi-1.4.12-no-OFED.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'gompi', 'version': '1.4.12-no-OFED'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goolf-1.4.10.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.0.10.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.0.10.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'ictce', 'version': '4.0.10'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.0.6.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'ictce', 'version': '4.0.6'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.1.13.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'ictce', 'version': '4.1.13'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.2.0.eb
@@ -8,15 +8,18 @@ The Readline library includes additional functions to maintain a list of previou
 to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'ictce', 'version' : '5.2.0'}
+toolchainopts = {'pic': True}
 
-sources = ['readline-%s.tar.gz' % version]
+sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']
 
-sanity_check_paths = {
-                      'files' : ['lib/libreadline.a', 'lib/libhistory.a'] + ['include/readline/%s' % x for x in ['chardefs.h', 'history.h',
-                                                                                                                 'keymaps.h', 'readline.h',
-                                                                                                                 'rlconf.h', 'rlstdc.h',
-                                                                                                                 'rltypedefs.h', 'tilde.h']],
-                      'dirs' : []
-                     }
+dependencies = [('ncurses', '5.9')]
 
+sanity_check_paths = {
+    'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
+              ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',
+                                                   'rlstdc.h', 'rltypedefs.h', 'tilde.h']],
+    'dirs' : [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.3.0.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.5.0.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iomkl-4.6.13.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iomkl-4.6.13.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'iomkl', 'version': '4.6.13'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iqacml-3.7.3.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'iqacml', 'version': '3.7.3'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iqacml-4.4.13.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iqacml-4.4.13.eb
@@ -8,6 +8,7 @@ description = """The GNU Readline library provides a set of functions for use by
  to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
 
 toolchain = {'name': 'iqacml', 'version': '4.4.13'}
+toolchainopts = {'pic': True}
 
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']


### PR DESCRIPTION
required for https://github.com/hpcugent/easybuild-easyblocks/pull/383
