### PR TITLE
{numlib}[gompi/2017b] imkl 2017.3.196

### DIFF
--- a/easybuild/easyconfigs/i/imkl/imkl-2017.3.196-gompi-2017b.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.3.196-gompi-2017b.eb
@@ -1,0 +1,38 @@
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
+
+name = 'imkl'
+version = '2017.3.196'
+
+homepage = 'http://software.intel.com/en-us/intel-mkl/'
+description = """Intel Math Kernel Library is a library of highly optimized,
+ extensively threaded math routines for science, engineering, and financial
+ applications that require maximum performance. Core math functions include
+ BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
+
+toolchain = {'name': 'gompi', 'version': '2017b'}
+
+sources = ['l_mkl_%(version)s.tgz']
+checksums = ['fd7295870fa164d6138c9818304f25f2bb263c814a6c6539c9fe4e104055f1ca']
+
+dontcreateinstalldir = 'True'
+
+license_file = HOME + '/licenses/intel/license.lic'
+
+interfaces = True
+
+postinstallcmds = [
+    # extract the examples
+    'tar xvzf %(installdir)s/mkl/examples/examples_cluster_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_cluster_f.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_f.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_f95.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_mic_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_mic_f.tgz -C %(installdir)s/mkl/examples/'
+]
+
+modextravars = {
+    'MKL_EXAMPLES': '%(installdir)s/mkl/examples/',
+}
+
+moduleclass = 'numlib'


### PR DESCRIPTION
@boegel For a project I needed gcc with openmpi and MKL, which so far was not available in EasyBuild.  So I quickly created a config for MKL building.  We may want to grow that into a gomkl toolchain in future, but right now I do not have the time for that.  So just a quick one here.