### PR TITLE
Add IPython 6.2.1 with jupyterhub 0.8.1.

### DIFF
--- a/easybuild/easyconfigs/c/configurable-http-proxy/configurable-http-proxy-3.1.1-foss-2017a-nodejs-8.9.4.eb
+++ b/easybuild/easyconfigs/c/configurable-http-proxy/configurable-http-proxy-3.1.1-foss-2017a-nodejs-8.9.4.eb
@@ -1,0 +1,24 @@
+easyblock = 'Binary'
+
+name = 'configurable-http-proxy'
+version = '3.1.1'
+nodejsver = '8.9.4'
+versionsuffix = '-nodejs-%s' % nodejsver
+
+homepage = 'https://github.com/jupyterhub/configurable-http-proxy'
+description = """HTTP proxy for node.js including a REST API for updating the routing table. Developed as a part of the Jupyter Hub multi-user server."""
+
+toolchain = {'name': 'foss', 'version': '2017a'}
+
+dependencies = [
+    ('nodejs', nodejsver),
+]
+
+source_urls = ['https://github.com/jupyterhub/configurable-http-proxy/archive/']
+sources = ['%(version)s.tar.gz']
+
+install_cmd = 'npm install --no-package-lock -g --prefix %(installdir)s %(version)s.tar.gz'
+
+sanity_check_commands = ['%(name)s --version']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/c/configurable-http-proxy/configurable-http-proxy-3.1.1-foss-2017a-nodejs-8.9.4.eb
+++ b/easybuild/easyconfigs/c/configurable-http-proxy/configurable-http-proxy-3.1.1-foss-2017a-nodejs-8.9.4.eb
@@ -6,7 +6,8 @@ nodejsver = '8.9.4'
 versionsuffix = '-nodejs-%s' % nodejsver
 
 homepage = 'https://github.com/jupyterhub/configurable-http-proxy'
-description = """HTTP proxy for node.js including a REST API for updating the routing table. Developed as a part of the Jupyter Hub multi-user server."""
+description = """HTTP proxy for node.js including a REST API for updating the routing table.
+ Developed as a part of the Jupyter Hub multi-user server."""
 
 toolchain = {'name': 'foss', 'version': '2017a'}
 

--- a/easybuild/easyconfigs/c/configurable-http-proxy/configurable-http-proxy-3.1.1-foss-2017a-nodejs-8.9.4.eb
+++ b/easybuild/easyconfigs/c/configurable-http-proxy/configurable-http-proxy-3.1.1-foss-2017a-nodejs-8.9.4.eb
@@ -17,6 +17,7 @@ dependencies = [
 
 source_urls = ['https://github.com/jupyterhub/configurable-http-proxy/archive/']
 sources = ['%(version)s.tar.gz']
+checksums = ['45079930e33c1322743e2700e699898136a193ada2227c2174741a23297aeec2']
 
 install_cmd = 'npm install --no-package-lock -g --prefix %(installdir)s %(version)s.tar.gz'
 

--- a/easybuild/easyconfigs/i/IPython/IPython-6.2.1-foss-2017a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-6.2.1-foss-2017a-Python-3.6.4.eb
@@ -26,113 +26,212 @@ exts_list = [
     # required for ipython
     ('Pygments', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/P/Pygments/'],
+        'checksums': [
+            'dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc',  # Pygments-2.2.0.tar.gz
+        ],
     }),
     ('ipython_genutils', '0.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/i/ipython_genutils/'],
+        'checksums': [
+            'eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8',  # ipython_genutils-0.2.0.tar.gz
+        ],
     }),
     ('ipython', version, {
         'source_urls': ['https://pypi.python.org/packages/source/i/ipython/'],
         'modulename': 'IPython',
+        'checksums': [
+            '51c158a6c8b899898d1c91c6b51a34110196815cc905f9be0fa5878e19355608',  # ipython-6.2.1.tar.gz
+        ],
     }),
     ('pexpect', '4.3.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pexpect/'],
