### PR TITLE
{bio}[foss/2016b] BCFtools 1.6 and HTSlib 1.6

### DIFF
--- a/easybuild/easyconfigs/b/BCFtools/BCFtools-1.6-foss-2016b.eb
+++ b/easybuild/easyconfigs/b/BCFtools/BCFtools-1.6-foss-2016b.eb
@@ -1,0 +1,33 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+
+easyblock = 'ConfigureMake'
+
+name = 'BCFtools'
+version = '1.6'
+
+homepage = 'http://www.htslib.org/'
+description = """Samtools is a suite of programs for interacting with high-throughput sequencing data.
+ BCFtools - Reading/writing BCF2/VCF/gVCF files and calling/filtering/summarising SNP and short indel sequence
+ variants"""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/samtools/%(namelower)s/releases/download/%(version)s']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['293010736b076cf684d2873928924fcc3d2c231a091084c2ac23a8045c7df982']
+
+dependencies = [
+    ('zlib', '1.2.8'),
+    ('HTSlib', '1.6'),
+    ('GSL', '2.3'),
+]
+
+configopts = "--with-htslib=$EBROOTHTSLIB --enable-libgsl"
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['bcftools', 'plot-vcfstats', 'vcfutils.pl']],
+    'dirs': ['libexec/bcftools']
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.6-foss-2016b.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.6-foss-2016b.eb
@@ -1,0 +1,31 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+
+easyblock = 'ConfigureMake'
+
+name = 'HTSlib'
+version = '1.6'
+
+homepage = "http://www.htslib.org/"
+description = """A C library for reading/writing high-throughput sequencing data.
+ This package includes the utilities bgzip and tabix"""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+
+source_urls = ['https://github.com/samtools/%(namelower)s/releases/download/%(version)s/']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['9588be8be0c2390a87b7952d644e7a88bead2991b3468371347965f2e0504ccb']
+
+# cURL added for S3 support
+dependencies = [
+    ('zlib', '1.2.8'),
+    ('bzip2', '1.0.6'),
+    ('XZ', '5.2.2'),
+    ('cURL', '7.49.1'),
+]
+
+sanity_check_paths = {
+    'files': ["bin/bgzip", "bin/tabix", "lib/libhts.%s" % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.6-foss-2016b.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.6-foss-2016b.eb
@@ -10,6 +10,7 @@ description = """A C library for reading/writing high-throughput sequencing data
  This package includes the utilities bgzip and tabix"""
 
 toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/samtools/%(namelower)s/releases/download/%(version)s/']
 sources = [SOURCELOWER_TAR_BZ2]


### PR DESCRIPTION
This adds BCFtools 1.6 for foss-2016b with the missing dependency HTSlib 1.6.