### PR TITLE
don't use bare Perl as dependency for 'git' with foss/2018a, use variant with extensions

### DIFF
--- a/easybuild/easyconfigs/g/git/git-2.16.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/g/git/git-2.16.1-foss-2018a.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('cURL', '7.58.0'),
     ('expat', '2.2.5'),
     ('gettext', '0.19.8.1', '-libxml2-2.9.7'),
-    ('Perl', '5.26.1', '-bare'),
+    ('Perl', '5.26.1'),
 ]
 
 preconfigopts = 'make configure && '


### PR DESCRIPTION
Using a bare Perl (i.e. without extensions) as dependency is problematic, since then this `git` module is incompatible with other modules that use a non-bare Perl as dependency.

Easiest solution is to just use the full Perl as dependency for `git`.