### PR TITLE
include NLopt as a dependency in R easyconfigs that include nloptr as extension

### DIFF
--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2015a.eb
@@ -13,7 +13,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  providing a common interface for a number of different free optimization routines 
  available online as well as original implementations of various other algorithms. """
 
-toolchain = {'name': 'intel', 'version': '2017a'}
+toolchain = {'name': 'foss', 'version': '2015a'}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2015a.eb
@@ -14,6 +14,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  available online as well as original implementations of various other algorithms. """
 
 toolchain = {'name': 'foss', 'version': '2015a'}
+toolchainopts = {'pic': True}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2015b.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2015b.eb
@@ -14,6 +14,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  available online as well as original implementations of various other algorithms. """
 
 toolchain = {'name': 'foss', 'version': '2015b'}
+toolchainopts = {'pic': True}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2015b.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2015b.eb
@@ -13,7 +13,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  providing a common interface for a number of different free optimization routines 
  available online as well as original implementations of various other algorithms. """
 
-toolchain = {'name': 'intel', 'version': '2017a'}
+toolchain = {'name': 'foss', 'version': '2015b'}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2016a.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2016a.eb
@@ -13,7 +13,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  providing a common interface for a number of different free optimization routines 
  available online as well as original implementations of various other algorithms. """
 
-toolchain = {'name': 'intel', 'version': '2017a'}
+toolchain = {'name': 'foss', 'version': '2016a'}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2016a.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2016a.eb
@@ -14,6 +14,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  available online as well as original implementations of various other algorithms. """
 
 toolchain = {'name': 'foss', 'version': '2016a'}
+toolchainopts = {'pic': True}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2016b.eb
@@ -14,6 +14,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  available online as well as original implementations of various other algorithms. """
 
 toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'pic': True}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-foss-2016b.eb
@@ -13,7 +13,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  providing a common interface for a number of different free optimization routines 
  available online as well as original implementations of various other algorithms. """
 
