### PR TITLE
also consider rdma-core-devel as alternative to libibverbs-devel OS dependency

### DIFF
--- a/easybuild/easyconfigs/g/GlobalArrays/GlobalArrays-5.3-intel-2015a-openib.eb
+++ b/easybuild/easyconfigs/g/GlobalArrays/GlobalArrays-5.3-intel-2015a-openib.eb
@@ -13,7 +13,7 @@ toolchainopts = {'usempi': True}
 source_urls = ['http://hpc.pnl.gov/globalarrays/download/']
 sources = ['ga-%(version_major)s-%(version_minor)s.tgz']
 
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 configopts = '--with-openib'
 configopts += ' --with-blas8="-L$BLAS_LIB_DIR $LIBBLAS" --with-lapack="-L$LAPACK_LIB_DIR $LIBLAPACK"'

--- a/easybuild/easyconfigs/g/GlobalArrays/GlobalArrays-5.4b-foss-2015a-openib.eb
+++ b/easybuild/easyconfigs/g/GlobalArrays/GlobalArrays-5.4b-foss-2015a-openib.eb
@@ -13,7 +13,7 @@ toolchainopts = {'usempi': True}
 source_urls = ['http://hpc.pnl.gov/globalarrays/download/']
 sources = ['ga-%s.tgz' % version.replace(".", "-")]
 
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 configopts = '--with-openib'
 configopts += ' --with-blas8="-L$BLAS_LIB_DIR $LIBBLAS" --with-lapack="-L$LAPACK_LIB_DIR $LIBLAPACK"'

--- a/easybuild/easyconfigs/n/NWChem/NWChem-6.6.revision27746-intel-2017a-2015-10-20-patches-20170814-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/n/NWChem/NWChem-6.6.revision27746-intel-2017a-2015-10-20-patches-20170814-Python-2.7.13.eb
@@ -79,7 +79,7 @@ dependencies = [('Python', '2.7.13')]
 # This easyconfig is using the default for armci_network (OPENIB) and
 # thus needs infiniband libraries.
 osdependencies = [
-    ('libibverbs-dev', 'libibverbs-devel'),
+    ('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel'),
     ('libibumad-dev', 'libibumad-devel'),
 ]
 

--- a/easybuild/easyconfigs/n/NWChem/NWChem-6.6.revision27746-iomkl-2017a-2015-10-20-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/n/NWChem/NWChem-6.6.revision27746-iomkl-2017a-2015-10-20-Python-2.7.12.eb
@@ -27,7 +27,7 @@ dependencies = [('Python', '2.7.12')]
 # This easyconfig is using the default for armci_network (OPENIB) and
 # thus needs infiniband libraries.
 osdependencies = [
-    ('libibverbs-dev', 'libibverbs-devel'),
+    ('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel'),
     ('libibumad-dev', 'libibumad-devel'),
 ]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.1-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.1-GCC-4.9.3-2.25.eb
