### PR TITLE
clean up use of wcleanAll in OpenFOAM-Extend easyconfigs, now handled by OpenFOAM easyblock

### DIFF
--- a/easybuild/easyconfigs/o/OpenFOAM-Extend/OpenFOAM-Extend-3.0-goolf-1.4.10-20140227.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM-Extend/OpenFOAM-Extend-3.0-goolf-1.4.10-20140227.eb
@@ -38,8 +38,6 @@ builddependencies = [
     ('CMake', '2.8.12'),
 ]
 
-prebuildopts = "(wcleanAll || echo 'all is fine') && "  # clean up everything first (and ignore any errors)
-
 # too many builds in parallel actually slows down the build
 maxparallel = 4
 

--- a/easybuild/easyconfigs/o/OpenFOAM-Extend/OpenFOAM-Extend-3.1-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM-Extend/OpenFOAM-Extend-3.1-gimkl-2.11.5.eb
@@ -40,8 +40,6 @@ builddependencies = [
 
 ]
 
-prebuildopts = "(wcleanAll || echo 'all is fine') && "  # clean up everything first (and ignore any errors)
-
 # too many builds in parallel actually slows down the build
 maxparallel = 4
 

--- a/easybuild/easyconfigs/o/OpenFOAM-Extend/OpenFOAM-Extend-3.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM-Extend/OpenFOAM-Extend-3.1-goolf-1.4.10.eb
@@ -38,8 +38,6 @@ builddependencies = [
     ('CMake', '2.8.12'),
 ]
 
-prebuildopts = "(wcleanAll || echo 'all is fine') && "  # clean up everything first (and ignore any errors)
-
 # too many builds in parallel actually slows down the build
 maxparallel = 4
 

--- a/easybuild/easyconfigs/o/OpenFOAM-Extend/OpenFOAM-Extend-3.2-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM-Extend/OpenFOAM-Extend-3.2-gimkl-2.11.5.eb
@@ -40,8 +40,6 @@ builddependencies = [
     ('CMake', '3.3.2'),
 ]
 
-prebuildopts = "(wcleanAll || echo 'all is fine') && "  # clean up everything first (and ignore any errors)
-
 # too many builds in parallel actually slows down the build
 maxparallel = 4
 

--- a/easybuild/easyconfigs/o/OpenFOAM-Extend/OpenFOAM-Extend-3.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM-Extend/OpenFOAM-Extend-3.2-intel-2016a.eb
@@ -40,8 +40,6 @@ builddependencies = [
     ('CMake', '3.5.2'),
 ]
 
-prebuildopts = "(wcleanAll || echo 'all is fine') && "  # clean up everything first (and ignore any errors)
-
 # too many builds in parallel actually slows down the build
 maxparallel = 4
 


### PR DESCRIPTION
see recently merged changes to OpenFOAM easyblock in https://github.com/easybuilders/easybuild-easyblocks/pull/780