### PR TITLE
specify that EasyBuild v3.5.0 is required in updated R easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10-bare.eb
@@ -10,16 +10,20 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('libpng', '1.5.13'),  # for plotting in R
     ('Java', '1.7.0_10', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []  # just to make it explicit this module doesn't include any extensions
 

--- a/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10.eb
@@ -9,16 +9,20 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('libpng', '1.5.13'),  # for plotting in R
     ('Java', '1.7.0_10', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0-bare.eb
@@ -10,16 +10,20 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('libpng', '1.5.13'),  # for plotting in R
     ('Java', '1.7.0_10', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []  # just to make it explicit this module doesn't include any extensions
 

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0.eb
@@ -9,16 +9,20 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('libpng', '1.5.13'),  # for plotting in R
     ('Java', '1.7.0_10', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-2.15.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-goolf-1.4.10.eb
@@ -9,16 +9,20 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('libpng', '1.6.2'),  # for plotting in R
     ('Java', '1.7.0_15', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-2.15.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-ictce-5.3.0.eb
@@ -9,16 +9,20 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('libpng', '1.6.2'),  # for plotting in R
     ('Java', '1.7.0_15', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.0.1-goolf-1.4.10-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.1-goolf-1.4.10-bare.eb
@@ -10,16 +10,20 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('libpng', '1.6.2'),  # for plotting in R
     ('Java', '1.7.0_21', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []  # just to make it explicit this module doesn't include any extensions
 

--- a/easybuild/easyconfigs/r/R/R-3.0.1-ictce-5.3.0-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.1-ictce-5.3.0-bare.eb
@@ -10,16 +10,20 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('libpng', '1.6.2'),  # for plotting in R
     ('Java', '1.7.0_21', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []  # just to make it explicit this module doesn't include any extensions
 

--- a/easybuild/easyconfigs/r/R/R-3.0.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-goolf-1.4.10.eb
@@ -9,16 +9,20 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('libpng', '1.6.6'),  # for plotting in R
     ('Java', '1.7.0_21', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0-bare.eb
@@ -10,16 +10,20 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('libpng', '1.6.6'),  # for plotting in R
     ('Java', '1.7.0_21', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []  # just to make it explicit this module doesn't include any extensions
 

--- a/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0.eb
@@ -9,16 +9,20 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('libpng', '1.6.6'),  # for plotting in R
     ('Java', '1.7.0_15', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.5.0.eb
@@ -9,16 +9,20 @@ toolchain = {'name': 'ictce', 'version': '5.5.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('libpng', '1.6.6'),  # for plotting in R
     ('Java', '1.7.0_15', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.1.0-ictce-5.5.0-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.0-ictce-5.5.0-bare.eb
@@ -10,16 +10,20 @@ toolchain = {'name': 'ictce', 'version': '5.5.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('libpng', '1.6.9'),  # for plotting in R
     ('Java', '1.7.0_60', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []
 

--- a/easybuild/easyconfigs/r/R/R-3.1.0-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.0-ictce-5.5.0.eb
@@ -9,16 +9,20 @@ toolchain = {'name': 'ictce', 'version': '5.5.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.2'),
     ('ncurses', '5.9'),
     ('libpng', '1.6.9'),  # for plotting in R
     ('Java', '1.7.0_60', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.2.5-bare-mt.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.2.5-bare-mt.eb
@@ -12,10 +12,6 @@ toolchainopts = {'precise': True, 'opt': True}  # 'openmp' is enabled in R by de
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -23,6 +19,14 @@ dependencies = [
     ('libjpeg-turbo', '1.3.1'),  # for plotting in R
     ('Java', '1.7.0_60', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []  # just to make it explicit this module doesn't include any extensions
 

--- a/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.2.5-default-mt.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.1-ictce-6.2.5-default-mt.eb
@@ -12,8 +12,6 @@ toolchainopts = {'precise': True, 'opt': True}  # 'openmp' is enabled in R by de
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -21,6 +19,12 @@ dependencies = [
     ('libjpeg-turbo', '1.3.1'),  # for plotting in R
     ('Java', '1.7.0_60', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = [
     # default libraries, only here to sanity check their presence

--- a/easybuild/easyconfigs/r/R/R-3.1.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.1-intel-2014b.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'intel', 'version': '2014b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -20,6 +16,14 @@ dependencies = [
     ('libjpeg-turbo', '1.3.1'),  # for plottting in R
     ('Java', '1.7.0_60', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.1.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.2-foss-2015a.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -20,6 +16,14 @@ dependencies = [
     ('libjpeg-turbo', '1.4.0'),  # for plottting in R
     ('Java', '1.8.0_25', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.1.2-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.2-goolf-1.5.14.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'goolf', 'version': '1.5.14'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -20,6 +16,14 @@ dependencies = [
     ('libjpeg-turbo', '1.4.0'),  # for plottting in R
     ('Java', '1.8.0_25', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.1.2-intel-2015a-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.2-intel-2015a-bare.eb
@@ -10,10 +10,6 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -21,6 +17,14 @@ dependencies = [
     ('libjpeg-turbo', '1.4.0'),  # for plottting in R
     ('Java', '1.8.0_25', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []
 

--- a/easybuild/easyconfigs/r/R/R-3.1.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.2-intel-2015a.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -20,6 +16,14 @@ dependencies = [
     ('libjpeg-turbo', '1.4.0'),  # for plottting in R
     ('Java', '1.8.0_25', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.1.3-foss-2015a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.3-foss-2015a.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -23,6 +19,14 @@ dependencies = [
     ('Tk', '8.6.4', '-no-X11'),  # for tcltk
     ('NLopt', '2.4.2'),  # for nloptr
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.1.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.3-intel-2015a.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -23,6 +19,14 @@ dependencies = [
     ('Tk', '8.6.4', '-no-X11'),  # for tcltk
     ('NLopt', '2.4.2'),  # for nloptr
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.2.0-foss-2015a-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.0-foss-2015a-bare.eb
@@ -10,10 +10,6 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -21,6 +17,14 @@ dependencies = [
     ('libjpeg-turbo', '1.4.0'),  # for plottting in R
     ('Java', '1.7.0_80', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []
 

--- a/easybuild/easyconfigs/r/R/R-3.2.0-goolf-1.7.20-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.0-goolf-1.7.20-bare.eb
@@ -10,10 +10,6 @@ toolchain = {'name': 'goolf', 'version': '1.7.20'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -21,6 +17,14 @@ dependencies = [
     ('libjpeg-turbo', '1.4.0'),  # for plottting in R
     ('Java', '1.7.0_80', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []
 

--- a/easybuild/easyconfigs/r/R/R-3.2.0-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.0-goolf-1.7.20.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'goolf', 'version': '1.7.20'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -25,6 +21,14 @@ dependencies = [
     ('libxml2', '2.9.2'),  # for XML
     ('NLopt', '2.4.2'),  # for nloptr
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.2.0-ictce-7.3.5-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.0-ictce-7.3.5-bare.eb
@@ -10,10 +10,6 @@ toolchain = {'name': 'ictce', 'version': '7.3.5'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -23,6 +19,14 @@ dependencies = [
     ('Tcl', '8.6.4'),  # for tcltk
     ('Tk', '8.6.4', '-no-X11'),  # for tcltk
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []
 

--- a/easybuild/easyconfigs/r/R/R-3.2.0-intel-2015a-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.0-intel-2015a-bare.eb
@@ -10,10 +10,6 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -21,6 +17,14 @@ dependencies = [
     ('libjpeg-turbo', '1.4.0'),  # for plottting in R
     ('Java', '1.7.0_80', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []
 

--- a/easybuild/easyconfigs/r/R/R-3.2.1-foss-2015b-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.1-foss-2015b-bare.eb
@@ -10,10 +10,6 @@ toolchain = {'name': 'foss', 'version': '2015b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -21,6 +17,14 @@ dependencies = [
     ('libjpeg-turbo', '1.4.1'),  # for plottting in R
     ('Java', '1.8.0_45', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []
 

--- a/easybuild/easyconfigs/r/R/R-3.2.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.1-foss-2015b.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'foss', 'version': '2015b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -25,6 +21,14 @@ dependencies = [
     ('libxml2', '2.9.2'),  # for XML
     ('NLopt', '2.4.2'),  # for nloptr
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015a.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -25,6 +21,14 @@ dependencies = [
     ('libxml2', '2.9.2'),  # for XML
     ('NLopt', '2.4.2'),  # for nloptr
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015b-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015b-bare.eb
@@ -10,10 +10,6 @@ toolchain = {'name': 'intel', 'version': '2015b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -21,6 +17,14 @@ dependencies = [
     ('libjpeg-turbo', '1.4.1'),  # for plottting in R
     ('Java', '1.8.0_45', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []
 

--- a/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.1-intel-2015b.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'intel', 'version': '2015b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -25,6 +21,14 @@ dependencies = [
     ('libxml2', '2.9.2'),  # for XML
     ('NLopt', '2.4.2'),  # for nloptr
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.2.3-foss-2015b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-foss-2015b.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'foss', 'version': '2015b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
@@ -28,6 +24,14 @@ dependencies = [
     ('GMP', '6.0.0a', '', ('GNU', '4.9.3-2.25')),  # for igraph
     ('NLopt', '2.4.2'),  # for nloptr
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016a-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016a-bare.eb
@@ -10,10 +10,6 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
@@ -21,6 +17,14 @@ dependencies = [
     ('libjpeg-turbo', '1.4.2'),  # for plottting in R
     ('Java', '1.8.0_72', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []
 

--- a/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016a.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
@@ -28,6 +24,14 @@ dependencies = [
     ('GMP', '6.1.0'),  # for igraph
     ('NLopt', '2.4.2'),  # for nloptr
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-foss-2016b.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
@@ -28,6 +24,14 @@ dependencies = [
     ('GMP', '6.1.1'),  # for igraph
     ('NLopt', '2.4.2'),  # for nloptr
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a-bare.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a-bare.eb
@@ -10,10 +10,6 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
@@ -21,6 +17,14 @@ dependencies = [
     ('libjpeg-turbo', '1.4.2'),  # for plottting in R
     ('Java', '1.8.0_72', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_list = []
 

--- a/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a-libX11-1.6.3.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a-libX11-1.6.3.eb
@@ -13,10 +13,6 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     (libx11, libxver),
     ('libXt', '1.1.5'),
@@ -37,6 +33,14 @@ dependencies = [
     ('GMP', '6.1.0'),  # for igraph
     ('NLopt', '2.4.2'),  # for nloptr
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.2.3-intel-2016a.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
@@ -28,6 +24,14 @@ dependencies = [
     ('GMP', '6.1.0'),  # for igraph
     ('NLopt', '2.4.2'),  # for nloptr
 ]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.3.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.1-foss-2016a.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
@@ -39,6 +35,14 @@ dependencies = [
 ]
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.3.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.1-foss-2016b.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
@@ -39,6 +35,14 @@ dependencies = [
 ]
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.3.1-intel-2016b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.1-intel-2016b.eb
@@ -9,10 +9,6 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
@@ -39,6 +35,14 @@ dependencies = [
 ]
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.3.3-foss-2016b-X11-20160819.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.3-foss-2016b-X11-20160819.eb
@@ -11,10 +11,6 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('X11', x11ver),
     ('Mesa', '12.0.2'),
@@ -45,6 +41,14 @@ dependencies = [
 ]
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.3.3-intel-2017a-X11-20170314.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.3-intel-2017a-X11-20170314.eb
@@ -11,10 +11,6 @@ toolchain = {'name': 'intel', 'version': '2017a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('X11', x11ver),
     ('Mesa', '17.0.2'),
@@ -45,6 +41,14 @@ dependencies = [
 ]
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.4.0-intel-2017a-X11-20170314.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.0-intel-2017a-X11-20170314.eb
@@ -11,10 +11,6 @@ toolchain = {'name': 'intel', 'version': '2017a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('X11', x11ver),
     ('Mesa', '17.0.2'),
@@ -47,6 +43,14 @@ dependencies = [
 ]
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.4.1-foss-2016b-X11-20160819.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.1-foss-2016b-X11-20160819.eb
@@ -17,10 +17,6 @@ source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 
 checksums = ['02b1135d15ea969a3582caeb95594a05e830a6debcdb5b85ed2d5836a6a3fc78']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('X11', x11ver),
     ('Mesa', '12.0.2'),
@@ -50,6 +46,14 @@ dependencies = [
 ]
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {

--- a/easybuild/easyconfigs/r/R/R-3.4.3-intel-2017b-X11-20171023.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.3-intel-2017b-X11-20171023.eb
@@ -12,10 +12,6 @@ sources = [SOURCE_TAR_GZ]
 source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s']
 checksums = ['7a3cb831de5b4151e1f890113ed207527b7d4b16df9ec6b35e0964170007f426']
 
-configopts = "--with-pic --enable-threads --enable-R-shlib"
-# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
-configopts += " --with-recommended-packages=no"
-
 dependencies = [
     ('X11', x11ver),
     ('Mesa', '17.2.4'),
@@ -48,6 +44,14 @@ dependencies = [
 ]
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
 
 exts_default_options = {
     'source_urls': [


### PR DESCRIPTION
follow-up for #5478, to make sure that EasyBuild v3.5.0 (which includes the updated R easyblock, cfr. https://github.com/easybuilders/easybuild-easyblocks/pull/1292 & https://github.com/easybuilders/easybuild-easyblocks/pull/1297) is used, otherwise we would end up with a suboptimal R installation...

Also fixed order of `configopts` vs `dependencies` easyconfig parameters...