### PR TITLE
remove unneeded --with-fft-incs configure option for ABINIT

### DIFF
--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.4-intel-2015a-incl-deps.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.4-intel-2015a-incl-deps.eb
@@ -20,7 +20,6 @@ configopts += "--with-dft-flavor='atompaw+bigdft+libxc+wannier90' "
 configopts += '--with-linalg-flavor=mkl --with-linalg-libs="-L$LAPACK_LIB_DIR $LIBLAPACK" '
 configopts += '--enable-mpi=yes --with-mpi-level=2 --enable-mpi-io=yes '
 configopts += '--with-fft-flavor=fftw3-mkl --with-fft-libs="-L$FFT_LIB_DIR $LIBFFT" '
-configopts += '--with-fft-incs=-I$FFT_INC_DIR/fftw '
 configopts += '--enable-gw-dpc="yes" --enable-64bit-flags="yes" '
 
 sanity_check_paths = {


### PR DESCRIPTION
I was checking whether the fix in https://github.com/easybuilders/easybuild-framework/pull/2323 was going to affect this easyconfig, but it turns out the `--with-fft-incs` can just be dropped (probably because the headers are available through `$CPATH` already).