### PR TITLE
include HWxtest as extension to fix issue with diveRsity in R 3.4.3 easyconfig file

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.4.3-intel-2017b-X11-20171023.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.3-intel-2017b-X11-20171023.eb
@@ -1441,6 +1441,9 @@ exts_list = [
     ('qgraph', '1.4.4', {
         'checksums': ['f62a908a4185f30c2f6924a69f1a569a636fa3053de1e92288367b498b93f841'],
     }),
+    ('HWxtest', '1.1.7', {
+        'checksums': ['7cfcf7860d655945f9d3bbda4590374d3100bb5da6b49956f2e701b910a20e0c'],
+    }),
     ('diveRsity', '1.9.90', {
         'checksums': ['b8f49cdbfbd82805206ad293fcb2dad65b962fb5523059a3e3aecaedf5c0ee86'],
     }),


### PR DESCRIPTION
fix for this issue that pops up when trying to run an analysis with `diveRsity`:

```
Error: Please install HWxtest: devtools::install_github('wrengels/HWxtest', 
         subdir='pkg')
Execution halted
```