### PR TITLE
bump hwloc dep for OpenMPI 2.1.2 that is part of iomkl/2018a to v1.11.8

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-iccifort-2018.1.163-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-iccifort-2018.1.163-GCC-6.4.0-2.28.eb
@@ -14,7 +14,7 @@ source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['e5bf7b2d7517f5cb7c9e1fed15d2df2da501669072477b21a513e892a22663bc']
 
-dependencies = [('hwloc', '1.11.7')]
+dependencies = [('hwloc', '1.11.8')]
 
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path


### PR DESCRIPTION
This change is required to avoid that two different types of gettext are used as dependency in easyconfigs using a `*-2018a` toolchain, cfr. check being added in #5970 .

We usually refrain from updating dependencies in existing easyconfig files, but I consider it acceptable in this particular case.

This changes the`OpenMPI` easyconfig included by @edmondac in #5878, so it would be great to get some feedback from him on this change.