### PR TITLE
Perl Download links Changed to cpan.metacpan.org

### DIFF
--- a/easybuild/easyconfigs/b/BioPerl/BioPerl-1.6.1-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/b/BioPerl/BioPerl-1.6.1-goolf-1.4.10-Perl-5.16.3.eb
@@ -9,7 +9,7 @@ description = """Bioperl is the product of a community effort to produce Perl co
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-source_urls = ['http://www.cpan.org/modules/by-module/Bio/CJFIELDS/']
+source_urls = ['http://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/']
 sources = [SOURCE_TAR_GZ]
 
 perl = 'Perl'

--- a/easybuild/easyconfigs/b/BioPerl/BioPerl-1.6.1-ictce-4.1.13-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/b/BioPerl/BioPerl-1.6.1-ictce-4.1.13-Perl-5.16.3.eb
@@ -9,7 +9,7 @@ description = """Bioperl is the product of a community effort to produce Perl co
 
 toolchain = {'name': 'ictce', 'version': '4.1.13'}
 
-source_urls = ['http://www.cpan.org/modules/by-module/Bio/CJFIELDS/']
+source_urls = ['http://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/']
 sources = [SOURCE_TAR_GZ]
 
 perl = 'Perl'

--- a/easybuild/easyconfigs/b/BioPerl/BioPerl-1.6.1-ictce-5.3.0-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/b/BioPerl/BioPerl-1.6.1-ictce-5.3.0-Perl-5.16.3.eb
@@ -9,7 +9,7 @@ description = """Bioperl is the product of a community effort to produce Perl co
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
-source_urls = ['http://www.cpan.org/modules/by-module/Bio/CJFIELDS/']
+source_urls = ['http://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/']
 sources = [SOURCE_TAR_GZ]
 
 perl = 'Perl'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.16.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.16.3-goolf-1.4.10.eb
@@ -14,207 +14,207 @@ runtest = 'test'
 exts_list = [
     ('IO::String', '1.08', {
         'source_tmpl': 'IO-String-1.08.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/IO/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('Data::Stag', '0.11', {
         'source_tmpl': 'Data-Stag-0.11.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Data/CMUNGALL/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CM/CMUNGALL/'],
     }),
     ('DB_File', '1.827', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/DB_File/PMQS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/P/PM/PMQS/'],
     }),
     ('DBI', '1.625', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/DBI/TIMB/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/T/TI/TIMB/'],
     }),
     ('Bio::Perl', '1.6.901', {
         'source_tmpl': 'BioPerl-1.6.901.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Bio/CJFIELDS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/'],
     }),
     ('Sub::Uplevel', '0.24', {
         'source_tmpl': 'Sub-Uplevel-0.24.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/DAGOLDEN/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/'],
     }),
     ('Tree::DAG_Node', '1.11', {
         'source_tmpl': 'Tree-DAG_Node-1.11.tgz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Tree/RSAVAGE/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RS/RSAVAGE/'],
     }),
     ('Try::Tiny', '0.12', {
         'source_tmpl': 'Try-Tiny-0.12.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DO/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Test::Fatal', '0.010', {
         'source_tmpl': 'Test-Fatal-0.010.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Test::Exception', '0.31', {
         'source_tmpl': 'Test-Exception-0.31.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/ADIE/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADIE/'],
     }),
     ('Test::Warn', '0.24', {
         'source_tmpl': 'Test-Warn-0.24.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/CHORNY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CH/CHORNY/'],
     }),
     ('Test::Requires', '0.06', {
         'source_tmpl': 'Test-Requires-0.06.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/TOKUHIROM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/T/TO/TOKUHIROM/'],
     }),
     ('Test::Tester', '0.108', {
         'source_tmpl': 'Test-Tester-0.108.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/FDALY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FD/FDALY/'],
     }),
     ('Params::Util', '1.07', {
         'source_tmpl': 'Params-Util-1.07.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Params/ADAMK/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK/'],
     }),
     ('Sub::Install', '0.926', {
         'source_tmpl': 'Sub-Install-0.926.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Data::OptList', '0.107', {
         'source_tmpl': 'Data-OptList-0.107.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Data/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Sub::Exporter', '0.985', {
         'source_tmpl': 'Sub-Exporter-0.985.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Test::Output', '1.01', {
         'source_tmpl': 'Test-Output-1.01.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/BDFOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BD/BDFOY/'],
     }),
     ('Module::Runtime', '0.013', {
         'source_tmpl': 'Module-Runtime-0.013.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Module/ZEFRAM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/Z/ZE/ZEFRAM/'],
     }),
     ('Module::Implementation', '0.06', {
         'source_tmpl': 'Module-Implementation-0.06.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Module/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('List::MoreUtils', '0.33', {
         'source_tmpl': 'List-MoreUtils-0.33.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/List/ADAMK/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK/'],
     }),
     ('Package::DeprecationManager', '0.13', {
         'source_tmpl': 'Package-DeprecationManager-0.13.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Package/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('Dist::CheckConflicts', '0.02', {
         'source_tmpl': 'Dist-CheckConflicts-0.02.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Dist/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Package::Stash', '0.34', {
         'source_tmpl': 'Package-Stash-0.34.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Package/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Class::Load', '0.20', {
         'source_tmpl': 'Class-Load-0.20.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Class/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('MRO::Compat', '0.12', {
         'source_tmpl': 'MRO-Compat-0.12.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/B/BO/BOBTFISH/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BO/BOBTFISH/'],
     }),
     ('Sub::Name', '0.05', {
         'source_tmpl': 'Sub-Name-0.05.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/FLORA/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FL/FLORA/'],
     }),
     ('Eval::Closure', '0.08', {
         'source_tmpl': 'Eval-Closure-0.08.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DO/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Sub::Exporter::Progressive', '0.001010', {
         'source_tmpl': 'Sub-Exporter-Progressive-0.001010.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/FREW/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FR/FREW/'],
     }),
     ('Devel::GlobalDestruction', '0.11', {
         'source_tmpl': 'Devel-GlobalDestruction-0.11.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Devel/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/H/HA/HAARG/'],
     }),
     ('boolean', '0.30', {
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/I/IN/INGY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/I/IN/INGY/'],
     }),
     ('Tie::IxHash', '1.23', {
         'source_tmpl': 'Tie-IxHash-1.23.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Tie/CHORNY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CH/CHORNY/'],
     }),
     ('Moose', '2.0801', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/MooseX/ETHER/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/ET/ETHER/'],
     }),
     ('Params::Validate', '1.07', {
         'source_tmpl': 'Params-Validate-1.07.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Params/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('DateTime::Locale', '0.45', {
         'source_tmpl': 'DateTime-Locale-0.45.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('Class::Singleton', '1.4', {
         'source_tmpl': 'Class-Singleton-1.4.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Class/ABW/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AB/ABW/'],
     }),
     ('DateTime::TimeZone', '1.58', {
         'source_tmpl': 'DateTime-TimeZone-1.58.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('DateTime', '1.01', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('Data::Types', '0.09', {
         'source_tmpl': 'Data-Types-0.09.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Data/DWHEELER/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DW/DWHEELER/'],
     }),
     ('DateTime::Tiny', '1.04', {
         'source_tmpl': 'DateTime-Tiny-1.04.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/ADAMK/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK/'],
     }),
     ('File::Slurp', '9999.19', {
         'source_tmpl': 'File-Slurp-9999.19.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/File/URI/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/U/UR/URI/'],
     }),
     ('HTTP::Date', '6.02', {
         'source_tmpl': 'HTTP-Date-6.02.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTTP/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('IO::HTML', '1.00', {
         'source_tmpl': 'IO-HTML-1.00.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/IO/CJM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CJ/CJM/'],
     }),
     ('LWP::MediaTypes', '6.02', {
         'source_tmpl': 'LWP-MediaTypes-6.02.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/LWP/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('URI', '1.60', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/URI/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('HTTP::Request', '6.06', {
         'source_tmpl': 'HTTP-Message-6.06.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTTP/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('HTML::Tagset', '3.20', {
         'source_tmpl': 'HTML-Tagset-3.20.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTML/PETDANCE/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/P/PE/PETDANCE/'],
     }),
     ('HTML::Entities', '3.70', {
         'source_tmpl': 'HTML-Parser-3.70.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTML/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('AnyEvent', '7.04', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/AnyEvent/MLEHMANN/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/M/ML/MLEHMANN/'],
     }),
     ('Mouse', '1.05', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/MouseX/GFUJI/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GF/GFUJI/'],
     }),
     ('XML::NamespaceSupport', '1.11', {
         'source_tmpl': 'XML-NamespaceSupport-1.11.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/XML/PERIGRIN/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/P/PE/PERIGRIN/'],
     }),
     ('XML::SAX::Base', '1.08', {
         'source_tmpl': 'XML-SAX-Base-1.08.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/XML/GRANTM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GR/GRANTM/'],
     }),
     ('XML::SAX', '0.99', {
         'source_tmpl': 'XML-SAX-0.99.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/XML/GRANTM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GR/GRANTM/'],
     }),
     ('Test::Harness', '3.28', {
         'source_tmpl': 'Test-Harness-3.28.tar.gz',

--- a/easybuild/easyconfigs/p/Perl/Perl-5.16.3-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.16.3-ictce-4.1.13.eb
@@ -14,208 +14,208 @@ runtest = 'test'
 exts_list = [
     ('IO::String', '1.08', {
         'source_tmpl': 'IO-String-1.08.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/IO/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('Data::Stag', '0.11', {
         'source_tmpl': 'Data-Stag-0.11.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Data/CMUNGALL/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CM/CMUNGALL/'],
     }),
     ('DB_File', '1.827', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/DB_File/PMQS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/P/PM/PMQS/'],
     }),
     ('DBI', '1.625', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/DBI/TIMB/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/T/TI/TIMB/'],
     }),
     ('Bio::Perl', '1.6.901', {
         'source_tmpl': 'BioPerl-1.6.901.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Bio/CJFIELDS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/'],
         'patches': ['BioPerl_disable-broken-test.patch'],
     }),
     ('Sub::Uplevel', '0.24', {
         'source_tmpl': 'Sub-Uplevel-0.24.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/DAGOLDEN/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/'],
     }),
     ('Tree::DAG_Node', '1.11', {
         'source_tmpl': 'Tree-DAG_Node-1.11.tgz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Tree/RSAVAGE/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RS/RSAVAGE/'],
     }),
     ('Try::Tiny', '0.12', {
         'source_tmpl': 'Try-Tiny-0.12.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DO/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Test::Fatal', '0.010', {
         'source_tmpl': 'Test-Fatal-0.010.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Test::Exception', '0.31', {
         'source_tmpl': 'Test-Exception-0.31.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/ADIE/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADIE/'],
     }),
     ('Test::Warn', '0.24', {
         'source_tmpl': 'Test-Warn-0.24.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/CHORNY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CH/CHORNY/'],
     }),
     ('Test::Requires', '0.06', {
         'source_tmpl': 'Test-Requires-0.06.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/TOKUHIROM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/T/TO/TOKUHIROM/'],
     }),
     ('Test::Tester', '0.108', {
         'source_tmpl': 'Test-Tester-0.108.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/FDALY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FD/FDALY/'],
     }),
     ('Params::Util', '1.07', {
         'source_tmpl': 'Params-Util-1.07.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Params/ADAMK/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK/'],
     }),
     ('Sub::Install', '0.926', {
         'source_tmpl': 'Sub-Install-0.926.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Data::OptList', '0.107', {
         'source_tmpl': 'Data-OptList-0.107.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Data/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Sub::Exporter', '0.985', {
         'source_tmpl': 'Sub-Exporter-0.985.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Test::Output', '1.01', {
         'source_tmpl': 'Test-Output-1.01.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/BDFOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BD/BDFOY/'],
     }),
     ('Module::Runtime', '0.013', {
         'source_tmpl': 'Module-Runtime-0.013.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Module/ZEFRAM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/Z/ZE/ZEFRAM/'],
     }),
     ('Module::Implementation', '0.06', {
         'source_tmpl': 'Module-Implementation-0.06.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Module/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('List::MoreUtils', '0.33', {
         'source_tmpl': 'List-MoreUtils-0.33.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/List/ADAMK/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK/'],
     }),
     ('Package::DeprecationManager', '0.13', {
         'source_tmpl': 'Package-DeprecationManager-0.13.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Package/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('Dist::CheckConflicts', '0.02', {
         'source_tmpl': 'Dist-CheckConflicts-0.02.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Dist/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Package::Stash', '0.34', {
         'source_tmpl': 'Package-Stash-0.34.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Package/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Class::Load', '0.20', {
         'source_tmpl': 'Class-Load-0.20.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Class/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('MRO::Compat', '0.12', {
         'source_tmpl': 'MRO-Compat-0.12.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/B/BO/BOBTFISH/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BO/BOBTFISH/'],
     }),
     ('Sub::Name', '0.05', {
         'source_tmpl': 'Sub-Name-0.05.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/FLORA/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FL/FLORA/'],
     }),
     ('Eval::Closure', '0.08', {
         'source_tmpl': 'Eval-Closure-0.08.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DO/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Sub::Exporter::Progressive', '0.001010', {
         'source_tmpl': 'Sub-Exporter-Progressive-0.001010.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/FREW/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FR/FREW/'],
     }),
     ('Devel::GlobalDestruction', '0.11', {
         'source_tmpl': 'Devel-GlobalDestruction-0.11.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Devel/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/H/HA/HAARG/'],
     }),
     ('boolean', '0.30', {
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/I/IN/INGY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/I/IN/INGY/'],
     }),
     ('Tie::IxHash', '1.23', {
         'source_tmpl': 'Tie-IxHash-1.23.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Tie/CHORNY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CH/CHORNY/'],
     }),
     ('Moose', '2.0801', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/MooseX/ETHER/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/ET/ETHER/'],
     }),
     ('Params::Validate', '1.07', {
         'source_tmpl': 'Params-Validate-1.07.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Params/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('DateTime::Locale', '0.45', {
         'source_tmpl': 'DateTime-Locale-0.45.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('Class::Singleton', '1.4', {
         'source_tmpl': 'Class-Singleton-1.4.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Class/ABW/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AB/ABW/'],
     }),
     ('DateTime::TimeZone', '1.58', {
         'source_tmpl': 'DateTime-TimeZone-1.58.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('DateTime', '1.01', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('Data::Types', '0.09', {
         'source_tmpl': 'Data-Types-0.09.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Data/DWHEELER/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DW/DWHEELER/'],
     }),
     ('DateTime::Tiny', '1.04', {
         'source_tmpl': 'DateTime-Tiny-1.04.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/ADAMK/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK/'],
     }),
     ('File::Slurp', '9999.19', {
         'source_tmpl': 'File-Slurp-9999.19.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/File/URI/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/U/UR/URI/'],
     }),
     ('HTTP::Date', '6.02', {
         'source_tmpl': 'HTTP-Date-6.02.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTTP/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('IO::HTML', '1.00', {
         'source_tmpl': 'IO-HTML-1.00.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/IO/CJM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CJ/CJM/'],
     }),
     ('LWP::MediaTypes', '6.02', {
         'source_tmpl': 'LWP-MediaTypes-6.02.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/LWP/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('URI', '1.60', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/URI/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('HTTP::Request', '6.06', {
         'source_tmpl': 'HTTP-Message-6.06.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTTP/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('HTML::Tagset', '3.20', {
         'source_tmpl': 'HTML-Tagset-3.20.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTML/PETDANCE/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/P/PE/PETDANCE/'],
     }),
     ('HTML::Entities', '3.70', {
         'source_tmpl': 'HTML-Parser-3.70.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTML/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('AnyEvent', '7.04', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/AnyEvent/MLEHMANN/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/M/ML/MLEHMANN/'],
     }),
     ('Mouse', '1.05', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/MouseX/GFUJI/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GF/GFUJI/'],
     }),
     ('XML::NamespaceSupport', '1.11', {
         'source_tmpl': 'XML-NamespaceSupport-1.11.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/XML/PERIGRIN/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/P/PE/PERIGRIN/'],
     }),
     ('XML::SAX::Base', '1.08', {
         'source_tmpl': 'XML-SAX-Base-1.08.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/XML/GRANTM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GR/GRANTM/'],
     }),
     ('XML::SAX', '0.99', {
         'source_tmpl': 'XML-SAX-0.99.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/XML/GRANTM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GR/GRANTM/'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Perl/Perl-5.16.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.16.3-ictce-5.3.0.eb
@@ -17,208 +17,208 @@ runtest = 'test'
 exts_list = [
     ('IO::String', '1.08', {
         'source_tmpl': 'IO-String-1.08.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/IO/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('Data::Stag', '0.11', {
         'source_tmpl': 'Data-Stag-0.11.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Data/CMUNGALL/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CM/CMUNGALL/'],
     }),
     ('DB_File', '1.827', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/DB_File/PMQS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/P/PM/PMQS/'],
     }),
     ('DBI', '1.625', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/DBI/TIMB/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/T/TI/TIMB/'],
     }),
     ('Bio::Perl', '1.6.901', {
         'source_tmpl': 'BioPerl-1.6.901.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Bio/CJFIELDS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/'],
         'patches': ['BioPerl_disable-broken-test.patch'],
     }),
     ('Sub::Uplevel', '0.24', {
         'source_tmpl': 'Sub-Uplevel-0.24.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/DAGOLDEN/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/'],
     }),
     ('Tree::DAG_Node', '1.11', {
         'source_tmpl': 'Tree-DAG_Node-1.11.tgz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Tree/RSAVAGE/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RS/RSAVAGE/'],
     }),
     ('Try::Tiny', '0.12', {
         'source_tmpl': 'Try-Tiny-0.12.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DO/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Test::Fatal', '0.010', {
         'source_tmpl': 'Test-Fatal-0.010.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Test::Exception', '0.31', {
         'source_tmpl': 'Test-Exception-0.31.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/ADIE/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADIE/'],
     }),
     ('Test::Warn', '0.24', {
         'source_tmpl': 'Test-Warn-0.24.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/CHORNY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CH/CHORNY/'],
     }),
     ('Test::Requires', '0.06', {
         'source_tmpl': 'Test-Requires-0.06.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/TOKUHIROM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/T/TO/TOKUHIROM/'],
     }),
     ('Test::Tester', '0.108', {
         'source_tmpl': 'Test-Tester-0.108.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/FDALY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FD/FDALY/'],
     }),
     ('Params::Util', '1.07', {
         'source_tmpl': 'Params-Util-1.07.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Params/ADAMK/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK/'],
     }),
     ('Sub::Install', '0.926', {
         'source_tmpl': 'Sub-Install-0.926.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Data::OptList', '0.107', {
         'source_tmpl': 'Data-OptList-0.107.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Data/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Sub::Exporter', '0.985', {
         'source_tmpl': 'Sub-Exporter-0.985.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Test::Output', '1.01', {
         'source_tmpl': 'Test-Output-1.01.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/BDFOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BD/BDFOY/'],
     }),
     ('Module::Runtime', '0.013', {
         'source_tmpl': 'Module-Runtime-0.013.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Module/ZEFRAM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/Z/ZE/ZEFRAM/'],
     }),
     ('Module::Implementation', '0.06', {
         'source_tmpl': 'Module-Implementation-0.06.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Module/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('List::MoreUtils', '0.33', {
         'source_tmpl': 'List-MoreUtils-0.33.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/List/ADAMK/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK/'],
     }),
     ('Package::DeprecationManager', '0.13', {
         'source_tmpl': 'Package-DeprecationManager-0.13.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Package/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('Dist::CheckConflicts', '0.02', {
         'source_tmpl': 'Dist-CheckConflicts-0.02.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Dist/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Package::Stash', '0.34', {
         'source_tmpl': 'Package-Stash-0.34.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Package/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Class::Load', '0.20', {
         'source_tmpl': 'Class-Load-0.20.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Class/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('MRO::Compat', '0.12', {
         'source_tmpl': 'MRO-Compat-0.12.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/B/BO/BOBTFISH/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BO/BOBTFISH/'],
     }),
     ('Sub::Name', '0.05', {
         'source_tmpl': 'Sub-Name-0.05.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/FLORA/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FL/FLORA/'],
     }),
     ('Eval::Closure', '0.08', {
         'source_tmpl': 'Eval-Closure-0.08.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DO/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Sub::Exporter::Progressive', '0.001010', {
         'source_tmpl': 'Sub-Exporter-Progressive-0.001010.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/FREW/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FR/FREW/'],
     }),
     ('Devel::GlobalDestruction', '0.11', {
         'source_tmpl': 'Devel-GlobalDestruction-0.11.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Devel/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/H/HA/HAARG/'],
     }),
     ('boolean', '0.30', {
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/I/IN/INGY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/I/IN/INGY/'],
     }),
     ('Tie::IxHash', '1.23', {
         'source_tmpl': 'Tie-IxHash-1.23.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Tie/CHORNY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CH/CHORNY/'],
     }),
     ('Moose', '2.0801', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/MooseX/ETHER/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/ET/ETHER/'],
     }),
     ('Params::Validate', '1.07', {
         'source_tmpl': 'Params-Validate-1.07.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Params/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('DateTime::Locale', '0.45', {
         'source_tmpl': 'DateTime-Locale-0.45.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('Class::Singleton', '1.4', {
         'source_tmpl': 'Class-Singleton-1.4.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Class/ABW/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AB/ABW/'],
     }),
     ('DateTime::TimeZone', '1.58', {
         'source_tmpl': 'DateTime-TimeZone-1.58.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('DateTime', '1.01', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('Data::Types', '0.09', {
         'source_tmpl': 'Data-Types-0.09.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Data/DWHEELER/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DW/DWHEELER/'],
     }),
     ('DateTime::Tiny', '1.04', {
         'source_tmpl': 'DateTime-Tiny-1.04.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/ADAMK/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK/'],
     }),
     ('File::Slurp', '9999.19', {
         'source_tmpl': 'File-Slurp-9999.19.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/File/URI/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/U/UR/URI/'],
     }),
     ('HTTP::Date', '6.02', {
         'source_tmpl': 'HTTP-Date-6.02.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTTP/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('IO::HTML', '1.00', {
         'source_tmpl': 'IO-HTML-1.00.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/IO/CJM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CJ/CJM/'],
     }),
     ('LWP::MediaTypes', '6.02', {
         'source_tmpl': 'LWP-MediaTypes-6.02.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/LWP/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('URI', '1.60', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/URI/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('HTTP::Request', '6.06', {
         'source_tmpl': 'HTTP-Message-6.06.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTTP/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('HTML::Tagset', '3.20', {
         'source_tmpl': 'HTML-Tagset-3.20.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTML/PETDANCE/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/P/PE/PETDANCE/'],
     }),
     ('HTML::Entities', '3.70', {
         'source_tmpl': 'HTML-Parser-3.70.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTML/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('AnyEvent', '7.04', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/AnyEvent/MLEHMANN/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/M/ML/MLEHMANN/'],
     }),
     ('Mouse', '1.05', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/MouseX/GFUJI/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GF/GFUJI/'],
     }),
     ('XML::NamespaceSupport', '1.11', {
         'source_tmpl': 'XML-NamespaceSupport-1.11.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/XML/PERIGRIN/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/P/PE/PERIGRIN/'],
     }),
     ('XML::SAX::Base', '1.08', {
         'source_tmpl': 'XML-SAX-Base-1.08.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/XML/GRANTM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GR/GRANTM/'],
     }),
     ('XML::SAX', '0.99', {
         'source_tmpl': 'XML-SAX-0.99.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/XML/GRANTM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GR/GRANTM/'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Perl/Perl-5.20.0-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.20.0-ictce-5.5.0.eb
@@ -13,367 +13,367 @@ sources = [SOURCELOWER_TAR_GZ]
 exts_list = [
     ('IO::String', '1.08', {
         'source_tmpl': 'IO-String-1.08.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/IO/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('Data::Stag', '0.14', {
         'source_tmpl': 'Data-Stag-0.14.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Data/CMUNGALL/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CM/CMUNGALL/'],
     }),
     ('DBI', '1.631', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/DBI/TIMB/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/T/TI/TIMB/'],
     }),
     ('Module::Build', '0.4205', {
         'source_tmpl': 'Module-Build-0.4205.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Module/LEONT/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/L/LE/LEONT/'],
     }),
     ('Devel::StackTrace', '1.32', {
         'source_tmpl': 'Devel-StackTrace-1.32.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Devel/DROLSKY'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
     }),
     ('Class::Data::Inheritable', '0.08', {
         'source_tmpl': 'Class-Data-Inheritable-0.08.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Class/TMTM'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/T/TM/TMTM'],
     }),
     ('Exception::Class', '1.38', {
         'source_tmpl': 'Exception-Class-1.38.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Exception/DROLSKY'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
     }),
     ('Test::Tester', '0.109', {
         'source_tmpl': 'Test-Tester-0.109.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/FDALY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FD/FDALY/'],
     }),
     ('Test::NoWarnings', '1.04', {
         'source_tmpl': 'Test-NoWarnings-1.04.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/ADAMK/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK/'],
     }),
     ('Test::Deep', '0.112', {
         'source_tmpl': 'Test-Deep-0.112.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Algorithm::Diff', '1.15', {
         'source_tmpl': 'Algorithm-Diff-1.15.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Algorithm/NEDKONZ/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/N/NE/NEDKONZ/'],
     }),
     ('Text::Diff', '1.41', {
         'source_tmpl': 'Text-Diff-1.41.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Text/OVID/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/O/OV/OVID/'],
     }),
     ('Test::Differences', '0.61', {
         'source_tmpl': 'Test-Differences-0.61.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/OVID/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/O/OV/OVID/'],
     }),
     ('Sub::Uplevel', '0.24', {
         'source_tmpl': 'Sub-Uplevel-0.24.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/DAGOLDEN/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/'],
     }),
     ('Test::Exception', '0.32', {
         'source_tmpl': 'Test-Exception-0.32.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/ADIE/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADIE/'],
     }),
     ('Test::Warn', '0.30', {
         'source_tmpl': 'Test-Warn-0.30.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/CHORNY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CH/CHORNY/'],
     }),
     ('Test::Most', '0.33', {
         'source_tmpl': 'Test-Most-0.33.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/OVID/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/O/OV/OVID/'],
     }),
     ('File::Slurp::Tiny', '0.003', {
         'source_tmpl': 'File-Slurp-Tiny-0.003.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/File/LEONT'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/L/LE/LEONT'],
     }),
     ('Tree::DAG_Node', '1.22', {
         'source_tmpl': 'Tree-DAG_Node-1.22.tgz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Tree/RSAVAGE/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RS/RSAVAGE/'],
     }),
     ('Try::Tiny', '0.20', {
         'source_tmpl': 'Try-Tiny-0.20.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DO/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Test::Fatal', '0.013', {
         'source_tmpl': 'Test-Fatal-0.013.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Test::Requires', '0.07', {
         'source_tmpl': 'Test-Requires-0.07.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/TOKUHIROM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/T/TO/TOKUHIROM/'],
     }),
     ('Params::Util', '1.07', {
         'source_tmpl': 'Params-Util-1.07.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Params/ADAMK/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK/'],
     }),
     ('Sub::Install', '0.927', {
         'source_tmpl': 'Sub-Install-0.927.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Data::OptList', '0.109', {
         'source_tmpl': 'Data-OptList-0.109.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Data/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Sub::Exporter', '0.987', {
         'source_tmpl': 'Sub-Exporter-0.987.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/RJBS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS/'],
     }),
     ('Capture::Tiny', '0.24', {
         'source_tmpl': 'Capture-Tiny-0.24.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/'],
     }),
     ('Test::Output', '1.03', {
         'source_tmpl': 'Test-Output-1.03.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/BDFOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BD/BDFOY/'],
     }),
     ('Module::Runtime', '0.014', {
         'source_tmpl': 'Module-Runtime-0.014.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Module/ZEFRAM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/Z/ZE/ZEFRAM/'],
     }),
     ('Module::Implementation', '0.07', {
         'source_tmpl': 'Module-Implementation-0.07.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Module/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('List::MoreUtils', '0.33', {
         'source_tmpl': 'List-MoreUtils-0.33.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/List/ADAMK/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK/'],
     }),
     ('Package::DeprecationManager', '0.13', {
         'source_tmpl': 'Package-DeprecationManager-0.13.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Package/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('Dist::CheckConflicts', '0.11', {
         'source_tmpl': 'Dist-CheckConflicts-0.11.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Dist/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Package::Stash', '0.36', {
         'source_tmpl': 'Package-Stash-0.36.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Package/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('TAP::Harness::Env', '3.30', {
         'source_tmpl': 'Test-Harness-3.30.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/LEONT/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/L/LE/LEONT/'],
     }),
     ('ExtUtils::Helpers', '0.022', {
         'source_tmpl': 'ExtUtils-Helpers-0.022.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/ExtUtils/LEONT'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/L/LE/LEONT'],
     }),
     ('ExtUtils::Config', '0.007', {
         'source_tmpl': 'ExtUtils-Config-0.007.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/ExtUtils/LEONT'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/L/LE/LEONT'],
     }),
     ('ExtUtils::InstallPaths', '0.010', {
         'source_tmpl': 'ExtUtils-InstallPaths-0.010.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/ExtUtils/LEONT'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/L/LE/LEONT'],
     }),
     ('Module::Build::Tiny', '0.036', {
         'source_tmpl': 'Module-Build-Tiny-0.036.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Module/LEONT/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/L/LE/LEONT/'],
     }),
     ('Class::Load', '0.21', {
         'source_tmpl': 'Class-Load-0.21.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Class/ETHER/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/ET/ETHER/'],
     }),
     ('MRO::Compat', '0.12', {
         'source_tmpl': 'MRO-Compat-0.12.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/B/BO/BOBTFISH/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BO/BOBTFISH/'],
     }),
     ('Sub::Name', '0.05', {
         'source_tmpl': 'Sub-Name-0.05.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/FLORA/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FL/FLORA/'],
     }),
     ('Eval::Closure', '0.11', {
         'source_tmpl': 'Eval-Closure-0.11.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DO/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Sub::Exporter::Progressive', '0.001011', {
         'source_tmpl': 'Sub-Exporter-Progressive-0.001011.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Sub/FREW/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FR/FREW/'],
     }),
     ('Devel::GlobalDestruction', '0.12', {
         'source_tmpl': 'Devel-GlobalDestruction-0.12.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Devel/HAARG'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/H/HA/HAARG'],
     }),
     ('boolean', '0.32', {
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/I/IN/INGY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/I/IN/INGY/'],
     }),
     ('Tie::IxHash', '1.23', {
         'source_tmpl': 'Tie-IxHash-1.23.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Tie/CHORNY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CH/CHORNY/'],
     }),
     ('Package::Stash::XS', '0.28', {
         'source_tmpl': 'Package-Stash-XS-0.28.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Package/DOY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY/'],
     }),
     ('Class::Load::XS', '0.08', {
         'source_tmpl': 'Class-Load-XS-0.08.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Class/ETHER/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/ET/ETHER/'],
     }),
     ('Moose', '2.1208', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/MooseX/ETHER/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/ET/ETHER/'],
     }),
     ('Params::Validate', '1.10', {
         'source_tmpl': 'Params-Validate-1.10.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Params/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('DateTime::Locale', '0.45', {
         'source_tmpl': 'DateTime-Locale-0.45.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('Class::Singleton', '1.4', {
         'source_tmpl': 'Class-Singleton-1.4.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Class/ABW/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AB/ABW/'],
     }),
     ('DateTime::TimeZone', '1.70', {
         'source_tmpl': 'DateTime-TimeZone-1.70.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('Test::Warnings', '0.014', {
         'source_tmpl': 'Test-Warnings-0.014.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/ETHER/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/ET/ETHER/'],
     }),
     ('DateTime', '1.10', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/DROLSKY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
     }),
     ('Data::Types', '0.09', {
         'source_tmpl': 'Data-Types-0.09.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Data/DWHEELER/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DW/DWHEELER/'],
     }),
     ('DateTime::Tiny', '1.04', {
         'source_tmpl': 'DateTime-Tiny-1.04.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/DateTime/ADAMK/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK/'],
     }),
     ('File::Slurp', '9999.19', {
         'source_tmpl': 'File-Slurp-9999.19.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/File/URI/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/U/UR/URI/'],
     }),
     ('HTTP::Date', '6.02', {
         'source_tmpl': 'HTTP-Date-6.02.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTTP/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('IO::HTML', '1.00', {
         'source_tmpl': 'IO-HTML-1.00.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/IO/CJM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CJ/CJM/'],
     }),
     ('LWP::MediaTypes', '6.02', {
         'source_tmpl': 'LWP-MediaTypes-6.02.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/LWP/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('URI', '1.60', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/URI/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('Encode::Locale', '1.03', {
         'source_tmpl': 'Encode-Locale-1.03.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Encode/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('HTTP::Request', '6.06', {
         'source_tmpl': 'HTTP-Message-6.06.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTTP/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('HTML::Tagset', '3.20', {
         'source_tmpl': 'HTML-Tagset-3.20.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTML/PETDANCE/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/P/PE/PETDANCE/'],
     }),
     ('HTML::Entities', '3.71', {
         'source_tmpl': 'HTML-Parser-3.71.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/HTML/GAAS/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS/'],
     }),
     ('AnyEvent', '7.07', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/AnyEvent/MLEHMANN/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/M/ML/MLEHMANN/'],
     }),
     ('Devel::CheckCompiler', '0.05', {
         'source_tmpl': 'Devel-CheckCompiler-0.05.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Devel/SYOHEX'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/S/SY/SYOHEX'],
     }),
     ('File::Copy::Recursive', '0.38', {
         'source_tmpl': 'File-Copy-Recursive-0.38.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/File/DMUEY/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DM/DMUEY/'],
     }),
     ('Cwd::Guard', '0.04', {
         'source_tmpl': 'Cwd-Guard-0.04.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Cwd/KAZEBURO'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/K/KA/KAZEBURO'],
     }),
     ('Module::Build::XSUtil', '0.10', {
         'source_tmpl': 'Module-Build-XSUtil-0.10.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Module/HIDEAKIO/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/H/HI/HIDEAKIO/'],
     }),
     ('Fennec::Lite', '0.004', {
         'source_tmpl': 'Fennec-Lite-0.004.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Fennec/EXODIST/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/EX/EXODIST/'],
     }),
     ('aliased', '0.31', {
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/O/OV/OVID/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/O/OV/OVID/'],
     }),
     ('Meta::Builder', '0.003', {
         'source_tmpl': 'Meta-Builder-0.003.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/E/EX/EXODIST/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/EX/EXODIST/'],
     }),
     ('Exporter::Declare', '0.113', {
         'source_tmpl': 'Exporter-Declare-0.113.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Exporter/EXODIST/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/EX/EXODIST/'],
     }),
     ('Mock::Quick', '1.107', {
         'source_tmpl': 'Mock-Quick-1.107.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/E/EX/EXODIST/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/EX/EXODIST/'],
     }),
     ('Test::Exception::LessClever', '0.006', {
         'source_tmpl': 'Test-Exception-LessClever-0.006.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/EXODIST/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/EX/EXODIST/'],
     }),
     ('Test::LeakTrace', '0.14', {
         'source_tmpl': 'Test-LeakTrace-0.14.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Test/GFUJI/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GF/GFUJI/'],
     }),
     ('Mouse', '2.3.0', {
-        'source_urls': ['http://www.cpan.org/modules/by-module/MouseX/GFUJI/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GF/GFUJI/'],
     }),
     ('XML::NamespaceSupport', '1.11', {
         'source_tmpl': 'XML-NamespaceSupport-1.11.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/XML/PERIGRIN/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/P/PE/PERIGRIN/'],
     }),
     ('XML::SAX::Base', '1.08', {
         'source_tmpl': 'XML-SAX-Base-1.08.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/XML/GRANTM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GR/GRANTM/'],
     }),
     ('XML::SAX', '0.99', {
         'source_tmpl': 'XML-SAX-0.99.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/XML/GRANTM/'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GR/GRANTM/'],
     }),
     ('Clone', '0.37', {
         'source_tmpl': 'Clone-0.37.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Clone/GARU'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GARU'],
     }),
     ('Config::General', '2.56', {
         'source_tmpl': 'Config-General-2.56.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Config/TLINDEN'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/T/TL/TLINDEN'],
     }),
     ('Font::TTF', '1.04', {
         'source_tmpl': 'Font-TTF-1.04.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Font/MHOSKEN'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/M/MH/MHOSKEN'],
     }),
     ('Math::Bezier', '0.01', {
         'source_tmpl': 'Math-Bezier-0.01.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Math/ABW'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AB/ABW'],
     }),
     ('Math::Round', '0.06', {
         'source_tmpl': 'Math-Round-0.06.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Math/GROMMEL'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GR/GROMMEL'],
     }),
     ('Math::VecStat', '0.08', {
         'source_tmpl': 'Math-VecStat-0.08.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Math/ASPINELLI'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AS/ASPINELLI'],
     }),
     ('Readonly', '1.04', {
         'source_tmpl': 'Readonly-1.04.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Readonly/SANKO'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/S/SA/SANKO'],
     }),
     ('Regexp::Common', '2013031301', {
         'source_tmpl': 'Regexp-Common-2013031301.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Regexp/ABIGAIL'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AB/ABIGAIL'],
     }),
     ('Set::IntSpan', '1.19', {
         'source_tmpl': 'Set-IntSpan-1.19.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Set/SWMCD'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/S/SW/SWMCD'],
     }),
     ('Text::Format', '0.59', {
         'source_tmpl': 'Text-Format-0.59.tar.gz',
-        'source_urls': ['http://www.cpan.org/modules/by-module/Text/SHLOMIF'],
+        'source_urls': ['http://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
     }),
 ]
 

--- a/easybuild/easyconfigs/x/XML-LibXML/XML-LibXML-2.0018-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/x/XML-LibXML/XML-LibXML-2.0018-goolf-1.4.10-Perl-5.16.3.eb
@@ -8,7 +8,7 @@ description = """Perl binding for libxml2"""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-source_urls = ['http://www.cpan.org/modules/by-module/XML/SHLOMIF/']
+source_urls = ['http://cpan.metacpan.org/authors/id/S/SH/SHLOMIF/']
 sources = [SOURCE_TAR_GZ]
 
 perl = 'Perl'

--- a/easybuild/easyconfigs/x/XML-LibXML/XML-LibXML-2.0018-ictce-4.1.13-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/x/XML-LibXML/XML-LibXML-2.0018-ictce-4.1.13-Perl-5.16.3.eb
@@ -8,7 +8,7 @@ description = """Perl binding for libxml2"""
 
 toolchain = {'name': 'ictce', 'version': '4.1.13'}
 
-source_urls = ['http://www.cpan.org/modules/by-module/XML/SHLOMIF/']
+source_urls = ['http://cpan.metacpan.org/authors/id/S/SH/SHLOMIF/']
 sources = [SOURCE_TAR_GZ]
 
 perl = 'Perl'

--- a/easybuild/easyconfigs/x/XML-Simple/XML-Simple-2.20-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/x/XML-Simple/XML-Simple-2.20-goolf-1.4.10-Perl-5.16.3.eb
@@ -8,7 +8,7 @@ description = """Easily read/write XML in Perl"""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-source_urls = ['http://www.cpan.org/modules/by-module/XML/GRANTM/']
+source_urls = ['http://cpan.metacpan.org/authors/id/G/GR/GRANTM/']
 sources = [SOURCE_TAR_GZ]
 
 perl = 'Perl'

--- a/easybuild/easyconfigs/x/XML-Simple/XML-Simple-2.20-ictce-4.1.13-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/x/XML-Simple/XML-Simple-2.20-ictce-4.1.13-Perl-5.16.3.eb
@@ -8,7 +8,7 @@ description = """Easily read/write XML in Perl"""
 
 toolchain = {'name': 'ictce', 'version': '4.1.13'}
 
-source_urls = ['http://www.cpan.org/modules/by-module/XML/GRANTM/']
+source_urls = ['http://cpan.metacpan.org/authors/id/G/GR/GRANTM/']
 sources = [SOURCE_TAR_GZ]
 
 perl = 'Perl'


### PR DESCRIPTION
Old versions from www.cpan.org, and search.cpan.org are disappearing. They can be found on cpan.metacpan.org. This PR changes all the source_urls to cpan.metacpan.org. 