+        'checksums': [
+            '8e287b171dbaf249d0b06b5f2e88cb7e694651d2d0b8c15bccb83170d3c55575',  # pexpect-4.3.1.tar.gz
+        ],
     }),
     ('pickleshare', '0.7.4', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pickleshare/'],
+        'checksums': [
+            '84a9257227dfdd6fe1b4be1319096c20eb85ff1e82c7932f36efccfe1b09737b',  # pickleshare-0.7.4.tar.gz
+        ],
     }),
     ('prompt_toolkit', '1.0.15', {
         'source_urls': ['https://pypi.python.org/packages/source/p/prompt_toolkit/'],
+        'checksums': [
+            '858588f1983ca497f1cf4ffde01d978a3ea02b01c8a26a8bbc5cd2e66d816917',  # prompt_toolkit-1.0.15.tar.gz
+        ],
     }),
     ('ptyprocess', '0.5.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/ptyprocess/'],
+        'checksums': [
+            'e64193f0047ad603b71f202332ab5527c5e52aa7c8b609704fc28c0dc20c4365',  # ptyprocess-0.5.2.tar.gz
+        ],
     }),
     ('simplegeneric', '0.8.1', {
         'source_urls': ['https://pypi.python.org/packages/source/s/simplegeneric/'],
         'source_tmpl': 'simplegeneric-%(version)s.zip',
+        'checksums': [
+            'dc972e06094b9af5b855b3df4a646395e43d1c9d0d39ed345b7393560d0b9173',  # simplegeneric-0.8.1.zip
+        ],
     }),
     ('traitlets', '4.3.2', {
         'source_urls': ['https://pypi.python.org/packages/source/t/traitlets/'],
+        'checksums': [
+            '9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835',  # traitlets-4.3.2.tar.gz
+        ],
     }),
     ('jedi', '0.11.1', {
         'source_urls': ['https://pypi.python.org/packages/source/j/jedi/'],
+        'checksums': [
+            'd6e799d04d1ade9459ed0f20de47c32f2285438956a677d083d3c98def59fa97',  # jedi-0.11.1.tar.gz
+        ],
     }),
     ('parso', '0.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/parso/'],
+        'checksums': [
+            '5815f3fe254e5665f3c5d6f54f086c2502035cb631a91341591b5a564203cffb',  # parso-0.1.1.tar.gz
+        ],
     }),
     ('wcwidth', '0.1.7', {
         'source_urls': ['https://pypi.python.org/packages/source/w/wcwidth/'],
+        'checksums': [
+            '3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e',  # wcwidth-0.1.7.tar.gz
+        ],
     }),
     # Required for iptest
     ('testpath', '0.3.1', {
         'source_urls': ['https://pypi.python.org/packages/source/t/testpath/'],
+        'checksums': [
+            '0d5337839c788da5900df70f8e01015aec141aa3fe7936cb0d0a2953f7ac7609',  # testpath-0.3.1.tar.gz
+        ],
     }),
     # Required for utils tests to pass
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+        'checksums': [
+            'f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98',  # nose-1.3.7.tar.gz
+        ],
     }),
     # required for notebook
     ('notebook', '5.3.1', {
         'source_urls': ['https://pypi.python.org/packages/source/n/notebook/'],
         'use_pip': True,
+        'checksums': [
+            '380bbed63117accbb13e42d01d06153c72da6a386f75c81ae4c174eaa11e738b',  # notebook-5.3.1.tar.gz
+        ],
     }),
     ('nbconvert', '5.3.1', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
         'use_pip': True,
+        'checksums': [
+            '12b1a4671d4463ab73af6e4cbcc965b62254e05d182cd54995dda0d0ef9e2db9',  # nbconvert-5.3.1.tar.gz
+        ],
     }),
     ('nbformat', '4.4.0', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nbformat/'],
         'use_pip': True,
+        'checksums': [
+            'f7494ef0df60766b7cabe0a3651556345a963b74dbc16bc7c18479041170d402',  # nbformat-4.4.0.tar.gz
+        ],
     }),
     ('Jinja2', '2.10', {
         'source_urls': ['https://pypi.python.org/packages/source/j/Jinja2/'],
+        'checksums': [
+            'f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4',  # Jinja2-2.10.tar.gz
+        ],
     }),
     ('Send2Trash', '1.4.2', {
         'source_urls': ['https://pypi.python.org/packages/source/s/Send2Trash/'],
+        'checksums': [
+            '725fbce571dffe0b640e2f1788d52c3c544b510f9d8f69b2597c8c2555bc8441',  # Send2Trash-1.4.2.tar.gz
+        ],
     }),
     ('bleach', '2.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/b/bleach/'],