@@ -19,7 +19,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-4.9.3-2.25.eb
@@ -19,7 +19,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-5.3.0-2.26.eb
@@ -19,7 +19,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-6.1.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-6.1.0-2.27.eb
@@ -20,7 +20,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.3-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.3-GCC-4.9.3-2.25.eb
@@ -20,7 +20,7 @@ configopts += '--with-cxxrtlib="-lgcc_s -lstdc++"'  # for vt-mpi-unify
 dependencies = [('hwloc', '1.11.3')]
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.4-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.4-GCC-5.3.0-2.26.eb
@@ -20,7 +20,7 @@ configopts += '--with-cxxrtlib="-lgcc_s -lstdc++"'  # for vt-mpi-unify
 dependencies = [('hwloc', '1.11.3')]
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-5.4.0-2.26.eb
@@ -19,7 +19,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-6.1.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-6.1.0-2.27.eb
@@ -20,7 +20,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-gcccuda-2016.08.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-gcccuda-2016.08.eb
@@ -19,7 +19,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--with-cuda=$CUDA_HOME '             # CUDA-aware build; N.B. --disable-dlopen is incompatible
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -20,7 +20,7 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 dependencies = [('hwloc', '1.11.3')]
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-PGI-16.7-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-PGI-16.7-GCC-5.4.0-2.26.eb
@@ -22,7 +22,7 @@ configopts += '--with-cxxrtlib="-lgcc_s -lstdc++"'  # for vt-mpi-unify
 dependencies = [('hwloc', '1.11.4')]
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -20,7 +20,7 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 dependencies = [('hwloc', '1.11.3')]
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3.eb
@@ -15,7 +15,7 @@ configopts = '--with-threads=posix --enable-shared --enable-mpi-threads --with-o
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 
 # needed for --with-openib
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mca_common_sm", "mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "open-pal", "open-rte"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-ictce-5.5.0.eb
@@ -24,7 +24,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-openib
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "open-pal", "open-rte"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.6.4.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.6.4.eb
@@ -19,7 +19,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-openib
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2.eb
@@ -19,7 +19,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-openib
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.7.2.eb
@@ -22,7 +22,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-openib
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.1.eb
@@ -20,7 +20,7 @@ configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in 
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-openib
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.2.eb
@@ -23,7 +23,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '
 dependencies = [('hwloc', '1.8.1')]
 
 # needed for --with-openib
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.3.eb
@@ -23,7 +23,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '
 dependencies = [('hwloc', '1.8.1')]
 
 # needed for --with-openib
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.2.144.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.2.144.eb
@@ -18,7 +18,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 dependencies = [('hwloc', '1.8.1')]
 
 # needed for --with-openib
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.4.211.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.4.211.eb
@@ -18,7 +18,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 dependencies = [('hwloc', '1.9')]
 
 # needed for --with-openib
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-GCC-4.8.2.eb
@@ -21,7 +21,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.1-GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.1-GCC-4.8.3.eb
@@ -19,7 +19,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-GCC-4.9.2.eb
@@ -19,7 +19,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-iccifort-2013_sp1.4.211.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-iccifort-2013_sp1.4.211.eb
@@ -19,7 +19,7 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 dependencies = [('hwloc', '1.9')]
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.8.4.eb
@@ -19,7 +19,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.9.2.eb
@@ -19,7 +19,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.1.133-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.1.133-GCC-4.9.2.eb
@@ -20,7 +20,7 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 dependencies = [('hwloc', '1.10.0')]
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.2.164-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.2.164-GCC-4.9.2.eb
@@ -20,7 +20,7 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 dependencies = [('hwloc', '1.10.0')]
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.5-GNU-4.9.2-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.5-GNU-4.9.2-2.25.eb
@@ -19,7 +19,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.6-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.6-GNU-4.9.3-2.25.eb
@@ -19,7 +19,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.8-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.8-GNU-4.9.3-2.25.eb
@@ -19,7 +19,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.8-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.8-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
@@ -20,7 +20,7 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 dependencies = [('hwloc', '1.11.1')]
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.0-GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.0-GCC-5.2.0.eb
@@ -20,7 +20,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 # VampirTrace is no longer used : https://www.open-mpi.org/community/lists/announce/2016/07/0085.php
 libs = ["mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
@@ -20,7 +20,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-gcccuda-2016.10.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-gcccuda-2016.10.eb
@@ -20,7 +20,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--with-cuda=$CUDA_HOME '             # CUDA-aware build; N.B. --disable-dlopen is incompatible
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-iccifort-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-iccifort-2017.1.132-GCC-5.4.0-2.26.eb
@@ -20,7 +20,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27.eb
@@ -21,7 +21,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-gcccuda-2017.01.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-gcccuda-2017.01.eb
@@ -21,7 +21,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--with-cuda=$CUDA_HOME '             # CUDA-aware build; N.B. --disable-dlopen is incompatible
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-iccifort-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-iccifort-2017.1.132-GCC-6.3.0-2.27.eb
@@ -20,7 +20,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.0-GCC-6.3.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.0-GCC-6.3.0-2.28.eb
@@ -21,7 +21,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-GCC-6.4.0-2.28.eb
@@ -23,7 +23,7 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 # configopts += '--with-slurm --with-pmi=/usr/include/slurm --with-pmi-libdir=/usr'
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-iccifort-2017.4.196-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-iccifort-2017.4.196-GCC-6.4.0-2.28.eb
@@ -22,7 +22,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 libs = ["mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]
 sanity_check_paths = {


### PR DESCRIPTION
fix for https://github.com/easybuilders/easybuild/issues/378

`libibverbs-devel` was replaced by `rdma-core-devel` in recent CentOS & co versions, so the `rpm -q libibverbs-devel` check fails