### PR TITLE
use gettext 0.19.8.1 on top of libxml2 2.9.7 as dep for git built with foss/2018a

### DIFF
--- a/easybuild/easyconfigs/g/git/git-2.16.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/g/git/git-2.16.1-foss-2018a.eb
@@ -19,7 +19,7 @@ builddependencies = [
 dependencies = [
     ('cURL', '7.58.0'),
     ('expat', '2.2.5'),
-    ('gettext', '0.19.8.1',  '', True),
+    ('gettext', '0.19.8.1', '-libxml2-2.9.7'),
     ('Perl', '5.26.1', '-bare'),
 ]
 


### PR DESCRIPTION
This change is required to avoid that two different types of `gettext` are used as dependency in easyconfigs using a `*-2018a` toolchain, cfr. check being added in #5970 .

We usually refrain from updating dependencies in existing easyconfig files, but I consider it acceptable in this particular case.

This changes the `git` easyconfig contributed by @RvDijk in #5750, so it would be great to get some feedback from him on this change.