### PR TITLE
also add checksums to Perl 5.24.1 easyconfig using intel/2017a

### DIFF
--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.1-intel-2017a.eb
@@ -9,6 +9,7 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.cpan.org/src/%(version_major)s.0']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['e6c185c9b09bdb3f1b13f678999050c639859a7ef39c8cad418448075f5918af']
 
 # !! order of extensions is important !!
 # extensions updated on April 4th 2017
@@ -16,891 +17,1113 @@ exts_list = [
     ('Config::General', '2.63', {
         'source_tmpl': 'Config-General-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TL/TLINDEN'],
+        'checksums': ['0a9bf977b8aabe76343e88095d2296c8a422410fd2a05a1901f2b20e2e1f6fad'],
     }),
     ('File::Listing', '6.04', {
         'source_tmpl': 'File-Listing-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+        'checksums': ['1e0050fcd6789a2179ec0db282bf1e90fb92be35d1171588bd9c47d52d959cf5'],
     }),
     ('ExtUtils::InstallPaths', '0.011', {
         'source_tmpl': 'ExtUtils-InstallPaths-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+        'checksums': ['7609fa048cdcf1451cad5b1d7d494f30e3d5bad0672d15404f1ea60e1df0067c'],
     }),
     ('ExtUtils::Helpers', '0.026', {
         'source_tmpl': 'ExtUtils-Helpers-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+        'checksums': ['de901b6790a4557cf4ec908149e035783b125bf115eb9640feb1bc1c24c33416'],
     }),
     ('Test::Harness', '3.38', {
         'source_tmpl': 'Test-Harness-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+        'checksums': ['af906dd279217a6db5064a058658f2b1d5aa1d307ed6f142d96ac4d339754c01'],
     }),
     ('ExtUtils::Config', '0.008', {
         'source_tmpl': 'ExtUtils-Config-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+        'checksums': ['ae5104f634650dce8a79b7ed13fb59d67a39c213a6776cfdaa3ee749e62f1a8c'],
     }),
     ('Module::Build::Tiny', '0.039', {
         'source_tmpl': 'Module-Build-Tiny-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+        'checksums': ['7d580ff6ace0cbe555bf36b86dc8ea232581530cbeaaea09bccb57b55797f11c'],
     }),
     ('aliased', '0.34', {
         'source_tmpl': 'aliased-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+        'checksums': ['c350524507cd827fab864e5d4c2cc350b1babaa12fa95aec0ca00843fcc7deeb'],
     }),
     ('Text::Glob', '0.11', {
         'source_tmpl': 'Text-Glob-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RC/RCLAMP'],
+        'checksums': ['069ccd49d3f0a2dedb115f4bdc9fbac07a83592840953d1fcdfc39eb9d305287'],
     }),
     ('Regexp::Common', '2016060801', {
         'source_tmpl': 'Regexp-Common-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/A/AB/ABIGAIL'],
+        'checksums': ['fc2fc178facf0292974d6511bad677dd038fe60d7ac118e3b83a1ca9e98a8403'],
     }),
     ('GO::Utils', '0.15', {
         'source_tmpl': 'go-perl-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/C/CM/CMUNGALL'],
+        'checksums': ['423d26155ee85ca51ab2270cee59f4e85b193e57ac3a29aff827298c0a396b12'],
     }),
     ('Module::Pluggable', '5.2', {
         'source_tmpl': 'Module-Pluggable-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SI/SIMONW'],
+        'checksums': ['b3f2ad45e4fd10b3fb90d912d78d8b795ab295480db56dc64e86b9fa75c5a6df'],
     }),
     ('Test::Fatal', '0.014', {
         'source_tmpl': 'Test-Fatal-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['bcdcef5c7b2790a187ebca810b0a08221a63256062cfab3c3b98685d91d1cbb0'],
     }),
     ('Test::Warnings', '0.026', {
         'source_tmpl': 'Test-Warnings-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+        'checksums': ['ae2b68b1b5616704598ce07f5118efe42dc4605834453b7b2be14e26f9cc9a08'],
     }),
     ('File::ShareDir::Install', '0.11', {
         'source_tmpl': 'File-ShareDir-Install-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+        'checksums': ['32bf8772e9fea60866074b27ff31ab5bc3f88972d61915e84cbbb98455e00cc8'],
     }),
     ('DateTime::Locale', '1.16', {
         'source_tmpl': 'DateTime-Locale-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+        'checksums': ['dfaf4c42149c0622e80721773b8d7229d7785280503585895c9fe9f51e076cfe'],
     }),
     ('DateTime::TimeZone', '2.11', {
         'source_tmpl': 'DateTime-TimeZone-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+        'checksums': ['a7c0b2581d2bf6d5cc535364099a67678a9f6ee608e5042dff9ef9c4c577ea6b'],
     }),
     ('Test::Requires', '0.10', {
         'source_tmpl': 'Test-Requires-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TOKUHIROM'],
+        'checksums': ['2768a391d50ab94b95cefe540b9232d7046c13ee86d01859e04c044903222eb5'],
     }),
     ('Module::Implementation', '0.09', {
         'source_tmpl': 'Module-Implementation-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+        'checksums': ['c15f1a12f0c2130c9efff3c2e1afe5887b08ccd033bd132186d1e7d5087fd66d'],
     }),
     ('Module::Build', '0.4222', {
         'source_tmpl': 'Module-Build-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+        'checksums': ['e74b45d9a74736472b74830599cec0d1123f992760f9cd97104f94bee800b160'],
     }),
     ('Module::Runtime', '0.014', {
         'source_tmpl': 'Module-Runtime-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/Z/ZE/ZEFRAM'],
+        'checksums': ['4c44fe0ea255a9fd00741ee545063f6692d2a28e7ef2fbaad1b24a92803362a4'],
     }),
     ('Try::Tiny', '0.28', {
         'source_tmpl': 'Try-Tiny-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+        'checksums': ['f1d166be8aa19942c4504c9111dade7aacb981bc5b3a2a5c5f6019646db8c146'],
     }),
     ('Params::Validate', '1.26', {
         'source_tmpl': 'Params-Validate-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+        'checksums': ['821ac3cfa9715b94f60926faf316b9ff722785594b37036202371ad2303a72ed'],
     }),
     ('List::MoreUtils', '0.418', {
         'source_tmpl': 'List-MoreUtils-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+        'checksums': ['365651edea4e0c806576e4dcfc3dfb98bb4cbb343bc5c3e04cdc7b5b71ed4988'],
     }),
     ('Exporter::Tiny', '0.044', {
         'source_tmpl': 'Exporter-Tiny-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TOBYINK'],
+        'checksums': ['eda868cc2da094b685ceace4245b83de11f439feb98e0ec8246cfbb9109c88ab'],
     }),
     ('Class::Singleton', '1.5', {
         'source_tmpl': 'Class-Singleton-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHAY'],
+        'checksums': ['38220d04f02e3a803193c2575a1644cce0b95ad4b95c19eb932b94e2647ef678'],
     }),
     ('DateTime', '1.42', {
         'source_tmpl': 'DateTime-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+        'checksums': ['efa4badf07365d1b03ee5527fc79baaf7d8b449bf7baad13599f04177232416e'],
     }),
     ('File::Find::Rule::Perl', '1.15', {
         'source_tmpl': 'File-Find-Rule-Perl-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+        'checksums': ['9a48433f86e08ce18e03526e2982de52162eb909d19735460f07eefcaf463ea6'],
     }),
     ('Readonly', '2.05', {
         'source_tmpl': 'Readonly-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SA/SANKO'],
+        'checksums': ['4b23542491af010d44a5c7c861244738acc74ababae6b8838d354dfb19462b5e'],
     }),
     ('Git', '0.41', {
         'source_tmpl': 'Git-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSOUTH'],
+        'checksums': ['9d4de21612253a1d3252ff7657d7e832dcf3cc2a748a8c84f73de618a3a38239'],
     }),
     ('Tree::DAG_Node', '1.29', {
         'source_tmpl': 'Tree-DAG_Node-%(version)s.tgz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE'],
+        'checksums': ['2d04eb011aa06cee633c367d1f322b8d937020fde5d5393fad6a26c93725c4a8'],
     }),
     ('Template', '2.26', {
         'source_tmpl': 'Template-Toolkit-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/A/AB/ABW'],
+        'checksums': ['e7e1cf36026f1ef96d8233e18a3fb39e1eafe9109edc639ecf25b20651cd76be'],
     }),
     ('FreezeThaw', '0.5001', {
         'source_tmpl': 'FreezeThaw-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/I/IL/ILYAZ/modules'],
+        'checksums': ['3c5e08329106f9cee3ab444b81331c5935f83084a151d88505e7a465da540f41'],
     }),
     ('DBI', '1.636', {
         'source_tmpl': 'DBI-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TI/TIMB'],
+        'checksums': ['8f7ddce97c04b4b7a000e65e5d05f679c964d62c8b02c94c1a7d815bb2dd676c'],
     }),
     ('DBD::SQLite', '1.54', {
         'source_tmpl': 'DBD-SQLite-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI'],
+        'checksums': ['3929a6dbd8d71630f0cb57f85dcef9588cd7ac4c9fa12db79df77b9d3a4d7269'],
     }),
     ('Math::Bezier', '0.01', {
         'source_tmpl': 'Math-Bezier-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/A/AB/ABW'],
+        'checksums': ['11a815fc45fdf0efabb1822ab77faad8b9eea162572c5f0940c8ed7d56e6b8b8'],
     }),
     ('Archive::Extract', '0.80', {
         'source_tmpl': 'Archive-Extract-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+        'checksums': ['25cbc2d5626c14d39a0b5e4fe8383941e085c9a7e0aa873d86e81b6e709025f4'],
     }),
     ('DBIx::Simple', '1.35', {
         'source_tmpl': 'DBIx-Simple-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/J/JU/JUERD'],
+        'checksums': ['445535b3dfab88140c7a0d2776b1e78f254dc7e9c81072d5a01afc95a5db499a'],
     }),
     ('Shell', '0.73', {
         'source_tmpl': 'Shell-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/F/FE/FERREIRA'],
+        'checksums': ['f7dbebf65261ed0e5abd0f57052b64d665a1a830bab4c8bbc220f235bd39caf5'],
     }),
     ('File::Spec', '3.62', {
         'source_tmpl': 'PathTools-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['36350e12f58871437ba03391f80a506e447e3c6630cc37d0625bc25ff1c7b4d2'],
     }),
     ('Test::Simple', '1.302078', {
         'source_tmpl': 'Test-Simple-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+        'checksums': ['ab47f3a980ad9aedb78a731719a0487f02a7bc30c17b65457e6dfc3a89a04c15'],
     }),
     ('Set::Scalar', '1.29', {
         'source_tmpl': 'Set-Scalar-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAVIDO'],
+        'checksums': ['a3dc1526f3dde72d3c64ea00007b86ce608cdcd93567cf6e6e42dc10fdc4511d'],
     }),
     ('IO::Stringy', '2.111', {
         'source_tmpl': 'IO-stringy-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DS/DSKOLL'],
+        'checksums': ['8c67fd6608c3c4e74f7324f1404a856c331dbf48d9deda6aaa8296ea41bf199d'],
     }),
     ('Encode::Locale', '1.05', {
         'source_tmpl': 'Encode-Locale-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+        'checksums': ['176fa02771f542a4efb1dbc2a4c928e8f4391bf4078473bd6040d8f11adb0ec1'],
     }),
     ('XML::SAX::Base', '1.09', {
         'source_tmpl': 'XML-SAX-Base-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GR/GRANTM'],
+        'checksums': ['66cb355ba4ef47c10ca738bd35999723644386ac853abbeb5132841f5e8a2ad0'],
     }),
     ('XML::NamespaceSupport', '1.12', {
         'source_tmpl': 'XML-NamespaceSupport-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PERIGRIN'],
+        'checksums': ['47e995859f8dd0413aa3f22d350c4a62da652e854267aa0586ae544ae2bae5ef'],
     }),
     ('XML::SAX', '0.99', {
         'source_tmpl': 'XML-SAX-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GR/GRANTM'],
+        'checksums': ['32b04b8e36b6cc4cfc486de2d859d87af5386dd930f2383c49347050d6f5ad84'],
     }),
     ('Test::LeakTrace', '0.15', {
         'source_tmpl': 'Test-LeakTrace-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GF/GFUJI'],
+        'checksums': ['efb8b58b6981efc6c9c4b4a3b550728f8c179f3c8d57c05724873011c08de65e'],
     }),
     ('Test::Exception', '0.43', {
         'source_tmpl': 'Test-Exception-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+        'checksums': ['156b13f07764f766d8b45a43728f2439af81a3512625438deab783b7883eb533'],
     }),
     ('Text::Table', '1.132', {
         'source_tmpl': 'Text-Table-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
+        'checksums': ['cd601742ee526a9c54b9fe0a4c051e1b09a23b75e2c97de14305218116aba516'],
     }),
     ('MIME::Types', '2.13', {
         'source_tmpl': 'MIME-Types-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MARKOV'],
+        'checksums': ['99c3376357bbe22cc8b6c78f560aa18d81621287695cd629008a6c4e66b77bf8'],
     }),
     ('Module::Build::XSUtil', '0.16', {
         'source_tmpl': 'Module-Build-XSUtil-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/H/HI/HIDEAKIO'],
+        'checksums': ['15762fa4e43b41302cff261c7ad75aacdc874f416981f206d783f20acd023adb'],
     }),
     ('Tie::Function', '0.02', {
         'source_tmpl': 'Tie-Function-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAVIDNICO/handy_tied_functions'],
+        'checksums': ['0b1617af218dfab911ba0fbd72210529a246efe140332da77fe3e03d11000117'],
     }),
     ('Template::Plugin::Number::Format', '1.06', {
         'source_tmpl': 'Template-Plugin-Number-Format-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DARREN'],
+        'checksums': ['0865836a1bcbc34d4a0ee34b5ccc14d7b511f1fd300bf390f002dac349539843'],
     }),
     ('HTML::Parser', '3.72', {
         'source_tmpl': 'HTML-Parser-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+        'checksums': ['ec28c7e1d9e67c45eca197077f7cdc41ead1bb4c538c7f02a3296a4bb92f608b'],
     }),
     ('Date::Handler', '1.2', {
         'source_tmpl': 'Date-Handler-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BB/BBEAUSEJ'],
+        'checksums': ['c36fd2b68d48c2e17417bf2873c78820f3ae02460fdf5976b8eeab887d59e16c'],
     }),
     ('Params::Util', '1.07', {
         'source_tmpl': 'Params-Util-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+        'checksums': ['30f1ec3f2cf9ff66ae96f973333f23c5f558915bb6266881eac7423f52d7c76c'],
     }),
     ('IO::HTML', '1.001', {
         'source_tmpl': 'IO-HTML-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/C/CJ/CJM'],
+        'checksums': ['ea78d2d743794adc028bc9589538eb867174b4e165d7d8b5f63486e6b828e7e0'],
     }),
     ('Data::Grove', '0.08', {
         'source_tmpl': 'libxml-perl-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/K/KM/KMACLEOD'],
+        'checksums': ['4571059b7b5d48b7ce52b01389e95d798bf5cf2020523c153ff27b498153c9cb'],
     }),
     ('Class::ISA', '0.36', {
         'source_tmpl': 'Class-ISA-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SM/SMUELLER'],
+        'checksums': ['8816f34e9a38e849a10df756030dccf9fe061a196c11ac3faafd7113c929b964'],
     }),
     ('URI', '1.71', {
         'source_tmpl': 'URI-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+        'checksums': ['9c8eca0d7f39e74bbc14706293e653b699238eeb1a7690cc9c136fb8c2644115'],
     }),
     ('Ima::DBI', '0.35', {
         'source_tmpl': 'Ima-DBI-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PERRIN'],
+        'checksums': ['8b481ceedbf0ae4a83effb80581550008bfdd3885ef01145e3733c7097c00a08'],
     }),
     ('Tie::IxHash', '1.23', {
         'source_tmpl': 'Tie-IxHash-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/C/CH/CHORNY'],
+        'checksums': ['fabb0b8c97e67c9b34b6cc18ed66f6c5e01c55b257dcf007555e0b027d4caf56'],
     }),
     ('GO', '0.04', {
         'source_tmpl': 'go-db-perl-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SJ/SJCARBON'],
+        'checksums': ['8eb73d591ad767e7cf26def40cffd84833875f1ad51e456960b9ed73dc23641b'],
     }),
     ('Class::DBI::SQLite', '0.11', {
         'source_tmpl': 'Class-DBI-SQLite-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA'],
+        'checksums': ['c4661b00afb7e53c97ac36e13f34dde43c1a93540a2f4ff97e6182b0c731e4e7'],
     }),
     ('Pod::POM', '2.01', {
         'source_tmpl': 'Pod-POM-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/N/NE/NEILB'],
+        'checksums': ['1b50fba9bbdde3ead192beeba0eaddd0c614e3afb1743fa6fff805f57c56f7f4'],
     }),
     ('Math::Round', '0.07', {
         'source_tmpl': 'Math-Round-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GR/GROMMEL'],
+        'checksums': ['73a7329a86e54a5c29a440382e5803095b58f33129e61a1df0093b4824de9327'],
     }),
     ('Text::Diff', '1.44', {
         'source_tmpl': 'Text-Diff-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/N/NE/NEILB'],
+        'checksums': ['57f7a0bed7d085d34a3ffab3a68140d7b816737c87b831086b4c0945bf483b10'],
     }),
     ('Log::Message::Simple', '0.10', {
         'source_tmpl': 'Log-Message-Simple-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+        'checksums': ['aa12d1a4c0ac260b94d448fa01feba242a8a85cb6cbfdc66432e3b5b468add96'],
     }),
     ('IO::Socket::SSL', '2.047', {
         'source_tmpl': 'IO-Socket-SSL-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SU/SULLR'],
+        'checksums': ['c5ad8e14174863194ad43c23a38c77e0b202a989cac9d3e13fb30efcf1d41158'],
     }),
     ('Fennec::Lite', '0.004', {
         'source_tmpl': 'Fennec-Lite-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+        'checksums': ['dce28e3932762c2ff92aa52d90405c06e898e81cb7b164ccae8966ae77f1dcab'],
     }),
     ('Sub::Uplevel', '0.2800', {
         'source_tmpl': 'Sub-Uplevel-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
+        'checksums': ['b4f3f63b80f680a421332d8851ddbe5a8e72fcaa74d5d1d98f3c8cc4a3ece293'],
     }),
     ('Meta::Builder', '0.003', {
         'source_tmpl': 'Meta-Builder-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+        'checksums': ['e7ac289b88d1662e87708d716877ac66a1a8414660996fe58c1db96d834a5375'],
     }),
     ('Exporter::Declare', '0.114', {
         'source_tmpl': 'Exporter-Declare-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+        'checksums': ['4bd70d6ca76f6f6ba7e4c618d4ac93b8593a58f1233ccbe18b10f5f204f1d4e4'],
     }),
     ('Getopt::Long', '2.49.1', {
         'source_tmpl': 'Getopt-Long-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/J/JV/JV'],
+        'checksums': ['98fad4235509aa24608d9ef895b5c60fe2acd2bca70ebdf1acaf6824e17a882f'],
     }),
     ('Log::Message', '0.08', {
         'source_tmpl': 'Log-Message-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+        'checksums': ['bd697dd62aaf26d118e9f0a0813429deb1c544e4501559879b61fcbdfe99fe46'],
     }),
     ('Mouse', 'v2.4.9', {
         'source_tmpl': 'Mouse-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SY/SYOHEX'],
+        'checksums': ['9640aae77bfee2fa9c739640c8da41482c183890f0901663f004867e12d540f8'],
     }),
     ('Test::Version', '2.05', {
         'source_tmpl': 'Test-Version-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/P/PL/PLICEASE'],
+        'checksums': ['39c0ec02663da0e56962bdafaef6790cf83d12b4d90e8a4cdc971d57d869d63f'],
     }),
     ('DBIx::Admin::TableInfo', '3.03', {
         'source_tmpl': 'DBIx-Admin-TableInfo-%(version)s.tgz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE'],
+        'checksums': ['a852530f95957a43aa794f2edf5f3fe4ecec35bd20150c38136d4c23d85328b6'],
     }),
     ('Net::HTTP', '6.13', {
         'source_tmpl': 'Net-HTTP-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/O/OA/OALDERS'],
+        'checksums': ['2d25e696c5239c8a4aa5a97f07ecaa77cf908cc72bbeef7fa6573570af31ce87'],
     }),
     ('Test::Deep', '1.126', {
         'source_tmpl': 'Test-Deep-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['159b42451e4018d9da97994f4ac46d5166abf9b6f343db30071c8fd1cfe0c7c2'],
     }),
     ('Test::Warn', '0.32', {
         'source_tmpl': 'Test-Warn-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BIGJ'],
+        'checksums': ['2fc516e71f9ef453be22a4619d91eb3f78df414a57dfa0fd745d3bff50bf73d2'],
     }),
     ('MRO::Compat', '0.13', {
         'source_tmpl': 'MRO-Compat-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG'],
+        'checksums': ['8a2c3b6ccc19328d5579d02a7d91285e2afd85d801f49d423a8eb16f323da4f8'],
     }),
     ('Moo', '2.003002', {
         'source_tmpl': 'Moo-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG'],
+        'checksums': ['f3e9741e79baa63e89f5a08706cd80d18c0a5a37e3d898847e002310e06582f1'],
     }),
     ('Hash::Merge', '0.200', {
         'source_tmpl': 'Hash-Merge-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+        'checksums': ['47f9f03330b7595c94e73bdd17dc6682ba59d1cc89e63f4e319617f4bb122a64'],
     }),
     ('SQL::Abstract', '1.84', {
         'source_tmpl': 'SQL-Abstract-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/I/IL/ILMARI'],
+        'checksums': ['655f4aa3d4ea7ca0a7bafb2beff84010d5c77f0ee4413baa0c86456bf6db5e75'],
     }),
     ('HTML::Form', '6.03', {
         'source_tmpl': 'HTML-Form-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+        'checksums': ['68c01d94f005d5ca9c4d55ad2a1bf3a8d034a5fc6db187d91a4c42f3fdc9fc36'],
     }),
     ('File::Copy::Recursive', '0.38', {
         'source_tmpl': 'File-Copy-Recursive-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DM/DMUEY'],
+        'checksums': ['84ccbddf3894a88a2c2b6be68ff6ef8960037803bb36aa228b31944cfdf6deeb'],
     }),
     ('Number::Compare', '0.03', {
         'source_tmpl': 'Number-Compare-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RC/RCLAMP'],
+        'checksums': ['83293737e803b43112830443fb5208ec5208a2e6ea512ed54ef8e4dd2b880827'],
     }),
     ('IPC::Run', '0.94', {
         'source_tmpl': 'IPC-Run-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TODDR'],
+        'checksums': ['2eb336c91a2b7ea61f98e5b2282d91020d39a484f16041e2365ffd30f8a5605b'],
     }),
     ('HTML::Entities::Interpolate', '1.10', {
         'source_tmpl': 'HTML-Entities-Interpolate-%(version)s.tgz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE'],
+        'checksums': ['f15a9df92c282419f7010964aca1ada844ddfae7afc735cd2ba1bb20883e955c'],
     }),
     ('Test::ClassAPI', '1.06', {
         'source_tmpl': 'Test-ClassAPI-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+        'checksums': ['06f82d076501701d78b8dc40b7688507bcc6c58b1beafd559e05bb0644df00a2'],
     }),
     ('Test::Most', '0.35', {
         'source_tmpl': 'Test-Most-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/O/OV/OVID'],
+        'checksums': ['9897a6f4d751598d2ed1047e01c1554b01d0f8c96c45e7e845229782bf6f657f'],
     }),
     ('Class::Accessor', '0.34', {
         'source_tmpl': 'Class-Accessor-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/K/KA/KASEI'],
+        'checksums': ['cdb1e0cdf8380fb9b63b44c33ce5afc1068736d55ac5904bf0eaa1efc1c3cefc'],
     }),
     ('Test::Differences', '0.64', {
         'source_tmpl': 'Test-Differences-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DC/DCANTRELL'],
+        'checksums': ['9f459dd9c2302a0a73e2f5528a0ce7d09d6766f073187ae2c69e603adf2eb276'],
     }),
     ('HTTP::Tiny', '0.070', {
         'source_tmpl': 'HTTP-Tiny-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
+        'checksums': ['74f385d1e96de887a4df5a222d93afdc7d81ea9ad721a56ff3d8449bb12f7733'],
     }),
     ('Package::DeprecationManager', '0.17', {
         'source_tmpl': 'Package-DeprecationManager-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+        'checksums': ['1d743ada482b5c9871d894966e87d4c20edc96931bb949fb2638b000ddd6684b'],
     }),
     ('Digest::SHA1', '2.13', {
         'source_tmpl': 'Digest-SHA1-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+        'checksums': ['68c1dac2187421f0eb7abf71452a06f190181b8fc4b28ededf5b90296fb943cc'],
     }),
     ('Date::Language', '2.30', {
         'source_tmpl': 'TimeDate-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GB/GBARR'],
+        'checksums': ['75bd254871cb5853a6aa0403ac0be270cdd75c9d1b6639f18ecba63c15298e86'],
     }),
     ('version', '0.9917', {
         'source_tmpl': 'version-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/J/JP/JPEACOCK'],
+        'checksums': ['d9ecb20dc5d7877b1f6cb1b1d2fb4149b1b25a8ec2d5fa09f1b5fbc62668b4c6'],
     }),
     ('Sub::Uplevel', '0.2800', {
         'source_tmpl': 'Sub-Uplevel-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
+        'checksums': ['b4f3f63b80f680a421332d8851ddbe5a8e72fcaa74d5d1d98f3c8cc4a3ece293'],
     }),
     ('XML::Bare', '0.53', {
         'source_tmpl': 'XML-Bare-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/C/CO/CODECHILD'],
+        'checksums': ['865e198e98d904be1683ef5a53a4948f02dabdacde59fc554a082ffbcc5baefd'],
         'patches': ['XML-Bare-0.53_icc.patch'],
     }),
     ('Dist::CheckConflicts', '0.11', {
         'source_tmpl': 'Dist-CheckConflicts-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DO/DOY'],
+        'checksums': ['ea844b9686c94d666d9d444321d764490b2cde2f985c4165b4c2c77665caedc4'],
     }),
     ('Sub::Name', '0.21', {
         'source_tmpl': 'Sub-Name-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+        'checksums': ['bd32e9dee07047c10ae474c9f17d458b6e9885a6db69474c7a494ccc34c27117'],
     }),
     ('Time::Piece', '1.31', {
         'source_tmpl': 'Time-Piece-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ES/ESAYM'],
+        'checksums': ['05084024dc6fcec9ea5218038d1933e9c2cc5aa5f769d70404480e977cd167b9'],
     }),
     ('Digest::HMAC', '1.03', {
         'source_tmpl': 'Digest-HMAC-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+        'checksums': ['3bc72c6d3ff144d73aefb90e9a78d33612d58cf1cd1631ecfb8985ba96da4a59'],
     }),
     ('HTTP::Negotiate', '6.01', {
         'source_tmpl': 'HTTP-Negotiate-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+        'checksums': ['1c729c1ea63100e878405cda7d66f9adfd3ed4f1d6cacaca0ee9152df728e016'],
     }),
     ('MIME::Lite', '3.030', {
         'source_tmpl': 'MIME-Lite-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['8f39901bc580bc3dce69e10415305e4435ff90264c63d29f707b4566460be962'],
     }),
     ('Crypt::Rijndael', '1.13', {
         'source_tmpl': 'Crypt-Rijndael-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+        'checksums': ['cd7209a6dfe0a3dc8caffe1aa2233b0e6effec7572d76a7a93feefffe636214e'],
     }),
     ('B::Lint', '1.20', {
         'source_tmpl': 'B-Lint-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['dc49408964fd8b7963859c92e013f0b9f92f74be5a7c2a78e3996279827c10b3'],
     }),
     ('Canary::Stability', '2012', {
         'source_tmpl': 'Canary-Stability-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/ML/MLEHMANN'],
+        'checksums': ['fd240b111d834dbae9630c59b42fae2145ca35addc1965ea311edf0d07817107'],
     }),
     ('AnyEvent', '7.13', {
         'source_tmpl': 'AnyEvent-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/ML/MLEHMANN'],
+        'checksums': ['a4103f4def9687b5545b3e6be1f29a5a24b59ff9a817b1afc27fb9bc268d04ad'],
     }),
     ('Object::Accessor', '0.48', {
         'source_tmpl': 'Object-Accessor-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+        'checksums': ['76cb824a27b6b4e560409fcf6fd5b3bfbbd38b72f1f3d37ed0b54bd9c0baeade'],
     }),
     ('Data::UUID', '1.221', {
         'source_tmpl': 'Data-UUID-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['3cc7b2a3a7b74b45a059e013f7fd878078500ea4b7269036f84556b022078667'],
     }),
     ('Test::Pod', '1.51', {
         'source_tmpl': 'Test-Pod-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+        'checksums': ['c1a1d3cedf4a579e3aad89c36f9878a8542b6656dbe71f1581420f49582d7efb'],
     }),
     ('AppConfig', '1.71', {
         'source_tmpl': 'AppConfig-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/N/NE/NEILB'],
+        'checksums': ['1177027025ecb09ee64d9f9f255615c04db5e14f7536c344af632032eb887b0f'],
     }),
     ('Net::SMTP::SSL', '1.04', {
         'source_tmpl': 'Net-SMTP-SSL-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['7b29c45add19d3d5084b751f7ba89a8e40479a446ce21cfd9cc741e558332a00'],
     }),
     ('XML::Tiny', '2.06', {
         'source_tmpl': 'XML-Tiny-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DC/DCANTRELL'],
+        'checksums': ['d2ca40496b96f6ff08e4f858c3a813a081983f5b5aa6ae76357e2b9a88886eea'],
     }),
     ('HTML::Tagset', '3.20', {
         'source_tmpl': 'HTML-Tagset-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PETDANCE'],
+        'checksums': ['adb17dac9e36cd011f5243881c9739417fd102fce760f8de4e9be4c7131108e2'],
     }),
     ('HTML::Tree', '5.03', {
         'source_tmpl': 'HTML-Tree-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/C/CJ/CJM'],
+        'checksums': ['7d6d73fca622aa74855a8b088faa39454a0f91b7af83c9ec0387f01eefc2148f'],
     }),
     ('Devel::GlobalDestruction', '0.14', {
         'source_tmpl': 'Devel-GlobalDestruction-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG'],
+        'checksums': ['34b8a5f29991311468fe6913cadaba75fd5d2b0b3ee3bb41fe5b53efab9154ab'],
     }),
     ('WWW::RobotRules', '6.02', {
         'source_tmpl': 'WWW-RobotRules-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+        'checksums': ['46b502e7a288d559429891eeb5d979461dd3ecc6a5c491ead85d165b6e03a51e'],
     }),
     ('Expect', '1.33', {
         'source_tmpl': 'Expect-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/J/JA/JACOBY'],
+        'checksums': ['fddfea6980c4f6771d979472e3e084fb55ca9b92bd39ebabdb2522594bf05ff2'],
     }),
     ('Term::UI', '0.46', {
         'source_tmpl': 'Term-UI-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+        'checksums': ['91946c80d7f4aab0ca4bfedc3bbe0a75b37cab1a29bd7bca3b3b7456d417e9a6'],
     }),
     ('Net::SNMP', 'v6.0.1', {
         'source_tmpl': 'Net-SNMP-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DT/DTOWN'],
+        'checksums': ['14c37bc1cbb3f3cdc7d6c13e0f27a859f14cdcfd5ea54a0467a88bc259b0b741'],
     }),
     ('XML::SAX::Writer', '0.56', {
         'source_tmpl': 'XML-SAX-Writer-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PERIGRIN'],
+        'checksums': ['d073f7a25072c8150317b86b99d07031316a15bffab99e63e5afe591c8217d03'],
     }),
     ('Statistics::Descriptive', '3.0612', {
         'source_tmpl': 'Statistics-Descriptive-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
+        'checksums': ['772413148e5e00efb32f277c4254aa78b9112490a896208dcd0025813afdbf7a'],
     }),
     ('Class::Load', '0.23', {
         'source_tmpl': 'Class-Load-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+        'checksums': ['f2bca579e72ea96c6b1c5ebc86dfa1929062c412443277f0bc0437e50874b28f'],
     }),
     ('LWP::Simple', '6.25', {
         'source_tmpl': 'libwww-perl-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/O/OA/OALDERS'],
+        'checksums': ['49c0110ef38d27a8963a082cf61ce245447871676b85ec9f2b9b41d6c2f37f33'],
     }),
     ('Time::Piece::MySQL', '0.06', {
         'source_tmpl': 'Time-Piece-MySQL-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/K/KA/KASEI'],
+        'checksums': ['319601feec17fae344988a5ee91cfc6a0bcfe742af77dba254724c3268b2a60f'],
     }),
     ('Package::Stash::XS', '0.28', {
         'source_tmpl': 'Package-Stash-XS-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DO/DOY'],
+        'checksums': ['23d8c5c25768ef1dc0ce53b975796762df0d6e244445d06e48d794886c32d486'],
     }),
     ('GD::Graph', '1.54', {
         'source_tmpl': 'GDGraph-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RU/RUZ'],
+        'checksums': ['b96f5c10b656c17d16ab65a1777c908297b028d3b6815f6d54b2337f006bfa4f'],
     }),
     ('Set::Array', '0.30', {
         'source_tmpl': 'Set-Array-%(version)s.tgz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE'],
+        'checksums': ['d9f024c8e3637feccdebcf6479b6754b6c92f1209f567feaf0c23818af31ee3c'],
     }),
     ('boolean', '0.46', {
         'source_tmpl': 'boolean-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/I/IN/INGY'],
+        'checksums': ['95c088085c3e83bf680fe6ce16d8264ec26310490f7d1680e416ea7a118f156a'],
     }),
     ('Number::Format', '1.75', {
         'source_tmpl': 'Number-Format-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/W/WR/WRW'],
+        'checksums': ['82d659cb16461764fd44d11a9ce9e6a4f5e8767dc1069eb03467c6e55de257f3'],
     }),
     ('Data::Stag', '0.14', {
         'source_tmpl': 'Data-Stag-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/C/CM/CMUNGALL'],
+        'checksums': ['4ab122508d2fb86d171a15f4006e5cf896d5facfa65219c0b243a89906258e59'],
     }),
     ('Test::NoWarnings', '1.04', {
         'source_tmpl': 'Test-NoWarnings-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+        'checksums': ['638a57658cb119af1fe5b15e73d47c2544dcfef84af0c6b1b2e97f08202b686c'],
     }),
     ('Crypt::DES', '2.07', {
         'source_tmpl': 'Crypt-DES-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DP/DPARIS'],
+        'checksums': ['2db1ebb5837b4cb20051c0ee5b733b4453e3137df0a92306034c867621edd7e7'],
     }),
     ('Exporter', '5.72', {
         'source_tmpl': 'Exporter-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TODDR'],
+        'checksums': ['cd13b7a0e91e8505a0ce4b25f40fab2c92bb28a99ef0d03da1001d95a32f0291'],
     }),
     ('Class::Inspector', '1.31', {
         'source_tmpl': 'Class-Inspector-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/P/PL/PLICEASE'],
+        'checksums': ['065f649f1f7a676f0496c37dc155cf4812edb77bdbb0e95d28c985deff930eeb'],
     }),
     ('Parse::RecDescent', '1.967014', {
         'source_tmpl': 'Parse-RecDescent-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/J/JT/JTBRAUN'],
+        'checksums': ['7041c483431fefd08eb66944fb5f8f7fb0fc595c08b33ed2f4c7037b8acccdcd'],
     }),
     ('Carp', '1.38', {
         'source_tmpl': 'Carp-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['a5a9ce3cbb959dfefa8c2dd16552567199b286d39b0e55053ca247c038977101'],
     }),
     ('XML::XPath', '1.40', {
         'source_tmpl': 'XML-XPath-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MANWAR'],
+        'checksums': ['2bf66f51fa786e3ce9273bfac6c842d0dd8dbaf5126a7964456a4a41e802ea1e'],
     }),
     ('Capture::Tiny', '0.46', {
         'source_tmpl': 'Capture-Tiny-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
+        'checksums': ['5d7a6a830cf7f2b2960bf8b8afaac16a537ede64f3023827acea5bd24ca77015'],
     }),
     ('JSON', '2.90', {
         'source_tmpl': 'JSON-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MAKAMAKA'],
+        'checksums': ['4ddbb3cb985a79f69a34e7c26cde1c81120d03487e87366f9a119f90f7bdfe88'],
     }),
     ('Sub::Exporter', '0.987', {
         'source_tmpl': 'Sub-Exporter-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['543cb2e803ab913d44272c7da6a70bb62c19e467f3b12aaac4c9523259b083d6'],
     }),
     ('Class::Load::XS', '0.09', {
         'source_tmpl': 'Class-Load-XS-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+        'checksums': ['bbec3b916df9e48827950a297bf53ef4dd59ed6376142099504307a42b553baa'],
     }),
     ('Set::IntSpan::Fast', '1.15', {
         'source_tmpl': 'Set-IntSpan-Fast-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/A/AN/ANDYA'],
+        'checksums': ['cfb1768c24f55208e87405b17f537f0f303fa141891d0b22d509a941aa57e24e'],
     }),
     ('Sub::Exporter::Progressive', '0.001013', {
         'source_tmpl': 'Sub-Exporter-Progressive-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/F/FR/FREW'],
+        'checksums': ['d535b7954d64da1ac1305b1fadf98202769e3599376854b2ced90c382beac056'],
     }),
     ('Data::Dumper::Concise', '2.022', {
         'source_tmpl': 'Data-Dumper-Concise-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/F/FR/FREW'],
+        'checksums': ['4c0f30edf539665f708db40d085bd1c4252c8ff3bad518ef177c0a17e6ebfb7c'],
     }),
     ('File::Slurp::Tiny', '0.004', {
         'source_tmpl': 'File-Slurp-Tiny-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+        'checksums': ['452995beeabf0e923e65fdc627a725dbb12c9e10c00d8018c16d10ba62757f1e'],
     }),
     ('Algorithm::Diff', '1.1903', {
         'source_tmpl': 'Algorithm-Diff-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TY/TYEMQ'],
+        'checksums': ['30e84ac4b31d40b66293f7b1221331c5a50561a39d580d85004d9c1fff991751'],
     }),
     ('AnyData', '0.12', {
         'source_tmpl': 'AnyData-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+        'checksums': ['be6a957f04a2feba9b305536b132deceba1f455db295b221a63e75567fadbcfc'],
     }),
     ('Text::Iconv', '1.7', {
         'source_tmpl': 'Text-Iconv-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MP/MPIOTR'],
+        'checksums': ['5b80b7d5e709d34393bcba88971864a17b44a5bf0f9e4bcee383d029e7d2d5c3'],
     }),
     ('Class::Data::Inheritable', '0.08', {
         'source_tmpl': 'Class-Data-Inheritable-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TM/TMTM'],
+        'checksums': ['9967feceea15227e442ec818723163eb6d73b8947e31f16ab806f6e2391af14a'],
     }),
     ('Text::Balanced', '2.03', {
         'source_tmpl': 'Text-Balanced-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHAY'],
+        'checksums': ['057753f8f0568b53921f66a60a89c30092b73329bcc61a2c43339ab70c9792c8'],
     }),
     ('strictures', '2.000003', {
         'source_tmpl': 'strictures-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG'],
+        'checksums': ['27f8ea096a521e9754d36ea32889c2cda28346d04e3e399e7ea118d182dbaf22'],
     }),
     ('Switch', '2.17', {
         'source_tmpl': 'Switch-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/C/CH/CHORNY'],
+        'checksums': ['31354975140fe6235ac130a109496491ad33dd42f9c62189e23f49f75f936d75'],
     }),
     ('File::Which', '1.21', {
         'source_tmpl': 'File-Which-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/P/PL/PLICEASE'],
+        'checksums': ['9def5f10316bfd944e56b7f8a2501be1d44c288325309462aa9345e340854bcc'],
     }),
     ('Email::Date::Format', '1.005', {
         'source_tmpl': 'Email-Date-Format-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['579c617e303b9d874411c7b61b46b59d36f815718625074ae6832e7bb9db5104'],
     }),
     ('Error', '0.17024', {
         'source_tmpl': 'Error-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
+        'checksums': ['074db7c783a67b0667eca64a4f6a0c3de94998afc92c01d6453163eb04b9150d'],
     }),
     ('Mock::Quick', '1.111', {
         'source_tmpl': 'Mock-Quick-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+        'checksums': ['ff786008bf8c022064ececd3b7ed89c76b35e8d1eac6cf472a9f51771c1c9f2c'],
     }),
     ('Text::CSV', '1.92', {
         'source_tmpl': 'Text-CSV-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI'],
+        'checksums': ['c705804519ab5ed9bfad7767704ec7725d8eb57f7c67af855353b7708ade6585'],
     }),
     ('Test::Output', '1.031', {
         'source_tmpl': 'Test-Output-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BD/BDFOY'],
+        'checksums': ['f8b8f37185717872727d06f6c078fa77db794410faf2f6da4d37b0b7650f7ea4'],
     }),
     ('Class::DBI', 'v3.0.17', {
         'source_tmpl': 'Class-DBI-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TM/TMTM'],
+        'checksums': ['541354fe361c56850cb11261f6ca089a14573fa764792447444ff736ae626206'],
     }),
     ('List::AllUtils', '0.14', {
         'source_tmpl': 'List-AllUtils-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+        'checksums': ['e45aa65927ae1975a000cc2fed14274627fa5e2bd09bab826a5f2c41d17ef6cd'],
     }),
     ('UNIVERSAL::moniker', '0.08', {
         'source_tmpl': 'UNIVERSAL-moniker-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/K/KA/KASEI'],
+        'checksums': ['94ce27a546cd57cb52e080a8f2533a7cc2350028388582485bd1039a37871f9c'],
     }),
     ('Exception::Class', '1.42', {
         'source_tmpl': 'Exception-Class-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+        'checksums': ['8bb4ee64d3770d6812bda36890ef5df418573287eb8eccbb106f04c981dea22b'],
     }),
     ('File::CheckTree', '4.42', {
         'source_tmpl': 'File-CheckTree-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['66fb417f8ff8a5e5b7ea25606156e70e204861c59fa8c3831925b4dd3f155f8a'],
     }),
     ('Math::VecStat', '0.08', {
         'source_tmpl': 'Math-VecStat-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/A/AS/ASPINELLI'],
+        'checksums': ['409a8e0e4b1025c8e80f628f65a9778aa77ab285161406ca4a6c097b13656d0d'],
     }),
     ('Pod::LaTeX', '0.61', {
         'source_tmpl': 'Pod-LaTeX-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TJ/TJENNESS'],
+        'checksums': ['15a840ea1c8a76cd3c865fbbf2fec33b03615c0daa50f9c800c54e0cf0659d46'],
     }),
     ('Eval::Closure', '0.14', {
         'source_tmpl': 'Eval-Closure-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DO/DOY'],
+        'checksums': ['ea0944f2f5ec98d895bef6d503e6e4a376fea6383a6bc64c7670d46ff2218cad'],
     }),
     ('HTTP::Request', '6.11', {
         'source_tmpl': 'HTTP-Message-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+        'checksums': ['e7b368077ae6a188d99920411d8f52a8e5acfb39574d4f5c24f46fd22533d81b'],
     }),
     ('XML::Twig', '3.52', {
         'source_tmpl': 'XML-Twig-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MI/MIROD'],
+        'checksums': ['fef75826c24f2b877d0a0d2645212fc4fb9756ed4d2711614ac15c497e8680ad'],
     }),
     ('IO::String', '1.08', {
         'source_tmpl': 'IO-String-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+        'checksums': ['2a3f4ad8442d9070780e58ef43722d19d1ee21a803bf7c8206877a10482de5a0'],
     }),
     ('XML::Simple', '2.22', {
         'source_tmpl': 'XML-Simple-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GR/GRANTM'],
+        'checksums': ['b9450ef22ea9644ae5d6ada086dc4300fa105be050a2030ebd4efd28c198eb49'],
     }),
     ('Sub::Install', '0.928', {
         'source_tmpl': 'Sub-Install-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['61e567a7679588887b7b86d427bc476ea6d77fffe7e0d17d640f89007d98ef0f'],
     }),
     ('HTTP::Cookies', '6.03', {
         'source_tmpl': 'HTTP-Cookies-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/O/OA/OALDERS'],
+        'checksums': ['05051f2761832317554b0be4b74012c35fd278f6af2c9d218f055e0de891457c'],
     }),
     ('Pod::Plainer', '1.04', {
         'source_tmpl': 'Pod-Plainer-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RM/RMBARKER'],
+        'checksums': ['1bbfbf7d1d4871e5a83bab2137e22d089078206815190eb1d5c1260a3499456f'],
     }),
     ('Test::Exception::LessClever', '0.009', {
         'source_tmpl': 'Test-Exception-LessClever-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+        'checksums': ['3b2731a44956a11f74b46b3ecf0734fab651e1c0bcf120f8b407aa1b4d43ac34'],
     }),
     ('LWP::MediaTypes', '6.02', {
         'source_tmpl': 'LWP-MediaTypes-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+        'checksums': ['18790b0cc5f0a51468495c3847b16738f785a2d460403595001e0b932e5db676'],
     }),
     ('Scalar::Util', '1.47', {
         'source_tmpl': 'Scalar-List-Utils-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PEVANS'],
+        'checksums': ['c483347372a96972d61fd186522a9dafc2da899ef2951964513b7e8efb37efe1'],
     }),
     ('Data::Section::Simple', '0.07', {
         'source_tmpl': 'Data-Section-Simple-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA'],
+        'checksums': ['0b3035ffdb909aa1f7ded6b608fa9d894421c82c097d51e7171170d67579a9cb'],
     }),
     ('Class::Trigger', '0.14', {
         'source_tmpl': 'Class-Trigger-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA'],
+        'checksums': ['6b1e45acc561e0708e00a2fcf16e157cad8b8963d1bf73726f77dd809b8aebc4'],
     }),
     ('HTTP::Daemon', '6.01', {
         'source_tmpl': 'HTTP-Daemon-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+        'checksums': ['43fd867742701a3f9fcc7bd59838ab72c6490c0ebaf66901068ec6997514adc2'],
     }),
     ('File::HomeDir', '1.00', {
         'source_tmpl': 'File-HomeDir-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+        'checksums': ['85b94f3513093ec0a25b91f9f2571918519ae6f2b7a1e8546f8f78d09a877143'],
     }),
     ('HTTP::Date', '6.02', {
         'source_tmpl': 'HTTP-Date-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+        'checksums': ['e8b9941da0f9f0c9c01068401a5e81341f0e3707d1c754f8e11f42a7e629e333'],
     }),
     ('Authen::SASL', '2.16', {
         'source_tmpl': 'Authen-SASL-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GB/GBARR'],
+        'checksums': ['6614fa7518f094f853741b63c73f3627168c5d3aca89b1d02b1016dc32854e09'],
     }),
     ('Clone', '0.38', {
         'source_tmpl': 'Clone-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GARU'],
+        'checksums': ['9fb0534bb7ef6ca1f6cc1dc3f29750d6d424394d14c40efdc77832fad3cebde8'],
     }),
     ('Data::Types', '0.09', {
         'source_tmpl': 'Data-Types-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DW/DWHEELER'],
+        'checksums': ['b2296fdcf9addc8e8fc39e15eb2c3d81145f6355258438bc783b12b02c41cb81'],
     }),
     ('Import::Into', '1.002005', {
         'source_tmpl': 'Import-Into-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG'],
+        'checksums': ['bd9e77a3fb662b40b43b18d3280cd352edf9fad8d94283e518181cc1ce9f0567'],
     }),
     ('DateTime::Tiny', '1.06', {
         'source_tmpl': 'DateTime-Tiny-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
+        'checksums': ['bd725df481d7223ee787e154c116098b08a129f55e0763194b07ebea3dda33ec'],
     }),
     ('DBD::AnyData', '0.110', {
         'source_tmpl': 'DBD-AnyData-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+        'checksums': ['247f0d88e55076fd3f6c7bf3fd527989d62fcc1ef9bde9bf2ee11c280adcaeab'],
     }),
     ('Text::Format', '0.60', {
         'source_tmpl': 'Text-Format-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
+        'checksums': ['664f313570604624ff9e1fc9b26b6d04e06897b3e4eac83089fc0905a692a2b8'],
     }),
     ('Devel::CheckCompiler', '0.07', {
         'source_tmpl': 'Devel-CheckCompiler-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SY/SYOHEX'],
+        'checksums': ['768b7697b4b8d4d372c7507b65e9dd26aa4223f7100183bbb4d3af46d43869b5'],
     }),
     ('Log::Handler', '0.88', {
         'source_tmpl': 'Log-Handler-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BL/BLOONIX'],
+        'checksums': ['45bf540ab2138ed3ff93afc205b0516dc75755b86acdcc5e75c41347833c293d'],
     }),
     ('DBIx::ContextualFetch', '1.03', {
         'source_tmpl': 'DBIx-ContextualFetch-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TM/TMTM'],
+        'checksums': ['85e2f805bfc81cd738c294316b27a515397036f397a0ff1c6c8d754c38530306'],
     }),
     ('Devel::StackTrace', '2.02', {
         'source_tmpl': 'Devel-StackTrace-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+        'checksums': ['cbbd96db0ecf194ed140198090eaea0e327d9a378a4aa15f9a34b3138a91931f'],
     }),
     ('Term::ReadKey', '2.14', {
         'source_tmpl': 'TermReadKey-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/K/KJ/KJALB'],
+        'checksums': ['6009158cd9889f8c00da78af99847ace5052f1ca04fa30eb3411fdc26d54c9a8'],
     }),
     ('Set::IntSpan', '1.19', {
         'source_tmpl': 'Set-IntSpan-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SW/SWMCD'],
+        'checksums': ['11b7549b13ec5d87cc695dd4c777cd02983dd5fe9866012877fb530f48b3dfd0'],
     }),
     ('Moose', '2.2004', {
         'source_tmpl': 'Moose-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+        'checksums': ['e4c881bf8d8fd5821aea8a8c7c57ed850c2373d4800949798a55c06ca9e8d2b0'],
     }),
     ('Algorithm::Dependency', '1.110', {
         'source_tmpl': 'Algorithm-Dependency-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+        'checksums': ['f27733e8d89cf2ab621284c2584da90ab0cb743ba2295ee739fe51bf92561e37'],
     }),
     ('Font::TTF', '1.06', {
         'source_tmpl': 'Font-TTF-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BH/BHALLISSY'],
+        'checksums': ['4b697d444259759ea02d2c442c9bffe5ffe14c9214084a01f743693a944cc293'],
     }),
     ('IPC::Run3', '0.048', {
         'source_tmpl': 'IPC-Run3-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['3d81c3cc1b5cff69cca9361e2c6e38df0352251ae7b41e2ff3febc850e463565'],
     }),
     ('File::Find::Rule', '0.34', {
         'source_tmpl': 'File-Find-Rule-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RC/RCLAMP'],
+        'checksums': ['7e6f16cc33eb1f29ff25bee51d513f4b8a84947bbfa18edb2d3cc40a2d64cafe'],
     }),
     ('SQL::Statement', '1.410', {
         'source_tmpl': 'SQL-Statement-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+        'checksums': ['7367fcda896367c96d98416cad423c9f98adb7e04b793c5c7deb3052a1213182'],
     }),
     ('File::Slurp', '9999.19', {
         'source_tmpl': 'File-Slurp-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/U/UR/URI'],
+        'checksums': ['ce29ebe995097ebd6e9bc03284714cdfa0c46dc94f6b14a56980747ea3253643'],
     }),
     ('Package::Stash', '0.37', {
         'source_tmpl': 'Package-Stash-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DO/DOY'],
+        'checksums': ['06ab05388f9130cd377c0e1d3e3bafeed6ef6a1e22104571a9e1d7bfac787b2c'],
     }),
     ('Data::OptList', '0.110', {
         'source_tmpl': 'Data-OptList-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['366117cb2966473f2559f2f4575ff6ae69e84c69a0f30a0773e1b51a457ef5c3'],
     }),
     ('CPANPLUS', '0.9164', {
         'source_tmpl': 'CPANPLUS-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+        'checksums': ['3fcd8c7bb1973df484236fc3d59ed17c8a35057f56546ba44bfc780b97fec0a8'],
     }),
     ('IO::Tty', '1.12', {
         'source_tmpl': 'IO-Tty-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TODDR'],
+        'checksums': ['a2ef8770d3309178203f8c8ac25e623e63cf76e97830fd3be280ade1a555290d'],
     }),
     ('Text::Soundex', '3.05', {
         'source_tmpl': 'Text-Soundex-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['f6dd55b4280b25dea978221839864382560074e1d6933395faee2510c2db60ed'],
     }),
     ('Lingua::EN::PluralToSingular', '0.19', {
         'source_tmpl': 'Lingua-EN-PluralToSingular-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BK/BKB'],
+        'checksums': ['c71b6c1aec01aae9c42aef0d9f147a437e91a7cc5cea6e4abbc35440638f299e'],
     }),
     ('Want', '0.29', {
         'source_tmpl': 'Want-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RO/ROBIN'],
+        'checksums': ['b4e4740b8d4cb783591273c636bd68304892e28d89e88abf9273b1de17f552f7'],
     }),
     ('Cwd::Guard', '0.05', {
         'source_tmpl': 'Cwd-Guard-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/K/KA/KAZEBURO'],
+        'checksums': ['7afc7ca2b9502e440241938ad97a3e7ebd550180ebd6142e1db394186b268e77'],
     }),
     ('Bundle::BioPerl', '2.1.9', {
         'source_tmpl': 'Bundle-BioPerl-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS'],
+        'checksums': ['c343ba97f49d86e7fb14aef4cfe3124992e2a5c3168e53a54606dd611d73e5c7'],
     }),
     ('Mail::Util', '2.18', {
         'source_tmpl': 'MailTools-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MARKOV'],
+        'checksums': ['dfee9e770257371112f20d978e637759e81bc4f19e97b083585c71ecab37b527'],
     }),
     ('Text::Template', '1.47', {
         'source_tmpl': 'Text-Template-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSCHOUT'],
+        'checksums': ['50d742c74482478aa01008d468290fcfbc0b9a1219cfe1284076f1f31f0be8fc'],
     }),
     ('PDF::API2', '2.031', {
         'source_tmpl': 'PDF-API2-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SS/SSIMMS'],
+        'checksums': ['6ea5d38f99dfb1e8acf57c9c7579659b3eee84944295a135f90e607e0a3f43e9'],
     }),
     ('Devel::CheckLib', '1.11', {
         'source_tmpl': 'Devel-CheckLib-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MATTN'],
+        'checksums': ['bd6d1c187e80be6de1f0d37add441ba8f14950c7bc1f54e764770ed484b232c1'],
     }),
     ('SVG', '2.77', {
         'source_tmpl': 'SVG-2.77.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/M/MA/MANWAR/'],
+        'checksums': ['1f01cf2dc666a2ba3bf5219ec9e2290143e5e569747431412c8423916a9846c5'],
     }),
     ('Statistics::Basic', '1.6611', {
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
+        'checksums': ['6855ce5615fd3e1af4cfc451a9bf44ff29a3140b4e7130034f1f0af2511a94fb'],
     }),
 ]
 


### PR DESCRIPTION
An easyconfig file for Perl 5.24.1 with `foss/2017a` was added in #4973 which includes checksums, so they should be included in the existing easyconfig using `intel/2017a` as well.