### PR TITLE
Lua/5.3.4 gcc 7.2.0 2.29.eb

### DIFF
--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.3.eb
@@ -13,7 +13,7 @@ source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
     'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
     'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
-    'http://www.multiprecision.org/mpc/download',  # MPC official
+    'http://ftpmirror.gnu.org/gnu/mpc',  # MPC official
 ]
 sources = [
     SOURCELOWER_TAR_BZ2,

--- a/easybuild/easyconfigs/l/Lua/Lua-5.3.4-GCC-7.2.0-2.29.eb
+++ b/easybuild/easyconfigs/l/Lua/Lua-5.3.4-GCC-7.2.0-2.29.eb
@@ -1,0 +1,27 @@
+easyblock = 'MakeInstall'
+
+buildopts = 'linux'
+installopts = 'INSTALL_TOP=%(installdir)s'
+
+name = "Lua"
+version = "5.3.4"
+
+homepage = "http://www.lua.org/"
+description = """Lua is a powerful, fast, lightweight, embeddable scripting language.
+ Lua combines simple procedural syntax with powerful data description constructs based
+ on associative arrays and extensible semantics. Lua is dynamically typed,
+ runs by interpreting bytecode for a register-based virtual machine,
+ and has automatic memory management with incremental garbage collection,
+ making it ideal for configuration, scripting, and rapid prototyping."""
+
+toolchain = {'name': 'GCC', 'version': '7.2.0-2.29'}
+
+source_urls = ['https://www.lua.org/ftp/']
+sources = [SOURCELOWER_TAR_GZ]
+
+sanity_check_paths = {
+    'files': ["bin/lua"],
+    'dirs': []
+}
+
+moduleclass = "lang"


### PR DESCRIPTION
Lua easyconfig exploting install instructions [here](https://www.lua.org/manual/5.3/readme.html) and not the file provided by `Lmod`. 

Needs https://github.com/easybuilders/easybuild-easyblocks/pull/1365.

