### PR TITLE
[lang]{foss/2017b) version push for Python 3 in foss/2017b

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-foss-2017b.eb
@@ -1,0 +1,214 @@
+name = 'Python'
+version = '3.6.3'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+ more effectively."""
+
+toolchain = {'name': 'foss', 'version': '2017b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+checksums = ['ab6193af1921b30f587b302fe385268510e80187ca83ca82d2bfe7ab544c6f91']
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+    ('libreadline', '7.0'),
+    ('ncurses', '6.0'),
+    ('SQLite', '3.20.1'),
+    ('GMP', '6.1.2'),
+    ('XZ', '5.2.3'),
+    ('libffi', '3.2.1'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    # ('OpenSSL', '1.0.2l'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# order is important!
+# package versions updated October 16th 2017
+exts_list = [
+    ('setuptools', '36.6.0', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+        'checksums': [
+            '62074589522a798da243f47348f38020d55b6c945652e2f2c09d3a96299812b7',  # setuptools-36.6.0.zip
+        ],
+    }),
+    ('pip', '9.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+        'checksums': [
+            '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d',  # pip-9.0.1.tar.gz
+        ],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+        'checksums': [
+            'f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98',  # nose-1.3.7.tar.gz
+        ],
+    }),
+    ('numpy', '1.13.3', {
+        'patches': ['numpy-1.12.0-mkl.patch'],
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/n/numpy'],
+        'checksums': [
+            '36ee86d5adbabc4fa2643a073f93d5504bdfed37a149a3a49f4dde259f35a750',  # numpy-1.13.3.zip
+            'f212296ed289eb1b4e3f703997499dee8a2cdd0af78b55e017477487b6377ca4',  # numpy-1.12.0-mkl.patch
+        ],
+    }),
+    ('scipy', '0.19.1', {
+        'source_tmpl': '%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
+        'checksums': [
+            'a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6',  # scipy-0.19.1.tar.gz
+        ],
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+        'checksums': [
+            '3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3',  # blist-1.3.6.tar.gz
+        ],
+    }),
+    ('mpi4py', '2.0.0', {
+        'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
+        'checksums': [
+            '6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81',  # mpi4py-2.0.0.tar.gz
+        ],
+    }),
+    ('paycheck', '1.0.2', {
+        'patches': ['paycheck-1.0.2_setup-open-README-utf8.patch'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+        'checksums': [
+            '6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34',  # paycheck-1.0.2.tar.gz
+            # paycheck-1.0.2_setup-open-README-utf8.patch
+            'ceb7f08aebf016cdcd94ae41c1c76c8c120907f85cbfce240d3a112afb264d79',
+        ],
+    }),
+    ('pbr', '3.1.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+        'checksums': [
+            '05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1',  # pbr-3.1.1.tar.gz
+        ],
+    }),
+    ('lockfile', '0.12.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
+        'checksums': [
+            '6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799',  # lockfile-0.12.2.tar.gz
+        ],
+    }),
+    ('Cython', '0.27.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+        'checksums': [
+            'e6840a2ba2704f4ffb40e454c36f73aeb440a4005453ee8d7ff6a00d812ba176',  # Cython-0.27.1.tar.gz
+        ],
+    }),
+    ('six', '1.11.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+        'checksums': [
+            '70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9',  # six-1.11.0.tar.gz
+        ],
+    }),
+    ('dateutil', '2.6.1', {
+        'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+        'checksums': [
+            '891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca',  # python-dateutil-2.6.1.tar.gz
+        ],
+    }),
+    ('deap', '1.0.2', {
+        'patches': ['deap-1.0.2_setup-open-README-utf8.patch'],
+        'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+        'checksums': [
+            'c52bd32b8f0143db3a0b90f2b976c920b588638d6999ca0d038d8b1c07f7950b',  # deap-1.0.2.post2.tar.gz
+            # deap-1.0.2_setup-open-README-utf8.patch
+            '39a3a08359321189a1b27a382eb309dfd4470cba9101997a6d527a2fd3a0ce93',
+        ],
+    }),
+    ('decorator', '4.1.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+        'checksums': [
+            '7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5',  # decorator-4.1.2.tar.gz
+        ],
+    }),
+    ('arff', '2.1.1', {
+        'source_tmpl': 'liac-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+        'checksums': [
+            'b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817',  # liac-arff-2.1.1.tar.gz
+        ],
+    }),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+        'checksums': [
+            'f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c',  # pycrypto-2.6.1.tar.gz
+        ],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+        'checksums': [
+            '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
+        ],
+    }),
+    ('cryptography', '2.1.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
+        'checksums': [
+            '2699ed21e1f73dd1bdb7b0b22a517295de07809d535b23e200dd22166037fe6f',  # cryptography-2.1.1.tar.gz
+        ],
+    }),
+    ('paramiko', '2.3.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+        'checksums': [
+            'fa6b4f5c9d88f27c60fd9578146ff24e99d4b9f63391ff1343305bfd766c4660',  # paramiko-2.3.1.tar.gz
+        ],
+    }),
+    ('pyparsing', '2.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+        'checksums': [
+            '0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04',  # pyparsing-2.2.0.tar.gz
+        ],
+    }),
+    ('netifaces', '0.10.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+        'checksums': [
+            '0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0',  # netifaces-0.10.6.tar.gz
+        ],
+    }),
+    ('netaddr', '0.7.19', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+        'checksums': [
+            '38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd',  # netaddr-0.7.19.tar.gz
+        ],
+    }),
+    ('pandas', '0.20.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+        'checksums': [
+            'a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66',  # pandas-0.20.3.tar.gz
+        ],
+    }),
+    ('virtualenv', '15.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
+        'checksums': [
+            '02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a',  # virtualenv-15.1.0.tar.gz
+        ],
+    }),
+    ('docopt', '0.6.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
+        'checksums': [
+            '49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491',  # docopt-0.6.2.tar.gz
+        ],
+    }),
+    ('joblib', '0.11', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
+        'checksums': [
+            '7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085',  # joblib-0.11.tar.gz
+        ],
+    }),
+]
+
+moduleclass = 'lang'


### PR DESCRIPTION
I need to build a few packages with Python support in foss/2017b and noticed the Python 3 in intel/2017b is "newer" than the one in foss/2017b