### PR TITLE
{chem}[intel/2015a] Octopus 4.1.2

### DIFF
--- a/easybuild/easyconfigs/e/ETSF_IO/ETSF_IO-1.0.4-intel-2015a.eb
+++ b/easybuild/easyconfigs/e/ETSF_IO/ETSF_IO-1.0.4-intel-2015a.eb
@@ -1,0 +1,32 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Jordi Blasco <jordi.blasco@nesi.org.nz>
+# New Zealand eScience Infrastructure (NeSI)
+easyblock = 'ConfigureMake'
+
+name = 'ETSF_IO'
+version = '1.0.4'
+
+homepage = 'http://www.etsf.eu/resources/software/libraries_and_tools'
+description = """A library of F90 routines to read/write the ETSF file 
+format has been written. It is called ETSF_IO and available under LGPL. """
+
+toolchain = {'name': 'intel', 'version': '2015a'}
+
+source_urls = ['http://www.etsf.eu/system/files']
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = "FC=$MPIF90 CC=$MPICC --with-netcdf-libs='-L$EBROOTNETCDF/lib -L$EBROOTNETCDFMINFORTRAN/lib -lnetcdf -lnetcdff' "
+configopts += "--with-netcdf-incs='-I$EBROOTNETCDF/include -I$EBROOTNETCDFMINFORTRAN/include' "
+
+dependencies = [ 
+    ('netCDF', '4.3.2'),
+    ('netCDF-Fortran', '4.4.0'),
+]
+
+sanity_check_paths = {
+    'files': ["bin/etsf_io"], 
+    'dirs': []
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxc/libxc-2.1.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.1.2-intel-2015a.eb
@@ -1,0 +1,36 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Jordi Blasco <jordi.blasco@nesi.org.nz>
+# New Zealand eScience Infrastructure (NeSI)
+easyblock = 'ConfigureMake'
+
+name = 'libxc'
+version = '2.1.2'
+
+homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
+ The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
+
+toolchain = {'name': 'intel', 'version': '2015a'}
+toolchainopts = {'opt': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+
+configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared'
+
+# From the libxc mailing list
+# To summarize: expect less tests to fail in libxc 2.0.2, but don't expect
+# a fully working testsuite soon (unless someone wants to volunteer to do
+# it, of course  ) In the meantime, unless the majority of the tests
+# fail, your build should be fine.
+#runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['lib/libxc.a', 'lib/libxc.so'],
+    'dirs': ['include'],
+}
+
+parallel = 1
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/m/METIS/METIS-5.1.0-intel-2015a.eb
+++ b/easybuild/easyconfigs/m/METIS/METIS-5.1.0-intel-2015a.eb
@@ -17,6 +17,6 @@ source_urls = [
 
 patches = ['METIS_IDXTYPEWIDTH.patch']
 
-builddependencies = [('CMake', '3.2.1')]
+builddependencies = [('CMake', '3.0.0')]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/n/netCDF-Fortran/netCDF-Fortran-4.4.0-intel-2015a.eb
+++ b/easybuild/easyconfigs/n/netCDF-Fortran/netCDF-Fortran-4.4.0-intel-2015a.eb
@@ -10,7 +10,7 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.unidata.ucar.edu/downloads/netcdf/ftp/']
+source_urls = ['ftp://ftp.unidata.ucar.edu/pub/netcdf/old/']
 
 dependencies = [('netCDF', '4.3.2')]
 

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.3.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.3.2-intel-2015a.eb
@@ -10,7 +10,7 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 toolchainopts = {'pic': True, 'usempi': True}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.unidata.ucar.edu/downloads/netcdf/ftp/']
+source_urls = ['ftp://ftp.unidata.ucar.edu/pub/netcdf/old/']
 
 patches = [
     'netCDF-4.3.2-with-HDF-1.8.13.patch',

--- a/easybuild/easyconfigs/o/octopus/octopus-4.1.2-intel-2015a-hybrid.eb
+++ b/easybuild/easyconfigs/o/octopus/octopus-4.1.2-intel-2015a-hybrid.eb
@@ -1,0 +1,57 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Jordi Blasco <jordi.blasco@nesi.org.nz>
+# New Zealand eScience Infrastructure (NeSI)
+easyblock = 'ConfigureMake'
+
+name = 'octopus'
+version = '4.1.2'
+versionsuffix = '-hybrid'
+
+homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Main_Page'
+description = """Octopus is a scientific program aimed at the ab initio virtual experimentation 
+on a hopefully ever-increasing range of system types. Electrons are described quantum-mechanically 
+within density-functional theory (DFT), in its time-dependent form (TDDFT) when doing simulations 
+in time. Nuclei are described classically as point particles. 
+Electron-nucleus interaction is described within the pseudopotential approximation."""
+
+toolchain = {'name': 'intel', 'version': '2015a'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+sources = ['octopus-%(version)s.tar.gz']
+source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=%(version)s/' ]
+
+dependencies = [
+    ('PFFT', '20150317'),
+    ('libxc', '2.1.2'),
+    ('netCDF', '4.3.2'),
+    ('netCDF-Fortran', '4.4.0'),
+    ('GSL', '1.16'),
+    ('ETSF_IO', '1.0.4'),
+    ('ParMETIS', '4.0.3'),
+    ('METIS', '5.1.0'),
+]
+
+#The standard Easybuild FCFLAGS doesn't work in this case for Intel Toolchain.
+configopts = "FC=$MPIF90 FCFLAGS='-O3 -xHost -openmp -ip -prec-div -static-intel -sox -I$MKLROOT/include' "
+configopts = "CFLAGS='-O3 -xHost -openmp -ip -prec-div -static-intel -sox -I$MKLROOT/include' "
+configopts += "--enable-openmp --enable-mpi --enable-newuoa --disable-python --disable-gdlib --with-fft=fftw3 --with-pfft-prefix=$EBROOTPFFT "
+configopts += "--with-gsl-prefix=$EBROOTGSL --with-etsf-io-prefix=$EBROOTETSF_IO "
+configopts += "--with-libxc-prefix=$EBROOTLIBXC --with-gsl-prefix=$EBROOTGSL "
+configopts += "--with-metis-prefix=$EBROOTMETIS --with-parmetis-prefix=$EBROOTPARMETIS "
+configopts += "LIBS_FFT='-Wl,--start-group -L$EBROOTPFFT/lib -L$EBROOTFFTW/lib -lpfft -lfftw3 -lfftw3_mpi -Wl,--end-group' "
+configopts += "LIBS_BLAS='-L$SCALAPACK_LIB_DIR -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -lmkl_blacs_intelmpi_lp64 -lpthread -lm' "
+# The configure script it doesn't accept the standard and suggested Intel MKL link options 
+#configopts += "LIBS_BLAS='-L$SCALAPACK_LIB_DIR $EBVARLIBLAPACK' "
+
+sanity_check_paths = {
+    'files': ["bin/octopus_mpi"], 
+    'dirs': []
+}
+
+runtest = 'installcheck' 
+
+# hybrid build (enable OpenMP)
+hybrid = True
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/o/octopus/octopus-4.1.2-intel-2015a-mpi.eb
+++ b/easybuild/easyconfigs/o/octopus/octopus-4.1.2-intel-2015a-mpi.eb
@@ -6,7 +6,7 @@ easyblock = 'ConfigureMake'
 
 name = 'octopus'
 version = '4.1.2'
-versionsuffix = '-hybrid'
+versionsuffix = '-mpi'
 
 homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Main_Page'
 description = """Octopus is a scientific program aimed at the ab initio virtual experimentation 
@@ -16,7 +16,7 @@ in time. Nuclei are described classically as point particles.
 Electron-nucleus interaction is described within the pseudopotential approximation."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
-toolchainopts = {'usempi': True, 'openmp': True, 'opt': True}
+toolchainopts = {'usempi': True, 'opt': True}
 
 sources = ['octopus-%(version)s.tar.gz']
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=%(version)s/' ]
@@ -33,14 +33,14 @@ dependencies = [
 ]
 
 #The standard Easybuild FCFLAGS doesn't work in this case for Intel Toolchain.
-configopts = "FC=$MPIF90 FCFLAGS='-O3 -xHost -openmp -ip -prec-div -static-intel -sox -I$MKLROOT/include' "
-configopts += "CFLAGS='-O3 -xHost -openmp -ip -prec-div -static-intel -sox -I$MKLROOT/include' "
-configopts += "--enable-openmp --enable-mpi --enable-newuoa --disable-python --disable-gdlib --with-fft=fftw3 --with-pfft-prefix=$EBROOTPFFT "
+configopts = "FC=$MPIF90 FCFLAGS='-O3 -xHost -ip -prec-div -static-intel -sox -I$MKLROOT/include' "
+configopts += "CFLAGS='-O3 -xHost -ip -prec-div -static-intel -sox -I$MKLROOT/include' "
+configopts += "--disable-openmp --enable-mpi --enable-newuoa --disable-python --disable-gdlib --with-fft=fftw3 --with-pfft-prefix=$EBROOTPFFT "
 configopts += "--with-gsl-prefix=$EBROOTGSL --with-etsf-io-prefix=$EBROOTETSF_IO "
 configopts += "--with-libxc-prefix=$EBROOTLIBXC --with-gsl-prefix=$EBROOTGSL "
 configopts += "--with-metis-prefix=$EBROOTMETIS --with-parmetis-prefix=$EBROOTPARMETIS "
 configopts += "LIBS_FFT='-Wl,--start-group -L$EBROOTPFFT/lib -L$EBROOTFFTW/lib -lpfft -lfftw3 -lfftw3_mpi -Wl,--end-group' "
-configopts += "LIBS_BLAS='-L$SCALAPACK_LIB_DIR -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -lmkl_blacs_intelmpi_lp64 -lpthread -lm' "
+configopts += "LIBS_BLAS='-L$SCALAPACK_LIB_DIR -lmkl_scalapack_lp64 -lmkl_blacs_intelmpi_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core' "
 # The configure script it doesn't accept the standard and suggested Intel MKL link options 
 #configopts += "LIBS_BLAS='-L$SCALAPACK_LIB_DIR $EBVARLIBLAPACK' "
 
@@ -50,8 +50,5 @@ sanity_check_paths = {
 }
 
 runtest = 'installcheck' 
-
-# hybrid build (enable OpenMP)
-hybrid = True
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/o/octopus/octopus-4.1.2-intel-2015a-smp.eb
+++ b/easybuild/easyconfigs/o/octopus/octopus-4.1.2-intel-2015a-smp.eb
@@ -6,7 +6,7 @@ easyblock = 'ConfigureMake'
 
 name = 'octopus'
 version = '4.1.2'
-versionsuffix = '-hybrid'
+versionsuffix = '-smp'
 
 homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Main_Page'
 description = """Octopus is a scientific program aimed at the ab initio virtual experimentation 
@@ -16,7 +16,7 @@ in time. Nuclei are described classically as point particles.
 Electron-nucleus interaction is described within the pseudopotential approximation."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
-toolchainopts = {'usempi': True, 'openmp': True, 'opt': True}
+toolchainopts = {'usempi': False, 'openmp': True, 'opt': True}
 
 sources = ['octopus-%(version)s.tar.gz']
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=%(version)s/' ]
@@ -28,30 +28,26 @@ dependencies = [
     ('netCDF-Fortran', '4.4.0'),
     ('GSL', '1.16'),
     ('ETSF_IO', '1.0.4'),
-    ('ParMETIS', '4.0.3'),
     ('METIS', '5.1.0'),
 ]
 
 #The standard Easybuild FCFLAGS doesn't work in this case for Intel Toolchain.
-configopts = "FC=$MPIF90 FCFLAGS='-O3 -xHost -openmp -ip -prec-div -static-intel -sox -I$MKLROOT/include' "
+configopts = "FC=$F90 FCFLAGS='-O3 -xHost -openmp -ip -prec-div -static-intel -sox -I$MKLROOT/include' "
 configopts += "CFLAGS='-O3 -xHost -openmp -ip -prec-div -static-intel -sox -I$MKLROOT/include' "
-configopts += "--enable-openmp --enable-mpi --enable-newuoa --disable-python --disable-gdlib --with-fft=fftw3 --with-pfft-prefix=$EBROOTPFFT "
+configopts += "--enable-openmp --disable-mpi --enable-newuoa --disable-python --disable-gdlib --with-fft=fftw3 --with-pfft-prefix=$EBROOTPFFT "
 configopts += "--with-gsl-prefix=$EBROOTGSL --with-etsf-io-prefix=$EBROOTETSF_IO "
 configopts += "--with-libxc-prefix=$EBROOTLIBXC --with-gsl-prefix=$EBROOTGSL "
-configopts += "--with-metis-prefix=$EBROOTMETIS --with-parmetis-prefix=$EBROOTPARMETIS "
-configopts += "LIBS_FFT='-Wl,--start-group -L$EBROOTPFFT/lib -L$EBROOTFFTW/lib -lpfft -lfftw3 -lfftw3_mpi -Wl,--end-group' "
-configopts += "LIBS_BLAS='-L$SCALAPACK_LIB_DIR -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -lmkl_blacs_intelmpi_lp64 -lpthread -lm' "
+configopts += "--with-metis-prefix=$EBROOTMETIS "
+configopts += "--with-blas='-L$LAPACK_LIB_DIR -Wl,--start-group -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -Wl,--end-group -lpthread ' "
+configopts += "LIBS_FFT='-L$EBROOTFFTW/lib -lfftw3' "
 # The configure script it doesn't accept the standard and suggested Intel MKL link options 
 #configopts += "LIBS_BLAS='-L$SCALAPACK_LIB_DIR $EBVARLIBLAPACK' "
 
 sanity_check_paths = {
-    'files': ["bin/octopus_mpi"], 
+    'files': ["bin/octopus"], 
     'dirs': []
 }
 
 runtest = 'installcheck' 
-
-# hybrid build (enable OpenMP)
-hybrid = True
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/p/PFFT/PFFT-20150317-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/PFFT/PFFT-20150317-intel-2015a.eb
@@ -1,0 +1,35 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Jordi Blasco <jordi.blasco@nesi.org.nz>
+# New Zealand eScience Infrastructure (NeSI)
+easyblock = 'ConfigureMake'
+
+name = 'PFFT'
+version = '20150317'
+
+homepage = 'https://www-user.tu-chemnitz.de/~mpip/software.php?lang=en'
+description = """PFFT is a software library for computing massively parallel, fast Fourier 
+transformations on distributed memory architectures. PFFT can be understood as a generalization
+of FFTW-MPI to multidimensional data decomposition."""
+
+toolchain = {'name': 'intel', 'version': '2015a'}
+toolchainopts = {'usempi': True}
+
+git_commit_id = '7bc4852add'
+sources = ['%s.tar.gz' % git_commit_id]
+source_urls = ['https://github.com/mpip/pfft/archive']
+
+dependencies = [
+    ('FFTW', '3.3.4'),
+    ('Autoconf', '2.69'),
+]
+
+preconfigopts = './bootstrap.sh && '
+configopts = ' --with-fftw3-libdir=$EBROOTFFTW'
+
+sanity_check_paths = {
+    'files': ['lib/libpfft.so.0.0.0', 'lib/libpfft.a'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/ParMETIS/ParMETIS-4.0.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/ParMETIS/ParMETIS-4.0.3-intel-2015a.eb
@@ -17,6 +17,6 @@ source_urls = [
 ]
 sources = [SOURCELOWER_TAR_GZ]
 
-builddependencies = [('CMake', '3.1.0', '', ('GCC', '4.9.2'))]
+builddependencies = [('CMake', '3.0.0')]
 
 moduleclass = 'math'


### PR DESCRIPTION
The source_urls of netCDF and netCDF-Fortran have been updated.
The versions of Cmake used by METIS and ParMETIS have been changed for software stack compatibility.
