### PR TITLE
[wip] Add MVAPICH2.2rc2 easyconfigs with extra libumad-devel dependancy

### DIFF
--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.4-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.4-GCC-5.4.0-2.26.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'Bison'
+version = '3.0.4'
+
+homepage = 'http://www.gnu.org/software/bison'
+description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
+ into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
+
+toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+builddependencies = [
+    ('M4', '1.4.17'),
+    # use same binutils version that was used when building GCC toolchain
+    ('binutils', '2.26', '', True),
+]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["bison", "yacc"]] + ["lib/liby.a"],
+    'dirs': [],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-2.2rc2-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-2.2rc2-GCC-4.9.3-2.25.eb
@@ -1,0 +1,19 @@
+name = 'MVAPICH2'
+version = '2.2rc2'
+
+homepage = 'http://mvapich.cse.ohio-state.edu/overview/mvapich2/'
+description = "This is an MPI 3.0 implementation.  It is based on MPICH2 and MVICH."
+
+toolchain = {'name': 'GCC', 'version': '4.9.3-2.25'}
+
+source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/']
+sources = [SOURCELOWER_TAR_GZ]
+
+osdependencies = [('libibverbs-dev','libibverbs-devel'),('libibmad-dev','libibmad-devel')]
+
+# Let's store the checksum in order to be sure it doesn't suddenly change
+checksums = ['f9082ffc3b853ad1b908cf7f169aa878']
+
+builddependencies = [('Bison', '3.0.4')]
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-2.2rc2-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-2.2rc2-GCC-5.4.0-2.26.eb
@@ -1,0 +1,19 @@
+name = 'MVAPICH2'
+version = '2.2rc2'
+
+homepage = 'http://mvapich.cse.ohio-state.edu/overview/mvapich2/'
+description = "This is an MPI 3.0 implementation.  It is based on MPICH2 and MVICH."
+
+toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
+
+source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/']
+sources = [SOURCELOWER_TAR_GZ]
+
+osdependencies = [('libibverbs-dev','libibverbs-devel'),('libibmad-dev','libibmad-devel')]
+
+# Let's store the checksum in order to be sure it doesn't suddenly change
+checksums = ['f9082ffc3b853ad1b908cf7f169aa878']
+
+builddependencies = [('Bison', '3.0.4')]
+
+moduleclass = 'mpi'


### PR DESCRIPTION
Add new easyconfig for mvpich2

I have also adde the extra line below, in order for that to be there, so that we don't have issues with error doing `./configure` and complains about --disable-mcast

```
osdependencies = [('libibmad-devel','libibverbs-devel')]
```

This is also fixes #3395
