### PR TITLE
New EasyConfigs for the Cray programming environment release 2017.08

### DIFF
--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2017.08.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2017.08.eb
@@ -1,0 +1,19 @@
+easyblock = 'CrayToolchain'
+
+name = 'CrayCCE'
+version = '2017.08'
+
+homepage = 'https://pubs.cray.com/browse/xc/article/released-cray-xc-programming-environments-1708---august-3-2017' 
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-cray module (PE release: August 2017).\n"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+dependencies = [
+    # PrgEnv version is not pinned, as Cray recommends to use the latest (default) version
+    ('PrgEnv-cray', EXTERNAL_MODULE),
+    ('cce/8.6.2', EXTERNAL_MODULE),
+    ('cray-libsci/17.09.1', EXTERNAL_MODULE),
+    ('cray-mpich/7.6.2', EXTERNAL_MODULE),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2017.08.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2017.08.eb
@@ -1,0 +1,19 @@
+easyblock = 'CrayToolchain'
+
+name = 'CrayGNU'
+version = '2017.08'
+
+homepage = 'https://pubs.cray.com/browse/xc/article/released-cray-xc-programming-environments-1708---august-3-2017' 
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module (PE release: August 2017).\n"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+dependencies = [
+    # PrgEnv version is not pinned, as Cray recommends to use the latest (default) version
+    ('PrgEnv-gnu', EXTERNAL_MODULE),
+    ('gcc/4.9.3', EXTERNAL_MODULE),
+    ('cray-libsci/17.09.1', EXTERNAL_MODULE),
+    ('cray-mpich/7.6.2', EXTERNAL_MODULE),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2017.08.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2017.08.eb
@@ -1,0 +1,19 @@
+easyblock = 'CrayToolchain'
+
+name = 'CrayIntel'
+version = '2017.08'
+
+homepage = 'https://pubs.cray.com/browse/xc/article/released-cray-xc-programming-environments-1708---august-3-2017' 
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-intel module (PE release: August 2017).\n"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+dependencies = [
+    # PrgEnv version is not pinned, as Cray recommends to use the latest (default) version
+    ('PrgEnv-intel', EXTERNAL_MODULE),
+    ('intel/17.0.4.196', EXTERNAL_MODULE),
+    ('cray-libsci/17.09.1', EXTERNAL_MODULE),
+    ('cray-mpich/7.6.2', EXTERNAL_MODULE),
+]
+
+moduleclass = 'toolchain'


### PR DESCRIPTION
Including EasyConfigs for the CrayCCE, CrayGNU and CrayIntel variants. We don't have PGI in our version of the Cray programming environment, so someone else would have to do that compiler.