### PR TITLE
disable optarch for libjpeg-turbo 1.5.1 built with intel/2017a

### DIFF
--- a/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-1.5.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-1.5.1-intel-2017a.eb
@@ -9,7 +9,7 @@ compression and decompression. libjpeg is a library that implements JPEG image e
 """
 
 toolchain = {'name': 'intel', 'version': '2017a'}
-toolchainopts = {'pic': True}
+toolchainopts = {'pic': True, 'optarch': False}
 
 source_urls = [SOURCEFORGE_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]


### PR DESCRIPTION
During the regression test for EasyBuild v3.4.1, the installation of `libjpeg-turbo` 1.5.1 with `intel/2017a` failed on Intel Haswell because of failing tests on CentOS 7.4, while it still worked fine on Intel Sandy Bridge.
It seems this started occurring after our updates from CentOS 7.3 to CentOS 7.4.

Since the tests only fail on some architectures, some architecture-specific optimisation is likely to blame.

Disabling `optarch` fixes the issue.