### PR TITLE
use non-interactive plotting backend by default for matplotlib 2.1.2

### DIFF
--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-foss-2018a-Python-2.7.14.eb
@@ -52,4 +52,8 @@ sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
+# use non-interactive plotting backend as default
+# see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
+modextravars = {'MPLBACKEND': 'Agg'}
+
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-foss-2018a-Python-3.6.4.eb
@@ -52,4 +52,8 @@ sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
+# use non-interactive plotting backend as default
+# see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
+modextravars = {'MPLBACKEND': 'Agg'}
+
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-intel-2018a-Python-2.7.14.eb
@@ -52,4 +52,8 @@ sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
+# use non-interactive plotting backend as default
+# see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
+modextravars = {'MPLBACKEND': 'Agg'}
+
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-intel-2018a-Python-3.6.4.eb
@@ -52,4 +52,8 @@ sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
+# use non-interactive plotting backend as default
+# see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
+modextravars = {'MPLBACKEND': 'Agg'}
+
 moduleclass = 'vis'


### PR DESCRIPTION
Without this, you run into this error (ever since including `Tkinter` as dependency to restore interactive plotting capabilities, cfr. #5658, #5689) when trying to make plots in an environment where X11 forwarding is not enabled.

```
>>> import numpy as np
>>> import matplotlib.pyplot as pl
>>> pl.plot(np.random.random(3), np.random.random(3))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/apps/gent/CO7/skylake-ib-PILOT/software/matplotlib/2.1.2-intel-2018a-Python-2.7.14/lib/python2.7/site-packages/matplotlib-2.1.2-py2.7-linux-x86_64.egg/matplotlib/pyplot.py", line 3250, in plot
    ax = gca()
  File "/apps/gent/CO7/skylake-ib-PILOT/software/matplotlib/2.1.2-intel-2018a-Python-2.7.14/lib/python2.7/site-packages/matplotlib-2.1.2-py2.7-linux-x86_64.egg/matplotlib/pyplot.py", line 962, in gca
    return gcf().gca(**kwargs)
  File "/apps/gent/CO7/skylake-ib-PILOT/software/matplotlib/2.1.2-intel-2018a-Python-2.7.14/lib/python2.7/site-packages/matplotlib-2.1.2-py2.7-linux-x86_64.egg/matplotlib/pyplot.py", line 592, in gcf
    return figure()
  File "/apps/gent/CO7/skylake-ib-PILOT/software/matplotlib/2.1.2-intel-2018a-Python-2.7.14/lib/python2.7/site-packages/matplotlib-2.1.2-py2.7-linux-x86_64.egg/matplotlib/pyplot.py", line 539, in figure
    **kwargs)
  File "/apps/gent/CO7/skylake-ib-PILOT/software/matplotlib/2.1.2-intel-2018a-Python-2.7.14/lib/python2.7/site-packages/matplotlib-2.1.2-py2.7-linux-x86_64.egg/matplotlib/backend_bases.py", line 171, in new_figure_manager
    return cls.new_figure_manager_given_figure(num, fig)
  File "/apps/gent/CO7/skylake-ib-PILOT/software/matplotlib/2.1.2-intel-2018a-Python-2.7.14/lib/python2.7/site-packages/matplotlib-2.1.2-py2.7-linux-x86_64.egg/matplotlib/backends/backend_tkagg.py", line 1049, in new_figure_manager_given_figure
    window = Tk.Tk(className="matplotlib")
  File "/apps/gent/CO7/skylake-ib-PILOT/software/Python/2.7.14-intel-2018a/lib/python2.7/lib-tk/Tkinter.py", line 1819, in __init__
    self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
_tkinter.TclError: couldn't connect to display "localhost:21.0"
```

I consider it more common to use`matplotlib` in a non-interactive environment, so the default should be to be able to create plots non-interactively imho...

@schiotz: thoughts?