### PR TITLE
(foss-2015b) Graphviz v2.38.0 plus dependencies (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/c/cairo/cairo-1.14.6-foss-2015b-GLib-2.49.5.eb
+++ b/easybuild/easyconfigs/c/cairo/cairo-1.14.6-foss-2015b-GLib-2.49.5.eb
@@ -1,0 +1,53 @@
+easyblock = 'ConfigureMake'
+
+name = 'cairo'
+version = '1.14.6'
+glibver = '2.49.5'
+versionsuffix = '-GLib-%s' % glibver
+
+homepage = 'http://cairographics.org'
+description = """Cairo is a 2D graphics library with support for multiple output devices.
+ Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers,
+ PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB"""
+
+toolchain = {'name': 'foss', 'version': '2015b'}
+
+source_urls = ['http://cairographics.org/releases/']
+sources = [SOURCE_TAR_XZ]
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('libpng', '1.6.21'),
+    ('freetype', '2.6.2'),
+    ('pixman', '0.34.0'),
+    ('fontconfig', '2.11.94'),
+    ('expat', '2.1.0'),
+    ('libX11', '1.6.3'),
+    ('libxcb', '1.11.1'),
+    ('libXrender', '0.9.9'),
+    ('libXext', '1.3.3'),
+    ('libXau', '1.0.8'),
+    ('libXdmcp', '1.1.2'),
+    ('GLib', glibver),
+]
+builddependencies = [
+    ('renderproto', '0.11'),
+    ('xproto', '7.0.28'),
+    ('xextproto', '7.3.0'),
+]
+
+# disable symbol lookup, which requires -lbfd, to avoid link issues with (non-PIC) libiberty.a provided by GCC
+configopts = "--enable-symbol-lookup=no --enable-gobject=yes --enable-svg=yes --enable-tee=yes "
+
+sanity_check_paths = {
+    'files': ['bin/cairo-trace', 'lib/cairo/libcairo-trace.so', 'lib/cairo/libcairo-trace.a',
+              'lib/libcairo.a', 'lib/libcairo-gobject.a', 'lib/libcairo-script-interpreter.a',
+              'lib/libcairo-gobject.so', 'lib/libcairo-script-interpreter.so', 'lib/libcairo.so'] +
+             ['include/cairo/cairo%s.h' % x for x in ['', '-deprecated', '-features', '-ft', '-gobject', '-pdf', '-ps',
+                                                      '-script', '-script-interpreter', '-svg', '-version', '-xcb',
+                                                      '-xlib', '-xlib-xrender']],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GLib/GLib-2.49.5-foss-2015b.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.49.5-foss-2015b.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'GLib'
+version = '2.49.5'
+
+homepage = 'http://www.gtk.org/'
+description = """GLib is one of the base libraries of the GTK+ project"""
+
+toolchain = {'name': 'foss', 'version': '2015b'}
+toolchainopts = {'pic': True}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+
+dependencies = [
+    ('libffi', '3.2.1'),
+    ('gettext', '0.19.7'),
+    ('libxml2', '2.9.2'),
+    ('PCRE', '8.38'),
+]
+
+builddependencies = [('Python', '2.7.10')]
+
+configopts = "--disable-maintainer-mode --disable-silent-rules --disable-libelf --disable-systemtap "
+configopts += "--enable-static --enable-shared"
+
+postinstallcmds = ["sed -i -e 's|#!.*python|#!/usr/bin/env python|' %(installdir)s/bin/*"]
+
+sanity_check_paths = {
+    'files': ['lib/libglib-%(version_major)s.0.a', 'lib/libglib-%%(version_major)s.0.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'include'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GObject-Introspection/GObject-Introspection-1.49.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/g/GObject-Introspection/GObject-Introspection-1.49.1-foss-2015b.eb
@@ -1,0 +1,51 @@
+easyblock = 'ConfigureMake'
+
+name = 'GObject-Introspection'
+version = '1.49.1'
+
+homepage = 'https://wiki.gnome.org/GObjectIntrospection/'
+description = """GObject introspection is a middleware layer between C libraries
+ (using GObject) and language bindings. The C library can be scanned at
+ compile time and generate a metadata file, in addition to the actual
+ native C library. Then at runtime, language bindings can read this
+ metadata and automatically provide bindings to call into the C library."""
+
+toolchain = {'name': 'foss', 'version': '2015b'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+
+glibver = '2.49.5'
+dependencies = [
+    ('Python', '2.7.10'),
+    ('GLib', glibver),
+    ('libffi', '3.2.1'),
+]
+
+builddependencies = [
+    ('Autotools', '20150215'),
+    ('flex', '2.6.0'),
+    ('Bison', '3.0.4'),
+    ('cairo', '1.14.6', '-GLib-%s' % glibver),
+]
+
+preconfigopts = "env GI_SCANNER_DISABLE_CACHE=true"
+# PKG_CONFIG_PATH=${EBROOTGLIB}/lib/pkgconfig:${PKG_CONFIG_PATH} GLIB_LIBS=-I${EBROOTGLIB}/include"
+
+#configopts = " "
+
+# avoid using hard-coded path to 'python' in shebang of scripts
+buildopts = "PYTHON=python"
+
+modextrapaths = {
+    'GI_TYPELIB_PATH': 'share',
+    'XDG_DATA_DIRS': 'share',
+}
+
+sanity_check_paths = {
+    'files': ['bin/g-ir-%s' % x for x in ['annotation-tool', 'compiler', 'generate', 'scanner']] +
+             ['lib/libgirepository-1.0.%s' % x for x in ['so', 'a']],
+    'dirs': ['include', 'share']
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-2.38.0-foss-2015b.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-2.38.0-foss-2015b.eb
@@ -1,0 +1,62 @@
+easyblock = 'ConfigureMake'
+
+name = 'Graphviz'
+version = '2.38.0'
+
+homepage = 'http://www.graphviz.org/'
+description = """Graphviz is open source graph visualization software. Graph visualization
+ is a way of representing structural information as diagrams of
+ abstract graphs and networks. It has important applications in networking,
+ bioinformatics,  software engineering, database and web design, machine learning,
+ and in visual interfaces for other technical domains."""
+
+toolchain = {'name': 'foss', 'version': '2015b'}
+
+source_urls = ['http://www.graphviz.org/pub/graphviz/stable/SOURCES/']
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('cairo', '1.14.6'),
+    ('expat', '2.1.0'),
+    ('freetype', '2.6.2'),
+    ('Ghostscript', '9.20'),
+    ('GTS', '0.7.6'),
+    ('Java', '1.8.0_74', '', True),
+    ('libpng', '1.6.21'),
+    ('Pango', '1.40.3'),
+    ('Perl', '5.22.1'),
+    ('Qt', '4.8.7'),
+    ('Tcl', '8.6.5'),
+    ('zlib', '1.2.8'),
+]
+
+builddependencies = [
+    ('M4', '1.4.17'),
+    ('SWIG', '3.0.8', '-Python-2.7.10'),
+]
+
+preconfigopts = "sed -i 's/install-data-hook$//g' tclpkg/Makefile.in && "
+configopts = '--enable-guile=no --enable-lua=no --enable-ocaml=no '
+configopts += '--enable-r=no --enable-ruby=no '
+
+prebuildopts = 'qmake -o cmd/gvedit/qMakefile cmd/gvedit/gvedit.pro && '
+
+sanity_check_paths = {
+    'files': ['bin/cluster', 'bin/dot', 'bin/gvmap',
+              'lib/libcdt.%s' % SHLIB_EXT, 'lib/libgvc.%s' % SHLIB_EXT, 'lib/libxdot.%s' % SHLIB_EXT],
+    'dirs': ['include', 'lib/graphviz']
+}
+
+sanity_check_commands = [
+    ("test ! -d $EBROOTTCL/lib/*/graphviz", ''),
+    ("test ! -d $EBROOTTCL/lib64/*/graphviz", ''),
+]
+
+modextrapaths = {
+    'PYTHONPATH': 'lib/graphviz/python',
+    'CLASSPATH': 'lib/graphviz/java/org/graphviz',
+    'LD_LIBRARY_PATH': 'lib/graphviz/java',
+    'TCLLIBPATH': 'lib/graphviz/tcl',
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/h/HarfBuzz/HarfBuzz-1.3.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/h/HarfBuzz/HarfBuzz-1.3.1-foss-2015b.eb
@@ -1,0 +1,37 @@
+easyblock = 'ConfigureMake'
+
+name = 'HarfBuzz'
+version = '1.3.1'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/HarfBuzz'
+description = """HarfBuzz is an OpenType text shaping engine."""
+
+toolchain = {'name': 'foss', 'version': '2015b'}
+
+source_urls = ['http://www.freedesktop.org/software/harfbuzz/release/']
+sources = [SOURCELOWER_TAR_BZ2]
+
+glibver = '2.49.5'
+dependencies = [
+    ('GLib', glibver),
+    ('cairo', '1.14.6', '-GLib-%s' % glibver),
+    ('freetype', '2.6.2'),
+]
+
+builddependencies = [('GObject-Introspection', '1.49.1')]
+
+configopts = "--enable-introspection=yes --with-gobject=yes --enable-static --enable-shared --with-cairo "
+
+buildopts = "INCLUDES=-I${EBROOTCAIRO}/include/cairo"
+
+modextrapaths = {
+    'GI_TYPELIB_PATH': 'share',
+    'XDG_DATA_DIRS': 'share',
+}
+
+sanity_check_paths = {
+    'files': ['lib/libharfbuzz.%s' % SHLIB_EXT, 'bin/hb-view'],
+    'dirs': []
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/Pango/Pango-1.40.3-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/Pango/Pango-1.40.3-foss-2015b.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'Pango'
+version = '1.40.3'
+
+homepage = 'http://www.pango.org/'
+description = """Pango is a library for laying out and rendering of text, with an emphasis on internationalization.
+Pango can be used anywhere that text layout is needed, though most of the work on Pango so far has been done in the
+context of the GTK+ widget toolkit. Pango forms the core of text and font handling for GTK+-2.x."""
+
+toolchain = {'name': 'foss', 'version': '2015b'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+
+glibver = '2.49.5'
+dependencies = [
+    ('X11', '20160819'),
+    ('GLib', glibver),
+    ('cairo', '1.14.6', '-GLib-%s' % glibver),
+    ('HarfBuzz', '1.3.1'),
+    ('renderproto', '0.11'),
+    ('xextproto', '7.3.0'),
+]
+
+builddependencies = [('GObject-Introspection', '1.49.1')]
+
+configopts = "--disable-silent-rules --enable-introspection=yes --enable-static --enable-shared "
+
+modextrapaths = {
+    'XDG_DATA_DIRS': 'share',
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/s/SWIG/SWIG-3.0.8-foss-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/s/SWIG/SWIG-3.0.8-foss-2015b-Python-2.7.10.eb
@@ -1,0 +1,23 @@
+name = 'SWIG'
+version = '3.0.8'
+
+homepage = 'http://www.swig.org/'
+description = """SWIG is a software development tool that connects programs written in C and C++ with
+ a variety of high-level programming languages."""
+
+toolchain = {'name': 'foss', 'version': '2015b'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+python = 'Python'
+pythonversion = '2.7.10'
+versionsuffix = '-%s-%s' % (python, pythonversion)
+
+dependencies = [
+    (python, pythonversion),
+    ('PCRE', '8.38'),
+]
+
+moduleclass = 'devel'


### PR DESCRIPTION
I had issues with a dependency having a minimum `GLib` version so had to create a new easyconfig for `cairo` with a version suffix - I tried to follow similar easyconfigs for this but there may be issues?

In addition, I also found issues with unspecified dependencies for `Pango` and had to add `renderproto` and `xextproto`.