### PR TITLE
use single-line description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     version = VERSION,
     author = "EasyBuild community",
     author_email = "easybuild@lists.ugent.be",
-    description = """Easyconfig files are simple build specification files for EasyBuild,
+    description = """Easyconfig files are simple build specification files for EasyBuild, \
 that specify the build parameters for software packages (version, compiler toolchain, dependency \
 versions, etc.).""",
     license = "GPLv2",


### PR DESCRIPTION
Recent versions of setuptools require the `description` field to be a single line, or else:

```
Upload failed (400): summary: Multiple lines are not allowed.
error: Upload failed (400): summary: Multiple lines are not allowed.
```