### PR TITLE
OpenBLAS build a DYNAMIC_ARCH, instead of a tuned for the build host …

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.3-2.25-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.3-2.25-LAPACK-3.5.0.eb
@@ -35,7 +35,7 @@ patches = [
 
 skipsteps = ['configure']
 
-buildopts = 'BINARY=64 USE_THREAD=1 CC="$CC" FC="$F77" NO_AFFINITY=1'
+buildopts = 'BINARY=64 USE_THREAD=1 CC="$CC" FC="$F77" NO_AFFINITY=1 DYNAMIC_ARCH=1'
 installopts = "USE_THREAD=1 PREFIX=%(installdir)s"
 
 # extensive testing can be enabled by uncommenting the line below


### PR DESCRIPTION
avoid having a per cpu generation openblas version:
ref:
https://github.com/xianyi/OpenBLAS/wiki/faq#choose_target_dynamic

example of generated builds:

```
[centos-easybuild c6/64bits OpenBLAS-0.2.14]$ ll /tmp/OpenBLAS-0.2.14-*/lib/libopenblas*4.a
-rw-r--r--. 1 centos centos 56296988 Oct 14 14:18 /tmp/OpenBLAS-0.2.14-DYNAMIC/lib/libopenblasp-r0.2.14.a
-rw-r--r--. 1 centos centos 25561066 Oct 14 13:58 /tmp/OpenBLAS-0.2.14-NEHALEM/lib/libopenblas_nehalemp-r0.2.14.a
-rw-r--r--. 1 centos centos 25749722 Oct 14 14:05 /tmp/OpenBLAS-0.2.14-SANDYBRIDGE/lib/libopenblas_sandybridgep-r0.2.14.a
```

these were built with:

```
make BINARY=64 USE_THREAD=1 CC=gcc FC=gfortran NO_AFFINITY=1 USE_THREAD=1 PREFIX=/tmp/OpenBLAS-0.2.14-NEHALEM TARGET=NEHALEM
make BINARY=64 USE_THREAD=1 CC=gcc FC=gfortran NO_AFFINITY=1 USE_THREAD=1 PREFIX=/tmp/OpenBLAS-0.2.14-SANDYBRIDGE TARGET=SANDYBRIDGE
make BINARY=64 USE_THREAD=1 CC=gcc FC=gfortran NO_AFFINITY=1 USE_THREAD=1 PREFIX=/tmp/OpenBLAS-0.2.14-DYNAMIC DYNAMIC_ARCH=1
```
