### PR TITLE
make both GCC and Clang first-case citizens in Clang-based toolchains (as opposed to using ClangGCC)

### DIFF
--- a/easybuild/easyconfigs/c/cgmpich/cgmpich-1.1.6.eb
+++ b/easybuild/easyconfigs/c/cgmpich/cgmpich-1.1.6.eb
@@ -9,17 +9,13 @@ description = """Clang and GFortran based compiler toolchain,
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-compname = 'ClangGCC'
-compver = '1.1.3'
-comp = (compname, compver)
-
-mpilib = 'MPICH'
-mpiver = '3.0.3'
+comp = ('GCC', '4.7.3')
 
 # compiler toolchain dependencies
 dependencies = [
     comp,
-    (mpilib, mpiver, '', comp),
+    ('Clang', '3.2', '', comp),
+    ('MPICH', '3.0.3', '', ('ClangGCC', '1.1.3')),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/cgmpolf/cgmpolf-1.1.6.eb
+++ b/easybuild/easyconfigs/c/cgmpolf/cgmpolf-1.1.6.eb
@@ -9,9 +9,7 @@ description = """Clang and GFortran based compiler toolchain,
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-comp_name = 'ClangGCC'
-comp_version = '1.1.3'
-comp = (comp_name, comp_version)
+comp = ('GCC', '4.7.3')
 
 blaslib = 'OpenBLAS'
 blasver = '0.2.6'
