### PR TITLE
WIP - MVAPICH2-2.1-GNU-5.1.0-2.25

### DIFF
--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-2.1-GNU-5.1.0-2.25.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-2.1-GNU-5.1.0-2.25.eb
@@ -1,0 +1,23 @@
+name = 'MVAPICH2'
+version = '2.1'
+
+homepage = 'http://mvapich.cse.ohio-state.edu/overview/mvapich2/'
+description = "This is an MPI 3.0 implementation.  It is based on MPICH2 and MVICH."
+
+toolchain = {'name': 'GNU', 'version': '5.1.0-2.25'}
+
+source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/']
+sources = [SOURCELOWER_TAR_GZ]
+
+preconfigopts = 'unset F90 && unset FC && unset F90FLAGS && unset FCFLAGS && '
+
+configopts += "--enable-btl-openib-failover --with-tm=/opt/pbs/default --with-openib "
+configopts += "--enable-threads=runtime --enable-shared --with-device=ch3:nemesis "
+configopts += "--disable-rdma-cm --enable-romio --with-file-system=lustre+nfs "
+
+# Let's store the checksum in order to be sure it doesn't suddenly change
+checksums = ['0095ceecb19bbb7fb262131cb9c2cdd6']
+
+builddependencies = [('Bison', '2.7')]
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-2.1-GNU-5.1.0-2.25.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-2.1-GNU-5.1.0-2.25.eb
@@ -11,7 +11,7 @@ sources = [SOURCELOWER_TAR_GZ]
 
 preconfigopts = 'unset F90 && unset FC && unset F90FLAGS && unset FCFLAGS && '
 
-configopts += "--enable-btl-openib-failover --with-tm=/opt/pbs/default --with-openib "
+configopts = "--enable-btl-openib-failover --with-tm=/opt/pbs/default --with-openib "
 configopts += "--enable-threads=runtime --enable-shared --with-device=ch3:nemesis "
 configopts += "--disable-rdma-cm --enable-romio --with-file-system=lustre+nfs "
 


### PR DESCRIPTION
Error during configure step:

```
ERROR: Build of /easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-2.1-GNU-5.1.0-2.25.eb failed (err: 'build failed (first 300 chars): Both $F90 and $FC set, can I overwrite $FC with $F90 (gfortran) ?')
```
