### PR TITLE
Easyconfig and patch file to install BLAST+ 2.6.0, tested at UAntwerp…

### DIFF
--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.6.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.6.0-intel-2016b-Python-2.7.12.eb
@@ -1,0 +1,85 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-94.html
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'BLAST+'
+version = '2.6.0'
+versionsuffix = '-Python-2.7.12'
+
+homepage = 'http://blast.ncbi.nlm.nih.gov/'
+description = """Basic Local Alignment Search Tool, or BLAST, is an algorithm
+ for comparing primary biological sequence information, such as the amino-acid
+ sequences of different proteins or the nucleotides of DNA sequences."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+
+sources = ['ncbi-blast-%(version)s+-src.tar.gz']
+source_urls = ['http://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/%(version)s/']
+
+# The patch contains two fixes:
+# - The authors forgot to reinstall the correct root configure script (which is 
+#   available as configure.orig).
+# - A correction to Makefile.in.top, install-toolkit target: The last install
+#   created an error message, so it has been replaced by two commands that 
+#   hopefully perform the action that the authors intended.
+patches = ['%(name)s-%(version)s_general-fixes.patch']
+
+# Loading this version of Boost will also automatically load Python, and the configure
+# of BLAST+ will discover it and enable Python support.
+#dependencies = [ 
+#	('Boost', '1.63.0', versionsuffix),
+#	('GMP', '6.1.1'),
+#	('libpng', '1.6.26'),
+#	('libjpeg-turbo', '1.5.0')
+#]
+dependencies = []
+
+# Select library type
+configopts  = '--with-static '   # Build failed when --with-dll was added.
+# Executables to generate
+configopts += '--with-static-exe --with-bin-release --without-debug --with-strip '
+# Use a couple of build-in libraries rather than their independent
+# counte3rpart, even if they are installed in seperate modules, to reduce dependencies.
+configopts += '--without-z --without-bz2 --without-pcre '
+# Enable support for SRA/VDB. Don't use a version that is already on the system,
+# but just get it from GitHub and compile into BLAST+. This again reduces dependencies.
+configopts += '--with-downloaded-vdb '
+
+# Uncomment the following lines to enable support for a Python module.
+# Make sure it is compatible with the Python used by Boost should you enable
+# support for a Boost module with Python support
+dependencies.append( ('Python', '2.7.12') )
+configopts += '--with-python=$EBROOTPYTHON '
+
+# Uncomment the following lines to enable Boost
+dependencies.append( ('Boost', '1.63.0', '-Python-2.7.12') )
+configopts += '--with-boost=$EBROOTBOOST '
+
+# Uncomment to enable the use of GMP
+dependencies.append( ('GMP', '6.1.1') )
+configopts += '--with-gmp=$EBROOTGMP '
+
+# Uncomment to enable PNG-support
+dependencies.append( ('libpng', '1.6.26') )
+configopts += '--with-png=$EBROOTLIBPNG '
+
+# Uncomment to enable JPEG-support
+dependencies.append( ('libjpeg-turbo', '1.5.0') )
+configopts += '--with-jpeg=$EBROOTLIBJPEGMINTURBO '
+
+sanity_check_paths = {
+    'files': ["bin/blastn", "bin/blastp", "bin/blastx"],
+    'dirs': []
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.6.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.6.0-intel-2016b-Python-2.7.12.eb
@@ -26,56 +26,49 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 sources = ['ncbi-blast-%(version)s+-src.tar.gz']
 source_urls = ['http://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/%(version)s/']
 
-# The patch contains two fixes:
-# - The authors forgot to reinstall the correct root configure script (which is 
-#   available as configure.orig).
-# - A correction to Makefile.in.top, install-toolkit target: The last install
-#   created an error message, so it has been replaced by two commands that 
-#   hopefully perform the action that the authors intended.
+# See the patch file for a description of the fixes.
 patches = ['%(name)s-%(version)s_general-fixes.patch']
 
-# Loading this version of Boost will also automatically load Python, and the configure
-# of BLAST+ will discover it and enable Python support.
-#dependencies = [ 
-#	('Boost', '1.63.0', versionsuffix),
-#	('GMP', '6.1.1'),
-#	('libpng', '1.6.26'),
-#	('libjpeg-turbo', '1.5.0')
-#]
+# START OF CONFIGURATION OF BLAST+
+
 dependencies = []
 
 # Select library type
 configopts  = '--with-static '   # Build failed when --with-dll was added.
-# Executables to generate
+# Options for the executables
 configopts += '--with-static-exe --with-bin-release --without-debug --with-strip '
-# Use a couple of build-in libraries rather than their independent
-# counte3rpart, even if they are installed in seperate modules, to reduce dependencies.
+
+# Enable three built-in modules.
+# This avoids having to figure out compatible versions of these libraries for each
+# installation.
 configopts += '--without-z --without-bz2 --without-pcre '
-# Enable support for SRA/VDB. Don't use a version that is already on the system,
-# but just get it from GitHub and compile into BLAST+. This again reduces dependencies.
+
+# Include a downloaded SRA/VDB (from GitHub).
 configopts += '--with-downloaded-vdb '
 
-# Uncomment the following lines to enable support for a Python module.
+# Uncomment/comment the following lines to enable/disable support for a Python module.
 # Make sure it is compatible with the Python used by Boost should you enable
 # support for a Boost module with Python support
 dependencies.append( ('Python', '2.7.12') )
 configopts += '--with-python=$EBROOTPYTHON '
 
-# Uncomment the following lines to enable Boost
+# Uncomment/comment the following lines to enable/disable Boost
 dependencies.append( ('Boost', '1.63.0', '-Python-2.7.12') )
 configopts += '--with-boost=$EBROOTBOOST '
 
-# Uncomment to enable the use of GMP
+# Uncomment/comment to enable/disable the use of GMP
 dependencies.append( ('GMP', '6.1.1') )
 configopts += '--with-gmp=$EBROOTGMP '
 
-# Uncomment to enable PNG-support
+# Uncomment/comment to enable/disable PNG-support
 dependencies.append( ('libpng', '1.6.26') )
 configopts += '--with-png=$EBROOTLIBPNG '
 
-# Uncomment to enable JPEG-support
+# Uncomment/comment to enable/disable JPEG-support
 dependencies.append( ('libjpeg-turbo', '1.5.0') )
 configopts += '--with-jpeg=$EBROOTLIBJPEGMINTURBO '
+
+# END OF CINFIGURATION OF BLAST+
 
 sanity_check_paths = {
     'files': ["bin/blastn", "bin/blastp", "bin/blastx"],

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.6.0_general-fixes.patch
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.6.0_general-fixes.patch
@@ -1,0 +1,27 @@
+diff -ru ncbi-blast-2.6.0+-src-orig/c++/configure ncbi-blast-2.6.0+-src/c++/configure
+diff -ru ncbi-blast-2.6.0+-src-orig/c++/src/build-system/Makefile.in.top ncbi-blast-2.6.0+-src/c++/src/build-system/Makefile.in.top
+# Patches:
+# - Configure script in the 2.6.0 release was not clean and imposed some options
+#   that caused a failure of the build process
+# - make install-toolkit produced an error that had make return an error code.
+#   The include file in common may not be needed, but will be copied to the install
+#   directory just to be sure.
+--- ncbi-blast-2.6.0+-src-orig/c++/configure	2016-12-07 20:38:29.000000000 +0100
++++ ncbi-blast-2.6.0+-src/c++/configure	2016-12-07 20:38:29.000000000 +0100
+@@ -1,3 +1,3 @@
+ #!/bin/sh
+ srcdir=`dirname $0`
+-exec $srcdir/configure.orig --without-debug --with-strip --with-openmp --with-mt --without-vdb --with-build-root=$srcdir/ReleaseMT ${1+"$@"}
++exec $srcdir/src/build-system/configure --srcdir=$srcdir ${1+"$@"}
+--- ncbi-blast-2.6.0+-src-orig/c++/src/build-system/Makefile.in.top	2014-11-12 17:41:55.000000000 +0100
++++ ncbi-blast-2.6.0+-src/c++/src/build-system/Makefile.in.top	2017-02-22 10:33:50.510622000 +0100
+@@ -51,7 +51,8 @@
+ 	    done
+ 	cd $(includedir0) && find * -name CVS -prune -o -print |\
+             cpio -pd $(pincludedir)
+-	$(INSTALL) -m 644 $(incdir)/* $(pincludedir)
++	$(INSTALL) -m 644 $(incdir)/*.h $(pincludedir)
++	$(INSTALL) -m 644 $(incdir)/common/*.h $(pincludedir)/common
+ ## set up appropriate build and status directories somewhere under $(libdir)?
+ 
+ install-gbench:

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.6.0_general-fixes.patch
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.6.0_general-fixes.patch
@@ -6,6 +6,8 @@ diff -ru ncbi-blast-2.6.0+-src-orig/c++/src/build-system/Makefile.in.top ncbi-bl
 # - make install-toolkit produced an error that had make return an error code.
 #   The include file in common may not be needed, but will be copied to the install
 #   directory just to be sure.
+#
+# Developed by Kurt Lust (UAntwerpen)
 --- ncbi-blast-2.6.0+-src-orig/c++/configure	2016-12-07 20:38:29.000000000 +0100
 +++ ncbi-blast-2.6.0+-src/c++/configure	2016-12-07 20:38:29.000000000 +0100
 @@ -1,3 +1,3 @@


### PR DESCRIPTION
…en on hopper with 2016b toolchain

I adapted a easyconfig to install BLAST+ 2.6.0 and made a new patch file. The patches should also work for other toolchains: they correct an error in the root configure script (the developers accidentally forgot to remove the clean configure.orig script back to configure) and a problem with the install-toolkit target in the Makefile that caused an error message.

There are plenty of comments in the EasyConfig so that other users can easily adapt it to their own needs.