### PR TITLE
Update FSLeyes to 0.20.0 (w dep modules)

### DIFF
--- a/easybuild/easyconfigs/f/FSLeyes/FSLeyes-0.20.0-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/f/FSLeyes/FSLeyes-0.20.0-intel-2017a-Python-2.7.13.eb
@@ -1,0 +1,48 @@
+easyblock = 'PythonPackage'
+
+name = 'FSLeyes'
+version = '0.20.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://git.fmrib.ox.ac.uk/fsl/fsleyes/fsleyes'
+description = "FSLeyes is the FSL image viewer."
+
+toolchain = {'name': 'intel', 'version': '2017a'}
+
+source_urls = [PYPI_LOWER_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('Python', '2.7.13'),
+    ('fslpy', '1.5.4', versionsuffix),
+    ('matplotlib', '2.0.2', versionsuffix + '-libpng-1.6.29'),
+    ('wxPython', '3.0.2.0', versionsuffix),
+
+    # These are provided explicitly because they otherwise would be
+    # installed in the build tree, and thus not available at runtime.
+    # This is apparently due to an issue in the FSLeyes setup.py?
+    ('Jinja2', '2.6', versionsuffix),
+    ('requests', '2.18.4', versionsuffix),
+    ('sphinx_rtd_theme', '0.2.5b2', versionsuffix),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [
+    # Unfortunately, fsleyes currently requires an X11 connection for this.
+    # ('fsleyes', '--version'),
+]
+
+# Try to pick up 'hicolor-icon-theme' (ought to be GTK+ dep?)
+# Fails as this doesn't like absolute paths
+# modextrapaths = {
+#     'GI_TYPELIB_PATH': '/usr/share',
+#     'XDG_DATA_DIRS': '/usr/share',
+# }
+
+modextravars = {'FSLDIR': '%(installdir)s'}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/f/fslpy/fslpy-1.5.4-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/f/fslpy/fslpy-1.5.4-intel-2017a-Python-2.7.13.eb
@@ -1,0 +1,29 @@
+easyblock = 'PythonPackage'
+
+name = 'fslpy'
+version = '1.5.4'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://pypi.python.org/pypi/fslpy'
+description = """Python programming library for FSL"""
+
+toolchain = {'name': 'intel', 'version': '2017a'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('Python', '2.7.13'),
+    ('wxPython', '3.0.2.0', versionsuffix),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+options = {
+    'modulename': 'fsl',
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/j/Jinja2/Jinja2-2.6-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/j/Jinja2/Jinja2-2.6-intel-2017a-Python-2.7.13.eb
@@ -1,0 +1,32 @@
+easyblock = "PythonPackage"
+
+name = "Jinja2"
+version = "2.6"
+
+homepage = "https://pypi.python.org/pypi/Jinja2"
+description = """Jinja2 is a template engine written in pure Python. It provides a Django inspired
+non-XML syntax but supports inline expressions and an optional sandboxed environment."""
+
+toolchain = {'name': 'intel', 'version': '2017a'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+python = "Python"
+pythonversion = "2.7.13"
+
+versionsuffix = "-%s-%s" % (python, pythonversion)
+
+dependencies = [
+    (python, pythonversion),
+]
+
+py_short_ver = ".".join(pythonversion.split(".")[0:2])
+pylibdir = "lib/python%s/site-packages/%s" % (py_short_ver, name)
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ["%s-%s-py%s.egg" % (pylibdir, version, py_short_ver)]
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/r/requests/requests-2.18.4-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/r/requests/requests-2.18.4-intel-2017a-Python-2.7.13.eb
@@ -1,0 +1,24 @@
+easyblock = 'PythonPackage'
+
+name = 'requests'
+version = '2.18.4'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://pypi.python.org/pypi/requests'
+description = """Python http for humans"""
+
+toolchain = {'name': 'intel', 'version': '2017a'}
+
+source_urls = [PYPI_LOWER_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('Python', '2.7.13'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/s/sphinx_rtd_theme/sphinx_rtd_theme-0.2.5b2-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/s/sphinx_rtd_theme/sphinx_rtd_theme-0.2.5b2-intel-2017a-Python-2.7.13.eb
@@ -1,0 +1,24 @@
+easyblock = 'PythonPackage'
+
+name = 'sphinx_rtd_theme'
+version = '0.2.5b2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://pypi.python.org/pypi/sphinx_rtd_theme'
+description = """Read the Docs theme for Sphinx"""
+
+toolchain = {'name': 'intel', 'version': '2017a'}
+
+source_urls = [PYPI_LOWER_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('Python', '2.7.13'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Update FSLeyes to the latest version.  Prior Bundle easyblock changed to
PythonPackage, with extensions changed to regular dependencies (some
explicit).

The rationale for reshuffling is that the setup.py for this version of FSLeyes
seems to be installing some of its dependencies into the build tree (instead
of the install tree), causing import failures at runtime.  This doesn't fix
the root problem, but works around it.

Also, set `$FSLDIR`, which the app expects.

---
This is more for feedback than immediate merge (probably).  There are several possible issues:

1. The prior easyconfig was adding a lot of things as extensions, whereas this uses explicit and implicit module deps.  The impetus for this is that for reasons unknown, during build some Python modules are being _installed_ into the _build_ tree, resulting in disaster.  I think this is probably due to funny business in `setup.py`, but I've given up trying to diagnose it, for the moment.  This version works around the issue by adding explicit dependencies--this seems to prevent the problem from happening.
2.  Zapped a number of deps that were present in 0.15 easyconfig.  Seems to work fine, but maybe some of these were important in some subtle way?
3.  Some of these Python modules might be Python-only.  Is there some way to not lock them to `intel-2017a`?
4.  It doesn't show here, but `sphinx_rtd_theme` won't build if `$LANG=C`.  Not sure how much that matters here, but annoying.