### PR TITLE
{numlib}[ictce/5.4.0, intel/2015a] PETSc 3.5.3 and 3.6.1(Complex support)

### DIFF
--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.5.3-ictce-5.4.0-complex.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.5.3-ictce-5.4.0-complex.eb
@@ -1,0 +1,39 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Jordi Blasco <jordi.blasco@nesi.org.nz>
+# New Zealand eScience Infrastructure (NeSI)
+
+name = "PETSc"
+version = "3.5.3"
+versionsuffix = '-complex'
+
+homepage = 'http://www.mcs.anl.gov/petsc'
+description = """PETSc, pronounced PET-see (the S is silent), is a suite of data 
+ structures and routines for the scalable (parallel) solution
+ of scientific applications modeled by partial differential equations."""
+
+toolchain = {'name': 'ictce', 'version': '5.4.0'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = ['http://ftp.mcs.anl.gov/pub/petsc/release-snapshots']
+sources = [SOURCELOWER_TAR_GZ]
+
+patches = [
+    'PETSc_ranlib-fix.patch',
+    'PETSc-%(version)s-zlibfix.patch',
+] 
+
+parmetis = 'ParMETIS'
+parmetis_ver = '4.0.3'
+dependencies = [
+    ('METIS', '5.1.0'),
+    (parmetis, parmetis_ver),
+    ('SCOTCH', '6.0.0_esmumps'),
+    ('SuiteSparse', '4.2.1', '-%s-%s' % (parmetis, parmetis_ver)),
+]
+
+with_complex = True 
+
+builddependencies = [('CMake', '3.0.0')]
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.5.3-zlibfix.patch
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.5.3-zlibfix.patch
@@ -1,0 +1,14 @@
+# Solves the problem with zlib. On certain systems binutils issue "no version information available"
+# due to easybuild provided zlib. The patch filters out lines contaning "no version information available"
+# from stderr in case of ar. PETSc decides based on the extistence of sderr whether a given program failed or not.
+# B. Hajgato August 7th 2014
+--- config/BuildSystem/config/setCompilers.py.orig	2014-06-30 20:42:41.000000000 +0200
++++ config/BuildSystem/config/setCompilers.py	2014-08-07 15:20:31.999008215 +0200
+@@ -1115,6 +1115,7 @@
+     arcUnix    = os.path.join(self.tmpDir, 'libconf1.a')
+     arcWindows = os.path.join(self.tmpDir, 'libconf1.lib')
+     def checkArchive(command, status, output, error):
++      error = '\n'.join([errx for errx in error.split('\n') if "no version information available" not in errx])
+       if error or status:
+         self.logError('archiver', status, output, error)
+         if os.path.isfile(objName):

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.6.1-intel-2015a-complex.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.6.1-intel-2015a-complex.eb
@@ -1,0 +1,39 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Jordi Blasco <jordi.blasco@nesi.org.nz>
+# New Zealand eScience Infrastructure (NeSI)
+
+name = "PETSc"
+version = "3.6.1"
+versionsuffix = '-complex'
+
+homepage = 'http://www.mcs.anl.gov/petsc'
+description = """PETSc, pronounced PET-see (the S is silent), is a suite of data 
+ structures and routines for the scalable (parallel) solution
+ of scientific applications modeled by partial differential equations."""
+
+toolchain = {'name': 'intel', 'version': '2015a'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = ['http://ftp.mcs.anl.gov/pub/petsc/release-snapshots']
+sources = [SOURCELOWER_TAR_GZ]
+
+patches = [
+    'PETSc_ranlib-fix.patch',
+    'PETSc-%(version)s-zlibfix.patch',
+] 
+
+parmetis = 'ParMETIS'
+parmetis_ver = '4.0.3'
+dependencies = [
+    ('METIS', '5.1.0'),
+    (parmetis, parmetis_ver),
+    ('SCOTCH', '6.0.0_esmumps'),
+    ('SuiteSparse', '4.4.3', '-%s-%s' % (parmetis, parmetis_ver)),
+]
+
+with_complex = True 
+
+builddependencies = [('CMake', '3.0.0')]
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.6.1-zlibfix.patch
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.6.1-zlibfix.patch
@@ -1,0 +1,10 @@
+--- config/BuildSystem/config/setCompilers.py.orig	2015-07-23 03:22:46.000000000 +1200
++++ config/BuildSystem/config/setCompilers.py	2015-08-13 11:26:45.043731899 +1200
+@@ -1138,6 +1138,7 @@
+     arcUnix    = os.path.join(self.tmpDir, 'libconf1.a')
+     arcWindows = os.path.join(self.tmpDir, 'libconf1.lib')
+     def checkArchive(command, status, output, error):
++      error = '\n'.join([errx for errx in error.split('\n') if "no version information available" not in errx])
+       if error or status:
+         self.logError('archiver', status, output, error)
+         if os.path.isfile(objName):


### PR DESCRIPTION
These new easyconfigs relies on the commit in the easyblock
https://github.com/hpcugent/easybuild-easyblocks/pull/661

Please, note that the following packages are not available on the new build because they are not coded for complex support.
- Boost
- FIAT
- ScientificPython
- Hypre
