### PR TITLE
switch to using TensorFlow as backend for recent versions of Keras

### DIFF
--- a/easybuild/easyconfigs/k/Keras/Keras-2.1.3-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/k/Keras/Keras-2.1.3-foss-2017b-Python-3.6.3.eb
@@ -16,13 +16,10 @@ checksums = ['7ca3a381523bad40a6922e88951a316664cb088fd01cea07e5ec8ada3327e3c7']
 
 dependencies = [
     ('Python', '3.6.3'),
-    ('Theano', '1.0.1', versionsuffix),
+    ('TensorFlow', '1.5.0', versionsuffix),
     ('h5py', '2.7.1', versionsuffix),
     ('PyYAML', '3.12', versionsuffix),
 ]
-
-# it defaults to Tensorflow
-modextravars = {'KERAS_BACKEND': 'theano'}
 
 sanity_check_paths = {
     'files': [],

--- a/easybuild/easyconfigs/k/Keras/Keras-2.1.3-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/k/Keras/Keras-2.1.3-foss-2017b-Python-3.6.3.eb
@@ -17,6 +17,7 @@ checksums = ['7ca3a381523bad40a6922e88951a316664cb088fd01cea07e5ec8ada3327e3c7']
 dependencies = [
     ('Python', '3.6.3'),
     ('TensorFlow', '1.5.0', versionsuffix),
+    ('Theano', '1.0.1', versionsuffix),
     ('h5py', '2.7.1', versionsuffix),
     ('PyYAML', '3.12', versionsuffix),
 ]


### PR DESCRIPTION
Now that we can properly build `TensorFlow` from source (cfr. https://github.com/easybuilders/easybuild-easyblocks/pull/1287), we should also use `TensorFlow` as backend for Keras (which is the default), since it performs a lot better than `Theano` (which is pretty much end of life).

requires ~~#5819~~ (`TensorFlow`)

cc @JensTimmerman 