### PR TITLE
Updated checksum for the OpenFOAM 4.1 tarball. Apparently, it changed…

### DIFF
--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-4.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-4.1-foss-2016b.eb
@@ -13,7 +13,7 @@ toolchainopts = {'cstd': 'c++11'}
 source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version_major)s.x/archive']
 sources = ['version-%(version)s.tar.gz']
 
-checksums = ['318a446c4ae6366c7296b61184acd37c']
+checksums = ['afd7d8e66e7db0ffaf519b14f1a8e1d4']
 
 patches = ['OpenFOAM-%(version)s-cleanup.patch']
 

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-4.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-4.1-intel-2017a.eb
@@ -13,7 +13,7 @@ toolchainopts = {'cstd': 'c++11'}
 source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version_major)s.x/archive']
 sources = ['version-%(version)s.tar.gz']
 
-checksums = ['318a446c4ae6366c7296b61184acd37c']
+checksums = ['afd7d8e66e7db0ffaf519b14f1a8e1d4']
 
 patches = ['OpenFOAM-%(version)s-cleanup.patch']
 


### PR DESCRIPTION
… due to a change to file headers imposed by GitHub.