### PR TITLE
add missing extensions required by MultiQC & stick to networkx

### DIFF
--- a/easybuild/easyconfigs/m/MultiQC/MultiQC-1.2-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/MultiQC/MultiQC-1.2-intel-2017b-Python-2.7.14.eb
@@ -53,6 +53,68 @@ exts_list = [
             'ddaa01a212cd6d641401cb01b605f4a4d9f37bfc93043d7f760ec70fb99ff9ff',  # Jinja2-2.9.6.tar.gz
         ],
     }),
+    # networkx 1.x is required, spectra does not support networkx 2.x yet
+    # see also https://github.com/ewels/MultiQC/issues/592
+    ('networkx', '1.11', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/networkx/'],
+        'checksums': [
+            '0d0e70e10dfb47601cbb3425a00e03e2a2e97477be6f80638fef91d54dd1e4b8',  # networkx-1.11.tar.gz
+        ],
+    }),
+    ('colormath', '2.1.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/colormath/'],
+        'checksums': [
+            '003a2b2d9c1f43aa7d90addf1863fb2d822463c839b1166ae3092950792f9707',  # colormath-2.1.1.tar.gz
+        ],
+    }),
+    ('spectra', '0.0.8', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/spectra/'],
+        'checksums': [
+            '851b88c9c0bba84e0be1fce5b9c02a7b4ef139a2b3e590b0d082d679e19f0759',  # spectra-0.0.8.tar.gz
+        ],
+    }),
+    ('certifi', '2017.7.27.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
+        'checksums': [
+            '40523d2efb60523e113b44602298f0960e900388cf3bb6043f645cf57ea9e3f5',  # certifi-2017.7.27.1.tar.gz
+        ],
+    }),
+    ('urllib3', '1.22', {
+        'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
+        'checksums': [
+            'cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f',  # urllib3-1.22.tar.gz
+        ],
+    }),
+    ('chardet', '3.0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
+        'checksums': [
+            '84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae',  # chardet-3.0.4.tar.gz
+        ],
+    }),
+    ('requests', '2.18.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
+        'checksums': [
+            '9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e',  # requests-2.18.4.tar.gz
+        ],
+    }),
+    ('Markdown', '2.6.9', {
+        'source_urls': ['https://pypi.python.org/packages/source/M/Markdown/'],
+        'checksums': [
+            '73af797238b95768b3a9b6fe6270e250e5c09d988b8e5b223fd5efa4e06faf81',  # Markdown-2.6.9.tar.gz
+        ],
+    }),
+    ('future', '0.16.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/f/future/'],
+        'checksums': [
+            'e39ced1ab767b5936646cedba8bcce582398233d6a627067d4c6a454c90cfedb',  # future-0.16.0.tar.gz
+        ],
+    }),
+    ('lzstring', '1.0.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/l/lzstring/'],
+        'checksums': [
+            'd54dd5a5f86837ccfc1343cc9f1cb0674d2d6ebd4b49f6408c35104f0a996cb4',  # lzstring-1.0.3.tar.gz
+        ],
+    }),
     ('multiqc', version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/multiqc/'],
         'checksums': [
@@ -67,6 +129,7 @@ sanity_check_paths = {
     'files': ['bin/multiqc'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
+sanity_check_commands = ["multiqc --help"]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 


### PR DESCRIPTION
The MultiQC installation provided via the easyconfig in #5229 doesn't work:

```
$ multiqc --help
Traceback (most recent call last):
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/haswell-ib/software/MultiQC/1.2-intel-2017b-Python-2.7.14/bin/multiqc", line 4, in <module>
    __import__('pkg_resources').run_script('multiqc==1.2', 'multiqc')
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 748, in run_script
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 1517, in run_script
  File "/user/scratchphanpy/gent/gvo000/gvo00002/vsc40023/easybuild_REGTEST/CO7/haswell-ib/software/MultiQC/1.2-intel-2017b-Python-2.7.14/lib/python2.7/site-packages/multiqc-1.2-py2.7.egg/EGG-INFO/scripts/multiqc", line 33, in <module>
    from multiqc.plots import table
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/haswell-ib/software/MultiQC/1.2-intel-2017b-Python-2.7.14/lib/python2.7/site-packages/multiqc-1.2-py2.7.egg/multiqc/plots/table.py", line 9, in <module>
    from multiqc.utils import config, report, util_functions, mqc_colour
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/haswell-ib/software/MultiQC/1.2-intel-2017b-Python-2.7.14/lib/python2.7/site-packages/multiqc-1.2-py2.7.egg/multiqc/utils/mqc_colour.py", line 7, in <module>
    import spectra
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/haswell-ib/software/MultiQC/1.2-intel-2017b-Python-2.7.14/lib/python2.7/site-packages/spectra-0.0.8-py2.7.egg/spectra/__init__.py", line 1, in <module>
    from .core import COLOR_SPACES, Color, Scale
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/haswell-ib/software/MultiQC/1.2-intel-2017b-Python-2.7.14/lib/python2.7/site-packages/spectra-0.0.8-py2.7.egg/spectra/core.py", line 1, in <module>
    from colormath import color_objects, color_conversions
  File "build/bdist.linux-x86_64/egg/colormath/color_conversions.py", line 167, in <module>
  File "build/bdist.linux-x86_64/egg/colormath/color_conversions.py", line 159, in decorator
  File "build/bdist.linux-x86_64/egg/colormath/color_conversions.py", line 125, in add_type_conversion
TypeError: add_edge() takes exactly 3 arguments (4 given)
```

We need to use networkx 1.11 since colormath requires by spectra doesn't support networkx 2.x yet, see also https://github.com/ewels/MultiQC/issues/592.