### PR TITLE
update R-bundle-Bioconductor Java version, etc

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.6-intel-2017b-R-3.4.3.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.6-intel-2017b-R-3.4.3.eb
@@ -112,8 +112,8 @@ exts_list = [
     ('GO.db', '3.5.0', {
         'checksums': ['656055d3e43f9b31c44ea895e831e0917092d5c899fad0e1c6070faa82ada109'],
     }),
-    ('limma', '3.34.5', {
-        'checksums': ['9618e6ff919bba74c6695fb9adcc64e97bad03179a033ecc91d619ce773f160c'],
+    ('limma', '3.34.6', {
+        'checksums': ['d41425207c3798f7ae40c7ab4d24f5786d2f2f952ce66aa9e20b1356901c293b'],
     }),
     ('RBGL', '1.54.0', {
         'checksums': ['675b6e7cd9be8c007aba42477c83b478e8bdd92174bc45f6f529a11187684aa2'],
@@ -175,8 +175,8 @@ exts_list = [
     ('RMySQL', '0.10.13', {
         'checksums': ['02396db92a2fa3e25ba448f0ae0b8244ca6b92a277e4f7a1784c004da8c81bc8'],
     }),
-    ('GenomicFeatures', '1.30.0', {
-        'checksums': ['1abe4b339a69d92d1ccb2c8af256a7c04466278deb58e4f8dc0a43e702de12ce'],
+    ('GenomicFeatures', '1.30.1', {
+        'checksums': ['e442b1b6ff361de442b7861b8934d8d0c45ad0d1a5dd3fcd1934ea3d41914d66'],
     }),
     ('bumphunter', '1.20.0', {
         'checksums': ['906a119be54151901d3bd266be33da512052d92a0f8ad26cf4ce28f93a80e029'],
@@ -422,8 +422,8 @@ exts_list = [
     ('scran', '1.6.6', {
         'checksums': ['af36853d8161ae0d95733fe679a67da7a5cfe3bdb66fad862a0f0eef581a48dd'],
     }),
-    ('SC3', '1.7.6', {
-        'checksums': ['9aa3703cf71fa5ad3fed2318788a3b33c90e6eadac5e63cab90495f883e3404e'],
+    ('SC3', '1.7.7', {
+        'checksums': ['3c703f15cdaf47d7543107afc0295bbd3befbbffc1a095fa25892b8b41213df5'],
     }),
     ('ComplexHeatmap', '1.17.1', {
         'checksums': ['9e71eec1020eed2075e87aad460df1c247674b820c0fdae0424d631c4bb9d3f4'],

--- a/easybuild/easyconfigs/r/R/R-3.4.3-foss-2017b-X11-20171023.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.3-foss-2017b-X11-20171023.eb
@@ -27,7 +27,7 @@ dependencies = [
     ('libpng', '1.6.32'),  # for plotting in R
     ('libjpeg-turbo', '1.5.2'),  # for plottting in R
     ('LibTIFF', '4.0.9'),
-    ('Java', '1.8.0_152', '', True),  # Java bindings are built if Java is found, might as well provide it
+    ('Java', '1.8.0_162', '', True),  # Java bindings are built if Java is found, might as well provide it
     ('Tcl', '8.6.7'),  # for tcltk
     ('Tk', '8.6.7'),  # for tcltk
     ('cURL', '7.55.1'),  # for RCurl

--- a/easybuild/easyconfigs/r/R/R-3.4.3-intel-2017b-X11-20171023.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.3-intel-2017b-X11-20171023.eb
@@ -27,7 +27,7 @@ dependencies = [
     ('libpng', '1.6.32'),  # for plotting in R
     ('libjpeg-turbo', '1.5.2'),  # for plottting in R
     ('LibTIFF', '4.0.8'),
-    ('Java', '1.8.0_152', '', True),  # Java bindings are built if Java is found, might as well provide it
+    ('Java', '1.8.0_162', '', True),  # Java bindings are built if Java is found, might as well provide it
     ('Tcl', '8.6.7'),  # for tcltk
     ('Tk', '8.6.7'),  # for tcltk
     ('cURL', '7.56.1'),  # for RCurl
@@ -421,7 +421,7 @@ exts_list = [
         'checksums': ['04f6fe7452ea63d1f2a77960934666132d2f90f139529515e795e35fed73af2e'],
     }),
     ('mgcv', '1.8-22', {
-        'checksums': ['5a3bb235cc798f617392ef4996f2d502233998b041db2a68377f3cea94b98694'],
+        'checksums': ['d4af7767e097ebde91c61d5ab4c62975dcb6b4ed6f545c09f5276a44ebc585cf'],
     }),
     ('robustbase', '0.92-8', {
         'checksums': ['bcbf894c7d3916fc92064f0f9152f6347560c9b98ec81d57b5705f8421b31e20'],
@@ -689,7 +689,7 @@ exts_list = [
         'checksums': ['8ef7cc5c641a8424400d9767475ca9b745f190122d800425fae5bd68facf1874'],
     }),
     ('Hmisc', '4.0-3', {
-        'checksums': ['1c612a72eeb618e624f131475f15d4a15b7e2044ad2045d56bf49aa7be3af1a8'],
+        'checksums': ['5d395286d699bcabb6460c91798019d84b1cfa7a033841aa3ac5a02f4407e4fd'],
     }),
     ('fastcluster', '1.1.24', {
         'checksums': ['82c939b79dbaf00c79b01f19b09a8fadb9a949397b8f65bc861c552e0485b995'],


### PR DESCRIPTION
Update Java version because the existing (1.8.0_152) is no longer
viable (i.e., downloadable).  Updated a few R packages for which the
old version no longer existed.  Also, updated the checksums for a few
modules.  Not sure why they would have changed.