### PR TITLE
{chem,data.lib,devel}[intel/2017b] AmberMini-16.16.0, LZO-2.09, mpi4py-3.0.0, netcdf4-python-1.3.1, numexpr-2.6.4, ParmEd-2.7.3, PyTables-3.4.2, pandas-0.21.0,  pymbar-3.0.3

### DIFF
--- a/easybuild/easyconfigs/a/AmberMini/AmberMini-16.16.0-intel-2017b.eb
+++ b/easybuild/easyconfigs/a/AmberMini/AmberMini-16.16.0-intel-2017b.eb
@@ -1,0 +1,20 @@
+easyblock = 'ConfigureMake'
+
+name = 'AmberMini'
+version = '16.16.0'
+
+homepage = 'https://github.com/choderalab/ambermini'
+description = """A stripped-down set of just antechamber, sqm, and tleap."""
+
+toolchain = {'name': 'intel', 'version': '2017b'}
+
+source_urls = ['https://github.com/choderalab/ambermini/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['fcd699a62248aa17a11d8eaa090a0c55e8ba735dcd9ec5fb33a8927da5ce1c5a']
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["sqm", "tleap"]],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2017b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2017b.eb
@@ -1,0 +1,32 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'LZO'
+version = '2.09'
+
+homepage = 'http://www.oberhumer.com/opensource/lzo/'
+description = "Portable lossless data compression library"
+
+source_urls = [homepage + 'download/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['f294a7ced313063c057c504257f437c8335c41bfeed23531ee4e6a2b87bcb34c']
+
+toolchain = {'name': 'intel', 'version': '2017b'}
+toolchainopts = {'pic': True}
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib', 'include']
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/m/mpi4py/mpi4py-3.0.0-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/mpi4py/mpi4py-3.0.0-intel-2017b-Python-3.6.3.eb
@@ -1,0 +1,24 @@
+easyblock = 'PythonPackage'
+
+name = 'mpi4py'
+version = '3.0.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://bitbucket.org/mpi4py/mpi4py'
+description = """MPI for Python (mpi4py) provides bindings of the Message Passing Interface (MPI) standard for
+ the Python programming language, allowing any Python program to exploit multiple processors."""
+
+toolchain = {'name': 'intel', 'version': '2017b'}
+
+source_urls = [BITBUCKET_DOWNLOADS]
+sources = [SOURCE_TAR_GZ]
+checksums = ['b457b02d85bdd9a4775a097fac5234a20397b43e073f14d9e29b6cd78c68efd7']
+
+dependencies = [('Python', '3.6.3')]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/mpi4py'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.3.1-intel-2017b-Python-3.6.3-HDF5-1.8.19.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.3.1-intel-2017b-Python-3.6.3-HDF5-1.8.19.eb
@@ -1,0 +1,25 @@
+name = 'netcdf4-python'
+version = '1.3.1'
+versionsuffix = '-Python-%(pyver)s-HDF5-1.8.19'
+
+homepage = 'https://unidata.github.io/netcdf4-python/'
+description = """Python/numpy interface to netCDF."""
+
+toolchain = {'name': 'intel', 'version': '2017b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/Unidata/netcdf4-python/archive/']
+sources = ['v%(version)srel.tar.gz']
+patches = ['netcdf4-python-1.1.8-avoid-diskless-test.patch']
+checksums = [
+    'a1674d281d54af9dd83e38f1be2dabed7de0f1bc8165adcd39c8dfddc4ec20b4',  # v1.3.1rel.tar.gz
+    'a8b262fa201d55f59015e1bc14466c1d113f807543bc1e05a22481ab0d216d72',  # netcdf4-python-1.1.8-avoid-diskless-test.patch
+]
+
+dependencies = [
+    ('Python', '3.6.3'),
+    ('netCDF', '4.4.1.1', '-HDF5-1.8.19'),
+    ('cURL', '7.56.0'),
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.3.1-intel-2017b-Python-3.6.3-HDF5-1.8.19.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.3.1-intel-2017b-Python-3.6.3-HDF5-1.8.19.eb
@@ -13,7 +13,8 @@ sources = ['v%(version)srel.tar.gz']
 patches = ['netcdf4-python-1.1.8-avoid-diskless-test.patch']
 checksums = [
     'a1674d281d54af9dd83e38f1be2dabed7de0f1bc8165adcd39c8dfddc4ec20b4',  # v1.3.1rel.tar.gz
-    'a8b262fa201d55f59015e1bc14466c1d113f807543bc1e05a22481ab0d216d72',  # netcdf4-python-1.1.8-avoid-diskless-test.patch
+    # netcdf4-python-1.1.8-avoid-diskless-test.patch
+    'a8b262fa201d55f59015e1bc14466c1d113f807543bc1e05a22481ab0d216d72',
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/n/numexpr/numexpr-2.6.4-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/n/numexpr/numexpr-2.6.4-intel-2017b-Python-3.6.3.eb
@@ -1,0 +1,28 @@
+easyblock = 'PythonPackage'
+
+name = 'numexpr'
+version = '2.6.4'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://code.google.com/p/numexpr/'
+description = """The numexpr package evaluates multiple-operator array expressions many times faster than NumPy can.
+ It accepts the expression as a string, analyzes it, rewrites it more efficiently, and compiles it on the fly into
+ code for its internal virtual machine (VM). Due to its integrated just-in-time (JIT) compiler, it does not require a
+ compiler at runtime."""
+
+toolchain = {'name': 'intel', 'version': '2017b'}
+
+source_urls = ['https://github.com/pydata/numexpr/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['049da1c07bd62d2aba29887130ccc9aff9b90962cb779a7b7ddc15e580368fba']
+
+dependencies = [
+    ('Python', '3.6.3'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/ParmEd/ParmEd-2.7.3-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/p/ParmEd/ParmEd-2.7.3-intel-2017b-Python-3.6.3.eb
@@ -1,0 +1,27 @@
+easyblock = 'PythonPackage'
+
+name = 'ParmEd'
+version = '2.7.3'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://parmed.github.io/ParmEd/html/index.html'
+description = """ParmEd is a general tool for aiding in investigations of biomolecular
+systems using popular molecular simulation packages, like Amber, CHARMM, and OpenMM
+written in Python."""
+
+toolchain = {'name': 'intel', 'version': '2017b'}
+
+source_urls = ['https://github.com/ParmEd/ParmEd/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['56b3097625be3a5037a5b3d7c4d9467a97f0dd44fea79cf2873f0e56d3409975']
+
+dependencies = [
+    ('Python', '3.6.3'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/p/PyTables/PyTables-3.4.2-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/p/PyTables/PyTables-3.4.2-intel-2017b-Python-3.6.3.eb
@@ -21,7 +21,7 @@ sources = ['v%(version)s.tar.gz']
 patches = ['pyTables-3.4.2-fix-libs.patch']
 checksums = [
     '629a0227bb2b315c5d97629073696609eaee41d0fc89e03f997412613cd46d3a',  # v3.4.2.tar.gz
-    'fca6d6a83b8eedf98f4a883d33d13cb59416483ba1ce2659ffafe5183df2c6bc',  # pyTables-3.4.2-fix-libs.patch
+    'f34a05573e7843e67dab011bede8436074362041747c028b409fac9f599231a3',  # pyTables-3.4.2-fix-libs.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/p/PyTables/PyTables-3.4.2-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/p/PyTables/PyTables-3.4.2-intel-2017b-Python-3.6.3.eb
@@ -1,0 +1,42 @@
+easyblock = 'PythonPackage'
+
+name = 'PyTables'
+version = '3.4.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.pytables.org'
+description = """PyTables is a package for managing hierarchical datasets and designed to efficiently and easily cope
+ with extremely large amounts of data. PyTables is built on top of the HDF5 library, using the Python language and the
+ NumPy package. It features an object-oriented interface that, combined with C extensions for the performance-critical
+ parts of the code (generated using Cython), makes it a fast, yet extremely easy to use tool for interactively browse,
+ process and search very large amounts of data. One important feature of PyTables is that it optimizes memory and disk
+ resources so that data takes much less space (specially if on-flight compression is used) than other solutions such as
+ relational or object oriented databases."""
+
+toolchain = {'name': 'intel', 'version': '2017b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/PyTables/PyTables/archive/']
+sources = ['v%(version)s.tar.gz']
+patches = ['pyTables-3.4.2-fix-libs.patch']
+checksums = [
+    '629a0227bb2b315c5d97629073696609eaee41d0fc89e03f997412613cd46d3a',  # v3.4.2.tar.gz
+    'fca6d6a83b8eedf98f4a883d33d13cb59416483ba1ce2659ffafe5183df2c6bc',  # pyTables-3.4.2-fix-libs.patch
+]
+
+dependencies = [
+    ('Python', '3.6.3'),
+    ('numexpr', '2.6.4', versionsuffix),
+    ('HDF5', '1.8.19'),
+    ('LZO', '2.09'),
+    ('Blosc', '1.12.1'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['pt2to3', 'ptdump', 'ptrepack']],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+options = {'modulename': 'tables'}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/p/PyTables/pyTables-3.4.2-fix-libs.patch
+++ b/easybuild/easyconfigs/p/PyTables/pyTables-3.4.2-fix-libs.patch
@@ -1,0 +1,12 @@
+--- PyTables-3.4.2/setup.py.orig	2017-11-10 17:26:25.248733569 +0100
++++ PyTables-3.4.2/setup.py	2017-11-10 17:27:19.629802770 +0100
+@@ -456,6 +456,9 @@
+ # is not a good idea.
+ CFLAGS = os.environ.get('CFLAGS', '').split()
+ LIBS = os.environ.get('LIBS', '').split()
++for idx, lib in enumerate(LIBS):
++    if lib.startswith("-l"):
++        LIBS[idx] = lib.replace("-l", "")
+ CONDA_PREFIX = os.environ.get('CONDA_PREFIX', '')
+ # We start using pkg-config since some distributions are putting HDF5
+ # (and possibly other libraries) in exotic locations.  See issue #442.

--- a/easybuild/easyconfigs/p/PyTables/pyTables-3.4.2-fix-libs.patch
+++ b/easybuild/easyconfigs/p/PyTables/pyTables-3.4.2-fix-libs.patch
@@ -1,3 +1,6 @@
+# pyTables expects that LIBS is a list of library names and will add
+# a -l by itself.
+# ward.poelmans@ugent.be
 --- PyTables-3.4.2/setup.py.orig	2017-11-10 17:26:25.248733569 +0100
 +++ PyTables-3.4.2/setup.py	2017-11-10 17:27:19.629802770 +0100
 @@ -456,6 +456,9 @@

--- a/easybuild/easyconfigs/p/pandas/pandas-0.21.0-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/p/pandas/pandas-0.21.0-intel-2017b-Python-3.6.3.eb
@@ -1,0 +1,24 @@
+easyblock = 'PythonPackage'
+
+name = 'pandas'
+version = '0.21.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = "https://pypi.python.org/pypi/pandas/"
+description = """pandas is an open source, BSD-licensed library providing high-performance, easy-to-use data structures
+ and data analysis tools for the Python programming language."""
+
+toolchain = {'name': 'intel', 'version': '2017b'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['5cd5cb30e72eeaf202f0e5e180780b897570e889d2db328c689a5a263405c559']
+
+dependencies = [('Python', '3.6.3')]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/pymbar/pymbar-3.0.3-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/p/pymbar/pymbar-3.0.3-intel-2017b-Python-3.6.3.eb
@@ -1,0 +1,28 @@
+easyblock = 'PythonPackage'
+
+name = 'pymbar'
+version = '3.0.3'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://pymbar.readthedocs.io/en/master/'
+description = """The pymbar package contains the pymbar suite of tools for the analysis of
+simulated and experimental data with the multistate Bennett acceptance
+ratio (MBAR) estimator."""
+
+toolchain = {'name': 'intel', 'version': '2017b'}
+
+source_urls = ['https://github.com/choderalab/pymbar/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['5e59bb9f3789ae723e85d4483d7d204e39425551f30df8cefc13c6e607af6398']
+
+dependencies = [
+    ('Python', '3.6.3'),
+    ('numexpr', '2.6.4', versionsuffix),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
These are easyconfigs related to alchemical free energy calculations with OpenMM.

Full disclosure: I stole the patch file `from /apps/gent/CO7/sandybridge/software/PyTables/3.4.2-intel-2017a-Python-3.6.1/easybuild/pyTables-3.4.2-fix-libs.patch`.