### PR TITLE
BUG: add missing libpng dependency to g2lib-1.4.0 for intel-2017a

### DIFF
--- a/easybuild/easyconfigs/g/g2clib/g2clib-1.6.0-intel-2017a.eb
+++ b/easybuild/easyconfigs/g/g2clib/g2clib-1.6.0-intel-2017a.eb
@@ -9,8 +9,10 @@ toolchain = {'name': 'intel', 'version': '2017a'}
 source_urls = [homepage]
 sources = ['%(name)s-%(version)s.tar']
 
-dependencies = [('JasPer', '1.900.1'),
-                ('libpng', '1.6.29'),]
+dependencies = [
+    ('JasPer', '1.900.1'),
+    ('libpng', '1.6.29'),
+]
 
 # parallel build tends to fail
 parallel = 1

--- a/easybuild/easyconfigs/g/g2clib/g2clib-1.6.0-intel-2017a.eb
+++ b/easybuild/easyconfigs/g/g2clib/g2clib-1.6.0-intel-2017a.eb
@@ -9,7 +9,8 @@ toolchain = {'name': 'intel', 'version': '2017a'}
 source_urls = [homepage]
 sources = ['%(name)s-%(version)s.tar']
 
-dependencies = [('JasPer', '1.900.1')]
+dependencies = [('JasPer', '1.900.1'),
+                ('libpng', '1.6.29'),]
 
 # parallel build tends to fail
 parallel = 1

--- a/easybuild/easyconfigs/g/g2lib/g2lib-1.4.0-intel-2017a.eb
+++ b/easybuild/easyconfigs/g/g2lib/g2lib-1.4.0-intel-2017a.eb
@@ -11,7 +11,8 @@ sources = ['%(name)s-%(version)s.tar']
 
 patches = ['fix_makefile.patch']
 
-dependencies = [('JasPer', '1.900.1')]
+dependencies = [('JasPer', '1.900.1'),
+                ('libpng', '1.6.29'),]
 
 buildopts = 'CFLAGS="$CFLAGS -DLINUXG95 -D__64BIT__" FFLAGS="$FFLAGS -fpp -I."'
 

--- a/easybuild/easyconfigs/g/g2lib/g2lib-1.4.0-intel-2017a.eb
+++ b/easybuild/easyconfigs/g/g2lib/g2lib-1.4.0-intel-2017a.eb
@@ -11,8 +11,10 @@ sources = ['%(name)s-%(version)s.tar']
 
 patches = ['fix_makefile.patch']
 
-dependencies = [('JasPer', '1.900.1'),
-                ('libpng', '1.6.29'),]
+dependencies = [
+    ('JasPer', '1.900.1'),
+    ('libpng', '1.6.29'),
+]
 
 buildopts = 'CFLAGS="$CFLAGS -DLINUXG95 -D__64BIT__" FFLAGS="$FFLAGS -fpp -I."'
 


### PR DESCRIPTION
When trying to build g2lib-1.4.0-intel-2017a, I got an error about `png.h` not being found. With this fix, the build succeeds.