### PR TITLE
Version 1.47 of Stacks using the foss-2016a toolchain.

### DIFF
--- a/easybuild/easyconfigs/s/Stacks/Stacks-1.47-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/Stacks/Stacks-1.47-foss-2016a.eb
@@ -24,7 +24,7 @@ sanity_check_paths = {
     'files': [
         'bin/%s' % binfile for binfile in [
             'clone_filter', 'denovo_map.pl', 'exec_velvet.pl', 'genotypes', 'index_radtags.pl', 'load_radtags.pl',
-            'populations', 'process_shortreads', 'ref_map.pl', 'sstacks', 'ustacks', 'cstacks', 
+            'populations', 'process_shortreads', 'ref_map.pl', 'sstacks', 'ustacks', 'cstacks',
             'export_sql.pl', 'kmer_filter', 'load_sequences.pl', 'process_radtags', 'pstacks',
             'sort_read_pairs.pl', 'stacks_export_notify.pl',
         ]

--- a/easybuild/easyconfigs/s/Stacks/Stacks-1.47-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/Stacks/Stacks-1.47-foss-2016a.eb
@@ -1,0 +1,35 @@
+easyblock = 'ConfigureMake'
+
+name = 'Stacks'
+version = '1.47'
+
+homepage = 'http://creskolab.uoregon.edu/stacks/'
+description = """Stacks is a software pipeline for building loci from short-read sequences, such as those generated on
+ the Illumina platform. Stacks was developed to work with restriction enzyme-based data, such as RAD-seq,
+ for the purpose of building genetic maps and conducting population genomics and phylogeography.
+"""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['http://catchenlab.life.illinois.edu/stacks/source/']
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('zlib', '1.2.8'),
+    ('SAMtools', '1.3.1'),
+    ('sparsehash', '2.0.2'),
+]
+
+sanity_check_paths = {
+    'files': [
+        'bin/%s' % binfile for binfile in [
+            'clone_filter', 'denovo_map.pl', 'exec_velvet.pl', 'genotypes', 'index_radtags.pl', 'load_radtags.pl',
+            'populations', 'process_shortreads', 'ref_map.pl', 'sstacks', 'ustacks', 'cstacks', 
+            'export_sql.pl', 'kmer_filter', 'load_sequences.pl', 'process_radtags', 'pstacks',
+            'sort_read_pairs.pl', 'stacks_export_notify.pl',
+        ]
+    ],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
Version 1.47 of Stacks using the foss-2016a toolchain. hstacks and estacks are no longer included in this version.