### PR TITLE
Gcc44

### DIFF
--- a/easybuild/easyconfigs/g/GCC/GCC-4.4.7.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.4.7.eb
@@ -17,7 +17,8 @@ dependencies = [
 
 languages = ['c', 'c++', 'fortran']
 
-configopts = "--with-gmp=$EBROOTGMP --with-mpfr=$EBROOTMPFR MAKEINFO=/bin/false"
+# the build will fail if a new version of texinfo is found, so disable
+configopts = "--with-gmp=$EBROOTGMP --with-mpfr=$EBROOTMPFR MAKEINFO=MISSING"
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4


### PR DESCRIPTION
Build fails if your version texinfo is too new.
