### PR TITLE
{bio}[foss/2018a] add MEGAHIT-1.1.2

### DIFF
--- a/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.1.2-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.1.2-foss-2018a-Python-2.7.14.eb
@@ -1,0 +1,42 @@
+easyblock = 'MakeCp'
+
+name = 'MEGAHIT'
+version = '1.1.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/voutcn/megahit'
+description = """An ultra-fast single-node solution for large and complex
+ metagenomics assembly via succinct de Bruijn graph"""
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+
+source_urls = ['https://github.com/voutcn/%(namelower)s/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['d0d3965dd49c6fdaea958ef66146cb6b30b7d51acbbfe94194c437f15a424cb5']
+
+dependencies = [
+    ('Python', '2.7.14'),
+]
+
+# This is the CPU-only version.
+#
+# We're specifying version because otherwise the Makefile will try to
+# guess it using 'git describe --tag', which seems less reliable.
+buildopts = 'version=v%(version)s verbose=1 use_gpu=0'
+
+files_to_copy = [
+    (['%(namelower)s', '%(namelower)s_asm_core', '%(namelower)s_sdbg_build', '%(namelower)s_toolkit'], 'bin'),
+    'LICENSE',
+    'README.md',
+]
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s', 'bin/%(namelower)s_asm_core', 'bin/%(namelower)s_sdbg_build', 'bin/%(namelower)s_toolkit'],
+    'dirs': []
+}
+
+sanity_check_commands = ['%(namelower)s -v']
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.1.2-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.1.2-foss-2018a-Python-2.7.14.eb
@@ -20,7 +20,7 @@ dependencies = [
 
 # This is the CPU-only version.
 #
-# We're specifying version because otherwise the Makefile will try to
+# We're specifying 'version' because otherwise the Makefile will try to
 # guess it using 'git describe --tag', which seems less reliable.
 buildopts = 'version=v%(version)s verbose=1 use_gpu=0'
 

--- a/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.1.2-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.1.2-foss-2018a-Python-2.7.14.eb
@@ -33,7 +33,7 @@ files_to_copy = [
 runtest = 'test'
 
 sanity_check_paths = {
-    'files': ['bin/%(namelower)s', 'bin/%(namelower)s_asm_core', 'bin/%(namelower)s_sdbg_build', 'bin/%(namelower)s_toolkit'],
+    'files': ['bin/%(namelower)s', 'bin/%(namelower)s_asm_core', 'bin/%(namelower)s_sdbg_build'],
     'dirs': []
 }
 


### PR DESCRIPTION
New module.  This version is cpu-only.  It's also possible to compile
this with CUDA, but it seems useful to have two separate
versions.  (Still working on getting a CUDA version to compile.)