### PR TITLE
add rdma-core-devel to OS dependencies for OpenMPI 3.0.0

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.0.0-GCC-7.2.0-2.29.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.0.0-GCC-7.2.0-2.29.eb
@@ -13,7 +13,7 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['0bbb279b88edc25bbded39520dab6d4b32020277a6088fb1456c9437a8231cf8']
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
 
 dependencies = [
     ('zlib', '1.2.11'),


### PR DESCRIPTION
Without the fix, this will not build on our CentOS7 cluster