### PR TITLE
{bio}[intel/2018a] HTSlib 1.7, SAMtools 1.7, SCons 3.0.1, cURL 7.58.0

### DIFF
--- a/easybuild/easyconfigs/c/cURL/cURL-7.58.0-intel-2018a.eb
+++ b/easybuild/easyconfigs/c/cURL/cURL-7.58.0-intel-2018a.eb
@@ -1,0 +1,45 @@
+easyblock = 'ConfigureMake'
+
+name = 'cURL'
+version = '7.58.0'
+
+homepage = 'http://curl.haxx.se'
+
+description = """
+ libcurl is a free and easy-to-use client-side URL transfer library,
+ supporting DICT, FILE, FTP, FTPS, Gopher, HTTP, HTTPS, IMAP, IMAPS, LDAP,
+ LDAPS, POP3, POP3S, RTMP, RTSP, SCP, SFTP, SMTP, SMTPS, Telnet and TFTP.
+ libcurl supports SSL certificates, HTTP POST, HTTP PUT, FTP uploading, HTTP
+ form based upload, proxies, cookies, user+password authentication (Basic,
+ Digest, NTLM, Negotiate, Kerberos), file transfer resume, http proxy tunneling
+ and more.
+"""
+
+toolchain = {'name': 'intel', 'version': '2018a'}
+
+source_urls = ['https://curl.haxx.se/download/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['cc245bf9a1a42a45df491501d97d5593392a03f7b4f07b952793518d97666115']
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    # ('OpenSSL', '1.1.0f')
+]
+
+osdependencies = [
+    ('openssl-devel', 'libssl-dev', 'libopenssl-devel'),
+]
+
+configopts = '--with-zlib'
+# configopts += '--with-ssl=$EBROOTOPENSSL'
+
+modextravars = {'CURL_INCLUDES': '%(installdir)s/include'}
+
+sanity_check_paths = {
+    'files': ['bin/curl', 'lib/libcurl.a', 'lib/libcurl.%s' % SHLIB_EXT],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.7-foss-2018a.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.7-foss-2018a.eb
@@ -1,0 +1,36 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+
+easyblock = 'ConfigureMake'
+
+name = 'HTSlib'
+version = '1.7'
+
+homepage = "http://www.htslib.org/"
+description = """A C library for reading/writing high-throughput sequencing data.
+ This package includes the utilities bgzip and tabix"""
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/samtools/%(namelower)s/releases/download/%(version)s/']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['be3d4e25c256acdd41bebb8a7ad55e89bb18e2fc7fc336124b1e2c82ae8886c6']
+
+# cURL added for S3 support
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('bzip2', '1.0.6'),
+    ('XZ', '5.2.3'),
+    ('cURL', '7.58.0'),
+]
+
+configopts = '--enable-libcurl'
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ["bin/bgzip", "bin/tabix", "lib/libhts.%s" % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/h/HTSlib/HTSlib-1.7-intel-2018a.eb
+++ b/easybuild/easyconfigs/h/HTSlib/HTSlib-1.7-intel-2018a.eb
@@ -1,0 +1,41 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# Author: Pablo Escobar Lopez
+# Swiss Institute of Bioinformatics
+# Biozentrum - University of Basel
+# 1.4 modified by:
+# Adam Huffman
+# The Francis Crick Institute
+
+easyblock = 'ConfigureMake'
+
+name = 'HTSlib'
+version = '1.7'
+
+homepage = "http://www.htslib.org/"
+description = """A C library for reading/writing high-throughput sequencing data.
+ This package includes the utilities bgzip and tabix"""
+
+toolchain = {'name': 'intel', 'version': '2018a'}
+
+source_urls = ['https://github.com/samtools/%(namelower)s/releases/download/%(version)s/']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['be3d4e25c256acdd41bebb8a7ad55e89bb18e2fc7fc336124b1e2c82ae8886c6']
+
+# cURL added for S3 support
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('bzip2', '1.0.6'),
+    ('XZ', '5.2.3'),
+    ('cURL', '7.58.0'),
+]
+
+configopts = '--enable-libcurl'
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ["bin/bgzip", "bin/tabix", "lib/libhts.%s" % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.7-foss-2018a-HTSlib-1.7.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.7-foss-2018a-HTSlib-1.7.eb
@@ -1,0 +1,57 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# Modified by: Adam Huffman
+# The Francis Crick Institute
+#
+# Modified for version 1.4 by: Kurt Lust, UAntwerpen
+#
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'SAMtools'
+version = '1.7'
+
+homepage = 'http://www.htslib.org/'
+description = """Samtools provide various utilities for manipulating alignments in the SAM format, 
+ including sorting, merging, indexing and generating alignments in a per-position format."""
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/samtools/%(namelower)s/releases/download/%(version)s']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['e7b09673176aa32937abd80f95f432809e722f141b5342186dfef6a53df64ca1']
+
+# SAMtools needs HTSlib, but the SAMtools source contains an HTSlib source
+# tree, and it will use that by default.  This probably works okay in trivial
+# scenarios (when HTSlib is not loaded), but it causes problems when another
+# module wants to use libraries contained in both.  Doing the standard thing
+# seems likely to work better.
+htsver = '1.7'
+versionsuffix = '-HTSlib-%s' % htsver
+
+dependencies = [
+    ('HTSlib', htsver),
+    ('ncurses', '6.0'),
+]
+
+# In principle, --with-htslib=system should work.  But until a workaround for
+# this issue is found, better to lock to the version explicitly.
+#   https://github.com/easybuilders/easybuild-easyconfigs/issues/5776
+configopts = '--with-htslib=$EBROOTHSTLIB'
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['bin/samtools', 'bin/ace2sam', 'bin/blast2sam.pl'],
+    'dirs': ['share/man/man1'],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.7-foss-2018a.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.7-foss-2018a.eb
@@ -1,0 +1,38 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# Modified by: Adam Huffman
+# The Francis Crick Institute
+#
+# Modified for version 1.4 by: Kurt Lust, UAntwerpen
+#
+##
+name = 'SAMtools'
+version = '1.7'
+
+homepage = 'http://www.htslib.org/'
+description = """SAM Tools provide various utilities for manipulating alignments in the SAM format, 
+ including sorting, merging, indexing and generating alignments in a per-position format."""
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/samtools/%(namelower)s/releases/download/%(version)s']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['e7b09673176aa32937abd80f95f432809e722f141b5342186dfef6a53df64ca1']
+
+# The htslib component of SAMtools 1.4 uses zlib, bzip2 and lzma compression.
+# The latter is currently provided by XZ.
+dependencies = [
+    ('ncurses', '6.0'),
+    ('zlib', '1.2.11'),
+    ('bzip2', '1.0.6'),
+    ('XZ', '5.2.3'),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.7-intel-2018a.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.7-intel-2018a.eb
@@ -1,0 +1,38 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# Modified by: Adam Huffman
+# The Francis Crick Institute
+#
+# Modified for version 1.4 by: Kurt Lust, UAntwerpen
+#
+##
+name = 'SAMtools'
+version = '1.7'
+
+homepage = 'http://www.htslib.org/'
+description = """SAM Tools provide various utilities for manipulating alignments in the SAM format, 
+ including sorting, merging, indexing and generating alignments in a per-position format."""
+
+toolchain = {'name': 'intel', 'version': '2018a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/samtools/%(namelower)s/releases/download/%(version)s']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['e7b09673176aa32937abd80f95f432809e722f141b5342186dfef6a53df64ca1']
+
+# The htslib component of SAMtools 1.4 uses zlib, bzip2 and lzma compression.
+# The latter is currently provided by XZ.
+dependencies = [
+    ('ncurses', '6.0'),
+    ('zlib', '1.2.11'),
+    ('bzip2', '1.0.6'),
+    ('XZ', '5.2.3'),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/s/SCons/SCons-3.0.1-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/s/SCons/SCons-3.0.1-foss-2018a-Python-3.6.4.eb
@@ -1,0 +1,26 @@
+easyblock = 'PythonPackage'
+
+name = 'SCons'
+version = '3.0.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.scons.org/'
+description = "SCons is a software construction tool."
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['24475e38d39c19683bc88054524df018fe6949d70fbd4c69e298d39a0269f173']
+
+dependencies = [('Python', '3.6.4')]
+
+sanity_check_paths = {
+    'files': ['bin/scons', 'bin/scons-time', 'bin/sconsign'],
+    'dirs': ['lib/%(namelower)s-%(version)s/%(name)s'],
+}
+
+# no Python module to import during sanity check
+options = {'modulename': False}
+
+moduleclass = 'devel'


### PR DESCRIPTION
These are reasonably straightforward updates to 2018a toolchains.
SAMtools is a little odd in that it has multiple flavors.

(I was working on an easyconfig for MetaBAT, which needs these, but
giving up for now.)