### PR TITLE
Qiime with newer anaconda

### DIFF
--- a/easybuild/easyconfigs/a/Anaconda2/Anaconda2-5.0.1.eb
+++ b/easybuild/easyconfigs/a/Anaconda2/Anaconda2-5.0.1.eb
@@ -1,0 +1,21 @@
+# author: Jillian Rowe <jillian.e.rowe@gmail.com>
+# config upgrade to v4.4.0 by Joachim Hein <joachim.hein@lunarc.lu.se>
+# config upgrade to v5.0.1 by Pablo Escobar
+easyblock = 'EB_Anaconda'
+
+name = 'Anaconda2'
+version = '5.0.1'
+
+homepage = 'https://www.continuum.io/anaconda-overview'
+description = """Built to complement the rich, open source Python community,
+the Anaconda platform provides an enterprise-ready data analytics platform 
+that empowers companies to adopt a modern open data science analytics architecture.
+"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+source_urls = ['https://repo.continuum.io/archive/']
+sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
+checksums = ['23c676510bc87c95184ecaeb327c0b2c88007278e0d698622e2dd8fb14d9faa4']
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/q/QIIME/QIIME-1.9.1.eb
+++ b/easybuild/easyconfigs/q/QIIME/QIIME-1.9.1.eb
@@ -17,7 +17,7 @@ toolchain = {'name': 'dummy', 'version': ''}
 requirements = "%(namelower)s=%(version)s matplotlib=1.4.3 mock nose"
 channels = ['bioconda', 'conda-forge']
 
-builddependencies = [('Anaconda2', '4.2.0')]
+builddependencies = [('Anaconda2', '5.0.1')]
 
 sanity_check_paths = {
     'files': ['bin/print_qiime_config.py'],

--- a/easybuild/easyconfigs/q/QIIME/QIIME-1.9.1.eb
+++ b/easybuild/easyconfigs/q/QIIME/QIIME-1.9.1.eb
@@ -14,7 +14,7 @@ description = """QIIME is an open-source bioinformatics pipeline for performing 
 
 toolchain = {'name': 'dummy', 'version': ''}
 
-requirements = "%(namelower)s=%(version)s matplotlib=1.4.3 mock nose"
+requirements = "%(namelower)s=%(version)s matplotlib=1.4.3 mock nose seqprep"
 channels = ['bioconda', 'conda-forge']
 
 builddependencies = [('Anaconda2', '5.0.1')]


### PR DESCRIPTION
When trying to install the QIIME easyconfig I got this error:

```
Traceback (most recent call last):
  File "/test-installs/apps/QIIME/1.9.1/bin/print_qiime_config.py", line 4, in <module>
    __import__('pkg_resources').run_script('qiime==1.9.1', 'print_qiime_config.py')
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 2927, in <module>
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 2913, in _call_aside
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 2940, in _initialize_master_working_set
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 635, in _build_master
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 943, in require
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 829, in resolve
pkg_resources.DistributionNotFound: The 'backports.shutil-get-terminal-size; python_version == "2.7"' distribution was not found and is required by IPython
```
I could workaround the issue by installing QIIME with the latest anaconda version . This PR provides the latest Anaconda esyconfig and the updated QIIME easyconfig to use it
