### PR TITLE
include io and statistics extensions to Octave 4.2.1 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a-mt.eb
+++ b/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a-mt.eb
@@ -71,6 +71,12 @@ exts_list = [
             'e4971524077a19e655c7c70c11d9a27ca1a3aa2638150c5779e72ebce9ec38b5',  # signal-1.3.2_fix-formula.patch
         ],
     }),
+    ('io', '2.4.10', {
+        'checksums': ['7ea51ea3eb0caa6da9029c7b045d410132cb3b063b12b5b5a43b82e48f47265d'],
+    }),
+    ('statistics', '1.3.0', {
+        'checksums': ['06454e3a7ae6d2b7c5f442638c29c28ea8e5976766373fffcf0e297d5d076a33'],
+    }),
 ]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/o/Octave/Octave-4.2.1-intel-2017a.eb
@@ -67,6 +67,12 @@ exts_list = [
             'e4971524077a19e655c7c70c11d9a27ca1a3aa2638150c5779e72ebce9ec38b5',  # signal-1.3.2_fix-formula.patch
         ],
     }),
+    ('io', '2.4.10', {
+        'checksums': ['7ea51ea3eb0caa6da9029c7b045d410132cb3b063b12b5b5a43b82e48f47265d'],
+    }),
+    ('statistics', '1.3.0', {
+        'checksums': ['06454e3a7ae6d2b7c5f442638c29c28ea8e5976766373fffcf0e297d5d076a33'],
+    }),
 ]
 
 moduleclass = 'math'


### PR DESCRIPTION
(requires https://github.com/easybuilders/easybuild-easyblocks/pull/1355 to correctly install only additional extensions in an existing Octave 4.2.1 installation using `--skip`)