### PR TITLE
fix source_urls for Szip 2.1 & include SHA256 checksum

### DIFF
--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-CrayGNU-2015.06.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-CrayGNU-2015.06.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'CrayGNU', 'version': '2015.06'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-CrayGNU-2015.11.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'CrayGNU', 'version': '2015.11'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-GCC-4.8.1.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'GCC', 'version': '4.8.1'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-GCCcore-5.4.0.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'GCCcore', 'version': '5.4.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-foss-2014b.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-foss-2014b.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'foss', 'version': '2014b'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-foss-2015a.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'foss', 'version': '2015a'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-foss-2015b.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'foss', 'version': '2015b'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-foss-2016a.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'foss', 'version': '2016a'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-foss-2016b.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'foss', 'version': '2016b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-foss-2017a.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-foss-2017a.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'foss', 'version': '2017a'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-gimkl-2.11.5.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'gimkl', 'version': '2.11.5'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-gimkl-2017a.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-gimkl-2017a.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'gimkl', 'version': '2017a'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-goolf-1.4.10.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-goolf-1.5.14.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'goolf', 'version': '1.5.14'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-goolf-1.5.16.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-goolf-1.5.16.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'goolf', 'version': '1.5.16'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-goolfc-2016.10.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-goolfc-2016.10.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'goolfc', 'version': '2016.10'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-ictce-5.2.0.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'ictce', 'version': '5.2.0'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-ictce-5.3.0.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-ictce-5.4.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-ictce-5.4.0.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'ictce', 'version': '5.4.0'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-ictce-5.5.0.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-ictce-6.1.5.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-ictce-6.1.5.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'ictce', 'version': '6.1.5'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-ictce-7.1.2.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'ictce', 'version': '7.1.2'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2014b.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'intel', 'version': '2014b'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2015a.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'intel', 'version': '2015a'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2015b.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'intel', 'version': '2015b'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2016.02-GCC-4.9.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2016a.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'intel', 'version': '2016a'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2016b.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2016b.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'intel', 'version': '2016b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2017.01.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2017.01.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'intel', 'version': '2017.01'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-intel-2017a.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'intel', 'version': '2017a'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-iomkl-2016.07.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-iomkl-2016.07.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'iomkl', 'version': '2016.07'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -9,8 +9,9 @@ description = "Szip compression software, providing lossless compression of scie
 toolchain = {'name': 'iomkl', 'version': '2016.09-GCC-4.9.3-2.25'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/previous/%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef']
 
 configopts = "--with-pic"
 


### PR DESCRIPTION
fix for #5117, the HDF support team reinstated the `szip-2.1.tar.gz` source tarball on my request, albeit in a slightly different location