### PR TITLE
fix checksum for OpenFOAM 5.0 source tarball

### DIFF
--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-5.0-intel-2017a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-5.0-intel-2017a.eb
@@ -14,7 +14,7 @@ source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version_major)s.x/archive
 sources = ['version-%(version)s.tar.gz']
 patches = ['OpenFOAM-%(version)s-cleanup.patch']
 checksums = [
-    '4bfd76f1a09748a5065c69b8a16928479206d6ac686b31e63b019643582c16b8',  # version-5.0.tar.gz
+    '9057d6a8bb9fa18802881feba215215699065e0b3c5cdd0c0e84cb29c9916c89',  # version-5.0.tar.gz
     '8ed6bfb8983d3a3777399ff4e9bc30f99b017fec2d93d3a738e91129c58731a9',  # OpenFOAM-5.0-cleanup.patch
 ]
 


### PR DESCRIPTION
The checksum included in #5233 was wrong because I determined it using a source tarball I downloade on Sept 5th 2017, which was before the GitHub-generated tarballs slightly changed (cfr. #5151)