### PR TITLE
save Theano's compile dir to /tmp-$USER to make it arch-specific

### DIFF
--- a/easybuild/easyconfigs/t/Theano/Theano-1.0.0-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/t/Theano/Theano-1.0.0-intel-2017b-Python-2.7.14.eb
@@ -19,10 +19,10 @@ dependencies = [('Python', '2.7.14')]
 # Include architecture name in compiledir to fix problems with architecture-specific compilation
 # when running the software on a heterogeneous compute cluster.
 # Change the environment variable "VSC_ARCH_LOCAL" to match your cluster setup.
-# import os
-# architecture = os.environ['VSC_ARCH_LOCAL']
-# modextravars = {'THEANO_FLAGS': 'compiledir_format=compiledir_%s-%%(short_platform)s-%%(processor)s-'
-#                  '%%(python_version)s-%%(python_bitwidth)s' % architecture}
+import os
+architecture = os.environ['VSC_ARCH_LOCAL']
+modextravars = {'THEANO_FLAGS': 'compiledir_format=compiledir_%s-%%(short_platform)s-%%(processor)s-'
+                 '%%(python_version)s-%%(python_bitwidth)s' % architecture}
 
 sanity_check_paths = {
     'files': ['bin/theano-cache', 'bin/theano-nose'],

--- a/easybuild/easyconfigs/t/Theano/Theano-1.0.0-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/t/Theano/Theano-1.0.0-intel-2017b-Python-2.7.14.eb
@@ -16,6 +16,14 @@ checksums = ['7bc82e4fcaac023cac23c390b30d5df81bc09d33568812df75b0bd2b86d2fa8f']
 
 dependencies = [('Python', '2.7.14')]
 
+# Include architecture name in compiledir to fix problems with architecture-specific compilation
+# when running the software on a heterogeneous compute cluster.
+# Change the environment variable "VSC_ARCH_LOCAL" to match your cluster setup.
+# import os
+# architecture = os.environ['VSC_ARCH_LOCAL']
+# modextravars = {'THEANO_FLAGS': 'compiledir_format=compiledir_%s-%%(short_platform)s-%%(processor)s-'
+#                  '%%(python_version)s-%%(python_bitwidth)s' % architecture}
+
 sanity_check_paths = {
     'files': ['bin/theano-cache', 'bin/theano-nose'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/t/Theano/Theano-1.0.0-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/t/Theano/Theano-1.0.0-intel-2017b-Python-2.7.14.eb
@@ -16,13 +16,11 @@ checksums = ['7bc82e4fcaac023cac23c390b30d5df81bc09d33568812df75b0bd2b86d2fa8f']
 
 dependencies = [('Python', '2.7.14')]
 
-# Include architecture name in compiledir to fix problems with architecture-specific compilation
+# Save the compiledir on the local disk to avoid issues,
 # when running the software on a heterogeneous compute cluster.
-# Change the environment variable "VSC_ARCH_LOCAL" to match your cluster setup.
+# Change temporary directory "/tmp" and  environment variable "USER" to match your cluster setup.
 import os
-architecture = os.environ['VSC_ARCH_LOCAL']
-modextravars = {'THEANO_FLAGS': 'compiledir_format=compiledir_%s-%%(short_platform)s-%%(processor)s-'
-                 '%%(python_version)s-%%(python_bitwidth)s' % architecture}
+modextravars = {'THEANO_FLAGS': 'base_compiledir=/tmp/theano-%s' % os.environ['USER']}
 
 sanity_check_paths = {
     'files': ['bin/theano-cache', 'bin/theano-nose'],


### PR DESCRIPTION
Include architecture name in compiledir to fix problems with architecture-specific compilation when running the software on a heterogeneous compute cluster.