-toolchain = {'name': 'intel', 'version': '2017a'}
+toolchain = {'name': 'foss', 'version': '2016b'}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-goolf-1.4.10.eb
@@ -17,6 +17,7 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['8099633de9d71cbc06cd435da993eb424bbcdbded8f803cdaa9fb8c6e09c8e89']
 
 sanity_check_paths = {
     'files': ["lib/libnlopt.a", "include/nlopt.h"],

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-goolf-1.4.10.eb
@@ -14,6 +14,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  available online as well as original implementations of various other algorithms. """
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchainopts = {'pic': True}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-goolf-1.7.20.eb
@@ -13,13 +13,11 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  providing a common interface for a number of different free optimization routines 
  available online as well as original implementations of various other algorithms. """
 
-toolchain = {'name': 'intel', 'version': '2017a'}
+toolchain = {'name': 'goolf', 'version': '1.7.20'}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['8099633de9d71cbc06cd435da993eb424bbcdbded8f803cdaa9fb8c6e09c8e89']
-
-configopts = '--enable-shared'
 
 sanity_check_paths = {
     'files': ["lib/libnlopt.a", "include/nlopt.h"],

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-goolf-1.7.20.eb
@@ -14,6 +14,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  available online as well as original implementations of various other algorithms. """
 
 toolchain = {'name': 'goolf', 'version': '1.7.20'}
+toolchainopts = {'pic': True}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2015a.eb
@@ -14,6 +14,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  available online as well as original implementations of various other algorithms. """
 
 toolchain = {'name': 'intel', 'version': '2015a'}
+toolchainopts = {'pic': True}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2015a.eb
@@ -13,7 +13,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  providing a common interface for a number of different free optimization routines 
  available online as well as original implementations of various other algorithms. """
 
-toolchain = {'name': 'intel', 'version': '2017a'}
+toolchain = {'name': 'intel', 'version': '2015a'}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2015b.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2015b.eb
@@ -14,6 +14,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  available online as well as original implementations of various other algorithms. """
 
 toolchain = {'name': 'intel', 'version': '2015b'}
+toolchainopts = {'pic': True}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2015b.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2015b.eb
@@ -13,7 +13,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  providing a common interface for a number of different free optimization routines 
  available online as well as original implementations of various other algorithms. """
 
-toolchain = {'name': 'intel', 'version': '2017a'}
+toolchain = {'name': 'intel', 'version': '2015b'}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2016a.eb
@@ -14,6 +14,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  available online as well as original implementations of various other algorithms. """
 
 toolchain = {'name': 'intel', 'version': '2016a'}
+toolchainopts = {'pic': True}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2016a.eb
@@ -13,7 +13,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  providing a common interface for a number of different free optimization routines 
  available online as well as original implementations of various other algorithms. """
 
-toolchain = {'name': 'intel', 'version': '2017a'}
+toolchain = {'name': 'intel', 'version': '2016a'}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2016b.eb
@@ -13,7 +13,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  providing a common interface for a number of different free optimization routines 
  available online as well as original implementations of various other algorithms. """
 
-toolchain = {'name': 'intel', 'version': '2017a'}
+toolchain = {'name': 'intel', 'version': '2016b'}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2016b.eb
@@ -14,6 +14,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  available online as well as original implementations of various other algorithms. """
 
 toolchain = {'name': 'intel', 'version': '2016b'}
+toolchainopts = {'pic': True}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2017a.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2017a.eb
@@ -14,6 +14,7 @@ description = """ NLopt is a free/open-source library for nonlinear optimization
  available online as well as original implementations of various other algorithms. """
 
 toolchain = {'name': 'intel', 'version': '2017a'}
+toolchainopts = {'pic': True}
 
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/r/R/R-3.1.3-foss-2015a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.3-foss-2015a.eb
@@ -22,6 +22,7 @@ dependencies = [
     ('Java', '1.8.0_25', '', True),  # Java bindings are built if Java is found, might as well provide it
     ('Tcl', '8.6.4'),  # for tcltk
     ('Tk', '8.6.4', '-no-X11'),  # for tcltk
+    ('NLopt', '2.4.2'),  # for nloptr
 ]
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'

--- a/easybuild/easyconfigs/r/R/R-3.1.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.3-intel-2015a.eb
@@ -22,6 +22,7 @@ dependencies = [
     ('Java', '1.8.0_25', '', True),  # Java bindings are built if Java is found, might as well provide it
     ('Tcl', '8.6.4'),  # for tcltk
     ('Tk', '8.6.4', '-no-X11'),  # for tcltk
+    ('NLopt', '2.4.2'),  # for nloptr
 ]
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'

--- a/easybuild/easyconfigs/r/R/R-3.2.0-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.0-goolf-1.7.20.eb
@@ -24,6 +24,7 @@ dependencies = [
     ('Tk', '8.6.4', '-no-X11'),  # for tcltk
     ('cURL', '7.43.0'),  # for RCurl
     ('libxml2', '2.9.2'),  # for XML
+    ('NLopt', '2.4.2'),  # for nloptr
 ]
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'

--- a/easybuild/easyconfigs/r/R/R-3.2.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.1-foss-2015b.eb
@@ -24,6 +24,7 @@ dependencies = [
     ('Tk', '8.6.4', '-no-X11'),  # for tcltk
     ('cURL', '7.43.0'),  # for RCurl
     ('libxml2', '2.9.2'),  # for XML
+    ('NLopt', '2.4.2'),  # for nloptr
 ]
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'

--- a/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015a.eb
@@ -24,6 +24,7 @@ dependencies = [
     ('Tk', '8.6.4', '-no-X11'),  # for tcltk
     ('cURL', '7.43.0'),  # for RCurl
     ('libxml2', '2.9.2'),  # for XML
+    ('NLopt', '2.4.2'),  # for nloptr
 ]
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'

--- a/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015b.eb
@@ -24,6 +24,7 @@ dependencies = [
     ('Tk', '8.6.4', '-no-X11'),  # for tcltk
     ('cURL', '7.43.0'),  # for RCurl
     ('libxml2', '2.9.2'),  # for XML
+    ('NLopt', '2.4.2'),  # for nloptr
 ]
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'

--- a/easybuild/easyconfigs/r/R/R-3.2.3-foss-2015b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-foss-2015b.eb
@@ -27,6 +27,7 @@ dependencies = [
     ('GDAL', '2.0.1'),  # for rgdal
     ('PROJ', '4.8.0'),  # for rgdal
     ('GMP', '6.0.0a', '', ('GNU', '4.9.3-2.25')),  # for igraph
+    ('NLopt', '2.4.2'),  # for nloptr
 ]
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'

--- a/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016a.eb
@@ -27,6 +27,7 @@ dependencies = [
     ('GDAL', '2.0.2'),  # for rgdal
     ('PROJ', '4.9.2'),  # for rgdal
     ('GMP', '6.1.0'),  # for igraph
+    ('NLopt', '2.4.2'),  # for nloptr
 ]
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'

--- a/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016b.eb
@@ -27,6 +27,7 @@ dependencies = [
     ('GDAL', '2.1.0'),  # for rgdal
     ('PROJ', '4.9.2'),  # for rgdal
     ('GMP', '6.1.1'),  # for igraph
+    ('NLopt', '2.4.2'),  # for nloptr
 ]
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'

--- a/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a-libX11-1.6.3.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a-libX11-1.6.3.eb
@@ -38,6 +38,7 @@ dependencies = [
     ('GDAL', '2.0.2'),  # for rgdal
     ('PROJ', '4.9.2'),  # for rgdal
     ('GMP', '6.1.0'),  # for igraph
+    ('NLopt', '2.4.2'),  # for nloptr
 ]
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'

--- a/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a.eb
@@ -27,6 +27,7 @@ dependencies = [
     ('GDAL', '2.0.2'),  # for rgdal
     ('PROJ', '4.9.2'),  # for rgdal
     ('GMP', '6.1.0'),  # for igraph
+    ('NLopt', '2.4.2'),  # for nloptr
 ]
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'

--- a/easybuild/easyconfigs/r/R/R-3.3.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.1-foss-2016a.eb
@@ -33,6 +33,7 @@ dependencies = [
     ('GDAL', '2.1.0'),  # for rgdal
     ('PROJ', '4.9.2'),  # for rgdal
     ('GMP', '6.1.1'),  # for igraph
+    ('NLopt', '2.4.2'),  # for nloptr
     # OS dependency should be preferred if the os version is more recent then this version,
     # it's nice to have an up to date openssl for security reasons
     # ('OpenSSL', '1.0.2h'),

--- a/easybuild/easyconfigs/r/R/R-3.3.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.1-foss-2016b.eb
@@ -33,6 +33,7 @@ dependencies = [
     ('GDAL', '2.1.0'),  # for rgdal
     ('PROJ', '4.9.2'),  # for rgdal
     ('GMP', '6.1.1'),  # for igraph
+    ('NLopt', '2.4.2'),  # for nloptr
     # OS dependency should be preferred if the os version is more recent then this version,
     # it's nice to have an up to date openssl for security reasons
     # ('OpenSSL', '1.0.2h'),

--- a/easybuild/easyconfigs/r/R/R-3.3.1-intel-2016b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.1-intel-2016b.eb
@@ -33,6 +33,7 @@ dependencies = [
     ('GDAL', '2.1.0'),  # for rgdal
     ('PROJ', '4.9.2'),  # for rgdal
     ('GMP', '6.1.1'),  # for igraph
+    ('NLopt', '2.4.2'),  # for nloptr
     # OS dependency should be preferred if the os version is more recent then this version,
     # it's nice to have an up to date openssl for security reasons
     # ('OpenSSL', '1.0.2h'),

--- a/easybuild/easyconfigs/r/R/R-3.3.3-foss-2016b-X11-20160819.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.3-foss-2016b-X11-20160819.eb
@@ -43,6 +43,7 @@ dependencies = [
     ('GDAL', '2.1.0'),  # for rgdal
     ('PROJ', '4.9.2'),  # for rgdal
     ('GMP', '6.1.1'),  # for igraph
+    ('NLopt', '2.4.2'),  # for nloptr
     # OS dependency should be preferred if the os version is more recent then this version,
     # it's nice to have an up to date openssl for security reasons
     # ('OpenSSL', '1.0.2h'),


### PR DESCRIPTION
Same fix as in #4481, applied consistently in all R easyconfigs that include `nloptr` extension.

Without this, the installation of the R easyconfigs that don't include `NLopt` as a dependency go into some kind of infinite loop when installing the `nloptr` extension...