### PR TITLE
{bio}[foss/2016b] Bowtie 1.2.1.1

### DIFF
--- a/easybuild/easyconfigs/b/Bowtie/Bowtie-1.2.1.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/b/Bowtie/Bowtie-1.2.1.1-foss-2016b.eb
@@ -1,0 +1,20 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+
+name = 'Bowtie'
+version = '1.2.1.1'
+
+homepage = 'http://bowtie-bio.sourceforge.net/index.shtml'
+description = """Bowtie is an ultrafast, memory-efficient short read aligner.
+ It aligns short DNA sequences (reads) to the human genome."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'pic': True}
+
+sources = ['%(namelower)s-%(version)s-src.zip']
+source_urls = ['http://download.sourceforge.net/bowtie-bio/']
+
+checksums = ['71d708c957380e115ba420a96ac5f8456c6a61760a5f4dbe06305df6a42131d8']
+
+dependencies = [('tbb', '2017_U5')]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/Bowtie/Bowtie-1.2.1.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/b/Bowtie/Bowtie-1.2.1.1-foss-2016b.eb
@@ -17,12 +17,4 @@ checksums = ['71d708c957380e115ba420a96ac5f8456c6a61760a5f4dbe06305df6a42131d8']
 
 dependencies = [('tbb', '2017_U5')]
 
-sanity_check_paths = {
-    'files': ['bin/%s' % x for x in ['bowtie', 'bowtie-align-l', 'bowtie-align-s', 'bowtie-build', 'bowtie-build-l',
-                                     'bowtie-build-s', 'bowtie-inspect', 'bowtie-inspect-l', 'bowtie-inspect-s']],
-    'dirs': []
-}
-
-sanity_check_commands = [('bowtie', '--version')]
-
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/Bowtie/Bowtie-1.2.1.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/b/Bowtie/Bowtie-1.2.1.1-foss-2016b.eb
@@ -18,7 +18,8 @@ checksums = ['71d708c957380e115ba420a96ac5f8456c6a61760a5f4dbe06305df6a42131d8']
 dependencies = [('tbb', '2017_U5')]
 
 sanity_check_paths = {
-    'files': ['bin/%s' % x for x in ['bowtie', 'bowtie-align-l', 'bowtie-align-s', 'bowtie-build', 'bowtie-build-l', 'bowtie-build-s', 'bowtie-inspect', 'bowtie-inspect-l', 'bowtie-inspect-s']],
+    'files': ['bin/%s' % x for x in ['bowtie', 'bowtie-align-l', 'bowtie-align-s', 'bowtie-build', 'bowtie-build-l',
+                                     'bowtie-build-s', 'bowtie-inspect', 'bowtie-inspect-l', 'bowtie-inspect-s']],
     'dirs': []
 }
 

--- a/easybuild/easyconfigs/b/Bowtie/Bowtie-1.2.1.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/b/Bowtie/Bowtie-1.2.1.1-foss-2016b.eb
@@ -17,4 +17,11 @@ checksums = ['71d708c957380e115ba420a96ac5f8456c6a61760a5f4dbe06305df6a42131d8']
 
 dependencies = [('tbb', '2017_U5')]
 
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['bowtie', 'bowtie-align-l', 'bowtie-align-s', 'bowtie-build', 'bowtie-build-l', 'bowtie-build-s', 'bowtie-inspect', 'bowtie-inspect-l', 'bowtie-inspect-s']],
+    'dirs': []
+}
+
+sanity_check_commands = [('bowtie', '--version')]
+
 moduleclass = 'bio'


### PR DESCRIPTION
This adds the current `Bowtie` for the `foss-2016b` toolchain.

One thing I mentioned after the build is that the options (`-O2 -march=corei7 -fPIC`) are passed twice (build with `eb --buildpath=/dev/shm --optarch=march=corei7 --prefix=/easybuild/test Bowtie-1.2.1.1-foss-2016b.eb -dr` on Ubuntu 16.04 and EasyBuild 3.3.1):

```
> bowtie --version
bowtie-align version 1.2.1.1
64-bit
Built on node018
Tue Jul 18 09:37:50 CEST 2017
Compiler: gcc version 5.4.0 (GCC) 
Options: -O3 -m64  -Wl,--hash-style=both -DWITH_TBB -DPOPCNT_CAPABILITY -O2 -march=corei7 -fPIC  -O2 -march=corei7 -fPIC 
Sizeof {int, long, long long, void*, size_t, off_t}: {4, 8, 8, 8, 8, 8}
```

Maybe something in the EasyBlock? Should I open an issue for this?