### PR TITLE
R ld library path fix

### DIFF
--- a/easybuild/easyconfigs/r/R/R-2.15.2-goalf-1.1.0-no-OFED-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-goalf-1.1.0-no-OFED-bare.eb
@@ -34,4 +34,8 @@ sanity_check_paths = {
     'dirs': []
 }
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/r/R/R-2.15.2-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-goalf-1.1.0-no-OFED.eb
@@ -139,4 +139,8 @@ exts_list = [
 
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10-bare.eb
@@ -34,4 +34,8 @@ sanity_check_paths = {
     'dirs': []
 }
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10.eb
@@ -138,4 +138,8 @@ exts_list = [
     ('gbm', '2.1', ext_options),
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.10.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.10.eb
@@ -138,4 +138,8 @@ exts_list = [
     ('gbm', '2.1', ext_options),
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.6-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.6-bare.eb
@@ -34,4 +34,8 @@ sanity_check_paths = {
     'dirs': []
 }
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.6.eb
@@ -138,4 +138,8 @@ exts_list = [
     ('gbm', '2.1', ext_options),
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0-bare.eb
@@ -34,4 +34,8 @@ sanity_check_paths = {
     'dirs': []
 }
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0.eb
@@ -138,4 +138,8 @@ exts_list = [
     ('gbm', '2.1', ext_options),
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-2.15.3-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-goalf-1.1.0-no-OFED.eb
@@ -143,4 +143,8 @@ exts_list = [
     ('gbm', '2.1', ext_options),
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-2.15.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-goolf-1.4.10.eb
@@ -143,4 +143,8 @@ exts_list = [
     ('gbm', '2.1', ext_options),
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-2.15.3-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-ictce-4.1.13.eb
@@ -143,4 +143,8 @@ exts_list = [
     ('gbm', '2.1', ext_options),
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-2.15.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-ictce-5.3.0.eb
@@ -143,4 +143,8 @@ exts_list = [
     ('gbm', '2.1', ext_options),
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.0.1-goalf-1.1.0-no-OFED-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.1-goalf-1.1.0-no-OFED-bare.eb
@@ -34,4 +34,8 @@ sanity_check_paths = {
     'dirs': []
 }
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.0.1-goolf-1.4.10-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.1-goolf-1.4.10-bare.eb
@@ -34,4 +34,8 @@ sanity_check_paths = {
     'dirs': []
 }
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.0.1-ictce-4.0.6-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.1-ictce-4.0.6-bare.eb
@@ -34,4 +34,8 @@ sanity_check_paths = {
     'dirs': []
 }
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.0.1-ictce-4.1.13-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.1-ictce-4.1.13-bare.eb
@@ -34,4 +34,8 @@ sanity_check_paths = {
     'dirs': []
 }
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.0.1-ictce-5.3.0-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.1-ictce-5.3.0-bare.eb
@@ -34,4 +34,8 @@ sanity_check_paths = {
     'dirs': []
 }
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.0.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-goolf-1.4.10.eb
@@ -169,4 +169,8 @@ exts_list = [
     ('pim', '1.1.5.4', rforge_options),
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0-bare.eb
@@ -33,4 +33,8 @@ sanity_check_paths = {
     'dirs': []
 }
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0.eb
@@ -168,4 +168,8 @@ exts_list = [
     ('pim', '1.1.5.4', rforge_options),
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.5.0.eb
@@ -168,4 +168,8 @@ exts_list = [
     ('pim', '1.1.5.4', rforge_options),
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.1.0-ictce-5.5.0-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.0-ictce-5.5.0-bare.eb
@@ -24,4 +24,8 @@ dependencies = [
 
 exts_list = []
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.1.0-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.0-ictce-5.5.0.eb
@@ -176,4 +176,8 @@ exts_list = [
     ('klaR', '0.6-11', ext_options),
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.2.5-bare-mt.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.2.5-bare-mt.eb
@@ -36,4 +36,8 @@ sanity_check_paths = {
     'dirs': []
 }
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.2.5-default-mt.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.2.5-default-mt.eb
@@ -67,4 +67,8 @@ exts_list = [
     'utils',
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.3.5-bare-mt.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.3.5-bare-mt.eb
@@ -36,4 +36,8 @@ sanity_check_paths = {
     'dirs': []
 }
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.3.5-default-mt.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.3.5-default-mt.eb
@@ -67,4 +67,8 @@ exts_list = [
     'utils',
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.1.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.1-intel-2014b.eb
@@ -309,4 +309,8 @@ exts_list = [
     ('klaR', '0.6-11', ext_options),
 ]
 
+modextrapaths = { 
+            'LD_LIBRARY_PATH': 'lib64/R/lib'
+}
+
 moduleclass = 'lang'


### PR DESCRIPTION
by default easybuild only adds $EBROOTR/lib64/ to LD_LIBRARY_PATH in R easyconfigs

some packages need $EBROOTR/lib64/R/lib in LD_LIBRARY_PATH to work correctly. As example, this one depends on this: https://github.com/hpcugent/easybuild-easyconfigs/pull/1149
