### PR TITLE
{lang} [intel/2016b] PyCUDA/2016.1.2 (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/p/PyCUDA/PyCUDA-2016.1.2-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/p/PyCUDA/PyCUDA-2016.1.2-intel-2016b-Python-2.7.12.eb
@@ -1,0 +1,31 @@
+easyblock = 'PythonPackage'
+
+name = 'PyCUDA'
+version = '2016.1.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://mathema.tician.de/software/pycuda'
+description = """PyCUDA lets you access Nvidia’s CUDA parallel computation API from Python."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+
+source_urls = [PYPI_LOWER_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('Python', '2.7.12'),
+    ('CUDA', '8.0.61', '', True),
+    ('Boost', '1.61.0', versionsuffix),
+]
+
+prebuildopts = "./configure.py --cuda-root=$EBROOTCUDA --boost-inc-dir=$EBROOTBOOST/include/boost/ "
+prebuildopts += "--boost-lib-dir=$EBROOTBOOST/lib/ --no-use-shipped-boost --boost-python-libname=boost_python && "
+
+options = {'modulename': '%(namelower)s'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'lang'


### PR DESCRIPTION
This version does not work:
PyCUDA-2016.1.2-intel-2017a-Python-2.7.13.eb