### PR TITLE
{bio}[intel/2017b] OpenMM 7.1.1

### DIFF
--- a/easybuild/easyconfigs/o/OpenMM/OpenMM-7.1.1-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/o/OpenMM/OpenMM-7.1.1-intel-2017b-Python-3.6.3.eb
@@ -1,0 +1,50 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# Author: Pablo Escobar Lopez
+# sciCORE - University of Basel
+# SIB Swiss Institute of Bioinformatics 
+
+easyblock = "CMakeMake"
+
+name = "OpenMM"
+version = "7.1.1"
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://simtk.org/home/openmm'
+description = """OpenMM is a toolkit for molecular simulation."""
+
+toolchain = {'name': 'intel', 'version': '2017b'}
+
+source_urls = ['https://github.com/pandegroup/openmm/archive/']
+sources = ['%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.9.5'),
+]
+
+separate_build_dir = True
+
+dependencies = [
+    ('Python', '3.6.3'),
+    ('SWIG', '3.0.12', '-Python-%(pyver)s'),
+]
+
+runtest = ' test'
+
+preinstallopts = ' export OPENMM_INCLUDE_PATH=%(installdir)s/include && '
+preinstallopts += ' export OPENMM_LIB_PATH=%(installdir)s/lib && '
+
+# required to install the python API
+installopts = ' && cd python && python setup.py build && python setup.py install --prefix=%(installdir)s'
+
+sanity_check_paths = {
+    'files': ["lib/libOpenMM.%s" % SHLIB_EXT, "lib/python%(pyshortver)s/site-packages/simtk/openmm/openmm.py"],
+    'dirs': []
+}
+
+modextrapaths = {
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
+    'OPENMM_INCLUDE_PATH': 'include',
+    'OPENMM_LIB_PATH': 'lib',
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/o/OpenMM/OpenMM-7.1.1-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/o/OpenMM/OpenMM-7.1.1-intel-2017b-Python-3.6.3.eb
@@ -13,13 +13,14 @@ homepage = 'https://simtk.org/home/openmm'
 description = """OpenMM is a toolkit for molecular simulation."""
 
 toolchain = {'name': 'intel', 'version': '2017b'}
+toolchainopts = {'opt': True}
 
 source_urls = ['https://github.com/pandegroup/openmm/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = ['ba915d1bc2ea8643c699e48fa4386646dc799a7b4f165350ff1317d8c71a1493']
 
 builddependencies = [
-    ('CMake', '3.9.5'),
+    ('CMake', '3.9.1'),
 ]
 
 separate_build_dir = True

--- a/easybuild/easyconfigs/o/OpenMM/OpenMM-7.1.1-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/o/OpenMM/OpenMM-7.1.1-intel-2017b-Python-3.6.3.eb
@@ -20,7 +20,7 @@ sources = ['%(version)s.tar.gz']
 checksums = ['ba915d1bc2ea8643c699e48fa4386646dc799a7b4f165350ff1317d8c71a1493']
 
 builddependencies = [
-    ('CMake', '3.9.1'),
+    ('CMake', '3.9.5'),
 ]
 
 separate_build_dir = True
@@ -30,7 +30,7 @@ dependencies = [
     ('SWIG', '3.0.12', '-Python-%(pyver)s'),
 ]
 
-runtest = ' test'
+runtest = 'test -e ARGS="-E \'(Integrator)|(Thermostat)|(Barostat)|(Rpmd)\'"'
 
 preinstallopts = ' export OPENMM_INCLUDE_PATH=%(installdir)s/include && '
 preinstallopts += ' export OPENMM_LIB_PATH=%(installdir)s/lib && '

--- a/easybuild/easyconfigs/o/OpenMM/OpenMM-7.1.1-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/o/OpenMM/OpenMM-7.1.1-intel-2017b-Python-3.6.3.eb
@@ -30,7 +30,7 @@ dependencies = [
     ('SWIG', '3.0.12', '-Python-%(pyver)s'),
 ]
 
-runtest = 'test -e ARGS="-E \'(Integrator)|(Thermostat)|(Barostat)|(Rpmd)\'"'
+runtest = """test -e ARGS="-E \'(Integrator)|(Thermostat)|(Barostat)|(Rpmd)\'" """
 
 preinstallopts = ' export OPENMM_INCLUDE_PATH=%(installdir)s/include && '
 preinstallopts += ' export OPENMM_LIB_PATH=%(installdir)s/lib && '

--- a/easybuild/easyconfigs/o/OpenMM/OpenMM-7.1.1-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/o/OpenMM/OpenMM-7.1.1-intel-2017b-Python-3.6.3.eb
@@ -16,6 +16,7 @@ toolchain = {'name': 'intel', 'version': '2017b'}
 
 source_urls = ['https://github.com/pandegroup/openmm/archive/']
 sources = ['%(version)s.tar.gz']
+checksums = ['ba915d1bc2ea8643c699e48fa4386646dc799a7b4f165350ff1317d8c71a1493']
 
 builddependencies = [
     ('CMake', '3.9.5'),


### PR DESCRIPTION
I'm trying to make an EasyConfig for the latest OpenMM version with recent Intel compilers.

I run into a rather silly issue. Easybuild complains that it cannot find `CMake/3.9.5-intel-2017b` but it should actually find `CMake/3.9.5-GCCcore-6.4.0`. There is something going wrong with the dependency resolution but I don't see how I can fix this. Any ideas?