### PR TITLE
get rid of references to 'hpcugent' organisation after move to github.com/easybuilders

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We'd love you to contribute back to EasyBuild, and here's how you can do it: the
 
 ### Fork easybuild-easyconfigs
 
-First, you'll need to fork [easybuild-easyconfigs on GitHub](http://github.com/hpcugent/easybuild-easyconfigs).
+First, you'll need to fork [easybuild-easyconfigs on GitHub](https://github.com/easybuilders/easybuild-easyconfigs).
 
 If you do not have a (free) GitHub account yet, you'll need to get one.
 
@@ -25,10 +25,10 @@ Pull the _develop_ branch from the main easybuild-easyconfigs repository:
 
 ```bash
 cd easybuild
-git remote add github_hpcugent git@github.com:hpcugent/easybuild-easyconfigs.git
+git remote add github_easybuilders git@github.com:easybuilders/easybuild-easyconfigs.git
 git branch develop
 git checkout develop
-git pull github_hpcugent develop
+git pull github_easybuilders develop
 ```
 
 ### Keep develop up-to-date
@@ -39,7 +39,7 @@ Make sure you update it every time you create a feature branch (see below):
 
 ```bash
 git checkout develop
-git pull github_hpcugent develop
+git pull github_easybuilders develop
 ```
 
 
@@ -49,7 +49,7 @@ git pull github_hpcugent develop
 ### Pick a branch name
 
 Please try and follow these guidelines when picking a branch name:
