### PR TITLE
update $R_LIBS in plotly easyconfig

### DIFF
--- a/easybuild/easyconfigs/p/plotly/plotly-4.7.1-intel-2017a-R-3.4.0.eb
+++ b/easybuild/easyconfigs/p/plotly/plotly-4.7.1-intel-2017a-R-3.4.0.eb
@@ -37,4 +37,6 @@ sanity_check_paths = {
     'dirs': [name],
 }
 
+modextrapaths = {'R_LIBS': ''}
+
 moduleclass = 'vis'


### PR DESCRIPTION
The sanity check for `plotly` fails because `$R_LIBS` does not get updated with the install location.

This went undetected because of the bug that was fixed in https://github.com/easybuilders/easybuild-framework/pull/2276