### PR TITLE
Update emacs 25.3 to gcccore 6.4

### DIFF
--- a/easybuild/easyconfigs/e/Emacs/Emacs-25.3-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/e/Emacs/Emacs-25.3-GCCcore-6.4.0.eb
@@ -1,0 +1,35 @@
+easyblock = 'ConfigureMake'
+
+name = 'Emacs'
+version = '25.3'
+
+homepage = 'http://www.gnu.org/software/emacs/'
+description = """GNU Emacs is an extensible, customizable text editor--and more.
+ At its core is an interpreter for Emacs Lisp, a dialect of the Lisp programming
+ language with extensions to support text editing."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+checksums = ['f72c6a1b48b6fbaca2b991eed801964a208a2f8686c70940013db26cd37983c9']
+
+builddependencies = [
+    ('binutils', '2.28'),
+]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('libpng', '1.6.32'),
+    ('libjpeg-turbo', '1.5.2'),
+    ('ncurses', '6.0'),
+]
+
+configopts = '--with-gif=no --with-tiff=no --with-x-toolkit=no --with-xpm=no '
+
+sanity_check_paths = {
+    'files': ["bin/emacs", "bin/emacs-%(version)s", "bin/emacsclient", "bin/etags"],
+    'dirs': []
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
It turns out to be very inconvenient to not have emacs and git that
share a toolchain.