### PR TITLE
remove superfluous $CPATH update in GLib 2.44.0 easyconfig

### DIFF
--- a/easybuild/easyconfigs/g/GLib/GLib-2.44.0-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.44.0-GCC-4.9.2.eb
@@ -19,6 +19,4 @@ dependencies = [
 ]
 builddependencies = [('Python', '2.7.9', '-bare')]
 
-modextrapaths = {'CPATH': ['include/glib-2.0', 'lib/glib-2.0/include']}
-
 moduleclass = 'vis'


### PR DESCRIPTION
After checking, it's not needed at all to update `$CPATH` like this for `GLib`...

(see also https://github.com/easybuilders/easybuild-easyconfigs/pull/5037/files#r134147655)

This is the only `GLib` easyconfig that includes this.