### PR TITLE
Blast 2.2.26

### DIFF
--- a/easybuild/easyconfigs/b/BLAST/BLAST-2.2.26_Linux_x86_64.eb
+++ b/easybuild/easyconfigs/b/BLAST/BLAST-2.2.26_Linux_x86_64.eb
@@ -7,6 +7,7 @@ easyblock = "Tarball"
 
 name = 'BLAST'
 version = '2.2.26'
+versionsuffix = "-Linux_x86_64"
 
 homepage = 'http://blast.ncbi.nlm.nih.gov/'
 description = """Basic Local Alignment Search Tool, or BLAST, is an algorithm


### PR DESCRIPTION
this is an older blast version in which many bioinfo apps rely on.

every BLAST version over 2.2.26 is BLAST+