- * use the number of the issue as a prefix for your branch name, e.g. `86_` for issue [#86](https://github.com/hpcugent/easybuild-framework/issues/86)
+ * use the number of the issue as a prefix for your branch name, e.g. `86_` for issue [#86](https://github.com/easybuilders/easybuild-framework/issues/86)
  * append a short but descriptive branch name, in which words are joined by underscores, e.g. `86_encoding_scheme`
 
 ### Create branch
@@ -113,7 +113,7 @@ If you're contributing code to an existing issue you can also convert the issue 
 GITHUBUSER=your_username && PASSWD=your_password && BRANCH=branch_name && ISSUE=issue_number && \
 curl --user "$GITHUBUSER:$PASSWD" --request POST \
 --data "{\"issue\": \"$ISSUE\", \"head\": \"$GITHUBUSER:$BRANCH\", \"base\": \"develop\"}" \
-https://api.github.com/repos/hpcugent/easybuild-easyconfigs/pulls
+https://api.github.com/repos/easybuilders/easybuild-easyconfigs/pulls
 ```
 This is currently only supported by github from the command line and not via the web interface.
 You might also want to look into [hub](https://github.com/defunkt/hub) for more command line features.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
-.. image:: http://hpcugent.github.io/easybuild/images/easybuild_logo_small.png
+.. image:: http://easybuilders.github.io/easybuild/images/easybuild_logo_small.png
    :align: center
 
-`EasyBuild <https://hpcugent.github.io/easybuild>`_ is a software build
+`EasyBuild <https://easybuilders.github.io/easybuild>`_ is a software build
 and installation framework that allows you to manage (scientific) software
 on High Performance Computing (HPC) systems in an efficient way.
 
@@ -15,7 +15,7 @@ The EasyBuild documentation is available at http://easybuild.readthedocs.org/.
 
 The easybuild-easyconfigs package is hosted on GitHub, along
 with an issue tracker for bug reports and feature requests, see
-http://github.com/hpcugent/easybuild-easyconfigs.
+https://github.com/easybuilders/easybuild-easyconfigs.
 
 Related Python packages:
 
@@ -23,23 +23,23 @@ Related Python packages:
 
   * the EasyBuild framework, which includes the ``easybuild.framework`` and ``easybuild.tools`` Python
     packages that provide general support for building and installing software
-  * GitHub repository: http://github.com/hpcugent/easybuild-framework
+  * GitHub repository: https://github.com/easybuilders/easybuild-framework
   * PyPi: https://pypi.python.org/pypi/easybuild-framework
 
 * **easybuild-easyblocks**
 
   * a collection of easyblocks that implement support for building and installing (groups of) software packages
-  * GitHub repository: http://github.com/hpcugent/easybuild-easyblocks
+  * GitHub repository: https://github.com/easybuilders/easybuild-easyblocks
   * package on PyPi: https://pypi.python.org/pypi/easybuild-easyblocks
 
 *Build status overview:*
 
 * **master** branch:
 
-  .. image:: https://travis-ci.org/hpcugent/easybuild-easyconfigs.svg?branch=master
-      :target: https://travis-ci.org/hpcugent/easybuild-easyconfigs/branches
+  .. image:: https://travis-ci.org/easybuilders/easybuild-easyconfigs.svg?branch=master
+      :target: https://travis-ci.org/easybuilders/easybuild-easyconfigs/branches
 
 * **develop** branch:
 
-  .. image:: https://travis-ci.org/hpcugent/easybuild-easyconfigs.svg?branch=develop
-      :target: https://travis-ci.org/hpcugent/easybuild-easyconfigs/branches
+  .. image:: https://travis-ci.org/easybuilders/easybuild-easyconfigs.svg?branch=develop
+      :target: https://travis-ci.org/easybuilders/easybuild-easyconfigs/branches

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: http://easybuilders.github.io/easybuild/images/easybuild_logo_small.png
+.. image:: https://easybuilders.github.io/easybuild/images/easybuild_logo_small.png
    :align: center
 
 `EasyBuild <https://easybuilders.github.io/easybuild>`_ is a software build

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -749,7 +749,7 @@ feature + bugfix release
     Xmipp (#1489)
 - added easyconfigs for new (Cray-specific) toolchains (#1538): CrayGNU, CrayIntel, CrayCCE
     - initially supported software (using CrayGNU toolchains): CP2K, GROMACS, HPL, Python + numpy/scipy, WRF (#1558)
-    - see also https://github.com/easybuilders/easybuild/wiki/EasyBuild-on-Cray
+    - see also http://easybuild.readthedocs.io/en/latest/Cray-support.html
 - added new easyconfigs for existing toolchains: goolf/1.5.16, intel/2014.06
 - added additional easyconfigs for various supported software packages: version updates, different toolchains, ...
     including GCC v5.1.0, OpenFOAM v2.3.1, R v3.1.3 and v3.2.0, PETSc/SLEPc v3.5.3, WIEN2k v14.1

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -749,7 +749,7 @@ feature + bugfix release
     Xmipp (#1489)
 - added easyconfigs for new (Cray-specific) toolchains (#1538): CrayGNU, CrayIntel, CrayCCE
     - initially supported software (using CrayGNU toolchains): CP2K, GROMACS, HPL, Python + numpy/scipy, WRF (#1558)
-    - see also https://github.com/hpcugent/easybuild/wiki/EasyBuild-on-Cray
+    - see also https://github.com/easybuilders/easybuild/wiki/EasyBuild-on-Cray
 - added new easyconfigs for existing toolchains: goolf/1.5.16, intel/2014.06
 - added additional easyconfigs for various supported software packages: version updates, different toolchains, ...
     including GCC v5.1.0, OpenFOAM v2.3.1, R v3.1.3 and v3.2.0, PETSc/SLEPc v3.5.3, WIEN2k v14.1
@@ -789,7 +789,7 @@ feature + bugfix release
 - various other enhancements, including:
     - don't define $LDSHARED in zlib easyconfigs (#1350)
         - this fixes the long-standing "no version information available" issue with zlib
-        - see also https://github.com/hpcugent/easybuild-framework/issues/108
+        - see also https://github.com/easybuilders/easybuild-framework/issues/108
     - add unit test to check that all extra_options keys are defined in EasyConfig instance (#1378)
     - add source MD5 checksums in all GCC easyconfigs (#1391)
     - speeding up the unit tests by avoiding rereading of same easyconfig file (#1432)
@@ -800,7 +800,7 @@ feature + bugfix release
     - revert version of Libint dependency to 1.1.4 in CP2K v2.5.1 easyconfig (#1144)
     - added Java dependencies to EMBOSS easyconfigs (#1167)
     - don't list 'lto' as a language in GCC easyconfigs (#1286)
-        - related to the fixes in the GCC easyblock, see hpcugent/easybuild-easyblocks#535
+        - related to the fixes in the GCC easyblock, see easybuilders/easybuild-easyblocks#535
     - rename libint2 easyconfigs as Libint v2 easyconfigs (#1287)
     - fix mpi4py source_urls in Python easyconfigs (#1306)
     - consistently use CLooG 0.18.0 for GCC 4.8 series (#1392)

--- a/easybuild/easyconfigs/TEMPLATE.eb
+++ b/easybuild/easyconfigs/TEMPLATE.eb
@@ -1,5 +1,5 @@
 # Note:
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # It was auto-generated based on a template easyconfig, so it should be used with care.
 easyblock = 'ConfigureMake'
 

--- a/easybuild/easyconfigs/__archive__/a/ABySS/ABySS-1.3.4-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/__archive__/a/ABySS/ABySS-1.3.4-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/a/ABySS/ABySS-1.3.4-ictce-4.0.6-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/__archive__/a/ABySS/ABySS-1.3.4-ictce-4.0.6-Python-2.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/a/AMOS/AMOS-3.1.0-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/a/AMOS/AMOS-3.1.0-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/a/AMOS/AMOS-3.1.0-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/a/AMOS/AMOS-3.1.0-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/a/Automake/Automake-1.13.4-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/__archive__/a/Automake/Automake-1.13.4-ictce-4.1.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/a/Automake/Automake-1.14-gcccuda-2.6.10.eb
+++ b/easybuild/easyconfigs/__archive__/a/Automake/Automake-1.14-gcccuda-2.6.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/a/a2ps/a2ps-4.14-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/a/a2ps/a2ps-4.14-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/a/a2ps/a2ps-4.14-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/a/a2ps/a2ps-4.14-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/a/aria2/aria2-1.15.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/a/aria2/aria2-1.15.1-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/a/aria2/aria2-1.15.1-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/a/aria2/aria2-1.15.1-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/BEEF/BEEF-0.1.1-r16-iomkl-4.6.13.eb
+++ b/easybuild/easyconfigs/__archive__/b/BEEF/BEEF-0.1.1-r16-iomkl-4.6.13.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Benjamin P. Roberts
 # New Zealand eScience Infrastructure
 # The University of Auckland, Auckland, New Zealand

--- a/easybuild/easyconfigs/__archive__/b/BFAST/BFAST-0.7.0a-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/b/BFAST/BFAST-0.7.0a-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/BFAST/BFAST-0.7.0a-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/b/BFAST/BFAST-0.7.0a-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/BLAST+/BLAST+-2.2.27-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/b/BLAST+/BLAST+-2.2.27-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/BLAST+/BLAST+-2.2.27-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/b/BLAST+/BLAST+-2.2.27-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/BLAST+/BLAST+-2.2.28-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/__archive__/b/BLAST+/BLAST+-2.2.28-ictce-4.1.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/__archive__/b/BWA/BWA-0.6.2-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/b/BWA/BWA-0.6.2-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/BWA/BWA-0.6.2-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/b/BWA/BWA-0.6.2-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/BWA/BWA-0.7.4-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/__archive__/b/BWA/BWA-0.7.4-ictce-4.1.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/BamTools/BamTools-2.2.3-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/b/BamTools/BamTools-2.2.3-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, George Tsouloupas <g.tsouloupas@cyi.ac.cy>

--- a/easybuild/easyconfigs/__archive__/b/Bash/Bash-4.2-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/b/Bash/Bash-4.2-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/__archive__/b/Bonnie++/Bonnie++-1.03e-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/b/Bonnie++/Bonnie++-1.03e-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/Bonnie++/Bonnie++-1.03e-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/b/Bonnie++/Bonnie++-1.03e-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/Bowtie2/Bowtie2-2.0.2-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/b/Bowtie2/Bowtie2-2.0.2-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/Bowtie2/Bowtie2-2.0.2-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/b/Bowtie2/Bowtie2-2.0.2-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/bbFTP/bbFTP-3.2.0-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/b/bbFTP/bbFTP-3.2.0-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/bbftpPRO/bbftpPRO-9.3.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/b/bbftpPRO/bbftpPRO-9.3.1-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/binutils/binutils-2.22-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/b/binutils/binutils-2.22-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/b/binutils/binutils-2.22-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/b/binutils/binutils-2.22-gompi-1.4.12-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/c/Chapel/Chapel-1.6.0-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/c/Chapel/Chapel-1.6.0-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/c/ClustalW2/ClustalW2-2.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/c/ClustalW2/ClustalW2-2.1-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/c/ClustalW2/ClustalW2-2.1-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/c/ClustalW2/ClustalW2-2.1-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/c/Corkscrew/Corkscrew-2.0-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/c/Corkscrew/Corkscrew-2.0-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/c/Corkscrew/Corkscrew-2.0-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/c/Corkscrew/Corkscrew-2.0-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/c/Cube/Cube-3.4.3-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/c/Cube/Cube-3.4.3-gompi-1.4.12-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/__archive__/c/Cube/Cube-4.2-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/c/Cube/Cube-4.2-gompi-1.4.12-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/__archive__/c/Cube/Cube-4.3-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/c/Cube/Cube-4.3-gompi-1.4.12-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/__archive__/c/Cufflinks/Cufflinks-2.0.2-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/c/Cufflinks/Cufflinks-2.0.2-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/c/ccache/ccache-3.1.9-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/c/ccache/ccache-3.1.9-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/c/ccache/ccache-3.1.9-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/c/ccache/ccache-3.1.9-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/c/cflow/cflow-1.4-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/c/cflow/cflow-1.4-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/c/cflow/cflow-1.4-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/c/cflow/cflow-1.4-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/c/cgdb/cgdb-0.6.5-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/c/cgdb/cgdb-0.6.5-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/c/cgdb/cgdb-0.6.5-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/c/cgdb/cgdb-0.6.5-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/e/ELinks/ELinks-0.12pre5-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/e/ELinks/ELinks-0.12pre5-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/e/ELinks/ELinks-0.12pre5-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/e/ELinks/ELinks-0.12pre5-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/e/ESPResSo/ESPResSo-3.1.1-goalf-1.1.0-no-OFED-parallel.eb
+++ b/easybuild/easyconfigs/__archive__/e/ESPResSo/ESPResSo-3.1.1-goalf-1.1.0-no-OFED-parallel.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Josh Berryman <josh.berryman@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/e/ESPResSo/ESPResSo-3.1.1-goalf-1.1.0-no-OFED-serial.eb
+++ b/easybuild/easyconfigs/__archive__/e/ESPResSo/ESPResSo-3.1.1-goalf-1.1.0-no-OFED-serial.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Josh Berryman <josh.berryman@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/e/ESPResSo/ESPResSo-3.1.1-ictce-4.0.6-parallel.eb
+++ b/easybuild/easyconfigs/__archive__/e/ESPResSo/ESPResSo-3.1.1-ictce-4.0.6-parallel.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Josh Berryman <josh.berryman@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/e/ESPResSo/ESPResSo-3.1.1-ictce-4.0.6-serial.eb
+++ b/easybuild/easyconfigs/__archive__/e/ESPResSo/ESPResSo-3.1.1-ictce-4.0.6-serial.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Josh Berryman <josh.berryman@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/e/Eigen/Eigen-3.1.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/e/Eigen/Eigen-3.1.1-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/e/Eigen/Eigen-3.1.1-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/e/Eigen/Eigen-3.1.1-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/e/Eigen/Eigen-3.1.4-goalf-1.5.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/e/Eigen/Eigen-3.1.4-goalf-1.5.12-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/e/Eigen/Eigen-3.1.4-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/__archive__/e/Eigen/Eigen-3.1.4-ictce-4.1.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/e/Extrae/Extrae-2.4.1-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/e/Extrae/Extrae-2.4.1-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/f/FASTX-Toolkit/FASTX-Toolkit-0.0.13.2-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/f/FASTX-Toolkit/FASTX-Toolkit-0.0.13.2-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/f/FASTX-Toolkit/FASTX-Toolkit-0.0.13.2-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/f/FASTX-Toolkit/FASTX-Toolkit-0.0.13.2-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/GDB/GDB-7.5.1-cgmpolf-1.1.6.eb
+++ b/easybuild/easyconfigs/__archive__/g/GDB/GDB-7.5.1-cgmpolf-1.1.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/GDB/GDB-7.5.1-cgmvolf-1.1.12rc1.eb
+++ b/easybuild/easyconfigs/__archive__/g/GDB/GDB-7.5.1-cgmvolf-1.1.12rc1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/GDB/GDB-7.5.1-cgmvolf-1.2.7.eb
+++ b/easybuild/easyconfigs/__archive__/g/GDB/GDB-7.5.1-cgmvolf-1.2.7.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/GDB/GDB-7.5.1-cgoolf-1.1.7.eb
+++ b/easybuild/easyconfigs/__archive__/g/GDB/GDB-7.5.1-cgoolf-1.1.7.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/GDB/GDB-7.5.1-gmvolf-1.7.12.eb
+++ b/easybuild/easyconfigs/__archive__/g/GDB/GDB-7.5.1-gmvolf-1.7.12.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipy as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipy as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/GDB/GDB-7.5.1-gmvolf-1.7.12rc1.eb
+++ b/easybuild/easyconfigs/__archive__/g/GDB/GDB-7.5.1-gmvolf-1.7.12rc1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipy as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipy as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/GDB/GDB-7.5.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/g/GDB/GDB-7.5.1-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.1-goolfc-1.3.12-hybrid.eb
+++ b/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.1-goolfc-1.3.12-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.1-goolfc-1.3.12-mt.eb
+++ b/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.1-goolfc-1.3.12-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-gmpolf-1.4.8-hybrid.eb
+++ b/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-gmpolf-1.4.8-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-gmpolf-1.4.8-mt.eb
+++ b/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-gmpolf-1.4.8-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-gmvolf-1.7.12-hybrid.eb
+++ b/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-gmvolf-1.7.12-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-gmvolf-1.7.12-mt.eb
+++ b/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-gmvolf-1.7.12-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-goalf-1.1.0-no-OFED-hybrid.eb
+++ b/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-goalf-1.1.0-no-OFED-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-goalf-1.1.0-no-OFED-mt.eb
+++ b/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-goalf-1.1.0-no-OFED-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-goolfc-2.6.10-hybrid.eb
+++ b/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-goolfc-2.6.10-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-goolfc-2.6.10-mt.eb
+++ b/easybuild/easyconfigs/__archive__/g/GROMACS/GROMACS-4.6.5-goolfc-2.6.10-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/__archive__/g/GTI/GTI-1.2.0-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/g/GTI/GTI-1.2.0-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/g/git/git-1.7.12-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/g/git/git-1.7.12-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/git/git-1.7.12-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/g/git/git-1.7.12-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/git/git-1.8.2-cgmpolf-1.1.6.eb
+++ b/easybuild/easyconfigs/__archive__/g/git/git-1.8.2-cgmpolf-1.1.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/git/git-1.8.2-cgmvolf-1.1.12rc1.eb
+++ b/easybuild/easyconfigs/__archive__/g/git/git-1.8.2-cgmvolf-1.1.12rc1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/git/git-1.8.2-cgmvolf-1.2.7.eb
+++ b/easybuild/easyconfigs/__archive__/g/git/git-1.8.2-cgmvolf-1.2.7.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/git/git-1.8.2-cgoolf-1.1.7.eb
+++ b/easybuild/easyconfigs/__archive__/g/git/git-1.8.2-cgoolf-1.1.7.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/git/git-1.8.2-gmvolf-1.7.12.eb
+++ b/easybuild/easyconfigs/__archive__/g/git/git-1.8.2-gmvolf-1.7.12.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/git/git-1.8.2-gmvolf-1.7.12rc1.eb
+++ b/easybuild/easyconfigs/__archive__/g/git/git-1.8.2-gmvolf-1.7.12rc1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/gnuplot/gnuplot-4.6.0-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/g/gnuplot/gnuplot-4.6.0-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/gnuplot/gnuplot-4.6.0-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/g/gnuplot/gnuplot-4.6.0-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/g/gzip/gzip-1.5-cgoolf-1.1.7.eb
+++ b/easybuild/easyconfigs/__archive__/g/gzip/gzip-1.5-cgoolf-1.1.7.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/__archive__/g/gzip/gzip-1.5-gmpolf-1.4.8.eb
+++ b/easybuild/easyconfigs/__archive__/g/gzip/gzip-1.5-gmpolf-1.4.8.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/__archive__/g/gzip/gzip-1.5-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/g/gzip/gzip-1.5-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/__archive__/g/gzip/gzip-1.5-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/g/gzip/gzip-1.5-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/__archive__/g/gzip/gzip-1.5-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/__archive__/g/gzip/gzip-1.5-ictce-4.1.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/__archive__/g/gzip/gzip-1.6-goolf-1.5.14-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/g/gzip/gzip-1.6-goolf-1.5.14-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/__archive__/h/HH-suite/HH-suite-2.0.16-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/h/HH-suite/HH-suite-2.0.16-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipy as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipy as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/h/HMMER/HMMER-3.0-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/h/HMMER/HMMER-3.0-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/h/HMMER/HMMER-3.0-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/h/HMMER/HMMER-3.0-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/h/HPCBIOS_Math/HPCBIOS_Math-20130829-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/h/HPCBIOS_Math/HPCBIOS_Math-20130829-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/i/Infernal/Infernal-1.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/i/Infernal/Infernal-1.1-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/i/Infernal/Infernal-1.1-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/i/Infernal/Infernal-1.1-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/i/Infernal/Infernal-1.1rc1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/i/Infernal/Infernal-1.1rc1-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/i/Infernal/Infernal-1.1rc1-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/i/Infernal/Infernal-1.1rc1-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/i/Iperf/Iperf-2.0.5-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/i/Iperf/Iperf-2.0.5-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/i/Iperf/Iperf-2.0.5-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/i/Iperf/Iperf-2.0.5-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/l/LWM2/LWM2-1.1-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/l/LWM2/LWM2-1.1-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/l/LZO/LZO-2.06-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/l/LZO/LZO-2.06-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/l/LZO/LZO-2.06-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/l/LZO/LZO-2.06-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/l/LZO/LZO-2.06-ictce-5.1.1.eb
+++ b/easybuild/easyconfigs/__archive__/l/LZO/LZO-2.06-ictce-5.1.1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/l/LibTIFF/LibTIFF-4.0.3-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/__archive__/l/LibTIFF/LibTIFF-4.0.3-ictce-4.1.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/l/lftp/lftp-4.4.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/l/lftp/lftp-4.4.1-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/l/libgtextutils/libgtextutils-0.6.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/l/libgtextutils/libgtextutils-0.6.1-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/l/libgtextutils/libgtextutils-0.6.1-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/l/libgtextutils/libgtextutils-0.6.1-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/l/libharu/libharu-2.2.0-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/__archive__/l/libharu/libharu-2.2.0-ictce-4.1.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/l/libunwind/libunwind-1.1-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/l/libunwind/libunwind-1.1-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/l/libyaml/libyaml-0.1.4-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/l/libyaml/libyaml-0.1.4-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Nils Christian <nils.christian@uni.lu>

--- a/easybuild/easyconfigs/__archive__/m/M4/M4-1.4.17-intel-para-2014.12.eb
+++ b/easybuild/easyconfigs/__archive__/m/M4/M4-1.4.17-intel-para-2014.12.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/__archive__/m/MCL/MCL-12.135-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/m/MCL/MCL-12.135-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/m/MCL/MCL-12.135-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/m/MCL/MCL-12.135-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/m/MCL/MCL-12.135-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/__archive__/m/MCL/MCL-12.135-ictce-4.1.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/m/MEME/MEME-4.8.0-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/m/MEME/MEME-4.8.0-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/m/MEME/MEME-4.8.0-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/m/MEME/MEME-4.8.0-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/m/MUMmer/MUMmer-3.23-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/m/MUMmer/MUMmer-3.23-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/m/MUMmer/MUMmer-3.23-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/m/MUMmer/MUMmer-3.23-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/m/MUMmer/MUMmer-3.23-ictce-4.1.13-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/__archive__/m/MUMmer/MUMmer-3.23-ictce-4.1.13-Perl-5.16.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/easybuild/easyconfigs/__archive__/m/MUST/MUST-1.2.0-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/m/MUST/MUST-1.2.0-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/m/MetaVelvet/MetaVelvet-1.2.01-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/m/MetaVelvet/MetaVelvet-1.2.01-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/m/MetaVelvet/MetaVelvet-1.2.01-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/m/MetaVelvet/MetaVelvet-1.2.01-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/m/mc/mc-4.6.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/m/mc/mc-4.6.1-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/m/mc/mc-4.6.1-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/m/mc/mc-4.6.1-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/m/mpiBLAST/mpiBLAST-1.6.0-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/m/mpiBLAST/mpiBLAST-1.6.0-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/easybuild/easyconfigs/__archive__/m/mpiBLAST/mpiBLAST-1.6.0-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/m/mpiBLAST/mpiBLAST-1.6.0-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/easybuild/easyconfigs/__archive__/n/NASM/NASM-2.07-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/n/NASM/NASM-2.07-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/n/NASM/NASM-2.07-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/n/NASM/NASM-2.07-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/n/NASM/NASM-2.07-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/__archive__/n/NASM/NASM-2.07-ictce-4.1.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/n/NASM/NASM-2.11.05-ictce-6.3.5.eb
+++ b/easybuild/easyconfigs/__archive__/n/NASM/NASM-2.11.05-ictce-6.3.5.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/n/NCBI-Toolkit/NCBI-Toolkit-9.0.0-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/n/NCBI-Toolkit/NCBI-Toolkit-9.0.0-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/easybuild/easyconfigs/__archive__/n/NCBI-Toolkit/NCBI-Toolkit-9.0.0-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/n/NCBI-Toolkit/NCBI-Toolkit-9.0.0-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/easybuild/easyconfigs/__archive__/n/nano/nano-2.2.6-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/n/nano/nano-2.2.6-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/n/nano/nano-2.2.6-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/n/nano/nano-2.2.6-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/o/OPARI2/OPARI2-1.0.7-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/o/OPARI2/OPARI2-1.0.7-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/o/OPARI2/OPARI2-1.1.1-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/o/OPARI2/OPARI2-1.1.1-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/o/OTF/OTF-1.12.4-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/o/OTF/OTF-1.12.4-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/o/OTF2/OTF2-1.2.1-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/o/OTF2/OTF2-1.2.1-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/p/PAPI/PAPI-5.0.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/p/PAPI/PAPI-5.0.1-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/p/PAPI/PAPI-5.0.1-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/p/PAPI/PAPI-5.0.1-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/p/PAPI/PAPI-5.2.0-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/p/PAPI/PAPI-5.2.0-gompi-1.4.12-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/p/PDT/PDT-3.19-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/p/PDT/PDT-3.19-gompi-1.4.12-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/__archive__/p/PLINK/PLINK-1.07-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/p/PLINK/PLINK-1.07-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>, Andreas Panteli <a.panteli@cyi.ac.cy>,

--- a/easybuild/easyconfigs/__archive__/p/PnMPI/PnMPI-1.2.0-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/p/PnMPI/PnMPI-1.2.0-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/p/parallel/parallel-20130122-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/p/parallel/parallel-20130122-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/p/parallel/parallel-20130122-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/p/parallel/parallel-20130122-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/r/RNAz/RNAz-2.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/r/RNAz/RNAz-2.1-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/r/RNAz/RNAz-2.1-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/r/RNAz/RNAz-2.1-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/s/SAMtools/SAMtools-0.1.18-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/s/SAMtools/SAMtools-0.1.18-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/s/SAMtools/SAMtools-0.1.18-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/s/SAMtools/SAMtools-0.1.18-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/s/SOAPdenovo/SOAPdenovo-1.05-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/s/SOAPdenovo/SOAPdenovo-1.05-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/s/SOAPdenovo/SOAPdenovo-1.05-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/s/SOAPdenovo/SOAPdenovo-1.05-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/s/Scalasca/Scalasca-1.4.3-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/s/Scalasca/Scalasca-1.4.3-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/s/Scalasca/Scalasca-2.0-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/s/Scalasca/Scalasca-2.0-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/s/Score-P/Score-P-1.2.1-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/s/Score-P/Score-P-1.2.1-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/s/Stow/Stow-1.3.3-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/s/Stow/Stow-1.3.3-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/s/Stow/Stow-1.3.3-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/s/Stow/Stow-1.3.3-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/t/TAU/TAU-2.22.2-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/t/TAU/TAU-2.22.2-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/t/Tar/Tar-1.26-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/t/Tar/Tar-1.26-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/__archive__/t/Tar/Tar-1.26-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/t/Tar/Tar-1.26-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/__archive__/t/TopHat/TopHat-2.0.4-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/t/TopHat/TopHat-2.0.4-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/t/TopHat/TopHat-2.0.8-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/t/TopHat/TopHat-2.0.8-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/t/tcsh/tcsh-6.18.01-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/t/tcsh/tcsh-6.18.01-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/__archive__/t/tcsh/tcsh-6.18.01-ictce-3.2.2.u3.eb
+++ b/easybuild/easyconfigs/__archive__/t/tcsh/tcsh-6.18.01-ictce-3.2.2.u3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/__archive__/t/tcsh/tcsh-6.18.01-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/__archive__/t/tcsh/tcsh-6.18.01-ictce-4.1.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/__archive__/t/tcsh/tcsh-6.18.01-iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/__archive__/t/tcsh/tcsh-6.18.01-iqacml-3.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/__archive__/u/UDUNITS/UDUNITS-2.1.24-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/u/UDUNITS/UDUNITS-2.1.24-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/__archive__/u/UDUNITS/UDUNITS-2.1.24-ictce-3.2.2.u3.eb
+++ b/easybuild/easyconfigs/__archive__/u/UDUNITS/UDUNITS-2.1.24-ictce-3.2.2.u3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/__archive__/u/UDUNITS/UDUNITS-2.1.24-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/u/UDUNITS/UDUNITS-2.1.24-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/__archive__/u/UDUNITS/UDUNITS-2.1.24-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/__archive__/u/UDUNITS/UDUNITS-2.1.24-ictce-4.1.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/__archive__/u/UDUNITS/UDUNITS-2.1.24-iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/__archive__/u/UDUNITS/UDUNITS-2.1.24-iqacml-3.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/__archive__/v/VTK/VTK-5.10.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/v/VTK/VTK-5.10.1-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/v/VTK/VTK-5.10.1-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/v/VTK/VTK-5.10.1-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/v/VTK/VTK-6.0.0-ictce-4.1.13-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/__archive__/v/VTK/VTK-6.0.0-ictce-4.1.13-Python-2.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.8.1-cgmpolf-1.1.6.eb
+++ b/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.8.1-cgmpolf-1.1.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.8.1-cgmvolf-1.1.12rc1.eb
+++ b/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.8.1-cgmvolf-1.1.12rc1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.8.1-cgmvolf-1.2.7.eb
+++ b/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.8.1-cgmvolf-1.2.7.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.8.1-cgoolf-1.1.7.eb
+++ b/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.8.1-cgoolf-1.1.7.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.8.1-gmvolf-1.7.12.eb
+++ b/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.8.1-gmvolf-1.7.12.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.8.1-gmvolf-1.7.12rc1.eb
+++ b/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.8.1-gmvolf-1.7.12rc1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.8.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.8.1-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.9.0-goalf-1.5.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/v/Valgrind/Valgrind-3.9.0-goalf-1.5.12-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Ghent University
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Ward Poelmans <wpoely86@gmail.com>

--- a/easybuild/easyconfigs/__archive__/v/VampirTrace/VampirTrace-5.14.4-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/v/VampirTrace/VampirTrace-5.14.4-gompi-1.4.12-no-OFED.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/__archive__/v/Velvet/Velvet-1.2.07-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/v/Velvet/Velvet-1.2.07-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/v/Velvet/Velvet-1.2.07-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/v/Velvet/Velvet-1.2.07-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/v/ViennaRNA/ViennaRNA-2.0.7-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/v/ViennaRNA/ViennaRNA-2.0.7-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/v/ViennaRNA/ViennaRNA-2.0.7-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/v/ViennaRNA/ViennaRNA-2.0.7-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/v/Viper/Viper-1.0.0-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/__archive__/v/Viper/Viper-1.0.0-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -22,7 +22,7 @@ versionsuffix = "-%s-%s" % (python, pythonversion)
 dependencies = [(python, pythonversion)]
 
 # hack, 'import viper' fails because VTK and numpy dependencies are missing
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/100
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/100
 options = {'modulename': 'os'}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/__archive__/v/Viper/Viper-1.0.0-ictce-4.0.6-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/__archive__/v/Viper/Viper-1.0.0-ictce-4.0.6-Python-2.7.3.eb
@@ -22,7 +22,7 @@ versionsuffix = "-%s-%s" % (python, pythonversion)
 dependencies = [(python, pythonversion)]
 
 # hack, 'import viper' fails because VTK and numpy dependencies are missing
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/100
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/100
 options = {'modulename': 'os'}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/__archive__/w/wiki2beamer/wiki2beamer-0.9.5-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/__archive__/w/wiki2beamer/wiki2beamer-0.9.5-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/y/YAML-Syck/YAML-Syck-1.27-ictce-4.1.13-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/__archive__/y/YAML-Syck/YAML-Syck-1.27-ictce-4.1.13-Perl-5.16.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013 Uni.Lu/LCSB
 # Authors::   Nils Christian <nils.christian@uni.lu>

--- a/easybuild/easyconfigs/__archive__/y/Yasm/Yasm-1.2.0-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/y/Yasm/Yasm-1.2.0-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/y/Yasm/Yasm-1.2.0-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/y/Yasm/Yasm-1.2.0-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/z/zsync/zsync-0.6.2-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/z/zsync/zsync-0.6.2-goalf-1.1.0-no-OFED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/__archive__/z/zsync/zsync-0.6.2-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/z/zsync/zsync-0.6.2-ictce-4.0.6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.0.3-x86_64_linux_gnu4.5.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.0.3-x86_64_linux_gnu4.5.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.0.5-x86_64_linux_gnu4.5.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.0.5-x86_64_linux_gnu4.5.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.2.1-x86_64_linux_gnu4.5.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.2.1-x86_64_linux_gnu4.5.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.4.3-goolf-1.4.10-ETSF_IO-1.0.4.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.4.3-goolf-1.4.10-ETSF_IO-1.0.4.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2014 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/a/ABySS/ABySS-1.3.4-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/a/ABySS/ABySS-1.3.4-goolf-1.4.10-Python-2.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/ABySS/ABySS-1.3.4-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/a/ABySS/ABySS-1.3.4-ictce-5.3.0-Python-2.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/ABySS/ABySS-1.3.6-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/a/ABySS/ABySS-1.3.6-goolf-1.4.10-Python-2.7.5.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/ABySS/ABySS-1.3.7-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/a/ABySS/ABySS-1.3.7-intel-2015a-Python-2.7.9.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/ABySS/ABySS-1.5.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/a/ABySS/ABySS-1.5.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Maxime Schmitt <maxime.schmitt@telecom-bretagne.eu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/ABySS/ABySS-1.9.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/a/ABySS/ABySS-1.9.0-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Maxime Schmitt <maxime.schmitt@telecom-bretagne.eu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/AFNI/AFNI-linux_openmp_64-goolf-1.5.14-20141023.eb
+++ b/easybuild/easyconfigs/a/AFNI/AFNI-linux_openmp_64-goolf-1.5.14-20141023.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'PackedBinary'

--- a/easybuild/easyconfigs/a/AFNI/AFNI-linux_openmp_64-intel-2015a-20141023.eb
+++ b/easybuild/easyconfigs/a/AFNI/AFNI-linux_openmp_64-intel-2015a-20141023.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'PackedBinary'

--- a/easybuild/easyconfigs/a/ALLPATHS-LG/ALLPATHS-LG-46968-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/a/ALLPATHS-LG/ALLPATHS-LG-46968-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>, 

--- a/easybuild/easyconfigs/a/ALLPATHS-LG/ALLPATHS-LG-52488-foss-2016a.eb
+++ b/easybuild/easyconfigs/a/ALLPATHS-LG/ALLPATHS-LG-52488-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>, 

--- a/easybuild/easyconfigs/a/AMOS/AMOS-3.1.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/a/AMOS/AMOS-3.1.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/AMOS/AMOS-3.1.0-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/a/AMOS/AMOS-3.1.0-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/APBS/APBS-1.4-linux-static-x86_64.eb
+++ b/easybuild/easyconfigs/a/APBS/APBS-1.4-linux-static-x86_64.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/a/ASHS/ASHS-rev103_20140612.eb
+++ b/easybuild/easyconfigs/a/ASHS/ASHS-rev103_20140612.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/a/AdapterRemoval/AdapterRemoval-2.2.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/a/AdapterRemoval/AdapterRemoval-2.2.0-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'MakeCp'
 

--- a/easybuild/easyconfigs/a/Aspera-CLI/Aspera-CLI-3.7.2.354.010c3b8.eb
+++ b/easybuild/easyconfigs/a/Aspera-CLI/Aspera-CLI-3.7.2.354.010c3b8.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Author: Daniel D. Kinnamon
 # Division of Human Genetics
 # The Ohio State University Wexner Medical Center

--- a/easybuild/easyconfigs/a/AutoDock_Vina/AutoDock_Vina-1.1.2_linux_x86.eb
+++ b/easybuild/easyconfigs/a/AutoDock_Vina/AutoDock_Vina-1.1.2_linux_x86.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/a/Automake/Automake-1.13.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.13.4-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.13.4-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.13.4-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.13.4-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.13.4-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Authors::   Alan O'Cais <a.ocais@fz-juelich.de>
 # $Id$

--- a/easybuild/easyconfigs/a/Automake/Automake-1.14-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.14-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.14-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.14-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.14-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.14-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.14-intel-2016a.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.14-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.14.1-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.14.1-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GCC-4.7.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GCC-4.8.4.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GCC-4.9.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GCC-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GCC-5.4.0-2.26.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GCCcore-4.9.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GCCcore-5.4.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GCCcore-6.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GNU-4.9.2-2.25.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GNU-4.9.2-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GNU-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GNU-5.1.0-2.25.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GNU-5.1.0-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-foss-2015a.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-foss-2015b.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-foss-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-foss-2016.04.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-foss-2016.04.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-foss-2016a.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-foss-2016b.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-gimkl-2.11.5.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-intel-2015a.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-intel-2015b.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-intel-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-intel-2016.02-GCC-4.9.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-intel-2016a.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-intel-2016b.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-iomkl-2016.07.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-iomkl-2016.07.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # 
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/a2ps/a2ps-4.14-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/a/a2ps/a2ps-4.14-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/a2ps/a2ps-4.14-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/a/a2ps/a2ps-4.14-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/annovar/annovar-2016Feb01-foss-2016a-Perl-5.22.1.eb
+++ b/easybuild/easyconfigs/a/annovar/annovar-2016Feb01-foss-2016a-Perl-5.22.1.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Modified by Adam Huffman
 # The Francis Crick Institute
 

--- a/easybuild/easyconfigs/a/argtable/argtable-2.13-foss-2015b.eb
+++ b/easybuild/easyconfigs/a/argtable/argtable-2.13-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/a/argtable/argtable-2.13-foss-2016b.eb
+++ b/easybuild/easyconfigs/a/argtable/argtable-2.13-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/a/argtable/argtable-2.13-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/a/argtable/argtable-2.13-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/a/aria2/aria2-1.15.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/a/aria2/aria2-1.15.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/a/aria2/aria2-1.15.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/a/aria2/aria2-1.15.1-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BCFtools/BCFtools-1.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BCFtools/BCFtools-1.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/BCFtools/BCFtools-1.3.1-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/b/BCFtools/BCFtools-1.3.1-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.1-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.1-GCC-4.8.4.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.2-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.2-GCC-4.8.2.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez, Wiktor Jurkowski
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.26.eb
+++ b/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.26.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'Tarball'
 

--- a/easybuild/easyconfigs/b/BEEF/BEEF-0.1.1-r16-intel-2015a.eb
+++ b/easybuild/easyconfigs/b/BEEF/BEEF-0.1.1-r16-intel-2015a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Benjamin P. Roberts
 # New Zealand eScience Infrastructure
 # The University of Auckland, Auckland, New Zealand

--- a/easybuild/easyconfigs/b/BFAST/BFAST-0.7.0a-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BFAST/BFAST-0.7.0a-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BFAST/BFAST-0.7.0a-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/b/BFAST/BFAST-0.7.0a-goolf-1.7.20.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BFAST/BFAST-0.7.0a-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/b/BFAST/BFAST-0.7.0a-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BH/BH-1.60.0-1-foss-2015b-R-3.2.3.eb
+++ b/easybuild/easyconfigs/b/BH/BH-1.60.0-1-foss-2015b-R-3.2.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author: Adam Huffman <adam.huffman@crick.ac.uk>
 # The Francis Crick Institute

--- a/easybuild/easyconfigs/b/BLASR/BLASR-2.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BLASR/BLASR-2.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/BLASR/BLASR-2.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/b/BLASR/BLASR-2.2-intel-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.27-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.27-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.28-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.28-goolf-1.4.10-Python-2.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.28-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.28-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.28-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.28-ictce-5.3.0-Python-2.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.28-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.28-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.30-foss-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.30-foss-2015a-Python-2.7.9.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.30-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.30-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.30-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.30-intel-2015a-Python-2.7.9.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.31-foss-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.31-foss-2015b-Python-2.7.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.31-intel-2015a-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.31-intel-2015a-Python-2.7.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.31-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.2.31-intel-2015b-Python-2.7.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.3.0-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.3.0-foss-2016a-Python-2.7.11.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.6.0-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.6.0-intel-2017a-Python-2.7.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/b/BLAST/BLAST-2.2.26-Linux_x86_64.eb
+++ b/easybuild/easyconfigs/b/BLAST/BLAST-2.2.26-Linux_x86_64.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/BLAT/BLAT-3.5-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BLAT/BLAT-3.5-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/b/BLAT/BLAT-3.5-ictce-5.5.0-libpng-1.6.9.eb
+++ b/easybuild/easyconfigs/b/BLAT/BLAT-3.5-ictce-5.5.0-libpng-1.6.9.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/b/BLAT/BLAT-3.5-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/b/BLAT/BLAT-3.5-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/b/BLAT/BLAT-3.5-intel-2016b.eb
+++ b/easybuild/easyconfigs/b/BLAT/BLAT-3.5-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/b/BLAT/BLAT-3.5-intel-2017a.eb
+++ b/easybuild/easyconfigs/b/BLAT/BLAT-3.5-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/b/BWA/BWA-0.6.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.6.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BWA/BWA-0.6.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.6.2-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BWA/BWA-0.7.13-foss-2015b.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.7.13-foss-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BWA/BWA-0.7.13-foss-2016a.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.7.13-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BWA/BWA-0.7.13-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.7.13-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>,

--- a/easybuild/easyconfigs/b/BWA/BWA-0.7.13-intel-2016a.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.7.13-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BWA/BWA-0.7.15-foss-2016a.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.7.15-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BWA/BWA-0.7.15-intel-2016b.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.7.15-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BWA/BWA-0.7.15-intel-2017a.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.7.15-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BWA/BWA-0.7.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.7.4-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BWA/BWA-0.7.4-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.7.4-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BWA/BWA-0.7.5a-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.7.5a-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/BXH_XCEDE_TOOLS/BXH_XCEDE_TOOLS-1.11.1.eb
+++ b/easybuild/easyconfigs/b/BXH_XCEDE_TOOLS/BXH_XCEDE_TOOLS-1.11.1.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/b/BamTools/BamTools-2.2.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BamTools/BamTools-2.2.3-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, George Tsouloupas <g.tsouloupas@cyi.ac.cy>

--- a/easybuild/easyconfigs/b/BamTools/BamTools-2.2.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/b/BamTools/BamTools-2.2.3-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, George Tsouloupas <g.tsouloupas@cyi.ac.cy>

--- a/easybuild/easyconfigs/b/BamTools/BamTools-2.4.0-foss-2015b.eb
+++ b/easybuild/easyconfigs/b/BamTools/BamTools-2.4.0-foss-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, George Tsouloupas <g.tsouloupas@cyi.ac.cy>

--- a/easybuild/easyconfigs/b/BamTools/BamTools-2.4.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/b/BamTools/BamTools-2.4.0-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, George Tsouloupas <g.tsouloupas@cyi.ac.cy>

--- a/easybuild/easyconfigs/b/BamUtil/BamUtil-1.0.13-foss-2015b.eb
+++ b/easybuild/easyconfigs/b/BamUtil/BamUtil-1.0.13-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author: Adam Huffman
 # adam.huffman@crick.ac.uk

--- a/easybuild/easyconfigs/b/BamUtil/BamUtil-1.0.13-intel-2016b.eb
+++ b/easybuild/easyconfigs/b/BamUtil/BamUtil-1.0.13-intel-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author: Adam Huffman
 # adam.huffman@crick.ac.uk

--- a/easybuild/easyconfigs/b/Bash/Bash-4.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/Bash/Bash-4.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/b/Bash/Bash-4.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/b/Bash/Bash-4.2-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/b/Bash/Bash-4.3-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/b/Bash/Bash-4.3-GCC-4.9.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 ##
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/b/BayPass/BayPass-2.1-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/b/BayPass/BayPass-2.1-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/b/BayeScEnv/BayeScEnv-1.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/b/BayeScEnv/BayeScEnv-1.1-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/b/BayeScEnv/BayeScEnv-1.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BayeScEnv/BayeScEnv-1.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/b/BayeScan/BayeScan-2.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/b/BayeScan/BayeScan-2.1-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/b/BayeScan/BayeScan-2.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BayeScan/BayeScan-2.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/b/BayesTraits/BayesTraits-1.0-linux32.eb
+++ b/easybuild/easyconfigs/b/BayesTraits/BayesTraits-1.0-linux32.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/BayesTraits/BayesTraits-2.0-Beta-Linux64.eb
+++ b/easybuild/easyconfigs/b/BayesTraits/BayesTraits-2.0-Beta-Linux64.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Beast/Beast-1.8.4.eb
+++ b/easybuild/easyconfigs/b/Beast/Beast-1.8.4.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Beast/Beast-2.1.3.eb
+++ b/easybuild/easyconfigs/b/Beast/Beast-2.1.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Beast/Beast-2.4.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/b/Beast/Beast-2.4.0-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Biopython/Biopython-1.61-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/b/Biopython/Biopython-1.61-goolf-1.4.10-Python-2.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>,

--- a/easybuild/easyconfigs/b/Biopython/Biopython-1.61-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/b/Biopython/Biopython-1.61-ictce-5.3.0-Python-2.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>,

--- a/easybuild/easyconfigs/b/Biopython/Biopython-1.65-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/b/Biopython/Biopython-1.65-foss-2016a-Python-2.7.11.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>,

--- a/easybuild/easyconfigs/b/Biopython/Biopython-1.68-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/b/Biopython/Biopython-1.68-foss-2016b-Python-2.7.12.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>,

--- a/easybuild/easyconfigs/b/Biopython/Biopython-1.68-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/b/Biopython/Biopython-1.68-intel-2016b-Python-2.7.12.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>,

--- a/easybuild/easyconfigs/b/Biopython/Biopython-1.68-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/b/Biopython/Biopython-1.68-intel-2016b-Python-3.5.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>,

--- a/easybuild/easyconfigs/b/Bismark/Bismark-0.10.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/Bismark/Bismark-0.10.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2014 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/b/BitSeq/BitSeq-0.7.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BitSeq/BitSeq-0.7.0-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bonnie++/Bonnie++-1.03e-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/Bonnie++/Bonnie++-1.03e-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/Bonnie++/Bonnie++-1.03e-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/b/Bonnie++/Bonnie++-1.03e-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/Bonnie++/Bonnie++-1.97-foss-2016a.eb
+++ b/easybuild/easyconfigs/b/Bonnie++/Bonnie++-1.97-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.0.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.0.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.0.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.0.2-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.0.5-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.0.5-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.0.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.0.6-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.1.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.1.0-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.1.0-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.1.0-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.0-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.2-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.4-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.5-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.5-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.5-intel-2015a.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.5-intel-2015a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.6-foss-2015b.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.6-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.6-intel-2015b.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.6-intel-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.7-foss-2015b.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.7-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.8-foss-2015b.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.8-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.8-foss-2016a.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.8-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.9-foss-2016a.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.9-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.9-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.9-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.9-intel-2016b.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.2.9-intel-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.3.2-intel-2017a.eb
+++ b/easybuild/easyconfigs/b/Bowtie2/Bowtie2-2.3.2-intel-2017a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/b/bam-readcount/bam-readcount-0.7.4-foss-2015b.eb
+++ b/easybuild/easyconfigs/b/bam-readcount/bam-readcount-0.7.4-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Adam Huffman
 # The Francis Crick Institute
 easyblock = 'CMakeMake'

--- a/easybuild/easyconfigs/b/bam2fastq/bam2fastq-1.1.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/bam2fastq/bam2fastq-1.1.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/b/bam2fastq/bam2fastq-1.1.0-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/b/bam2fastq/bam2fastq-1.1.0-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/b/bbFTP/bbFTP-3.2.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/bbFTP/bbFTP-3.2.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/bbFTP/bbFTP-3.2.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/b/bbFTP/bbFTP-3.2.1-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/bbcp/bbcp-12.01.30.00.0-amd64_linux26.eb
+++ b/easybuild/easyconfigs/b/bbcp/bbcp-12.01.30.00.0-amd64_linux26.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/bbftpPRO/bbftpPRO-9.3.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/bbftpPRO/bbftpPRO-9.3.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/bbftpPRO/bbftpPRO-9.3.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/b/bbftpPRO/bbftpPRO-9.3.1-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/bc/bc-1.06.95-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/b/bc/bc-1.06.95-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 ##
 

--- a/easybuild/easyconfigs/b/binutils/binutils-2.22-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.22-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/binutils/binutils-2.22-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.22-goolf-1.5.14.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>

--- a/easybuild/easyconfigs/b/biodeps/biodeps-1.6-goolf-1.4.10-extended.eb
+++ b/easybuild/easyconfigs/b/biodeps/biodeps-1.6-goolf-1.4.10-extended.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/biodeps/biodeps-1.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/biodeps/biodeps-1.6-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/biodeps/biodeps-1.6-ictce-5.3.0-extended.eb
+++ b/easybuild/easyconfigs/b/biodeps/biodeps-1.6-ictce-5.3.0-extended.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/biodeps/biodeps-1.6-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/b/biodeps/biodeps-1.6-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/b/bwakit/bwakit-0.7.15_x64-linux.eb
+++ b/easybuild/easyconfigs/b/bwakit/bwakit-0.7.15_x64-linux.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/c/CAP3/CAP3-20071221-intel-x86.eb
+++ b/easybuild/easyconfigs/c/CAP3/CAP3-20071221-intel-x86.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/CAP3/CAP3-20071221-intel-x86_64.eb
+++ b/easybuild/easyconfigs/c/CAP3/CAP3-20071221-intel-x86_64.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/CAP3/CAP3-20071221-opteron.eb
+++ b/easybuild/easyconfigs/c/CAP3/CAP3-20071221-opteron.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.5.4-ictce-5.3.0-2011-03-07.eb
+++ b/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.5.4-ictce-5.3.0-2011-03-07.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, George Tsouloupas <g.tsouloupas@cyi.ac.cy>

--- a/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.6.1-foss-2015b-2012-08-27.eb
+++ b/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.6.1-foss-2015b-2012-08-27.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.6.1-goolf-1.4.10-2012-08-27.eb
+++ b/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.6.1-goolf-1.4.10-2012-08-27.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.6.1-ictce-5.5.0-2012-08-27.eb
+++ b/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.6.1-ictce-5.5.0-2012-08-27.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.6.4-GNU-4.9.3-2.25-2015-0603.eb
+++ b/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.6.4-GNU-4.9.3-2.25-2015-0603.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.6.4-foss-2015b-2015-0603.eb
+++ b/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.6.4-foss-2015b-2015-0603.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.6.6-foss-2016b.eb
+++ b/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.6.6-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'MakeCp'
 

--- a/easybuild/easyconfigs/c/CEM/CEM-0.9.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/CEM/CEM-0.9.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/CHASE/CHASE-20130626.eb
+++ b/easybuild/easyconfigs/c/CHASE/CHASE-20130626.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/c/CONTRAfold/CONTRAfold-2.02-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/CONTRAfold/CONTRAfold-2.02-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/CONTRAlign/CONTRAlign-2.01-goolf-1.4.10-proteins.eb
+++ b/easybuild/easyconfigs/c/CONTRAlign/CONTRAlign-2.01-goolf-1.4.10-proteins.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/c/CONTRAlign/CONTRAlign-2.01-goolf-1.4.10-rna.eb
+++ b/easybuild/easyconfigs/c/CONTRAlign/CONTRAlign-2.01-goolf-1.4.10-rna.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/c/CUDA/CUDA-5.0.35-1.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-5.0.35-1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA, Ghent University
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/easybuild/easyconfigs/c/CUDA/CUDA-5.0.35-GCC-4.6.4-1.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-5.0.35-GCC-4.6.4-1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA, Ghent University
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/easybuild/easyconfigs/c/CUDA/CUDA-5.5.22-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-5.5.22-GCC-4.7.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA, Ghent University
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/easybuild/easyconfigs/c/CUDA/CUDA-5.5.22-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-5.5.22-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA, Ghent University
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/easybuild/easyconfigs/c/CUDA/CUDA-5.5.22.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-5.5.22.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA, Ghent University
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/easybuild/easyconfigs/c/CUDA/CUDA-6.0.37.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-6.0.37.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB, Ghent University
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>, Kenneth Hoste

--- a/easybuild/easyconfigs/c/CUDA/CUDA-6.5.14.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-6.5.14.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB, Ghent University
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>, Kenneth Hoste

--- a/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-GCC-4.9.4-2.25.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-GCC-4.9.4-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2016 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA, Ghent University, Microway
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste, Eliot Eshelman

--- a/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB, Ghent University,
 # Forschungszentrum Juelich

--- a/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # 
 # Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB, Ghent University,
 # Forschungszentrum Juelich

--- a/easybuild/easyconfigs/c/CVS/CVS-1.11.23-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/c/CVS/CVS-1.11.23-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 ##
 

--- a/easybuild/easyconfigs/c/CVS/CVS-1.11.23-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/c/CVS/CVS-1.11.23-GCCcore-4.9.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 ##
 

--- a/easybuild/easyconfigs/c/ChIP-Seq/ChIP-Seq-1.5-1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/ChIP-Seq/ChIP-Seq-1.5-1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/c/ChIP-Seq/ChIP-Seq-1.5-1-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/c/ChIP-Seq/ChIP-Seq-1.5-1-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/c/Chapel/Chapel-1.10.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/Chapel/Chapel-1.10.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/Chapel/Chapel-1.10.0-goolf-1.6.10.eb
+++ b/easybuild/easyconfigs/c/Chapel/Chapel-1.10.0-goolf-1.6.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/Chapel/Chapel-1.6.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/Chapel/Chapel-1.6.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/Chapel/Chapel-1.7.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/Chapel/Chapel-1.7.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/Chapel/Chapel-1.8.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/Chapel/Chapel-1.8.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/Chapel/Chapel-1.8.0-goolf-1.6.10.eb
+++ b/easybuild/easyconfigs/c/Chapel/Chapel-1.8.0-goolf-1.6.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/Chapel/Chapel-1.9.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/Chapel/Chapel-1.9.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/Chapel/Chapel-1.9.0-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/c/Chapel/Chapel-1.9.0-goolf-1.5.14.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Authors::   Jordi Blasco (NeSI) <jordi.blasco@nesi.org.nz>
 # License::   MIT/GPL

--- a/easybuild/easyconfigs/c/Chapel/Chapel-1.9.0-goolf-1.6.10.eb
+++ b/easybuild/easyconfigs/c/Chapel/Chapel-1.9.0-goolf-1.6.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/Check/Check-0.9.12-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/Check/Check-0.9.12-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/Chimera/Chimera-1.10-linux_x86_64.eb
+++ b/easybuild/easyconfigs/c/Chimera/Chimera-1.10-linux_x86_64.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/Circos/Circos-0.69-5-foss-2016b-Perl-5.24.0.eb
+++ b/easybuild/easyconfigs/c/Circos/Circos-0.69-5-foss-2016b-Perl-5.24.0.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'Tarball'
 

--- a/easybuild/easyconfigs/c/Clang/Clang-3.2-GCC-4.7.3.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-3.2-GCC-4.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013 Dmitri Gribenko
 # Authors:: Dmitri Gribenko <gribozavr@gmail.com>

--- a/easybuild/easyconfigs/c/Clang/Clang-3.3-GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-3.3-GCC-4.8.1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013 Dmitri Gribenko, Ward Poelmans
 # Authors:: Dmitri Gribenko <gribozavr@gmail.com>

--- a/easybuild/easyconfigs/c/Clang/Clang-3.4-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-3.4-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013 Dmitri Gribenko, Ward Poelmans
 # Authors:: Dmitri Gribenko <gribozavr@gmail.com>

--- a/easybuild/easyconfigs/c/Clang/Clang-3.4.1-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-3.4.1-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013 Dmitri Gribenko, Ward Poelmans
 # Authors:: Dmitri Gribenko <gribozavr@gmail.com>

--- a/easybuild/easyconfigs/c/Clang/Clang-3.4.2-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-3.4.2-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014 Dmitri Gribenko, Ward Poelmans
 # Authors:: Dmitri Gribenko <gribozavr@gmail.com>

--- a/easybuild/easyconfigs/c/Clang/Clang-3.6.0-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-3.6.0-GCC-4.9.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013 Dmitri Gribenko, Ward Poelmans
 # Authors:: Dmitri Gribenko <gribozavr@gmail.com>

--- a/easybuild/easyconfigs/c/Clang/Clang-3.6.1-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-3.6.1-GCC-4.9.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013 Dmitri Gribenko, Ward Poelmans
 # Authors:: Dmitri Gribenko <gribozavr@gmail.com>

--- a/easybuild/easyconfigs/c/Clang/Clang-3.7.0-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-3.7.0-GNU-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Dmitri Gribenko, Ward Poelmans
 # Authors:: Dmitri Gribenko <gribozavr@gmail.com>

--- a/easybuild/easyconfigs/c/Clang/Clang-3.7.1-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-3.7.1-GCC-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Dmitri Gribenko, Ward Poelmans
 # Authors:: Dmitri Gribenko <gribozavr@gmail.com>

--- a/easybuild/easyconfigs/c/Clang/Clang-3.7.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-3.7.1-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Dmitri Gribenko, Ward Poelmans
 # Authors:: Dmitri Gribenko <gribozavr@gmail.com>

--- a/easybuild/easyconfigs/c/Clang/Clang-3.8.0-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-3.8.0-GCC-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Dmitri Gribenko, Ward Poelmans
 # Authors:: Dmitri Gribenko <gribozavr@gmail.com>

--- a/easybuild/easyconfigs/c/Clang/Clang-3.8.1-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-3.8.1-GCC-5.4.0-2.26.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Dmitri Gribenko, Ward Poelmans
 # Authors:: Dmitri Gribenko <gribozavr@gmail.com>

--- a/easybuild/easyconfigs/c/Clang/Clang-3.8.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-3.8.1-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Dmitri Gribenko, Ward Poelmans
 # Authors:: Dmitri Gribenko <gribozavr@gmail.com>

--- a/easybuild/easyconfigs/c/Clustal-Omega/Clustal-Omega-1.2.0-foss-2015b.eb
+++ b/easybuild/easyconfigs/c/Clustal-Omega/Clustal-Omega-1.2.0-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/Clustal-Omega/Clustal-Omega-1.2.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/c/Clustal-Omega/Clustal-Omega-1.2.0-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/Clustal-Omega/Clustal-Omega-1.2.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/Clustal-Omega/Clustal-Omega-1.2.0-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/ClustalW2/ClustalW2-2.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/c/ClustalW2/ClustalW2-2.1-foss-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/ClustalW2/ClustalW2-2.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/c/ClustalW2/ClustalW2-2.1-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/ClustalW2/ClustalW2-2.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/ClustalW2/ClustalW2-2.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/ClustalW2/ClustalW2-2.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/c/ClustalW2/ClustalW2-2.1-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/ConnectomeWorkbench/ConnectomeWorkbench-1.2.2.eb
+++ b/easybuild/easyconfigs/c/ConnectomeWorkbench/ConnectomeWorkbench-1.2.2.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/c/Cookiecutter/Cookiecutter-1.4.0-goolf-1.7.20-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/c/Cookiecutter/Cookiecutter-1.4.0-goolf-1.7.20-Python-2.7.11.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/c/Coot/Coot-0.8.1-binary-Linux-x86_64-rhel-6-python-gtk2.eb
+++ b/easybuild/easyconfigs/c/Coot/Coot-0.8.1-binary-Linux-x86_64-rhel-6-python-gtk2.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Adam Mazur
 # Research IT
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/Corkscrew/Corkscrew-2.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/Corkscrew/Corkscrew-2.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/Corkscrew/Corkscrew-2.0-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/c/Corkscrew/Corkscrew-2.0-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/Cube/Cube-4.2-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/c/Cube/Cube-4.2-goolf-1.5.14.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/c/Cube/Cube-4.2.3-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/c/Cube/Cube-4.2.3-goolf-1.5.14.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Authors::   Jordi Blasco <jordi.blasco@nesi.org.nz>
 # License::   New BSD
 #

--- a/easybuild/easyconfigs/c/Cube/Cube-4.3-foss-2015a.eb
+++ b/easybuild/easyconfigs/c/Cube/Cube-4.3-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/c/Cube/Cube-4.3.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/c/Cube/Cube-4.3.2-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/c/Cube/Cube-4.3.4-foss-2016a.eb
+++ b/easybuild/easyconfigs/c/Cube/Cube-4.3.4-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2016 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-1.3.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-1.3.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.0.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.0.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.0.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.0.2-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.1.1-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.1.1-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/ccache/ccache-3.1.9-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/ccache/ccache-3.1.9-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/ccache/ccache-3.1.9-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/c/ccache/ccache-3.1.9-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/ccache/ccache-3.2.5.eb
+++ b/easybuild/easyconfigs/c/ccache/ccache-3.2.5.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/ccache/ccache-3.3.1.eb
+++ b/easybuild/easyconfigs/c/ccache/ccache-3.3.1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/ccache/ccache-3.3.3.eb
+++ b/easybuild/easyconfigs/c/ccache/ccache-3.3.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/cflow/cflow-1.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/cflow/cflow-1.4-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/cflow/cflow-1.4-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/c/cflow/cflow-1.4-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/cgdb/cgdb-0.6.5-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/cgdb/cgdb-0.6.5-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/cgdb/cgdb-0.6.5-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/c/cgdb/cgdb-0.6.5-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/c/ctffind/ctffind-4.0.17-intel-2015b.eb
+++ b/easybuild/easyconfigs/c/ctffind/ctffind-4.0.17-intel-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-4.0.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-4.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author:    Stephane Thiell <sthiell@stanford.edu>
 ##

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-5.0-CUDA-7.5.18.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-5.0-CUDA-7.5.18.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author:    Stephane Thiell <sthiell@stanford.edu>
 ##

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-5.0-rc.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-5.0-rc.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author:    Stephane Thiell <sthiell@stanford.edu>
 ##

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-5.1-CUDA-8.0.44.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-5.1-CUDA-8.0.44.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author:    Stephane Thiell <sthiell@stanford.edu>
 ##

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-6.0-CUDA-8.0.61.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-6.0-CUDA-8.0.61.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author:    Stephane Thiell <sthiell@stanford.edu>
 ##

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.3-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.3-goolf-1.4.10-Python-2.7.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.3-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.3-goolf-1.4.10-Python-2.7.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.4.1-foss-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.4.1-foss-2014b-Python-2.7.8.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.4.1-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.4.1-goolf-1.4.10-Python-2.7.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.5-foss-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.5-foss-2014b-Python-2.7.8.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.6-foss-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.6-foss-2014b-Python-2.7.8.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.7-foss-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.7-foss-2014b-Python-2.7.8.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.7.1-foss-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.7.1-foss-2014b-Python-2.7.8.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.8.1-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.8.1-intel-2015a-Python-2.7.9.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.9.1-foss-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.9.1-foss-2015b-Python-2.7.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.9.1-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.9.1-foss-2016a-Python-2.7.11.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.9.1-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.9.1-foss-2016b-Python-2.7.12.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/d/DIALIGN-TX/DIALIGN-TX-1.0.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/d/DIALIGN-TX/DIALIGN-TX-1.0.2-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/d/DIAMOND/DIAMOND-0.8.35-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/d/DIAMOND/DIAMOND-0.8.35-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/d/DIAMOND/DIAMOND-0.9.6-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/d/DIAMOND/DIAMOND-0.9.6-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/d/DMTCP/DMTCP-2.4.5.eb
+++ b/easybuild/easyconfigs/d/DMTCP/DMTCP-2.4.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/d/DMTCP/DMTCP-2.5.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/d/DMTCP/DMTCP-2.5.0-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/d/DSRC/DSRC-2.0rc-linux-64-bit.eb
+++ b/easybuild/easyconfigs/d/DSRC/DSRC-2.0rc-linux-64-bit.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2015 NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/d/DendroPy/DendroPy-3.12.0-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/d/DendroPy/DendroPy-3.12.0-goolf-1.4.10-Python-2.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2014 The Cyprus Institute
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/d/DicomBrowser/DicomBrowser-1.7.0b5-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/d/DicomBrowser/DicomBrowser-1.7.0b5-Java-1.7.0_80.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/d/Diffutils/Diffutils-3.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/d/Diffutils/Diffutils-3.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/d/Diffutils/Diffutils-3.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/d/Diffutils/Diffutils-3.2-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/d/Diffutils/Diffutils-3.3-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/d/Diffutils/Diffutils-3.3-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/d/disambiguate/disambiguate-1.0.0-goolf-1.7.20-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/d/disambiguate/disambiguate-1.0.0-goolf-1.7.20-Python-2.7.11.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/d/drFAST/drFAST-1.0.0.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/d/drFAST/drFAST-1.0.0.0-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/d/drFAST/drFAST-1.0.0.0-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/d/drFAST/drFAST-1.0.0.0-ictce-6.2.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.0.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.0.1-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.1-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.1-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.1-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.4-foss-2016b.eb
+++ b/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.4-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2013.11-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2013.11-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Authors::   Inge Gutheil <i.gutheil@fz-juelich.de>, Alan O'Cais <a.ocais@fz-juelich.de>
 # License::   MIT/GPL

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2013.11-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2013.11-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Authors::   Inge Gutheil <i.gutheil@fz-juelich.de>, Alan O'Cais <a.ocais@fz-juelich.de>
 # License::   MIT/GPL

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2016.05.004-intel-2016b.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2016.05.004-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Authors::   Inge Gutheil <i.gutheil@fz-juelich.de>, Alan O'Cais <a.ocais@fz-juelich.de>
 # License::   MIT/GPL

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2016.05.004-intel-2017a.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2016.05.004-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Authors::   Inge Gutheil <i.gutheil@fz-juelich.de>, Alan O'Cais <a.ocais@fz-juelich.de>
 # License::   MIT/GPL

--- a/easybuild/easyconfigs/e/ELPH/ELPH-1.0.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/e/ELPH/ELPH-1.0.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/e/ELPH/ELPH-1.0.1-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/e/ELPH/ELPH-1.0.1-ictce-6.2.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/e/ELinks/ELinks-0.12pre5-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/e/ELinks/ELinks-0.12pre5-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/ELinks/ELinks-0.12pre5-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/e/ELinks/ELinks-0.12pre5-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-3.1.1-goolf-1.4.10-parallel.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-3.1.1-goolf-1.4.10-parallel.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Josh Berryman <josh.berryman@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-3.1.1-goolf-1.4.10-serial.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-3.1.1-goolf-1.4.10-serial.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Josh Berryman <josh.berryman@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-3.1.1-ictce-5.3.0-parallel.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-3.1.1-ictce-5.3.0-parallel.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Josh Berryman <josh.berryman@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-3.1.1-ictce-5.3.0-serial.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-3.1.1-ictce-5.3.0-serial.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Josh Berryman <josh.berryman@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/ETSF_IO/ETSF_IO-1.0.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/e/ETSF_IO/ETSF_IO-1.0.4-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2014 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/e/ETSF_IO/ETSF_IO-1.0.4-intel-2015b.eb
+++ b/easybuild/easyconfigs/e/ETSF_IO/ETSF_IO-1.0.4-intel-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2014 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.0.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.0.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.0.1'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.0.1'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.2.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.0.2'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.2.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.0.2'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.1.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.1.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.1.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.1.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.1.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.1.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.10.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.10.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.10.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.10.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.10.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.10.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.11.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.11.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.11.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.11.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.11.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.11.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.11.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.11.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.11.1'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.11.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.11.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.11.1'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.12.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.12.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.12.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.12.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.12.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.12.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.12.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.12.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.12.1'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.12.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.12.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.12.1'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.13.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.13.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.13.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.13.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.13.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.13.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.14.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.14.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.14.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.14.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.14.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.14.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = "1.15.0"
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = "1.15.0"
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = "1.15.1"
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = "1.15.1"
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.2.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = "1.15.2"
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.2.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = "1.15.2"
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = "1.16.0"
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = "1.16.0"
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = "1.16.1"
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = "1.16.1"
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.2.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = "1.16.2"
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.2.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = "1.16.2"
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.2.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.2.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.2.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.2.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.3.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.3.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.3.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.3.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.4.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.4.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.4.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.4.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.4.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.4.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.5.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.5.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.5.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.5.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.5.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.5.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.6.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.6.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.6.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.6.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.6.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.6.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.7.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.7.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.7.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.7.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.7.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.7.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.8.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.8.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.8.1'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.8.1'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.2.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.8.2'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.2.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.8.2'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.9.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.9.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.9.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.9.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.9.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '1.9.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.0.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.0.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = "2.0.0"
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.0.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.0.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = "2.0.0"
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.1.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.1.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.1.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.1.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.1.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.1.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.1.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.1.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.1.1'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.1.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.1.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.1.1'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.2.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.2.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.2.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.2.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.3.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.3.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.3.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.3.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.4.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.4.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.4.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.4.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.4.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.4.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.5.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.5.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.5.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.5.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.5.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.5.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.6.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.6.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.6.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.6.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.6.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.6.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.7.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.7.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.7.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.7.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.7.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.7.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.8.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.8.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.8.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.8.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.8.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.8.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.8.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.8.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.8.1'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.8.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.8.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.8.1'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.8.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.8.2.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.8.2'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.8.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.8.2.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.8.2'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.9.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.9.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.9.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.9.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.9.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '2.9.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.0.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.0.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.0.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.0.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.0.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.0.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.0.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.0.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.0.1'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.0.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.0.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.0.1'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.0.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.0.2.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.0.2'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.0.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.0.2.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.0.2'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.1.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.1.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.1.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.1.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.1.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.1.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.1.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.1.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.1.1'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.1.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.1.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.1.1'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.1.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.1.2.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.1.2'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.1.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.1.2.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.1.2'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.2.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.2.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.2.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.2.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.2.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.2.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.2.1'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.2.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.2.1.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.2.1'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.3.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.3.0'
 
-homepage = 'http://easybuilders.github.io/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.3.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '3.3.0'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.io/easybuild'
 description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""

--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.1.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.1.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.1.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.1.1-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.1.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.1.4-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.1.4-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.1.4-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.1.4-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.1.4-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.2.0-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.2.0-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.2.2-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.2.2-goolf-1.5.14.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.2.2-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.2.2-ictce-7.1.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.2.2-intel-2014b.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.2.2-intel-2014b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.2.6-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.2.6-goolf-1.7.20.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/ErlangOTP/ErlangOTP-R16B02-goolf-1.4.10-no-Java.eb
+++ b/easybuild/easyconfigs/e/ErlangOTP/ErlangOTP-R16B02-goolf-1.4.10-no-Java.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/e/Exonerate/Exonerate-2.2.0-foss-2015b.eb
+++ b/easybuild/easyconfigs/e/Exonerate/Exonerate-2.2.0-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/e/Exonerate/Exonerate-2.2.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/e/Exonerate/Exonerate-2.2.0-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/e/Exonerate/Exonerate-2.2.0-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/e/Exonerate/Exonerate-2.2.0-ictce-5.3.0.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/e/Exonerate/Exonerate-2.4.0-foss-2015b.eb
+++ b/easybuild/easyconfigs/e/Exonerate/Exonerate-2.4.0-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/e/Exonerate/Exonerate-2.4.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/e/Exonerate/Exonerate-2.4.0-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/e/Exonerate/Exonerate-2.4.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/e/Exonerate/Exonerate-2.4.0-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/e/Extrae/Extrae-3.0.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/e/Extrae/Extrae-3.0.1-foss-2015a.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/e/eXpress/eXpress-1.5.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/e/eXpress/eXpress-1.5.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/f/FASTA/FASTA-36.3.5e-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/FASTA/FASTA-36.3.5e-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'MakeCp'
 

--- a/easybuild/easyconfigs/f/FASTA/FASTA-36.3.5e-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/f/FASTA/FASTA-36.3.5e-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>,

--- a/easybuild/easyconfigs/f/FASTA/FASTA-36.3.5e-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/f/FASTA/FASTA-36.3.5e-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>,

--- a/easybuild/easyconfigs/f/FASTX-Toolkit/FASTX-Toolkit-0.0.13.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/f/FASTX-Toolkit/FASTX-Toolkit-0.0.13.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/f/FASTX-Toolkit/FASTX-Toolkit-0.0.13.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/f/FASTX-Toolkit/FASTX-Toolkit-0.0.13.2-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/f/FASTX-Toolkit/FASTX-Toolkit-0.0.14-foss-2015b.eb
+++ b/easybuild/easyconfigs/f/FASTX-Toolkit/FASTX-Toolkit-0.0.14-foss-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/f/FASTX-Toolkit/FASTX-Toolkit-0.0.14-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/FASTX-Toolkit/FASTX-Toolkit-0.0.14-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/f/FASTX-Toolkit/FASTX-Toolkit-0.0.14-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/FASTX-Toolkit/FASTX-Toolkit-0.0.14-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/f/FASTX-Toolkit/FASTX-Toolkit-0.0.14-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/f/FASTX-Toolkit/FASTX-Toolkit-0.0.14-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/f/FASTX-Toolkit/FASTX-Toolkit-0.0.14-intel-2015a.eb
+++ b/easybuild/easyconfigs/f/FASTX-Toolkit/FASTX-Toolkit-0.0.14-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/f/FFLAS-FFPACK/FFLAS-FFPACK-2.2.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/FFLAS-FFPACK/FFLAS-FFPACK-2.2.0-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipe; see https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipe; see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2016 Riccardo Murri <riccardo.murri@gmail.com>
 # Authors::   Riccardo Murri <riccardo.murri@gmail.com>

--- a/easybuild/easyconfigs/f/FLAC/FLAC-1.3.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/f/FLAC/FLAC-1.3.1-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author:    Stephane Thiell <sthiell@stanford.edu>
 ###

--- a/easybuild/easyconfigs/f/FSA/FSA-1.15.8-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/f/FSA/FSA-1.15.8-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/NTUA, Swiss Institute of Bioinformatics
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Pablo Escobar Lopez

--- a/easybuild/easyconfigs/f/FSA/FSA-1.15.8-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/f/FSA/FSA-1.15.8-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/NTUA, Swiss Institute of Bioinformatics
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Pablo Escobar Lopez

--- a/easybuild/easyconfigs/f/FastQC/FastQC-0.10.1-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/f/FastQC/FastQC-0.10.1-Java-1.7.0_80.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors:: Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/f/Firefox/Firefox-44.0.2.eb
+++ b/easybuild/easyconfigs/f/Firefox/Firefox-44.0.2.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/f/fastPHASE/fastPHASE-1.4.8.eb
+++ b/easybuild/easyconfigs/f/fastPHASE/fastPHASE-1.4.8.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/f/fastQValidator/fastQValidator-0.1.1a-20151214-goolf-1.7.20-aadc6f9.eb
+++ b/easybuild/easyconfigs/f/fastQValidator/fastQValidator-0.1.1a-20151214-goolf-1.7.20-aadc6f9.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/f/fastqz/fastqz-1.5-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/f/fastqz/fastqz-1.5-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2015 NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/f/file/file-5.17-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/f/file/file-5.17-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 ##
 

--- a/easybuild/easyconfigs/f/file/file-5.25-intel-2016a.eb
+++ b/easybuild/easyconfigs/f/file/file-5.25-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 ##
 

--- a/easybuild/easyconfigs/f/file/file-5.28-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/file/file-5.28-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 ##
 

--- a/easybuild/easyconfigs/f/file/file-5.30-intel-2017a.eb
+++ b/easybuild/easyconfigs/f/file/file-5.30-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 ##
 

--- a/easybuild/easyconfigs/f/findutils/findutils-4.2.33-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/f/findutils/findutils-4.2.33-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/f/findutils/findutils-4.2.33-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/f/findutils/findutils-4.2.33-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/f/findutils/findutils-4.4.2-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/f/findutils/findutils-4.4.2-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/f/fqzcomp/fqzcomp-4.6-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/f/fqzcomp/fqzcomp-4.6-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2015 NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/GATK/GATK-2.5-2-Java-1.7.0_10.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-2.5-2-Java-1.7.0_10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/g/GATK/GATK-2.6-5-Java-1.7.0_10.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-2.6-5-Java-1.7.0_10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/g/GATK/GATK-2.7-4-Java-1.7.0_10.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-2.7-4-Java-1.7.0_10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/g/GATK/GATK-2.8-1-Java-1.7.0_10.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-2.8-1-Java-1.7.0_10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/g/GATK/GATK-3.0-0-Java-1.7.0_10.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-3.0-0-Java-1.7.0_10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2014 Cyprus Institute
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/g/GATK/GATK-3.3-0-Java-1.7.0_21.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-3.3-0-Java-1.7.0_21.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>,

--- a/easybuild/easyconfigs/g/GATK/GATK-3.3-0-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-3.3-0-Java-1.7.0_80.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>,

--- a/easybuild/easyconfigs/g/GATK/GATK-3.3-0-Java-1.8.0_66.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-3.3-0-Java-1.8.0_66.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>,

--- a/easybuild/easyconfigs/g/GATK/GATK-3.5-Java-1.8.0_66.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-3.5-Java-1.8.0_66.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>,

--- a/easybuild/easyconfigs/g/GATK/GATK-3.5-Java-1.8.0_74.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-3.5-Java-1.8.0_74.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>,

--- a/easybuild/easyconfigs/g/GATK/GATK-3.6-Java-1.8.0_92.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-3.6-Java-1.8.0_92.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>,

--- a/easybuild/easyconfigs/g/GATK/GATK-3.7-Java-1.8.0_112.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-3.7-Java-1.8.0_112.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>,

--- a/easybuild/easyconfigs/g/GCC/GCC-system.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-system.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/g/GD/GD-2.66-foss-2016b-Perl-5.24.0.eb
+++ b/easybuild/easyconfigs/g/GD/GD-2.66-foss-2016b-Perl-5.24.0.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'PerlModule'
 

--- a/easybuild/easyconfigs/g/GDB/GDB-7.5.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/GDB/GDB-7.5.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/GEM-library/GEM-library-20130406-045632_pre-release-3_Linux-x86_64.eb
+++ b/easybuild/easyconfigs/g/GEM-library/GEM-library-20130406-045632_pre-release-3_Linux-x86_64.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/g/GEMSTAT/GEMSTAT-1.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/GEMSTAT/GEMSTAT-1.0-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/g/GFOLD/GFOLD-1.1.4-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/g/GFOLD/GFOLD-1.1.4-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/g/GFOLD/GFOLD-1.1.4-intel-2016a.eb
+++ b/easybuild/easyconfigs/g/GFOLD/GFOLD-1.1.4-intel-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/g/GIMPS/GIMPS-p95v279-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/g/GIMPS/GIMPS-p95v279-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/GIMPS/GIMPS-p95v279.linux64.eb
+++ b/easybuild/easyconfigs/g/GIMPS/GIMPS-p95v279.linux64.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/GLIMMER/GLIMMER-3.02b-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/GLIMMER/GLIMMER-3.02b-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/g/GLIMMER/GLIMMER-3.02b-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/g/GLIMMER/GLIMMER-3.02b-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2014-01-21-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2014-01-21-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2014-06-10-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2014-06-10-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2015-12-31.v2-foss-2015b.eb
+++ b/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2015-12-31.v2-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2016-05-01-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2016-05-01-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2016-11-07-foss-2016b.eb
+++ b/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2016-11-07-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016-foss-2016b-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016-foss-2016b-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
 #                                 Ghent University / The Francis Crick Institute

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016-foss-2016b-mt.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016-foss-2016b-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
 #                                 Ghent University / The Francis Crick Institute

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.1-foss-2017a-PLUMED.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.1-foss-2017a-PLUMED.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
 #                                 Ghent University / The Francis Crick Institute

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.2-foss-2017a.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.2-foss-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
 #                                 Ghent University / The Francis Crick Institute

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-foss-2017a.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-foss-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
 #                                 Ghent University / The Francis Crick Institute

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-intel-2017a.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
 #                                 Ghent University / The Francis Crick Institute

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-3.3.3-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-3.3.3-goolf-1.5.14.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.1-goolf-1.4.10-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.1-goolf-1.4.10-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.1-goolf-1.4.10-mt.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.1-goolf-1.4.10-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.1-ictce-5.3.0-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.1-ictce-5.3.0-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.1-ictce-5.3.0-mt.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.1-ictce-5.3.0-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.5-goolf-1.4.10-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.5-goolf-1.4.10-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.5-goolf-1.4.10-mt.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.5-goolf-1.4.10-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.5-ictce-5.5.0-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.5-ictce-5.5.0-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.5-ictce-5.5.0-mt.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.5-ictce-5.5.0-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@tgac.ac.uk>, Fotis Georgatos <fotis@cern.ch>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.7-CrayGNU-2015.06-mpi.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.7-CrayGNU-2015.06-mpi.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.7-CrayGNU-2015.11-mpi.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.7-CrayGNU-2015.11-mpi.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.7-CrayIntel-2015.11-mpi.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-4.6.7-CrayIntel-2015.11-mpi.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.0.2-ictce-7.1.2-mt.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.0.2-ictce-7.1.2-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.0.4-intel-2015a-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.0.4-intel-2015a-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.0.4-intel-2015a-mt.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.0.4-intel-2015a-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.0.5-intel-2015a-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.0.5-intel-2015a-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.0.7-intel-2015a-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.0.7-intel-2015a-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.1-intel-2015b-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.1-intel-2015b-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.2-foss-2015b-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.2-foss-2015b-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.2-foss-2016a-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.2-foss-2016a-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.2-foss-2016a-mt.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.2-foss-2016a-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.2-goolf-1.7.20-mt.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.2-goolf-1.7.20-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.2-intel-2016a-hybrid-dp.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.2-intel-2016a-hybrid-dp.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.2-intel-2016a-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.2-intel-2016a-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.4-foss-2016b-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.4-foss-2016b-hybrid.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.4-foss-2016b-mt.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.4-foss-2016b-mt.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
 # Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \

--- a/easybuild/easyconfigs/g/GROMOS++/GROMOS++-1.0.2211-goolf-1.5.14-openmp.eb
+++ b/easybuild/easyconfigs/g/GROMOS++/GROMOS++-1.0.2211-goolf-1.5.14-openmp.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Benjamin P. Roberts
 # New Zealand eScience Infrastructure
 # The University of Auckland, Auckland, New Zealand 

--- a/easybuild/easyconfigs/g/GROMOS++/GROMOS++-1.0.2211-goolf-1.5.14-serial.eb
+++ b/easybuild/easyconfigs/g/GROMOS++/GROMOS++-1.0.2211-goolf-1.5.14-serial.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Benjamin P. Roberts
 # New Zealand eScience Infrastructure
 # The University of Auckland, Auckland, New Zealand 

--- a/easybuild/easyconfigs/g/GTI/GTI-1.2.0-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/g/GTI/GTI-1.2.0-goolf-1.5.14.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/g/GTOOL/GTOOL-0.7.5.eb
+++ b/easybuild/easyconfigs/g/GTOOL/GTOOL-0.7.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/g/Givaro/Givaro-4.0.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/Givaro/Givaro-4.0.1-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipe; see https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipe; see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2016 Riccardo Murri <riccardo.murri@gmail.com>
 # Authors::   Riccardo Murri <riccardo.murri@gmail.com>

--- a/easybuild/easyconfigs/g/gawk/gawk-4.0.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/gawk/gawk-4.0.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/gawk/gawk-4.0.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/g/gawk/gawk-4.0.2-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/gencore_variant_detection/gencore_variant_detection-1.0.eb
+++ b/easybuild/easyconfigs/g/gencore_variant_detection/gencore_variant_detection-1.0.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/g/git-lfs/git-lfs-1.1.1.eb
+++ b/easybuild/easyconfigs/g/git-lfs/git-lfs-1.1.1.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/g/git/git-1.7.12-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/git/git-1.7.12-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/git/git-1.7.12-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/g/git/git-1.7.12-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/git/git-1.8.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/git/git-1.8.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/git/git-1.8.3.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/git/git-1.8.3.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/git/git-1.8.5.6-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/g/git/git-1.8.5.6-GCC-4.9.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/git/git-2.2.2-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/g/git/git-2.2.2-GCC-4.9.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/git/git-2.4.1-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/g/git/git-2.4.1-GCC-4.9.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/gnuplot/gnuplot-4.6.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/gnuplot/gnuplot-4.6.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/gnuplot/gnuplot-4.6.0-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/g/gnuplot/gnuplot-4.6.0-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/gnuplot/gnuplot-4.6.6-intel-2014b.eb
+++ b/easybuild/easyconfigs/g/gnuplot/gnuplot-4.6.6-intel-2014b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.0-intel-2014b.eb
+++ b/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.0-intel-2014b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>

--- a/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.0-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.0-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>

--- a/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.1-intel-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>

--- a/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.3-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.3-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>

--- a/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.3-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>

--- a/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.5-foss-2016b.eb
+++ b/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.5-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>

--- a/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.5-intel-2016b.eb
+++ b/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.5-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>

--- a/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.6-intel-2017a.eb
+++ b/easybuild/easyconfigs/g/gnuplot/gnuplot-5.0.6-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>

--- a/easybuild/easyconfigs/g/grabix/grabix-0.1.6-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/g/grabix/grabix-0.1.6-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/g/gromosXX/gromosXX-1.0.1737-goolf-1.5.14-mpi.eb
+++ b/easybuild/easyconfigs/g/gromosXX/gromosXX-1.0.1737-goolf-1.5.14-mpi.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Benjamin P. Roberts
 # New Zealand eScience Infrastructure
 # The University of Auckland, Auckland, New Zealand 

--- a/easybuild/easyconfigs/g/gromosXX/gromosXX-1.0.1737-goolf-1.5.14-openmp.eb
+++ b/easybuild/easyconfigs/g/gromosXX/gromosXX-1.0.1737-goolf-1.5.14-openmp.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Benjamin P. Roberts
 # New Zealand eScience Infrastructure
 # The University of Auckland, Auckland, New Zealand 

--- a/easybuild/easyconfigs/g/gromosXX/gromosXX-1.0.1737-goolf-1.5.14-serial.eb
+++ b/easybuild/easyconfigs/g/gromosXX/gromosXX-1.0.1737-goolf-1.5.14-serial.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Benjamin P. Roberts
 # New Zealand eScience Infrastructure
 # The University of Auckland, Auckland, New Zealand 

--- a/easybuild/easyconfigs/g/gzip/gzip-1.5-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/gzip/gzip-1.5-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/g/gzip/gzip-1.5-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/g/gzip/gzip-1.5-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipy as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipy as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Author::    Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/g/gzip/gzip-1.6-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/g/gzip/gzip-1.6-goolf-1.5.14.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/g/gzip/gzip-1.6-goolf-1.6.10.eb
+++ b/easybuild/easyconfigs/g/gzip/gzip-1.6-goolf-1.6.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/g/gzip/gzip-1.6-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/g/gzip/gzip-1.6-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/g/gzip/gzip-1.6-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/g/gzip/gzip-1.6-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/g/gzip/gzip-1.6-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/g/gzip/gzip-1.6-ictce-6.2.5.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/h/HAPGEN2/HAPGEN2-2.2.0.eb
+++ b/easybuild/easyconfigs/h/HAPGEN2/HAPGEN2-2.2.0.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/h/HH-suite/HH-suite-2.0.16-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HH-suite/HH-suite-2.0.16-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipy as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipy as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HMMER/HMMER-3.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HMMER/HMMER-3.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HMMER/HMMER-3.0-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/h/HMMER/HMMER-3.0-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HMMER/HMMER-3.1b1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HMMER/HMMER-3.1b1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Nils Christian <nils.christian@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HMMER/HMMER-3.1b1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/h/HMMER/HMMER-3.1b1-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Nils Christian <nils.christian@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HMMER/HMMER-3.1b1-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/h/HMMER/HMMER-3.1b1-ictce-6.2.5.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Nils Christian <nils.christian@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HMMER/HMMER-3.1b2-foss-2016a.eb
+++ b/easybuild/easyconfigs/h/HMMER/HMMER-3.1b2-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Nils Christian <nils.christian@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HMMER/HMMER-3.1b2-intel-2015a.eb
+++ b/easybuild/easyconfigs/h/HMMER/HMMER-3.1b2-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Nils Christian <nils.christian@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HMMER/HMMER-3.1b2-intel-2017a.eb
+++ b/easybuild/easyconfigs/h/HMMER/HMMER-3.1b2-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Nils Christian <nils.christian@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HPCBIOS_Bioinfo/HPCBIOS_Bioinfo-20130829-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HPCBIOS_Bioinfo/HPCBIOS_Bioinfo-20130829-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HPCBIOS_Bioinfo/HPCBIOS_Bioinfo-20130829-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/h/HPCBIOS_Bioinfo/HPCBIOS_Bioinfo-20130829-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HPCBIOS_Debuggers/HPCBIOS_Debuggers-20130829-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HPCBIOS_Debuggers/HPCBIOS_Debuggers-20130829-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HPCBIOS_LifeSciences/HPCBIOS_LifeSciences-20130829-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HPCBIOS_LifeSciences/HPCBIOS_LifeSciences-20130829-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HPCBIOS_LifeSciences/HPCBIOS_LifeSciences-20130829-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/h/HPCBIOS_LifeSciences/HPCBIOS_LifeSciences-20130829-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HPCBIOS_Math/HPCBIOS_Math-20130829-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HPCBIOS_Math/HPCBIOS_Math-20130829-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HPCBIOS_Math/HPCBIOS_Math-20130829-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/h/HPCBIOS_Math/HPCBIOS_Math-20130829-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HPCBIOS_Profilers/HPCBIOS_Profilers-20130829-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HPCBIOS_Profilers/HPCBIOS_Profilers-20130829-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.2.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.2.1-foss-2015a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.2.1-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.2.1-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.2.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.2.1-intel-2015a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.2.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.2.1-intel-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.3-foss-2016a.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.3-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.3-intel-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.3.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.3.1-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.3.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.3.1-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.3.1-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.3.1-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.3.1-intel-2016b.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.3.1-intel-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.3.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.3.2-intel-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.4-foss-2016b.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.4-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.4-intel-2016b.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.4-intel-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.4.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.4.1-intel-2017a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-20160107-intel-2017a-PacBio.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-20160107-intel-2017a-PacBio.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/i/IDBA-UD/IDBA-UD-1.1.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/i/IDBA-UD/IDBA-UD-1.1.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/i/IGV/IGV-2.3.68-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/i/IGV/IGV-2.3.68-Java-1.7.0_80.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/i/IGV/IGV-2.3.80-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/i/IGV/IGV-2.3.80-Java-1.7.0_80.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/i/IGVTools/IGVTools-2.3.68-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/i/IGVTools/IGVTools-2.3.68-Java-1.7.0_80.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/i/IGVTools/IGVTools-2.3.72-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/i/IGVTools/IGVTools-2.3.72-Java-1.7.0_80.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/i/IGVTools/IGVTools-2.3.75-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/i/IGVTools/IGVTools-2.3.75-Java-1.7.0_80.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/i/IMOD/IMOD-4.7.15_RHEL6-64_CUDA6.0.eb
+++ b/easybuild/easyconfigs/i/IMOD/IMOD-4.7.15_RHEL6-64_CUDA6.0.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # authors:
 # * Pablo Escobar Lopez (sciCORE - University of Basel - SIB Swiss Institute of Bioinformatics)
 # * Benjamin Roberts (Landcare Research NZ Ltd)

--- a/easybuild/easyconfigs/i/IMPUTE2/IMPUTE2-2.3.0_x86_64_dynamic.eb
+++ b/easybuild/easyconfigs/i/IMPUTE2/IMPUTE2-2.3.0_x86_64_dynamic.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/i/IMPUTE2/IMPUTE2-2.3.0_x86_64_static.eb
+++ b/easybuild/easyconfigs/i/IMPUTE2/IMPUTE2-2.3.0_x86_64_static.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/i/IMPUTE2/IMPUTE2-2.3.2_x86_64_dynamic.eb
+++ b/easybuild/easyconfigs/i/IMPUTE2/IMPUTE2-2.3.2_x86_64_dynamic.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/i/IMPUTE2/IMPUTE2-2.3.2_x86_64_static.eb
+++ b/easybuild/easyconfigs/i/IMPUTE2/IMPUTE2-2.3.2_x86_64_static.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/i/IOR/IOR-2.10.3-goolf-1.4.10-mpiio.eb
+++ b/easybuild/easyconfigs/i/IOR/IOR-2.10.3-goolf-1.4.10-mpiio.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/i/IOR/IOR-2.10.3-intel-2014b-mpiio.eb
+++ b/easybuild/easyconfigs/i/IOR/IOR-2.10.3-intel-2014b-mpiio.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/i/IOR/IOR-3.0.1-foss-2016a-mpiio.eb
+++ b/easybuild/easyconfigs/i/IOR/IOR-3.0.1-foss-2016a-mpiio.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/i/IPython/IPython-4.1.0-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-4.1.0-goolf-1.4.10-Python-2.7.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/i/IPython/IPython-4.2.0-goolf-1.7.20-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-4.2.0-goolf-1.7.20-Python-2.7.11.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/i/IPython/IPython-4.2.0-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-4.2.0-intel-2016a-Python-2.7.11.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.2-9-intel-2016a.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.2-9-intel-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.3-1-intel-2016b.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.3-1-intel-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.5-10-foss-2016b.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.5-10-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.5-4-intel-2017a.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.5-4-intel-2017a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1rc1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1rc1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1rc1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1rc1-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/i/Iperf/Iperf-2.0.5-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/i/Iperf/Iperf-2.0.5-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/i/Iperf/Iperf-2.0.5-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/i/Iperf/Iperf-2.0.5-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/i/IsoInfer/IsoInfer-0.9.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/i/IsoInfer/IsoInfer-0.9.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Authors: Kenneth Hoste (UGent), Pablo Escobar Lopez (Unibas)
 
 easyblock = 'MakeCp'

--- a/easybuild/easyconfigs/i/IsoInfer/IsoInfer-0.9.1-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/i/IsoInfer/IsoInfer-0.9.1-ictce-6.2.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Authors: Kenneth Hoste (UGent), Pablo Escobar Lopez (Unibas)
 
 easyblock = 'MakeCp'

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.0.109'

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.0.109'

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.0.109'

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.0.109'

--- a/easybuild/easyconfigs/i/icc/icc-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.1.150-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.1.150'

--- a/easybuild/easyconfigs/i/icc/icc-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.1.150-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.1.150'

--- a/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.2.181'

--- a/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.2.181'

--- a/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.2.181'

--- a/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.2.181'

--- a/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.3.210'

--- a/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.3.210'

--- a/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.3.210'

--- a/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.3.210'

--- a/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.3.210'

--- a/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2016.3.210'

--- a/easybuild/easyconfigs/i/icc/icc-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.0.098-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2017.0.098'

--- a/easybuild/easyconfigs/i/icc/icc-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.0.098-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2017.0.098'

--- a/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/icc/icc-2017.2.174-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.2.174-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2017.2.174'

--- a/easybuild/easyconfigs/i/icc/icc-2017.2.174-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.2.174-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'icc'
 version = '2017.2.174'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.0.109-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.0.109-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.0.109-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.0.109-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.0.109.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.0.109.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.1.150-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.1.150-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.2.181-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.2.181-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.2.181-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.2.181-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.2.181-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.2.181-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.2.181-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.2.181-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.3.210-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.3.210-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.3.210-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.3.210-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2017.0.098-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2017.0.098-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2017.1.132-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2017.1.132-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2017.1.132-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2017.1.132-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2017.2.174-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2017.2.174-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = 'Toolchain'
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2017.2.174-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2017.2.174-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = 'Toolchain'
 
 name = 'iccifort'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.0.109'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.0.109'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.0.109'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.0.109'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.1.150-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.1.150'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.1.150-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.1.150'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.2.181'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.2.181'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.2.181'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.2.181'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.3.210'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.3.210'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.3.210'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.3.210'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.3.210'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2016.3.210'

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.0.098-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2017.0.098'

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.0.098-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2017.0.098'

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.2.174-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.2.174-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2017.2.174'

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.2.174-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.2.174-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'ifort'
 version = '2017.2.174'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.00-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.00-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.00-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.00-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.01-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.01-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.01-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.01-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.02-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.02-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.02-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.02-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.02-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.02-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.02-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.02-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016b.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016b.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016b.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016b.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017.00-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017.00-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017.00-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017.00-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017.01-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017.01-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017.01-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017.01-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017.02-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017.02-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017.02-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017.02-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017a.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017a.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017a.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017a.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpi'

--- a/easybuild/easyconfigs/i/iimpic/iimpic-2016.10.eb
+++ b/easybuild/easyconfigs/i/iimpic/iimpic-2016.10.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpic'

--- a/easybuild/easyconfigs/i/iimpic/iimpic-2016.10.eb
+++ b/easybuild/easyconfigs/i/iimpic/iimpic-2016.10.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iimpic'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.0.109-iimpi-2016.00-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.0.109-iimpi-2016.00-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.0.109'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.0.109-iimpi-2016.00-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.0.109-iimpi-2016.00-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.0.109'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.1.150-iimpi-2016.01-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.1.150-iimpi-2016.01-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.1.150'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.1.150-iimpi-2016.01-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.1.150-iimpi-2016.01-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.1.150'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-iimpi-2016.02-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-iimpi-2016.02-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.2.181'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-iimpi-2016.02-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-iimpi-2016.02-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.2.181'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-iimpi-2016.02-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-iimpi-2016.02-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.2.181'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-iimpi-2016.02-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-iimpi-2016.02-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.2.181'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-pompi-2016.03.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-pompi-2016.03.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.2.181'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-pompi-2016.03.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.2.181-pompi-2016.03.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.2.181'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.3.210'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.3.210'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.3.210'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.3.210'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.3.210'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.3.210'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016b.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016b.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.3.210'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016b.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016b.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.3.210'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpic-2016.10.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpic-2016.10.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.3.210'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpic-2016.10.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpic-2016.10.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.3.210'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-pompi-2016.04.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-pompi-2016.04.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.3.210'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-pompi-2016.04.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-pompi-2016.04.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.3.210'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-pompi-2016.09.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-pompi-2016.09.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.3.210'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-pompi-2016.09.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-pompi-2016.09.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '11.3.3.210'

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.0.098-iimpi-2017.00-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.0.098-iimpi-2017.00-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '2017.0.098'

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.0.098-iimpi-2017.00-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.0.098-iimpi-2017.00-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '2017.0.098'

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iimpi-2017.01-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iimpi-2017.01-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iimpi-2017.01-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iimpi-2017.01-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iimpi-2017a.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iimpi-2017a.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iimpi-2017a.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iimpi-2017a.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iompi-2017.01.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iompi-2017.01.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iompi-2017.01.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iompi-2017.01.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iompi-2017a.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iompi-2017a.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iompi-2017a.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iompi-2017a.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.2.174-iimpi-2017.02-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.2.174-iimpi-2017.02-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '2017.2.174'

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.2.174-iimpi-2017.02-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.2.174-iimpi-2017.02-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'imkl'
 version = '2017.2.174'

--- a/easybuild/easyconfigs/i/impi/impi-2017.0.098-iccifort-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2017.0.098-iccifort-2017.0.098-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '2017.0.098'

--- a/easybuild/easyconfigs/i/impi/impi-2017.0.098-iccifort-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2017.0.098-iccifort-2017.0.098-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '2017.0.098'

--- a/easybuild/easyconfigs/i/impi/impi-2017.1.132-iccifort-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2017.1.132-iccifort-2017.1.132-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/impi/impi-2017.1.132-iccifort-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2017.1.132-iccifort-2017.1.132-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/impi/impi-2017.1.132-iccifort-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2017.1.132-iccifort-2017.1.132-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/impi/impi-2017.1.132-iccifort-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2017.1.132-iccifort-2017.1.132-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '2017.1.132'

--- a/easybuild/easyconfigs/i/impi/impi-2017.2.174-iccifort-2017.2.174-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2017.2.174-iccifort-2017.2.174-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '2017.2.174'

--- a/easybuild/easyconfigs/i/impi/impi-2017.2.174-iccifort-2017.2.174-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2017.2.174-iccifort-2017.2.174-GCC-6.3.0-2.27.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '2017.2.174'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.1.109-iccifort-2016.0.109-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.1.109-iccifort-2016.0.109-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.1.109'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.1.109-iccifort-2016.0.109-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.1.109-iccifort-2016.0.109-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.1.109'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.2.150-iccifort-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.2.150-iccifort-2016.1.150-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.2.150'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.2.150-iccifort-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.2.150-iccifort-2016.1.150-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.2.150'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.2.181-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.2.181-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.3.181'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.2.181-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.2.181-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.3.181'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.2.181-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.2.181-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.3.181'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.2.181-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.2.181-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.3.181'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.3.181'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.3.181'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.3.210-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.3.210-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.3.181'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.3.210-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.3.210-GCC-5.3.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.3.181'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.3.181'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.3.181'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifortcuda-2016.10.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifortcuda-2016.10.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.3.181'

--- a/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifortcuda-2016.10.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.3.181-iccifortcuda-2016.10.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 
 name = 'impi'
 version = '5.1.3.181'

--- a/easybuild/easyconfigs/i/intel/intel-2016.00.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016.00.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'intel'

--- a/easybuild/easyconfigs/i/intel/intel-2016.00.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016.00.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'intel'

--- a/easybuild/easyconfigs/i/intel/intel-2016.01.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016.01.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'intel'

--- a/easybuild/easyconfigs/i/intel/intel-2016.01.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016.01.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'intel'

--- a/easybuild/easyconfigs/i/iompi/iompi-2017.01.eb
+++ b/easybuild/easyconfigs/i/iompi/iompi-2017.01.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iompi'

--- a/easybuild/easyconfigs/i/iompi/iompi-2017.01.eb
+++ b/easybuild/easyconfigs/i/iompi/iompi-2017.01.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iompi'

--- a/easybuild/easyconfigs/i/iompi/iompi-2017a.eb
+++ b/easybuild/easyconfigs/i/iompi/iompi-2017a.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iompi'

--- a/easybuild/easyconfigs/i/iompi/iompi-2017a.eb
+++ b/easybuild/easyconfigs/i/iompi/iompi-2017a.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild/
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
 easyblock = "Toolchain"
 
 name = 'iompi'

--- a/easybuild/easyconfigs/j/JAGS/JAGS-3.4.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/j/JAGS/JAGS-3.4.0-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/j/JAGS/JAGS-3.4.0-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/j/JAGS/JAGS-3.4.0-ictce-6.2.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/j/JAGS/JAGS-3.4.0-intel-2014b.eb
+++ b/easybuild/easyconfigs/j/JAGS/JAGS-3.4.0-intel-2014b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/j/JAGS/JAGS-4.2.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/j/JAGS/JAGS-4.2.0-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/j/JAGS/JAGS-4.2.0-intel-2016a.eb
+++ b/easybuild/easyconfigs/j/JAGS/JAGS-4.2.0-intel-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/j/Jellyfish/Jellyfish-1.1.11-foss-2016a.eb
+++ b/easybuild/easyconfigs/j/Jellyfish/Jellyfish-1.1.11-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/j/Jellyfish/Jellyfish-1.1.11-foss-2016b.eb
+++ b/easybuild/easyconfigs/j/Jellyfish/Jellyfish-1.1.11-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/j/Jellyfish/Jellyfish-2.1.3-foss-2014b.eb
+++ b/easybuild/easyconfigs/j/Jellyfish/Jellyfish-2.1.3-foss-2014b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/j/Jellyfish/Jellyfish-2.1.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/j/Jellyfish/Jellyfish-2.1.3-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/j/Jellyfish/Jellyfish-2.2.3-intel-2015b.eb
+++ b/easybuild/easyconfigs/j/Jellyfish/Jellyfish-2.2.3-intel-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/j/Jellyfish/Jellyfish-2.2.4-foss-2015b.eb
+++ b/easybuild/easyconfigs/j/Jellyfish/Jellyfish-2.2.4-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/j/Jellyfish/Jellyfish-2.2.4-intel-2015b.eb
+++ b/easybuild/easyconfigs/j/Jellyfish/Jellyfish-2.2.4-intel-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/j/Jellyfish/Jellyfish-2.2.6-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/j/Jellyfish/Jellyfish-2.2.6-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/j/jModelTest/jModelTest-2.1.10r20160303-Java-1.8.0_92.eb
+++ b/easybuild/easyconfigs/j/jModelTest/jModelTest-2.1.10r20160303-Java-1.8.0_92.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/j/jModelTest/jModelTest-2.1.9r20160115-goolf-1.4.10-Java-1.7.0_75.eb
+++ b/easybuild/easyconfigs/j/jModelTest/jModelTest-2.1.9r20160115-goolf-1.4.10-Java-1.7.0_75.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/k/kallisto/kallisto-0.43.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/k/kallisto/kallisto-0.43.1-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'CMakeMake'
 

--- a/easybuild/easyconfigs/k/khmer/khmer-1.1-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/k/khmer/khmer-1.1-goolf-1.4.10-Python-2.7.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/k/khmer/khmer-1.4.1-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/k/khmer/khmer-1.4.1-foss-2016b-Python-2.7.12.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/l/LAME/LAME-3.99.5-foss-2015a.eb
+++ b/easybuild/easyconfigs/l/LAME/LAME-3.99.5-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author:    Stephane Thiell <sthiell@stanford.edu>
 ###

--- a/easybuild/easyconfigs/l/LAME/LAME-3.99.5-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/LAME/LAME-3.99.5-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author:    Stephane Thiell <sthiell@stanford.edu>
 ###

--- a/easybuild/easyconfigs/l/LASTZ/LASTZ-1.02.00-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/l/LASTZ/LASTZ-1.02.00-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/l/LWM2/LWM2-1.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/LWM2/LWM2-1.1-ictce-5.3.0.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/l/LZO/LZO-2.06-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.06-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LZO/LZO-2.06-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.06-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-intel-2017a.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LeadIT/LeadIT-2.1.9.eb
+++ b/easybuild/easyconfigs/l/LeadIT/LeadIT-2.1.9.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.3-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.3-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.3-intel-2014.06.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.3-intel-2014.06.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.3-intel-2014b.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.3-intel-2014b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.3-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.3-intel-2015b.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.3-intel-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.4-foss-2015a.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.4-foss-2015a.eb
@@ -1,6 +1,6 @@
 # Built with EasyBuild version 2.2.0dev on 2015-06-16_10-51-42
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.4-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.4-intel-2015a.eb
@@ -1,6 +1,6 @@
 # Built with EasyBuild version 2.2.0dev on 2015-06-16_10-51-42
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.4beta-foss-2015a.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.4beta-foss-2015a.eb
@@ -1,6 +1,6 @@
 # Built with EasyBuild version 2.2.0dev on 2015-06-16_10-51-42
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.4beta-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.4beta-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.6-foss-2015a.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.6-foss-2015a.eb
@@ -1,6 +1,6 @@
 # Built with EasyBuild version 2.2.0dev on 2015-06-16_10-51-42
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.6-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.6-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Alan O'Cais (JSC)

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.6-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.6-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Alan O'Cais (JSC)

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.6-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.6-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Alan O'Cais (JSC)

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.6-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.6-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Alan O'Cais (JSC)

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.7-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.7-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Alan O'Cais (JSC)

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.7-intel-2017a.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.7-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Alan O'Cais (JSC)

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.8-intel-2017a.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.8-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Alan O'Cais (JSC)

--- a/easybuild/easyconfigs/l/LinBox/LinBox-1.4.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/LinBox/LinBox-1.4.0-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipe; see https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipe; see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2016 Riccardo Murri <riccardo.murri@gmail.com>
 # Authors::   Riccardo Murri <riccardo.murri@gmail.com>

--- a/easybuild/easyconfigs/l/lbzip2/lbzip2-2.5-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/l/lbzip2/lbzip2-2.5-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/l/less/less-458-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/l/less/less-458-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 ##
 

--- a/easybuild/easyconfigs/l/lftp/lftp-4.4.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/lftp/lftp-4.4.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/lftp/lftp-4.6.4-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/l/lftp/lftp-4.6.4-GNU-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libgd/libgd-2.2.4-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/libgd/libgd-2.2.4-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'ConfigureMake'
 

--- a/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.6.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.6.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.6.1-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.6.1-goolf-1.7.20.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.6.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.6.1-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.6.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.6.1-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.7-foss-2015b.eb
+++ b/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.7-foss-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.7-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.7-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.7-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/libgtextutils/libgtextutils-0.7-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libharu/libharu-2.2.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libharu/libharu-2.2.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libharu/libharu-2.2.0-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/libharu/libharu-2.2.0-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libharu/libharu-2.3.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/libharu/libharu-2.3.0-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libharu/libharu-2.3.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/libharu/libharu-2.3.0-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libharu/libharu-2.3.0-intel-2017a.eb
+++ b/easybuild/easyconfigs/l/libharu/libharu-2.3.0-intel-2017a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libungif/libungif-4.1.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libungif/libungif-4.1.4-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libungif/libungif-4.1.4-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/libungif/libungif-4.1.4-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/l/libyaml/libyaml-0.1.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libyaml/libyaml-0.1.4-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Nils Christian <nils.christian@uni.lu>

--- a/easybuild/easyconfigs/l/libyaml/libyaml-0.1.4-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/libyaml/libyaml-0.1.4-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Nils Christian <nils.christian@uni.lu>

--- a/easybuild/easyconfigs/l/libyaml/libyaml-0.1.6-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libyaml/libyaml-0.1.6-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Nils Christian <nils.christian@uni.lu>

--- a/easybuild/easyconfigs/l/libyaml/libyaml-0.1.6-intel-2015b.eb
+++ b/easybuild/easyconfigs/l/libyaml/libyaml-0.1.6-intel-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Nils Christian <nils.christian@uni.lu>

--- a/easybuild/easyconfigs/l/libyaml/libyaml-0.1.6-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libyaml/libyaml-0.1.6-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Nils Christian <nils.christian@uni.lu>

--- a/easybuild/easyconfigs/l/libyaml/libyaml-0.1.6-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libyaml/libyaml-0.1.6-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Nils Christian <nils.christian@uni.lu>

--- a/easybuild/easyconfigs/l/libyaml/libyaml-0.1.7.eb
+++ b/easybuild/easyconfigs/l/libyaml/libyaml-0.1.7.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Nils Christian <nils.christian@uni.lu>

--- a/easybuild/easyconfigs/l/likwid/likwid-4.2.0-foss-2017a.eb
+++ b/easybuild/easyconfigs/l/likwid/likwid-4.2.0-foss-2017a.eb
@@ -1,7 +1,7 @@
 ##
 # -*- mode: python; -*-
 # EasyBuild reciPY for LikWid -- see https://github.com/RRZE-HPC/likwid
-# as per https://github.com/hpcugent/easybuild
+# as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2017 UL HPC -- hpc.uni.lu
 # Authors::   UL HPC Team <hpc-sysadmins@uni.lu>

--- a/easybuild/easyconfigs/l/likwid/likwid-4.2.0-intel-2017a.eb
+++ b/easybuild/easyconfigs/l/likwid/likwid-4.2.0-intel-2017a.eb
@@ -1,7 +1,7 @@
 ##
 # -*- mode: python; -*-
 # EasyBuild reciPY for LikWid -- see https://github.com/RRZE-HPC/likwid
-# as per https://github.com/hpcugent/easybuild
+# as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2017 UL HPC -- hpc.uni.lu
 # Authors::   UL HPC Team <hpc-sysadmins@uni.lu>

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.06.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.06.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.11.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.7.2.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.2.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.4.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2-binutils-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2-binutils-2.25.eb
@@ -17,7 +17,7 @@ source_urls = [GNU_SOURCE]
 builddependencies = [('binutils', '2.25', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-2.25.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-binutils-2.25.eb
@@ -17,7 +17,7 @@ source_urls = [GNU_SOURCE]
 builddependencies = [('binutils', '2.25', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.1.0-binutils-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.1.0-binutils-2.25.eb
@@ -17,7 +17,7 @@ source_urls = [GNU_SOURCE]
 builddependencies = [('binutils', '2.25', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.4.0-2.26.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.2.eb
@@ -17,7 +17,7 @@ source_urls = [GNU_SOURCE]
 builddependencies = [('binutils', '2.25', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS='-fgnu89-inline'"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.3.eb
@@ -17,7 +17,7 @@ source_urls = [GNU_SOURCE]
 builddependencies = [('binutils', '2.25', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS='-fgnu89-inline'"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.4.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.4.eb
@@ -17,7 +17,7 @@ source_urls = [GNU_SOURCE]
 builddependencies = [('binutils', '2.25', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS='-fgnu89-inline'"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.3.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.3.0.eb
@@ -17,7 +17,7 @@ source_urls = [GNU_SOURCE]
 builddependencies = [('binutils', '2.26', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.4.0.eb
@@ -17,7 +17,7 @@ source_urls = [GNU_SOURCE]
 builddependencies = [('binutils', '2.26', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.1.0.eb
@@ -17,7 +17,7 @@ source_urls = [GNU_SOURCE]
 builddependencies = [('binutils', '2.27', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.2.0.eb
@@ -17,7 +17,7 @@ source_urls = [GNU_SOURCE]
 builddependencies = [('binutils', '2.27', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.2-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.2-2.25.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.3-2.25.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-5.1.0-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-5.1.0-2.25.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2014b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2014b.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015.05.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015.05.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015a.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015a.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015b.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016.04.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016.04.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016a.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016a.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS='-fgnu89-inline'"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016b.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-gimkl-2.11.5.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-5.4.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-5.4.0.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-5.5.0.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-7.1.2.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2014b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2014b.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2015a.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2015a.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2015b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2015b.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016.02-GCC-4.9.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016a.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016a.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016b.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17.eb
@@ -16,7 +16,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-5.4.0.eb
@@ -17,7 +17,7 @@ source_urls = [GNU_SOURCE]
 builddependencies = [('binutils', '2.26', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-6.3.0.eb
@@ -17,7 +17,7 @@ source_urls = [GNU_SOURCE]
 builddependencies = [('binutils', '2.27', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-6.4.0.eb
@@ -18,7 +18,7 @@ checksums = ['ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab']
 builddependencies = [('binutils', '2.28', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-7.1.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-7.1.0.eb
@@ -17,7 +17,7 @@ source_urls = [GNU_SOURCE]
 builddependencies = [('binutils', '2.28', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18.eb
@@ -16,7 +16,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/MACH/MACH-1.0.18.eb
+++ b/easybuild/easyconfigs/m/MACH/MACH-1.0.18.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/m/MACS/MACS-1.4.2-1-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/m/MACS/MACS-1.4.2-1-goolf-1.4.10-Python-2.7.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MACS2/MACS2-2.1.0.20150731-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/MACS2/MACS2-2.1.0.20150731-goolf-1.4.10-Python-2.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2015 Virginia Bioinformatics Institute at Virginia Tech
 # Authors::   Dominik L. Borkowski <dominik.borkowski@gmail.com>

--- a/easybuild/easyconfigs/m/MAFFT/MAFFT-7.130-goolf-1.4.10-with-extensions.eb
+++ b/easybuild/easyconfigs/m/MAFFT/MAFFT-7.130-goolf-1.4.10-with-extensions.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MAFFT/MAFFT-7.130-ictce-5.3.0-with-extensions.eb
+++ b/easybuild/easyconfigs/m/MAFFT/MAFFT-7.130-ictce-5.3.0-with-extensions.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MAFFT/MAFFT-7.305-foss-2016b-with-extensions.eb
+++ b/easybuild/easyconfigs/m/MAFFT/MAFFT-7.305-foss-2016b-with-extensions.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MATIO/MATIO-1.5.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/MATIO/MATIO-1.5.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014-2015 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/m/MATIO/MATIO-1.5.2-intel-2015b.eb
+++ b/easybuild/easyconfigs/m/MATIO/MATIO-1.5.2-intel-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014-2015 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/m/MCL/MCL-12.135-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/MCL/MCL-12.135-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/MCL/MCL-12.135-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/m/MCL/MCL-12.135-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/MEGACC/MEGACC-7.0.18-1.eb
+++ b/easybuild/easyconfigs/m/MEGACC/MEGACC-7.0.18-1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2016, UNIGE
 # Authors::   Yann Sagon <yann.sagon@unige.ch>

--- a/easybuild/easyconfigs/m/MEME/MEME-4.8.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/MEME/MEME-4.8.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/MEME/MEME-4.8.0-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/m/MEME/MEME-4.8.0-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/MM-align/MM-align-20130815-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/MM-align/MM-align-20130815-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/m/MMSEQ/MMSEQ-1.0.8-linux64-static.eb
+++ b/easybuild/easyconfigs/m/MMSEQ/MMSEQ-1.0.8-linux64-static.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MOSAIK/MOSAIK-2.2.28-goolf-1.4.10-20140425-24cf06.eb
+++ b/easybuild/easyconfigs/m/MOSAIK/MOSAIK-2.2.28-goolf-1.4.10-20140425-24cf06.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/m/MOSAIK/MOSAIK-2.2.28-ictce-6.2.5-20140425-24cf06.eb
+++ b/easybuild/easyconfigs/m/MOSAIK/MOSAIK-2.2.28-ictce-6.2.5-20140425-24cf06.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/m/MPJ-Express/MPJ-Express-0.44-foss-2016a-Java-1.8.0_92.eb
+++ b/easybuild/easyconfigs/m/MPJ-Express/MPJ-Express-0.44-foss-2016a-Java-1.8.0_92.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/m/MPJ-Express/MPJ-Express-0.44-goolf-1.4.10-Java-1.7.0_75.eb
+++ b/easybuild/easyconfigs/m/MPJ-Express/MPJ-Express-0.44-goolf-1.4.10-Java-1.7.0_75.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/m/MRIcron/MRIcron-20150601.eb
+++ b/easybuild/easyconfigs/m/MRIcron/MRIcron-20150601.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/m/MUMmer/MUMmer-3.23-foss-2016b.eb
+++ b/easybuild/easyconfigs/m/MUMmer/MUMmer-3.23-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/MUMmer/MUMmer-3.23-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/m/MUMmer/MUMmer-3.23-goolf-1.4.10-Perl-5.16.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/easybuild/easyconfigs/m/MUMmer/MUMmer-3.23-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/MUMmer/MUMmer-3.23-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/MUMmer/MUMmer-3.23-ictce-5.3.0-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/m/MUMmer/MUMmer-3.23-ictce-5.3.0-Perl-5.16.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/easybuild/easyconfigs/m/MUMmer/MUMmer-3.23-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/m/MUMmer/MUMmer-3.23-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/MUMmer/MUMmer-4.0.0beta-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/m/MUMmer/MUMmer-4.0.0beta-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/m/MUSCLE/MUSCLE-3.8.31-foss-2016a.eb
+++ b/easybuild/easyconfigs/m/MUSCLE/MUSCLE-3.8.31-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MUSCLE/MUSCLE-3.8.31-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/MUSCLE/MUSCLE-3.8.31-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MUSCLE/MUSCLE-3.8.31-i86linux64.eb
+++ b/easybuild/easyconfigs/m/MUSCLE/MUSCLE-3.8.31-i86linux64.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Andreas Panteli <a.panteli@cyi.ac.cy>,

--- a/easybuild/easyconfigs/m/MUSCLE/MUSCLE-3.8.31-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/m/MUSCLE/MUSCLE-3.8.31-ictce-5.5.0.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MUSCLE/MUSCLE-3.8.31-intel-2016a.eb
+++ b/easybuild/easyconfigs/m/MUSCLE/MUSCLE-3.8.31-intel-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MUST/MUST-1.2.0-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/m/MUST/MUST-1.2.0-goolf-1.5.14.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/m/MUSTANG/MUSTANG-3.2.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/MUSTANG/MUSTANG-3.2.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MView/MView-1.57-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/m/MView/MView-1.57-goolf-1.4.10-Perl-5.16.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/m/MaCH/MaCH-1.0.18.c-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/MaCH/MaCH-1.0.18.c-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MaCH/MaCH-1.0.18.c-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/m/MaCH/MaCH-1.0.18.c-ictce-6.2.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MaSuRCA/MaSuRCA-3.2.2-foss-2016a.eb
+++ b/easybuild/easyconfigs/m/MaSuRCA/MaSuRCA-3.2.2-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2017 University of Geneva
 # Authors::   Yann Sagon <yann.sagon@unige.ch>

--- a/easybuild/easyconfigs/m/Maq/Maq-0.7.0.eb
+++ b/easybuild/easyconfigs/m/Maq/Maq-0.7.0.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/m/Mawk/Mawk-1.3.4-goolf-1.4.10-20150503.eb
+++ b/easybuild/easyconfigs/m/Mawk/Mawk-1.3.4-goolf-1.4.10-20150503.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/m/MetaVelvet/MetaVelvet-1.2.01-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/MetaVelvet/MetaVelvet-1.2.01-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/MetaVelvet/MetaVelvet-1.2.01-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/m/MetaVelvet/MetaVelvet-1.2.01-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/MethPipe/MethPipe-3.0.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/MethPipe/MethPipe-3.0.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2014 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/m/MethPipe/MethPipe-3.0.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/m/MethPipe/MethPipe-3.0.1-intel-2014b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2014 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/m/Minia/Minia-2.0.7-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/m/Minia/Minia-2.0.7-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/m/Minimac/Minimac-20140110-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/Minimac/Minimac-20140110-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/Minimac2/Minimac2-2014.9.15-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/m/Minimac2/Minimac2-2014.9.15-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/m/Modeller/Modeller-9.13-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/m/Modeller/Modeller-9.13-goolf-1.4.10-Python-2.7.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MotEvo/MotEvo-1.02-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/MotEvo/MotEvo-1.02-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MuTect/MuTect-1.1.4-Java-1.7.0_76.eb
+++ b/easybuild/easyconfigs/m/MuTect/MuTect-1.1.4-Java-1.7.0_76.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MuTect/MuTect-1.1.4-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/m/MuTect/MuTect-1.1.4-Java-1.7.0_80.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MuTect/MuTect-1.1.7-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/m/MuTect/MuTect-1.1.7-Java-1.7.0_80.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/MultiQC/MultiQC-0.7-goolf-1.7.20-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/MultiQC/MultiQC-0.7-goolf-1.7.20-Python-2.7.11.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/m/MultiQC/MultiQC-0.9-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/MultiQC/MultiQC-0.9-foss-2016b-Python-2.7.12.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Adam Huffman
 # The Francis Crick Institute
 # Elements derived from work by Pablo Escobar

--- a/easybuild/easyconfigs/m/make/make-3.82-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/m/make/make-3.82-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipy as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipy as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/make/make-3.82-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/make/make-3.82-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipy as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipy as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/make/make-3.82-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/m/make/make-3.82-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipy as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipy as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/make/make-3.82-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/m/make/make-3.82-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipy as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipy as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/make/make-4.1-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/m/make/make-4.1-GCC-4.9.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipy as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipy as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/mc/mc-4.6.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/mc/mc-4.6.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/mc/mc-4.6.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/m/mc/mc-4.6.1-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/mc/mc-4.8.13-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/m/mc/mc-4.8.13-GCC-4.9.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/mdtest/mdtest-1.7.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/mdtest/mdtest-1.7.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/mdtest/mdtest-1.7.1-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/m/mdtest/mdtest-1.7.1-ictce-6.2.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/mdtest/mdtest-1.9.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/mdtest/mdtest-1.9.3-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/mdtest/mdtest-1.9.3-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/m/mdtest/mdtest-1.9.3-ictce-6.2.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/m/mpiBLAST/mpiBLAST-1.6.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/mpiBLAST/mpiBLAST-1.6.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/m/mpiBLAST/mpiBLAST-1.6.0-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/m/mpiBLAST/mpiBLAST-1.6.0-ictce-5.2.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/easybuild/easyconfigs/m/mpiBLAST/mpiBLAST-1.6.0-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/m/mpiBLAST/mpiBLAST-1.6.0-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/easybuild/easyconfigs/m/mpmath/mpmath-0.19-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/mpmath/mpmath-0.19-foss-2016a-Python-2.7.11.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author: Adam Huffman
 # adam.huffman@crick.ac.uk

--- a/easybuild/easyconfigs/m/mpmath/mpmath-0.19-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/mpmath/mpmath-0.19-intel-2016a-Python-2.7.11.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author: Adam Huffman
 # adam.huffman@crick.ac.uk

--- a/easybuild/easyconfigs/m/mrFAST/mrFAST-2.6.0.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/mrFAST/mrFAST-2.6.0.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/m/mrFAST/mrFAST-2.6.0.1-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/m/mrFAST/mrFAST-2.6.0.1-ictce-6.2.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/m/mrsFAST/mrsFAST-2.6.0.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/mrsFAST/mrsFAST-2.6.0.4-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/m/mrsFAST/mrsFAST-2.6.0.4-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/m/mrsFAST/mrsFAST-2.6.0.4-ictce-6.2.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/n/NASM/NASM-2.07-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.07-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.07-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.07-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.07-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.07-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.07-intel-2014b.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.07-intel-2014b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.05-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.05-goolf-1.7.20.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.05-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.05-ictce-6.2.5.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.05-intel-2014.06.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.05-intel-2014.06.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.05-intel-2014b.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.05-intel-2014b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.05-intel-2015a.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.05-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.06-foss-2015a.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.06-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.06-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.06-goolf-1.5.14.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.06-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.06-goolf-1.7.20.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.06-intel-2015a.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.06-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.06-intel-2015b.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.06-intel-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.08-foss-2015a.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.08-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.08-foss-2015b.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.08-foss-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.08-foss-2016a.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.08-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.08-foss-2016b.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.08-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.08-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.08-gimkl-2.11.5.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.08-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.08-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.08-intel-2015a.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.08-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.08-intel-2015b.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.08-intel-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.11.08-intel-2016a.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.11.08-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.12.01-foss-2016a.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.12.01-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.12.01-intel-2016a.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.12.01-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.12.02-foss-2016a.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.12.02-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.12.02-foss-2016b.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.12.02-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.12.02-intel-2016b.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.12.02-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NASM/NASM-2.12.02-intel-2017a.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.12.02-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NCBI-Toolkit/NCBI-Toolkit-9.0.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/n/NCBI-Toolkit/NCBI-Toolkit-9.0.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2017a.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2017a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/n/nano/nano-2.2.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/n/nano/nano-2.2.6-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/nano/nano-2.2.6-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/n/nano/nano-2.2.6-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/n/ncview/ncview-2.1.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/n/ncview/ncview-2.1.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/n/ncview/ncview-2.1.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/n/ncview/ncview-2.1.2-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/n/ncview/ncview-2.1.7-intel-2016b.eb
+++ b/easybuild/easyconfigs/n/ncview/ncview-2.1.7-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/o/OCaml/OCaml-4.01.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/o/OCaml/OCaml-4.01.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/o/OCaml/OCaml-4.01.0-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/o/OCaml/OCaml-4.01.0-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/o/OCaml/OCaml-4.02.3-foss-2015a.eb
+++ b/easybuild/easyconfigs/o/OCaml/OCaml-4.02.3-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/o/OCaml/OCaml-4.02.3-foss-2016a.eb
+++ b/easybuild/easyconfigs/o/OCaml/OCaml-4.02.3-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/o/OPARI2/OPARI2-1.1.1-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/o/OPARI2/OPARI2-1.1.1-goolf-1.5.14.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/o/OPARI2/OPARI2-1.1.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/o/OPARI2/OPARI2-1.1.2-foss-2015a.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/o/OPARI2/OPARI2-1.1.2-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/o/OPARI2/OPARI2-1.1.2-goolf-1.5.14.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Authors::   Jordi Blasco <jordi.blasco@nesi.org.nz>
 # License::   New BSD
 #

--- a/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2016 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/o/OTF/OTF-1.12.4-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/o/OTF/OTF-1.12.4-goolf-1.5.14.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/o/OTF/OTF-1.12.4-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/o/OTF/OTF-1.12.4-ictce-5.3.0.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/o/OTF2/OTF2-1.2.1-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-1.2.1-goolf-1.5.14.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/o/OTF2/OTF2-1.2.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-1.2.1-ictce-5.3.0.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/o/OTF2/OTF2-1.5.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-1.5.1-foss-2015a.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/o/OTF2/OTF2-2.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-2.0-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013-2016 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 #             Markus Geimer <m.geimer@fz-juelich.de>

--- a/easybuild/easyconfigs/o/OTF2/OTF2-2.0-foss-2017a.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-2.0-foss-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013-2016 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 #             Markus Geimer <m.geimer@fz-juelich.de>

--- a/easybuild/easyconfigs/o/Oases/Oases-0.2.08-foss-2016b.eb
+++ b/easybuild/easyconfigs/o/Oases/Oases-0.2.08-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/o/Oases/Oases-0.2.08-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/o/Oases/Oases-0.2.08-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/o/Oases/Oases-0.2.08-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/o/Oases/Oases-0.2.08-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/o/Oases/Oases-0.2.08-intel-2015a.eb
+++ b/easybuild/easyconfigs/o/Oases/Oases-0.2.08-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/o/OpenMM/OpenMM-6.1-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/o/OpenMM/OpenMM-6.1-goolf-1.4.10-Python-2.7.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/o/OptiX/OptiX-3.8.0-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OptiX/OptiX-3.8.0-GNU-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Authors::   Stephane Thiell <sthiell@stanford.edu>
 ##
 easyblock = 'Binary'

--- a/easybuild/easyconfigs/o/OptiX/OptiX-3.9.0-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OptiX/OptiX-3.9.0-GNU-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Authors::   Stephane Thiell <sthiell@stanford.edu>
 ##
 easyblock = 'Binary'

--- a/easybuild/easyconfigs/o/o2scl/o2scl-0.913-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/o/o2scl/o2scl-0.913-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/PAML/PAML-4.7-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/PAML/PAML-4.7-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/p/PAML/PAML-4.7-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/PAML/PAML-4.7-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (UGent)

--- a/easybuild/easyconfigs/p/PAPI/PAPI-5.0.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/PAPI/PAPI-5.0.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/p/PAPI/PAPI-5.0.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/PAPI/PAPI-5.0.1-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/p/PAPI/PAPI-5.2.0-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/PAPI/PAPI-5.2.0-goolf-1.5.14.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>

--- a/easybuild/easyconfigs/p/PAPI/PAPI-5.2.0-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/PAPI/PAPI-5.2.0-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/p/PAPI/PAPI-5.4.0-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/PAPI/PAPI-5.4.0-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/p/PAPI/PAPI-5.4.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/PAPI/PAPI-5.4.1-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/p/PAPI/PAPI-5.4.3-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/PAPI/PAPI-5.4.3-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/p/PBZIP2/PBZIP2-1.1.8-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/PBZIP2/PBZIP2-1.1.8-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/PBZIP2/PBZIP2-1.1.8-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/p/PBZIP2/PBZIP2-1.1.8-ictce-6.2.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/PCC/PCC-20131024.eb
+++ b/easybuild/easyconfigs/p/PCC/PCC-20131024.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/p/PDT/PDT-3.19-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/PDT/PDT-3.19-goolf-1.5.14.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/p/PDT/PDT-3.19-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/PDT/PDT-3.19-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/p/PDT/PDT-3.20-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/PDT/PDT-3.20-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/p/PDT/PDT-3.20-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/PDT/PDT-3.20-goolf-1.5.14.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Authors::   Jordi Blasco <jordi.blasco@nesi.org.nz>
 # License::   New BSD
 #

--- a/easybuild/easyconfigs/p/PDT/PDT-3.22-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/PDT/PDT-3.22-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2016 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/p/PEAR/PEAR-0.9.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/PEAR/PEAR-0.9.6-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/p/PEAR/PEAR-0.9.8-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/PEAR/PEAR-0.9.8-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'ConfigureMake'
 

--- a/easybuild/easyconfigs/p/PEAR/PEAR-0.9.8-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/PEAR/PEAR-0.9.8-intel-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'ConfigureMake'
 

--- a/easybuild/easyconfigs/p/PGDSpider/PGDSpider-2.1.0.3-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/p/PGDSpider/PGDSpider-2.1.0.3-Java-1.7.0_80.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/p/PHASE/PHASE-2.1.1.eb
+++ b/easybuild/easyconfigs/p/PHASE/PHASE-2.1.1.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/p/PLINK/PLINK-1.07-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/PLINK/PLINK-1.07-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/PLINK/PLINK-1.07-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/PLINK/PLINK-1.07-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/PLINK/PLINK-1.07-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/PLINK/PLINK-1.07-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/PLINK/PLINK-1.07-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/PLINK/PLINK-1.07-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>, Andreas Panteli <a.panteli@cyi.ac.cy>,

--- a/easybuild/easyconfigs/p/PLINK/PLINK-1.07-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/p/PLINK/PLINK-1.07-ictce-6.2.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/PLINKSEQ/PLINKSEQ-0.10-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/p/PLINKSEQ/PLINKSEQ-0.10-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/POV-Ray/POV-Ray-3.7.0.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/POV-Ray/POV-Ray-3.7.0.0-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/p/PRACE/PRACE-20130605-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/PRACE/PRACE-20130605-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/p/PRACE/PRACE-20130605-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/PRACE/PRACE-20130605-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/p/PRANK/PRANK-130820-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/PRANK/PRANK-130820-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/p/PRANK/PRANK-130820-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/PRANK/PRANK-130820-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/p/PRANK/PRANK-140110-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/PRANK/PRANK-140110-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/PRINSEQ/PRINSEQ-0.20.4-foss-2015b-Perl-5.20.3.eb
+++ b/easybuild/easyconfigs/p/PRINSEQ/PRINSEQ-0.20.4-foss-2015b-Perl-5.20.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/p/PRINSEQ/PRINSEQ-0.20.4-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/p/PRINSEQ/PRINSEQ-0.20.4-goolf-1.4.10-Perl-5.16.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/p/PROJ/PROJ-4.8.0-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-4.8.0-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014-2015 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/p/PROJ/PROJ-4.8.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-4.8.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014-2015 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/p/PROJ/PROJ-4.8.0-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-4.8.0-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014-2015 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/p/PROJ/PROJ-4.9.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-4.9.1-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014-2015 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/p/PROJ/PROJ-4.9.2-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-4.9.2-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014-2015 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/p/PROJ/PROJ-4.9.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-4.9.2-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014-2015 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/p/PROJ/PROJ-4.9.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-4.9.2-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014-2015 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/p/PROJ/PROJ-4.9.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-4.9.2-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014-2015 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/p/PROJ/PROJ-4.9.3-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-4.9.3-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014-2015 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/p/PROJ/PROJ-4.9.3-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-4.9.3-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014-2015 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/p/PROJ/PROJ-4.9.3-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-4.9.3-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2014-2015 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/p/Parallel-ForkManager/Parallel-ForkManager-1.06-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/p/Parallel-ForkManager/Parallel-ForkManager-1.06-goolf-1.4.10-Perl-5.16.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>

--- a/easybuild/easyconfigs/p/Paraver/Paraver-4.4.5-GCC-4.7.3.eb
+++ b/easybuild/easyconfigs/p/Paraver/Paraver-4.4.5-GCC-4.7.3.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/p/Paraver/Paraver-4.5.6-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Paraver/Paraver-4.5.6-foss-2015a.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/p/PeakSeq/PeakSeq-1.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/PeakSeq/PeakSeq-1.3-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/PhyML/PhyML-20120412-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/PhyML/PhyML-20120412-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/PhyML/PhyML-20131016-goolf-1.4.10devel.eb
+++ b/easybuild/easyconfigs/p/PhyML/PhyML-20131016-goolf-1.4.10devel.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/Pindel/Pindel-0.2.5a7-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Pindel/Pindel-0.2.5a7-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/Pindel/Pindel-0.2.5b8-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/Pindel/Pindel-0.2.5b8-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/Platanus/Platanus-1.2.4-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/p/Platanus/Platanus-1.2.4-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/p/Pmw/Pmw-1.3.3-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/p/Pmw/Pmw-1.3.3-goolf-1.4.10-Python-2.7.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Adam Mazur
 # Research IT
 # Biozentrum, University of Basel

--- a/easybuild/easyconfigs/p/PnMPI/PnMPI-1.2.0-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/PnMPI/PnMPI-1.2.0-goolf-1.5.14.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/p/PyQt/PyQt-4.11.3-goolf-1.5.14-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/p/PyQt/PyQt-4.11.3-goolf-1.5.14-Python-2.7.9.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/p/PyQt/PyQt-4.11.3-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/p/PyQt/PyQt-4.11.3-intel-2015a-Python-2.7.9.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/p/PyQt/PyQt-4.11.4-foss-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/p/PyQt/PyQt-4.11.4-foss-2015a-Python-2.7.9.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/p/PyQt/PyQt-4.11.4-intel-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/p/PyQt/PyQt-4.11.4-intel-2014b-Python-2.7.8.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/p/PyQt/PyQt-4.11.4-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/p/PyQt/PyQt-4.11.4-intel-2015a-Python-2.7.9.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/p/PyQt/PyQt-4.11.4-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/p/PyQt/PyQt-4.11.4-intel-2016a-Python-2.7.11.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/p/PyQt/PyQt-4.11.4-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/p/PyQt/PyQt-4.11.4-intel-2016b-Python-2.7.12.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/p/PyQt/PyQt-4.12-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/p/PyQt/PyQt-4.12-foss-2016b-Python-2.7.12.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/p/PyQt/PyQt-4.12-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/p/PyQt/PyQt-4.12-intel-2016b-Python-2.7.12.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/p/PyQt/PyQt-4.12-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/p/PyQt/PyQt-4.12-intel-2017a-Python-2.7.13.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.10.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.10.0-intel-2016b-Python-2.7.12.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.9.0-goolf-1.7.20-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.9.0-goolf-1.7.20-Python-2.7.11.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.9.1.4-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.9.1.4-foss-2016b-Python-2.7.12.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/p/pBWA/pBWA-0.5.9_1.21009-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/pBWA/pBWA-0.5.9_1.21009-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2014 Cyprus Institute
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/p/parallel/parallel-20130122-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/parallel/parallel-20130122-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/p/parallel/parallel-20130122-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/parallel/parallel-20130122-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/p/perl-app-cpanminus/perl-app-cpanminus-1.7039.eb
+++ b/easybuild/easyconfigs/p/perl-app-cpanminus/perl-app-cpanminus-1.7039.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/p/picard/picard-2.1.0.eb
+++ b/easybuild/easyconfigs/p/picard/picard-2.1.0.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Adam Huffman
 # The Francis Crick Institute
 

--- a/easybuild/easyconfigs/p/pigz/pigz-2.3.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/pigz/pigz-2.3.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/pigz/pigz-2.3.1-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/p/pigz/pigz-2.3.1-ictce-6.2.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/pigz/pigz-2.3.3-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/pigz/pigz-2.3.3-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/p/pigz/pigz-2.3.3-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/pigz/pigz-2.3.3-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/q/QIIME/QIIME-1.9.1.eb
+++ b/easybuild/easyconfigs/q/QIIME/QIIME-1.9.1.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/q/QuadProg++/QuadProg++-1.2.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/q/QuadProg++/QuadProg++-1.2.1-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/q/QuadProg++/QuadProg++-1.2.1-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/q/QuadProg++/QuadProg++-1.2.1-ictce-6.2.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/q/Quip/Quip-1.1.8-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/q/Quip/Quip-1.1.8-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2015 NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/q/qtop/qtop-53-1.eb
+++ b/easybuild/easyconfigs/q/qtop/qtop-53-1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/r/RAxML/RAxML-8.1.1-goolf-1.4.10-mpi-avx.eb
+++ b/easybuild/easyconfigs/r/RAxML/RAxML-8.1.1-goolf-1.4.10-mpi-avx.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/r/RAxML/RAxML-8.1.1-goolf-1.4.10-mpi-sse3.eb
+++ b/easybuild/easyconfigs/r/RAxML/RAxML-8.1.1-goolf-1.4.10-mpi-sse3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/r/RAxML/RAxML-8.1.1-goolf-1.4.10-mt-avx.eb
+++ b/easybuild/easyconfigs/r/RAxML/RAxML-8.1.1-goolf-1.4.10-mt-avx.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/r/RAxML/RAxML-8.1.1-goolf-1.4.10-mt-sse3.eb
+++ b/easybuild/easyconfigs/r/RAxML/RAxML-8.1.1-goolf-1.4.10-mt-sse3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/r/RCS/RCS-5.7-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/RCS/RCS-5.7-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/r/RCS/RCS-5.7-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/RCS/RCS-5.7-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/r/RNAz/RNAz-2.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/r/RNAz/RNAz-2.1-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'ConfigureMake'
 

--- a/easybuild/easyconfigs/r/RNAz/RNAz-2.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/RNAz/RNAz-2.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/r/RNAz/RNAz-2.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/RNAz/RNAz-2.1-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/r/RSEQtools/RSEQtools-0.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/RSEQtools/RSEQtools-0.6-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/r/RSeQC/RSeQC-2.6.3-foss-2015b-Python-2.7.10-R-3.2.3.eb
+++ b/easybuild/easyconfigs/r/RSeQC/RSeQC-2.6.3-foss-2015b-Python-2.7.10-R-3.2.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Adam Huffman
 # The Francis Crick Institute
 

--- a/easybuild/easyconfigs/r/RSeQC/RSeQC-2.6.4-foss-2016b-Python-2.7.12-R-3.3.1.eb
+++ b/easybuild/easyconfigs/r/RSeQC/RSeQC-2.6.4-foss-2016b-Python-2.7.12-R-3.3.1.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Adam Huffman
 # The Francis Crick Institute
 

--- a/easybuild/easyconfigs/r/Reads2snp/Reads2snp-2.0.eb
+++ b/easybuild/easyconfigs/r/Reads2snp/Reads2snp-2.0.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/r/rCUDA/rCUDA-4.0.1_linux_64_Ubuntu10.04.eb
+++ b/easybuild/easyconfigs/r/rCUDA/rCUDA-4.0.1_linux_64_Ubuntu10.04.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/r/rCUDA/rCUDA-5.0_linux_64_scientificLinux6.eb
+++ b/easybuild/easyconfigs/r/rCUDA/rCUDA-5.0_linux_64_scientificLinux6.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/r/rSeq/rSeq-0.2.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/rSeq/rSeq-0.2.0-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/r/rainbow/rainbow-2.0.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/rainbow/rainbow-2.0.4-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/r/rpmrebuild/rpmrebuild-2.11.eb
+++ b/easybuild/easyconfigs/r/rpmrebuild/rpmrebuild-2.11.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2016 Forschungszentrum Juelich GmbH
 # Authors::   Damian Alvarez <d.alvarez@fz-juelich.de>

--- a/easybuild/easyconfigs/s/SAGE/SAGE-6.3.eb
+++ b/easybuild/easyconfigs/s/SAGE/SAGE-6.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/s/SAGE/SAGE-6.4.eb
+++ b/easybuild/easyconfigs/s/SAGE/SAGE-6.4.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-0.1.18-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-0.1.18-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-0.1.18-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-0.1.18-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-0.1.19-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-0.1.19-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-0.1.19-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-0.1.19-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.1-foss-2014b.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.1-foss-2014b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.1-intel-2014b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.1-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.2-foss-2015a-HTSlib-1.2.1.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.2-foss-2015a-HTSlib-1.2.1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.2-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.2-foss-2015b.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.2-foss-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.2-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.2-goolf-1.7.20.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.2-intel-2015a-HTSlib-1.2.1.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.2-intel-2015a-HTSlib-1.2.1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.2-intel-2015b-HTSlib-1.2.1.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.2-intel-2015b-HTSlib-1.2.1.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3-foss-2015b.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3-foss-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3.1-foss-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3.1-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3.1-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3.1-intel-2016b-HTSlib-1.3.2.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3.1-intel-2016b-HTSlib-1.3.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3.1-intel-2016b.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3.1-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.4-foss-2016b.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.4-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.4-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.4-intel-2016b.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.4-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.4-intel-2017a.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.4-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.4.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.4.1-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.5-intel-2017a.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.5-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SCALCE/SCALCE-2.7-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/s/SCALCE/SCALCE-2.7-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2015 NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SCANMS/SCANMS-2.02-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/s/SCANMS/SCANMS-2.02-goolf-1.4.10-Perl-5.16.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/SDCC/SDCC-3.3.0.eb
+++ b/easybuild/easyconfigs/s/SDCC/SDCC-3.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SDL2/SDL2-2.0.4-intel-2016b.eb
+++ b/easybuild/easyconfigs/s/SDL2/SDL2-2.0.4-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SHAPEIT/SHAPEIT-2.r837.GLIBCv2.12.eb
+++ b/easybuild/easyconfigs/s/SHAPEIT/SHAPEIT-2.r837.GLIBCv2.12.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/s/SIBELia/SIBELia-3.0.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SIBELia/SIBELia-3.0.4-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/SIONlib/SIONlib-1.6.1-foss-2016a-tools.eb
+++ b/easybuild/easyconfigs/s/SIONlib/SIONlib-1.6.1-foss-2016a-tools.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2016 Juelich Supercomputing Centre, Germany
 # Authors::   Markus Geimer <m.geimer@fz-juelich.de>

--- a/easybuild/easyconfigs/s/SIONlib/SIONlib-1.6.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/SIONlib/SIONlib-1.6.1-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2016 Juelich Supercomputing Centre, Germany
 # Authors::   Markus Geimer <m.geimer@fz-juelich.de>

--- a/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.1-foss-2017a-tools.eb
+++ b/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.1-foss-2017a-tools.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2016 Juelich Supercomputing Centre, Germany
 # Authors::   Markus Geimer <m.geimer@fz-juelich.de>

--- a/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.1-foss-2017a.eb
+++ b/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.1-foss-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2016 Juelich Supercomputing Centre, Germany
 # Authors::   Markus Geimer <m.geimer@fz-juelich.de>

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.4-goolf-1.5.14-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.4-goolf-1.5.14-Python-2.7.9.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.4-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.4-intel-2015a-Python-2.7.9.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.8-foss-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.8-foss-2015a-Python-2.7.9.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.8-intel-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.8-intel-2014b-Python-2.7.8.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.8-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.8-intel-2015a-Python-2.7.9.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/s/SIP/SIP-4.18-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.18-foss-2016a-Python-2.7.11.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/s/SIP/SIP-4.18-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.18-intel-2016a-Python-2.7.11.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/s/SIP/SIP-4.18.1-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.18.1-foss-2016a-Python-2.7.11.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/s/SIP/SIP-4.18.1-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.18.1-intel-2016b-Python-2.7.12.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/s/SIP/SIP-4.19-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.19-foss-2016b-Python-2.7.12.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/s/SIP/SIP-4.19-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.19-intel-2016b-Python-2.7.12.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/s/SIP/SIP-4.19.2-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.19.2-intel-2017a-Python-2.7.13.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Bart Verleye
 # Center for eResearch, Auckland
 easyblock = 'ConfigureMakePythonPackage'

--- a/easybuild/easyconfigs/s/SMALT/SMALT-0.7.5-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SMALT/SMALT-0.7.5-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SMALT/SMALT-0.7.5-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/s/SMALT/SMALT-0.7.5-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SOAPaligner/SOAPaligner-2.21_Linux-x86_64.eb
+++ b/easybuild/easyconfigs/s/SOAPaligner/SOAPaligner-2.21_Linux-x86_64.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/SOAPdenovo/SOAPdenovo-1.05-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SOAPdenovo/SOAPdenovo-1.05-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SOAPdenovo/SOAPdenovo-1.05-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/s/SOAPdenovo/SOAPdenovo-1.05-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SPAdes/SPAdes-3.0.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SPAdes/SPAdes-3.0.0-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/SPAdes/SPAdes-3.1.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SPAdes/SPAdes-3.1.0-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/SPAdes/SPAdes-3.10.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/s/SPAdes/SPAdes-3.10.1-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/s/SPAdes/SPAdes-3.6.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SPAdes/SPAdes-3.6.2-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/s/SPAdes/SPAdes-3.6.2-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/s/SPAdes/SPAdes-3.6.2-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/s/SPAdes/SPAdes-3.9.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/SPAdes/SPAdes-3.9.0-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/s/SPAdes/SPAdes-3.9.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/s/SPAdes/SPAdes-3.9.0-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.10.0-foss-2015a.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.10.0-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-GCC-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-GCC-5.4.0-2.26.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-GCCcore-6.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-foss-2016.04.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-foss-2016.04.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.14.1-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.14.1-GCCcore-4.9.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.17.0-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.17.0-GCCcore-6.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.7.17-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.7.17-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.7.17-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.7.17-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.1-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-GCC-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-GNU-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-foss-2015b.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-foss-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-gimkl-2.11.5.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-goolf-1.7.20.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-intel-2015b.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.10.2-intel-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.4.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.4.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.5-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.5-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.6-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.6-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.6-intel-2014b.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.6-intel-2014b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-GCC-4.8.4.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-GCC-4.9.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-foss-2015.05.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-foss-2015.05.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-foss-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-gompi-1.5.16.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-gompi-1.5.16.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-goolf-1.5.14.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-goolf-1.5.16.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-goolf-1.5.16.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-goolf-1.7.20.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.8.1-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.8.9-foss-2015a.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.8.9-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-CrayGNU-2015.11.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-CrayGNU-2016.03.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-CrayGNU-2016.03.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-GCC-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-gimkl-2.11.5.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-goolf-1.7.20.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-intel-2015b.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-intel-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-intel-2016.02-GCC-4.9.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-iomkl-2016.07.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-iomkl-2016.07.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/SRA-Toolkit/SRA-Toolkit-2.3.5-centos_linux64.eb
+++ b/easybuild/easyconfigs/s/SRA-Toolkit/SRA-Toolkit-2.3.5-centos_linux64.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/SRA-Toolkit/SRA-Toolkit-2.5.4-1-centos_linux64.eb
+++ b/easybuild/easyconfigs/s/SRA-Toolkit/SRA-Toolkit-2.5.4-1-centos_linux64.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/SSAHA2/SSAHA2-2.5.5-i686.eb
+++ b/easybuild/easyconfigs/s/SSAHA2/SSAHA2-2.5.5-i686.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/SSAHA2/SSAHA2-2.5.5-x86_64.eb
+++ b/easybuild/easyconfigs/s/SSAHA2/SSAHA2-2.5.5-x86_64.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/STAR-Fusion/STAR-Fusion-0.6.0-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/s/STAR-Fusion/STAR-Fusion-0.6.0-goolf-1.4.10-Perl-5.16.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/s/STAR/STAR-2.3.0e-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/STAR/STAR-2.3.0e-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/STAR/STAR-2.5.0a-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/s/STAR/STAR-2.5.0a-GNU-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/s/STAR/STAR-2.5.0a-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/STAR/STAR-2.5.0a-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/s/STAR/STAR-2.5.1b-foss-2015b.eb
+++ b/easybuild/easyconfigs/s/STAR/STAR-2.5.1b-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/s/STAR/STAR-2.5.1b-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/STAR/STAR-2.5.1b-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/s/STAR/STAR-2.5.2a-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/STAR/STAR-2.5.2a-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/s/STAR/STAR-2.5.2a-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/s/STAR/STAR-2.5.2a-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/s/STAR/STAR-2.5.2b-intel-2016b.eb
+++ b/easybuild/easyconfigs/s/STAR/STAR-2.5.2b-intel-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/s/STAR/STAR-2.5.3a-intel-2017a.eb
+++ b/easybuild/easyconfigs/s/STAR/STAR-2.5.3a-intel-2017a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/s/Sambamba/Sambamba-0.6.6.eb
+++ b/easybuild/easyconfigs/s/Sambamba/Sambamba-0.6.6.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.2-foss-2015a.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.3-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.3-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013-2016 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 #             Markus Geimer <m.geimer@fz-juelich.de>

--- a/easybuild/easyconfigs/s/Score-P/Score-P-1.2.1-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-1.2.1-goolf-1.5.14.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/s/Score-P/Score-P-1.2.3-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-1.2.3-goolf-1.5.14.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Authors::   Jordi Blasco <jordi.blasco@nesi.org.nz>
 # License::   New BSD
 #

--- a/easybuild/easyconfigs/s/Score-P/Score-P-1.4-foss-2015a.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-1.4-foss-2015a.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/s/Score-P/Score-P-2.0.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-2.0.1-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013-2016 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 #             Markus Geimer <m.geimer@fz-juelich.de>

--- a/easybuild/easyconfigs/s/Seaborn/Seaborn-0.6.0-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/s/Seaborn/Seaborn-0.6.0-goolf-1.4.10-Python-2.7.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/Seaborn/Seaborn-0.6.0-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/s/Seaborn/Seaborn-0.6.0-intel-2015b-Python-2.7.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/Seaborn/Seaborn-0.7.1-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/s/Seaborn/Seaborn-0.7.1-intel-2016b-Python-2.7.12.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics (SIB)
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/SelEstim/SelEstim-1.1.4-Linux-64bits.eb
+++ b/easybuild/easyconfigs/s/SelEstim/SelEstim-1.1.4-Linux-64bits.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/s/SeqAn/SeqAn-2.3.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/s/SeqAn/SeqAn-2.3.2-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/s/SeqPrep/SeqPrep-1.2-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/s/SeqPrep/SeqPrep-1.2-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/s/Seqmagick/Seqmagick-0.6.1-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/s/Seqmagick/Seqmagick-0.6.1-foss-2016a-Python-2.7.11.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2016 University of Geneva Switzerland
 # Authors::   Yann Sagon <yann.sagon@unige.ch>

--- a/easybuild/easyconfigs/s/SoX/SoX-14.4.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/s/SoX/SoX-14.4.2-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author:    Stephane Thiell <sthiell@stanford.edu>
 ###

--- a/easybuild/easyconfigs/s/SolexaQA++/SolexaQA++-3.1.5-foss-2016b.eb
+++ b/easybuild/easyconfigs/s/SolexaQA++/SolexaQA++-3.1.5-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Adam Huffman
 # The Francis Crick Institute
 easyblock = 'MakeCp'

--- a/easybuild/easyconfigs/s/SortMeRNA/SortMeRNA-2.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/SortMeRNA/SortMeRNA-2.1-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/Stow/Stow-1.3.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/Stow/Stow-1.3.3-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/Stow/Stow-1.3.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/s/Stow/Stow-1.3.3-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/s/StringTie/StringTie-1.2.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/StringTie/StringTie-1.2.2-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/s/StringTie/StringTie-1.3.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/s/StringTie/StringTie-1.3.0-intel-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/s/StringTie/StringTie-1.3.3-intel-2017a.eb
+++ b/easybuild/easyconfigs/s/StringTie/StringTie-1.3.3-intel-2017a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/s/StringTie/StringTie-1.3.3b-foss-2016b.eb
+++ b/easybuild/easyconfigs/s/StringTie/StringTie-1.3.3b-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'MakeCp'
 

--- a/easybuild/easyconfigs/s/Subread/Subread-1.5.0-p1-foss-2015b.eb
+++ b/easybuild/easyconfigs/s/Subread/Subread-1.5.0-p1-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Adam Huffman
 # The Francis Crick Institute
 easyblock = 'MakeCp'

--- a/easybuild/easyconfigs/s/Subread/Subread-1.5.0-p1-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/Subread/Subread-1.5.0-p1-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Adam Huffman
 # The Francis Crick Institute
 easyblock = 'MakeCp'

--- a/easybuild/easyconfigs/s/Subread/Subread-1.5.0-p1-foss-2016b.eb
+++ b/easybuild/easyconfigs/s/Subread/Subread-1.5.0-p1-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Adam Huffman
 # The Francis Crick Institute
 easyblock = 'MakeCp'

--- a/easybuild/easyconfigs/s/samblaster/samblaster-0.1.24-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/s/samblaster/samblaster-0.1.24-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/s/segemehl/segemehl-0.1.7-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/segemehl/segemehl-0.1.7-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/segemehl/segemehl-0.2.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/s/segemehl/segemehl-0.2.0-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'MakeCp'
 

--- a/easybuild/easyconfigs/s/segemehl/segemehl-0.2.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/segemehl/segemehl-0.2.0-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/s/sickle/sickle-1.210-goolf-1.4.10-bab15f7.eb
+++ b/easybuild/easyconfigs/s/sickle/sickle-1.210-goolf-1.4.10-bab15f7.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/s/skewer/skewer-0.2.2-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/s/skewer/skewer-0.2.2-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/s/splitRef/splitRef-0.0.2.eb
+++ b/easybuild/easyconfigs/s/splitRef/splitRef-0.0.2.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/s/sratoolkit/sratoolkit-2.5.7.eb
+++ b/easybuild/easyconfigs/s/sratoolkit/sratoolkit-2.5.7.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author: Adam Huffman
 # adam.huffman@crick.ac.uk

--- a/easybuild/easyconfigs/s/stress/stress-1.0.4-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/s/stress/stress-1.0.4-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/s/synchronicity/synchronicity-1.1.9.1-foss-2015b-R-3.2.3.eb
+++ b/easybuild/easyconfigs/s/synchronicity/synchronicity-1.1.9.1-foss-2015b-R-3.2.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Author: Adam Huffman <adam.huffman@crick.ac.uk>
 # The Francis Crick Institute

--- a/easybuild/easyconfigs/t/TAU/TAU-2.22.2-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/t/TAU/TAU-2.22.2-goolf-1.5.14.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/t/TCC/TCC-0.9.26.eb
+++ b/easybuild/easyconfigs/t/TCC/TCC-0.9.26.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/t/TREE-PUZZLE/TREE-PUZZLE-5.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/t/TREE-PUZZLE/TREE-PUZZLE-5.2-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/t/Tar/Tar-1.26-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/t/Tar/Tar-1.26-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/t/Tar/Tar-1.26-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/t/Tar/Tar-1.26-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipy as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipy as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Author::    Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/easybuild/easyconfigs/t/Tesla-Deployment-Kit/Tesla-Deployment-Kit-5.319.43.eb
+++ b/easybuild/easyconfigs/t/Tesla-Deployment-Kit/Tesla-Deployment-Kit-5.319.43.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/t/TopHat/TopHat-2.0.10-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/t/TopHat/TopHat-2.0.10-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>, Jens Timmerman

--- a/easybuild/easyconfigs/t/TopHat/TopHat-2.0.13-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/t/TopHat/TopHat-2.0.13-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/t/TopHat/TopHat-2.0.14-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/t/TopHat/TopHat-2.0.14-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/t/TopHat/TopHat-2.0.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/t/TopHat/TopHat-2.0.4-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/t/TopHat/TopHat-2.0.8-goolf-1.4.10-biodeps-1.6-extended.eb
+++ b/easybuild/easyconfigs/t/TopHat/TopHat-2.0.8-goolf-1.4.10-biodeps-1.6-extended.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/t/TopHat/TopHat-2.0.8-ictce-5.3.0-biodeps-1.6-extended.eb
+++ b/easybuild/easyconfigs/t/TopHat/TopHat-2.0.8-ictce-5.3.0-biodeps-1.6-extended.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/t/TopHat/TopHat-2.0.8-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/t/TopHat/TopHat-2.0.8-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>, Jens Timmerman

--- a/easybuild/easyconfigs/t/TopHat/TopHat-2.1.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/t/TopHat/TopHat-2.1.0-intel-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/t/TopHat/TopHat-2.1.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/t/TopHat/TopHat-2.1.1-foss-2015b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/t/TopHat/TopHat-2.1.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/t/TopHat/TopHat-2.1.1-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/t/TopHat/TopHat-2.1.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/t/TopHat/TopHat-2.1.1-intel-2017a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/t/TotalView/TotalView-8.11.0-0-linux-x86-64.eb
+++ b/easybuild/easyconfigs/t/TotalView/TotalView-8.11.0-0-linux-x86-64.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/t/TotalView/TotalView-8.11.0-2-linux-x86-64.eb
+++ b/easybuild/easyconfigs/t/TotalView/TotalView-8.11.0-2-linux-x86-64.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipy as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipy as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/t/TotalView/TotalView-8.12.0-0-linux-x86-64.eb
+++ b/easybuild/easyconfigs/t/TotalView/TotalView-8.12.0-0-linux-x86-64.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild recipy as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild recipy as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/t/Trimmomatic/Trimmomatic-0.32-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/t/Trimmomatic/Trimmomatic-0.32-Java-1.7.0_80.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/t/Trinity/Trinity-2.0.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/t/Trinity/Trinity-2.0.4-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/t/Trinity/Trinity-2.0.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/t/Trinity/Trinity-2.0.6-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/t/Trinity/Trinity-2.2.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/t/Trinity/Trinity-2.2.0-foss-2016a.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/t/tabix/tabix-0.2.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/t/tabix/tabix-0.2.6-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/t/tabix/tabix-0.2.6-intel-2014b.eb
+++ b/easybuild/easyconfigs/t/tabix/tabix-0.2.6-intel-2014b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/t/tabix/tabix-0.2.6-intel-2016b.eb
+++ b/easybuild/easyconfigs/t/tabix/tabix-0.2.6-intel-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-CrayGNU-2015.06.eb
+++ b/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-CrayGNU-2015.06.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-CrayGNU-2015.11.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-CrayIntel-2015.11.eb
+++ b/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-CrayIntel-2015.11.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-foss-2015a.eb
+++ b/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-goolf-1.5.14.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-intel-2014b.eb
+++ b/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-intel-2014b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-intel-2015a.eb
+++ b/easybuild/easyconfigs/t/tcsh/tcsh-6.18.01-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/t/tcsh/tcsh-6.19.00-intel-2015a.eb
+++ b/easybuild/easyconfigs/t/tcsh/tcsh-6.19.00-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/t/tcsh/tcsh-6.19.00-intel-2016a.eb
+++ b/easybuild/easyconfigs/t/tcsh/tcsh-6.19.00-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/t/tcsh/tcsh-6.20.00-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/t/tcsh/tcsh-6.20.00-GCCcore-5.4.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg/Computer Science and Communications Research Unit
 # Authors::   Valentin Plugaru <valentin.plugaru@gmail.com>

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.1.24-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.1.24-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.1.24-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.1.24-ictce-5.2.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.1.24-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.1.24-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.1.24-ictce-5.4.0.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.1.24-ictce-5.4.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.1.24-intel-2014b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.1.24-intel-2014b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.19-intel-2015a.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.19-intel-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.19-intel-2015b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.19-intel-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.20-foss-2016a.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.20-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.20-intel-2016b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.20-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.24-intel-2017a.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.24-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
 # Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (Ghent University)

--- a/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.11-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.11-goolf-1.4.10-Perl-5.16.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.11-ictce-5.5.0-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.11-ictce-5.5.0-Perl-5.16.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.12-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.12-goolf-1.4.10-Perl-5.16.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.14-foss-2015b-Perl-5.20.3.eb
+++ b/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.14-foss-2015b-Perl-5.20.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.14-foss-2016a-Perl-5.22.1.eb
+++ b/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.14-foss-2016a-Perl-5.22.1.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.14-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.14-goolf-1.4.10-Perl-5.16.3.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.14-goolf-1.7.20-Perl-5.22.2.eb
+++ b/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.14-goolf-1.7.20-Perl-5.22.2.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.14-intel-2016a-Perl-5.22.1.eb
+++ b/easybuild/easyconfigs/v/VCFtools/VCFtools-0.1.14-intel-2016a-Perl-5.22.1.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/v/VEGAS/VEGAS-0.8.27.eb
+++ b/easybuild/easyconfigs/v/VEGAS/VEGAS-0.8.27.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Ravi Tripathi
 # Email: ravi89@uab.edu
 

--- a/easybuild/easyconfigs/v/VMD/VMD-1.9.3-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/v/VMD/VMD-1.9.3-intel-2016b-Python-2.7.12.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Authors::   Stephane Thiell <sthiell@stanford.edu>
 ##
 name = 'VMD'

--- a/easybuild/easyconfigs/v/VTK/VTK-5.10.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-5.10.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/VTK/VTK-5.10.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-5.10.1-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/VTK/VTK-6.3.0-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-6.3.0-foss-2016b-Python-2.7.12.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/VTK/VTK-6.3.0-intel-2015b-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-6.3.0-intel-2015b-Python-2.7.11.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/VTK/VTK-6.3.0-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-6.3.0-intel-2016a-Python-2.7.11.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/VTK/VTK-6.3.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-6.3.0-intel-2016b-Python-2.7.12.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/VTK/VTK-7.0.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-7.0.0-intel-2016b-Python-2.7.12.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/VTK/VTK-7.1.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-7.1.0-intel-2016b-Python-2.7.12.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/VTK/VTK-7.1.1-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-7.1.1-intel-2017a-Python-2.7.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/Valgrind/Valgrind-3.8.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/v/Valgrind/Valgrind-3.8.1-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/Vampir/Vampir-8.4.1-demo.eb
+++ b/easybuild/easyconfigs/v/Vampir/Vampir-8.4.1-demo.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/v/Vampir/Vampir-8.4.1.eb
+++ b/easybuild/easyconfigs/v/Vampir/Vampir-8.4.1.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/v/VampirServer/VampirServer-8.4.1-gompi-2015a.eb
+++ b/easybuild/easyconfigs/v/VampirServer/VampirServer-8.4.1-gompi-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>

--- a/easybuild/easyconfigs/v/VampirTrace/VampirTrace-5.14.4-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/v/VampirTrace/VampirTrace-5.14.4-goolf-1.5.14.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/v/VarScan/VarScan-2.3.6-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/v/VarScan/VarScan-2.3.6-Java-1.7.0_80.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Adam Huffman
 # The Francis Crick Institute
 

--- a/easybuild/easyconfigs/v/VarScan/VarScan-2.4.1-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/v/VarScan/VarScan-2.4.1-Java-1.7.0_80.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Adam Huffman, based on initial work by Jordi Blasco
 # The Francis Crick Institute
 

--- a/easybuild/easyconfigs/v/Velvet/Velvet-1.2.07-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/v/Velvet/Velvet-1.2.07-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/Velvet/Velvet-1.2.07-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/v/Velvet/Velvet-1.2.07-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/Velvet/Velvet-1.2.09-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/v/Velvet/Velvet-1.2.09-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>, Andreas Panteli <a.panteli@cyi.ac.cy>

--- a/easybuild/easyconfigs/v/Velvet/Velvet-1.2.09-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/v/Velvet/Velvet-1.2.09-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>, Andreas Panteli <a.panteli@cyi.ac.cy>

--- a/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-goolf-1.4.10-mt-kmer_31.eb
+++ b/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-goolf-1.4.10-mt-kmer_31.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>, Andreas Panteli <a.panteli@cyi.ac.cy>

--- a/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-goolf-1.4.10-mt-kmer_57.eb
+++ b/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-goolf-1.4.10-mt-kmer_57.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>, Andreas Panteli <a.panteli@cyi.ac.cy>

--- a/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-goolf-1.4.10-mt-kmer_63.eb
+++ b/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-goolf-1.4.10-mt-kmer_63.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2013 The Cyprus Institute
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>, Andreas Panteli <a.panteli@cyi.ac.cy>

--- a/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-intel-2015b-mt-kmer_100-Perl-5.20.3.eb
+++ b/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-intel-2015b-mt-kmer_100-Perl-5.20.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, 2012-2013 The Cyprus Institute
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>,

--- a/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-intel-2015b-mt-kmer_100.eb
+++ b/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-intel-2015b-mt-kmer_100.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, 2012-2013 The Cyprus Institute
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>,

--- a/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-intel-2015b-mt-kmer_31-Perl-5.20.3.eb
+++ b/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-intel-2015b-mt-kmer_31-Perl-5.20.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, 2012-2013 The Cyprus Institute
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>,

--- a/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-intel-2015b-mt-kmer_31.eb
+++ b/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-intel-2015b-mt-kmer_31.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, 2012-2013 The Cyprus Institute
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>,

--- a/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-intel-2017a-mt-kmer_37.eb
+++ b/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-intel-2017a-mt-kmer_37.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, 2012-2013 The Cyprus Institute
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>,

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.1.6-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.1.6-ictce-5.5.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.2.3-intel-2016b.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.2.3-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.3.4-foss-2016b.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.3.4-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'ConfigureMake'
 

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.3.5-intel-2017a.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.3.5-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/v/Vim/Vim-7.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/v/Vim/Vim-7.4-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/v/Vim/Vim-8.0-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/v/Vim/Vim-8.0-foss-2016a-Python-2.7.11.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/v/Viper/Viper-1.0.0-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/v/Viper/Viper-1.0.0-goolf-1.4.10-Python-2.7.3.eb
@@ -22,7 +22,7 @@ versionsuffix = "-%s-%s" % (python, pythonversion)
 dependencies = [(python, pythonversion)]
 
 # hack, 'import viper' fails because VTK and numpy dependencies are missing
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/100
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/100
 options = {'modulename': 'os'}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/v/Viper/Viper-1.0.0-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/v/Viper/Viper-1.0.0-ictce-5.3.0-Python-2.7.3.eb
@@ -23,7 +23,7 @@ versionsuffix = "-%s-%s" % (python, pythonversion)
 dependencies = [(python, pythonversion)]
 
 # hack, 'import viper' fails because VTK and numpy dependencies are missing
-# see https://github.com/hpcugent/easybuild-easyconfigs/issues/100
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/100
 options = {'modulename': 'os'}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/v/vsc-mympirun/vsc-mympirun-3.2.1.eb
+++ b/easybuild/easyconfigs/v/vsc-mympirun/vsc-mympirun-3.2.1.eb
@@ -3,7 +3,7 @@ easyblock = 'VersionIndependentPythonPackage'
 name = 'vsc-mympirun'
 version = '3.2.1'
 
-homepage = 'http://github.com/hpcugent/vsc-mympirun/'
+homepage = 'https://github.com/hpcugent/vsc-mympirun/'
 description = """VSC-tools is a set of Python libraries and scripts that are commonly used within HPC-UGent."""
 
 # we build this to work with every python version

--- a/easybuild/easyconfigs/v/vt/vt-0.577-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/v/vt/vt-0.577-goolf-1.7.20.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics

--- a/easybuild/easyconfigs/w/WEKA/WEKA-3.6.12-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/w/WEKA/WEKA-3.6.12-Java-1.7.0_80.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/w/WEKA/WEKA-3.7.0-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/w/WEKA/WEKA-3.7.0-Java-1.7.0_80.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/w/WHAM/WHAM-2.0.9-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/w/WHAM/WHAM-2.0.9-goolf-1.4.10.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/w/WHAM/WHAM-2.0.9-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/w/WHAM/WHAM-2.0.9-ictce-6.2.5.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel

--- a/easybuild/easyconfigs/w/wiki2beamer/wiki2beamer-0.9.5-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/w/wiki2beamer/wiki2beamer-0.9.5-goolf-1.4.10-Python-2.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/w/wiki2beamer/wiki2beamer-0.9.5-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/w/wiki2beamer/wiki2beamer-0.9.5-ictce-5.3.0-Python-2.7.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/w/wkhtmltopdf/wkhtmltopdf-0.12.3-Linux-x86_64.eb
+++ b/easybuild/easyconfigs/w/wkhtmltopdf/wkhtmltopdf-0.12.3-Linux-x86_64.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
 # SIB Swiss Institute of Bioinformatics 

--- a/easybuild/easyconfigs/w/wxPropertyGrid/wxPropertyGrid-1.4.15-GCC-4.7.3.eb
+++ b/easybuild/easyconfigs/w/wxPropertyGrid/wxPropertyGrid-1.4.15-GCC-4.7.3.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/w/wxPropertyGrid/wxPropertyGrid-1.4.15-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/w/wxPropertyGrid/wxPropertyGrid-1.4.15-GCC-4.9.2.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
 # Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # License::   New BSD

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2_compat-libs.patch
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2_compat-libs.patch
@@ -1,5 +1,5 @@
 include two 5.1.2aplha symbols that were included in XZ 5.1.2alpha which are required by the 'rpm' command on CentOS 7.x
-see also https://github.com/hpcugent/easybuild-easyconfigs/issues/4036
+see also https://github.com/easybuilders/easybuild-easyconfigs/issues/4036
 original patch: xz-5.2.2-compat-libs.patch, cfr. https://git.centos.org/patch/rpms!xz.git/3f035cee1da9f864609885e5ef2a1be77cd37eee
 
 --- src/liblzma/liblzma.map.orig	2015-09-29 12:57:36.000000000 +0200

--- a/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-goolf-1.4.10-Perl-5.16.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013 Uni.Lu/LCSB
 # Authors::   Nils Christian <nils.christian@uni.lu>

--- a/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-ictce-5.3.0-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-ictce-5.3.0-Perl-5.16.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2013 Uni.Lu/LCSB
 # Authors::   Nils Christian <nils.christian@uni.lu>

--- a/easybuild/easyconfigs/y/Yasm/Yasm-1.2.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/y/Yasm/Yasm-1.2.0-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/y/Yasm/Yasm-1.2.0-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/y/Yasm/Yasm-1.2.0-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-foss-2015a.eb
+++ b/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-foss-2015a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-foss-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-foss-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-foss-2017a.eb
+++ b/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-foss-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-gimkl-2.11.5.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-gimkl-2017a.eb
+++ b/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-gimkl-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-intel-2015b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-intel-2016a.eb
+++ b/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-intel-2016a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-intel-2016b.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-intel-2017a.eb
+++ b/easybuild/easyconfigs/y/Yasm/Yasm-1.3.0-intel-2017a.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/z/ZPAQ/ZPAQ-7.00-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/z/ZPAQ/ZPAQ-7.00-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2015 NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/z/zsync/zsync-0.6.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/z/zsync/zsync-0.6.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/easybuild/easyconfigs/z/zsync/zsync-0.6.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/z/zsync/zsync-0.6.2-ictce-5.3.0.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -109,7 +109,7 @@ that specify the build parameters for software packages (version, compiler toolc
 versions, etc.).""",
     license = "GPLv2",
     keywords = "software build building installation installing compilation HPC scientific",
-    url = "http://hpcugent.github.com/easybuild",
+    url = "http://easybuilders.github.io/easybuild/",
     data_files = get_data_files(),
     long_description = read("README.rst"),
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ that specify the build parameters for software packages (version, compiler toolc
 versions, etc.).""",
     license = "GPLv2",
     keywords = "software build building installation installing compilation HPC scientific",
-    url = "http://easybuilders.github.io/easybuild/",
+    url = "https://easybuilders.github.io/easybuild/",
     data_files = get_data_files(),
     long_description = read("README.rst"),
     classifiers = [

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -240,6 +240,15 @@ def template_easyconfig_test(self, spec):
     error_msg = "Found use of '$root', not compatible with modules in Lua syntax, use '%%(installdir)s' instead: %s"
     self.assertFalse(res, error_msg % res)
 
+    # make sure old GitHub urls for EasyBuild that include 'hpcugent' are no longer used
+    old_urls = [
+        'github.com/hpcugent/easybuild',
+        'hpcugent.github.com/easybuild',
+        'hpcugent.github.io/easybuild',
+    ]
+    for old_url in old_urls:
+        self.assertFalse(old_url in ec.rawtxt, "Old URL '%s' not found in %s" % (old_url, spec))
+
     # make sure all patch files are available
     specdir = os.path.dirname(spec)
     specfn = os.path.basename(spec)

--- a/test/easyconfigs/styletests.py
+++ b/test/easyconfigs/styletests.py
@@ -8,7 +8,7 @@
 # the Hercules foundation (http://www.herculesstichting.be/in_English)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/easyconfigs/suite.py
+++ b/test/easyconfigs/suite.py
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This is a PITA to review, I'm aware, but except for `CONTRIBUTING.md`, `README.rst` and `RELEASE_NOTES` the changes were made via scripting, so there shouldn't be any mistakes...