### PR TITLE
avoid downloads when installing matplotlib 2.1.0 w/ Python 2.7.14

### DIFF
--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-2.7.14.eb
@@ -25,15 +25,19 @@ exts_list = [
         'modulename': 'cycler',
         'source_tmpl': 'cycler-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/C/Cycler'],
-        'checksums': [
-            'cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8',  # cycler-0.10.0.tar.gz
-        ],
+        'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
+    }),
+    ('subprocess32', '3.2.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/subprocess32'],
+        'checksums': ['1e450a4a4c53bf197ad6402c564b9f7a53539385918ef8f12bdf430a61036590'],
+    }),
+    ('backports.functools_lru_cache', '1.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/backports.functools_lru_cache'],
+        'checksums': ['31f235852f88edc1558d428d890663c49eb4514ffec9f3650e7f3c9e4a12e36f'],
     }),
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
-        'checksums': [
-            '4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387',  # matplotlib-2.1.0.tar.gz
-        ],
+        'checksums': ['4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387'],
     }),
 ]
 


### PR DESCRIPTION
Installing `matplotlib` 2.1.0 automagically pulls in `subprocess32` and `backports.functools_lru_cache` (only with Python 2.x, since these are backported modules from Python 3.x), we should be doing that ourselves to support offline installation.