### PR TITLE
{devel}[foss-2016b] Boost 1.54.0

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.54.0-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.54.0-foss-2016b-Python-2.7.12.eb
@@ -1,0 +1,31 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+
+name = 'Boost'
+version = '1.54.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.boost.org/'
+description = "Boost provides free peer-reviewed portable C++ source libraries."
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'usempi': True, 'pic': True, 'cstd': 'c++0x'}
+
+sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
+source_urls = ['https://sourceforge.net/projects/%(namelower)s/files/%(namelower)s/%(version)s']
+
+patches = [
+    '%(name)s-%(version)s_fix-allocator.patch',
+    '%(name)s-%(version)s_fix-int64_t-support.patch',
+    '%(name)s-%(version)s_fix-make_tuple-namespace.patch',
+]
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('Python', '2.7.12'),
+]
+
+# also build boost_mpi
+boost_mpi = True
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.54.0_fix-allocator.patch
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.54.0_fix-allocator.patch
@@ -1,0 +1,13 @@
+* fix build error: No best alternative for libs/coroutine/build/allocator_sources
+author: Paul Jähne
+--- libs/coroutine/build/Jamfile.v2
++++ libs/coroutine/build/Jamfile.v2
+@@ -40,7 +40,7 @@
+     : detail/standard_stack_allocator_posix.cpp
+     ;
+ 
+-explicit yield_sources ;
++explicit allocator_sources ;
+ 
+ lib boost_coroutine
+     : allocator_sources

--- a/easybuild/easyconfigs/b/Boost/Boost-1.54.0_fix-int64_t-support.patch
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.54.0_fix-int64_t-support.patch
@@ -1,0 +1,16 @@
+* fix build error: int64_t support
+author: Paul Jähne
+--- boost/cstdint.hpp
++++ boost/cstdint.hpp
+@@ -41,7 +41,10 @@
+ // so we disable use of stdint.h when GLIBC does not define __GLIBC_HAVE_LONG_LONG.
+ // See https://svn.boost.org/trac/boost/ticket/3548 and http://sources.redhat.com/bugzilla/show_bug.cgi?id=10990
+ //
+-#if defined(BOOST_HAS_STDINT_H) && (!defined(__GLIBC__) || defined(__GLIBC_HAVE_LONG_LONG))
++#if defined(BOOST_HAS_STDINT_H)                                 \
++  && (!defined(__GLIBC__)                                       \
++      || defined(__GLIBC_HAVE_LONG_LONG)                        \
++      || (defined(__GLIBC__) && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 17)))))
+ 
+ // The following #include is an implementation artifact; not part of interface.
+ # ifdef __hpux

--- a/easybuild/easyconfigs/b/Boost/Boost-1.54.0_fix-make_tuple-namespace.patch
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.54.0_fix-make_tuple-namespace.patch
@@ -1,0 +1,22 @@
+* fix build error: could not convert 'std::make_tuple(_Elements&& ...)
+author: Paul Jähne
+--- libs/mpi/src/python/py_nonblocking.cpp
++++ libs/mpi/src/python/py_nonblocking.cpp
+@@ -118,7 +118,7 @@
+     pair<status, request_list::iterator> result = 
+       wait_any(requests.begin(), requests.end());
+ 
+-    return make_tuple(
++    return boost::python::make_tuple(
+         result.second->get_value_or_none(),
+         result.first, 
+         distance(requests.begin(), result.second));
+@@ -134,7 +134,7 @@
+       test_any(requests.begin(), requests.end());
+ 
+     if (result)
+-      return make_tuple(
++      return boost::python::make_tuple(
+           result->second->get_value_or_none(),
+           result->first, 
+           distance(requests.begin(), result->second));


### PR DESCRIPTION
This adds `boost` in the ancient version `1.54.0` for the `foss-2016b` toolchain. This version is needed by [bcl2fastq](https://support.illumina.com/sequencing/sequencing_software/bcl2fastq-conversion-software.html) which I will add later in another pull request.