### PR TITLE
{chem}[foss,2016b] GPAW 1.2.0

### DIFF
--- a/easybuild/easyconfigs/a/ASE/ASE-3.13.0-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.13.0-foss-2016b-Python-3.5.2.eb
@@ -9,23 +9,21 @@ in the Python scripting language."""
 
 toolchain = {'name': 'foss', 'version': '2016b'}
 
-# source_urls = ['https://wiki.fysik.dtu.dk/ase-files/']
-# sources = ['python-%s-%s.tar.gz' % (name.lower(), version)]
-source_urls = ['https://pypi.python.org/packages/84/a8/664c99fc94510163b5289c8e475660182f0f6ba098c549879bc5d36c17fd/']
-sources = ['%s-%s.tar.gz' % (name.lower(), version)]
+source_urls = [PYPI_LOWER_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
 python = 'Python'
 pythonver = '3.5.2'
-pythonshortver = '.'.join(pythonver.split('.')[0:2])
 versionsuffix = '-%s-%s' % (python, pythonver)
 
 dependencies = [
    (python, pythonver),
-   ('matplotlib', '1.5.3', '-Python-' + pythonver)
+   ('matplotlib', '1.5.3', versionsuffix)
 ]
 
 sanity_check_paths = {
-    'files': ['bin/ase-gui'],
-    'dirs': ['lib/python%s/site-packages/%s' % (pythonshortver, name.lower())]
+    'files': ['bin/ase-build', 'bin/ase-db', 'bin/ase-gui', 'bin/ase-info', 'bin/ase-run'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(namelower)s'],
 }
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/a/ASE/ASE-3.13.0-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.13.0-foss-2016b-Python-3.5.2.eb
@@ -2,6 +2,7 @@ easyblock = "PythonPackage"
 
 name = 'ASE'
 version = '3.13.0'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://wiki.fysik.dtu.dk/ase/'
 description = """ASE is a python package providing an open source Atomic Simulation Environment
@@ -12,12 +13,8 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 
-python = 'Python'
-pythonver = '3.5.2'
-versionsuffix = '-%s-%s' % (python, pythonver)
-
 dependencies = [
-   (python, pythonver),
+   ('Python', '3.5.2'),
    ('matplotlib', '1.5.3', versionsuffix)
 ]
 

--- a/easybuild/easyconfigs/a/ASE/ASE-3.13.0-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.13.0-foss-2016b-Python-3.5.2.eb
@@ -1,0 +1,31 @@
+easyblock = "PythonPackage"
+
+name = 'ASE'
+version = '3.13.0'
+
+homepage = 'https://wiki.fysik.dtu.dk/ase/'
+description = """ASE is a python package providing an open source Atomic Simulation Environment
+in the Python scripting language."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+
+# source_urls = ['https://wiki.fysik.dtu.dk/ase-files/']
+# sources = ['python-%s-%s.tar.gz' % (name.lower(), version)]
+source_urls = ['https://pypi.python.org/packages/84/a8/664c99fc94510163b5289c8e475660182f0f6ba098c549879bc5d36c17fd/']
+sources = ['%s-%s.tar.gz' % (name.lower(), version)]
+python = 'Python'
+pythonver = '3.5.2'
+pythonshortver = '.'.join(pythonver.split('.')[0:2])
+versionsuffix = '-%s-%s' % (python, pythonver)
+
+dependencies = [
+   (python, pythonver),
+   ('matplotlib', '1.5.1', '-Python-' + pythonver)
+]
+
+sanity_check_paths = {
+    'files': ['bin/ase-gui'],
+    'dirs': ['lib/python%s/site-packages/%s' % (pythonshortver, name.lower())]
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/a/ASE/ASE-3.13.0-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.13.0-foss-2016b-Python-3.5.2.eb
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 sanity_check_paths = {
-    'files': ['bin/ase-build', 'bin/ase-db', 'bin/ase-gui', 'bin/ase-info', 'bin/ase-run'],
+    'files': ['bin/ase-' + p for p in ['build', 'db', 'gui', 'info', 'run']],
     'dirs': ['lib/python%(pyshortver)s/site-packages/%(namelower)s'],
 }
 

--- a/easybuild/easyconfigs/a/ASE/ASE-3.13.0-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.13.0-foss-2016b-Python-3.5.2.eb
@@ -20,7 +20,7 @@ versionsuffix = '-%s-%s' % (python, pythonver)
 
 dependencies = [
    (python, pythonver),
-   ('matplotlib', '1.5.1', '-Python-' + pythonver)
+   ('matplotlib', '1.5.3', '-Python-' + pythonver)
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/ASE/ASE-3.13.0-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.13.0-foss-2016b-Python-3.5.2.eb
@@ -13,10 +13,7 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 
-dependencies = [
-   ('Python', '3.5.2'),
-   ('matplotlib', '1.5.3', versionsuffix)
-]
+dependencies = [('Python', '3.5.2'), ('matplotlib', '1.5.3', versionsuffix)]
 
 sanity_check_paths = {
     'files': ['bin/ase-' + p for p in ['build', 'db', 'gui', 'info', 'run']],

--- a/easybuild/easyconfigs/a/ASE/ASE-3.13.0-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.13.0-foss-2016b-Python-3.5.2.eb
@@ -13,7 +13,10 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 
-dependencies = [('Python', '3.5.2'), ('matplotlib', '1.5.3', versionsuffix)]
+dependencies = [
+    ('Python', '3.5.2'),
+    ('matplotlib', '1.5.3', versionsuffix)
+]
 
 sanity_check_paths = {
     'files': ['bin/ase-' + p for p in ['build', 'db', 'gui', 'info', 'run']],

--- a/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-customize.patch
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-customize.patch
@@ -1,18 +1,26 @@
---- customize.py	2017-02-24 15:10:13.635016617 +0100
-+++ /home/camp/mikst/Desktop/customize.py	2017-02-24 15:19:02.267012659 +0100
-@@ -32,15 +32,21 @@
+--- gpaw-1.2.0-orig/customize.py	2017-05-24 11:57:38.765096571 +0200
++++ gpaw-1.2.0/customize.py	    2017-05-24 11:58:43.189777767 +0200
+@@ -27,20 +27,28 @@
+ 
+     libraries += ['somelib', 'otherlib']
+ """
+-
++import os
+ # compiler = 'gcc'
  # mpicompiler = 'mpicc'  # use None if you don't want to build a gpaw-python
  # mpilinker = 'mpicc'
  # platform_id = ''
 -# scalapack = False
 +scalapack = True
