### PR TITLE
fix reference to github.com/hpcugent in GROMACS easyconfig

### DIFF
--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-goolfc-2017.01.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-goolfc-2017.01.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
 #                                 Ghent University / The Francis Crick Institute


### PR DESCRIPTION
Tests were broken in `develop` after #4585 was merged (cc @verdurin).

@easybuilders/easybuild-easyconfigs-maintainers The tests have been made stricter recently (e.g. style tests), so it's important to re-trigger tests for PRs that were tested a while ago (by closing/opening the PR, Travis supports no other way of re-triggering tests without adding an extra commit...).

I'll look into better Travis notifications, since I wasn't notified of the breakage either; were you @verdurin?