@@ -28,7 +26,8 @@ comp_mpi_tc = (comp_mpi_tc_name, comp_mpi_tc_ver)
 # because of toolchain definition being verified against list of modules.
 dependencies = [
     comp,
-    ('MPICH', '3.0.3', '', comp),  # part of cgmpich-1.1.6
+    ('Clang', '3.2', '', comp),
+    ('MPICH', '3.0.3', '', ('ClangGCC', '1.1.3')),  # part of cgmpich-1.1.6
     (blaslib, blasver, blassuff, comp_mpi_tc),
     ('FFTW', '3.3.3', '', comp_mpi_tc),
     ('ScaLAPACK', '2.0.2', blas, comp_mpi_tc),

--- a/easybuild/easyconfigs/c/cgmvapich2/cgmvapich2-1.1.12rc1.eb
+++ b/easybuild/easyconfigs/c/cgmvapich2/cgmvapich2-1.1.12rc1.eb
@@ -9,17 +9,13 @@ description = """Clang and GFortran based compiler toolchain,
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-compname = 'ClangGCC'
-compver = '1.1.3'
-comp = (compname, compver)
-
-mpilib = 'MVAPICH2'
-mpiver = '1.9rc1'
+comp = ('GCC', '4.7.3')
 
 # Compiler toolchain dependencies.
 dependencies = [
     comp,
-    (mpilib, mpiver, '', comp),
+    ('Clang', '3.2', '', comp),
+    ('MVAPICH2', '1.9rc1', '', ('ClangGCC', '1.1.3')),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/cgmvapich2/cgmvapich2-1.2.7.eb
+++ b/easybuild/easyconfigs/c/cgmvapich2/cgmvapich2-1.2.7.eb
@@ -9,15 +9,13 @@ description = """Clang and GFortran based compiler toolchain,
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-comp = ('ClangGCC', '1.2.3')
-
-mpilib = 'MVAPICH2'
-mpiver = '1.9'
+comp = ('GCC', '4.8.1')
 
 # Compiler toolchain dependencies.
 dependencies = [
     comp,
-    (mpilib, mpiver, '', comp),
+    ('Clang', '3.3', '', comp),
+    ('MVAPICH2', '1.9', '', ('ClangGCC', '1.2.3')),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/cgmvolf/cgmvolf-1.1.12rc1.eb
+++ b/easybuild/easyconfigs/c/cgmvolf/cgmvolf-1.1.12rc1.eb
@@ -9,9 +9,7 @@ description = """Clang and GFortran based compiler toolchain,
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-comp_name = 'ClangGCC'
-comp_version = '1.1.3'
-comp = (comp_name, comp_version)
+comp = ('GCC', '4.7.3')
 
 blaslib = 'OpenBLAS'
 blasver = '0.2.6'
@@ -27,8 +25,9 @@ comp_mpi_tc = (comp_mpi_tc_name, comp_mpi_tc_ver)
 # We need ClangGCC and MVAPICH2 as explicit dependencies instead of cgmvapich2 toolchain
 # because of toolchain definition being verified against list of modules.
 dependencies = [
-    comp,
-    ('MVAPICH2', '1.9rc1', '', comp),  # part of cgmvapich2-1.1.12rc1
+    comp,  # part of cgmvapich2
+    ('Clang', '3.2', '', comp),  # part of cgmvapich2
+    ('MVAPICH2', '1.9rc1', '', ('ClangGCC', '1.1.3')),  # part of cgmvapich2
     (blaslib, blasver, blassuff, comp_mpi_tc),
     ('FFTW', '3.3.3', '', comp_mpi_tc),
     ('ScaLAPACK', '2.0.2', blas, comp_mpi_tc),

--- a/easybuild/easyconfigs/c/cgmvolf/cgmvolf-1.2.7.eb
+++ b/easybuild/easyconfigs/c/cgmvolf/cgmvolf-1.2.7.eb
@@ -9,7 +9,7 @@ description = """Clang and GFortran based compiler toolchain,
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-comp = ('ClangGCC', '1.2.3')
+comp = ('GCC', '4.8.1')
 
 blaslib = 'OpenBLAS'
 blasver = '0.2.6'
@@ -24,7 +24,8 @@ comp_mpi_tc = ('cgmvapich2', version)
 # because of toolchain definition being verified against list of modules.
 dependencies = [
     comp,  # part of cgmvapich2
-    ('MVAPICH2', '1.9', '', comp),  # part of cgmvapich2
+    ('Clang', '3.3', '', comp),  # part of cgmvapich2
+    ('MVAPICH2', '1.9', '', ('ClangGCC', '1.2.3')),  # part of cgmvapich2
     (blaslib, blasver, blassuff, comp_mpi_tc),
     ('FFTW', '3.3.3', '', comp_mpi_tc),
     ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc),

--- a/easybuild/easyconfigs/c/cgompi/cgompi-1.1.7.eb
+++ b/easybuild/easyconfigs/c/cgompi/cgompi-1.1.7.eb
@@ -9,17 +9,13 @@ description = """Clang and GFortran based compiler toolchain,
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-compname = 'ClangGCC'
-compver = '1.1.3'
-comp = (compname, compver)
-
-mpilib = 'OpenMPI'
-mpiver = '1.6.4'
+comp = ('GCC', '4.7.3')
 
 # compiler toolchain dependencies
 dependencies = [
     comp,
-    (mpilib, mpiver, '', comp),
+    ('Clang', '3.2', '', comp),
+    ('OpenMPI', '1.6.4', '', ('ClangGCC', '1.1.3')),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/cgoolf/cgoolf-1.1.7.eb
+++ b/easybuild/easyconfigs/c/cgoolf/cgoolf-1.1.7.eb
@@ -9,9 +9,7 @@ description = """Clang and GFortran based compiler toolchain,
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-comp_name = 'ClangGCC'
-comp_version = '1.1.3'
-comp = (comp_name, comp_version)
+comp = ('GCC', '4.7.3')
 
 blaslib = 'OpenBLAS'
 blasver = '0.2.6'
@@ -27,8 +25,9 @@ comp_mpi_tc = (comp_mpi_tc_name, comp_mpi_tc_ver)
 # We need ClangGCC and OpenMPI as explicit dependencies instead of cgompi toolchain
 # because of toolchain definition being verified against list of modules.
 dependencies = [
-    comp,
-    ('OpenMPI', '1.6.4', '', comp),  # part of cgompi-1.1.7
+    comp,  # part of cgompi
+    ('Clang', '3.2', '', comp),  # part of cgompi
+    ('OpenMPI', '1.6.4', '', ('ClangGCC', '1.1.3')),  # part of cgompi
     (blaslib, blasver, blassuff, comp_mpi_tc),
     ('FFTW', '3.3.3', '', comp_mpi_tc),
     ('ScaLAPACK', '2.0.2', blas, comp_mpi_tc),


### PR DESCRIPTION
required with https://github.com/hpcugent/easybuild-framework/pull/1053

This fixes the compatibility of the Clang-based toolchains with HierarchicalMNS.
