### PR TITLE
build recent PLUMED versions with all modules enabled

### DIFF
--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.3.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.3.0-foss-2016b.eb
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 preconfigopts = 'env FC=$MPIF90 LIBS="$LIBLAPACK $LIBS" '
-configopts = ' --exec-prefix=%(installdir)s --enable-gsl'
+configopts = ' --exec-prefix=%(installdir)s --enable-gsl --enable-modules=all'
 prebuildopts = 'source sourceme.sh && '
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.3.0-foss-2017a.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.3.0-foss-2017a.eb
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 preconfigopts = 'env FC=$MPIF90 LIBS="$LIBLAPACK $LIBS" '
-configopts = ' --exec-prefix=%(installdir)s --enable-gsl'
+configopts = ' --exec-prefix=%(installdir)s --enable-gsl --enable-modules=all'
 prebuildopts = 'source sourceme.sh && '
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.3.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.3.0-intel-2016b.eb
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 preconfigopts = 'env FC=$MPIF90 LIBS="$LIBLAPACK $LIBS" '
-configopts = ' --exec-prefix=%(installdir)s --enable-gsl'
+configopts = ' --exec-prefix=%(installdir)s --enable-gsl --enable-modules=all'
 prebuildopts = 'source sourceme.sh && '
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.3.4-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.3.4-intel-2017b.eb
@@ -27,7 +27,7 @@ dependencies = [
 ]
 
 preconfigopts = 'env FC=$MPIF90 LIBS="$LIBLAPACK $LIBS" '
-configopts = ' --exec-prefix=%(installdir)s --enable-gsl'
+configopts = ' --exec-prefix=%(installdir)s --enable-gsl --enable-modules=all'
 prebuildopts = 'source sourceme.sh && '
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.4.0-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.4.0-intel-2017b.eb
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 preconfigopts = 'env FC=$MPIF90 LIBS="$LIBLAPACK $LIBS" '
-configopts = ' --exec-prefix=%(installdir)s --enable-gsl'
+configopts = ' --exec-prefix=%(installdir)s --enable-gsl --enable-modules=all'
 prebuildopts = 'source sourceme.sh && '
 
 sanity_check_paths = {


### PR DESCRIPTION
without this:

```
$ plumed config show | grep ^module | grep off
module adjmat off (default-off)
module crystallization off (default-off)
module drr off (default-off)
module eds off (default-off)
module manyrestraints off (default-off)
module ves off (default-off)
```

with this:

```
$ plumed config show | grep ^module | grep off
module adjmat on (default-off)
module crystallization on (default-off)
module drr on (default-off)
module eds on (default-off)
module manyrestraints on (default-off)
module ves on (default-off)
```