### PR TITLE
Add Time::HiRes to recent Perl versions

### DIFF
--- a/easybuild/easyconfigs/p/Perl/Perl-5.22.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.22.1-foss-2016a.eb
@@ -888,6 +888,10 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.22.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.22.1-foss-2016b.eb
@@ -888,6 +888,10 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.22.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.22.1-intel-2016a.eb
@@ -889,6 +889,10 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.22.2-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.22.2-goolf-1.7.20.eb
@@ -887,6 +887,10 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.22.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.22.2-intel-2016a.eb
@@ -888,6 +888,10 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.0-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.0-GCC-5.4.0-2.26.eb
@@ -895,6 +895,10 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.0-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.0-GCCcore-4.9.3.eb
@@ -897,6 +897,10 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.0-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.0-GCCcore-5.4.0.eb
@@ -898,6 +898,10 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.0-foss-2016b.eb
@@ -895,6 +895,10 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.0-intel-2016b.eb
@@ -896,6 +896,10 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.1-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.1-GCCcore-6.3.0.eb
@@ -1126,6 +1126,10 @@ exts_list = [
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
         'checksums': ['6855ce5615fd3e1af4cfc451a9bf44ff29a3140b4e7130034f1f0af2511a94fb'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.1-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.1-GCCcore-6.3.0.eb
@@ -1127,8 +1127,9 @@ exts_list = [
         'checksums': ['6855ce5615fd3e1af4cfc451a9bf44ff29a3140b4e7130034f1f0af2511a94fb'],
     }),
     ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.1-foss-2017a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.1-foss-2017a.eb
@@ -1125,8 +1125,9 @@ exts_list = [
         'checksums': ['6855ce5615fd3e1af4cfc451a9bf44ff29a3140b4e7130034f1f0af2511a94fb'],
     }),
     ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.1-foss-2017a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.1-foss-2017a.eb
@@ -1124,6 +1124,10 @@ exts_list = [
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
         'checksums': ['6855ce5615fd3e1af4cfc451a9bf44ff29a3140b4e7130034f1f0af2511a94fb'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.1-intel-2017a.eb
@@ -1126,8 +1126,9 @@ exts_list = [
         'checksums': ['6855ce5615fd3e1af4cfc451a9bf44ff29a3140b4e7130034f1f0af2511a94fb'],
     }),
     ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.1-intel-2017a.eb
@@ -1125,6 +1125,10 @@ exts_list = [
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
         'checksums': ['6855ce5615fd3e1af4cfc451a9bf44ff29a3140b4e7130034f1f0af2511a94fb'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-GCCcore-6.4.0.eb
@@ -1147,8 +1147,9 @@ exts_list = [
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
     ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-GCCcore-6.4.0.eb
@@ -1146,6 +1146,10 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI'],
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-foss-2017b.eb
@@ -1145,8 +1145,9 @@ exts_list = [
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
     ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-foss-2017b.eb
@@ -1144,6 +1144,10 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI'],
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2017b.eb
@@ -1149,8 +1149,9 @@ exts_list = [
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
     ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2017b.eb
@@ -1148,6 +1148,10 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI'],
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2018.00.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2018.00.eb
@@ -1149,8 +1149,9 @@ exts_list = [
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
     ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2018.00.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2018.00.eb
@@ -1148,6 +1148,10 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI'],
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2018.01.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2018.01.eb
@@ -1149,8 +1149,9 @@ exts_list = [
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
     ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2018.01.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2018.01.eb
@@ -1148,6 +1148,10 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI'],
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
 ]
 
 moduleclass = 'lang'


### PR DESCRIPTION
This module is used by `QUAST`. See https://github.com/easybuilders/easybuild-easyconfigs/pull/5610#issuecomment-356604042.