### PR TITLE
 add missing --enable-ld-version-script configure option for LibTIFF 4.0.9 built with GCCcore/6.4.0

### DIFF
--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.9-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.9-GCCcore-6.4.0.eb
@@ -31,6 +31,8 @@ builddependencies = [
     ('binutils', '2.28'),
 ]
 
+configopts = " --enable-ld-version-script "
+
 sanity_check_paths = {
     'files': ['bin/tiffinfo'],
     'dirs': [],


### PR DESCRIPTION
cfr. https://lists.ugent.be/wws/arc/easybuild/2018-03/msg00000.html