### PR TITLE
updated glimmer easyconfigs

### DIFF
--- a/easybuild/easyconfigs/e/ELPH/ELPH-1.0.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/e/ELPH/ELPH-1.0.1-ictce-5.3.0.eb
@@ -1,0 +1,36 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Pablo Escobar Lopez
+# Swiss Institute of Bioinformatics
+# Biozentrum - University of Basel
+
+easyblock='MakeCp'
+
+name = 'ELPH'
+version = '1.0.1'
+
+homepage = 'http://ccb.jhu.edu/software/ELPH/index.shtml'
+description = """ ELPH is a general-purpose Gibbs sampler for finding motifs in a set 
+ of DNA or protein sequences. The program takes as input a set containing anywhere from 
+ a few dozen to thousands of sequences, and searches through them for the most common motif, 
+ assuming that each sequence contains one copy of the motif. We have used ELPH to find 
+ patterns such as ribosome binding sites (RBSs) and exon splicing enhancers (ESEs). """
+
+toolchain = {'name': 'ictce', 'version': '5.3.0'}
+
+source_urls = ['http://ccb.jhu.edu/software/ELPH/']
+sources = [SOURCE_TAR_GZ]
+
+start_dir = 'sources'
+
+buildopts = ' CC="$CC"'
+
+parallel = 1
+
+files_to_copy = [ (["elph"], "bin"), "COPYRIGHT", "LICENSE", "Readme.ELPH", "VERSION" ] 
+
+sanity_check_paths = {
+    'files': ["bin/elph"],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GLIMMER/GLIMMER-3.02b-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/GLIMMER/GLIMMER-3.02b-goolf-1.4.10.eb
@@ -3,6 +3,7 @@
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>
+# Updated::   Pablo Escobar <pablo.escobarlopez@unibas.ch>
 # License::   MIT/GPL
 #
 ##
@@ -20,13 +21,27 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 source_urls = ['http://www.cbcb.umd.edu/software/glimmer']
 sources = ['%%(namelower)s%s.tar.gz' % ''.join(version.split('.'))]
 
+dependencies = [('ELPH', '1.0.1')]
+
 buildopts = '-C ./src'
 
 files_to_copy = ["bin", "docs", "glim302notes.pdf", "lib", "LICENSE", "sample-run", "scripts"]
+
+# add scripts dir to PATH
+modextrapaths = {
+	'PATH': 'scripts'
+}
 
 sanity_check_paths = {
     'files': ["bin/glimmer3", "glim302notes.pdf", "LICENSE"],
     'dirs': ["docs", "lib", "sample-run", "scripts"]
 }
+
+# fix hardcoded path to scripts folder
+postinstallcmds = ["sed -i -e 's|/fs/szgenefinding/Glimmer3/scripts|%(installdir)s/scripts|' %(installdir)s/scripts/*"]
+# fix hardcoded path to bin folder
+postinstallcmds += ["sed -i -e 's|/fs/szgenefinding/Glimmer3/bin|%(installdir)s/bin|' %(installdir)s/scripts/*"]
+# fix hardcoded path to elph binary
+postinstallcmds += ["sed -i -e 's|/nfshomes/adelcher/bin/elph|${EBROOTELPH}/bin/elph|' %(installdir)s/scripts/*"]
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GLIMMER/GLIMMER-3.02b-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/g/GLIMMER/GLIMMER-3.02b-ictce-5.3.0.eb
@@ -3,6 +3,7 @@
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>
+# Updated::   Pablo Escobar <pablo.escobarlopez@unibas.ch>
 # License::   MIT/GPL
 #
 ##
@@ -20,13 +21,27 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 source_urls = ['http://www.cbcb.umd.edu/software/glimmer']
 sources = ['%%(namelower)s%s.tar.gz' % ''.join(version.split('.'))]
 
+dependencies = [('ELPH', '1.0.1')]
+
 buildopts = '-C ./src'
 
 files_to_copy = ["bin", "docs", "glim302notes.pdf", "lib", "LICENSE", "sample-run", "scripts"]
+
+# add scripts dir to PATH
+modextrapaths = {
+	'PATH': 'scripts'
+}
 
 sanity_check_paths = {
     'files': ["bin/glimmer3", "glim302notes.pdf", "LICENSE"],
     'dirs': ["docs", "lib", "sample-run", "scripts"]
 }
+
+# fix hardcoded path to scripts folder
+postinstallcmds = ["sed -i -e 's|/fs/szgenefinding/Glimmer3/scripts|%(installdir)s/scripts|' %(installdir)s/scripts/*"]
+# fix hardcoded path to bin folder
+postinstallcmds += ["sed -i -e 's|/fs/szgenefinding/Glimmer3/bin|%(installdir)s/bin|' %(installdir)s/scripts/*"]
+# fix hardcoded path to elph binary
+postinstallcmds += ["sed -i -e 's|/nfshomes/adelcher/bin/elph|${EBROOTELPH}/bin/elph|' %(installdir)s/scripts/*"]
 
 moduleclass = 'bio'


### PR DESCRIPTION
updated easyconfig for GLIMMER to add the missing dependencies and fix the hardoced paths in provided scripts. 

From GLIMMER README:

```
Scripts for running the programs are in directory scripts.  Each
  needs to be edited near the top to specify the correct location
  (give the full path) where you have the bin and scripts directories
  on your system. 
```

```
 Some scripts (including g3-iterated.csh) use the program elph, which
  needs to be separately downloaded and installed.
```
