### PR TITLE
Removed unnecessary build dependencies for OpenMPI

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-GCC-4.8.2.eb
@@ -11,11 +11,6 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/d
 
 patches = ['OpenMPI-%(version)s-vt_cupti_events.patch']
 
-builddependencies = [
-    ('Automake', '1.14'),
-    ('Autoconf', '2.69'),
-]
-
 dependencies = [('hwloc', '1.7.2')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-gcccuda-2.6.10.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-gcccuda-2.6.10.eb
@@ -11,11 +11,6 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/d
 
 patches = ['OpenMPI-%(version)s-vt_cupti_events.patch']
 
-builddependencies = [
-    ('Automake', '1.14'),
-    ('Autoconf', '2.69'),
-]
-
 dependencies = [('hwloc', '1.8')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '


### PR DESCRIPTION
Some cleanup: When building OpenMPI from a release tarball, Autoconf/Automake are not necessary. Both the gompi and gompic toolchains build successfully without specifying Autoconf/Automake as build dependencies for OpenMPI.
