### PR TITLE
Hmmer installation fix

### DIFF
--- a/easybuild/easyconfigs/h/HMMER/HMMER-3.1b1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HMMER/HMMER-3.1b1-goolf-1.4.10.eb
@@ -23,11 +23,11 @@ description = """HMMER is used for searching sequence databases for homologs of 
  came at significant computational expense, but in the new HMMER3 project, HMMER is now
  essentially as fast as BLAST."""
 
-toolchain = {'version': '1.4.10', 'name': 'goolf'}
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 sources = ['hmmer-%(version)s-linux-intel-x86_64.tar.gz']
 source_urls = ['http://selab.janelia.org/software/hmmer%(version_major)s/%(version)s/']
-patches = ['hmmer-3.1b1_link-LIBS-utests.patch']
+patches = ['hmmer-%(version)s_link-LIBS-utests.patch']
 
 installopts = ' && cd easel && make install'
 

--- a/easybuild/easyconfigs/h/HMMER/HMMER-3.1b1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/h/HMMER/HMMER-3.1b1-ictce-5.3.0.eb
@@ -23,11 +23,11 @@ description = """HMMER is used for searching sequence databases for homologs of 
  came at significant computational expense, but in the new HMMER3 project, HMMER is now
  essentially as fast as BLAST."""
 
-toolchain = {'version': '5.3.0', 'name': 'ictce'}
+toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
 sources = ['hmmer-%(version)s-linux-intel-x86_64.tar.gz']
 source_urls = ['http://selab.janelia.org/software/hmmer%(version_major)s/%(version)s/']
-patches = ['hmmer-3.1b1_link-LIBS-utests.patch']
+patches = ['hmmer-%(version)s_link-LIBS-utests.patch']
 
 installopts = ' && cd easel && make install'
 

--- a/easybuild/easyconfigs/h/HMMER/HMMER-3.1b1-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/h/HMMER/HMMER-3.1b1-ictce-6.2.5.eb
@@ -23,11 +23,11 @@ description = """HMMER is used for searching sequence databases for homologs of 
  came at significant computational expense, but in the new HMMER3 project, HMMER is now
  essentially as fast as BLAST."""
 
-toolchain = {'version': '6.2.5', 'name': 'ictce'}
+toolchain = {'name': 'ictce', 'version': '6.2.5'}
 
 sources = ['hmmer-%(version)s-linux-intel-x86_64.tar.gz']
 source_urls = ['http://selab.janelia.org/software/hmmer%(version_major)s/%(version)s/']
-patches = ['hmmer-3.1b1_link-LIBS-utests.patch']
+patches = ['hmmer-%(version)s_link-LIBS-utests.patch']
 
 installopts = ' && cd easel && make install'
 


### PR DESCRIPTION
previous hmmer easyconfig were not copying all the binaries to the install_dir

added extra installopts to fix it and also extended sanity_check

also added extra easyconfig for ictce-6.2.5
