### PR TITLE
Added OpenMPI configopts for support of Slurm scheduler.

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-Slurm-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-Slurm-GCC-5.4.0-2.26.eb
@@ -1,0 +1,33 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = '1.10.3'
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-2 implementation."""
+
+toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+
+dependencies = [('hwloc', '1.11.3')]
+
+configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
+configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--with-slurm --with-pmi=/usr/include/slurm --with-pmi-libdir=/usr '  # Support of Slurm
+
+# needed for --with-verbs
+osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+
+libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
+    'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-Slurm-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-Slurm-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -1,0 +1,40 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = '1.10.3'
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-2 implementation."""
+
+toolchain = {'name': 'iccifort', 'version': '2016.3.210-GCC-5.4.0-2.26'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+
+
+configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
+configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--with-slurm --with-pmi=/usr/include/slurm --with-pmi-libdir=/usr '  # Support of Slurm
+
+dependencies = [('hwloc', '1.11.3')]
+
+# needed for --with-verbs
+osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+
+libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
+    'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
+
+sanity_check_commands = [
+    ('mpicc --version | grep icc', ''),
+    ('mpicxx --version | grep icpc', ''),
+    ('mpifort --version | grep ifort', ''),
+]
+
+moduleclass = 'mpi'


### PR DESCRIPTION
Based on OpenMPI-1.10.3-GCC-5.4.0-2.26.eb and OpenMPI-1.10.3-iccifort-2016.3.210-GCC-5.4.0-2.26.eb, I added this line in order to make OpenMPI interoperate with the Slurm scheduler:
configopts += '--with-slurm --with-pmi=/usr/include/slurm --with-pmi-libdir=/usr
 '  # Support of Slurm