### PR TITLE
{bio}[intel/2018a] update SOAPdenovo2-r241

### DIFF
--- a/easybuild/easyconfigs/s/SOAPdenovo2/SOAPdenovo2-r241-intel-2018a.eb
+++ b/easybuild/easyconfigs/s/SOAPdenovo2/SOAPdenovo2-r241-intel-2018a.eb
@@ -1,0 +1,39 @@
+#    With <3 for EasyBuild
+#
+#    EasyConfig for SOAPdenovo2:
+#    ----------------------------------------------------------------------------
+#    Copyright: 2013 - Gregor Mendel Institute of Molecular Plant Biology GmBH
+#    License: MIT
+#    Authors: Petar <petar.forai@gmi.oeaw.ac.at> Forai
+#    ----------------------------------------------------------------------------
+
+easyblock = "MakeCp"
+
+name = 'SOAPdenovo2'
+version = 'r241'
+
+homepage = 'http://soap.genomics.org.cn/index.html'
+description = """SOAPdenovo is a novel short-read assembly method that can build a 
+ de novo draft assembly for human-sized genomes. The program is specially designed to 
+ assemble Illumina short reads. It creates new opportunities for building reference 
+ sequences and carrying out accurate analyses of unexplored genomes in a cost effective way. 
+ SOAPdenovo2 is the successor of SOAPdenovo."""
+
+toolchain = {'name': 'intel', 'version': '2018a'}
+
+github_account = 'aquaskyline'
+source_urls = [GITHUB_SOURCE]
+sources = ['%(version)s.tar.gz']
+checksums = ['e623b11f78bf885c22ccf265f70b3952828c6cfb05cfb3d17c49c984bcb5eeda']
+
+# parallel build is broken
+maxparallel = 1
+
+files_to_copy = [(['SOAPdenovo-127mer', 'SOAPdenovo-63mer', 'SOAPdenovo-fusion'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/SOAPdenovo-63mer', 'bin/SOAPdenovo-127mer', 'bin/SOAPdenovo-fusion'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
Note that latest source is now on github.  Killed 'optarch' (which
defaults to True anyway?) and 'pic' (seems unnecessary).