### PR TITLE
autodetects SSE2 vs Altivec (IBM Power) vs none

### DIFF
--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2015b.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2015b.eb
@@ -17,10 +17,10 @@ preconfigopts = """
     grep sse2 /proc/cpuinfo >& /dev/null
     if [ $? -eq 0 ] ; then 
       echo "Found SSE2"
-      export CLINE1="--enable-single --enable-sse2 --enable-mpi"
-      export CLINE2="--enable-long-double --enable-mpi"
-      export CLINE3="--enable-quad-precision"
-      export CLINE4="--enable-sse2 --enable-mpi"
+      CLINE1="--enable-single --enable-sse2 --enable-mpi"
+      CLINE2="--enable-long-double --enable-mpi"
+      CLINE3="--enable-quad-precision"
+      CLINE4="--enable-sse2 --enable-mpi"
     else
       grep altivec /proc/cpuinfo >& /dev/null
       if [ $? -eq 0 ] ; then 

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2015b.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2015b.eb
@@ -13,22 +13,47 @@ toolchainopts = {'optarch': True, 'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage]
 
-common_configopts = "--enable-threads --enable-openmp --with-pic"
+preconfigopts = """
+    grep sse2 /proc/cpuinfo >& /dev/null
+    if [ $? -eq 0 ] ; then 
+      echo "Found SSE2"
+      export CLINE1="--enable-single --enable-sse2 --enable-mpi"
+      export CLINE2="--enable-long-double --enable-mpi"
+      export CLINE3="--enable-quad-precision"
+      export CLINE4="--enable-sse2 --enable-mpi"
+    else
+      grep altivec /proc/cpuinfo >& /dev/null
+      if [ $? -eq 0 ] ; then 
+        echo "Found Altivec"
+        CLINE1="--enable-mpi"
+        CLINE2="--enable-single --enable-mpi"
+        CLINE3="--enable-long-double --enable-mpi"
+        CLINE4="--enable-single --enable-altivec --enable-mpi"
+      else
+        echo "Unknown vector processor"
+        CLINE1=""
+        CLINE2="--enable-mpi"
+        CLINE3="--enable-single --enable-mpi"
+        CLINE4="--enable-long-double --enable-mpi"
+      fi
+    fi
+"""
 
+common_configopts = "--enable-threads --enable-openmp --with-pic"
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
-    common_configopts + " --enable-long-double --enable-mpi",
-    common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+    common_configopts + " $CLINE1",
+    common_configopts + " $CLINE2",
+    common_configopts + " $CLINE3",
+    common_configopts + " $CLINE4",  # default as last
 ]
 
 sanity_check_paths = {
-    'files': ['bin/fftw%s' % x for x in ['-wisdom', '-wisdom-to-conf', 'f-wisdom', 'l-wisdom', 'q-wisdom']] +
+    'files': ['bin/fftw%s' % x for x in ['-wisdom', '-wisdom-to-conf', 'f-wisdom', 'l-wisdom']] +
              ['include/fftw3%s' % x for x in ['-mpi.f03', '-mpi.h', '.f', '.f03',
-                                              '.h', 'l-mpi.f03', 'l.f03', 'q.f03']] +
-             ['lib/libfftw3%s%s.a' % (x, y) for x in ['', 'f', 'l'] for y in ['', '_mpi', '_omp', '_threads']] +
-             ['lib/libfftw3q.a', 'lib/libfftw3q_omp.a'],
+                                              '.h', 'l-mpi.f03', 'l.f03']] +
+             ['lib/libfftw3%s%s.a' % (x, y) for x in ['', 'f', 'l'] for y in ['', '_mpi', '_omp', '_threads']],
     'dirs': ['lib/pkgconfig'],
 }
 
 moduleclass = 'numlib'
+


### PR DESCRIPTION
We need to do what we can to remove SSE stuff where we can. (/me speaking plurally ;)

I was told to put this in an easyblock at some point but, really, my python is lame and my bash is at least readable (and easily updated).

Personally... I think the ConfigureMake easyblock rocks and we should convert all the easyblock.py stuff to .eb files.   It worked really well with Trinity lately: http://www.siliconslick.com/easybuild/ebfiles_repo_cleaned/ada/Trinity/Trinity-2.1.1-intel-2015B.eb

Anyway... with this change:

1) it still configures/compiles the same on our x86_64 systems
2) it attempts to use the altivec feature of Power processors (which is new)

Tear it apart (with kindness please... tis the season to be kind... hope yours is kind to you)
