### PR TITLE
{bio}[foss/2016b] GROMACS v2016.3 (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-foss-2016b-GPU-enabled-build.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-foss-2016b-GPU-enabled-build.eb
@@ -1,0 +1,45 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
+#                                 Ghent University / The Francis Crick Institute
+# Authors::
+# * Wiktor Jurkowski <wiktor.jurkowski@gmail.com>
+# * Fotis Georgatos <fotis@cern.ch>
+# * George Tsouloupas <g.tsouloupas@cyi.ac.cy>
+# * Kenneth Hoste <kenneth.hoste@ugent.be>
+# * Adam Huffman <adam.huffman@crick.ac.uk>
+# License::   MIT/GPL
+##
+
+name = 'GROMACS'
+version = '2016.3'
+versionsuffix = '-GPU-enabled-build'
+
+homepage = 'http://www.gromacs.org'
+description = """
+GROMACS is a versatile package to perform molecular dynamics,
+ i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles.
+
+This is a GPU enabled build, containing both MPI and threadMPI builds.
+"""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
+sources = [SOURCELOWER_TAR_GZ]
+
+patches = [
+    'GROMACS-%(version)s_amend_search_for_nvml_lib.patch',
+]
+
+dependencies = [
+    ('CUDA', '8.0.61_375.26'),
+]
+
+builddependencies = [
+    ('CMake', '3.7.2'),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-foss-2016b-GPU-enabled.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-foss-2016b-GPU-enabled.eb
@@ -14,7 +14,7 @@
 
 name = 'GROMACS'
 version = '2016.3'
-versionsuffix = '-GPU-enabled-build'
+versionsuffix = '-GPU-enabled'
 
 homepage = 'http://www.gromacs.org'
 description = """
@@ -30,6 +30,10 @@ toolchainopts = {'openmp': True, 'usempi': True}
 source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
 sources = [SOURCELOWER_TAR_GZ]
 
+checksums = [
+    '7bf00e74a9d38b7cef9356141d20e4ba9387289cbbfd4d11be479ef932d77d27',     # gromacs-2016.3.tar.gz
+]
+
 patches = [
     'GROMACS-%(version)s_amend_search_for_nvml_lib.patch',
 ]
@@ -43,3 +47,4 @@ builddependencies = [
 ]
 
 moduleclass = 'bio'
+

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-foss-2016b-GPU-enabled.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-foss-2016b-GPU-enabled.eb
@@ -47,4 +47,3 @@ builddependencies = [
 ]
 
 moduleclass = 'bio'
-

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3_amend_search_for_nvml_lib.patch
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3_amend_search_for_nvml_lib.patch
@@ -8,7 +8,7 @@ diff -ru gromacs-2016.orig/cmake/FindNVML.cmake gromacs-2016/cmake/FindNVML.cmak
    # passed to the installer, or the root where they later found the
    # kit to be installed. Below, we cater for both possibilities.
 -  set( NVML_LIB_PATHS /usr/lib64 )
-+  set( NVML_LIB_PATHS /usr/lib64 /usr/lib/nvidia-367 /usr/lib/nvidia-375)
++  set( NVML_LIB_PATHS /usr/lib64 /usr/lib64/nvidia /usr/lib/nvidia-367 /usr/lib/nvidia-375)
    if(GPU_DEPLOYMENT_KIT_ROOT_DIR)
        list(APPEND NVML_LIB_PATHS
            "${GPU_DEPLOYMENT_KIT_ROOT_DIR}/src/gdk/nvml/lib"


### PR DESCRIPTION
I selected toolchain foss2016 and not foss2017 because CUDA doesn't support GCC 6.3 at its latest version.

The NVML library location depends on driver version. On my system the NVML library is located in /usr/lib64/nvidia. Therefore, I include it in patch file that modifies FindNVML.cmake.