### PR TITLE
fix bug in fftw3x_cdft/makefile affecting -fPIC build

### DIFF
--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.0.109-iimpi-2016.00-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.0.109-iimpi-2016.00-GCC-4.9.3-2.25.eb
@@ -22,4 +22,19 @@ license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic
 
 interfaces = True
 
+postinstallcmds = [
+    # fix bug in makefile for cdft fftw3 wrappers
+    "sed -i'' -e 's/CFLAGS = /CFLAGS += /' %(installdir)s/mkl/interfaces/fftw3x_cdft/makefile",
+    # extract the examples
+    'tar xvzf %(installdir)s/mkl/examples/examples_cluster.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_f.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_f95.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_mic.tgz -C %(installdir)s/mkl/examples/'
+]
+
+modextravars = {
+    'MKL_EXAMPLES': '%(installdir)s/mkl/examples/',
+}
+
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.1.150-iimpi-2016.01-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.1.150-iimpi-2016.01-GCC-4.9.3-2.25.eb
@@ -16,15 +16,13 @@ checksums = ['b57ff502b5f97f2f783e4bbda7ce42b3']
 
 dontcreateinstalldir = 'True'
 
-# license file
-import os
-license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True
 
-moduleclass = 'numlib'
-
 postinstallcmds = [
+    # fix bug in makefile for cdft fftw3 wrappers affecting -fPIC build
+    "sed -i'' -e 's/CFLAGS = /CFLAGS += /' %(installdir)s/mkl/interfaces/fftw3x_cdft/makefile",
     # extract the examples
     'tar xvzf %(installdir)s/mkl/examples/examples_cluster.tgz -C %(installdir)s/mkl/examples/',
     'tar xvzf %(installdir)s/mkl/examples/examples_core_c.tgz -C %(installdir)s/mkl/examples/',
@@ -36,3 +34,5 @@ postinstallcmds = [
 modextravars = {
     'MKL_EXAMPLES': '%(installdir)s/mkl/examples/',
 }
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.1.150-iimpi-7.5.5-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.1.150-iimpi-7.5.5-GCC-4.9.3-2.25.eb
@@ -13,10 +13,23 @@ sources = ['l_mkl_%(version)s.tgz']
 
 dontcreateinstalldir = 'True'
 
-# license file
-import os
-license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True
+
+postinstallcmds = [
+    # fix bug in makefile for cdft fftw3 wrappers affecting -fPIC build
+    "sed -i'' -e 's/CFLAGS = /CFLAGS += /' %(installdir)s/mkl/interfaces/fftw3x_cdft/makefile",
+    # extract the examples
+    'tar xvzf %(installdir)s/mkl/examples/examples_cluster.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_f.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_f95.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_mic.tgz -C %(installdir)s/mkl/examples/'
+]
+
+modextravars = {
+    'MKL_EXAMPLES': '%(installdir)s/mkl/examples/',
+}
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.1.150-iimpi-8.1.5-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.1.150-iimpi-8.1.5-GCC-4.9.3-2.25.eb
@@ -13,10 +13,23 @@ sources = ['l_mkl_%(version)s.tgz']
 
 dontcreateinstalldir = 'True'
 
-# license file
-import os
-license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True
+
+postinstallcmds = [
+    # fix bug in makefile for cdft fftw3 wrappers affecting -fPIC build
+    "sed -i'' -e 's/CFLAGS = /CFLAGS += /' %(installdir)s/mkl/interfaces/fftw3x_cdft/makefile",
+    # extract the examples
+    'tar xvzf %(installdir)s/mkl/examples/examples_cluster.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_f.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_f95.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_mic.tgz -C %(installdir)s/mkl/examples/'
+]
+
+modextravars = {
+    'MKL_EXAMPLES': '%(installdir)s/mkl/examples/',
+}
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-iimpi-2016.02-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-iimpi-2016.02-GCC-4.9.3-2.25.eb
@@ -21,6 +21,8 @@ license_file = HOME + '/licenses/intel/license.lic'
 interfaces = True
 
 postinstallcmds = [
+    # fix bug in makefile for cdft fftw3 wrappers affecting -fPIC build
+    "sed -i'' -e 's/CFLAGS = /CFLAGS += /' %(installdir)s/mkl/interfaces/fftw3x_cdft/makefile",
     # extract the examples
     'tar xvzf %(installdir)s/mkl/examples/examples_cluster.tgz -C %(installdir)s/mkl/examples/',
     'tar xvzf %(installdir)s/mkl/examples/examples_core_c.tgz -C %(installdir)s/mkl/examples/',

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-iimpi-2016.02-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-iimpi-2016.02-GCC-5.3.0-2.26.eb
@@ -21,6 +21,8 @@ license_file = HOME + '/licenses/intel/license.lic'
 interfaces = True
 
 postinstallcmds = [
+    # fix bug in makefile for cdft fftw3 wrappers affecting -fPIC build
+    "sed -i'' -e 's/CFLAGS = /CFLAGS += /' %(installdir)s/mkl/interfaces/fftw3x_cdft/makefile",
     # extract the examples
     'tar xvzf %(installdir)s/mkl/examples/examples_cluster.tgz -C %(installdir)s/mkl/examples/',
     'tar xvzf %(installdir)s/mkl/examples/examples_core_c.tgz -C %(installdir)s/mkl/examples/',

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-pompi-2016.03.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-pompi-2016.03.eb
@@ -21,6 +21,8 @@ license_file = HOME + '/licenses/intel/license.lic'
 interfaces = True
 
 postinstallcmds = [
+    # fix bug in makefile for cdft fftw3 wrappers affecting -fPIC build
+    "sed -i'' -e 's/CFLAGS = /CFLAGS += /' %(installdir)s/mkl/interfaces/fftw3x_cdft/makefile",
     # extract the examples
     'tar xvzf %(installdir)s/mkl/examples/examples_cluster.tgz -C %(installdir)s/mkl/examples/',
     'tar xvzf %(installdir)s/mkl/examples/examples_core_c.tgz -C %(installdir)s/mkl/examples/',


### PR DESCRIPTION
+ fix inconsistencies w.r.t. `license_file` and `postinstallcmds` while we're at it

cfr. https://github.com/hpcugent/easybuild-easyblocks/issues/977