### PR TITLE
add check to see whether binutils is included as build dep when GCCore toolchain is used

### DIFF
--- a/easybuild/easyconfigs/b/BWA/BWA-0.7.15-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.7.15-GCCcore-5.4.0.eb
@@ -23,4 +23,6 @@ toolchainopts = {'pic': True}
 sources = ['v%(version)s.tar.gz']
 source_urls = ['https://github.com/lh3/%(name)s/archive/']
 
+builddependencies = [('binutils', '2.26')]
+
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/Bowtie/Bowtie-1.1.2-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/b/Bowtie/Bowtie-1.1.2-GCCcore-5.4.0.eb
@@ -15,4 +15,6 @@ toolchainopts = {'pic': True}
 sources = ['%(namelower)s-%(version)s-src.zip']
 source_urls = ['http://download.sourceforge.net/bowtie-bio/']
 
+builddependencies = [('binutils', '2.26')]
+
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/Bowtie/Bowtie-1.1.2-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/b/Bowtie/Bowtie-1.1.2-GCCcore-6.3.0.eb
@@ -16,4 +16,6 @@ sources = ['%(namelower)s-%(version)s-src.zip']
 source_urls = ['http://download.sourceforge.net/bowtie-bio/']
 checksums = ['b1e9ccc825207efd1893d9e33244c681bcb89b9b2b811eb95a9f5a92eab637ae']
 
+builddependencies = [('binutils', '2.27')]
+
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-GCCcore-5.4.0.eb
@@ -11,6 +11,7 @@ sources = ['%(namelower)s-%(version)s.src.tar.gz']
 source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
 
 builddependencies = [
+    ('binutils', '2.26'),
     ('CMake', '3.7.1'),
     ('flex', '2.6.0'),
     ('Bison', '3.0.4'),

--- a/easybuild/easyconfigs/g/gSOAP/gSOAP-2.8.48-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/g/gSOAP/gSOAP-2.8.48-GCCcore-6.3.0.eb
@@ -19,6 +19,7 @@ sources = ['%(namelower)s_%(version)s.zip']
 source_urls = ['https://downloads.sourceforge.net/project/gsoap%(version_major)s/gsoap-%(version_major_minor)s/']
 
 builddependencies = [
+    ('binutils', '2.27'),
     ('Bison', '3.0.4'),
     ('flex', '2.6.3'),
 ]

--- a/easybuild/easyconfigs/g/gzip/gzip-1.8-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/g/gzip/gzip-1.8-GCCcore-6.4.0.eb
@@ -16,6 +16,8 @@ source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['1ff7aedb3d66a0d73f442f6261e4b3860df6fd6c94025c2cb31a202c9c60fe0e']
 
+builddependencies = [('binutils', '2.28')]
+
 sanity_check_paths = {
     'files': ["bin/gunzip", "bin/gzip", "bin/uncompress"],
     'dirs': [],

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.0-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.0-GCCcore-4.9.3.eb
@@ -10,7 +10,7 @@ toolchainopts = {'pic': True}
 source_urls = ['http://www.cpan.org/src/%(version_major)s.0']
 sources = [SOURCELOWER_TAR_GZ]
 
-dependencies = [('binutils', '2.25')]
+builddependencies = [('binutils', '2.25')]
 
 exts_list = [
     ('Config::General', '2.61', {

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -249,6 +249,17 @@ def template_easyconfig_test(self, spec):
     for old_url in old_urls:
         self.assertFalse(old_url in ec.rawtxt, "Old URL '%s' not found in %s" % (old_url, spec))
 
+    # make sure binutils is included as a build dep if toolchain is GCCcore
+    if ec['toolchain']['name'] == 'GCCcore':
+        # with 'Tarball' easyblock: only unpacking, no building; Eigen is also just a tarball
+        requires_binutils = ec['easyblock'] not in ['Tarball'] and ec['name'] not in ['Eigen']
+        # if no sources/extensions/components are specified, it's just a bundle (nothing is being compiled)
+        requires_binutils &= bool(ec['sources'] or ec['exts_list'] or ec.get('components'))
+
+        if requires_binutils:
+            dep_names = [d['name'] for d in ec['builddependencies']]
+            self.assertTrue('binutils' in dep_names, "binutils is a build dep in %s: %s" % (spec, dep_names))
+
     # make sure all patch files are available
     specdir = os.path.dirname(spec)
     specfn = os.path.basename(spec)


### PR DESCRIPTION
I've been bitten by forgetting to include `binutils` as a build dep a couple of times, leading to rather obscure build errors sometimes. This should hopefully help...