### PR TITLE
allow two dependency variants if one is for Python 2.x, other is for Python 3.x

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -199,6 +199,13 @@ class EasyConfigTest(TestCase):
                 if len(v2_dep_vars) == 1 and len(v3_dep_vars) == 1:
                     res = True
 
+            # two variants is OK if one is for Python 2.x and the other is for Python 3.x (based on versionsuffix)
+            elif len(dep_vars) == 2:
+                py2_dep_vars = [x for x in dep_vars.keys() if '; versionsuffix: -Python-2.' in x]
+                py3_dep_vars = [x for x in dep_vars.keys() if '; versionsuffix: -Python-3.' in x]
+                if len(py2_dep_vars) == 1 and len(py3_dep_vars) == 1:
+                    res = True
+
             return res
 
         # restrict to checking dependencies of easyconfigs using common toolchains (start with 2018a)


### PR DESCRIPTION
enhancement for the check added in #5970, to allow dependencies for both Python 2.x & Python 3.x

For example (from #6020):

```
FAIL: test_dep_versions_per_toolchain_generation (test.easyconfigs.easyconfigs.EasyConfigTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/easybuilders/easybuild-easyconfigs/test/easyconfigs/easyconfigs.py", line 236, in test_dep_versions_per_toolchain_generation
    self.assertFalse(multi_dep_vars, error_msg)
AssertionError: No multi-variant deps found for '^.*-(?P<tc_gen>201[89][ab]).*\.eb$' easyconfigs:

found 2 variants of 'pkgconfig' dependency in easyconfigs using '2018a' toolchain generation
* version: 1.3.1; versionsuffix: -Python-2.7.14 as dep for set(['h5py-2.7.1-foss-2018a-Python-2.7.14.eb', 'h5py-2.7.1-intel-2018a-Python-2.7.14.eb'])
* version: 1.3.1; versionsuffix: -Python-3.6.4 as dep for set(['h5py-2.7.1-intel-2018a-Python-3.6.4.eb', 'h5py-2.7.1-foss-2018a-Python-3.6.4.eb'])

```