### PR TITLE
enable -fPIC in ncurses 5.9 ictce/5.2.0 easyconfig, just like in the others

### DIFF
--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9-ictce-5.2.0.eb
@@ -7,6 +7,7 @@ and more. It uses Terminfo format, supports pads and color and multiple highligh
 function-key mapping, and has all the other SYSV-curses enhancements over BSD Curses."""
 
 toolchain = {'name': 'ictce', 'version': '5.2.0'}
+toolchainopts = {'optarch': True, 'pic': True}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]


### PR DESCRIPTION
required for Python build (statically linking in libncurses.a in libpython2.7.so)
