### PR TITLE
use latest libjpeg-turbo 1.5.3 in GraphicsMagick/Ghostscript foss/2018a easyconfigs

### DIFF
--- a/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.22-GCCcore-6.4.0-cairo-1.14.12.eb
+++ b/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.22-GCCcore-6.4.0-cairo-1.14.12.eb
@@ -22,7 +22,7 @@ dependencies = [
     ('zlib', '1.2.11'),
     ('libpng', '1.6.34'),
     ('freetype', '2.9'),
-    ('libjpeg-turbo', '1.5.2'),
+    ('libjpeg-turbo', '1.5.3'),
     ('expat', '2.2.5'),
     ('GLib', '2.54.3'),
     ('cairo', '1.14.12'),

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.28-foss-2018a.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.28-foss-2018a.eb
@@ -23,7 +23,7 @@ dependencies = [
     ('bzip2', '1.0.6'),
     ('freetype', '2.9'),
     ('libpng', '1.6.34'),
-    ('libjpeg-turbo', '1.5.2'),
+    ('libjpeg-turbo', '1.5.3'),
     ('LibTIFF', '4.0.9'),
     ('libxml2', '2.9.7'),
     ('XZ', '5.2.3'),


### PR DESCRIPTION
PR #5982 should have been using `libjpeg-turbo` 1.5.3, for compatibility with `gnuplot` (cfr. #5955)...