++
 +libraries = ['readline',
 +             'gfortran',
-+             'scalapack',
 +             'openblas',
-+             'xc'] 
++             'xc']
  
-+extra_compile_args = ['-O2', '-std=c99', '-fPIC', '-Wall']
++scalapack_libs = [libfile[3:-2] for libfile in
++                  os.getenv('SCALAPACK_STATIC_LIBS').split(',')]
++mpi_libraries += scalapack_libs
  # Use ScaLAPACK:
  # Warning! At least scalapack 2.0.1 is required!
  # See https://trac.fysik.dtu.dk/projects/gpaw/ticket/230

--- a/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-customize.patch
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-customize.patch
@@ -1,0 +1,28 @@
+--- customize.py	2017-02-24 15:10:13.635016617 +0100
++++ /home/camp/mikst/Desktop/customize.py	2017-02-24 15:19:02.267012659 +0100
+@@ -32,15 +32,21 @@
+ # mpicompiler = 'mpicc'  # use None if you don't want to build a gpaw-python
+ # mpilinker = 'mpicc'
+ # platform_id = ''
+-# scalapack = False
++scalapack = True
++libraries = ['readline',
++             'gfortran',
++             'scalapack',
++             'openblas',
++             'xc'] 
+ 
++extra_compile_args = ['-O2', '-std=c99', '-fPIC', '-Wall']
+ # Use ScaLAPACK:
+ # Warning! At least scalapack 2.0.1 is required!
+ # See https://trac.fysik.dtu.dk/projects/gpaw/ticket/230
+ if scalapack:
+-    libraries += ['scalapack-openmpi',
+-                  'blacsCinit-openmpi',
+-                  'blacs-openmpi']
++#    libraries += ['scalapack-openmpi',
++#                  'blacsCinit-openmpi',
++#                  'blacs-openmpi']
+     define_macros += [('GPAW_NO_UNDERSCORE_CBLACS', '1')]
+     define_macros += [('GPAW_NO_UNDERSCORE_CSCALAPACK', '1')]
+ 

--- a/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-customize.patch
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-customize.patch
@@ -1,3 +1,6 @@
+This patch is used to build GPAW with the foss-2016b toolchain allowing GPAW
+to use Openblas and Scalapack
+Author: Mikkel Strange, Technical University of Denmark, Denmark
 --- gpaw-1.2.0-orig/customize.py	2017-05-24 11:57:38.765096571 +0200
 +++ gpaw-1.2.0/customize.py	    2017-05-24 11:58:43.189777767 +0200
 @@ -27,20 +27,28 @@

--- a/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-foss-2016b-Python-3.5.2.eb
@@ -8,13 +8,12 @@ description = """GPAW is a density-functional theory (DFT) Python code based on 
 method and the atomic simulation environment (ASE). It uses real-space uniform grids and multigrid methods or 
 atom-centered basis-functions."""
 toolchain = {'name': 'foss', 'version': '2016b'}
-source_urls = ['https://pypi.python.org/packages/3c/ed/c06fc0960c1ddc8bb5ae6a23d1164ffa78324758a3bfb50c677278bef14a']
+source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['GPAW-1.2.0-customize.patch']
 python = 'Python'
 pythonver = '3.5.2'
