### PR TITLE
{bio}[foss/2016b] MapSplice 2.2.1

### DIFF
--- a/easybuild/easyconfigs/m/MapSplice/MapSplice-2.2.1-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/MapSplice/MapSplice-2.2.1-foss-2016b-Python-2.7.12.eb
@@ -15,11 +15,7 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://protocols.netlab.uky.edu/~zeng']
 sources = ['%(name)s-v%(version)s.zip']
-
-patches = [
-    '%(name)s-%(version)s_fix-build-gcc.patch',
-]
-
+patches = ['%(name)s-%(version)s_fix-build-gcc.patch']
 checksums = [
     '4f3c1cb49ba0abcfc952de5946ee0b56db28c51f4f4d4f5abca66b4461ca7d05',  # MapSplice-v2.2.1.zip
     '30c29dfde280b9614b4624224eed0927243acb45f99554e898de29df4c967a29',  # MapSplice-2.2.1_fix-build-gcc.patch

--- a/easybuild/easyconfigs/m/MapSplice/MapSplice-2.2.1-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/MapSplice/MapSplice-2.2.1-foss-2016b-Python-2.7.12.eb
@@ -1,0 +1,41 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+
+easyblock = 'MakeCp'
+
+name = 'MapSplice'
+version = '2.2.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.netlab.uky.edu/p/bioinfo/%(name)s2'
+description = """MapSplice is a software for mapping RNA-seq data to reference genome for splice
+ junction discovery that depends only on reference genome, and not on any further annotations."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://protocols.netlab.uky.edu/~zeng']
+sources = ['%(name)s-v%(version)s.zip']
+
+patches = [
+    '%(name)s-%(version)s_fix-build-gcc.patch',
+]
+
+checksums = [
+    '4f3c1cb49ba0abcfc952de5946ee0b56db28c51f4f4d4f5abca66b4461ca7d05',  # MapSplice-v2.2.1.zip
+    '30c29dfde280b9614b4624224eed0927243acb45f99554e898de29df4c967a29',  # MapSplice-2.2.1_fix-build-gcc.patch
+]
+
+dependencies = [
+    ('Python', '2.7.12'),
+]
+
+files_to_copy = ['bin', 'mapsplice.py', 'Copyright.txt']
+
+sanity_check_paths = {
+    'files': ['%(namelower)s.py'],
+    'dirs': ['bin'],
+}
+
+modloadmsg = "To use MapSplice run: python $EBROOTMAPSPLICE/mapsplice.py\n"
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/MapSplice/MapSplice-2.2.1-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/MapSplice/MapSplice-2.2.1-foss-2016b-Python-2.7.12.eb
@@ -18,7 +18,7 @@ sources = ['%(name)s-v%(version)s.zip']
 patches = ['%(name)s-%(version)s_fix-build-gcc.patch']
 checksums = [
     '4f3c1cb49ba0abcfc952de5946ee0b56db28c51f4f4d4f5abca66b4461ca7d05',  # MapSplice-v2.2.1.zip
-    '30c29dfde280b9614b4624224eed0927243acb45f99554e898de29df4c967a29',  # MapSplice-2.2.1_fix-build-gcc.patch
+    '726f3177de67058f192788d8c352155a946817fc837af71389b9a542a51515fb',  # MapSplice-2.2.1_fix-build-gcc.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/m/MapSplice/MapSplice-2.2.1_fix-build-gcc.patch
+++ b/easybuild/easyconfigs/m/MapSplice/MapSplice-2.2.1_fix-build-gcc.patch
@@ -1,0 +1,41 @@
+* fix build error with gcc >= 4.9: redeclaration of ... may not have default arguments
+--- src/bowtie/ebwt.h.orig
++++ src/bowtie/ebwt.h
+@@ -1070,7 +1070,7 @@
+ 	// Building
+ 	static TStr join(vector<TStr>& l, uint32_t seed);
+ 	static TStr join(vector<FileBuf*>& l, vector<RefRecord>& szs, uint32_t sztot, const RefReadInParams& refparams, uint32_t seed);
+-	void joinToDisk(vector<FileBuf*>& l, vector<RefRecord>& szs, vector<uint32_t>& plens, uint32_t sztot, const RefReadInParams& refparams, TStr& ret, ostream& out1, ostream& out2, uint32_t seed);
++	void joinToDisk(vector<FileBuf*>& l, vector<RefRecord>& szs, vector<uint32_t>& plens, uint32_t sztot, const RefReadInParams& refparams, TStr& ret, ostream& out1, ostream& out2, uint32_t seed = 0);
+ 	void buildToDisk(InorderBlockwiseSA<TStr>& sa, const TStr& s, ostream& out1, ostream& out2);
+ 
+ 	// I/O
+@@ -3935,7 +3935,7 @@
+ 	TStr& ret,
+ 	ostream& out1,
+ 	ostream& out2,
+-	uint32_t seed = 0)
++	uint32_t seed)
+ {
+ 	RandomSource rand; // reproducible given same seed
+ 	rand.init(seed);
+--- src/MapSplice/ebwt.h.orig
++++ src/MapSplice/ebwt.h
+@@ -1077,7 +1077,7 @@
+ 	// Building
+ 	static TStr join(vector<TStr>& l, uint32_t seed);
+ 	static TStr join(vector<FileBuf*>& l, vector<RefRecord>& szs, uint32_t sztot, const RefReadInParams& refparams, uint32_t seed);
+-	void joinToDisk(vector<FileBuf*>& l, vector<RefRecord>& szs, vector<uint32_t>& plens, uint32_t sztot, const RefReadInParams& refparams, TStr& ret, ostream& out1, ostream& out2, uint32_t seed);
++	void joinToDisk(vector<FileBuf*>& l, vector<RefRecord>& szs, vector<uint32_t>& plens, uint32_t sztot, const RefReadInParams& refparams, TStr& ret, ostream& out1, ostream& out2, uint32_t seed = 0);
+ 	void buildToDisk(InorderBlockwiseSA<TStr>& sa, const TStr& s, ostream& out1, ostream& out2);
+ 
+ 	// I/O
+@@ -3942,7 +3942,7 @@
+ 	TStr& ret,
+ 	ostream& out1,
+ 	ostream& out2,
+-	uint32_t seed = 0)
++	uint32_t seed)
+ {
+ 	RandomSource rand; // reproducible given same seed
+ 	rand.init(seed);

--- a/easybuild/easyconfigs/m/MapSplice/MapSplice-2.2.1_fix-build-gcc.patch
+++ b/easybuild/easyconfigs/m/MapSplice/MapSplice-2.2.1_fix-build-gcc.patch
@@ -1,4 +1,5 @@
 * fix build error with gcc >= 4.9: redeclaration of ... may not have default arguments
+author: Paul Jähne
 --- src/bowtie/ebwt.h.orig
 +++ src/bowtie/ebwt.h
 @@ -1070,7 +1070,7 @@


### PR DESCRIPTION
This adds MapSplice.

The patch is needed because since GCC version 4.9 default arguments on the definition are not allowed and have to be moved to the declaration. I also submitted the patch to the developers.