### PR TITLE
fix checksum for Szip 2.1.1

### DIFF
--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-6.3.0.eb
@@ -14,7 +14,7 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['897dda94e1d4bf88c91adeaad88c07b468b18eaf2d6125c47acac57e540904a9']
+checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 
 builddependencies = [
     ('binutils', '2.28'),

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-6.4.0.eb
@@ -14,7 +14,7 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['897dda94e1d4bf88c91adeaad88c07b468b18eaf2d6125c47acac57e540904a9']
+checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 
 builddependencies = [
     ('binutils', '2.28'),


### PR DESCRIPTION
Apparently the `szip-2.1.1.tar.gz` have been updated in place...

The new tarball is a cleaned up version, here's a comparison with the previous one:

```
$ diff -u szip-2.1.1.orig szip-2.1.1 | grep -A 1 '^diff'
diff --git a/szip-2.1.1.orig/autom4te.cache/output.0 b/szip-2.1.1.orig/autom4te.cache/output.0
deleted file mode 100644
--
diff --git a/szip-2.1.1.orig/autom4te.cache/output.1 b/szip-2.1.1.orig/autom4te.cache/output.1
deleted file mode 100644
--
diff --git a/szip-2.1.1.orig/autom4te.cache/output.2 b/szip-2.1.1.orig/autom4te.cache/output.2
deleted file mode 100644
--
diff --git a/szip-2.1.1.orig/autom4te.cache/requests b/szip-2.1.1.orig/autom4te.cache/requests
deleted file mode 100644
--
diff --git a/szip-2.1.1.orig/autom4te.cache/traces.0 b/szip-2.1.1.orig/autom4te.cache/traces.0
deleted file mode 100644
--
diff --git a/szip-2.1.1.orig/autom4te.cache/traces.1 b/szip-2.1.1.orig/autom4te.cache/traces.1
deleted file mode 100644
--
diff --git a/szip-2.1.1.orig/autom4te.cache/traces.2 b/szip-2.1.1.orig/autom4te.cache/traces.2
deleted file mode 100644
--
diff --git a/szip-2.1.1.orig/src/SZconfig.h.in~ b/szip-2.1.1.orig/src/SZconfig.h.in~
deleted file mode 100644
```