### PR TITLE
{lang} [ictce 7.3.5] Python 2.7.9 and 2.7.10 (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-7.3.5.eb
@@ -1,0 +1,18 @@
+# Author: Maxime Schmitt <maxime.schmitt@telecom-bretagne.eu>, Université du Luxembourg
+#
+
+name = 'bzip2'
+version = '1.0.6'
+
+homepage = 'http://www.bzip.org/'
+description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
+ compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
+ compressors), whilst being around twice as fast at compression and six times faster at decompression."""
+
+toolchain = {'name': 'ictce', 'version': '7.3.5'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://www.bzip.org/%(version)s']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-7.3.5.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'libreadline'
+version = '6.3'
+
+homepage = 'http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html'
+description = """The GNU Readline library provides a set of functions for use by applications that
+ allow users to edit command lines as they are typed in. Both Emacs and vi editing modes are available.
+ The Readline library includes additional functions to maintain a list of previously-entered command lines,
+ to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
+
+toolchain = {'name': 'ictce', 'version': '7.3.5'}
+toolchainopts = {'pic': True}
+
+sources = ['readline-%(version)s.tar.gz']
+source_urls = ['http://ftp.gnu.org/gnu/readline']
+
+preconfigopts = " LDFLAGS='-ltinfo' "
+
+dependencies = [('ncurses', '5.9')]
+
+sanity_check_paths = {
+    'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
+              ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',
+                                                   'rlstdc.h', 'rltypedefs.h', 'tilde.h']],
+    'dirs' : [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9-ictce-7.3.5.eb
@@ -1,0 +1,15 @@
+name = 'ncurses'
+version = '5.9'
+
+homepage = 'http://www.gnu.org/software/ncurses/'
+description = """The Ncurses (new curses) library is a free software emulation of curses in System V Release 4.0,
+ and more. It uses Terminfo format, supports pads and color and multiple highlights and forms characters and
+ function-key mapping, and has all the other SYSV-curses enhancements over BSD Curses."""
+
+toolchain = {'name': 'ictce', 'version': '7.3.5'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.4.10.eb
@@ -41,6 +41,9 @@ exts_list = [
     }),
     ('numpy', '1.9.2', {
         'source_urls': ['https://pypi.python.org/packages/source/n/numpy/'],
+        'patches': [
+                'numpy-1.8.0-mkl.patch',
+        ], 
     }),
     ('scipy', '0.15.1', {
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy/'],
@@ -111,9 +114,6 @@ exts_list = [
     }),
     ('pandas', '0.16.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
-    }),
-    ('matplotlib', '1.4.3', {
-         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.4.10.eb
@@ -16,7 +16,7 @@ sources = [SOURCE_TGZ]
 # python needs bzip2 to build the bz2 package
 dependencies = [
     ('bzip2', '1.0.6'),
-    ('zlib', '1.2.8'),
+    ('zlib', '1.2.7'),
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.4.10.eb
@@ -1,0 +1,120 @@
+# Authors: Sarah Diehl <sarah.diehl@uni.lu>, Université du Luxembourg
+#
+
+name = 'Python'
+version = '2.7.10'
+
+homepage = 'http://python.org/'
+description = "Python is a programming language that lets you work more quickly and integrate your systems more effectively."
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('libreadline', '6.2'),
+    ('ncurses', '5.9'),
+    ('SQLite', '3.8.10.2'),
+    ('Tk', '8.5.12'),
+#   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
+#   nice to have an up to date openssl for security reasons
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# order is important!
+# package versions updated Jun 8th 2015
+exts_list = [
+    ('setuptools', '17.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+    }),
+    ('pip', '7.0.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+    }),
+    ('numpy', '1.9.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/numpy/'],
+    }),
+    ('scipy', '0.15.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/scipy/'],
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+    }),
+    ('mpi4py', '1.3.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mpi4py/'],
+    }),
+    ('paycheck', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+    }),
+    ('argparse', '1.3.0', {
+        'source_urls': ['http://pypi.python.org/packages/source/a/argparse/'],
+    }),
+    ('pbr', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+    }),
+    ('lockfile', '0.10.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
+    }),
+    ('Cython', '0.22', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+    }),
+    ('six', '1.9.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+    }),
+    ('dateutil', '2.4.2', {
+        'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+    }),
+    ('deap', '1.0.2', {
+        'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+    }),
+    ('decorator', '3.4.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+    }),
+    ('arff', '2.0.2', {
+        'source_tmpl': 'liac-%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+    }),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+    }),
+    ('paramiko', '1.15.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+    }),
+    ('pyparsing', '2.0.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+    }),
+    ('netifaces', '0.10.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+    }),
+    ('netaddr', '0.7.14', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+    }),
+    ('mock', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
+    }),
+    ('pytz', '2015.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
+    }),
+    ('pandas', '0.16.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+    }),
+    ('matplotlib', '1.4.3', {
+         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-ictce-7.3.5-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-ictce-7.3.5-bare.eb
@@ -1,0 +1,30 @@
+# Author: Maxime Schmitt <maxime.schmitt@telecom-bretagne.eu>, Université du Luxembourg
+#
+
+name = 'Python'
+version = '2.7.10'
+versionsuffix = '-bare'
+
+homepage = 'http://python.org/'
+description = "Python is a programming language that lets you work more quickly and integrate your systems more effectively."
+
+toolchain = {'name': 'ictce', 'version': '7.3.5'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('libreadline', '6.3'),
+    ('ncurses', '5.9'),
+    ('SQLite', '3.8.8.1'),
+#   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
+#   nice to have an up to date openssl for security reasons
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-ictce-7.3.5.eb
@@ -1,0 +1,119 @@
+# Author: Maxime Schmitt <maxime.schmitt@telecom-bretagne.eu>, Université du Luxembourg
+#
+
+name = 'Python'
+version = '2.7.10'
+
+homepage = 'http://python.org/'
+description = "Python is a programming language that lets you work more quickly and integrate your systems more effectively."
+
+toolchain = {'name': 'ictce', 'version': '7.3.5'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('libreadline', '6.3'),
+    ('ncurses', '5.9'),
+    ('SQLite', '3.8.8.1'),
+#   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
+#   nice to have an up to date openssl for security reasons
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# order is important!
+# package versions updated Jun 8th 2015
+exts_list = [
+    ('setuptools', '17.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+    }),
+    ('pip', '7.0.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+    }),
+    ('numpy', '1.9.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/numpy/'],
+    }),
+    ('scipy', '0.15.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/scipy/'],
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+    }),
+    ('mpi4py', '1.3.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mpi4py/'],
+    }),
+    ('paycheck', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+    }),
+    ('argparse', '1.3.0', {
+        'source_urls': ['http://pypi.python.org/packages/source/a/argparse/'],
+    }),
+    ('pbr', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+    }),
+    ('lockfile', '0.10.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
+    }),
+    ('Cython', '0.22', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+    }),
+    ('six', '1.9.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+    }),
+    ('dateutil', '2.4.2', {
+        'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+    }),
+    ('deap', '1.0.2', {
+        'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+    }),
+    ('decorator', '3.4.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+    }),
+    ('arff', '2.0.2', {
+        'source_tmpl': 'liac-%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+    }),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+    }),
+    ('paramiko', '1.15.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+    }),
+    ('pyparsing', '2.0.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+    }),
+    ('netifaces', '0.10.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+    }),
+    ('netaddr', '0.7.14', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+    }),
+    ('mock', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
+    }),
+    ('pytz', '2015.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
+    }),
+    ('pandas', '0.16.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+    }),
+    ('matplotlib', '1.4.3', {
+         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-ictce-7.3.5.eb
@@ -40,6 +40,9 @@ exts_list = [
     }),
     ('numpy', '1.9.2', {
         'source_urls': ['https://pypi.python.org/packages/source/n/numpy/'],
+        'patches': [
+                'numpy-1.8.0-mkl.patch',
+        ], 
     }),
     ('scipy', '0.15.1', {
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy/'],
@@ -110,9 +113,6 @@ exts_list = [
     }),
     ('pandas', '0.16.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
-    }),
-    ('matplotlib', '1.4.3', {
-         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-ictce-7.3.5.eb
@@ -66,7 +66,7 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
     }),
     ('Cython', '0.22', {
-        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+        'source_urls': ['https://pypi.python.org/packages/source/C/Cython/'],
     }),
     ('six', '1.9.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-ictce-7.3.5-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-ictce-7.3.5-bare.eb
@@ -1,0 +1,30 @@
+# Author: Maxime Schmitt <maxime.schmitt@telecom-bretagne.eu>, Université du Luxembourg
+#
+
+name = 'Python'
+version = '2.7.9'
+versionsuffix = '-bare'
+
+homepage = 'http://python.org/'
+description = "Python is a programming language that lets you work more quickly and integrate your systems more effectively."
+
+toolchain = {'name': 'ictce', 'version': '7.3.5'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('libreadline', '6.3'),
+    ('ncurses', '5.9'),
+    ('SQLite', '3.8.8.1'),
+#   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
+#   nice to have an up to date openssl for security reasons
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-ictce-7.3.5.eb
@@ -1,0 +1,119 @@
+# Author: Maxime Schmitt <maxime.schmitt@telecom-bretagne.eu>, Université du Luxembourg
+#
+
+name = 'Python'
+version = '2.7.9'
+
+homepage = 'http://python.org/'
+description = "Python is a programming language that lets you work more quickly and integrate your systems more effectively."
+
+toolchain = {'name': 'ictce', 'version': '7.3.5'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('libreadline', '6.3'),
+    ('ncurses', '5.9'),
+    ('SQLite', '3.8.8.1'),
+#   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
+#   nice to have an up to date openssl for security reasons
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# order is important!
+# package versions updated Jun 8th 2015
+exts_list = [
+    ('setuptools', '17.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+    }),
+    ('pip', '7.0.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+    }),
+    ('numpy', '1.9.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/numpy/'],
+    }),
+    ('scipy', '0.15.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/scipy/'],
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+    }),
+    ('mpi4py', '1.3.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mpi4py/'],
+    }),
+    ('paycheck', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+    }),
+    ('argparse', '1.3.0', {
+        'source_urls': ['http://pypi.python.org/packages/source/a/argparse/'],
+    }),
+    ('pbr', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+    }),
+    ('lockfile', '0.10.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
+    }),
+    ('Cython', '0.22', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+    }),
+    ('six', '1.9.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+    }),
+    ('dateutil', '2.4.2', {
+        'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+    }),
+    ('deap', '1.0.2', {
+        'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+    }),
+    ('decorator', '3.4.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+    }),
+    ('arff', '2.0.2', {
+        'source_tmpl': 'liac-%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+    }),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+    }),
+    ('paramiko', '1.15.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+    }),
+    ('pyparsing', '2.0.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+    }),
+    ('netifaces', '0.10.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+    }),
+    ('netaddr', '0.7.14', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+    }),
+    ('mock', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
+    }),
+    ('pytz', '2015.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
+    }),
+    ('pandas', '0.16.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+    }),
+    ('matplotlib', '1.4.3', {
+         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-ictce-7.3.5.eb
@@ -66,7 +66,7 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
     }),
     ('Cython', '0.22', {
-        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+        'source_urls': ['https://pypi.python.org/packages/source/C/Cython/'],
     }),
     ('six', '1.9.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-ictce-7.3.5.eb
@@ -40,6 +40,9 @@ exts_list = [
     }),
     ('numpy', '1.9.2', {
         'source_urls': ['https://pypi.python.org/packages/source/n/numpy/'],
+        'patches': [
+                'numpy-1.8.0-mkl.patch',
+        ],
     }),
     ('scipy', '0.15.1', {
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy/'],
@@ -110,9 +113,6 @@ exts_list = [
     }),
     ('pandas', '0.16.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
-    }),
-    ('matplotlib', '1.4.3', {
-         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
     }),
 ]
 

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-goolf-1.4.10.eb
@@ -1,0 +1,40 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'SQLite'
+version = '3.8.10.2'
+
+homepage = 'http://www.sqlite.org/'
+description = 'SQLite: SQL Database Engine in a C Library'
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+# eg. http://www.sqlite.org/2014/sqlite-autoconf-3080600.tar.gz
+source_urls = ['http://www.sqlite.org/2015/']
+version_str = '%(version_major)s' + ''.join('%02d' % int(x) for x in version.split('.')[1:])
+sources = ['sqlite-autoconf-%s.tar.gz' % version_str]
+
+dependencies = [
+    ('libreadline', '6.2'),
+    ('Tcl', '8.5.12'),
+]
+
+parallel = 1
+
+sanity_check_paths = {
+    'files': ['bin/sqlite3', 'include/sqlite3ext.h', 'include/sqlite3.h', 'lib/libsqlite3.a', 'lib/libsqlite3.so'],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-ictce-7.3.5.eb
@@ -1,0 +1,36 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Maxime Schmitt <maxime.schmitt@telecom-bretagne.eu>, Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'SQLite'
+version = '3.8.8.1'
+
+homepage = 'http://www.sqlite.org/'
+description = 'SQLite: SQL Database Engine in a C Library'
+
+toolchain = {'name': 'ictce', 'version': '7.3.5'}
+
+# eg. http://www.sqlite.org/2014/sqlite-autoconf-3080600.tar.gz
+source_urls = ['http://www.sqlite.org/2015/']
+version_str = '%(version_major)s' + ''.join('%02d' % int(x) for x in version.split('.')[1:])
+sources = ['sqlite-autoconf-%s.tar.gz' % version_str]
+
+dependencies = [
+    ('libreadline', '6.3'),
+    ('Tcl', '8.6.3'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/sqlite3'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.3-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.3-ictce-7.3.5.eb
@@ -1,0 +1,28 @@
+# Author: Maxime Schmitt <maxime.schmitt@telecom-bretagne.eu>, Université du Luxembourg
+#
+
+easyblock = 'ConfigureMake'
+
+name = 'Tcl'
+version = '8.6.3'
+
+homepage = 'http://www.tcl.tk/'
+description = """Tcl (Tool Command Language) is a very powerful but easy to learn dynamic programming language,
+suitable for a very wide range of uses, including web and desktop applications, networking, administration, testing and many more."""
+
+toolchain = {'name': 'ictce', 'version': '7.3.5'}
+
+source_urls = ["http://prdownloads.sourceforge.net/tcl"]
+sources = ['%(namelower)s%(version)s-src.tar.gz']
+
+dependencies = [ 
+    ('zlib', '1.2.8'),
+]
+
+configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
+
+runtest = 'test'
+
+start_dir = 'unix'
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.8-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.8-ictce-7.3.5.eb
@@ -1,0 +1,22 @@
+easyblock = 'ConfigureMake'
+
+name = 'zlib'
+version = '1.2.8'
+
+homepage = 'http://www.zlib.net/'
+description = """zlib is designed to be a free, general-purpose, legally unencumbered -- that is, 
+ not covered by any patents -- lossless data-compression library for use on virtually any 
+ computer hardware and operating system."""
+
+toolchain = {'name': 'ictce', 'version': '7.3.5'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [('http://sourceforge.net/projects/libpng/files/zlib/%s' % version, 'download')]
+
+sanity_check_paths = {
+    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a', 'lib/libz.so'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
Hi, here are the easyconfigs to build Python 2.7.9 with ictce 7.3.5 and Python 2.7.10 with ictce 7.3.5 and goolf 1.4.10 with their dependencies.

I aggregated all the versions in a single PR since I think that if there are changes needed they would be the same for all of them considering how close they are.

There are some dependencies that are from another pending PR: #1649 
