### PR TITLE
consistently add Autotools build dep in recent netCDF easyconfigs

### DIFF
--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.4.1.1-foss-2017b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.4.1.1-foss-2017b.eb
@@ -19,6 +19,7 @@ dependencies = [
 ]
 
 builddependencies = [
+    ('Autotools', '20170619'),
     ('CMake', '3.9.4'),
     ('Doxygen', '1.8.13'),
 ]

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.4.1.1-intel-2017b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.4.1.1-intel-2017b.eb
@@ -19,6 +19,7 @@ dependencies = [
 ]
 
 builddependencies = [
+    ('Autotools', '20170619'),
     ('CMake', '3.9.4'),
     ('Doxygen', '1.8.13'),
 ]

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.5.0-intel-2017b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.5.0-intel-2017b.eb
@@ -19,6 +19,7 @@ dependencies = [
 ]
 
 builddependencies = [
+    ('Autotools', '20170619'),
     ('CMake', '3.9.5'),
     ('Doxygen', '1.8.13'),
 ]


### PR DESCRIPTION
See also #5077 & https://github.com/easybuilders/easybuild-easyblocks/issues/1233 .

During the review of #5353 we discovered that some recently merged netCDF easyconfigs were missing the `Autotools` build dep...