+        'checksums': [
+            '38fc8cbebea4e787d8db55d6f324820c7f74362b70db9142c1ac7920452d1a19',  # bleach-2.1.2.tar.gz
+        ],
     }),
     ('jsonschema', '2.6.0', {
         'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema/'],
+        'checksums': [
+            '6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02',  # jsonschema-2.6.0.tar.gz
+        ],
     }),
     ('pandocfilters', '1.4.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandocfilters/'],
+        'checksums': [
+            'b3dd70e169bb5449e6bc6ff96aea89c5eea8c5f6ab5e207fc2f521a2cf4a0da9',  # pandocfilters-1.4.2.tar.gz
+        ],
     }),
     ('pyzmq', '16.0.4', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyzmq/'],
         'modulename': 'zmq',
+        'checksums': [
+            'bc23fad15d6da82081e89ea0b254a7b6efe6d1c4c58edb16f28e4b4d880086b2',  # pyzmq-16.0.4.tar.gz
+        ],
     }),
     ('MarkupSafe', '1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/m/MarkupSafe/'],
+        'checksums': [
+            'a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665',  # MarkupSafe-1.0.tar.gz
+        ],
     }),
     ('entrypoints', '0.2.3', {
         'source_urls': ['https://pypi.python.org/packages/source/e/entrypoints/'],
+        'checksums': [
+            'd2d587dde06f99545fb13a383d2cd336a8ff1f359c5839ce3a64c917d10c029f',  # entrypoints-0.2.3.tar.gz
+        ],
     }),
     ('html5lib', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/h/html5lib/'],
+        'checksums': [
+            '66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736',  # html5lib-1.0.1.tar.gz
+        ],
     }),
     ('jupyter_client', '5.2.2', {
         'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_client/'],
         'use_pip': True,
+        'checksums': [
+            '83d5e23132f0d8f79ccd3939f53fb9fa97f88a896a85114dc48d0e86909b06c4',  # jupyter_client-5.2.2.tar.gz
+        ],
     }),
     ('jupyter_core', '4.4.0', {
         'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_core/'],
         'use_pip': True,
+        'checksums': [
+            'ba70754aa680300306c699790128f6fbd8c306ee5927976cbe48adacf240c0b7',  # jupyter_core-4.4.0.tar.gz
+        ],
     }),
     ('mistune', '0.8.3', {
         'source_urls': ['https://pypi.python.org/packages/source/m/mistune/'],
+        'checksums': [
+            'bc10c33bfdcaa4e749b779f62f60d6e12f8215c46a292d05e486b869ae306619',  # mistune-0.8.3.tar.gz
+        ],
     }),
     ('terminado', '0.8.1', {
         'source_urls': ['https://pypi.python.org/packages/source/t/terminado/'],
+        'checksums': [
+            '55abf9ade563b8f9be1f34e4233c7b7bde726059947a593322e8a553cc4c067a',  # terminado-0.8.1.tar.gz
+        ],
     }),
     ('tornado', '4.5.3', {
         'source_urls': ['https://pypi.python.org/packages/source/t/tornado/'],
+        'checksums': [
+            '6d14e47eab0e15799cf3cdcc86b0b98279da68522caace2bd7ce644287685f0a',  # tornado-4.5.3.tar.gz
+        ],
     }),
     ('webencodings', '0.5.1', {
         'source_urls': ['https://pypi.python.org/packages/source/w/webencodings/'],
+        'checksums': [
+            'b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923',  # webencodings-0.5.1.tar.gz
+        ],
     }),
     ('ipykernel', '4.8.0', {
         'source_urls': ['https://pypi.python.org/packages/source/i/ipykernel/'],
+        'checksums': [
+            'dedc199df6a38725c732986dfa606c245fb8fe0fe999b33a0c305b73d80c6774',  # ipykernel-4.8.0.tar.gz
+        ],
     }),
 ]
 

