### PR TITLE
add sanity check command in matplotlib easyconfigs built with intel toolchain to ensure Tkinter is available

### DIFF
--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.2-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.2-intel-2016b-Python-2.7.12.eb
@@ -39,6 +39,8 @@ sanity_check_paths = {
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.2-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.2-intel-2016b-Python-3.5.2.eb
@@ -39,6 +39,8 @@ sanity_check_paths = {
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.3-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.3-intel-2016b-Python-2.7.12.eb
@@ -39,6 +39,8 @@ sanity_check_paths = {
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.3-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.3-intel-2016b-Python-3.5.2.eb
@@ -39,6 +39,8 @@ sanity_check_paths = {
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.0-intel-2016b-Python-2.7.12.eb
@@ -39,6 +39,8 @@ sanity_check_paths = {
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.0-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.0-intel-2017a-Python-2.7.13.eb
@@ -16,7 +16,8 @@ exts_defaultclass = 'PythonPackage'
 
 dependencies = [
     ('Python', '2.7.13'),
-    ('freetype', '2.7.1'),
+    ('Tkinter', '%(pyver)s', versionsuffix),
+    ('freetype', '2.7.1', '-libpng-1.6.29'),
 ]
 
 exts_list = [
@@ -37,6 +38,8 @@ sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
+
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.1-intel-2017a-Python-3.6.1.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.1-intel-2017a-Python-3.6.1.eb
@@ -16,7 +16,8 @@ exts_defaultclass = 'PythonPackage'
 
 dependencies = [
     ('Python', '3.6.1'),
-    ('freetype', '2.7.1'),
+    ('Tkinter', '%(pyver)s', versionsuffix),
+    ('freetype', '2.7.1', '-libpng-1.6.29'),
 ]
 
 exts_list = [
@@ -37,6 +38,8 @@ sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
+
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-2.7.13-Qt-4.8.7.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-2.7.13-Qt-4.8.7.eb
@@ -17,6 +17,7 @@ exts_defaultclass = 'PythonPackage'
 
 dependencies = [
     ('Python', '2.7.13'),
+    ('Tkinter', '%(pyver)s', '-Python-%(pyver)s'),
     ('Qt', qtver),
     ('PyQt', '4.12', '-Python-%(pyver)s'),
     ('freetype', '2.7.1', '-libpng-1.6.29'),
@@ -40,6 +41,8 @@ sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
+
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-2.7.13-libpng-1.6.29.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-2.7.13-libpng-1.6.29.eb
@@ -17,6 +17,7 @@ exts_defaultclass = 'PythonPackage'
 
 dependencies = [
     ('Python', '2.7.13'),
+    ('Tkinter', '%(pyver)s', '-Python-%(pyver)s'),
     ('freetype', '2.7.1', '-libpng-%s' % libpng_ver),
 ]
 
@@ -38,6 +39,8 @@ sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
+
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-2.7.13.eb
@@ -16,7 +16,8 @@ exts_defaultclass = 'PythonPackage'
 
 dependencies = [
     ('Python', '2.7.13'),
-    ('freetype', '2.7.1'),
+    ('Tkinter', '%(pyver)s', versionsuffix),
+    ('freetype', '2.7.1', '-libpng-1.6.29'),
 ]
 
 exts_list = [
@@ -37,6 +38,8 @@ sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
+
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-3.6.1-libpng-1.6.29.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-3.6.1-libpng-1.6.29.eb
@@ -17,6 +17,7 @@ exts_defaultclass = 'PythonPackage'
 
 dependencies = [
     ('Python', '3.6.1'),
+    ('Tkinter', '%(pyver)s', '-Python-%(pyver)s'),
     ('freetype', '2.7.1', '-libpng-%s' % libpng_ver),
 ]
 
@@ -38,6 +39,8 @@ sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
+
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-2.7.14.eb
@@ -16,8 +16,9 @@ exts_defaultclass = 'PythonPackage'
 
 dependencies = [
     ('Python', '2.7.14'),
+    ('Tkinter', '%(pyver)s', versionsuffix),
     ('libpng', '1.6.32'),
-    ('freetype', '2.8.1'),
+    ('freetype', '2.8'),
 ]
 
 exts_list = [
@@ -48,6 +49,8 @@ sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
+
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-3.6.3.eb
@@ -16,8 +16,9 @@ exts_defaultclass = 'PythonPackage'
 
 dependencies = [
     ('Python', '3.6.3'),
+    ('Tkinter', '%(pyver)s', versionsuffix),
     ('libpng', '1.6.32'),
-    ('freetype', '2.8.1'),
+    ('freetype', '2.8'),
 ]
 
 exts_list = [
@@ -40,6 +41,8 @@ sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
+
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-2.7.14.eb
@@ -16,6 +16,7 @@ exts_defaultclass = 'PythonPackage'
 
 dependencies = [
     ('Python', '2.7.14'),
+    ('Tkinter', '%(pyver)s', versionsuffix),
     ('libpng', '1.6.32'),
     ('freetype', '2.8'),
 ]
@@ -40,6 +41,8 @@ sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
+
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-3.6.3.eb
@@ -16,6 +16,7 @@ exts_defaultclass = 'PythonPackage'
 
 dependencies = [
     ('Python', '3.6.3'),
+    ('Tkinter', '%(pyver)s', versionsuffix),
     ('libpng', '1.6.32'),
     ('freetype', '2.8'),
 ]
@@ -40,6 +41,8 @@ sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
+
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/t/Tkinter/Tkinter-2.7.14-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/t/Tkinter/Tkinter-2.7.14-intel-2017b-Python-2.7.14.eb
@@ -1,0 +1,20 @@
+name = 'Tkinter'
+version = '2.7.14'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://python.org/'
+description = """Tkinter module, built with the Python buildsystem"""
+
+toolchain = {'name': 'intel', 'version': '2017b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.python.org/ftp/python/%(version)s/']
+sources = ['Python-%(version)s.tgz']
+checksums = ['304c9b202ea6fbd0a4a8e0ad3733715fbd4749f2204a9173a58ec53c32ea73e8']
+
+dependencies = [
+    ('Python', version),
+    ('Tk', '8.6.7'),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tkinter/Tkinter-3.6.1-intel-2017a-Python-3.6.1.eb
+++ b/easybuild/easyconfigs/t/Tkinter/Tkinter-3.6.1-intel-2017a-Python-3.6.1.eb
@@ -1,0 +1,20 @@
+name = 'Tkinter'
+version = '3.6.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://python.org/'
+description = """Tkinter module, built with the Python buildsystem"""
+
+toolchain = {'name': 'intel', 'version': '2017a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.python.org/ftp/python/%(version)s/']
+sources = ['Python-%(version)s.tgz']
+checksums = ['aa50b0143df7c89ce91be020fe41382613a817354b33acdc6641b44f8ced3828']
+
+dependencies = [
+    ('Python', version),
+    ('Tk', '8.6.6'),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tkinter/Tkinter-3.6.3-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/t/Tkinter/Tkinter-3.6.3-intel-2017b-Python-3.6.3.eb
@@ -1,0 +1,20 @@
+name = 'Tkinter'
+version = '3.6.3'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://python.org/'
+description = """Tkinter module, built with the Python buildsystem"""
+
+toolchain = {'name': 'intel', 'version': '2017b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.python.org/ftp/python/%(version)s/']
+sources = ['Python-%(version)s.tgz']
+checksums = ['ab6193af1921b30f587b302fe385268510e80187ca83ca82d2bfe7ab544c6f91']
+
+dependencies = [
+    ('Python', version),
+    ('Tk', '8.6.7'),
+]
+
+moduleclass = 'lang'


### PR DESCRIPTION
follow-up for ~~#5689~~ (cc @schiotz)

I was forced to also fiddle with the `freetype` dependency in some `matplotlib` easyconfig to avoid introducing conflicts (since `Tkinter` indirectly depends on `freetype`).
We usually don't do that, but here that was the more sensible option, especially since it doesn't introduce any conflicts elsewhere (where `matplotlib` is used as a dependency).