### PR TITLE
{bio}[intel/2017a] AUGUSTUS: add make clean, add latest version

### DIFF
--- a/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.3-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.3-intel-2017a-Python-2.7.13.eb
@@ -1,7 +1,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'AUGUSTUS'
-version = '3.2.3'
+version = '3.3'
 versionsuffix = '-Python-2.7.13'
 
 homepage = 'http://bioinf.uni-greifswald.de/augustus/'
@@ -33,7 +33,7 @@ buildopts = 'COMPGENEPRED=true SQLITE=true ZIPINPUT=true CXX="$CXX" LINK.cc="$CX
 installopts = 'INSTALLDIR=%(installdir)s'
 
 sanity_check_paths = {
-    'files': ['bin/aln2wig', 'bin/augustus', 'bin/bam2hints', 'bin/bam2wig', 'bin/espoca', 'bin/etraining',
+    'files': ['bin/augustus', 'bin/bam2hints', 'bin/espoca', 'bin/etraining',
               'bin/fastBlockSearch', 'bin/filterBam', 'bin/getSeq', 'bin/homGeneMapping', 'bin/joingenes',
               'bin/load2sqlitedb', 'bin/prepareAlign'],
     'dirs': ['config', 'scripts'],

--- a/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.3_fix-hardcoding.patch
+++ b/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.3_fix-hardcoding.patch
@@ -1,0 +1,57 @@
+fix hardcoded compiler names in Makefile + don't try to link binaries in /usr/local/bin
+author: Kenneth Hoste (HPC-UGent)
+--- augustus-3.2.3/auxprogs/compileSpliceCands/Makefile.orig	2017-05-02 20:40:04.471986962 +0200
++++ augustus-3.2.3/auxprogs/compileSpliceCands/Makefile	2017-05-02 20:40:30.812468384 +0200
+@@ -1,8 +1,8 @@
+ compileSpliceCands : compileSpliceCands.o list.h list.o
+-	gcc $(LDFLAGS) -o compileSpliceCands compileSpliceCands.o list.o;
++	$(CC) $(LDFLAGS) -o compileSpliceCands compileSpliceCands.o list.o;
+ #	cp compileSpliceCands ../../bin
+ compileSpliceCands.o : compileSpliceCands.c 
+-	gcc -Wall -pedantic -ansi $(CPPFLAGS) -c compileSpliceCands.c 
++	$(CC) -Wall -pedantic -ansi $(CPPFLAGS) -c compileSpliceCands.c 
+ 
+ all : compileSpliceCands
+ 
+--- augustus-3.2.3/auxprogs/homGeneMapping/src/Makefile.orig	2017-05-04 10:12:47.633497259 +0200
++++ augustus-3.2.3/auxprogs/homGeneMapping/src/Makefile	2017-05-04 10:12:56.313614398 +0200
+@@ -7,7 +7,7 @@
+ # database access for retrieval of hints
+ # SQLITE = true
+ 
+-CC      = g++
++CC      = $(CXX)
+ 
+ # Notes: - "-Wno-sign-compare" eliminates a high number of warnings (see footnote below). Please adopt
+ #          a strict signed-only usage strategy to avoid mistakes since we are not warned about this.
+--- augustus-3.2.3/auxprogs/joingenes/Makefile.orig	2017-05-04 10:46:28.700811811 +0200
++++ augustus-3.2.3/auxprogs/joingenes/Makefile	2017-05-04 10:46:35.380911653 +0200
+@@ -1,4 +1,4 @@
+-CC=g++
++CC=$(CXX)
+ CFLAGS=-Wall -std=gnu++0x
+ 
+ all: joingenes
+--- augustus-3.2.3/Makefile.orig	2017-05-04 09:54:03.568352171 +0200
++++ augustus-3.2.3/Makefile	2017-05-04 09:54:11.968330382 +0200
+@@ -17,13 +17,13 @@
+ install:
+ 	install -d $(INSTALLDIR)
+ 	cp -a config bin scripts $(INSTALLDIR)
+-	ln -sf $(INSTALLDIR)/bin/augustus /usr/local/bin/augustus
+-	ln -sf $(INSTALLDIR)/bin/etraining /usr/local/bin/etraining
+-	ln -sf $(INSTALLDIR)/bin/prepareAlign /usr/local/bin/prepareAlign
+-	ln -sf $(INSTALLDIR)/bin/fastBlockSearch /usr/local/bin/fastBlockSearch
+-	ln -sf $(INSTALLDIR)/bin/load2db /usr/local/bin/load2db
+-	ln -sf $(INSTALLDIR)/bin/getSeq /usr/local/bin/getSeq
+-	ln -sf $(INSTALLDIR)/bin/espoca /usr/local/bin/espoca
++	#ln -sf $(INSTALLDIR)/bin/augustus /usr/local/bin/augustus
++	#ln -sf $(INSTALLDIR)/bin/etraining /usr/local/bin/etraining
++	#ln -sf $(INSTALLDIR)/bin/prepareAlign /usr/local/bin/prepareAlign
++	#ln -sf $(INSTALLDIR)/bin/fastBlockSearch /usr/local/bin/fastBlockSearch
++	#ln -sf $(INSTALLDIR)/bin/load2db /usr/local/bin/load2db
++	#ln -sf $(INSTALLDIR)/bin/getSeq /usr/local/bin/getSeq
++	#ln -sf $(INSTALLDIR)/bin/espoca /usr/local/bin/espoca
+ 
+ # for internal purposes:
+ release:


### PR DESCRIPTION
Add 'make clean' because the upstream tarball includes built binaries
and mere 'make' won't rebuild them (leaving them with possibly invalid
dynamic library dependencies).  This addresses
https://github.com/easybuilders/easybuild-easyconfigs/issues/6044

Also add version for latest release.