### PR TITLE
{bio}[foss/2016b] NextGenMap 0.5.5

### DIFF
--- a/easybuild/easyconfigs/n/NextGenMap/NextGenMap-0.5.5-foss-2016b.eb
+++ b/easybuild/easyconfigs/n/NextGenMap/NextGenMap-0.5.5-foss-2016b.eb
@@ -22,7 +22,9 @@ builddependencies = [('CMake', '3.7.2')]
 
 separate_build_dir = True
 
-installopts = ' && cp -r ../%(name)s-%(version)s/bin/ngm-%(version)s/. %(installdir)s/bin/'
+skipsteps = ['install']
+
+buildopts = ' && cp -r ../%(name)s-%(version)s/bin/ngm-%(version)s/. %(installdir)s/bin/'
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['ngm', 'ngm-core', 'ngm-log', 'ngm-utils', 'oclTool']],

--- a/easybuild/easyconfigs/n/NextGenMap/NextGenMap-0.5.5-foss-2016b.eb
+++ b/easybuild/easyconfigs/n/NextGenMap/NextGenMap-0.5.5-foss-2016b.eb
@@ -1,0 +1,32 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+
+easyblock = 'CMakeMake'
+
+name = 'NextGenMap'
+version = '0.5.5'
+
+homepage = 'http://cibiv.github.io/%(name)s/'
+description = """NextGenMap is a flexible highly sensitive short read mapping tool that
+ handles much higher mismatch rates than comparable algorithms while still outperforming
+ them in terms of runtime."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'pic': True}
+
+source_urls = [' https://github.com/Cibiv/%(namelower)s/archive/']
+sources = ['v%(version)s.tar.gz']
+
+checksums = ['c205e6cb312d2f495106435f10fb446e6fb073dd1474f4f74ab5980ba9803661']
+
+builddependencies = [('CMake', '3.7.2')]
+
+separate_build_dir = True
+
+installopts = ' && cp -r ../%(name)s-%(version)s/bin/ngm-%(version)s/. %(installdir)s/bin/'
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['ngm', 'ngm-core', 'ngm-log', 'ngm-utils', 'oclTool']],
+    'dirs': ['bin/opencl']
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
This adds NextGenMap.

I can't think of a good `sanity_check_commands` line because printing the help message returns with non-zero exit code (says: `unrecognized option` :/ I opened an issue for this: https://github.com/Cibiv/NextGenMap/issues/29) and a real example would need additional data.

One other thing to note: by default the binaries are placed under `bin/ngm-<version>/` so I copy them with `installopts` one directory up. Is this ok?