### PR TITLE
{chem} [intel/2017b] QuantumESPRESSO v6.2

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.2-intel-2017b.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.2-intel-2017b.eb
@@ -1,0 +1,46 @@
+name = 'QuantumESPRESSO'
+version = '6.2'
+
+homepage = 'http://www.pwscf.org/'
+description = """Quantum ESPRESSO  is an integrated suite of computer codes
+ for electronic-structure calculations and materials modeling at the nanoscale.
+ It is based on density-functional theory, plane waves, and pseudopotentials
+  (both norm-conserving and ultrasoft)."""
+
+toolchain = {'name': 'intel', 'version': '2017b'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+sources = [
+    'qe-%(version)s.tar.gz',
+    'qe-gipaw-%(version)s.tar.gz',
+    'wannier90-2.1.0.tar.gz',
+]
+
+# Manual download required, qe-forge doesn't 404, and EB can't handle github archives well,
+# since the qe and qe-gipaw get the exact same filename ("6.2.tar.gz").
+# wget http://qe-forge.org/gf/download/frsrelease/244/1114/qe-6.2.tar.gz
+# wget http://qe-forge.org/gf/download/frsrelease/245/1119/qe-gipaw-6.2.tar.gz
+
+source_urls = [
+    # 'https://github.com/QEF/q-e/archive/',  # qe
+    # 'https://github.com/dceresoli/qe-gipaw/archive/',  # qe-gipaw
+    'http://www.wannier.org/code/',  # wannier90
+]
+
+# source checksums
+checksums = [
+    'c5b7db155e01ebfba2c7977df94bd6e70ca8fe9fb51fb08aa2a8a3ef4398325d',  # qe-6.2.tar.gz
+    '6fa50ea4e87fc2c4aaf3fb6f3ff3e04eab590ba4895761dae1bc56079fbca8b5',  # qe-gipaw-6.2.tar.gz
+    'ee90108d4bc4aa6a1cf16d72abebcb3087cf6c1007d22dda269eb7e7076bddca',  # wannier90-2.1.0.tar.gz
+]
+
+dependencies = [
+    ('FoX', '4.1.2'),
+]
+
+buildopts = 'all w90 gipaw xspectra pwall ph epw'
+
+# parallel build tends to fail
+parallel = 1
+
+moduleclass = 'chem'


### PR DESCRIPTION
New config for 6.2. Dropped several previously used third party modules as they didn't immediately build cleanly, and the person requesting the installation didn't have any interest in them.

Downloads are problematic, and requires manual downloading to work due to easybuilders/easybuild#390

edit: depends on ~~#5496~~