### PR TITLE
Contributing LAMMPS and LAMMPS with GPU package in single and double …

### DIFF
--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-1Feb2014-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-1Feb2014-goolf-1.4.10.eb
@@ -1,0 +1,29 @@
+easyblock = "MakeCp"
+
+name = "LAMMPS"
+version = "1Feb14"
+
+homepage = 'http://lammps.sandia.gov/'
+description = """LAMMPS is a classical molecular dynamics code,
+and an acronym for Large-scale Atomic/Molecular Massively Parallel Simulator."""
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+patches = ['LAMMPS-1Feb2014_makefile-deps.patch']
+
+prebuildopts = 'mkdir bin && cd src &&'
+
+buildopts = 'openmpi && cp lmp_openmpi ../bin'
+
+files_to_copy = ["bench", "bin", "doc", "examples", "lib", "LICENSE", 
+                 "potentials", "python", "README", "src", "tools"]
+
+sanity_check_paths = {
+    'files': ['bin/lmp_openmpi'],
+    'dirs': [],
+}
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-1Feb2014-goolfc-1.3.12-gpu-double.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-1Feb2014-goolfc-1.3.12-gpu-double.eb
@@ -1,0 +1,35 @@
+easyblock = "MakeCp"
+
+name = "LAMMPS"
+version = "1Feb14"
+versionsuffix = "-gpu-double" 
+
+homepage = 'http://lammps.sandia.gov/'
+description = """LAMMPS is a classical molecular dynamics code, 
+and an acronym for Large-scale Atomic/Molecular Massively Parallel Simulator."""
+
+toolchain = {'name': 'goolfc', 'version': '1.3.12'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+patches = [
+    'LAMMPS-1Feb2014_makefile-deps.patch',
+    'LAMMPS-1Feb2014_gpu_package-double.patch',
+]
+
+prebuildopts = 'cd lib/gpu && make -f Makefile.linux.double && cd ../.. &&'
+prebuildopts += ' mkdir bin && cd src && make yes-gpu &&'
+
+buildopts = 'openmpi && cp lmp_openmpi ../bin'
+
+files_to_copy = ["bench", "bin", "doc", "examples", "lib", "LICENSE", 
+                 "potentials", "python", "README", "src", "tools"]
+
+sanity_check_paths = {
+    'files': ['bin/lmp_openmpi'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-1Feb2014-goolfc-1.3.12-gpu.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-1Feb2014-goolfc-1.3.12-gpu.eb
@@ -1,0 +1,35 @@
+easyblock = "MakeCp"
+
+name = "LAMMPS"
+version = "1Feb14"
+versionsuffix = "-gpu" 
+
+homepage = 'http://lammps.sandia.gov/'
+description = """LAMMPS is a classical molecular dynamics code, 
+and an acronym for Large-scale Atomic/Molecular Massively Parallel Simulator."""
+
+toolchain = {'name': 'goolfc', 'version': '1.3.12'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+patches = [
+    'LAMMPS-1Feb2014_makefile-deps.patch',
+    'LAMMPS-1Feb2014_gpu_package.patch',
+]
+
+prebuildopts = 'cd lib/gpu && make -f Makefile.linux && cd ../.. &&'
+prebuildopts += ' mkdir bin && cd src && make yes-gpu &&'
+
+buildopts = 'openmpi && cp lmp_openmpi ../bin'
+
+files_to_copy = ["bench", "bin", "doc", "examples", "lib", "LICENSE", 
+                 "potentials", "python", "README", "src", "tools"]
+
+sanity_check_paths = {
+    'files': ['bin/lmp_openmpi'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-1Feb2014_gpu_package-double.patch
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-1Feb2014_gpu_package-double.patch
@@ -1,0 +1,21 @@
+Patch to set the correct paths for CUDA
+Thekla Loizou July 2015
+--- lib/gpu/Makefile.linux.double.orig	2014-10-17 14:34:06.953493000 +0300
++++ lib/gpu/Makefile.linux.double	2014-10-17 14:32:34.558367000 +0300
+@@ -7,7 +7,7 @@
+ 
+ EXTRAMAKE = Makefile.lammps.standard
+ 
+-CUDA_HOME = /usr/local/cuda
++CUDA_HOME = $(EBROOTCUDA)
+ NVCC = nvcc
+ 
+ # Tesla CUDA
+--- lib/gpu/Makefile.lammps.standard.orig	2014-10-17 14:32:54.414313000 +0300
++++ lib/gpu/Makefile.lammps.standard	2014-10-17 14:33:12.184488000 +0300
+@@ -2,4 +2,4 @@
+ 
+ gpu_SYSINC =
+ gpu_SYSLIB = -lcudart -lcuda
+-gpu_SYSPATH = -L/usr/local/cuda/lib64
++gpu_SYSPATH = -L$(EBROOTCUDA)/lib64

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-1Feb2014_gpu_package.patch
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-1Feb2014_gpu_package.patch
@@ -1,0 +1,21 @@
+Patch to set the correct paths for CUDA
+Thekla Loizou July 2015
+--- lib/gpu/Makefile.linux.orig	2014-10-17 14:34:06.953493000 +0300
++++ lib/gpu/Makefile.linux	2014-10-17 14:32:34.558367000 +0300
+@@ -7,7 +7,7 @@
+ 
+ EXTRAMAKE = Makefile.lammps.standard
+ 
+-CUDA_HOME = /usr/local/cuda
++CUDA_HOME = $(EBROOTCUDA)
+ NVCC = nvcc
+ 
+ # Tesla CUDA
+--- lib/gpu/Makefile.lammps.standard.orig	2014-10-17 14:32:54.414313000 +0300
++++ lib/gpu/Makefile.lammps.standard	2014-10-17 14:33:12.184488000 +0300
+@@ -2,4 +2,4 @@
+ 
+ gpu_SYSINC =
+ gpu_SYSLIB = -lcudart -lcuda
+-gpu_SYSPATH = -L/usr/local/cuda/lib64
++gpu_SYSPATH = -L$(EBROOTCUDA)/lib64

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-1Feb2014_makefile-deps.patch
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-1Feb2014_makefile-deps.patch
@@ -1,0 +1,30 @@
+Patch to set the correct paths for LAMMPS dependencies
+Thekla Loizou July 2015
+--- src/MAKE/Makefile.openmpi.orig	2014-10-17 12:46:28.862970000 +0300
++++ src/MAKE/Makefile.openmpi	2014-10-17 12:47:01.973616000 +0300
+@@ -38,9 +38,9 @@
+ # PATH = path for MPI library
+ # LIB = name of MPI library
+ 
+-MPI_INC =       
+-MPI_PATH = 
+-MPI_LIB =	
++MPI_INC =       -I$(EBROOTOPENMPI)/include
++MPI_PATH =      -L$(EBROOTOPENMPI)/lib
++MPI_LIB =       -lmpi -lpthread
+ 
+ # FFT library, OPTIONAL
+ # see discussion in doc/Section_start.html#2_2 (step 6)
+@@ -49,9 +49,9 @@
+ # PATH = path for FFT library
+ # LIB = name of FFT library
+ 
+-FFT_INC =       -DFFT_FFTW
+-FFT_PATH = 
+-FFT_LIB =	-lfftw
++FFT_INC =       -DFFT_FFTW3
++FFT_PATH =      -L$(EBROOTFFTW)/lib
++FFT_LIB =       -lfftw3
+ 
+ # JPEG and/or PNG library, OPTIONAL
+ # see discussion in doc/Section_start.html#2_2 (step 7)


### PR DESCRIPTION
…precision

Contributing LAMMPS built with goolf toolchain and LAMMPS built with goolfc toolchain because CUDA is needed to build LAMMPS with the gpu package within LAMMPS. gpu package comes with single and double precision.
