### PR TITLE
bump version for libyaml, SQLite & Tcl easyconfigs that use GCCcore/6.4.0

### DIFF
--- a/easybuild/easyconfigs/l/libyaml/libyaml-0.1.7-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libyaml/libyaml-0.1.7-GCCcore-6.4.0.eb
@@ -10,7 +10,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'libyaml'
-version = '0.1.6'
+version = '0.1.7'
 
 homepage = 'http://pyyaml.org/wiki/LibYAML'
 
@@ -20,7 +20,7 @@ toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
 source_urls = ['http://pyyaml.org/download/libyaml/']
 sources = ['yaml-%(version)s.tar.gz']
-checksums = ['7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749']
+checksums = ['8088e457264a98ba451a90b8661fcb4f9d6f478f7265d48322a196cec2480729']
 
 builddependencies = [
     ('binutils', '2.28'),

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.20.1-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.20.1-GCCcore-6.4.0.eb
@@ -13,7 +13,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'SQLite'
-version = '3.19.3'
+version = '3.20.1'
 
 homepage = 'http://www.sqlite.org/'
 
@@ -26,7 +26,7 @@ toolchainopts = {'pic': True}
 source_urls = ['http://www.sqlite.org/2017/']
 version_str = '%%(version_major)s%s00' % ''.join('%02d' % int(x) for x in version.split('.')[1:])
 sources = ['sqlite-autoconf-%s.tar.gz' % version_str]
-checksums = ['06129c03dced9f87733a8cba408871bd60673b8f93b920ba8d815efab0a06301']
+checksums = ['ec66595b29bc0798b023a5122021ea646ab4fa9e2f735937c5426feeba950742']
 
 builddependencies = [
     ('binutils', '2.28'),
@@ -34,7 +34,7 @@ builddependencies = [
 
 dependencies = [
     ('libreadline', '7.0'),
-    ('Tcl', '8.6.6'),
+    ('Tcl', '8.6.7'),
 ]
 
 parallel = 1

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.7-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.7-GCCcore-6.4.0.eb
@@ -1,7 +1,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'Tcl'
-version = '8.6.6'
+version = '8.6.7'
 
 homepage = 'http://www.tcl.tk/'
 
@@ -15,7 +15,7 @@ toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
-checksums = ['a265409781e4b3edcc4ef822533071b34c3dc6790b893963809b9fe221befe07']
+checksums = ['7c6b8f84e37332423cfe5bae503440d88450da8cc1243496249faa5268026ba5']
 
 builddependencies = [
     ('binutils', '2.28'),


### PR DESCRIPTION
follow-up for #5073, fleshed out from #5072