-pythonshortver = '.'.join(pythonver.split('.')[0:2])
 versionsuffix = '-%s-%s' % (python, pythonver)
 
 dependencies = [
@@ -25,8 +24,8 @@ dependencies = [
 ]
 
 sanity_check_paths = {
-    'files': ['bin/gpaw%s' % x for x in ['', '-basis', '-mpisim', '-python', '-setup']],
-    'dirs': ['lib/python%s/site-packages/%s' % (pythonshortver, name.lower())]
+    'files': ['bin/gpaw' + for x in ['', '-basis', '-mpisim', '-python', '-setup']],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(namelower)s']
 }
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-foss-2016b-Python-3.5.2.eb
@@ -1,0 +1,31 @@
+easyblock = "PythonPackage"
+
+name = 'GPAW'
+version = '1.2.0'
+
+homepage = 'https://wiki.fysik.dtu.dk/gpaw/'
+description = """GPAW is a density-functional theory (DFT) Python code based on the projector-augmented wave (PAW)
+method and the atomic simulation environment (ASE). It uses real-space uniform grids and multigrid methods or 
+atom-centered basis-functions."""
+toolchain = {'name': 'foss', 'version': '2016b'}
+source_urls = ['https://pypi.python.org/packages/3c/ed/c06fc0960c1ddc8bb5ae6a23d1164ffa78324758a3bfb50c677278bef14a']
+sources = [SOURCELOWER_TAR_GZ]
+
+patches = ['GPAW-1.2.0-customize.patch']
+python = 'Python'
+pythonver = '3.5.2'
+pythonshortver = '.'.join(pythonver.split('.')[0:2])
+versionsuffix = '-%s-%s' % (python, pythonver)
+
+dependencies = [
+    (python, pythonver),
+    ('ASE', '3.13.0', versionsuffix),
+    ('libxc', '3.0.0'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/gpaw%s' % x for x in ['', '-basis', '-mpisim', '-python', '-setup']],
+    'dirs': ['lib/python%s/site-packages/%s' % (pythonshortver, name.lower())]
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-foss-2016b-Python-3.5.2.eb
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 sanity_check_paths = {
-    'files': ['bin/gpaw' + for x in ['', '-basis', '-mpisim', '-python', '-setup']],
+    'files': ['bin/gpaw' + x for x in ['', '-basis', '-mpisim', '-python', '-setup']],
     'dirs': ['lib/python%(pyshortver)s/site-packages/%(namelower)s']
 }
 

--- a/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-foss-2016b-Python-3.5.2.eb
@@ -21,6 +21,7 @@ dependencies = [
     (python, pythonver),
     ('ASE', '3.13.0', versionsuffix),
     ('libxc', '3.0.0'),
+    ('libreadline', '6.3')
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-1.2.0-foss-2016b-Python-3.5.2.eb
@@ -2,6 +2,7 @@ easyblock = "PythonPackage"
 
 name = 'GPAW'
 version = '1.2.0'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://wiki.fysik.dtu.dk/gpaw/'
 description = """GPAW is a density-functional theory (DFT) Python code based on the projector-augmented wave (PAW)
@@ -12,12 +13,9 @@ source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['GPAW-1.2.0-customize.patch']
-python = 'Python'
-pythonver = '3.5.2'
-versionsuffix = '-%s-%s' % (python, pythonver)
 
 dependencies = [
-    (python, pythonver),
+    ('Python', '3.5.2'),
     ('ASE', '3.13.0', versionsuffix),
     ('libxc', '3.0.0'),
     ('libreadline', '6.3')

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.0-foss-2016b.eb
@@ -8,6 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
@@ -22,7 +23,8 @@ configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared --enable-fortran'
 runtest = 'check'
 
 sanity_check_paths = {
-    'files': ['lib/libxc%s.%s' % (x,y) for x in ['', 'f90'] for y in ['a', SHLIB_EXT]],
+    'files': ['lib/libxc%s.%s' % (x, y) for x in ['', 'f90']
+              for y in ['a', SHLIB_EXT]],
     'dirs': ['include'],
 }
 

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.0-foss-2016b.eb
@@ -1,0 +1,31 @@
+easyblock = 'ConfigureMake'
+
+name = 'libxc'
+version = '3.0.0'
+
+homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
+ The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+
+configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared --enable-fortran'
+
+# From the libxc mailing list
+# To summarize: expect less tests to fail in libxc 2.0.2, but don't expect
+# a fully working testsuite soon (unless someone wants to volunteer to do
+# it, of course  ) In the meantime, unless the majority of the tests
+# fail, your build should be fine.
+# runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['lib/libxc%s.%s' % (x,y) for x in ['', 'f90'] for y in ['a', SHLIB_EXT]],
+    'dirs': ['include'],
+}
+
+parallel = 1
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.0-foss-2016b.eb
@@ -19,7 +19,7 @@ configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared --enable-fortran'
 # a fully working testsuite soon (unless someone wants to volunteer to do
 # it, of course  ) In the meantime, unless the majority of the tests
 # fail, your build should be fine.
-# runtest = 'check'
+runtest = 'check'
 
 sanity_check_paths = {
     'files': ['lib/libxc%s.%s' % (x,y) for x in ['', 'f90'] for y in ['a', SHLIB_EXT]],


### PR DESCRIPTION
Latest releases of GPAW (v 1.2.0) and ASE (v 3.13.0) for the foss-2016b toolchain.

One thing to note is that to have GPAW use FFTW, FFTW should be compiled with shared libraries, otherwise GPAW uses numpy's FFTs.