### PR TITLE
Add cairo to GCCcore

### DIFF
--- a/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-GCCcore-4.9.3.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'Autoconf'
+version = '2.69'
+
+homepage = 'http://www.gnu.org/software/autoconf/'
+description = """Autoconf is an extensible package of M4 macros that produce shell scripts
+ to automatically configure software source code packages. These scripts can adapt the
+ packages to many kinds of UNIX-like systems without manual user intervention. Autoconf
+ creates a configuration script for a package from a template file that lists the
+ operating system features that the package can use, in the form of M4 macro calls."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('M4', '1.4.17'),
+    ('binutils', '2.25')
+]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["autoconf", "autoheader", "autom4te", "autoreconf", "autoscan",
+                                     "autoupdate", "ifnames"]],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GCCcore-4.9.3.eb
@@ -1,0 +1,34 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'Automake'
+version = "1.15"
+
+homepage = 'http://www.gnu.org/software/automake/automake.html'
+description = "Automake: GNU Standards-compliant Makefile generator"
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+builddependencies = [('binutils', '2.25')]
+dependencies = [('Autoconf', '2.69')]
+
+sanity_check_paths = {
+    'files': ['bin/automake', 'bin/aclocal'],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Autotools/Autotools-20150215-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/a/Autotools/Autotools-20150215-GCCcore-4.9.3.eb
@@ -1,0 +1,17 @@
+easyblock = 'Bundle'
+
+name = 'Autotools'
+version = '20150215'  # date of the most recent change
+
+homepage = 'http://autotools.io'
+description = """This bundle collect the standard GNU build tools: Autoconf, Automake and libtool"""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+dependencies = [
+    ('Autoconf', '2.69'),  # 20120424
+    ('Automake', '1.15'),  # 20150105
+    ('libtool', '2.4.6'),  # 20150215
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-4.9.3.eb
@@ -1,0 +1,17 @@
+name = 'bzip2'
+version = '1.0.6'
+
+homepage = 'http://www.bzip.org/'
+description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
+ compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
+ compressors), whilst being around twice as fast at compression and six times faster at decompression."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://www.bzip.org/%(version)s']
+
+dependencies = [('binutils', '2.25')]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/c/Coreutils/Coreutils-8.25-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/c/Coreutils/Coreutils-8.25-GCCcore-4.9.3.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = "Coreutils"
+version = "8.25"
+
+homepage = 'http://www.gnu.org/software/coreutils/'
+description = """The GNU Core Utilities are the basic file, shell and text manipulation utilities of the
+ GNU operating system.  These are the core utilities which are expected to exist on every operating system."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+
+dependencies = [('binutils', '2.25')]
+
+sanity_check_paths = {
+    'files': ['bin/sort', 'bin/echo', 'bin/du', 'bin/date', 'bin/true'],
+    'dirs': []
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/c/cairo/cairo-1.14.6-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/c/cairo/cairo-1.14.6-GCCcore-4.9.3.eb
@@ -1,0 +1,62 @@
+easyblock = 'ConfigureMake'
+
+name = 'cairo'
+version = '1.14.6'
+
+homepage = 'http://cairographics.org'
+description = """Cairo is a 2D graphics library with support for multiple output devices.
+ Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers,
+ PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB"""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+source_urls = ['http://cairographics.org/releases/']
+sources = [SOURCE_TAR_XZ]
+
+glibver = '2.47.5'
+
+builddependencies = [
+    ('Coreutils', '8.25'),
+    ('xorg-macros', '1.19.0'),
+    ('pkg-config', '0.29'),
+    ('xproto', '7.0.28'),
+    ('kbproto', '1.0.7'),
+    ('renderproto', '0.11'),
+    ('xcb-proto', '1.11'),
+    ('xextproto', '7.3.0'),
+]
+
+dependencies = [
+    ('binutils', '2.25'),
+    ('libX11', '1.6.3'),
+    ('libpthread-stubs', '0.3'),
+    ('libXrender', '0.9.9'),
+    ('freetype', '2.6.2'),
+    ('fontconfig', '2.11.94'),
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('libpng', '1.6.21'),
+    ('pixman', '0.34.0'),
+    ('expat', '2.1.0'),
+    ('GLib', glibver),
+    ('libxcb', '1.11.1'),
+    ('libXext', '1.3.3'),
+]
+
+# disable symbol lookup, which requires -lbfd, to avoid link issues with (non-PIC) libiberty.a provided by GCC
+configopts = "--enable-symbol-lookup=no --enable-gobject=yes --enable-svg=yes --enable-tee=yes "
+
+# workaround for "hidden symbol .* in .* is referenced by DSO" and "ld: final link failed: Bad value"
+buildopts = 'LD="$CC"'
+
+sanity_check_paths = {
+    'files': ['bin/cairo-trace', 'lib/cairo/libcairo-trace.so', 'lib/cairo/libcairo-trace.a',
+              'lib/libcairo.a', 'lib/libcairo-gobject.a', 'lib/libcairo-script-interpreter.a',
+              'lib/libcairo-gobject.so', 'lib/libcairo-script-interpreter.so', 'lib/libcairo.so'] +
+             ['include/cairo/cairo%s.h' % x for x in ['', '-deprecated', '-features', '-ft', '-gobject', '-pdf', '-ps',
+                                                      '-script', '-script-interpreter', '-svg', '-version', '-xcb',
+                                                      '-xlib', '-xlib-xrender']],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/e/expat/expat-2.1.0-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/e/expat/expat-2.1.0-GCCcore-4.9.3.eb
@@ -1,0 +1,20 @@
+easyblock = 'ConfigureMake'
+
+name = 'expat'
+version = '2.1.0'
+
+homepage = 'http://expat.sourceforge.net/'
+description = """Expat is an XML parser library written in C. It is a stream-oriented parser in which an application
+ registers handlers for things the parser might find in the XML document (like start tags)"""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [SOURCEFORGE_SOURCE]
+
+dependencies = [
+    ('binutils', '2.25'),
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/f/fontconfig/fontconfig-2.11.94-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/f/fontconfig/fontconfig-2.11.94-GCCcore-4.9.3.eb
@@ -1,0 +1,24 @@
+easyblock = 'ConfigureMake'
+
+name = 'fontconfig'
+version = '2.11.94'
+
+homepage = 'http://www.freedesktop.org/software/fontconfig'
+description = """Fontconfig is a library designed to provide system-wide font configuration, customization and
+application access."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+source_urls = ['http://www.freedesktop.org/software/fontconfig/release/']
+sources = [SOURCE_TAR_GZ]
+
+
+dependencies = [
+    ('expat', '2.1.0'),
+    ('freetype', '2.6.2'),
+    ('binutils' , '2.25'),
+]
+
+configopts = '--disable-docs '
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.2-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.2-GCCcore-4.9.3.eb
@@ -1,0 +1,27 @@
+name = 'freetype'
+version = '2.6.2'
+
+homepage = 'http://freetype.org'
+description = """FreeType 2 is a software font engine that is designed to be small, efficient, highly customizable, and
+ portable while capable of producing high-quality output (glyph images). It can be used in graphics libraries, display
+ servers, font conversion tools, text image generation tools, and many other products as well."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+source_urls = [GNU_SAVANNAH_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('libpng', '1.6.21'),
+    ('binutils', '2.25'),
+]
+
+configopts = '--with-harfbuzz=no'
+
+sanity_check_paths = {
+    'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
+              'lib/pkgconfig/freetype2.pc'],
+    'dirs': ['include/freetype2'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GLib/GLib-2.47.5-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.47.5-GCCcore-4.9.3.eb
@@ -1,0 +1,36 @@
+easyblock = 'ConfigureMake'
+
+name = 'GLib'
+version = '2.47.5'
+
+homepage = 'http://www.gtk.org/'
+description = """GLib is one of the base libraries of the GTK+ project"""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+
+dependencies = [
+    ('binutils', '2.25'),
+    ('libffi', '3.2.1'),
+    ('gettext', '0.19.7'),
+    ('libxml2', '2.9.3'),
+    ('PCRE', '8.38'),
+]
+
+# In GCCcore we use Python from the OS
+# builddependencies = [('Python', '2.7.11')]
+allow_system_deps = [('Python', SYS_PYTHON_VERSION)]
+
+configopts = "--disable-maintainer-mode --disable-silent-rules --disable-libelf --enable-static --enable-shared"
+
+postinstallcmds = ["sed -i -e 's|#!.*python|#!/usr/bin/env python|' %(installdir)s/bin/*"]
+
+sanity_check_paths = {
+    'files': ['lib/libglib-%(version_major)s.0.a', 'lib/libglib-%%(version_major)s.0.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'include'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.7-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.7-GCCcore-4.9.3.eb
@@ -1,0 +1,22 @@
+easyblock = 'ConfigureMake'
+
+name = 'gettext'
+version = '0.19.7'
+
+homepage = 'http://www.gnu.org/software/gettext/'
+description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
+and documentation"""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+configopts = '--without-emacs'
+
+dependencies = [
+    ('binutils', '2.25'),
+]
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/i/inputproto/inputproto-2.3.1-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/i/inputproto/inputproto-2.3.1-GCCcore-4.9.3.eb
@@ -1,0 +1,21 @@
+easyblock = 'ConfigureMake'
+
+name = 'inputproto'
+version = '2.3.1'
+
+homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+description = """X.org InputProto protocol headers."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://xorg.freedesktop.org/archive/individual/proto/']
+
+dependencies = [('binutils', '2.25')]
+
+sanity_check_paths = {
+    'files': ['include/X11/extensions/%s' % x for x in ['XI2.h', 'XI.h',  'XIproto.h', 'XI2proto.h']],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/k/kbproto/kbproto-1.0.7-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/k/kbproto/kbproto-1.0.7-GCCcore-4.9.3.eb
@@ -9,7 +9,7 @@ description = """X.org KBProto protocol headers."""
 toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://xorg.freedesktop.org/archive/individual/proto/']
+source_urls = [XORG_PROTO_SOURCE]
 
 dependencies = [('binutils', '2.25')]
 

--- a/easybuild/easyconfigs/k/kbproto/kbproto-1.0.7-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/k/kbproto/kbproto-1.0.7-GCCcore-4.9.3.eb
@@ -1,0 +1,21 @@
+easyblock = 'ConfigureMake'
+
+name = 'kbproto'
+version = '1.0.7'
+
+homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+description = """X.org KBProto protocol headers."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://xorg.freedesktop.org/archive/individual/proto/']
+
+dependencies = [('binutils', '2.25')]
+
+sanity_check_paths = {
+    'files': ['include/X11/extensions/%s' % x for x in ['XKBgeom.h', 'XKB.h',  'XKBproto.h', 'XKBsrv.h', 'XKBstr.h']],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libX11/libX11-1.6.3-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/l/libX11/libX11-1.6.3-GCCcore-4.9.3.eb
@@ -1,0 +1,38 @@
+easyblock = 'ConfigureMake'
+
+name = 'libX11'
+version = '1.6.3'
+
+homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+description = """X11 client-side library"""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = [XORG_LIB_SOURCE]
+
+builddependencies = [
+    ('xextproto', '7.3.0'),
+    ('xcb-proto', '1.11'),
+    ('inputproto', '2.3.1'),
+    ('xproto', '7.0.28'),
+    ('libpthread-stubs', '0.3'),
+    ('kbproto', '1.0.7'),
+    ('xtrans', '1.3.5'),
+]
+
+dependencies = [
+    ('binutils', '2.25'),
+    ('libxcb', '1.11.1'),
+]
+
+sanity_check_paths = {
+    'files': ['include/X11/%s' % x for x in [
+        'cursorfont.h', 'ImUtil.h', 'Xcms.h', 'XKBlib.h', 'XlibConf.h', 'Xlib.h', 'Xlibint.h', 'Xlib-xcb.h',
+        'Xlocale.h', 'Xregion.h', 'Xresource.h', 'Xutil.h',
+    ]
+    ],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libXau/libXau-1.0.8-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/l/libXau/libXau-1.0.8-GCCcore-4.9.3.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'libXau'
+version = '1.0.8'
+
+homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+description = """The libXau package contains a library implementing the X11 Authorization Protocol.
+This is useful for restricting client access to the display."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'optarch': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://xorg.freedesktop.org/archive/individual/lib/']
+
+dependencies = [
+    ('binutils', '2.25'),
+]
+
+builddependencies = [
+    ('xproto', '7.0.28'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/libXau.a', 'lib/libXau.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libXdmcp/libXdmcp-1.1.2-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/l/libXdmcp/libXdmcp-1.1.2-GCCcore-4.9.3.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'libXdmcp'
+version = '1.1.2'
+
+homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+description = """The libXdmcp package contains a library implementing the X Display Manager Control Protocol. This is
+useful for allowing clients to interact with the X Display Manager.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'optarch': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://xorg.freedesktop.org/archive/individual/lib/']
+
+builddependencies = [
+    ('xproto', '7.0.28'),
+]
+dependencies = [
+    ('binutils', '2.25'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a', 'lib/%%(name)s.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libXext/libXext-1.3.3-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/l/libXext/libXext-1.3.3-GCCcore-4.9.3.eb
@@ -1,0 +1,39 @@
+easyblock = 'ConfigureMake'
+
+name = 'libXext'
+version = '1.3.3'
+
+homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+description = """Common X Extensions library"""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'optarch': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://xorg.freedesktop.org/archive/individual/lib/']
+
+builddependencies = [
+    ('Coreutils', '8.25'),
+    ('xorg-macros', '1.19.0'),
+    ('pkg-config', '0.29'),
+    ('xproto', '7.0.28'),
+    ('kbproto', '1.0.7'),
+    ('xextproto', '7.3.0'),
+]
+
+dependencies = [
+    ('binutils', '2.25'),
+    ('libX11', '1.6.3'),
+    ('libpthread-stubs', '0.3'),
+]
+
+sanity_check_paths = {
+    'files': ['include/X11/extensions/%s' % x for x in [
+        'dpms.h', 'extutil.h', 'MITMisc.h', 'multibuf.h', 'security.h', 'shape.h', 'sync.h', 'Xag.h', 'Xcup.h',
+        'Xdbe.h', 'XEVI.h', 'Xext.h', 'Xge.h', 'XLbx.h', 'XShm.h', 'xtestext1.h',
+    ]
+    ],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libXrender/libXrender-0.9.9-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/l/libXrender/libXrender-0.9.9-GCCcore-4.9.3.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'libXrender'
+version = '0.9.9'
+
+homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+description = """X11 client-side library"""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = [XORG_LIB_SOURCE]
+
+builddependencies = [
+    ('Coreutils', '8.25'),
+    ('xorg-macros', '1.19.0'),
+    ('pkg-config', '0.29'),
+    ('xproto', '7.0.28'),
+    ('kbproto', '1.0.7'),
+    ('renderproto', '0.11'),
+]
+
+dependencies = [
+    ('binutils', '2.25'),
+    ('libX11', '1.6.3'),
+    ('libpthread-stubs', '0.3'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/libXrender.a'],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libffi/libffi-3.2.1-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/l/libffi/libffi-3.2.1-GCCcore-4.9.3.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'libffi'
+version = '3.2.1'
+
+homepage = 'http://sourceware.org/libffi/'
+description = """The libffi library provides a portable, high level programming interface to various calling
+conventions. This allows a programmer to call any function specified by a call interface description at run-time."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+source_urls = [
+    'ftp://sourceware.org/pub/libffi/',
+    'http://www.mirrorservice.org/sites/sourceware.org/pub/libffi/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('binutils', '2.25')]
+
+sanity_check_paths = {
+    'files': [('lib/libffi.%s' % SHLIB_EXT, 'lib64/libffi.%s' % SHLIB_EXT), ('lib/libffi.a', 'lib64/libffi.a')],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libpng/libpng-1.6.21-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/l/libpng/libpng-1.6.21-GCCcore-4.9.3.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'libpng'
+version = '1.6.21'
+
+homepage = 'http://www.libpng.org/pub/png/libpng.html'
+description = "libpng is the official PNG reference library"
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('zlib', '1.2.8'),
+    ('binutils', '2.25'),
+]
+
+configopts = "--with-pic"
+
+majminver = ''.join(version.split('.')[:2])
+sanity_check_paths = {
+    'files': ['include/pngconf.h', 'include/png.h', 'include/pnglibconf.h', 'lib/libpng.a',
+              'lib/libpng.%s' % SHLIB_EXT, 'lib/libpng%s.a' % majminver, 'lib/libpng%s.%s' % (majminver, SHLIB_EXT)],
+    'dirs': ['bin', 'include/libpng%s' % majminver, 'share/man'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libpthread-stubs/libpthread-stubs-0.3-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/l/libpthread-stubs/libpthread-stubs-0.3-GCCcore-4.9.3.eb
@@ -1,0 +1,24 @@
+easyblock = 'ConfigureMake'
+
+name = 'libpthread-stubs'
+version = '0.3'
+
+homepage = 'http://xcb.freedesktop.org/'
+description = """The X protocol C-language Binding (XCB) is a replacement for Xlib featuring a small footprint,
+latency hiding, direct access to the protocol, improved threading support, and extensibility."""
+
+source_urls = ['http://xcb.freedesktop.org/dist/']
+sources = [SOURCELOWER_TAR_GZ]
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+dependencies = [
+    ('binutils', '2.25'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/pkgconfig/pthread-stubs.pc'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libtool/libtool-2.4.6-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/l/libtool/libtool-2.4.6-GCCcore-4.9.3.eb
@@ -1,0 +1,20 @@
+easyblock = 'ConfigureMake'
+
+name = 'libtool'
+version = '2.4.6'
+
+homepage = 'http://www.gnu.org/software/libtool'
+description = """GNU libtool is a generic library support script. Libtool hides the complexity of using shared libraries
+ behind a consistent, portable interface."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [
+    ('M4', '1.4.17'),
+    ('binutils', '2.25')
+]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxcb/libxcb-1.11.1-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/l/libxcb/libxcb-1.11.1-GCCcore-4.9.3.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'libxcb'
+version = '1.11.1'
+
+homepage = 'http://xcb.freedesktop.org/'
+description = """The X protocol C-language Binding (XCB) is a replacement for Xlib featuring a small footprint,
+latency hiding, direct access to the protocol, improved threading support, and extensibility."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+source_urls = ['http://xcb.freedesktop.org/dist/']
+sources = [SOURCELOWER_TAR_GZ]
+
+builddependencies = [
+    ('xcb-proto', '1.11'),
+    ('xproto', '7.0.28'),
+    ('libpthread-stubs', '0.3'),
+]
+dependencies = [
+    ('binutils', '2.25'),
+    ('libXau', '1.0.8'),
+    ('libXdmcp', '1.1.2'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/libxcb%s.a' % x for x in ['', '-composite', '-damage', '-dpms', '-dri2', '-glx',
+                                             '-randr', '-record', '-render', '-res', '-screensaver',
+                                             '-shape', '-shm', '-sync', '-xevie', '-xf86dri', '-xfixes',
+                                             '-xinerama', '-xprint', '-xtest', '-xv', '-xvmc']],
+    'dirs': ['include/xcb', 'lib/pkgconfig'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.3-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.3-GCCcore-4.9.3.eb
@@ -1,0 +1,32 @@
+easyblock = 'ConfigureMake'
+
+name = 'libxml2'
+version = '2.9.3'
+
+homepage = 'http://xmlsoft.org/'
+description = """Libxml2 is the XML C parser and 
+toolchain developed for the Gnome project
+ (but usable outside of the Gnome platform)."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'pic': True}
+
+source_urls = [
+    'http://xmlsoft.org/sources/',
+    'http://xmlsoft.org/sources/old/'
+]
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = 'CC="$CC" CXX="$CXX" --with-pic --without-python --with-zlib=$EBROOTZLIB'
+
+dependencies = [
+    ('binutils', '2.25'),
+    ('zlib', '1.2.8'),
+]
+
+sanity_check_paths = {
+    'files': [('lib/libxml2.a', 'lib64/libxml2.a'), ('lib/libxml2.%s' % SHLIB_EXT, 'lib64/libxml2.%s' % SHLIB_EXT)],
+    'dirs': ['bin', 'include/libxml2/libxml'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/PCRE/PCRE-8.38-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/p/PCRE/PCRE-8.38-GCCcore-4.9.3.eb
@@ -1,0 +1,22 @@
+easyblock = 'ConfigureMake'
+
+name = 'PCRE'
+version = '8.38'
+
+homepage = 'http://www.pcre.org/'
+description = """
+ The PCRE library is a set of functions that implement regular expression pattern matching using the same syntax
+ and semantics as Perl 5.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('binutils', '2.25')]
+
+configopts = "--with-pic --disable-cpp --enable-utf --enable-unicode-properties"
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/pixman/pixman-0.34.0-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/p/pixman/pixman-0.34.0-GCCcore-4.9.3.eb
@@ -1,0 +1,22 @@
+easyblock = 'ConfigureMake'
+
+name = "pixman"
+version = '0.34.0'
+
+homepage = 'http://www.pixman.org/'
+description = """Pixman is a low-level software library for pixel manipulation, providing features such as image
+compositing and trapezoid rasterization. Important users of pixman are the cairo graphics library and the X server."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+source_urls = ['http://cairographics.org/releases/']
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [('binutils', '2.25')]
+
+sanity_check_paths = {
+    'files': ['lib/libpixman-1.%s' % SHLIB_EXT],
+    'dirs': []
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29-GCCcore-4.9.3.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'pkg-config'
+version = '0.29'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/pkg-config/'
+description = """pkg-config is a helper tool used when compiling applications and libraries. It helps you insert the
+ correct compiler options on the command line so an application can use
+  gcc -o test test.c `pkg-config --libs --cflags glib-2.0`
+ for instance, rather than hard-coding values on where to find glib (or other libraries)."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+
+dependencies = [('binutils', '2.25')]
+
+# don't use PAX, it might break.
+tar_config_opts = True
+
+configopts = " --with-internal-glib"
+
+sanity_check_paths = {
+    'files': ['bin/pkg-config'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/r/renderproto/renderproto-0.11-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/r/renderproto/renderproto-0.11-GCCcore-4.9.3.eb
@@ -1,0 +1,24 @@
+easyblock = 'ConfigureMake'
+
+name = 'renderproto'
+version = '0.11'
+
+homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+description = "Xrender protocol and ancillary headers"
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'optarch': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://xorg.freedesktop.org/archive/individual/proto/']
+
+dependencies = [
+    ('binutils', '2.25'),
+]
+
+sanity_check_paths = {
+    'files': ['include/X11/extensions/%s' % x for x in ['render.h', 'renderproto.h']],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/x/xcb-proto/xcb-proto-1.11-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/x/xcb-proto/xcb-proto-1.11-GCCcore-4.9.3.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'xcb-proto'
+version = '1.11'
+
+homepage = 'http://xcb.freedesktop.org/'
+description = """The X protocol C-language Binding (XCB) is a replacement for Xlib featuring a small footprint,
+latency hiding, direct access to the protocol, improved threading support, and extensibility."""
+
+# even though xcb-proto is installed with configure-make-make install, nothing is actually built;
+# only .py files are installed using Python, and some .xlm flies copied, so OK to use dummy toolchain
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+source_urls = ['http://xcb.freedesktop.org/dist/']
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('binutils', '2.25'),
+]
+
+allow_system_deps = [('Python', SYS_PYTHON_VERSION)]
+
+pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[0:2])
+
+sanity_check_paths = {
+    'files': ['lib/pkgconfig/xcb-proto.pc'],
+    'dirs': ['lib/python%s/site-packages/xcbgen' % pyshortver]
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/x/xextproto/xextproto-7.3.0-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/x/xextproto/xextproto-7.3.0-GCCcore-4.9.3.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'xextproto'
+version = '7.3.0'
+
+homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+description = """XExtProto protocol headers."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://xorg.freedesktop.org/archive/individual/proto/']
+
+dependencies = [
+    ('binutils', '2.25'),
+]
+
+sanity_check_paths = {
+    'files': ['include/X11/extensions/%s' % x for x in [
+        'agproto.h', 'cupproto.h', 'dbeproto.h', 'dpmsproto.h', 'EVIproto.h', 'geproto.h', 'lbxproto.h',
+        'mitmiscproto.h', 'multibufproto.h', 'securproto.h', 'shapeproto.h', 'shm.h', 'shmstr.h', 'syncproto.h',
+        'xtestconst.h', 'xtestext1proto.h'
+    ]
+    ],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/x/xorg-macros/xorg-macros-1.19.0-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/x/xorg-macros/xorg-macros-1.19.0-GCCcore-4.9.3.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'xorg-macros'
+version = '1.19.0'
+
+homepage = 'http://cgit.freedesktop.org/xorg/util/macros'
+description = """X.org macros utilities."""
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+source_urls = ['http://cgit.freedesktop.org/xorg/util/macros/snapshot']  # no slash ('/') at the end!
+sources = ['util-macros-%(version)s.tar.gz']
+
+builddependencies = [('Autotools', '20150215')]
+
+dependencies = [
+    ('binutils', '2.25'),
+]
+
+preconfigopts = './autogen.sh && '
+
+sanity_check_paths = {
+    'files': ['share/pkgconfig/xorg-macros.pc'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/x/xproto/xproto-7.0.28-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/x/xproto/xproto-7.0.28-GCCcore-4.9.3.eb
@@ -1,0 +1,27 @@
+easyblock = 'ConfigureMake'
+
+name = 'xproto'
+version = '7.0.28'
+
+homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+description = "X protocol and ancillary headers"
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://xorg.freedesktop.org/archive/individual/proto/']
+
+dependencies = [
+    ('binutils', '2.25'),
+]
+
+sanity_check_paths = {
+    'files': ['include/X11/%s' % x for x in ['ap_keysym.h', 'HPkeysym.h', 'keysym.h', 'Xalloca.h',
+                                             'Xatom.h', 'XF86keysym.h', 'Xfuncs.h', 'Xmd.h', 'Xos.h', 'Xpoll.h', 'Xprotostr.h',
+                                             'Xw32defs.h', 'Xwindows.h', 'DECkeysym.h', 'keysymdef.h', 'Sunkeysym.h', 'Xarch.h',
+                                             'Xdefs.h', 'Xfuncproto.h', 'X.h', 'Xosdefs.h', 'Xos_r.h', 'Xproto.h', 'Xthreads.h',
+                                             'XWDFile.h', 'Xwinsock.h']],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/x/xtrans/xtrans-1.3.5-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/x/xtrans/xtrans-1.3.5-GCCcore-4.9.3.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'xtrans'
+version = '1.3.5'
+
+homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+description = """xtrans includes a number of routines to make X implementations transport-independent;
+ at time of writing, it includes support for UNIX sockets, IPv4, IPv6, and DECnet.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = [XORG_LIB_SOURCE]
+
+dependencies = [
+    ('binutils', '2.25'),
+]
+
+sanity_check_paths = {
+    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtrans.h', 'Xtransint.h', 
+                                                    'Xtranslcl.c', 'Xtranssock.c', 'Xtransutil.c']],
+    'dirs': [],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Add cairo to GCCcore so all toolchains can access it in a HMNS.

Works nicely with `--minimal-toolchains` and has improvements to work on more bare bones systems (particularly for `freetype` which caused a sneaky cyclical dependency on `HarfBuzz`)
