### PR TITLE
add easyconfigs for PerfExpert, ROSE, HPCToolkit + deps

### DIFF
--- a/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69.eb
+++ b/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69.eb
@@ -1,0 +1,20 @@
+name = 'Autoconf'
+version = '2.69'
+
+homepage = 'http://www.gnu.org/software/autoconf/'
+description = """Autoconf is an extensible package of M4 macros that produce shell scripts to automatically configure software source code packages. These scripts can adapt the packages to many kinds of UNIX-like systems without manual user intervention. Autoconf creates a configuration script for a package from a template file that lists the operating system features that the package can use, in the form of M4 macro calls."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('M4', '1.4.16')]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["autoconf", "autoheader", "autom4te", "autoreconf",
+                                     "autoscan", "autoupdate", "ifnames"]],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.2.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.2.eb
@@ -1,0 +1,20 @@
+name = 'Bison'
+version = '3.0.2'
+
+homepage = 'http://www.gnu.org/software/bison'
+description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
+into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+builddependencies = [('M4', '1.4.17')]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["bison", "yacc"]] + ["lib/liby.a"],
+    'dirs': [],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.47.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.47.0.eb
@@ -1,0 +1,21 @@
+name = 'Boost'
+version = '1.47.0'
+
+homepage = 'http://www.boost.org/'
+description = """Boost provides free peer-reviewed portable C++ source libraries."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
+
+dependencies = [('bzip2', '1.0.6')]
+
+configopts = '--without-libraries=python'
+
+toolset = 'gcc'
+
+osdependencies = ['zlib-devel']
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.47.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.47.0.eb
@@ -4,7 +4,7 @@ version = '1.47.0'
 homepage = 'http://www.boost.org/'
 description = """Boost provides free peer-reviewed portable C++ source libraries."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 toolchainopts = {'pic': True}
 
 source_urls = [SOURCEFORGE_SOURCE]

--- a/easybuild/easyconfigs/b/byacc/byacc-20140422.eb
+++ b/easybuild/easyconfigs/b/byacc/byacc-20140422.eb
@@ -1,0 +1,18 @@
+name = 'byacc'
+version = '20140422'
+
+homepage = 'http://invisible-island.net/byacc/byacc.html'
+description = """Berkeley Yacc (byacc) is generally conceded to be the best yacc variant available.
+In contrast to bison, it is written to avoid dependencies upon a particular compiler."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = [SOURCELOWER_TGZ]
+source_urls = ['ftp://invisible-island.net/byacc']
+
+sanity_check_paths = {
+    'files': ["bin/yacc"],
+    'dirs': [],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39.eb
@@ -1,0 +1,14 @@
+name = 'flex'
+version = '2.5.39'
+
+homepage = 'http://flex.sourceforge.net/'
+description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners. A scanner, 
+sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/g/GMP/GMP-5.0.5.eb
+++ b/easybuild/easyconfigs/g/GMP/GMP-5.0.5.eb
@@ -1,0 +1,20 @@
+name = 'GMP'
+version = '5.0.5'
+
+homepage = 'http://gmplib.org/'
+description = """GMP is a free library for arbitrary precision arithmetic, 
+operating on signed integers, rational numbers, and floating point numbers. """
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = [GNU_SOURCE]
+
+runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['lib/libgmp.so', 'include/gmp.h'],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/g/google-sparsehash/google-sparsehash-2.0.2.eb
+++ b/easybuild/easyconfigs/g/google-sparsehash/google-sparsehash-2.0.2.eb
@@ -1,0 +1,24 @@
+name = 'google-sparsehash'
+version = '2.0.2'
+
+homepage = 'http://code.google.com/p/google-sparsehash/'
+description = """An extremely memory-efficient hash_map implementation. 2 bits/entry overhead! The SparseHash library
+contains several hash-map implementations, including implementations that optimize for space or speed."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchainopts = {'optarch': True}
+
+sources = ['%s-%s.tar.gz' % (name.split('-')[1].lower(), version)]
+source_urls = ['http://sparsehash.googlecode.com/files']
+
+runtest = "check"
+
+sanity_check_paths = {
+    'files': ['include/sparsehash/%s' % x for x in ['dense_hash_map', 'dense_hash_set', 'sparse_hash_map',
+                                                    'sparse_hash_set', 'sparsetable', 'template_util.h', 'type_traits.h'
+                                                    ]
+              ],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/g/guile/guile-1.8.8.eb
+++ b/easybuild/easyconfigs/g/guile/guile-1.8.8.eb
@@ -1,0 +1,30 @@
+name = 'guile'
+version = '1.8.8'
+
+homepage = 'http://www.gnu.org/software/guile'
+description = """Guile is the GNU Ubiquitous Intelligent Language for Extensions,
+the official extension language for the GNU operating system."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [
+    ('libtool', '2.4.2'),
+    ('GMP', '5.0.5'),
+    ('libunistring', '0.9.3'),
+    ('pkg-config', '0.27.1'),
+    ('libffi', '3.0.11'),
+    ('libreadline', '6.2'),
+]
+
+configopts = " --enable-error-on-warning=no"
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["guile", 'guile-config', 'guile-snarf', 'guile-tools']] +
+             ["lib/libguile.a", "include/libguile.h"],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/h/HPCToolkit/HPCToolkit-5.3.2.eb
+++ b/easybuild/easyconfigs/h/HPCToolkit/HPCToolkit-5.3.2.eb
@@ -1,0 +1,34 @@
+name = 'HPCToolkit'
+version = '5.3.2'
+
+homepage = 'http://hpctoolkit.org/'
+description = """HPCToolkit is an integrated suite of tools for measurement and analysis of program performance
+ on computers ranging from multicore desktop systems to the nation's largest supercomputers."""
+
+toolchain = {'name': 'dummy', 'version': ''}  # empty version to make sure dependencies are loaded
+
+rev = 'r4197'
+source_urls = [GOOGLECODE_SOURCE]
+sources = [
+    '%%(namelower)s-%%(version)s-%s.tar.gz' % rev,
+    '%%(namelower)s-externals-%%(version)s-%s.tar.gz' % rev,
+]
+
+dependencies = [
+    ('Boost', '1.47.0', '', True),
+    ('PAPI', '5.3.0'),
+]
+
+start_dir = "%%(builddir)s/%%(namelower)s-%%(version)s-%s" % rev
+preconfigopts = "mkdir -p %(installdir)s/externals && cp -a ../hpctoolkit-externals-*/* %(installdir)s/externals && cd %(installdir)s/externals && "
+preconfigopts += "./configure --with-boost=$EBROOTBOOST && make && cd - && "
+configopts = "--with-externals=%(installdir)s/externals --with-papi=$EBROOTPAPI"
+
+keeppreviousinstall = True
+
+sanity_check_paths = {
+    'files': ['bin/hpc%s' % x for x in ['link', 'prof', 'run', 'struct', 'summary']] + ['include/hpctoolkit.h'],
+    'dirs': ['lib/hpctoolkit'],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/j/Java/Java-1.7.0_10.eb
+++ b/easybuild/easyconfigs/j/Java/Java-1.7.0_10.eb
@@ -12,4 +12,6 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 altver = '%su%s' % (vp.split('.')[1], vs)
 sources = ['jdk-%s-linux-x64.tar.gz' % altver]
 
+modextrapaths = {'LD_LIBRARY_PATH': ['jre/lib/amd64/server']}  # for libjvm.so
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/j/Java/Java-1.7.0_15.eb
+++ b/easybuild/easyconfigs/j/Java/Java-1.7.0_15.eb
@@ -12,4 +12,6 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 altver = '%su%s' % (vp.split('.')[1], vs)
 sources = ['jdk-%s-linux-x64.tar.gz' % altver]
 
+modextrapaths = {'LD_LIBRARY_PATH': ['jre/lib/amd64/server']}  # for libjvm.so
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/j/Java/Java-1.7.0_21.eb
+++ b/easybuild/easyconfigs/j/Java/Java-1.7.0_21.eb
@@ -12,4 +12,6 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 altver = '%su%s' % (vp.split('.')[1], vs)
 sources = ['jdk-%s-linux-x64.tar.gz' % altver]
 
+modextrapaths = {'LD_LIBRARY_PATH': ['jre/lib/amd64/server']}  # for libjvm.so
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/j/Java/Java-1.7.0_40.eb
+++ b/easybuild/easyconfigs/j/Java/Java-1.7.0_40.eb
@@ -12,4 +12,6 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 altver = '%su%s' % (vp.split('.')[1], vs)
 sources = ['jdk-%s-linux-x64.tar.gz' % altver]
 
+modextrapaths = {'LD_LIBRARY_PATH': ['jre/lib/amd64/server']}  # for libjvm.so
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/j/Java/Java-1.7.0_45.eb
+++ b/easybuild/easyconfigs/j/Java/Java-1.7.0_45.eb
@@ -12,4 +12,6 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 altver = '%su%s' % (vp.split('.')[1], vs)
 sources = ['jdk-%s-linux-x64.tar.gz' % altver]
 
+modextrapaths = {'LD_LIBRARY_PATH': ['jre/lib/amd64/server']}  # for libjvm.so
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/l/libffi/libffi-3.0.11.eb
+++ b/easybuild/easyconfigs/l/libffi/libffi-3.0.11.eb
@@ -1,0 +1,24 @@
+name = 'libffi'
+version = '3.0.11'
+
+homepage = 'http://sourceware.org/libffi'
+description = """The libffi library provides a portable, high level programming interface to various calling conventions.
+This allows a programmer to call any function specified by a call interface description at run-time.
+
+FFI stands for Foreign Function Interface. A foreign function interface is the popular name for the interface that
+allows code written in one language to call code written in another language."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+source_urls = [
+    'ftp://sourceware.org/pub/libffi/',
+    'http://www.mirrorservice.org/sites/sourceware.org/pub/libffi/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+
+sanity_check_paths = {
+    'files': ['lib/libffi.a'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11.eb
+++ b/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11.eb
@@ -1,0 +1,31 @@
+name = 'libmatheval'
+version = '1.1.11'
+
+homepage = 'http://www.gnu.org/software/libmatheval/'
+description = """GNU libmatheval is a library (callable from C and Fortran) to parse
+ and evaluate symbolic expressions input as text."""
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+toolchain = {'name': 'dummy', 'version': ''}
+toolchainopts = {'pic': True}
+
+dependencies = [
+    ('flex', '2.5.39'),
+    ('Bison', '3.0.2'),
+    ('byacc', '20140422'),
+    ('guile', '1.8.8'),
+]
+
+configopts = '--with-pic '
+
+# fix for guile-config being broken because shebang line contains full path to bin/guile
+configopts += 'GUILE_CONFIG="$EBROOTGUILE/bin/guile -e main -s $EBROOTGUILE/bin/guile-config"'
+
+sanity_check_paths = {
+    'files': ['lib/libmatheval.a', 'include/matheval.h'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2.eb
@@ -1,0 +1,25 @@
+name = 'libreadline'
+version = '6.2'
+
+homepage = 'http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html'
+description = """The GNU Readline library provides a set of functions for use by applications that
+ allow users to edit command lines as they are typed in. Both Emacs and vi editing modes are available.
+ The Readline library includes additional functions to maintain a list of previously-entered command lines,
+ to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+toolchainopts = {'pic': True}
+
+sources = ['readline-%(version)s.tar.gz']
+source_urls = ['http://ftp.gnu.org/gnu/readline']
+
+dependencies = [('ncurses', '5.9')]
+
+sanity_check_paths = {
+    'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
+              ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',
+                                                   'rlstdc.h', 'rltypedefs.h', 'tilde.h']],
+    'dirs' : [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libtool/libtool-2.4.2.eb
+++ b/easybuild/easyconfigs/l/libtool/libtool-2.4.2.eb
@@ -1,0 +1,13 @@
+name = 'libtool'
+version = '2.4.2'
+
+homepage = 'http://www.gnu.org/software/libtool'
+description = """GNU libtool is a generic library support script. Libtool hides the complexity of using shared libraries
+behind a consistent, portable interface."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libunistring/libunistring-0.9.3.eb
+++ b/easybuild/easyconfigs/l/libunistring/libunistring-0.9.3.eb
@@ -1,0 +1,22 @@
+name = 'libunistring'
+version = '0.9.3'
+
+homepage = 'http://www.gnu.org/software/libunistring/'
+description = """This library provides functions for manipulating Unicode strings and for manipulating C strings
+according to the Unicode standard."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+parallel = 1
+
+sanity_check_paths = {
+    'files' : ['lib/libunistring.a', 'lib/libunistring.so', 'include/unistring'] +
+              ['include/uni%s.h' % x for x in ['case', 'conv', 'ctype', 'lbrk', 'name', 'norm',
+                                               'stdio', 'str', 'types', 'wbrk', 'width']],
+    'dirs' : [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.1.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.1.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'libxml2'
+version = '2.9.1'
+
+homepage = 'http://xmlsoft.org/'
+description = """Libxml2 is the XML C parser and toolchain developed for the Gnome project (but usable
+outside of the Gnome platform)."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = [
+    'http://xmlsoft.org/sources/',
+    'http://xmlsoft.org/sources/old/'
+]
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = 'CC="$CC" CXX="$CXX" --with-pic --without-python'
+makeopts = 'LDFLAGS="-L$EBROOTZLIB/lib" V=1'
+
+dependencies = [('zlib', '1.2.7')]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17.eb
@@ -1,0 +1,23 @@
+name = 'M4'
+version = '1.4.17'
+
+homepage = 'http://www.gnu.org/software/m4/m4.html'
+description = """GNU M4 is an implementation of the traditional Unix macro processor.
+It is mostly SVR4 compatible although it has some extensions 
+(for example, handling more than 9 positional parameters to macros).
+GNU M4 also has built-in functions for including files, running shell commands, doing arithmetic, etc.
+"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+configopts = "--enable-cxx"
+
+sanity_check_paths = {
+    'files': ["bin/m4"],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9.eb
@@ -1,0 +1,15 @@
+name = 'ncurses'
+version = '5.9'
+
+homepage = 'http://www.gnu.org/software/ncurses/'
+description = """The Ncurses (new curses) library is a free software emulation of curses in System V Release 4.0,
+and more. It uses Terminfo format, supports pads and color and multiple highlights and forms characters and
+function-key mapping, and has all the other SYSV-curses enhancements over BSD Curses."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/PAPI/PAPI-5.3.0.eb
+++ b/easybuild/easyconfigs/p/PAPI/PAPI-5.3.0.eb
@@ -1,0 +1,44 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
+# Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_07-02.html
+##
+
+name = 'PAPI'
+version = '5.3.0'
+
+homepage = 'http://icl.cs.utk.edu/projects/papi/'
+description = """PAPI provides the tool designer and application engineer with a consistent interface and
+ methodology for use of the performance counter hardware found in most major microprocessors. PAPI enables
+ software engineers to see, in near real time, the relation between software performance and processor events.
+ In addition Component PAPI provides access to a collection of components
+ that expose performance measurement opportunites across the hardware and software stack."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+# Example download URL, for reference: http://icl.cs.utk.edu/projects/papi/downloads/papi-5.0.0.tar.gz
+source_urls = ['http://icl.cs.utk.edu/projects/papi/downloads/']
+sources = [SOURCELOWER_TAR_GZ]
+
+start_dir = 'src'
+
+# parallel build doesn't always work
+parallel = 1
+
+runtest = 'fulltest'
+
+sanity_check_paths = {
+    'files': ["bin/papi_%s" % x for x in ["avail", "clockres", "command_line", "component_avail",
+                                          "cost", "decode", "error_codes", "event_chooser",
+                                          "mem_info", "multiplex_cost", "native_avail", "version",
+                                          "xml_event_info"]],
+    'dirs': [],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/p/PerfExpert/PerfExpert-4.1.1.eb
+++ b/easybuild/easyconfigs/p/PerfExpert/PerfExpert-4.1.1.eb
@@ -1,0 +1,53 @@
+name = 'PerfExpert'
+version = '4.1.1'
+
+homepage = "https://www.tacc.utexas.edu/perfexpert"
+description = """PerfExpert is a tool that combines a simple user interface with a sophisticated analysis engine to:
+ (i) detect and diagnosis the causes for any core-, socket-, and node-level performance bottlenecks in each procedure
+ and loop of an application; (ii) apply pattern-based software transformations on the application source code to
+ enhance performance on identified bottlenecks; and (iii) provide performance analysis report and suggestions for
+ bottleneck remediation for application’s performance bottlenecks which we are unable to optimize automatically."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+# download from https://github.com/TACC/perfexpert/releases
+sources = [SOURCELOWER_TAR_GZ]
+
+patches = ['PerfExpert-4.1.1_PAPI-5.3.patch']
+
+dependencies = [
+    ('libxml2', '2.9.1'),
+    ('PAPI', '5.3.0'),
+    ('libmatheval', '1.1.11'),
+    ('SQLite', '3.8.4.3'),
+    ('Java', '1.7.0_45', '', True),
+    ('ROSE', '0.9.5a'),
+    ('HPCToolkit', '5.3.2'),
+    ('google-sparsehash', '2.0.2'),
+]
+
+builddependencies = [
+    ('Autoconf', '2.69'),
+    ('Bison', '3.0.2'),
+]
+
+preconfigopts = "./autogen.sh && "
+configopts = "--with-libxml2-include=$EBROOTLIBXML2/include/libxml2 --with-jvm=$EBROOTJAVA/jre/lib/amd64/server "
+configopts += "--with-papi=$EBROOTPAPI --with-rose=$EBROOTROSE --with-boost=$EBROOTBOOST --with-sqlite=$EBROOTSQLITE "
+configopts += "--with-matheval=$EBROOTMATHEVAL --with-gmp=$EBROOTGMP --with-sparsehash=$EBROOTGOOGLEMINSPARSEHASH/include "
+
+# parallel building tends to break
+parallel = 1
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['hound', 'loop_interchange', 'macpo-analyze', 'macpo.sh', 'minst',
+                                     'nested_c_loops', 'perfexpert', 'perfexpert_analyzer', 'perfexpert_ct',
+                                     'perfexpert_get_compiler_info.pl', 'perfexpert_recommender',
+                                     'perfexpert_run_exp', 'sniffer']] +
+             ['include/macpo_record.h', 'include/mrt.h'] +
+             ['lib/lib%s.a' % x for x in ['mrt', 'perfexpert_module', 'perfexpert_module_hpctoolkit']] +
+             ['lib/lib%s.so' % x for x in ['perfexpert_module', 'perfexpert_module_hpctoolkit']],
+    'dirs': ['etc'],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/PerfExpert/PerfExpert-4.1.1_PAPI-5.3.patch
+++ b/easybuild/easyconfigs/p/PerfExpert/PerfExpert-4.1.1_PAPI-5.3.patch
@@ -1,0 +1,34 @@
+--- perfexpert-4.1.1/tools/sniffer/sniffer.c.orig	2013-10-20 18:27:58.000000000 -0500
++++ perfexpert-4.1.1/tools/sniffer/sniffer.c	2014-04-24 12:10:10.000000000 -0500
+@@ -620,13 +620,13 @@
+                 "GFLOPS_(%%_max).scalar = (%s / PAPI_TOT_CYC) / 8",
+                 event_list[FP_COMP_OPS_EXE_SSE_FP_SCALAR_SINGLE_SSE_SCALAR_DOUBLE].PAPI_event_name);
+         } else {
+-            USE_EVENT(FP_COMP_OPS_EXE_SSE_FP_SCALAR);
++            USE_EVENT(FP_COMP_OPS_EXE_SSE_FP_SCALAR_SINGLE);
+             USE_EVENT(FP_COMP_OPS_EXE_SSE_SCALAR_DOUBLE);
+             USE_EVENT(SIMD_FP_256_PACKED_SINGLE);
+             USE_EVENT(SIMD_FP_256_PACKED_DOUBLE);
+             USE_EVENT(FP_COMP_OPS_EXE_SSE_FP_PACKED_DOUBLE);
+             USE_EVENT(FP_COMP_OPS_EXE_SSE_PACKED_SINGLE);
+-            
++
+             sprintf(overall,
+                 "GFLOPS_(%%_max).overall = ((%s*8 + (%s + %s)*4 + %s*2 + %s + %s) / PAPI_TOT_CYC) / 8",
+                 event_list[SIMD_FP_256_PACKED_SINGLE].PAPI_event_name,
+@@ -701,13 +701,13 @@
+             USE_EVENT(FP_COMP_OPS_EXE_SSE_FP_SCALAR_SINGLE_SSE_SCALAR_DOUBLE);
+             USE_EVENT(FP_COMP_OPS_EXE_SSE_FP_PACKED_DOUBLE);
+             USE_EVENT(FP_COMP_OPS_EXE_SSE_PACKED_SINGLE);
+-            
++
+             sprintf(temp_str, "%s + %s + %s",
+                 event_list[FP_COMP_OPS_EXE_SSE_PACKED_SINGLE].PAPI_event_name,
+                 event_list[FP_COMP_OPS_EXE_SSE_FP_PACKED_DOUBLE].PAPI_event_name,
+                 event_list[FP_COMP_OPS_EXE_SSE_FP_SCALAR_SINGLE_SSE_SCALAR_DOUBLE].PAPI_event_name);
+         } else {
+-            USE_EVENT(FP_COMP_OPS_EXE_SSE_FP_SCALAR);
++            USE_EVENT(FP_COMP_OPS_EXE_SSE_FP_SCALAR_SINGLE);
+             USE_EVENT(FP_COMP_OPS_EXE_SSE_SCALAR_DOUBLE);
+             USE_EVENT(FP_COMP_OPS_EXE_SSE_FP_PACKED_DOUBLE);
+             USE_EVENT(FP_COMP_OPS_EXE_SSE_PACKED_SINGLE);

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.27.1.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.27.1.eb
@@ -1,0 +1,23 @@
+name = 'pkg-config'
+version = '0.27.1'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/pkg-config/'
+description = """pkg-config is a helper tool used when compiling applications and libraries. It helps you insert the
+correct compiler options on the command line so an application can use  
+gcc -o test test.c `pkg-config --libs --cflags glib-2.0`
+for instance, rather than hard-coding values on where to find glib (or other libraries).
+"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+
+configopts = " --with-internal-glib"
+
+sanity_check_paths = {
+    'files': ['bin/pkg-config'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/r/ROSE/ROSE-0.9.5a.eb
+++ b/easybuild/easyconfigs/r/ROSE/ROSE-0.9.5a.eb
@@ -1,0 +1,28 @@
+name = 'ROSE'
+version = '0.9.5a'
+
+homepage = 'http://rosecompiler.org/'
+description = """A compiler infrastructure to build source-to-source program transformation and analysis tools."""
+
+toolchain = {'name': 'dummy', 'version': ''}  # empty version to make sure dependencies are loaded
+
+# available in https://github.com/TACC/perfexpert/archive/externals-v1.0.tar.gz
+sources = ['%(namelower)s-%(version)s-without-EDG-20584.tar.gz']
+checksums = ['eb3063a32c981084b738c71e142a89b2']
+
+dependencies = [
+    ('Java', '1.7.0_45', '', True),
+    ('Boost', '1.47.0', '', True),
+]
+
+configure_cmd_prefix = "mkdir obj && cd obj && ."  # the '.' is required to trigger '&& ../configure ...'
+
+configopts = "--with-java=$EBROOTJAVA/bin/javac --with-boost=$EBROOTBOOST "
+configopts += "--with-gomp_omp_runtime_library=$EBROOTGCC/lib64 "
+configopts += "--disable-tutorial-directory --disable-projects-directory --disable-tests-directory "
+configopts += "--disable-opencl --disable-php --disable-cuda --disable-binary-analysis --disable-java "
+
+premakeopts = "cd obj && "
+preinstallopts = premakeopts
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.4.3.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.4.3.eb
@@ -1,0 +1,35 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
+# Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+name = 'SQLite'
+version = '3.8.4.3'
+
+homepage = 'http://www.hwaci.com/sw/sqlite/'
+description = "SQLite: SQL Database Engine in a C Library"
+
+# eg. http://www.hwaci.com/sw/sqlite/2013/sqlite-autoconf-3080100.tar.gz
+source_urls = ['http://www.hwaci.com/sw/sqlite/2014']
+sources = ['sqlite-autoconf-%s0%s0%s0%s.tar.gz' % tuple(version.split('.'))]  # very weird way to calculate your filename
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+dependencies = [
+    ('libreadline', '6.2'),
+    ('Tcl', '8.6.1'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/sqlite3'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.1.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.1.eb
@@ -1,0 +1,19 @@
+name = 'Tcl'
+version = '8.6.1'
+
+homepage = 'http://www.tcl.tk/'
+description = """Tcl (Tool Command Language) is a very powerful but easy to learn dynamic programming language,
+suitable for a very wide range of uses, including web and desktop applications, networking, administration, testing and many more."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+source_urls = ["http://prdownloads.sourceforge.net/tcl"]
+sources = ['%(namelower)s%(version)s-src.tar.gz']
+
+configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
+
+runtest = 'test'
+
+start_dir = 'unix'
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.7.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.7.eb
@@ -1,0 +1,20 @@
+name = 'zlib'
+version = '1.2.7'
+
+homepage = 'http://www.zlib.net/'
+description = """zlib is designed to be a free, general-purpose, legally unencumbered -- that is, 
+not covered by any patents -- lossless data-compression library for use on virtually any 
+computer hardware and operating system."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [('http://sourceforge.net/projects/libpng/files/zlib/%(version)s', 'download')]
+
+sanity_check_paths = {
+    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a', 'lib/libz.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
I've deliberately used a `dummy` toolchain here, to obtain a PerfExpert build that works with other toolchains too...

This is not airtight though, mostly because of the huge list of dependencies. If PerfExpert is to be used with a particular application that has a dependency in common with PerfExpert, PerfExpert will need to be built with the same compiler toolchain to make them compatible.

This might be troublesome, since e.g. ROSE requires a GCC 4.4 or older 4.x (so I should probably use a GCC-4.4 module as build dependency for ROSE to make sure that build works).
