### PR TITLE
fix source_urls for recent versions of ABINIT

### DIFF
--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-8.0.8b-foss-2016b.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-8.0.8b-foss-2016b.eb
@@ -10,9 +10,9 @@ description = """ABINIT is a package whose main program allows one to find the t
 
 toolchain = {'name': 'foss', 'version': '2016b'}
 
-source_urls = ['http://ftp.abinit.org/']
+source_urls = ['https://www.abinit.org/sites/default/files/packages/']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['abc9e303bfa7f9f43f95598f87d84d5d']
+checksums = ['37ad5f0f215d2a36e596383cb6e54de3313842a0390ce8d6b48a423d3ee25af2']
 
 configopts = "--with-mpi-prefix=$EBROOTOPENMPI --with-trio-flavor='etsf_io+netcdf' --with-dft=flavor='libxc' "
 configopts += '--with-netcdf-incs="-I$EBROOTNETCDF/include -I$EBROOTNETCDFMINFORTRAN/include" '

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-8.0.8b-intel-2016b.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-8.0.8b-intel-2016b.eb
@@ -10,9 +10,9 @@ description = """ABINIT is a package whose main program allows one to find the t
 
 toolchain = {'name': 'intel', 'version': '2016b'}
 
-source_urls = ['http://ftp.abinit.org/']
+source_urls = ['https://www.abinit.org/sites/default/files/packages/']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['abc9e303bfa7f9f43f95598f87d84d5d']
+checksums = ['37ad5f0f215d2a36e596383cb6e54de3313842a0390ce8d6b48a423d3ee25af2']
 
 configopts = "--with-mpi-prefix=$EBROOTIMPI/intel64 --with-trio-flavor='etsf_io+netcdf' --with-dft=flavor='libxc' "
 configopts += '--with-netcdf-incs="-I$EBROOTNETCDF/include -I$EBROOTNETCDFMINFORTRAN/include" '

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-8.2.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-8.2.2-foss-2016b.eb
@@ -10,9 +10,9 @@ description = """ABINIT is a package whose main program allows one to find the t
 
 toolchain = {'name': 'foss', 'version': '2016b'}
 
-source_urls = ['http://ftp.abinit.org/']
+source_urls = ['https://www.abinit.org/sites/default/files/packages/']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['5f25250e06fdc0815c224ffd29858860']
+checksums = ['e43544a178d758b0deff3011c51ef7c957d7f2df2ce8543366d68016af9f3ea1']
 
 configopts = "--with-mpi-prefix=$EBROOTOPENMPI --with-trio-flavor='etsf_io+netcdf' --with-dft=flavor='libxc' "
 configopts += '--with-netcdf-incs="-I$EBROOTNETCDF/include -I$EBROOTNETCDFMINFORTRAN/include" '

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-8.2.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-8.2.2-intel-2016b.eb
@@ -10,9 +10,9 @@ description = """ABINIT is a package whose main program allows one to find the t
 
 toolchain = {'name': 'intel', 'version': '2016b'}
 
-source_urls = ['http://ftp.abinit.org/']
+source_urls = ['https://www.abinit.org/sites/default/files/packages/']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['5f25250e06fdc0815c224ffd29858860']
+checksums = ['e43544a178d758b0deff3011c51ef7c957d7f2df2ce8543366d68016af9f3ea1']
 
 configopts = "--with-mpi-prefix=$EBROOTIMPI/intel64 --with-trio-flavor='etsf_io+netcdf' --with-dft=flavor='libxc' "
 configopts += '--with-netcdf-incs="-I$EBROOTNETCDF/include -I$EBROOTNETCDFMINFORTRAN/include" '


### PR DESCRIPTION
triggered by @vanzod's PR #5760

cfr. https://www.abinit.org/packages

I couldn't find a new download location for ABINIT 8.0.8, so I left that as is