### PR TITLE
fix PR refs for 2018a toolchain definitions

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -10,7 +10,7 @@ v3.5.1 (January 16th 2018)
 --------------------------
 
 bugfix/update release
-- added easyconfigs for foss/2018a and intel/2018a common toolchains (#4768), (#4618)
+- added easyconfigs for foss/2018a and intel/2018a common toolchains (#5577), (#5578)
 - added example easyconfig files for 26 new software packages:
   - BeautifulSoup (#5601), Calendrical (#5588), ChimPipe (#5560), crb-blast (#5124)), dammit (#5125), deepTools (#5536),
     FastQ_Screen (#5404), FoX (#5496), GffCompare (#5581), GlimmerHMM (#5559), LocARNA (#5548), MapSplice (#5566),

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -40,6 +40,7 @@ bugfix/update release
   - fix for dependencies was set twice in OpenMPI 3.0.0 easyconfig (#5619)
   - fix download URL in comment of Kent tools easyconfigs (#5633)
   - add SHA256 checksums to various easyconfigs (#5635, #5636, #5639)
+  - add rdma-core-devel to OS dependencies for OpenMPI 3.0.0 (#5648)
 
 
 v3.5.0 (December 15th 2017)


### PR DESCRIPTION
Not sure how these were included wrongly, but they should be fixed before #5650 is merged.