### PR TITLE
{bio}[dummy/] Long Ranger v2.1.3 linux x86 64 (WIP)

### DIFF
--- a/easybuild/easyconfigs/l/LongRanger/LongRanger-2.1.3.eb
+++ b/easybuild/easyconfigs/l/LongRanger/LongRanger-2.1.3.eb
@@ -1,0 +1,32 @@
+easyblock = 'Tarball'
+
+name = 'LongRanger'
+version = '2.1.3'
+
+homepage = 'https://support.10xgenomics.com/genome-exome/software/pipelines/latest/what-is-long-ranger'
+description = """Long Ranger is a set of analysis pipelines that processes Chromium sequencing
+  output to align reads and call and phase SNPs, indels, and structural variants. There are
+  five main pipelines, each triggered by a longranger command"""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+#AWSAccessKeyId = 'AKIAJAZONYDS6QUPQVBA&Expires=1494505800'
+#Signature = 'xgrf9Tt4irlRbTO6W6F7cSnNOck%3D'
+md5sum = 'ac9ce51bab40570b37584040479db49d'
+
+# NOTE: Download from: https://s3-us-west-2.amazonaws.com/10x.files/releases/genome/longranger-2.1.3.tar.gz?AWSAccessKeyId=AKIAJAZONYDS6QUPQVBA&Expires=1494505800&Signature=xgrf9Tt4irlRbTO6W6F7cSnNOck%3D
+
+source_urls = ['https://s3-us-west-2.amazonaws.com/10x.files/releases/genome/']
+sources = ['%(namelower)s-%(version)s.tar.gz']
+checksums = [('md5', md5sum)]
+
+sanity_check_paths = {
+    'files': ['longranger'],
+    'dirs': [],
+}
+
+modextrapaths = {
+    'PATH': "",
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
The URL for obtaining the source contains a suffix such that EasyBuild cannot determine the file type for unpacking. How should this be dealt with? I'm currently relying on the user to download the file manually and have it available when `eb` is invoked to install `LongRanger`.

