### PR TITLE
fix version and source for Seurat, add extensions required by Seurat in R 3.4.0 easyconfig

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.4.0-intel-2017a-X11-20170314.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.0-intel-2017a-X11-20170314.eb
@@ -528,6 +528,13 @@ exts_list = [
     ('ucminf', '1.1-4', ext_options),
     ('ordinal', '2015.6-28', ext_options),
     ('Rtsne', '0.13', dict(ext_options.items() + [('patches', ['Rtsne-0.13_icpc-wd308.patch'])])),
+    ('cowplot', '0.7.0', ext_options),
+    ('tsne', '0.1-3', ext_options),
+    ('pbapply', '1.3-3', ext_options),
+    ('RcppProgress', '0.3', ext_options),
+    ('sn', '1.5-0', ext_options),
+    ('tclust', '1.2-7', ext_options),
+    ('ranger', '0.8.0', ext_options),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/s/Seurat/Seurat-1.4.0.16-intel-2017a-R-3.4.0.eb
+++ b/easybuild/easyconfigs/s/Seurat/Seurat-1.4.0.16-intel-2017a-R-3.4.0.eb
@@ -1,7 +1,7 @@
 easyblock = 'RPackage'
 
 name = 'Seurat'
-version = '1.4.0'
+version = '1.4.0.16'
 versionsuffix = '-R-%(rver)s'
 
 homepage = 'http://satijalab.org/seurat'
@@ -9,8 +9,11 @@ description = "Seurat is an R package designed for QC, analysis, and exploration
 
 toolchain = {'name': 'intel', 'version': '2017a'}
 
-source_urls = ['https://github.com/satijalab/seurat/releases/download/v%(version_major_minor)s.0/']
-sources = ['%(name)s_%(version)s.tgz']
+source_urls = ['https://github.com/satijalab/seurat/archive/']
+sources = [{
+    'filename': SOURCE_TAR_GZ,
+    'download_filename': '3bd092a.tar.gz',
+}]
 
 dependencies = [('R', '3.4.0', '-X11-20170314')]
 

--- a/easybuild/easyconfigs/s/Seurat/Seurat-1.4.0.16-intel-2017a-R-3.4.0.eb
+++ b/easybuild/easyconfigs/s/Seurat/Seurat-1.4.0.16-intel-2017a-R-3.4.0.eb
@@ -14,6 +14,7 @@ sources = [{
     'filename': SOURCE_TAR_GZ,
     'download_filename': '3bd092a.tar.gz',
 }]
+checksums = ['2079b09698aadc1f3fdd3de5ac708add7196f4713d9f6a01b85d05b3a6ba2ec5']
 
 dependencies = [('R', '3.4.0', '-X11-20170314')]
 


### PR DESCRIPTION
Loading Seurat in R results in the following error:

```
> library(Seurat)
Error: package ‘Seurat’ was built for x86_64-apple-darwin13.4.0
```

This went undetected because of a bug in the EasyBuild framework where the `library(...)` import checks for R extensions were basically being skipped, see https://github.com/easybuilders/easybuild-framework/pull/2276.

The problem was the we were using the binary release of Seurat, rather than the source tarball...

As it turns out, several R extensions were also missing as dependencies.