### PR TITLE
scorep/30rc1: gnu build fails in build-backend/libscorep_measurement.la

### DIFF
--- a/easybuild/easyconfigs/s/Score-P/Score-P-3.0-rc1-CrayGNU-2016.06.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-3.0-rc1-CrayGNU-2016.06.eb
@@ -13,6 +13,7 @@ easyblock = 'EB_Score_minus_P'
 
 name = 'Score-P'
 version = '3.0-rc1'
+versionsuffix = '-debug'
 
 homepage = 'http://www.score-p.org'
 description = """The Score-P measurement infrastructure is a highly scalable and
@@ -26,13 +27,13 @@ sources = ['scorep-%(version)s.tar.gz']
 checksums = [ '097f26b7d23609e1c2666384c0683485' ]
 
 dependencies = [
-    ('libiberty', '5.3.0-scorep', '', True),
-    ('libunwind', '1.1-scorep', '', True),
-    ('Cube', '4.3.4-debug', '', True),
-    ('OPARI2', '2.0', '', True),
-#PR3501    ('OTF2', '2.0', '', True),
-    ('SIONlib', '1.6.2-tools', '', True),
-    ('PDT', '3.22', '', True),
+    ('libiberty', '5.3.0-GCC-system', '', True),
+    ('libunwind', '1.1-GCC-system', '', True),
+    ('Cube', '4.3.4-GCC-system', '', True),
+    ('OPARI2', '2.0-GCC-system', '', True),
+#PR3501    ('OTF2', '2.0-GCC-system', '', True),
+    ('SIONlib', '1.6.2-GCC-system', '', True),
+    ('PDT', '3.22-GCC-system', '', True),
     ('papi/5.4.3.2', EXTERNAL_MODULE),
     ('vampir/9.1', EXTERNAL_MODULE),
 ]

--- a/easybuild/easyconfigs/s/Score-P/Score-P-3.0-rc1-CrayGNU-2016.06.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-3.0-rc1-CrayGNU-2016.06.eb
@@ -21,8 +21,8 @@ description = """The Score-P measurement infrastructure is a highly scalable and
 
 toolchain = {'name': 'CrayGNU', 'version': '2016.06'}
 
-sources = ['scorep-%(version)s.tar.gz']
 source_urls = ['http://www.vi-hps.org/upload/packages/scorep/']
