### PR TITLE
{bio}[foss/2016b] BamTools 2.5.0

### DIFF
--- a/easybuild/easyconfigs/b/BamTools/BamTools-2.5.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/b/BamTools/BamTools-2.5.0-foss-2016b.eb
@@ -1,0 +1,19 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+
+name = 'BamTools'
+version = '2.5.0'
+
+homepage = 'https://github.com/pezmaster31/%(namelower)s'
+description = "BamTools provides both a programmer's API and an end-user's toolkit for handling BAM files."
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/pezmaster31/%(namelower)s/archive']
+sources = ['v%(version)s.tar.gz']
+
+checksums = ['85e02e04998a67cbda7ab68cdab36cee133db024e814b34e06bb617b627caf9c']
+
+builddependencies = [('CMake', '3.7.2')]
+
+moduleclass = 'bio'


### PR DESCRIPTION
This adds version 2.5.0 of BamTools `--try-software-version` doesn't work because they changed some paths.