### PR TITLE
Update OpenMPI-1.10.3-GCC-5.4.0-2.26.eb

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-5.4.0-2.26.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['pax_disable.patch']
+
 dependencies = [('hwloc', '1.11.3')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '


### PR DESCRIPTION
pax patch for non-interactive, automated builds