### PR TITLE
M4: Fix option passed to configure

### DIFF
--- a/easybuild/easyconfigs/m/M4/M4-1.4.16-GCC-4.6.3.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16-GCC-4.6.3.eb
@@ -20,7 +20,7 @@ checksums = [
     '7c223ab254e9ba2d8ad5dc427889b5ad37304917c178ed541b8b95e24d9ee8d5',  # M4-1.4.16-no-gets.patch
 ]
 
-configopts = "--enable-cxx"
+configopts = "--enable-c++"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.16-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16-GCC-4.7.2.eb
@@ -20,7 +20,7 @@ checksums = [
     '7c223ab254e9ba2d8ad5dc427889b5ad37304917c178ed541b8b95e24d9ee8d5',  # M4-1.4.16-no-gets.patch
 ]
 
-configopts = "--enable-cxx"
+configopts = "--enable-c++"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.16-GCC-4.7.3.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16-GCC-4.7.3.eb
@@ -20,7 +20,7 @@ checksums = [
     '7c223ab254e9ba2d8ad5dc427889b5ad37304917c178ed541b8b95e24d9ee8d5',  # M4-1.4.16-no-gets.patch
 ]
 
-configopts = "--enable-cxx"
+configopts = "--enable-c++"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.16-GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16-GCC-4.8.1.eb
@@ -20,7 +20,7 @@ checksums = [
     '7c223ab254e9ba2d8ad5dc427889b5ad37304917c178ed541b8b95e24d9ee8d5',  # M4-1.4.16-no-gets.patch
 ]
 
-configopts = "--enable-cxx"
+configopts = "--enable-c++"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.16-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16-GCC-4.8.2.eb
@@ -19,7 +19,7 @@ checksums = [
     '7c223ab254e9ba2d8ad5dc427889b5ad37304917c178ed541b8b95e24d9ee8d5',  # M4-1.4.16-no-gets.patch
 ]
 
-configopts = "--enable-cxx"
+configopts = "--enable-c++"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.16-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16-goolf-1.4.10.eb
@@ -20,7 +20,7 @@ checksums = [
     '7c223ab254e9ba2d8ad5dc427889b5ad37304917c178ed541b8b95e24d9ee8d5',  # M4-1.4.16-no-gets.patch
 ]
 
-configopts = "--enable-cxx"
+configopts = "--enable-c++"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.16-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16-goolf-1.5.14.eb
@@ -20,7 +20,7 @@ checksums = [
     '7c223ab254e9ba2d8ad5dc427889b5ad37304917c178ed541b8b95e24d9ee8d5',  # M4-1.4.16-no-gets.patch
 ]
 
-configopts = "--enable-cxx"
+configopts = "--enable-c++"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.16-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16-ictce-5.3.0.eb
@@ -19,7 +19,7 @@ checksums = [
     '7c223ab254e9ba2d8ad5dc427889b5ad37304917c178ed541b8b95e24d9ee8d5',  # M4-1.4.16-no-gets.patch
 ]
 
-configopts = "--enable-cxx"
+configopts = "--enable-c++"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.16-ictce-5.4.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16-ictce-5.4.0.eb
@@ -19,7 +19,7 @@ checksums = [
     '7c223ab254e9ba2d8ad5dc427889b5ad37304917c178ed541b8b95e24d9ee8d5',  # M4-1.4.16-no-gets.patch
 ]
 
-configopts = "--enable-cxx"
+configopts = "--enable-c++"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.16-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16-ictce-5.5.0.eb
@@ -18,7 +18,7 @@ checksums = [
     '7c223ab254e9ba2d8ad5dc427889b5ad37304917c178ed541b8b95e24d9ee8d5',  # M4-1.4.16-no-gets.patch
 ]
 
-configopts = "--enable-cxx"
+configopts = "--enable-c++"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.16-ictce-6.1.5.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16-ictce-6.1.5.eb
@@ -19,7 +19,7 @@ checksums = [
     '7c223ab254e9ba2d8ad5dc427889b5ad37304917c178ed541b8b95e24d9ee8d5',  # M4-1.4.16-no-gets.patch
 ]
 
-configopts = "--enable-cxx"
+configopts = "--enable-c++"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.16-intel-2014b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16-intel-2014b.eb
@@ -18,7 +18,7 @@ checksums = [
     '7c223ab254e9ba2d8ad5dc427889b5ad37304917c178ed541b8b95e24d9ee8d5',  # M4-1.4.16-no-gets.patch
 ]
 
-configopts = "--enable-cxx"
+configopts = "--enable-c++"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.16.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16.eb
@@ -20,7 +20,7 @@ checksums = [
     '7c223ab254e9ba2d8ad5dc427889b5ad37304917c178ed541b8b95e24d9ee8d5',  # M4-1.4.16-no-gets.patch
 ]
 
-configopts = "--enable-cxx"
+configopts = "--enable-c++"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.06.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.06.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.11.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.7.2.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.2.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.4.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2-binutils-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2-binutils-2.25.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.25', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-2.25.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-binutils-2.25.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.25', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.1.0-binutils-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.1.0-binutils-2.25.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.25', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.2.0.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.4.0-2.26.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.2.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.25', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS='-fgnu89-inline'"
+configopts = "--enable-c++ CPPFLAGS='-fgnu89-inline'"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.3.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.25', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS='-fgnu89-inline'"
+configopts = "--enable-c++ CPPFLAGS='-fgnu89-inline'"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.4.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.4.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.25', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS='-fgnu89-inline'"
+configopts = "--enable-c++ CPPFLAGS='-fgnu89-inline'"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.3.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.3.0.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.26', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.4.0.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.26', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.1.0.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.27', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.2.0.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.27', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.2-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.2-2.25.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.3-2.25.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-5.1.0-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-5.1.0-2.25.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2014b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2014b.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015.05.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015.05.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015a.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015a.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015b.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016.04.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016.04.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016a.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016a.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS='-fgnu89-inline'"
+configopts = "--enable-c++ CPPFLAGS='-fgnu89-inline'"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016b.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-gimkl-2.11.5.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-5.4.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-5.4.0.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-5.5.0.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-7.1.2.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2014b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2014b.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2015a.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2015a.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2015b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2015b.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016.02-GCC-4.9.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016a.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016a.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016b.eb
@@ -16,7 +16,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-iomkl-2016.07.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-iomkl-2016.07.eb
@@ -14,7 +14,7 @@ source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -14,7 +14,7 @@ source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17.eb
@@ -20,7 +20,7 @@ checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ['bin/m4'],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-5.3.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-5.3.0.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.26', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-5.4.0.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.26', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-5.5.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-5.5.0.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.26', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-6.3.0.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.27', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-6.4.0.eb
@@ -25,7 +25,7 @@ builddependencies = [
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ['bin/m4'],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-7.1.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-7.1.0.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.28', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-7.2.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-7.2.0.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.29', '', True)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ['bin/m4'],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-system.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-system.eb
@@ -18,7 +18,7 @@ checksums = ['ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18.eb
@@ -20,7 +20,7 @@ checksums = ['ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab']
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
-configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ['bin/m4'],


### PR DESCRIPTION
While it seems to only have an impact on the testsuite for the included gnulib and not on M4 itself, `--enable-cxx` is not a valid configure option of M4 and ignored (with a warning message).  Thus, use the correct `--enable-c++` instead.