### PR TITLE
Added Rmpi patch file for R built with intel toolchains incl. impi 5.x)

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.3.3-intel-2017a-X11-20170314.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.3-intel-2017a-X11-20170314.eb
@@ -77,7 +77,7 @@ exts_list = [
     'tools',
     'utils',
     # non-standard libraries, should be specified with fixed versions!
-    ('Rmpi', '0.6-6', ext_options),
+    ('Rmpi', '0.6-6', dict(ext_options.items() + [('patches', ['Rmpi-0.6-5_impi5.patch'])])),
     ('abind', '1.4-5', ext_options),
     ('magic', '1.5-6', ext_options),
     ('geometry', '0.3-6', dict(ext_options.items() + [('patches', ['geometry-0.3-4-icc.patch'])])),

--- a/easybuild/easyconfigs/r/R/R-3.4.0-intel-2017a-X11-20170314.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.0-intel-2017a-X11-20170314.eb
@@ -77,7 +77,7 @@ exts_list = [
     'tools',
     'utils',
     # non-standard libraries, should be specified with fixed versions!
-    ('Rmpi', '0.6-6', ext_options),
+    ('Rmpi', '0.6-6', dict(ext_options.items() + [('patches', ['Rmpi-0.6-5_impi5.patch'])])),
     ('abind', '1.4-5', ext_options),
     ('magic', '1.5-6', ext_options),
     ('geometry', '0.3-6', dict(ext_options.items() + [('patches', ['geometry-0.3-4-icc.patch'])])),


### PR DESCRIPTION
Without the patch the `Rmpi` build fails since it tries to link against `libmpich` instead of `libmpi`.