### PR TITLE
clean up configure options that are now handled by R easyblock

### DIFF
--- a/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10-bare.eb
@@ -10,8 +10,7 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0-bare.eb
@@ -10,8 +10,7 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-2.15.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-goolf-1.4.10.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-2.15.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-ictce-5.3.0.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.0.1-goolf-1.4.10-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.1-goolf-1.4.10-bare.eb
@@ -10,8 +10,7 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.0.1-ictce-5.3.0-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.1-ictce-5.3.0-bare.eb
@@ -10,8 +10,7 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.0.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-goolf-1.4.10.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0-bare.eb
@@ -10,8 +10,8 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
 dependencies = [

--- a/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.5.0.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'ictce', 'version': '5.5.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS_MT" LAPACK_LIBS="$LIBLAPACK_MT"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.1.0-ictce-5.5.0-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.0-ictce-5.5.0-bare.eb
@@ -10,8 +10,7 @@ toolchain = {'name': 'ictce', 'version': '5.5.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.1.0-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.0-ictce-5.5.0.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'ictce', 'version': '5.5.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.2.5-bare-mt.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.2.5-bare-mt.eb
@@ -12,8 +12,8 @@ toolchainopts = {'precise': True, 'opt': True}  # 'openmp' is enabled in R by de
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS_MT" LAPACK_LIBS="$LIBLAPACK_MT"'  # use multi-thread BLAS/LAPACK
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
 dependencies = [

--- a/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.2.5-default-mt.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.2.5-default-mt.eb
@@ -12,8 +12,7 @@ toolchainopts = {'precise': True, 'opt': True}  # 'openmp' is enabled in R by de
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS_MT" LAPACK_LIBS="$LIBLAPACK_MT"'  # use multi-thread BLAS/LAPACK
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 
 dependencies = [
     ('libreadline', '6.3'),

--- a/easybuild/easyconfigs/r/R/R-3.1.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.1-intel-2014b.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'intel', 'version': '2014b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.1.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.2-foss-2015a.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.1.2-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.2-goolf-1.5.14.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'goolf', 'version': '1.5.14'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.1.2-intel-2015a-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.2-intel-2015a-bare.eb
@@ -10,8 +10,7 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.1.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.2-intel-2015a.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.1.3-foss-2015a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.3-foss-2015a.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.1.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.3-intel-2015a.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.2.0-foss-2015a-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.0-foss-2015a-bare.eb
@@ -10,8 +10,8 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
 dependencies = [

--- a/easybuild/easyconfigs/r/R/R-3.2.0-goolf-1.7.20-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.0-goolf-1.7.20-bare.eb
@@ -10,8 +10,8 @@ toolchain = {'name': 'goolf', 'version': '1.7.20'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
 dependencies = [

--- a/easybuild/easyconfigs/r/R/R-3.2.0-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.0-goolf-1.7.20.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'goolf', 'version': '1.7.20'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.2.0-ictce-7.3.5-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.0-ictce-7.3.5-bare.eb
@@ -10,8 +10,8 @@ toolchain = {'name': 'ictce', 'version': '7.3.5'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
 dependencies = [

--- a/easybuild/easyconfigs/r/R/R-3.2.0-intel-2015a-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.0-intel-2015a-bare.eb
@@ -10,8 +10,8 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
 dependencies = [

--- a/easybuild/easyconfigs/r/R/R-3.2.1-foss-2015b-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.1-foss-2015b-bare.eb
@@ -10,8 +10,8 @@ toolchain = {'name': 'foss', 'version': '2015b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
 dependencies = [

--- a/easybuild/easyconfigs/r/R/R-3.2.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.1-foss-2015b.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'foss', 'version': '2015b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015a.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015b-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015b-bare.eb
@@ -10,8 +10,8 @@ toolchain = {'name': 'intel', 'version': '2015b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
 dependencies = [

--- a/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015b.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'intel', 'version': '2015b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.2.3-foss-2015b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-foss-2015b.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'foss', 'version': '2015b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016a-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016a-bare.eb
@@ -10,8 +10,8 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
 dependencies = [

--- a/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016a.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016b.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a-bare.eb
@@ -10,8 +10,8 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
 dependencies = [

--- a/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a-libX11-1.6.3.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a-libX11-1.6.3.eb
@@ -13,10 +13,7 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=yes --enable-R-shlib"
-# Enable graphics capabilities for plotting.
-configopts += " --with-cairo --with-libpng --with-jpeglib --with-libtiff"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.3.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.1-foss-2016a.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.3.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.1-foss-2016b.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.3.1-intel-2016b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.1-intel-2016b.eb
@@ -9,8 +9,7 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=no --enable-R-shlib"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.3.3-foss-2016b-X11-20160819.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.3-foss-2016b-X11-20160819.eb
@@ -11,12 +11,7 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=yes --enable-R-shlib"
-# actually use Tcl/Tk
-configopts += ' --with-tcl-config=$EBROOTTCL/lib/tclConfig.sh --with-tk-config=$EBROOTTK/lib/tkConfig.sh '
-# Enable graphics capabilities for plotting.
-configopts += " --with-cairo --with-libpng --with-jpeglib --with-libtiff"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.3.3-intel-2017a-X11-20170314.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.3-intel-2017a-X11-20170314.eb
@@ -11,12 +11,7 @@ toolchain = {'name': 'intel', 'version': '2017a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=yes --enable-R-shlib"
-# actually use Tcl/Tk
-configopts += ' --with-tcl-config=$EBROOTTCL/lib/tclConfig.sh --with-tk-config=$EBROOTTK/lib/tkConfig.sh '
-# Enable graphics capabilities for plotting.
-configopts += " --with-cairo --with-libpng --with-jpeglib --with-libtiff"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.4.0-intel-2017a-X11-20170314.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.0-intel-2017a-X11-20170314.eb
@@ -11,12 +11,7 @@ toolchain = {'name': 'intel', 'version': '2017a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=yes --enable-R-shlib"
-# Actually use Tcl/Tk
-configopts += ' --with-tcl-config=$EBROOTTCL/lib/tclConfig.sh --with-tk-config=$EBROOTTK/lib/tkConfig.sh '
-# Enable graphics capabilities for plotting.
-configopts += " --with-cairo --with-libpng --with-jpeglib --with-libtiff"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 

--- a/easybuild/easyconfigs/r/R/R-3.4.1-foss-2016b-X11-20160819.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.1-foss-2016b-X11-20160819.eb
@@ -17,12 +17,7 @@ source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 checksums = ['02b1135d15ea969a3582caeb95594a05e830a6debcdb5b85ed2d5836a6a3fc78']
 
-preconfigopts = 'BLAS_LIBS="$LIBBLAS" LAPACK_LIBS="$LIBLAPACK"'
-configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=yes --enable-R-shlib"
-# actually use Tcl/Tk
-configopts += ' --with-tcl-config=$EBROOTTCL/lib/tclConfig.sh --with-tk-config=$EBROOTTK/lib/tkConfig.sh '
-# Enable graphics capabilities for plotting.
-configopts += " --with-cairo --with-libpng --with-jpeglib --with-libtiff"
+configopts = "--with-pic --enable-threads --enable-R-shlib"
 # some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 


### PR DESCRIPTION
The R easyblock has been updated in `develop` to automatically add configure options based on dependencies, see:

* ~~https://github.com/easybuilders/easybuild-easyblocks/pull/1292~~
* ~~https://github.com/easybuilders/easybuild-easyblocks/pull/1297~~
* ~~https://github.com/easybuilders/easybuild-easyblocks/pull/1300~~
* ~~https://github.com/easybuilders/easybuild-easyblocks/pull/1303~~

This cleanup basically only avoids that configure options are listed twice.