### PR TITLE
Make `ncurses` easyconfigs work on Debian/Ubuntu

### DIFF
--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9.eb
@@ -14,7 +14,10 @@ toolchainopts = {'optarch': True, 'pic': True}
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
-patches = ['ncurses-%(version)s_configure_darwin.patch']
+patches = [
+        'ncurses-%(version)s_configure_darwin.patch',
+        'ncurses-5.9_gcc5x.patch',
+]
 
 configopts = [
     # default build

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9_gcc5x.patch
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9_gcc5x.patch
@@ -1,0 +1,21 @@
+Index: ncurses-5.9.20131221/ncurses/base/MKlib_gen.sh
+===================================================================
+--- ncurses-5.9.20131221/ncurses/base/MKlib_gen.sh 2011-06-04 21:14:08.000000000 +0200
++++ ncurses-5.9.20131221/ncurses/base/MKlib_gen.sh 2015-04-26 00:47:06.911680782 +0200
+@@ -62,7 +62,15 @@
+ if test "${LC_CTYPE+set}"    = set; then LC_CTYPE=C;    export LC_CTYPE;    fi
+ if test "${LC_COLLATE+set}"  = set; then LC_COLLATE=C;  export LC_COLLATE;  fi
+ 
+-preprocessor="$1 -DNCURSES_INTERNALS -I../include"
++# Work around "unexpected" output of GCC 5.1.0's cpp w.r.t. #line directives
++# by simply suppressing them:
++case `$1 -dumpversion 2>/dev/null` in
++    5.*)  # assume a "broken" one
++        preprocessor="$1 -P -DNCURSES_INTERNALS -I../include"
++        ;;
++    *)
++        preprocessor="$1 -DNCURSES_INTERNALS -I../include"
++esac
+ AWK="$2"
+ USE="$3"
+ 

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0.eb
@@ -13,10 +13,8 @@ toolchainopts = {'optarch': True, 'pic': True}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
+patches = ['ncurses-6.0_mawk_compatibility.patch']
 
-# ncurses-6.0 builds fail with `mawk`, so force use of `gawk`
-# see http://lists.gnu.org/archive/html/bug-ncurses/2015-08/msg00013.html
-preconfigopts = "env AWK=/usr/bin/gawk "
 configopts = [
     # default build
     '--with-shared --enable-overwrite',

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0.eb
@@ -14,6 +14,9 @@ toolchainopts = {'optarch': True, 'pic': True}
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
+# ncurses-6.0 builds fail with `mawk`, so force use of `gawk`
+# see http://lists.gnu.org/archive/html/bug-ncurses/2015-08/msg00013.html
+preconfigopts = "env AWK=/usr/bin/gawk "
 configopts = [
     # default build
     '--with-shared --enable-overwrite',

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0_mawk_compatibility.patch
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0_mawk_compatibility.patch
@@ -1,0 +1,19 @@
+# Originally from: ncurses 6.0 - patch 20150810 - Thomas E. Dickey
+# See: http://invisible-island.net/ncurses/ (-> Development ncurses patches since previous release)
+#
+# Debian's `mawk` package does not support POSIX RE character classes,
+# so patch the `MKlib_gen.sh` script to use TAB+SPACE instead. 
+#
+Index: ncurses/base/MKlib_gen.sh
+Prereq:  1.50 
+--- ncurses-6.0-20150808+/ncurses/base/MKlib_gen.sh	2015-08-07 00:48:24.000000000 +0000
++++ ncurses-6.0-20150810/ncurses/base/MKlib_gen.sh	2015-08-10 08:56:39.000000000 +0000
+@@ -72,7 +72,7 @@
+ # appears in gcc 5.0 and (with modification) in 5.1, making it necessary to
+ # determine if we are using gcc, and if so, what version because the proposed
+ # solution uses a nonstandard option.
+-PRG=`echo "$1" | $AWK '{ sub(/^[[:space:]]*/,""); sub(/[[:space:]].*$/, ""); print; }' || exit 0`
++PRG=`echo "$1" | $AWK '{ sub(/^[ 	]*/,""); sub(/[ 	].*$/, ""); print; }' || exit 0`
+ FSF=`"$PRG" --version 2>/dev/null || exit 0 | fgrep "Free Software Foundation" | head -n 1`
+ ALL=`"$PRG" -dumpversion 2>/dev/null || exit 0`
+ ONE=`echo "$ALL" | sed -e 's/\..*$//'`


### PR DESCRIPTION
Fixes issue #3622 when building on Debian/Ubuntu.