--- a/easybuild/easyconfigs/i/IPython/IPython-6.2.1-foss-2017a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-6.2.1-foss-2017a-Python-3.6.4.eb
@@ -1,0 +1,153 @@
+easyblock = 'Bundle'
+
+name = 'IPython'
+version = '6.2.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://ipython.org/index.html'
+description = """IPython provides a rich architecture for interactive computing with:
+ Powerful interactive shells (terminal and Qt-based).
+ A browser-based notebook with support for code, text, mathematical expressions, inline plots and other rich media.
+ Support for interactive data visualization and use of GUI toolkits.
+ Flexible, embeddable interpreters to load into your own projects.
+ Easy to use, high performance tools for parallel computing."""
+
+toolchain = {'name': 'foss', 'version': '2017a'}
+
+dependencies = [
+    ('Python', '3.6.4'),
+    ('ZeroMQ', '4.2.2'),
+]
+
+exts_defaultclass = 'PythonPackage'
+exts_filter = ("python -c 'import %(ext_name)s'", '')
+
+exts_list = [
+    # required for ipython
+    ('Pygments', '2.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/P/Pygments/'],
+    }),
+    ('ipython_genutils', '0.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipython_genutils/'],
+    }),
+    ('ipython', version, {
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipython/'],
+        'modulename': 'IPython',
+    }),
+    ('pexpect', '4.3.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pexpect/'],
+    }),
+    ('pickleshare', '0.7.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pickleshare/'],
+    }),
+    ('prompt_toolkit', '1.0.15', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/prompt_toolkit/'],
+    }),
+    ('ptyprocess', '0.5.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/ptyprocess/'],
+    }),
+    ('simplegeneric', '0.8.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/simplegeneric/'],
+        'source_tmpl': 'simplegeneric-%(version)s.zip',
+    }),
+    ('traitlets', '4.3.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/t/traitlets/'],
+    }),
+    ('jedi', '0.11.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/jedi/'],
+    }),
+    ('parso', '0.1.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/parso/'],
+    }),
+    ('wcwidth', '0.1.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/w/wcwidth/'],
+    }),
+    # Required for iptest
+    ('testpath', '0.3.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/t/testpath/'],
+    }),
+    # Required for utils tests to pass
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+    }),
+    # required for notebook
+    ('notebook', '5.3.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/notebook/'],
+        'use_pip': True,
+    }),
+    ('nbconvert', '5.3.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
+        'use_pip': True,
+    }),
+    ('nbformat', '4.4.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nbformat/'],
+        'use_pip': True,
+    }),
+    ('Jinja2', '2.10', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/Jinja2/'],
+    }),
+    ('Send2Trash', '1.4.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/Send2Trash/'],
+    }),
+    ('bleach', '2.1.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/bleach/'],
+    }),
+    ('jsonschema', '2.6.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema/'],
+    }),
+    ('pandocfilters', '1.4.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandocfilters/'],
+    }),
+    ('pyzmq', '16.0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyzmq/'],
+        'modulename': 'zmq',
+    }),
+    ('MarkupSafe', '1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/MarkupSafe/'],
+    }),
+    ('entrypoints', '0.2.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/entrypoints/'],
+    }),
+    ('html5lib', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/h/html5lib/'],
+    }),
+    ('jupyter_client', '5.2.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_client/'],
+        'use_pip': True,
+    }),
+    ('jupyter_core', '4.4.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_core/'],
+        'use_pip': True,
+    }),
+    ('mistune', '0.8.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mistune/'],
+    }),
+    ('terminado', '0.8.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/t/terminado/'],
+    }),
+    ('tornado', '4.5.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/t/tornado/'],
+    }),
+    ('webencodings', '0.5.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/w/webencodings/'],
+    }),
+    ('ipykernel', '4.8.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipykernel/'],
+    }),
+]
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+sanity_check_paths = {
+    'files': ['bin/ipython'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/IPython'],
+}
+
+sanity_check_commands = [
+    ('ipython -h', ''),
+    ('ipython notebook --help', ''),
+    ('iptest', ''),
+    ('iptest3', ''),
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/j/jupyterhub/jupyterhub-0.8.1-foss-2017a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/j/jupyterhub/jupyterhub-0.8.1-foss-2017a-Python-3.6.4.eb
@@ -5,7 +5,8 @@ version = '0.8.1'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://jupyter.org'
-description = """JupyterHub is a multiuser version of the Jupyter (IPython) notebook designed for centralized deployments in companies, university classrooms and research labs."""
+description = """JupyterHub is a multiuser version of the Jupyter (IPython) notebook designed
+ for centralized deployments in companies, university classrooms and research labs."""
 
 toolchain = {'name': 'foss', 'version': '2017a'}
 

--- a/easybuild/easyconfigs/j/jupyterhub/jupyterhub-0.8.1-foss-2017a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/j/jupyterhub/jupyterhub-0.8.1-foss-2017a-Python-3.6.4.eb
@@ -23,39 +23,72 @@ exts_filter = ("python -c 'import %(ext_name)s'", '')
 exts_list = [
     ('pamela', '0.3.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pamela/'],
+        'checksums': [
+            '1e198446a6cdd87704aa0def7621d62e7c20b0e6068e2788b9a866a8355e5d6b',  # pamela-0.3.0.tar.gz
+        ],
     }),
     ('SQLAlchemy', '1.1.15', {
         'source_urls': ['https://pypi.python.org/packages/source/s/SQLAlchemy/'],
+        'checksums': [
+            '8b79a5ed91cdcb5abe97b0045664c55c140aec09e5dd5c01303e23de5fe7a95a',  # SQLAlchemy-1.1.15.tar.gz
+        ],
     }),
     ('alembic', '0.9.7', {
         'source_urls': ['https://pypi.python.org/packages/source/a/alembic/'],
+        'checksums': [
+            '46f4849c6dce69f54dd5001b3215b6a983dee6b17512efee10e237fa11f20cfa',  # alembic-0.9.7.tar.gz
+        ],
     }),
     ('requests', '2.18.4', {
         'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
+        'checksums': [
+            '9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e',  # requests-2.18.4.tar.gz
+        ],
     }),
     ('python-oauth2', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/python-oauth2/'],
         'modulename': 'oauth2',
+        'checksums': [
+            '5583b5cea3e6cc154800f7a04a061fc7673cb12c75ad9413e607d4472d062d28',  # python-oauth2-1.0.1.tar.gz
+        ],
     }),
     ('Mako', '1.0.7', {
         'source_urls': ['https://pypi.python.org/packages/source/m/Mako/'],
+        'checksums': [
+            '4e02fde57bd4abb5ec400181e4c314f56ac3e49ba4fb8b0d50bba18cb27d25ae',  # Mako-1.0.7.tar.gz
+        ],
     }),
     ('python-editor', '1.0.3', {
         'source_urls': ['https://pypi.python.org/packages/source/p/python_editor/'],
         'modulename': 'editor',
+        'checksums': [
+            'a3c066acee22a1c94f63938341d4fb374e3fdd69366ed6603d7b24bed1efc565',  # python-editor-1.0.3.tar.gz
+        ],
     }),
     ('urllib3', '1.22', {
         'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
+        'checksums': [
+            'cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f',  # urllib3-1.22.tar.gz
+        ],
     }),
     ('certifi', '2018.1.18', {
         'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
+        'checksums': [
+            'edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d',  # certifi-2018.1.18.tar.gz
+        ],
     }),
     ('chardet', '3.0.4', {
         'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
+        'checksums': [
+            '84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae',  # chardet-3.0.4.tar.gz
+        ],
     }),
     ('jupyterhub', version, {
         'source_urls': ['https://pypi.python.org/packages/source/j/jupyterhub/'],
         'use_pip': True,
+        'checksums': [
+            '100cf18d539802807a45450d38fefbb376cf1c810f3b1b31be31638829a5c69c',  # jupyterhub-0.8.1.tar.gz
+        ],
     }),
 ]
 

