### PR TITLE
fix order of extensions for FSLeyes, add missing MarkupSafe (dep for Jinja2)

### DIFF
--- a/easybuild/easyconfigs/f/FSLeyes/FSLeyes-0.15.0-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/f/FSLeyes/FSLeyes-0.15.0-intel-2017a-Python-2.7.13.eb
@@ -22,61 +22,50 @@ dependencies = [
 exts_defaultclass = 'PythonPackage'
 
 exts_list = [
+    ('MarkupSafe', '1.0', {
+        'modulename': 'markupsafe',
+        'source_urls': ['https://pypi.python.org/packages/source/M/MarkupSafe/'],
+        'checksums': ['a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665'],
+    }),
     ('Jinja2', '2.9.6', {
         'source_urls': ['https://pypi.python.org/packages/source/J/Jinja2'],
-        'checksums': [
-            'ddaa01a212cd6d641401cb01b605f4a4d9f37bfc93043d7f760ec70fb99ff9ff',  # Jinja2-2.9.6.tar.gz
-        ],
+        'checksums': ['ddaa01a212cd6d641401cb01b605f4a4d9f37bfc93043d7f760ec70fb99ff9ff'],
     }),
     ('indexed-gzip', '0.6.0', {
         'modulename': 'indexed_gzip',
         'source_tmpl': 'v%(version)s.tar.gz',
         'source_urls': ['https://github.com/pauldmccarthy/indexed_gzip/archive/'],
-        'checksums': [
-            '3b9a2e60601b8d41fa9f9597cd803abf4c88a3087fa288411c03a3ec31abb6a8',  # v0.6.0.tar.gz
-        ],
+        'checksums': ['3b9a2e60601b8d41fa9f9597cd803abf4c88a3087fa288411c03a3ec31abb6a8'],
     }),
     ('PyOpenGL-accelerate', '3.1.1a1', {
         'modulename': 'OpenGL_accelerate',
         'source_urls': ['https://pypi.python.org/packages/source/P/PyOpenGL-accelerate'],
-        'checksums': [
-            '3d37af9f2565febf214e1da2a5fe019561992d34026ce2a5f51972e121b84cdd',  # PyOpenGL-accelerate-3.1.1a1.tar.gz
-        ],
+        'checksums': ['3d37af9f2565febf214e1da2a5fe019561992d34026ce2a5f51972e121b84cdd'],
     }),
     ('PyOpenGL', '3.1.1a1', {
         'modulename': 'OpenGL',
         'source_urls': ['https://pypi.python.org/packages/source/P/PyOpenGL'],
-        'checksums': [
-            'c96d909b359abe3271b746bacf7e6ba52935141e2406a8f90231e4e44dfa4075',  # PyOpenGL-3.1.1a1.tar.gz
-        ],
+        'checksums': ['c96d909b359abe3271b746bacf7e6ba52935141e2406a8f90231e4e44dfa4075'],
     }),
     ('fsleyes-widgets', '0.0.6', {
         'modulename': 'fsleyes_widgets',
         'source_urls': ['https://pypi.python.org/packages/source/f/fsleyes-widgets'],
-        'checksums': [
-            '24029ae8b7b5dd917e643dfd8ba8385b28979833b6a977437fc3b0dbe45e3b1f',  # fsleyes-widgets-0.0.6.tar.gz
-        ],
-    }),
-    ('fsleyes-props', '1.2.1', {
-        'modulename': 'fsleyes_props',
-        'source_urls': ['https://pypi.python.org/packages/source/f/fsleyes-props'],
-        'checksums': [
-            'd18f186ede16bb7f96d838ecc8b933e84fb5e99dd3294af70cf727b72d6b0a3a',  # fsleyes-props-1.2.1.tar.gz
-        ],
+        'checksums': ['24029ae8b7b5dd917e643dfd8ba8385b28979833b6a977437fc3b0dbe45e3b1f'],
     }),
     ('fslpy', '1.2.0', {
         'modulename': 'fsl',
         'source_urls': ['https://pypi.python.org/packages/source/f/fslpy'],
-        'checksums': [
-            '3978c81773823046bfea7eb41aa273a00bbb01faddcc3621974d204ed2fcb8b6',  # fslpy-1.2.0.tar.gz
-        ],
+        'checksums': ['3978c81773823046bfea7eb41aa273a00bbb01faddcc3621974d204ed2fcb8b6'],
+    }),
+    ('fsleyes-props', '1.2.1', {
+        'modulename': 'fsleyes_props',
+        'source_urls': ['https://pypi.python.org/packages/source/f/fsleyes-props'],
+        'checksums': ['d18f186ede16bb7f96d838ecc8b933e84fb5e99dd3294af70cf727b72d6b0a3a'],
     }),
     (name, version, {
         'source_tmpl': 'fsleyes-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/f/fsleyes'],
-        'checksums': [
-            'e1feadd322b8cbd8714f239ebc3246a4317f26079116397f4b555d3aeb29fe02',  # fsleyes-0.15.0.tar.gz
-        ],
+        'checksums': ['e1feadd322b8cbd8714f239ebc3246a4317f26079116397f4b555d3aeb29fe02'],
     }),
 ]
 


### PR DESCRIPTION
Installation of FSLeyes is now broken because of the wrong order.

A newer version of `fslpy` is pulled in when installing `fsleyes-props`, which doesn't work...