### PR TITLE
Texlive 20170524

### DIFF
--- a/easybuild/easyconfigs/t/texlive/texlive-20170524-foss-2016b.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20170524-foss-2016b.eb
@@ -1,0 +1,71 @@
+# Easybuild easyconfig
+#
+# John Dey jfdey@fredhutch.org
+#
+# TexLive 2017
+# Net Install for texlive requires a configuration file named: texlive.profile
+# texlive.profile needs to be located in the current working directory
+# where eb is run.  Cut/Paste and uncomment the following section to create
+# the texlive.profile
+#
+# BEGIN texlive.profile
+#TEXDIR         $EBROOTTEXLIVE/texlive/2017
+#TEXMFLOCAL     $EBROOTTEXLIVE/texlive/texmf-local
+#TEXMFSYSCONFIG $EBROOTTEXLIVE/texlive/2017/texmf-config
+#TEXMFSYSVAR    $EBROOTTEXLIVE/texlive/2017/texmf-var
+# END texlive.profile
+
+easyblock = 'Tarball'
+
+name = 'texlive'
+version = '20170524'
+
+homepage = 'http://tug.org'
+description = """TeX is a typesetting language. Instead of visually
+formatting your text, you enter your manuscript text intertwined with TeX
+commands in a plain text file. You then run TeX to produce formatted output,
+such as a PDF file. Thus, in contrast to standard word processors, your
+document is a separate file that does not pretend to be a representation
+of the final typeset output, and so can be easily edited and manipulated."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+
+source_urls = ['ftp://tug.org/texlive/historic/2017/']
+sources = ['install-tl-unx.tar.gz']
+
+dependencies = [
+    ('X11', '20160819'),
+    ('libpng', '1.6.24'),
+    ('libGLU', '9.0.0'),
+    ('Perl', '5.24.1'),
+    ('HarfBuzz', '1.3.1'), 
+    ('poppler', '0.54.0'),
+    ('cairo', '1.14.6'),
+    ('fontconfig', '2.12.1'),
+    ('zlib', '1.2.8'),
+    ('graphite2', '1.3.10'),
+]
+
+postinstallcmds = ['%(builddir)s/install-tl-%(version)s/install-tl \
+                   -profile /app/easybuild/fh_easyconfigs/texlive.profile']
+
+modextrapaths = {
+    'PATH': 'texlive/2017/bin/x86_64-linux',
+    'INFOPATH': 'texlive/2017/texmf-dist/doc/info',
+    'MANPATH': 'texlive/2017/texmf-dist/doc/man',
+}
+modextravars = {
+    'TEXMFHOME': '%(installdir)s/texlive/2017/texmf-dist'
+}
+
+sanity_check_paths = {
+    'dirs': ['texlive/2017/bin/x86_64-linux',
+             'texlive/2017/texmf-dist',
+             ],
+    'files': [
+       'texlive/2017/bin/x86_64-linux/tex',
+       'texlive/2017/bin/x86_64-linux/latex'
+    ],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/texlive/texlive.profile
+++ b/easybuild/easyconfigs/t/texlive/texlive.profile
@@ -1,0 +1,11 @@
+# NOTE: This file must be updated by hand before texlive can be installed.
+# Update Environment paths to be compatible with your local easybuild software environment.
+#
+# Texlive install script will not interpolate this file.
+# Substitue $EBROOTTEXLIVE with the actaul value for your site.
+#
+# This file needs to be updated for different versions of texlive
+TEXDIR         $EBROOTTEXLIVE/texlive/2017
+TEXMFLOCAL     $EBROOTTEXLIVE/texlive/texmf-local
+TEXMFSYSCONFIG $EBROOTTEXLIVE/texlive/2017/texmf-config
+TEXMFSYSVAR    $EBROOTTEXLIVE/texlive/2017/texmf-var


### PR DESCRIPTION
texlive is very ugly.  The easyconfig is not self-contained and requires a small config file for the texlive installer script.  The config file if performing the equivalent of --prefix.  This will break with Jenkins. 