### PR TITLE
clean up BamTools easyconfigs to rely on updated easyblock + add SHA256 checksums

### DIFF
--- a/easybuild/easyconfigs/b/BamTools/BamTools-2.2.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/BamTools/BamTools-2.2.3-goolf-1.4.10.eb
@@ -15,11 +15,10 @@ description = """BamTools provides both a programmer's API and an end-user's too
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-sources = ['v%(version)s.tar.gz']
 source_urls = ['https://github.com/pezmaster31/bamtools/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['92ddef44801a1f8f01ce1a397f83e0f8b5e1ae8ad92c620f2dafaaf8d54cf178']
 
 builddependencies = [('CMake', '2.8.4')]
-
-files_to_copy = ["bin", "lib", "include", "docs", "LICENSE", "README"]
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/BamTools/BamTools-2.2.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/b/BamTools/BamTools-2.2.3-ictce-5.3.0.eb
@@ -15,11 +15,10 @@ description = """BamTools provides both a programmer's API and an end-user's too
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
-sources = ['v%(version)s.tar.gz']
 source_urls = ['https://github.com/pezmaster31/bamtools/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['92ddef44801a1f8f01ce1a397f83e0f8b5e1ae8ad92c620f2dafaaf8d54cf178']
 
 builddependencies = [('CMake', '2.8.4')]
-
-files_to_copy = ["bin", "lib", "include", "docs", "LICENSE", "README"]
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/BamTools/BamTools-2.4.0-foss-2015b.eb
+++ b/easybuild/easyconfigs/b/BamTools/BamTools-2.4.0-foss-2015b.eb
@@ -15,17 +15,10 @@ description = """BamTools provides both a programmer's API and an end-user's too
 
 toolchain = {'name': 'foss', 'version': '2015b'}
 
-sources = ['v%(version)s.tar.gz']
 source_urls = ['https://github.com/pezmaster31/bamtools/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['f1fe82b8871719e0fb9ed7be73885f5d0815dd5c7277ee33bd8f67ace961e13e']
 
 builddependencies = [('CMake', '3.4.1')]
-
-files_to_copy = ["bin", "lib", "include", "docs", "LICENSE", "README"]
-
-sanity_check_paths = {
-    'files': ["bin/bamtools", "include/shared/bamtools_global.h", "lib/libbamtools.a",
-              "lib/libbamtools.so", "lib/libbamtools-utils.a", "lib/libjsoncpp.a"],
-    'dirs': ["include/api", "docs"]
-}
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/BamTools/BamTools-2.4.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/b/BamTools/BamTools-2.4.0-foss-2016b.eb
@@ -15,17 +15,10 @@ description = """BamTools provides both a programmer's API and an end-user's too
 
 toolchain = {'name': 'foss', 'version': '2016b'}
 
-sources = ['v%(version)s.tar.gz']
 source_urls = ['https://github.com/pezmaster31/bamtools/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['f1fe82b8871719e0fb9ed7be73885f5d0815dd5c7277ee33bd8f67ace961e13e']
 
 builddependencies = [('CMake', '3.4.3')]
-
-files_to_copy = ["bin", "lib", "include", "docs", "LICENSE", "README"]
-
-sanity_check_paths = {
-    'files': ["bin/bamtools", "include/shared/bamtools_global.h", "lib/libbamtools.a",
-              "lib/libbamtools.so", "lib/libbamtools-utils.a", "lib/libjsoncpp.a"],
-    'dirs': ["include/api", "docs"]
-}
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/BamTools/BamTools-2.4.0-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/b/BamTools/BamTools-2.4.0-goolf-1.7.20.eb
@@ -6,11 +6,10 @@ description = """BamTools provides both a programmer's API and an end-user's too
 
 toolchain = {'name': 'goolf', 'version': '1.7.20'}
 
-sources = ['v%(version)s.tar.gz']
 source_urls = ['https://github.com/pezmaster31/bamtools/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['f1fe82b8871719e0fb9ed7be73885f5d0815dd5c7277ee33bd8f67ace961e13e']
 
 builddependencies = [('CMake', '2.8.12')]
-
-files_to_copy = ["bin", "lib", "include", "docs", "LICENSE", "README"]
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/BamTools/BamTools-2.4.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/b/BamTools/BamTools-2.4.1-intel-2017a.eb
@@ -6,11 +6,10 @@ description = """BamTools provides both a programmer's API and an end-user's too
 
 toolchain = {'name': 'intel', 'version': '2017a'}
 
-sources = ['v%(version)s.tar.gz']
 source_urls = ['https://github.com/pezmaster31/bamtools/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['933a0c1a83c88c1dac8078c0c0e82f6794c75cb927265399404bc2cc2611204b']
 
 builddependencies = [('CMake', '3.8.0')]
-
-files_to_copy = ['bin', 'lib', 'include', 'docs', 'LICENSE', 'README']
 
 moduleclass = 'bio'


### PR DESCRIPTION
`files_to_copy` was required, but not anymore thanks to updated `BamTools` easyblock in ~~https://github.com/easybuilders/easybuild-easyblocks/pull/1332~~


  