### PR TITLE
{bio}[foss/2016b] fastq-tools 0.8

### DIFF
--- a/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
@@ -23,7 +23,8 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
-preconfigopts = './autogen.sh && '
+# unsetting LIBS is needed because configure script can't handle it properly if it is already defined
+preconfigopts = './autogen.sh && unset LIBS && '
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['fastq-grep', 'fastq-kmers', 'fastq-match', 'fastq-qscale',

--- a/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
@@ -26,7 +26,7 @@ dependencies = [
 preconfigopts = './autogen.sh && '
 
 sanity_check_paths = {
-    'files': ['bin/%s' % x for x in ['fastq-grep', 'fastq-kmers', 'fastq-match', 'fastq-match',
+    'files': ['bin/%s' % x for x in ['fastq-grep', 'fastq-kmers', 'fastq-match', 'fastq-qscale',
                                      'fastq-qual', 'fastq-qualadj', 'fastq-sample', 'fastq-sort',
                                      'fastq-uniq']],
     'dirs': ['share/man/man1'],

--- a/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
@@ -5,7 +5,7 @@ easyblock = 'ConfigureMake'
 name = 'fastq-tools'
 version = '0.8'
 
-homepage = 'https://homes.cs.washington.edu/~dcjones/fastq-tools/'
+homepage = 'https://homes.cs.washington.edu/~dcjones/%(name)s/'
 description = """This package provides a number of small and efficient programs to perform
  common tasks with high throughput sequencing data in the FASTQ format. All of the programs
  work with typical FASTQ files as well as gzipped FASTQ files."""

--- a/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
@@ -1,4 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 
 easyblock = 'ConfigureMake'
 

--- a/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
@@ -1,0 +1,35 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+
+easyblock = 'ConfigureMake'
+
+name = 'fastq-tools'
+version = '0.8'
+
+homepage = 'http://homes.cs.washington.edu/~dcjones/fastq-tools/'
+description = """This package provides a number of small and efficient programs to perform
+ common tasks with high throughput sequencing data in the FASTQ format. All of the programs
+ work with typical FASTQ files as well as gzipped FASTQ files."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/dcjones/%(name)s/archive/']
+sources = ['v%(version)s.tar.gz']
+
+checksums = ['8d6f3d5e26ac3fd6f07543fdf572404c']
+
+dependencies = [
+    ('PCRE', '8.38'),
+    ('zlib', '1.2.8'),
+]
+
+preconfigopts = './autogen.sh && '
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['fastq-grep', 'fastq-kmers', 'fastq-match', 'fastq-match',
+                                     'fastq-qual', 'fastq-qualadj', 'fastq-sample', 'fastq-sort',
+                                     'fastq-uniq']],
+    'dirs': ['share/man/man1'],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
@@ -5,7 +5,7 @@ easyblock = 'ConfigureMake'
 name = 'fastq-tools'
 version = '0.8'
 
-homepage = 'http://homes.cs.washington.edu/~dcjones/fastq-tools/'
+homepage = 'https://homes.cs.washington.edu/~dcjones/fastq-tools/'
 description = """This package provides a number of small and efficient programs to perform
  common tasks with high throughput sequencing data in the FASTQ format. All of the programs
  work with typical FASTQ files as well as gzipped FASTQ files."""

--- a/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
@@ -16,7 +16,7 @@ toolchainopts = {'pic': True}
 source_urls = ['https://github.com/dcjones/%(name)s/archive/']
 sources = ['v%(version)s.tar.gz']
 
-checksums = ['8d6f3d5e26ac3fd6f07543fdf572404c']
+checksums = ['948613a7a4850cbb8ea55e93abd30b52f72c5b6c8815305a5c76620e451abd78']
 
 dependencies = [
     ('PCRE', '8.38'),


### PR DESCRIPTION
This adds fastq-tools.

I had one issue with the easyconfig during the build. The `LIBS` variable somehow becomes `LIBS = -lm -lpthread-lm` and this obviously results in `error: cannot find -lpthread-lm` during linking. Here is the log of the build: [easybuild-fastq-tools-0.8-20171123.134323.HYgMZ.log](https://github.com/easybuilders/easybuild-easyconfigs/files/1499421/easybuild-fastq-tools-0.8-20171123.134323.HYgMZ.log)
