### PR TITLE
hard disable UCX support in recent OpenMPI versions, to dance around bug in OpenMPI configure script

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.0-GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.0-GCC-5.2.0.eb
@@ -18,6 +18,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
@@ -18,6 +18,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-gcccuda-2016.10.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-gcccuda-2016.10.eb
@@ -18,6 +18,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--with-cuda=$CUDA_HOME '             # CUDA-aware build; N.B. --disable-dlopen is incompatible
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-iccifort-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-iccifort-2017.1.132-GCC-5.4.0-2.26.eb
@@ -18,6 +18,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27-opa.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27-opa.eb
@@ -20,6 +20,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-psm2 '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-psm2
 osdependencies = [('libpsm2', 'libpsm2-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27.eb
@@ -19,6 +19,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-gcccuda-2017.01.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-gcccuda-2017.01.eb
@@ -19,6 +19,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--with-cuda=$CUDA_HOME '             # CUDA-aware build; N.B. --disable-dlopen is incompatible
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-iccifort-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-iccifort-2017.1.132-GCC-6.3.0-2.27.eb
@@ -18,6 +18,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.0-GCC-6.3.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.0-GCC-6.3.0-2.28.eb
@@ -19,6 +19,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-GCC-6.4.0-2.28.eb
@@ -18,6 +18,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # to enable SLURM integration (site-specific)
 # configopts += '--with-slurm --with-pmi=/usr/include/slurm --with-pmi-libdir=/usr'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-gcccuda-2017.02.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-gcccuda-2017.02.eb
@@ -18,6 +18,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--with-cuda=$CUDA_HOME '     # CUDA-aware build; N.B. --disable-dlopen is incompatible
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # to enable SLURM integration (site-specific)
 # configopts += '--with-slurm --with-pmi=/usr/include/slurm --with-pmi-libdir=/usr'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-gcccuda-2017b.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-gcccuda-2017b.eb
@@ -18,6 +18,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--with-cuda=$CUDA_HOME '     # CUDA-aware build; N.B. --disable-dlopen is incompatible
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # to enable SLURM integration (site-specific)
 # configopts += '--with-slurm --with-pmi=/usr/include/slurm --with-pmi-libdir=/usr'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-iccifort-2017.4.196-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-iccifort-2017.4.196-GCC-6.4.0-2.28.eb
@@ -20,6 +20,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-GCC-6.4.0-2.28.eb
@@ -18,6 +18,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # to enable SLURM integration (site-specific)
 # configopts += '--with-slurm --with-pmi=/usr/include/slurm --with-pmi-libdir=/usr'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-iccifort-2018.1.163-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-iccifort-2018.1.163-GCC-6.4.0-2.28.eb
@@ -20,6 +20,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.0.0-GCC-7.2.0-2.29.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.0.0-GCC-7.2.0-2.29.eb
@@ -24,6 +24,7 @@ configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # to enable SLURM integration (site-specific)
 # configopts += '--with-slurm --with-pmi=/usr/include/slurm --with-pmi-libdir=/usr'


### PR DESCRIPTION
fix for #5805