+sources = ['scorep-%(version)s.tar.gz']
 checksums = [ '097f26b7d23609e1c2666384c0683485' ]
 
 dependencies = [
@@ -35,30 +35,17 @@ dependencies = [
     ('PDT', '3.22', '', True),
     ('papi/5.4.3.2', EXTERNAL_MODULE),
     ('vampir/9.1', EXTERNAL_MODULE),
-#    ('craype-broadwell', EXTERNAL_MODULE),  ==> eb --optarch=broadwell scorep.eb
-#    ('Qt', '5.7.0-debug', '', True),
-#    ('zlib', '1.2.8-scorep', '', True),
-#    ('binutils', '2.26-scorep', '', True),
-#    ('craype-accel-nvidia35', EXTERNAL_MODULE),
-#    ('cudatoolkit/7.0.28-1.0502.10742.5.1', EXTERNAL_MODULE),
 ]
 
-configopts = '--enable-shared'
-
+configopts  = ' --enable-shared'
 configopts += ' --with-libpmi-include=/opt/cray/pe/pmi/default/include'
 configopts += ' --with-libpmi-lib=/opt/cray/pe/pmi/default/lib64'
 configopts += ' --with-librca-include=/opt/cray/rca/default/include'
 configopts += ' --with-librca-lib=/opt/cray/rca/default/lib64'
-# -------
-# gcc: error: unrecognized command line option '-craype-verbose'
-# because -craype-verbose is supported only by the Cray wrappers (cc):
-# => fix it by setting CFLAGS/CXXFLAGS
-configopts += ' CC=cc CFLAGS=-O2'       # !needed for build-score
-configopts += ' CXX=CC CXXFLAGS=-O2'    # !needed for build-score
 
 sanity_check_paths = {
     'files': ["bin/scorep", "include/scorep/SCOREP_User.h",
-              ("lib/backend/libscorep_adapter_mpi_event.a",
+             ("lib/backend/libscorep_adapter_mpi_event.a",
               "lib/libscorep_adapter_mpi_event.%s" % SHLIB_EXT) ],
     'dirs': [],
 }

--- a/easybuild/easyconfigs/s/Score-P/Score-P-3.0-rc1-CrayGNU-2016.06.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-3.0-rc1-CrayGNU-2016.06.eb
@@ -30,7 +30,7 @@ dependencies = [
     ('libunwind', '1.1-scorep', '', True),
     ('Cube', '4.3.4-debug', '', True),
     ('OPARI2', '2.0', '', True),
-    ('OTF2', '2.0', '', True),
+#PR3501    ('OTF2', '2.0', '', True),
     ('SIONlib', '1.6.2-tools', '', True),
     ('PDT', '3.22', '', True),
     ('papi/5.4.3.2', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/s/Score-P/Score-P-3.0-rc1-CrayGNU-2016.06.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-3.0-rc1-CrayGNU-2016.06.eb
@@ -1,0 +1,70 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# Copyright:: Copyright 2013-2016 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'Score-P'
+version = '3.0-rc1'
+
+homepage = 'http://www.score-p.org'
+description = """The Score-P measurement infrastructure is a highly scalable and
+ easy-to-use tool suite for profiling, event tracing, and online analysis of HPC
+ applications."""
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.06'}
+
+sources = ['scorep-%(version)s.tar.gz']
+source_urls = ['http://www.vi-hps.org/upload/packages/scorep/']
+checksums = [ '097f26b7d23609e1c2666384c0683485' ]
+
+dependencies = [
+    ('libiberty', '5.3.0-scorep', '', True),
+    ('libunwind', '1.1-scorep', '', True),
+    ('Cube', '4.3.4-debug', '', True),
+    ('OPARI2', '2.0', '', True),
+    ('OTF2', '2.0', '', True),
+    ('SIONlib', '1.6.2-tools', '', True),
+    ('PDT', '3.22', '', True),
+    ('papi/5.4.3.2', EXTERNAL_MODULE),
+    ('vampir/9.1', EXTERNAL_MODULE),
+#    ('craype-broadwell', EXTERNAL_MODULE),  ==> eb --optarch=broadwell scorep.eb
+#    ('Qt', '5.7.0-debug', '', True),
+#    ('zlib', '1.2.8-scorep', '', True),
+#    ('binutils', '2.26-scorep', '', True),
+#    ('craype-accel-nvidia35', EXTERNAL_MODULE),
+#    ('cudatoolkit/7.0.28-1.0502.10742.5.1', EXTERNAL_MODULE),
+]
+
+configopts = '--enable-shared'
+
+configopts += ' --with-libpmi-include=/opt/cray/pe/pmi/default/include'
+configopts += ' --with-libpmi-lib=/opt/cray/pe/pmi/default/lib64'
+configopts += ' --with-librca-include=/opt/cray/rca/default/include'
+configopts += ' --with-librca-lib=/opt/cray/rca/default/lib64'
+# -------
+# gcc: error: unrecognized command line option '-craype-verbose'
+# because -craype-verbose is supported only by the Cray wrappers (cc):
+# => fix it by setting CFLAGS/CXXFLAGS
+configopts += ' CC=cc CFLAGS=-O2'       # !needed for build-score
+configopts += ' CXX=CC CXXFLAGS=-O2'    # !needed for build-score
+
+sanity_check_paths = {
+    'files': ["bin/scorep", "include/scorep/SCOREP_User.h",
+              ("lib/backend/libscorep_adapter_mpi_event.a",
+              "lib/libscorep_adapter_mpi_event.%s" % SHLIB_EXT) ],
+    'dirs': [],
+}
+
+# Ensure that local metric documentation is found by Cube GUI
+modextrapaths = { 'CUBE_DOCPATH': 'share/doc/scorep/profile' }
+modextravars = { 'CRAYPE_LINK_TYPE' : 'dynamic' }
+
+moduleclass = 'perf'


### PR DESCRIPTION
@geimer In preparation for CSCS upgrade, i am trying to build scorep/30rc1 on Cray/CLE6
using CrayGNU/2016.06. The recipe fails with:

```
  libtool:   error: error: cannot install 'libscorep_measurement.la' to a directory 
not ending in /apps/common/UES/sandbox/jgp/efface/easybuild/software/
OTF2/2.0/lib/backend
  Makefile:13796: recipe for target 'install-libLTLIBRARIES' failed
  make[4]: *** [install-libLTLIBRARIES] Error 1
  make[4]: Leaving directory '/dev/shm/piccinal/ScoreP/3.0-rc1/
CrayGNU-2016.06/scorep-3.0-rc1/build-backend'
```

My manual workaround is to manually edit build-backend/libscorep_measurement.la and to replace:

```
libdir='/home/users/p01991/EB/easybuild/software/OTF2/2.0/lib/backend'
with:
libdir='path_to_install_dir/lib/backend'
```
- Do you know how to do this from the easyconfig file ?
- Is there a fix for this issue ?

```
brisi01: libtool (GNU libtool) 2.4.2
```
