### PR TITLE
consistently use empty toolchain version in icc easyconfigs to ensure that GCC(core) dep is loaded during installation

### DIFF
--- a/easybuild/easyconfigs/i/icc/icc-11.1.073-32bit.eb
+++ b/easybuild/easyconfigs/i/icc/icc-11.1.073-32bit.eb
@@ -5,7 +5,7 @@ versionsuffix = '-32bit'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_cproc_p_%s.tgz' % version]
 

--- a/easybuild/easyconfigs/i/icc/icc-11.1.073.eb
+++ b/easybuild/easyconfigs/i/icc/icc-11.1.073.eb
@@ -4,7 +4,7 @@ version = '11.1.073'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_cproc_p_%s.tgz' % version]
 

--- a/easybuild/easyconfigs/i/icc/icc-11.1.075.eb
+++ b/easybuild/easyconfigs/i/icc/icc-11.1.075.eb
@@ -4,7 +4,7 @@ version = '11.1.075'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_cproc_p_%s_intel64.tgz' % version]
 

--- a/easybuild/easyconfigs/i/icc/icc-2011.10.319.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2011.10.319.eb
@@ -4,7 +4,7 @@ version = '2011.10.319'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_intel64_%s.tgz' % version]
 

--- a/easybuild/easyconfigs/i/icc/icc-2011.13.367.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2011.13.367.eb
@@ -4,7 +4,7 @@ version = '2011.13.367'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%s.tgz' % version]
 

--- a/easybuild/easyconfigs/i/icc/icc-2011.3.174.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2011.3.174.eb
@@ -4,7 +4,7 @@ version = '2011.3.174'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_intel64_%s.tgz' % version]
 

--- a/easybuild/easyconfigs/i/icc/icc-2011.6.233.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2011.6.233.eb
@@ -4,7 +4,7 @@ version = '2011.6.233'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_intel64_%s.tgz' % version]
 

--- a/easybuild/easyconfigs/i/icc/icc-2013.1.117.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2013.1.117.eb
@@ -4,7 +4,7 @@ version = '2013.1.117'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%s.tgz' % version]
 

--- a/easybuild/easyconfigs/i/icc/icc-2013.2.146.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2013.2.146.eb
@@ -4,7 +4,7 @@ version = '2013.2.146'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%s.tgz' % version]
 

--- a/easybuild/easyconfigs/i/icc/icc-2013.3.163.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2013.3.163.eb
@@ -4,7 +4,7 @@ version = '2013.3.163'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%s.tgz' % version]
 

--- a/easybuild/easyconfigs/i/icc/icc-2013.4.183.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2013.4.183.eb
@@ -4,7 +4,7 @@ version = '2013.4.183'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2013.5.192.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2013.5.192.eb
@@ -4,7 +4,7 @@ version = '2013.5.192'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2013_sp1.0.080.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2013_sp1.0.080.eb
@@ -4,7 +4,7 @@ version = '2013_sp1.0.080'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2013_sp1.1.106.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2013_sp1.1.106.eb
@@ -4,7 +4,7 @@ version = '2013_sp1.1.106'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2013_sp1.2.144.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2013_sp1.2.144.eb
@@ -4,7 +4,7 @@ version = '2013_sp1.2.144'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2013_sp1.3.174.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2013_sp1.3.174.eb
@@ -4,7 +4,7 @@ version = '2013_sp1.3.174'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2013_sp1.4.211.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2013_sp1.4.211.eb
@@ -5,7 +5,7 @@ version = '2013_sp1.4.211'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2015.0.090.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2015.0.090.eb
@@ -4,7 +4,7 @@ version = '2015.0.090'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2015.1.133.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2015.1.133.eb
@@ -4,7 +4,7 @@ version = '2015.1.133'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2015.3.187.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2015.3.187.eb
@@ -4,7 +4,7 @@ version = '2015.3.187'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
@@ -6,7 +6,7 @@ version = '2016.0.109'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-4.9.3-2.25.eb
@@ -6,7 +6,7 @@ version = '2016.2.181'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_update%(version_minor)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-5.3.0-2.26.eb
@@ -6,7 +6,7 @@ version = '2016.2.181'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_update%(version_minor)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-4.9.3-2.25.eb
@@ -6,7 +6,7 @@ version = '2016.3.210'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_update%(version_minor)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.3.0-2.26.eb
@@ -6,7 +6,7 @@ version = '2016.3.210'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_update%(version_minor)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.4.0-2.26.eb
@@ -6,7 +6,7 @@ version = '2016.3.210'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_update%(version_minor)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.0.098-GCC-5.4.0-2.26.eb
@@ -6,7 +6,7 @@ version = '2017.0.098'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-5.4.0-2.26.eb
@@ -6,7 +6,7 @@ version = '2017.1.132'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_composer_edition_for_cpp.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-6.3.0-2.27.eb
@@ -6,7 +6,7 @@ version = '2017.1.132'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_composer_edition_for_cpp.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2017.2.174-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.2.174-GCC-6.3.0-2.27.eb
@@ -6,7 +6,7 @@ version = '2017.2.174'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_composer_edition_for_cpp.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2017.4.196-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.4.196-GCC-6.4.0-2.28.eb
@@ -6,7 +6,7 @@ version = '2017.4.196'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "Intel C and C++ compilers"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_composer_edition_for_cpp.tgz']
 


### PR DESCRIPTION
The GCCcore module on top of which `icc` is often installed is not loaded when `'dummy'` is used as version, which affects the outcome of `gcc -print-multiarch`, see https://github.com/easybuilders/easybuild-easyblocks/pull/1237 and https://github.com/easybuilders/easybuild-easyblocks/pull/1249.