### PR TITLE
disable new rfkill feature in util-linux that requires recent kernel

### DIFF
--- a/easybuild/easyconfigs/u/util-linux/util-linux-2.31-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/u/util-linux/util-linux-2.31-GCCcore-6.4.0.eb
@@ -18,7 +18,7 @@ checksums = ['d5950e4b2839d00aa3781f439bfada8091bc6ed8180d8262c53b4e4304e2d299']
 # disable wall and friends (requires group changing permissions for install user)
 # install systemd service files in install dir
 # install bash completion files in install dir
-configopts = "--disable-chfn-chsh --disable-login --disable-su "
+configopts = "--disable-chfn-chsh --disable-login --disable-su --disable-rfkill "
 configopts += "--disable-wall --disable-use-tty-group "
 configopts += "--disable-makeinstall-chown --disable-makeinstall-setuid "
 configopts += "--with-systemdsystemunitdir='${prefix}/systemd' "


### PR DESCRIPTION
Installation of `util-linux` 2.31 fails on systems with older kernel with:

```
sys-utils/rfkill.c:67:12: error: 'RFKILL_TYPE_FM' undeclared here (not in a function)
  { .type = RFKILL_TYPE_FM,        .name = "fm",           .desc = "FM" },
            ^~~~~~~~~~~~~~
  CC       sys-utils/setarch.o
make[2]: *** [sys-utils/rfkill-rfkill.o] Error 1
```

Recent kernel is required for this to work:

```
$ grep RFKILL_TYPE_FM  /usr/include/linux/rfkill.h
 * @RFKILL_TYPE_FM: switch is on a FM radio device.
        RFKILL_TYPE_FM,
$ rpm -q --whatprovides /usr/include/linux/rfkill.h
kernel-headers-3.10.0-693.5.2.el7.ug.x86_64
```

`rfkill` feature (disabling/enabling of wireless devices) is utterly useless in HPC context imho, so OK to disable.

cc @verdurin, @migueldiascosta 