### PR TITLE
add patch for signal package in Octave 4.2.1 easyconfigs (+ add SHA256 checksums)

### DIFF
--- a/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a.eb
@@ -9,8 +9,11 @@ toolchainopts = {'cstd': 'c++11'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-
 patches = ['%(name)s-%(version)s_intel.patch']
+checksums = [
+    '80c28f6398576b50faca0e602defb9598d6f7308b0903724442c2a35a605333b',  # octave-4.2.1.tar.gz
+    'f35b6e28f1ceaf7e67c935544ad2547931a30cd03ab0a1587715c6bd94521de9',  # Octave-4.2.1_intel.patch
+]
 
 builddependencies = [
     ('Bison', '3.0.4'),
@@ -54,8 +57,16 @@ pkg_url = 'https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Pac
 exts_default_options = {'source_urls': [pkg_url]}
 
 exts_list = [
-    ('control', '3.0.0'),
-    ('signal', '1.3.2'),
+    ('control', '3.0.0', {
+        'checksums': ['41e9a5627565444140cf8bb8cf978239245355a6fc7d61ff122327d8f822eca6'],
+    }),
+    ('signal', '1.3.2', {
+        'patches': ['signal-1.3.2_fix-formula.patch'],
+        'checksums': [
+            'a277f12e9f47cc66a8c56ab26284ac4839b223f32de13e35e710401fd0539b60',  # signal-1.3.2.tar.gz
+            'a3defda6cebbe0ac9fa77230e4a69f1b15f0fdc54ac7a11d4aac2302e95eabdd',  # signal-1.3.2_fix-formula.patch
+        ],
+    }),
 ]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/o/Octave/signal-1.3.2_fix-formula.patch
+++ b/easybuild/easyconfigs/o/Octave/signal-1.3.2_fix-formula.patch
@@ -1,0 +1,14 @@
+fix for bug in gausswin making it produce wrong results
+see https://savannah.gnu.org/bugs/index.php?51657
+author: Kenneth Hoste (HPC-UGent)
+--- signal-1.3.2/inst/gausswin.m.orig	2017-12-11 14:27:49.593981000 +0100
++++ signal-1.3.2/inst/gausswin.m	2017-12-11 14:30:59.032409000 +0100
+@@ -37,7 +37,7 @@
+     a = 2.5;
+   endif
+ 
+-  w = exp ( -0.5 * ( a/m * [ -(m-1) : 2 : m-1 ]' ) .^ 2 );
++  w = exp ( -0.5 * ( a/(m-1) * [ -(m-1) : 2 : m-1 ]' ) .^ 2 );
+ 
+ endfunction
+ 


### PR DESCRIPTION
requires https://github.com/easybuilders/easybuild-easyblocks/pull/1318 for patch to be actually picked up