--- a/easybuild/easyconfigs/j/jupyterhub/jupyterhub-0.8.1-foss-2017a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/j/jupyterhub/jupyterhub-0.8.1-foss-2017a-Python-3.6.4.eb
@@ -1,0 +1,70 @@
+easyblock = 'Bundle'
+
+name = 'jupyterhub'
+version = '0.8.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://jupyter.org'
+description = """JupyterHub is a multiuser version of the Jupyter (IPython) notebook designed for centralized deployments in companies, university classrooms and research labs."""
+
+toolchain = {'name': 'foss', 'version': '2017a'}
+
+dependencies = [
+    ('Python', '3.6.4'),
+    ('IPython', '6.2.1', '-Python-%(pyver)s'),
+    ('configurable-http-proxy', '3.1.1', '-nodejs-8.9.4'),
+]
+
+# this is a bundle of Python packages
+exts_defaultclass = 'PythonPackage'
+exts_filter = ("python -c 'import %(ext_name)s'", '')
+
+exts_list = [
+    ('pamela', '0.3.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pamela/'],
+    }),
+    ('SQLAlchemy', '1.1.15', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/SQLAlchemy/'],
+    }),
+    ('alembic', '0.9.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/a/alembic/'],
+    }),
+    ('requests', '2.18.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
+    }),
+    ('python-oauth2', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-oauth2/'],
+        'modulename': 'oauth2',
+    }),
+    ('Mako', '1.0.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/Mako/'],
+    }),
+    ('python-editor', '1.0.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/python_editor/'],
+        'modulename': 'editor',
+    }),
+    ('urllib3', '1.22', {
+        'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
+    }),
+    ('certifi', '2018.1.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
+    }),
+    ('chardet', '3.0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
+    }),
+    ('jupyterhub', version, {
+        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterhub/'],
+        'use_pip': True,
+    }),
+]
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+sanity_check_paths = {
+    'files': ['bin/jupyterhub'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/jupyterhub'],
+}
+
+sanity_check_commands = ['jupyterhub --help']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/n/nodejs/nodejs-8.9.4-foss-2017a.eb
+++ b/easybuild/easyconfigs/n/nodejs/nodejs-8.9.4-foss-2017a.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'nodejs'
+version = '8.9.4'
+
+homepage = 'http://nodejs.org'
+
+description = """Node.js is a platform built on Chrome's JavaScript runtime 
+ for easily building fast, scalable network applications. Node.js uses an 
+ event-driven, non-blocking I/O model that makes it lightweight and efficient, 
+ perfect for data-intensive real-time applications that run across distributed devices."""
+
+toolchain = {'name': 'foss', 'version': '2017a'}
+toolchainopts = {'lowopt': True}
+
+sources = ['node-v%(version)s.tar.gz']
+
+source_urls = ['http://nodejs.org/dist/v%(version)s/']
+
+# Python is required (only) as build dependency
+allow_system_deps = [('Python', SYS_PYTHON_VERSION)]
+
+sanity_check_paths = {
+    'files': ["bin/node", "bin/npm"],
+    'dirs': ["lib/node_modules", "include/node"]
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/n/nodejs/nodejs-8.9.4-foss-2017a.eb
+++ b/easybuild/easyconfigs/n/nodejs/nodejs-8.9.4-foss-2017a.eb
@@ -14,8 +14,8 @@ toolchain = {'name': 'foss', 'version': '2017a'}
 toolchainopts = {'lowopt': True}
 
 sources = ['node-v%(version)s.tar.gz']
-
 source_urls = ['http://nodejs.org/dist/v%(version)s/']
+checksums = ['729b44b32b2f82ecd5befac4f7518de0c4e3add34e8fe878f745740a66cbbc01']
 
 # Python is required (only) as build dependency
 allow_system_deps = [('Python', SYS_PYTHON_VERSION)]

--- a/easybuild/easyconfigs/p/Python/Python-3.6.4-foss-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.4-foss-2017a.eb
@@ -14,8 +14,8 @@ sources = [SOURCE_TGZ]
 # python needs bzip2 to build the bz2 package
 dependencies = [
     ('bzip2', '1.0.6'),
-    ('zlib', '1.2.8'),
-    ('libreadline', '6.3'),
+    ('zlib', '1.2.11'),
+    ('libreadline', '7.0'),
     ('ncurses', '6.0'),
     ('SQLite', '3.17.0'),
     ('GMP', '6.1.2'),

--- a/easybuild/easyconfigs/p/Python/Python-3.6.4-foss-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.4-foss-2017a.eb
@@ -1,0 +1,213 @@
+name = 'Python'
+version = '3.6.4'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+ more effectively."""
+
+toolchain = {'name': 'foss', 'version': '2017a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('libreadline', '6.3'),
+    ('ncurses', '6.0'),
+    ('SQLite', '3.17.0'),
+    ('GMP', '6.1.2'),
+    ('XZ', '5.2.3'),
+    ('libffi', '3.2.1'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    # ('OpenSSL', '1.0.2k'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# order is important!
+# package versions updated October 16th 2017
+exts_list = [
+    ('setuptools', '36.6.0', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+        'checksums': [
+            '62074589522a798da243f47348f38020d55b6c945652e2f2c09d3a96299812b7',  # setuptools-36.6.0.zip
+        ],
+    }),
+    ('pip', '9.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+        'checksums': [
+            '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d',  # pip-9.0.1.tar.gz
+        ],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+        'checksums': [
+            'f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98',  # nose-1.3.7.tar.gz
+        ],
+    }),
+    ('numpy', '1.13.3', {
+        'patches': ['numpy-1.12.0-mkl.patch'],
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/n/numpy'],
+        'checksums': [
+            '36ee86d5adbabc4fa2643a073f93d5504bdfed37a149a3a49f4dde259f35a750',  # numpy-1.13.3.zip
+            'f212296ed289eb1b4e3f703997499dee8a2cdd0af78b55e017477487b6377ca4',  # numpy-1.12.0-mkl.patch
+        ],
+    }),
+    ('scipy', '0.19.1', {
+        'source_tmpl': '%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
+        'checksums': [
+            'a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6',  # scipy-0.19.1.tar.gz
+        ],
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+        'checksums': [
+            '3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3',  # blist-1.3.6.tar.gz
+        ],
+    }),
+    ('mpi4py', '2.0.0', {
+        'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
+        'checksums': [
+            '6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81',  # mpi4py-2.0.0.tar.gz
+        ],
+    }),
+    ('paycheck', '1.0.2', {
+        'patches': ['paycheck-1.0.2_setup-open-README-utf8.patch'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+        'checksums': [
+            '6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34',  # paycheck-1.0.2.tar.gz
+            # paycheck-1.0.2_setup-open-README-utf8.patch
+            'ceb7f08aebf016cdcd94ae41c1c76c8c120907f85cbfce240d3a112afb264d79',
+        ],
+    }),
+    ('pbr', '3.1.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+        'checksums': [
+            '05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1',  # pbr-3.1.1.tar.gz
+        ],
+    }),
+    ('lockfile', '0.12.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
+        'checksums': [
+            '6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799',  # lockfile-0.12.2.tar.gz
+        ],
+    }),
+    ('Cython', '0.27.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+        'checksums': [
+            'e6840a2ba2704f4ffb40e454c36f73aeb440a4005453ee8d7ff6a00d812ba176',  # Cython-0.27.1.tar.gz
+        ],
+    }),
+    ('six', '1.11.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+        'checksums': [
+            '70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9',  # six-1.11.0.tar.gz
+        ],
+    }),
+    ('dateutil', '2.6.1', {
+        'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+        'checksums': [
+            '891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca',  # python-dateutil-2.6.1.tar.gz
+        ],
+    }),
+    ('deap', '1.0.2', {
+        'patches': ['deap-1.0.2_setup-open-README-utf8.patch'],
+        'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+        'checksums': [
+            'c52bd32b8f0143db3a0b90f2b976c920b588638d6999ca0d038d8b1c07f7950b',  # deap-1.0.2.post2.tar.gz
+            # deap-1.0.2_setup-open-README-utf8.patch
+            '39a3a08359321189a1b27a382eb309dfd4470cba9101997a6d527a2fd3a0ce93',
+        ],
+    }),
+    ('decorator', '4.1.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+        'checksums': [
+            '7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5',  # decorator-4.1.2.tar.gz
+        ],
+    }),
+    ('arff', '2.1.1', {
+        'source_tmpl': 'liac-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+        'checksums': [
+            'b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817',  # liac-arff-2.1.1.tar.gz
+        ],
+    }),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+        'checksums': [
+            'f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c',  # pycrypto-2.6.1.tar.gz
+        ],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+        'checksums': [
+            '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
+        ],
+    }),
+    ('cryptography', '2.1.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
+        'checksums': [
+            '2699ed21e1f73dd1bdb7b0b22a517295de07809d535b23e200dd22166037fe6f',  # cryptography-2.1.1.tar.gz
+        ],
+    }),
+    ('paramiko', '2.3.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+        'checksums': [
+            'fa6b4f5c9d88f27c60fd9578146ff24e99d4b9f63391ff1343305bfd766c4660',  # paramiko-2.3.1.tar.gz
+        ],
+    }),
+    ('pyparsing', '2.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+        'checksums': [
+            '0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04',  # pyparsing-2.2.0.tar.gz
+        ],
+    }),
+    ('netifaces', '0.10.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+        'checksums': [
+            '0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0',  # netifaces-0.10.6.tar.gz
+        ],
+    }),
+    ('netaddr', '0.7.19', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+        'checksums': [
+            '38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd',  # netaddr-0.7.19.tar.gz
+        ],
+    }),
+    ('pandas', '0.20.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+        'checksums': [
+            'a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66',  # pandas-0.20.3.tar.gz
+        ],
+    }),
+    ('virtualenv', '15.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
+        'checksums': [
+            '02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a',  # virtualenv-15.1.0.tar.gz
+        ],
+    }),
+    ('docopt', '0.6.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
+        'checksums': [
+            '49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491',  # docopt-0.6.2.tar.gz
+        ],
+    }),
+    ('joblib', '0.11', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
+        'checksums': [
+            '7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085',  # joblib-0.11.tar.gz
+        ],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-3.6.4-foss-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.4-foss-2017a.eb
@@ -10,6 +10,7 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
+checksums = ['7dc453e1a93c083388eb1a23a256862407f8234a96dc4fae0fc7682020227486']
 
 # python needs bzip2 to build the bz2 package
 dependencies = [


### PR DESCRIPTION
This includes:

- current IPython (v6.2.1) bundled with the notebook as well as nbconvert, nbformat, jupyter and all the dependencies
- current jupyterhub (v0.8.1) with dependencies

Both rely on Python 3.6.4 (included as well).