### PR TITLE
{math}[intel/2017a] Octave: add ext packages, fix mkoctfile bug

### DIFF
--- a/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a-mt.eb
+++ b/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a-mt.eb
@@ -6,14 +6,15 @@ homepage = 'http://www.gnu.org/software/octave/'
 description = """GNU Octave is a high-level interpreted language, primarily intended for numerical computations."""
 
 toolchain = {'name': 'intel', 'version': '2017a'}
-toolchainopts = {'cstd': 'c++11'}
+toolchainopts = {'cstd': 'c++11', 'pic': True}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-patches = ['%(name)s-%(version)s_intel.patch']
+patches = ['%(name)s-%(version)s_intel.patch', '%(name)s-%(version)s_mkoctfile.patch']
 checksums = [
     '80c28f6398576b50faca0e602defb9598d6f7308b0903724442c2a35a605333b',  # octave-4.2.1.tar.gz
     'f35b6e28f1ceaf7e67c935544ad2547931a30cd03ab0a1587715c6bd94521de9',  # Octave-4.2.1_intel.patch
+    'ed014514cbaf0f65642b24ae2fe2f7f29adebc0dad7b25859ed9345bca161a9c',  # Octave-4.2.1_mkoctfile.patch
 ]
 
 builddependencies = [
@@ -48,6 +49,8 @@ dependencies = [
     ('SuiteSparse', '4.5.5', '-METIS-5.1.0'),
     ('GraphicsMagick', '1.3.25'),
     ('FFTW', '3.3.6'),
+    ('GSL', '2.3'),             # for gsl extension
+    ('PostgreSQL', '9.6.2', '-Python-2.7.13'),  # for io extension
 ]
 
 # link with multi-threaded BLAS/LAPACK library
@@ -60,9 +63,31 @@ configopts += '--enable-fortran-calling-convention=gfortran'
 pkg_url = 'https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/'
 exts_default_options = {'source_urls': [pkg_url]}
 
+# order matters (deps first)
 exts_list = [
     ('control', '3.0.0', {
         'checksums': ['41e9a5627565444140cf8bb8cf978239245355a6fc7d61ff122327d8f822eca6'],
+    }),
+    ('general', '2.0.0', {
+        'checksums': ['80a6921bea3437ea233873ca4382bdc7c31c9e61bd1bcb9059da18db39df7194'],
+    }),
+    ('gsl', '2.1.0', {
+        'checksums': ['940142b7d655d9196e1ec5197b4176388c69671e03ba8da717782d9f040fcedb'],
+    }),
+    ('image', '2.6.2', {
+        'checksums': ['fe01e0683dd55de985662bd86eefcf4cd0dc46c53050fd15e65d17370b2833d9'],
+    }),
+    ('io', '2.4.9', {
+        'checksums': ['519493c9635d8461fec1ecf6240ce364d6ead2906743c612fe5a33a5dc6f8f7c'],
+    }),
+    ('struct', '1.0.14', {      # required by optim
+        'checksums': ['ad4e17687bc24650f032757271b20b70fe32c35513d4dd9ab1e549919df36b47'],
+    }),
+    ('optim', '1.5.2', {
+        'checksums': ['7b36033c5581559dc3e7616f97d402bc44dde0dfd74c0e3afdf47d452a76dddf'],
+    }),
+    ('parallel', '3.1.1', {
+        'checksums': ['4cd8f4619557c91c046882b056322da8de7f6047bfce6f102f40565bd4b4b37f'],
     }),
     ('signal', '1.3.2', {
         'patches': ['signal-1.3.2_fix-formula.patch'],
@@ -70,6 +95,9 @@ exts_list = [
             'a277f12e9f47cc66a8c56ab26284ac4839b223f32de13e35e710401fd0539b60',  # signal-1.3.2.tar.gz
             'e4971524077a19e655c7c70c11d9a27ca1a3aa2638150c5779e72ebce9ec38b5',  # signal-1.3.2_fix-formula.patch
         ],
+    }),
+    ('splines', '1.3.2', {
+        'checksums': ['61cb4c8420e23e7a9febd014ecfc4314d8977635976571edaae7749f651d2b1f'],
     }),
 ]
 

--- a/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a-mt.eb
+++ b/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a-mt.eb
@@ -32,7 +32,7 @@ dependencies = [
     ('X11', '20170314'),
     ('PCRE', '8.40'),
     ('ncurses', '6.0'),
-    ('libreadline', '6.3'),
+    ('libreadline', '7.0'),
     ('arpack-ng', '3.5.0'),
     ('cURL', '7.53.1'),
     ('FLTK', '1.3.4'),

--- a/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a-mt.eb
+++ b/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a-mt.eb
@@ -10,7 +10,10 @@ toolchainopts = {'cstd': 'c++11', 'pic': True}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-patches = ['%(name)s-%(version)s_intel.patch', '%(name)s-%(version)s_mkoctfile.patch']
+patches = [
+    '%(name)s-%(version)s_intel.patch',
+    '%(name)s-%(version)s_mkoctfile.patch',
+]
 checksums = [
     '80c28f6398576b50faca0e602defb9598d6f7308b0903724442c2a35a605333b',  # octave-4.2.1.tar.gz
     'f35b6e28f1ceaf7e67c935544ad2547931a30cd03ab0a1587715c6bd94521de9',  # Octave-4.2.1_intel.patch

--- a/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a.eb
@@ -9,7 +9,10 @@ toolchainopts = {'cstd': 'c++11', 'pic': True}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-patches = ['%(name)s-%(version)s_intel.patch', '%(name)s-%(version)s_mkoctfile.patch']
+patches = [
+    '%(name)s-%(version)s_intel.patch',
+    '%(name)s-%(version)s_mkoctfile.patch',
+]
 checksums = [
     '80c28f6398576b50faca0e602defb9598d6f7308b0903724442c2a35a605333b',  # octave-4.2.1.tar.gz
     'f35b6e28f1ceaf7e67c935544ad2547931a30cd03ab0a1587715c6bd94521de9',  # Octave-4.2.1_intel.patch

--- a/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a.eb
@@ -5,14 +5,15 @@ homepage = 'http://www.gnu.org/software/octave/'
 description = """GNU Octave is a high-level interpreted language, primarily intended for numerical computations."""
 
 toolchain = {'name': 'intel', 'version': '2017a'}
-toolchainopts = {'cstd': 'c++11'}
+toolchainopts = {'cstd': 'c++11', 'pic': True}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-patches = ['%(name)s-%(version)s_intel.patch']
+patches = ['%(name)s-%(version)s_intel.patch', '%(name)s-%(version)s_mkoctfile.patch']
 checksums = [
     '80c28f6398576b50faca0e602defb9598d6f7308b0903724442c2a35a605333b',  # octave-4.2.1.tar.gz
     'f35b6e28f1ceaf7e67c935544ad2547931a30cd03ab0a1587715c6bd94521de9',  # Octave-4.2.1_intel.patch
+    'ed014514cbaf0f65642b24ae2fe2f7f29adebc0dad7b25859ed9345bca161a9c',  # Octave-4.2.1_mkoctfile.patch
 ]
 
 builddependencies = [
@@ -47,6 +48,8 @@ dependencies = [
     ('SuiteSparse', '4.5.5', '-METIS-5.1.0'),
     ('GraphicsMagick', '1.3.25'),
     ('FFTW', '3.3.6'),
+    ('GSL', '2.3'),             # for gsl extension
+    ('PostgreSQL', '9.6.2', '-Python-2.7.13'),  # for io extension
 ]
 
 configopts = '--disable-docs '
@@ -56,9 +59,31 @@ configopts += '--enable-fortran-calling-convention=gfortran'
 pkg_url = 'https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/'
 exts_default_options = {'source_urls': [pkg_url]}
 
+# order matters (deps first)
 exts_list = [
     ('control', '3.0.0', {
         'checksums': ['41e9a5627565444140cf8bb8cf978239245355a6fc7d61ff122327d8f822eca6'],
+    }),
+    ('general', '2.0.0', {
+        'checksums': ['80a6921bea3437ea233873ca4382bdc7c31c9e61bd1bcb9059da18db39df7194'],
+    }),
+    ('gsl', '2.1.0', {
+        'checksums': ['940142b7d655d9196e1ec5197b4176388c69671e03ba8da717782d9f040fcedb'],
+    }),
+    ('struct', '1.0.14', {      # required by optim
+        'checksums': ['ad4e17687bc24650f032757271b20b70fe32c35513d4dd9ab1e549919df36b47'],
+    }),
+    ('image', '2.6.2', {
+        'checksums': ['fe01e0683dd55de985662bd86eefcf4cd0dc46c53050fd15e65d17370b2833d9'],
+    }),
+    ('io', '2.4.9', {
+        'checksums': ['519493c9635d8461fec1ecf6240ce364d6ead2906743c612fe5a33a5dc6f8f7c'],
+    }),
+    ('optim', '1.5.2', {
+        'checksums': ['7b36033c5581559dc3e7616f97d402bc44dde0dfd74c0e3afdf47d452a76dddf'],
+    }),
+    ('parallel', '3.1.1', {
+        'checksums': ['4cd8f4619557c91c046882b056322da8de7f6047bfce6f102f40565bd4b4b37f'],
     }),
     ('signal', '1.3.2', {
         'patches': ['signal-1.3.2_fix-formula.patch'],
@@ -66,6 +91,9 @@ exts_list = [
             'a277f12e9f47cc66a8c56ab26284ac4839b223f32de13e35e710401fd0539b60',  # signal-1.3.2.tar.gz
             'e4971524077a19e655c7c70c11d9a27ca1a3aa2638150c5779e72ebce9ec38b5',  # signal-1.3.2_fix-formula.patch
         ],
+    }),
+    ('splines', '1.3.2', {
+        'checksums': ['61cb4c8420e23e7a9febd014ecfc4314d8977635976571edaae7749f651d2b1f'],
     }),
 ]
 

--- a/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a.eb
@@ -31,7 +31,7 @@ dependencies = [
     ('X11', '20170314'),
     ('PCRE', '8.40'),
     ('ncurses', '6.0'),
-    ('libreadline', '6.3'),
+    ('libreadline', '7.0'),
     ('arpack-ng', '3.5.0'),
     ('cURL', '7.53.1'),
     ('FLTK', '1.3.4'),

--- a/easybuild/easyconfigs/o/Octave/Octave-4.2.1_mkoctfile.patch
+++ b/easybuild/easyconfigs/o/Octave/Octave-4.2.1_mkoctfile.patch
@@ -1,0 +1,24 @@
+fix mkoctfile mishandling of --fp-model source flag format
+# bug reported and fixed; this patch backported from
+# http://hg.savannah.gnu.org/hgweb/octave/rev/298c6a6bd869
+diff --git a/src/mkoctfile.in.cc b/src/mkoctfile.in.cc
+index 7309dd7..4556b4a 100644
+--- a/src/mkoctfile.in.cc
++++ b/src/mkoctfile.in.cc
+@@ -590,6 +590,16 @@ main (int argc, char **argv)
+         {
+           // Pass through any unrecognized options
+           pass_on_options += (" " + arg);
++          // Check for an additional argument following the option
++          if (i < argc-1)
++            {
++              arg = argv[i+1];
++              if (arg[0] != '-')
++                {
++                  pass_on_options += (' ' + arg);
++                  i++;
++                }
++            }
+         }
+       else
+         {

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.0-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.0-intel-2017a.eb
@@ -1,0 +1,905 @@
+name = 'Perl'
+version = '5.24.0'
+
+homepage = 'http://www.perl.org/'
+description = """Larry Wall's Practical Extraction and Report Language"""
+
+toolchain = {'name': 'intel', 'version': '2017a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.cpan.org/src/%(version_major)s.0']
+sources = [SOURCELOWER_TAR_GZ]
+
+exts_list = [
+    ('Config::General', '2.61', {
+        'source_tmpl': 'Config-General-2.61.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TL/TLINDEN'],
+    }),
+    ('File::Listing', '6.04', {
+        'source_tmpl': 'File-Listing-6.04.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('ExtUtils::InstallPaths', '0.011', {
+        'source_tmpl': 'ExtUtils-InstallPaths-0.011.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('ExtUtils::Helpers', '0.022', {
+        'source_tmpl': 'ExtUtils-Helpers-0.022.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('Test::Harness', '3.36', {
+        'source_tmpl': 'Test-Harness-3.36.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('ExtUtils::Config', '0.008', {
+        'source_tmpl': 'ExtUtils-Config-0.008.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('Module::Build::Tiny', '0.039', {
+        'source_tmpl': 'Module-Build-Tiny-0.039.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('aliased', '0.34', {
+        'source_tmpl': 'aliased-0.34.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Text::Glob', '0.09', {
+        'source_tmpl': 'Text-Glob-0.09.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RC/RCLAMP'],
+    }),
+    ('Regexp::Common', '2016060801', {
+        'source_tmpl': 'Regexp-Common-2016060801.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/A/AB/ABIGAIL'],
+    }),
+    ('GO::Utils', '0.15', {
+        'source_tmpl': 'go-perl-0.15.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/C/CM/CMUNGALL'],
+    }),
+    ('Module::Pluggable', '5.2', {
+        'source_tmpl': 'Module-Pluggable-5.2.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SI/SIMONW'],
+    }),
+    ('Test::Fatal', '0.014', {
+        'source_tmpl': 'Test-Fatal-0.014.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Test::Warnings', '0.026', {
+        'source_tmpl': 'Test-Warnings-0.026.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('DateTime::Locale', '1.05', {
+        'source_tmpl': 'DateTime-Locale-1.05.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('DateTime::TimeZone', '2.00', {
+        'source_tmpl': 'DateTime-TimeZone-2.00.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('Test::Requires', '0.10', {
+        'source_tmpl': 'Test-Requires-0.10.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TOKUHIROM'],
+    }),
+    ('Module::Implementation', '0.09', {
+        'source_tmpl': 'Module-Implementation-0.09.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('Module::Build', '0.4218', {
+        'source_tmpl': 'Module-Build-0.4218.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('Module::Runtime', '0.014', {
+        'source_tmpl': 'Module-Runtime-0.014.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/Z/ZE/ZEFRAM'],
+    }),
+    ('Try::Tiny', '0.24', {
+        'source_tmpl': 'Try-Tiny-0.24.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Params::Validate', '1.24', {
+        'source_tmpl': 'Params-Validate-1.24.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('List::MoreUtils', '0.416', {
+        'source_tmpl': 'List-MoreUtils-0.416.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+    }),
+    ('Exporter::Tiny', '0.042', {
+        'source_tmpl': 'Exporter-Tiny-0.042.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TOBYINK'],
+    }),
+    ('Class::Singleton', '1.5', {
+        'source_tmpl': 'Class-Singleton-1.5.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHAY'],
+    }),
+    ('DateTime', '1.34', {
+        'source_tmpl': 'DateTime-1.34.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('File::Find::Rule::Perl', '1.15', {
+        'source_tmpl': 'File-Find-Rule-Perl-1.15.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Readonly', '2.05', {
+        'source_tmpl': 'Readonly-2.05.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SA/SANKO'],
+    }),
+    ('Git', '0.41', {
+        'source_tmpl': 'Git-0.41.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSOUTH'],
+    }),
+    ('Tree::DAG_Node', '1.29', {
+        'source_tmpl': 'Tree-DAG_Node-1.29.tgz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE'],
+    }),
+    ('Template', '2.26', {
+        'source_tmpl': 'Template-Toolkit-2.26.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/A/AB/ABW'],
+    }),
+    ('FreezeThaw', '0.5001', {
+        'source_tmpl': 'FreezeThaw-0.5001.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/I/IL/ILYAZ/modules'],
+    }),
+    ('DBI', '1.636', {
+        'source_tmpl': 'DBI-1.636.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TI/TIMB'],
+    }),
+    ('DBD::SQLite', '1.50', {
+        'source_tmpl': 'DBD-SQLite-1.50.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI'],
+    }),
+    ('Math::Bezier', '0.01', {
+        'source_tmpl': 'Math-Bezier-0.01.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/A/AB/ABW'],
+    }),
+    ('Archive::Extract', '0.76', {
+        'source_tmpl': 'Archive-Extract-0.76.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+    }),
+    ('DBIx::Simple', '1.35', {
+        'source_tmpl': 'DBIx-Simple-1.35.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JU/JUERD'],
+    }),
+    ('Shell', '0.73', {
+        'source_tmpl': 'Shell-0.73.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/F/FE/FERREIRA'],
+    }),
+    ('File::Spec', '3.62', {
+        'source_tmpl': 'PathTools-3.62.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('ExtUtils::MakeMaker', '7.18', {
+        'source_tmpl': 'ExtUtils-MakeMaker-7.18.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+    }),
+    ('Test::Simple', '1.302037', {
+        'source_tmpl': 'Test-Simple-1.302037.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('Set::Scalar', '1.29', {
+        'source_tmpl': 'Set-Scalar-1.29.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAVIDO'],
+    }),
+    ('IO::Stringy', '2.111', {
+        'source_tmpl': 'IO-stringy-2.111.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DS/DSKOLL'],
+    }),
+    ('Encode::Locale', '1.05', {
+        'source_tmpl': 'Encode-Locale-1.05.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('XML::SAX::Base', '1.08', {
+        'source_tmpl': 'XML-SAX-Base-1.08.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GR/GRANTM'],
+    }),
+    ('XML::NamespaceSupport', '1.11', {
+        'source_tmpl': 'XML-NamespaceSupport-1.11.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PERIGRIN'],
+    }),
+    ('XML::SAX', '0.99', {
+        'source_tmpl': 'XML-SAX-0.99.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GR/GRANTM'],
+    }),
+    ('Test::LeakTrace', '0.15', {
+        'source_tmpl': 'Test-LeakTrace-0.15.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GF/GFUJI'],
+    }),
+    ('Test::Exception', '0.43', {
+        'source_tmpl': 'Test-Exception-0.43.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('Text::Table', '1.130', {
+        'source_tmpl': 'Text-Table-1.130.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
+    }),
+    ('MIME::Types', '2.13', {
+        'source_tmpl': 'MIME-Types-2.13.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MARKOV'],
+    }),
+    ('Module::Build::XSUtil', '0.16', {
+        'source_tmpl': 'Module-Build-XSUtil-0.16.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/H/HI/HIDEAKIO'],
+    }),
+    ('Tie::Function', '0.02', {
+        'source_tmpl': 'Tie-Function-0.02.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAVIDNICO/handy_tied_functions'],
+    }),
+    ('Template::Plugin::Number::Format', '1.06', {
+        'source_tmpl': 'Template-Plugin-Number-Format-1.06.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DARREN'],
+    }),
+    ('HTML::Parser', '3.72', {
+        'source_tmpl': 'HTML-Parser-3.72.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('Date::Handler', '1.2', {
+        'source_tmpl': 'Date-Handler-1.2.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BB/BBEAUSEJ'],
+    }),
+    ('Params::Util', '1.07', {
+        'source_tmpl': 'Params-Util-1.07.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+    }),
+    ('IO::HTML', '1.001', {
+        'source_tmpl': 'IO-HTML-1.001.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/C/CJ/CJM'],
+    }),
+    ('Data::Grove', '0.08', {
+        'source_tmpl': 'libxml-perl-0.08.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/K/KM/KMACLEOD'],
+    }),
+    ('Class::ISA', '0.36', {
+        'source_tmpl': 'Class-ISA-0.36.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SM/SMUELLER'],
+    }),
+    ('URI', '1.71', {
+        'source_tmpl': 'URI-1.71.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Ima::DBI', '0.35', {
+        'source_tmpl': 'Ima-DBI-0.35.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PERRIN'],
+    }),
+    ('Tie::IxHash', '1.23', {
+        'source_tmpl': 'Tie-IxHash-1.23.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/C/CH/CHORNY'],
+    }),
+    ('GO', '0.04', {
+        'source_tmpl': 'go-db-perl-0.04.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SJ/SJCARBON'],
+    }),
+    ('Class::DBI::SQLite', '0.11', {
+        'source_tmpl': 'Class-DBI-SQLite-0.11.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA'],
+    }),
+    ('Pod::POM', '2.01', {
+        'source_tmpl': 'Pod-POM-2.01.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/N/NE/NEILB'],
+    }),
+    ('Math::Round', '0.07', {
+        'source_tmpl': 'Math-Round-0.07.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GR/GROMMEL'],
+    }),
+    ('Text::Diff', '1.44', {
+        'source_tmpl': 'Text-Diff-1.44.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/N/NE/NEILB'],
+    }),
+    ('Log::Message::Simple', '0.10', {
+        'source_tmpl': 'Log-Message-Simple-0.10.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+    }),
+    ('IO::Socket::SSL', '2.029', {
+        'source_tmpl': 'IO-Socket-SSL-2.029.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SU/SULLR'],
+    }),
+    ('Fennec::Lite', '0.004', {
+        'source_tmpl': 'Fennec-Lite-0.004.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('Sub::Uplevel', '0.25', {
+        'source_tmpl': 'Sub-Uplevel-0.25.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
+    }),
+    ('Meta::Builder', '0.003', {
+        'source_tmpl': 'Meta-Builder-0.003.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('Exporter::Declare', '0.114', {
+        'source_tmpl': 'Exporter-Declare-0.114.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('Getopt::Long', '2.48', {
+        'source_tmpl': 'Getopt-Long-2.48.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JV/JV'],
+    }),
+    ('Log::Message', '0.08', {
+        'source_tmpl': 'Log-Message-0.08.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+    }),
+    ('Mouse', 'v2.4.5', {
+        'source_tmpl': 'Mouse-v2.4.5.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SY/SYOHEX'],
+    }),
+    ('Test::Version', '2.04', {
+        'source_tmpl': 'Test-Version-2.04.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PL/PLICEASE'],
+    }),
+    ('DBIx::Admin::TableInfo', '3.01', {
+        'source_tmpl': 'DBIx-Admin-TableInfo-3.01.tgz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE'],
+    }),
+    ('Net::HTTP', '6.09', {
+        'source_tmpl': 'Net-HTTP-6.09.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Test::Deep', '1.120', {
+        'source_tmpl': 'Test-Deep-1.120.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Test::Warn', '0.30', {
+        'source_tmpl': 'Test-Warn-0.30.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/C/CH/CHORNY'],
+    }),
+    ('MRO::Compat', '0.12', {
+        'source_tmpl': 'MRO-Compat-0.12.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BO/BOBTFISH'],
+    }),
+    ('Moo', '2.002004', {
+        'source_tmpl': 'Moo-2.002004.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG'],
+    }),
+    ('Hash::Merge', '0.200', {
+        'source_tmpl': 'Hash-Merge-0.200.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+    }),
+    ('SQL::Abstract', '1.81', {
+        'source_tmpl': 'SQL-Abstract-1.81.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RI/RIBASUSHI'],
+    }),
+    ('HTML::Form', '6.03', {
+        'source_tmpl': 'HTML-Form-6.03.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('File::Copy::Recursive', '0.38', {
+        'source_tmpl': 'File-Copy-Recursive-0.38.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DM/DMUEY'],
+    }),
+    ('Number::Compare', '0.03', {
+        'source_tmpl': 'Number-Compare-0.03.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RC/RCLAMP'],
+    }),
+    ('IPC::Run', '0.94', {
+        'source_tmpl': 'IPC-Run-0.94.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TODDR'],
+    }),
+    ('HTML::Entities::Interpolate', '1.09', {
+        'source_tmpl': 'HTML-Entities-Interpolate-1.09.tgz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE'],
+    }),
+    ('Test::ClassAPI', '1.06', {
+        'source_tmpl': 'Test-ClassAPI-1.06.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+    }),
+    ('Test::Most', '0.34', {
+        'source_tmpl': 'Test-Most-0.34.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/O/OV/OVID'],
+    }),
+    ('Class::Accessor', '0.34', {
+        'source_tmpl': 'Class-Accessor-0.34.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/K/KA/KASEI'],
+    }),
+    ('Test::Differences', '0.64', {
+        'source_tmpl': 'Test-Differences-0.64.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DC/DCANTRELL'],
+    }),
+    ('HTTP::Tiny', '0.058', {
+        'source_tmpl': 'HTTP-Tiny-0.058.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
+    }),
+    ('Package::DeprecationManager', '0.17', {
+        'source_tmpl': 'Package-DeprecationManager-0.17.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('Digest::SHA1', '2.13', {
+        'source_tmpl': 'Digest-SHA1-2.13.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('Date::Language', '2.30', {
+        'source_tmpl': 'TimeDate-2.30.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GB/GBARR'],
+    }),
+    ('version', '0.9917', {
+        'source_tmpl': 'version-0.9917.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JP/JPEACOCK'],
+    }),
+    ('Sub::Uplevel', '0.25', {
+        'source_tmpl': 'Sub-Uplevel-0.25.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
+    }),
+    ('XML::Bare', '0.53', {
+        'source_tmpl': 'XML-Bare-0.53.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/C/CO/CODECHILD'],
+        'patches': ['XML-Bare-0.53_icc.patch'],
+    }),
+    ('Dist::CheckConflicts', '0.11', {
+        'source_tmpl': 'Dist-CheckConflicts-0.11.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DO/DOY'],
+    }),
+    ('Sub::Name', '0.15', {
+        'source_tmpl': 'Sub-Name-0.15.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Time::Piece', '1.31', {
+        'source_tmpl': 'Time-Piece-1.31.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ES/ESAYM'],
+    }),
+    ('Digest::HMAC', '1.03', {
+        'source_tmpl': 'Digest-HMAC-1.03.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('HTTP::Negotiate', '6.01', {
+        'source_tmpl': 'HTTP-Negotiate-6.01.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('MIME::Lite', '3.030', {
+        'source_tmpl': 'MIME-Lite-3.030.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Crypt::Rijndael', '1.13', {
+        'source_tmpl': 'Crypt-Rijndael-1.13.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('B::Lint', '1.20', {
+        'source_tmpl': 'B-Lint-1.20.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Canary::Stability', '2011', {
+        'source_tmpl': 'Canary-Stability-2011.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/ML/MLEHMANN'],
+    }),
+    ('AnyEvent', '7.12', {
+        'source_tmpl': 'AnyEvent-7.12.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/ML/MLEHMANN'],
+    }),
+    ('Object::Accessor', '0.48', {
+        'source_tmpl': 'Object-Accessor-0.48.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+    }),
+    ('Data::UUID', '1.221', {
+        'source_tmpl': 'Data-UUID-1.221.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Test::Pod', '1.51', {
+        'source_tmpl': 'Test-Pod-1.51.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('AppConfig', '1.71', {
+        'source_tmpl': 'AppConfig-1.71.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/N/NE/NEILB'],
+    }),
+    ('Net::SMTP::SSL', '1.03', {
+        'source_tmpl': 'Net-SMTP-SSL-1.03.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('XML::Tiny', '2.06', {
+        'source_tmpl': 'XML-Tiny-2.06.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DC/DCANTRELL'],
+    }),
+    ('HTML::Tagset', '3.20', {
+        'source_tmpl': 'HTML-Tagset-3.20.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PETDANCE'],
+    }),
+    ('HTML::Tree', '5.03', {
+        'source_tmpl': 'HTML-Tree-5.03.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/C/CJ/CJM'],
+    }),
+    ('Devel::GlobalDestruction', '0.13', {
+        'source_tmpl': 'Devel-GlobalDestruction-0.13.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG'],
+    }),
+    ('WWW::RobotRules', '6.02', {
+        'source_tmpl': 'WWW-RobotRules-6.02.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('Expect', '1.33', {
+        'source_tmpl': 'Expect-1.33.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JA/JACOBY/'],
+    }),
+    ('Term::UI', '0.46', {
+        'source_tmpl': 'Term-UI-0.46.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+    }),
+    ('Net::SNMP', 'v6.0.1', {
+        'source_tmpl': 'Net-SNMP-v6.0.1.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DT/DTOWN'],
+    }),
+    ('XML::SAX::Writer', '0.56', {
+        'source_tmpl': 'XML-SAX-Writer-0.56.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PERIGRIN'],
+    }),
+    ('Statistics::Descriptive', '3.0612', {
+        'source_tmpl': 'Statistics-Descriptive-3.0612.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
+    }),
+    ('Class::Load', '0.23', {
+        'source_tmpl': 'Class-Load-0.23.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('LWP::Simple', '6.15', {
+        'source_tmpl': 'libwww-perl-6.15.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Time::Piece::MySQL', '0.06', {
+        'source_tmpl': 'Time-Piece-MySQL-0.06.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/K/KA/KASEI'],
+    }),
+    ('Package::Stash::XS', '0.28', {
+        'source_tmpl': 'Package-Stash-XS-0.28.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DO/DOY'],
+    }),
+    ('GD::Graph', '1.52', {
+        'source_tmpl': 'GDGraph-1.52.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RU/RUZ'],
+    }),
+    ('Set::Array', '0.30', {
+        'source_tmpl': 'Set-Array-0.30.tgz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE'],
+    }),
+    ('boolean', '0.45', {
+        'source_tmpl': 'boolean-0.45.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/I/IN/INGY'],
+    }),
+    ('Number::Format', '1.75', {
+        'source_tmpl': 'Number-Format-1.75.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/W/WR/WRW'],
+    }),
+    ('Data::Stag', '0.14', {
+        'source_tmpl': 'Data-Stag-0.14.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/C/CM/CMUNGALL'],
+    }),
+    ('Test::NoWarnings', '1.04', {
+        'source_tmpl': 'Test-NoWarnings-1.04.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+    }),
+    ('Crypt::DES', '2.07', {
+        'source_tmpl': 'Crypt-DES-2.07.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DP/DPARIS'],
+    }),
+    ('Exporter', '5.72', {
+        'source_tmpl': 'Exporter-5.72.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TODDR'],
+    }),
+    ('Class::Inspector', '1.28', {
+        'source_tmpl': 'Class-Inspector-1.28.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+    }),
+    ('Parse::RecDescent', '1.967013', {
+        'source_tmpl': 'Parse-RecDescent-1.967013.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JT/JTBRAUN'],
+    }),
+    ('Carp', '1.38', {
+        'source_tmpl': 'Carp-1.38.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('XML::XPath', '1.37', {
+        'source_tmpl': 'XML-XPath-1.37.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MANWAR'],
+    }),
+    ('Capture::Tiny', '0.42', {
+        'source_tmpl': 'Capture-Tiny-0.42.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
+    }),
+    ('JSON', '2.90', {
+        'source_tmpl': 'JSON-2.90.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MAKAMAKA'],
+    }),
+    ('Sub::Exporter', '0.987', {
+        'source_tmpl': 'Sub-Exporter-0.987.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Class::Load::XS', '0.09', {
+        'source_tmpl': 'Class-Load-XS-0.09.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Set::IntSpan::Fast', '1.15', {
+        'source_tmpl': 'Set-IntSpan-Fast-1.15.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/A/AN/ANDYA'],
+    }),
+    ('Sub::Exporter::Progressive', '0.001011', {
+        'source_tmpl': 'Sub-Exporter-Progressive-0.001011.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/F/FR/FREW'],
+    }),
+    ('Data::Dumper::Concise', '2.022', {
+        'source_tmpl': 'Data-Dumper-Concise-2.022.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/F/FR/FREW'],
+    }),
+    ('File::Slurp::Tiny', '0.004', {
+        'source_tmpl': 'File-Slurp-Tiny-0.004.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('Algorithm::Diff', '1.1903', {
+        'source_tmpl': 'Algorithm-Diff-1.1903.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TY/TYEMQ'],
+    }),
+    ('AnyData', '0.12', {
+        'source_tmpl': 'AnyData-0.12.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+    }),
+    ('Text::Iconv', '1.7', {
+        'source_tmpl': 'Text-Iconv-1.7.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MP/MPIOTR'],
+    }),
+    ('Class::Data::Inheritable', '0.08', {
+        'source_tmpl': 'Class-Data-Inheritable-0.08.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TM/TMTM'],
+    }),
+    ('Text::Balanced', '2.03', {
+        'source_tmpl': 'Text-Balanced-2.03.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHAY'],
+    }),
+    ('strictures', '2.000003', {
+        'source_tmpl': 'strictures-2.000003.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG'],
+    }),
+    ('Switch', '2.17', {
+        'source_tmpl': 'Switch-2.17.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/C/CH/CHORNY'],
+    }),
+    ('File::Which', '1.21', {
+        'source_tmpl': 'File-Which-1.21.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PL/PLICEASE'],
+    }),
+    ('Email::Date::Format', '1.005', {
+        'source_tmpl': 'Email-Date-Format-1.005.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Error', '0.17024', {
+        'source_tmpl': 'Error-0.17024.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
+    }),
+    ('Mock::Quick', '1.111', {
+        'source_tmpl': 'Mock-Quick-1.111.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('Text::CSV', '1.33', {
+        'source_tmpl': 'Text-CSV-1.33.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MAKAMAKA'],
+    }),
+    ('Test::Output', '1.03', {
+        'source_tmpl': 'Test-Output-1.03.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BD/BDFOY'],
+    }),
+    ('Class::DBI', '3.0.17', {
+        'source_tmpl': 'Class-DBI-v3.0.17.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TM/TMTM'],
+    }),
+    ('List::AllUtils', '0.11', {
+        'source_tmpl': 'List-AllUtils-0.11.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('UNIVERSAL::moniker', '0.08', {
+        'source_tmpl': 'UNIVERSAL-moniker-0.08.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/K/KA/KASEI'],
+    }),
+    ('Exception::Class', '1.40', {
+        'source_tmpl': 'Exception-Class-1.40.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('File::CheckTree', '4.42', {
+        'source_tmpl': 'File-CheckTree-4.42.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Math::VecStat', '0.08', {
+        'source_tmpl': 'Math-VecStat-0.08.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/A/AS/ASPINELLI'],
+    }),
+    ('Pod::LaTeX', '0.61', {
+        'source_tmpl': 'Pod-LaTeX-0.61.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TJ/TJENNESS'],
+    }),
+    ('Eval::Closure', '0.14', {
+        'source_tmpl': 'Eval-Closure-0.14.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DO/DOY'],
+    }),
+    ('HTTP::Request', '6.11', {
+        'source_tmpl': 'HTTP-Message-6.11.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('XML::Twig', '3.49', {
+        'source_tmpl': 'XML-Twig-3.49.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MI/MIROD'],
+    }),
+    ('IO::String', '1.08', {
+        'source_tmpl': 'IO-String-1.08.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('XML::Simple', '2.22', {
+        'source_tmpl': 'XML-Simple-2.22.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GR/GRANTM'],
+    }),
+    ('Sub::Install', '0.928', {
+        'source_tmpl': 'Sub-Install-0.928.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('HTTP::Cookies', '6.01', {
+        'source_tmpl': 'HTTP-Cookies-6.01.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('Pod::Plainer', '1.04', {
+        'source_tmpl': 'Pod-Plainer-1.04.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RM/RMBARKER'],
+    }),
+    ('Test::Exception::LessClever', '0.007', {
+        'source_tmpl': 'Test-Exception-LessClever-0.007.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('LWP::MediaTypes', '6.02', {
+        'source_tmpl': 'LWP-MediaTypes-6.02.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('Scalar::Util', '1.45', {
+        'source_tmpl': 'Scalar-List-Utils-1.45.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PEVANS'],
+    }),
+    ('Data::Section::Simple', '0.07', {
+        'source_tmpl': 'Data-Section-Simple-0.07.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA'],
+    }),
+    ('Class::Trigger', '0.14', {
+        'source_tmpl': 'Class-Trigger-0.14.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA'],
+    }),
+    ('HTTP::Daemon', '6.01', {
+        'source_tmpl': 'HTTP-Daemon-6.01.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('File::HomeDir', '1.00', {
+        'source_tmpl': 'File-HomeDir-1.00.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+    }),
+    ('HTTP::Date', '6.02', {
+        'source_tmpl': 'HTTP-Date-6.02.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('Authen::SASL', '2.16', {
+        'source_tmpl': 'Authen-SASL-2.16.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GB/GBARR'],
+    }),
+    ('Clone', '0.38', {
+        'source_tmpl': 'Clone-0.38.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GARU'],
+    }),
+    ('Data::Types', '0.09', {
+        'source_tmpl': 'Data-Types-0.09.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DW/DWHEELER'],
+    }),
+    ('Import::Into', '1.002005', {
+        'source_tmpl': 'Import-Into-1.002005.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG'],
+    }),
+    ('DateTime::Tiny', '1.06', {
+        'source_tmpl': 'DateTime-Tiny-1.06.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
+    }),
+    ('DBD::AnyData', '0.110', {
+        'source_tmpl': 'DBD-AnyData-0.110.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+    }),
+    ('Text::Format', '0.59', {
+        'source_tmpl': 'Text-Format-0.59.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
+    }),
+    ('Devel::CheckCompiler', '0.06', {
+        'source_tmpl': 'Devel-CheckCompiler-0.06.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SY/SYOHEX'],
+    }),
+    ('Log::Handler', '0.84', {
+        'source_tmpl': 'Log-Handler-0.84.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BL/BLOONIX'],
+    }),
+    ('DBIx::ContextualFetch', '1.03', {
+        'source_tmpl': 'DBIx-ContextualFetch-1.03.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TM/TMTM'],
+    }),
+    ('Devel::StackTrace', '2.01', {
+        'source_tmpl': 'Devel-StackTrace-2.01.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('Term::ReadKey', '2.33', {
+        'source_tmpl': 'TermReadKey-2.33.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JS/JSTOWE'],
+    }),
+    ('Set::IntSpan', '1.19', {
+        'source_tmpl': 'Set-IntSpan-1.19.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SW/SWMCD'],
+    }),
+    ('Moose', '2.1804', {
+        'source_tmpl': 'Moose-2.1804.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Algorithm::Dependency', '1.110', {
+        'source_tmpl': 'Algorithm-Dependency-1.110.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+    }),
+    ('Font::TTF', '1.05', {
+        'source_tmpl': 'Font-TTF-1.05.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MH/MHOSKEN'],
+    }),
+    ('IPC::Run3', '0.048', {
+        'source_tmpl': 'IPC-Run3-0.048.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('File::Find::Rule', '0.34', {
+        'source_tmpl': 'File-Find-Rule-0.34.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RC/RCLAMP'],
+    }),
+    ('SQL::Statement', '1.410', {
+        'source_tmpl': 'SQL-Statement-1.410.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+    }),
+    ('File::Slurp', '9999.19', {
+        'source_tmpl': 'File-Slurp-9999.19.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/U/UR/URI'],
+    }),
+    ('Package::Stash', '0.37', {
+        'source_tmpl': 'Package-Stash-0.37.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DO/DOY'],
+    }),
+    ('Data::OptList', '0.110', {
+        'source_tmpl': 'Data-OptList-0.110.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('CPANPLUS', '0.9160', {
+        'source_tmpl': 'CPANPLUS-0.9160.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+    }),
+    ('IO::Tty', '1.12', {
+        'source_tmpl': 'IO-Tty-1.12.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TODDR'],
+    }),
+    ('Text::Soundex', '3.05', {
+        'source_tmpl': 'Text-Soundex-3.05.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Lingua::EN::PluralToSingular', '0.18', {
+        'source_tmpl': 'Lingua-EN-PluralToSingular-0.18.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BK/BKB'],
+    }),
+    ('Want', '0.29', {
+        'source_tmpl': 'Want-0.29.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RO/ROBIN'],
+    }),
+    ('Cwd::Guard', '0.05', {
+        'source_tmpl': 'Cwd-Guard-0.05.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/K/KA/KAZEBURO'],
+    }),
+    ('Bundle::BioPerl', '2.1.9', {
+        'source_tmpl': 'Bundle-BioPerl-2.1.9.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS'],
+    }),
+    ('Mail::Util', '2.18', {
+        'source_tmpl': 'MailTools-2.18.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MARKOV'],
+    }),
+    ('Text::Template', '1.46', {
+        'source_tmpl': 'Text-Template-1.46.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/M/MJ/MJD'],
+    }),
+    ('PDF::API2', '2.031', {
+        'source_tmpl': 'PDF-API2-2.031.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/S/SS/SSIMMS/'],
+    }),
+    ('SVG', '2.77', {
+        'source_tmpl': 'SVG-2.77.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/M/MA/MANWAR/'],
+    }),
+    ('Statistics::Basic', '1.6611', {
+        'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
+    }),
+    ('Time::HiRes', '01.02', {
+        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/PostgreSQL/PostgreSQL-9.6.2-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/p/PostgreSQL/PostgreSQL-9.6.2-intel-2017a-Python-2.7.13.eb
@@ -20,7 +20,7 @@ source_urls = ['http://ftp.postgresql.org/pub/source/v%(version)s/']
 sources = [SOURCELOWER_TAR_GZ]
 
 dependencies = [
-    ('libreadline', '6.3'),
+    ('libreadline', '7.0'),
     ('zlib', '1.2.11'),
     ('Python', '2.7.13'),
     # OS dependency should be preferred if the os version is more recent then this version,

--- a/easybuild/easyconfigs/p/PostgreSQL/PostgreSQL-9.6.2-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/p/PostgreSQL/PostgreSQL-9.6.2-intel-2017a-Python-2.7.13.eb
@@ -1,0 +1,46 @@
+easyblock = 'ConfigureMake'
+
+name = 'PostgreSQL'
+version = '9.6.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://www.postgresql.org/'
+description = """PostgreSQL is a powerful, open source object-relational database system.
+ It is fully ACID compliant, has full support for foreign keys,
+ joins, views, triggers, and stored procedures (in multiple languages).
+ It includes most SQL:2008 data types, including INTEGER,
+ NUMERIC, BOOLEAN, CHAR, VARCHAR, DATE, INTERVAL, and TIMESTAMP.
+ It also supports storage of binary large objects, including pictures,
+ sounds, or video. It has native programming interfaces for C/C++, Java,
+ .Net, Perl, Python, Ruby, Tcl, ODBC, among others, and exceptional documentation."""
+
+toolchain = {'name': 'intel', 'version': '2017a'}
+
+source_urls = ['http://ftp.postgresql.org/pub/source/v%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('libreadline', '6.3'),
+    ('zlib', '1.2.11'),
+    ('Python', '2.7.13'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    # ('OpenSSL', '1.0.2h'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+builddependencies = [
+    ('Bison', '3.0.4'),
+    ('flex', '2.6.4'),
+    ('Perl', '5.24.0'),
+]
+
+configopts = '--with-python --with-openssl'
+
+sanity_check_paths = {
+    'files': ['bin/psql', 'bin/pg_config', 'lib/libpq.a', 'lib/libpq.%s' % SHLIB_EXT],
+    'dirs': ['share/postgresql'],
+}
+
+moduleclass = 'data'


### PR DESCRIPTION
Add several commonly used Octave Forge packages to
Octave-4.2.1-intel-2017a.eb (and -mt version).  Also add PostgreSQL and Perl
dependencies these packages require.

Fix a bug in mkoctfile that prevents shared library extensions (e.g., 'image')
from compiling with intel.

(At the moment, the -mt and non-mt version segfault in Qt when X11 used.  This
is true for develop as well, so this PR doesn't appear to be the cause.)