### PR TITLE
fix permissions on make_raw_alos.pl script in ROI_PAC installation

### DIFF
--- a/easybuild/easyconfigs/r/ROI_PAC/ROI_PAC-3.0.1-intel-2017a-Perl-5.24.1.eb
+++ b/easybuild/easyconfigs/r/ROI_PAC/ROI_PAC-3.0.1-intel-2017a-Perl-5.24.1.eb
@@ -41,6 +41,8 @@ postinstallcmds = [
     "cp -a INT_SCR/* %(installdir)s/bin",
     # fix shebang in Perl scripts
     "sed -i 's@^#!.*/bin/perl.*@#!/usr/bin/env perl@g' %(installdir)s//bin/*.pl",
+    # fix permissions of make_raw_alos.pl
+    "chmod a+rx %(installdir)s/bin/make_raw_alos.pl",
 ]
 
 sanity_check_paths = {


### PR DESCRIPTION
only has `rwxr--r--` by default...