### PR TITLE
{chem}[intel-2015a] Quantum espresso 5.2.0 (MPI and Hybrid versions)

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.2.0-intel-2015a-hybrid.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.2.0-intel-2015a-hybrid.eb
@@ -4,6 +4,7 @@
 # # New Zealand eScience Infrastructure (NeSI)
 name = 'QuantumESPRESSO'
 version = "5.2.0"
+versionsuffix = '-hybrid'
 
 homepage = 'http://www.pwscf.org/'
 description = """Quantum ESPRESSO  is an integrated suite of computer codes
@@ -12,7 +13,7 @@ description = """Quantum ESPRESSO  is an integrated suite of computer codes
   (both norm-conserving and ultrasoft)."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
-toolchainopts = {'usempi': True}
+toolchainopts = {'usempi': True, 'openmp': True}
 
 # This EB file only contains the Complete QE distribution.
 # In order to install external packages like Yambo, SaX, plumed, add them in sources and buildopts
@@ -56,5 +57,8 @@ parallel = 1
 # In order to extend QE with external packages, extend buildopts
 # buildopts = 'all w90 want yambo plumed gipaw xspectra'
 buildopts = 'all'
+
+# hybrid build (enable OpenMP)
+hybrid = True
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.2.0-intel-2015a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.2.0-intel-2015a.eb
@@ -1,0 +1,52 @@
+name = 'QuantumESPRESSO'
+version = "5.2.0"
+
+homepage = 'http://www.pwscf.org/'
+description = """Quantum ESPRESSO  is an integrated suite of computer codes
+ for electronic-structure calculations and materials modeling at the nanoscale.
+ It is based on density-functional theory, plane waves, and pseudopotentials
+  (both norm-conserving and ultrasoft)."""
+
+toolchain = {'name': 'intel', 'version': '2015a'}
+toolchainopts = {'usempi': True}
+
+# major part of this list was determined from espresso-%(version)s/install/plugins_list
+sources = [
+    'espresso-%(version)s.tar.gz',
+    'xspectra-%(version)s.tar.gz',
+    'PWgui-%(version)s.tar.gz',
+    'pwcond-%(version)s.tar.gz',
+    'PHonon-%(version)s.tar.gz',
+    'neb-%(version)s.tar.gz',
+    'GWW-%(version)s.tar.gz',
+    'tddfpt-%(version)s.tar.gz',
+    'atomic-%(version)s.tar.gz',
+]
+
+missing_sources = [
+    'wannier90-1.2.tar.gz',
+    'plumed-1.3-qe.tar.gz',
+    'want-2.5.0-base.tar.gz',
+    'yambo-4.0.1-rev.89.zip',
+    'qe-gipaw-5.1.tar.gz',
+    'SaX-2.0.2.tar.gz',
+]
+
+source_urls = [
+    'http://files.qe-forge.org/index.php?file=',  # others
+]
+
+#patches = [
+#    'yambo-3.2.5_fix-objects-files.patch',
+#    'QuantumESPRESSO-%(version)s_yambo-fftw.patch',
+#]
+
+# gipaw excluded, because v5.0 isn't stable
+# xspectra v%(version)s is nowhere to be found
+#buildopts = 'all w90 want yambo plumed gipaw xspectra'
+buildopts = 'all'
+
+# parallel build tends to fail
+parallel = 1
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.2.0-intel-2015a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.2.0-intel-2015a.eb
@@ -1,3 +1,7 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# # Author: Jordi Blasco <jordi.blasco@nesi.org.nz>
+# # New Zealand eScience Infrastructure (NeSI)
 name = 'QuantumESPRESSO'
 version = "5.2.0"
 
@@ -10,7 +14,8 @@ description = """Quantum ESPRESSO  is an integrated suite of computer codes
 toolchain = {'name': 'intel', 'version': '2015a'}
 toolchainopts = {'usempi': True}
 
-# major part of this list was determined from espresso-%(version)s/install/plugins_list
+# This EB file only contains the Complete QE distribution.
+# In order to install external packages like Yambo, SaX, plumed, add them in sources and buildopts
 sources = [
     'espresso-%(version)s.tar.gz',
     'xspectra-%(version)s.tar.gz',
@@ -27,23 +32,26 @@ missing_sources = [
     'wannier90-1.2.tar.gz',
     'plumed-1.3-qe.tar.gz',
     'want-2.5.0-base.tar.gz',
-    'yambo-4.0.1-rev.89.zip',
+    'yambo-3.4.1-rev.64.zip',
     'qe-gipaw-5.1.tar.gz',
     'SaX-2.0.2.tar.gz',
 ]
 
 source_urls = [
+    'http://www.qe-forge.org/gf/download/frsrelease/195/806/',
+    'http://www.qe-forge.org/gf/download/frsrelease/195/805/',
+    'http://www.qe-forge.org/gf/download/frsrelease/195/804/',
+    'http://www.qe-forge.org/gf/download/frsrelease/195/803/',
+    'http://www.qe-forge.org/gf/download/frsrelease/195/802/',
+    'http://www.qe-forge.org/gf/download/frsrelease/195/800/',
+    'http://www.qe-forge.org/gf/download/frsrelease/195/799/',
+    'http://www.qe-forge.org/gf/download/frsrelease/195/798/',
+    'http://www.qe-forge.org/gf/download/frsrelease/195/797/',
     'http://files.qe-forge.org/index.php?file=',  # others
 ]
 
-#patches = [
-#    'yambo-3.2.5_fix-objects-files.patch',
-#    'QuantumESPRESSO-%(version)s_yambo-fftw.patch',
-#]
-
-# gipaw excluded, because v5.0 isn't stable
-# xspectra v%(version)s is nowhere to be found
-#buildopts = 'all w90 want yambo plumed gipaw xspectra'
+# In order to extend QE with external packages, extend buildopts
+# buildopts = 'all w90 want yambo plumed gipaw xspectra'
 buildopts = 'all'
 
 # parallel build tends to fail


### PR DESCRIPTION
This EB file only contains the Complete QE distribution. In order to install external packages like Yambo, SaX, plumed, add them in sources and buildopts.
