### PR TITLE
fix check for binutils build dep when GCCcore used as toolchain

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -256,9 +256,9 @@ def template_easyconfig_test(self, spec):
 
         # let's also exclude the very special case where the system GCC is used as GCCcore, and only apply this
         # exception to the dependencies of binutils (since we should eventually build a new binutils with GCCcore)
-        binutils_complete_dependencies = ['M4', 'Bison', 'flex', 'help2man', 'zlib', 'binutils']
-        requires_binutils &= bool(ec['toolchain']['version'] == 'system' and
-                                  ec['name'] not in binutils_complete_dependencies)
+        if ec['toolchain']['version'] == 'system':
+            binutils_complete_dependencies = ['M4', 'Bison', 'flex', 'help2man', 'zlib', 'binutils']
+            requires_binutils &= bool(ec['name'] not in binutils_complete_dependencies)
             
         # if no sources/extensions/components are specified, it's just a bundle (nothing is being compiled)
         requires_binutils &= bool(ec['sources'] or ec['exts_list'] or ec.get('components'))


### PR DESCRIPTION
check got broken due to flawed logic via #4136 (cc @ocaisa)

discovered by @wpoely86 in #4136