### PR TITLE
switch to using install_target rather than now deprecated use_easy_install and use_setup_py_develop

### DIFF
--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.0-cli.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.0-cli.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('vsc-base', '2.4.2'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 # use 'hod' rather than 'hanythingondemand' in module name

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.0-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.0-intel-2015b-Python-2.7.10.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('setuptools', '1.4.2', '', True),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'hod'}

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.1-cli.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.1-cli.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('vsc-base', '2.4.2'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 # use 'hod' rather than 'hanythingondemand' in module name

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.1-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.1-intel-2015b-Python-2.7.10.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('setuptools', '1.4.2', '', True),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'hod'}

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.2-cli.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.2-cli.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('vsc-base', '2.4.2'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 # use 'hod' rather than 'hanythingondemand' in module name

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.2-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.2-intel-2015b-Python-2.7.10.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('setuptools', '1.4.2', '', True),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'hod'}

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.3-cli.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.3-cli.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('vsc-base', '2.4.2'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 # use 'hod' rather than 'hanythingondemand' in module name

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.3-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.3-intel-2015b-Python-2.7.10.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('setuptools', '1.4.2', '', True),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'hod'}

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.4-cli.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.4-cli.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('vsc-base', '2.4.2'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 # use 'hod' rather than 'hanythingondemand' in module name

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.4-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.4-intel-2015b-Python-2.7.10.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('setuptools', '1.4.2', '', True),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'hod'}

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.0-cli.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.0-cli.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('vsc-base', '2.5.1'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 # use 'hod' rather than 'hanythingondemand' in module name

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.0-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.0-intel-2016a-Python-2.7.11.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('vsc-mympirun', '3.4.2', versionsuffix + '-vsc-base-2.5.1'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'hod'}

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.1-cli.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.1-cli.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('vsc-base', '2.5.1'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 # use 'hod' rather than 'hanythingondemand' in module name

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.1-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.1-intel-2016a-Python-2.7.11.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('vsc-mympirun', '3.4.2', versionsuffix + '-vsc-base-2.5.1'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'hod'}

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.2-cli.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.2-cli.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('vsc-base', '2.5.1'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 # use 'hod' rather than 'hanythingondemand' in module name

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.2-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.2-intel-2016a-Python-2.7.11.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('vsc-mympirun', '3.4.2', versionsuffix + '-vsc-base-2.5.1'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'hod'}

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.3-cli.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.3-cli.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('vsc-base', '2.5.1'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 # use 'hod' rather than 'hanythingondemand' in module name

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.3-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.3-intel-2016b-Python-2.7.12.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('vsc-mympirun', '3.4.3', versionsuffix),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'hod'}

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.4-cli.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.4-cli.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('vsc-base', '2.5.1'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 # use 'hod' rather than 'hanythingondemand' in module name

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.4-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.1.4-intel-2016b-Python-2.7.12.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('vsc-mympirun', '3.4.3', versionsuffix),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'hod'}

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.2.0-cli.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.2.0-cli.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('vsc-base', '2.5.1'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 # use 'hod' rather than 'hanythingondemand' in module name

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.2.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.2.0-intel-2016b-Python-2.7.12.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('vsc-mympirun', '3.4.3', versionsuffix),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'hod'}

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.2.2-cli.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.2.2-cli.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('vsc-base', '2.5.8'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 # use 'hod' rather than 'hanythingondemand' in module name

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.2.2-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.2.2-intel-2016b-Python-2.7.12.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('vsc-mympirun', '3.4.3', versionsuffix),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'hod'}

--- a/easybuild/easyconfigs/t/tvb-data/tvb-data-1.5-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/t/tvb-data/tvb-data-1.5-intel-2016a-Python-2.7.11.eb
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 buildininstalldir = True
-use_setup_py_develop = True
+install_target = 'develop'
 
 options = {'modulename': 'tvb_data'}
 

--- a/easybuild/easyconfigs/t/tvb-data/tvb-data-20150915-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/t/tvb-data/tvb-data-20150915-intel-2016a-Python-2.7.11.eb
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 buildininstalldir = True
-use_setup_py_develop = True
+install_target = 'develop'
 
 options = {'modulename': 'tvb_data'}
 

--- a/easybuild/easyconfigs/t/tvb-framework/tvb-framework-1.5-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/t/tvb-framework/tvb-framework-1.5-intel-2016a-Python-2.7.11.eb
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 buildininstalldir = True
-use_setup_py_develop = True
+install_target = 'develop'
 
 options = {'modulename': 'tvb.core'}
 

--- a/easybuild/easyconfigs/t/tvb-framework/tvb-framework-20150921-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/t/tvb-framework/tvb-framework-20150921-intel-2016a-Python-2.7.11.eb
@@ -23,7 +23,7 @@ dependencies = [
 ]
 
 buildininstalldir = True
-use_setup_py_develop = True
+install_target = 'develop'
 
 options = {'modulename': 'tvb.core'}
 

--- a/easybuild/easyconfigs/t/tvb-library/tvb-library-1.5-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/t/tvb-library/tvb-library-1.5-intel-2016a-Python-2.7.11.eb
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 buildininstalldir = True
-use_setup_py_develop = True
+install_target = 'develop'
 
 options = {'modulename': 'tvb.simulator'}
 

--- a/easybuild/easyconfigs/t/tvb-library/tvb-library-20150922-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/t/tvb-library/tvb-library-20150922-intel-2016a-Python-2.7.11.eb
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 buildininstalldir = True
-use_setup_py_develop = True
+install_target = 'develop'
 
 options = {'modulename': 'tvb.simulator'}
 

--- a/easybuild/easyconfigs/v/vsc-base/vsc-base-2.4.2.eb
+++ b/easybuild/easyconfigs/v/vsc-base/vsc-base-2.4.2.eb
@@ -13,7 +13,7 @@ sources = [SOURCE_TAR_GZ]
 source_urls = [PYPI_SOURCE]
 
 # install as zipped egg to make sure that tools that use this as a dependency are responsive
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'vsc.utils'}

--- a/easybuild/easyconfigs/v/vsc-base/vsc-base-2.5.1.eb
+++ b/easybuild/easyconfigs/v/vsc-base/vsc-base-2.5.1.eb
@@ -13,7 +13,7 @@ sources = [SOURCE_TAR_GZ]
 source_urls = [PYPI_SOURCE]
 
 # install as zipped egg to make sure that tools that use this as a dependency are responsive
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'vsc.utils'}

--- a/easybuild/easyconfigs/v/vsc-base/vsc-base-2.5.8.eb
+++ b/easybuild/easyconfigs/v/vsc-base/vsc-base-2.5.8.eb
@@ -13,7 +13,7 @@ sources = [SOURCE_TAR_GZ]
 source_urls = [PYPI_SOURCE]
 
 # install as zipped egg to make sure that tools that use this as a dependency are responsive
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 options = {'modulename': 'vsc.utils'}

--- a/easybuild/easyconfigs/v/vsc-mympirun/vsc-mympirun-3.4.2-vsc-base-2.4.2.eb
+++ b/easybuild/easyconfigs/v/vsc-mympirun/vsc-mympirun-3.4.2-vsc-base-2.4.2.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('setuptools', '1.4.2'),
 ]
 
-use_easy_install = True
+install_target = 'easy_install'
 zipped_egg = True
 
 # we ship something in bin/fake


### PR DESCRIPTION
This replaces `use_setup_py_develop` and `use_easy_install` with `install_target = 'develop'` and `install_target = 'easy_install'`. Follow up for ~~https://github.com/easybuilders/easybuild-easyblocks/pull/1341~~

edit: requires https://github.com/easybuilders/easybuild-easyblocks/pull/1342 !