### PR TITLE
{chem}[intel/2017b] NWChem 6.8.revision47

### DIFF
--- a/easybuild/easyconfigs/n/NWChem/NWChem-6.8.revision47-intel-2017b-2017-12-14-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/n/NWChem/NWChem-6.8.revision47-intel-2017b-2017-12-14-Python-2.7.14.eb
@@ -1,0 +1,41 @@
+name = 'NWChem'
+revision = 47
+version = '6.8.revision%s' % revision
+verdate = '2017-12-14'
+versionsuffix = '-%s-Python-%%(pyver)s' % verdate
+
+homepage = 'http://www.nwchem-sw.org'
+description = """NWChem aims to provide its users with computational chemistry tools that are scalable both in
+ their ability to treat large scientific computational chemistry problems efficiently, and in their use of available
+ parallel computing resources from high-performance parallel supercomputers to conventional workstation clusters.
+ NWChem software can handle: biomolecules, nanostructures, and solid-state; from quantum to classical, and all
+ combinations; Gaussian basis functions or plane-waves; scaling from one to thousands of processors; properties
+ and relativity."""
+
+toolchain = {'name': 'intel', 'version': '2017b'}
+toolchainopts = {'i8': True}
+
+source_urls = ['https://github.com/nwchemgit/nwchem/releases/download/v%(version_major_minor)s-release/']
+sources = ['nwchem-%%(version_major_minor)s-release.revision-v%%(version_major_minor)s-%s-gdf6c956-src.%s.tar.bz2'
+           % (revision, verdate)]
+patches = [
+    'NWChem_fix-date.patch',
+]
+checksums = [
+    # nwchem-6.8-release.revision-v6.8-47-gdf6c956-src.2017-12-14.tar.bz2
+    '83d875d7e4c9dd1f52bdb059376c26fdf9b14940a411594db55545ad4ca3cb14',
+    '215ec54f6132f2c9306bd636456722a36f0f1d98a67a0c8cbd10c5d1eed68feb',  # NWChem_fix-date.patch
+]
+
+dependencies = [('Python', '2.7.14')]
+
+# This easyconfig is using the default for armci_network (OPENIB) and
+# thus needs infiniband libraries.
+osdependencies = [
+    ('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel'),
+    ('libibumad-dev', 'libibumad-devel'),
+]
+
+modules = 'all python'
+
+moduleclass = 'chem'


### PR DESCRIPTION
Version bump to 6.8. Source code hosting has moved to github.