### PR TITLE
drop use of --disable-dlopen in (recent) OpenMPI easyconfigs due to negative performance impact

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.1-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.1-GCC-4.9.3-2.25.eb
@@ -16,7 +16,6 @@ dependencies = [('hwloc', '1.11.2')]
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-4.9.3-2.25.eb
@@ -16,7 +16,6 @@ dependencies = [('hwloc', '1.11.2')]
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-5.3.0-2.26.eb
@@ -16,7 +16,6 @@ dependencies = [('hwloc', '1.11.3')]
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-6.1.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-6.1.0-2.27.eb
@@ -17,7 +17,6 @@ dependencies = [('hwloc', '1.11.3')]
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.3-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.3-GCC-4.9.3-2.25.eb
@@ -14,7 +14,6 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/d
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--with-cxxrtlib="-lgcc_s -lstdc++"'  # for vt-mpi-unify
 
 dependencies = [('hwloc', '1.11.3')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.4-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.4-GCC-5.3.0-2.26.eb
@@ -14,7 +14,6 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/d
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--with-cxxrtlib="-lgcc_s -lstdc++"'  # for vt-mpi-unify
 
 dependencies = [('hwloc', '1.11.3')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-5.4.0-2.26.eb
@@ -17,7 +17,6 @@ dependencies = [('hwloc', '1.11.3')]
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-6.1.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-6.1.0-2.27.eb
@@ -17,7 +17,6 @@ dependencies = [('hwloc', '1.11.3')]
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -15,7 +15,6 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/d
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 dependencies = [('hwloc', '1.11.3')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-PGI-16.7-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-PGI-16.7-GCC-5.4.0-2.26.eb
@@ -16,7 +16,6 @@ checksums = ['fb2fdb6a5b65c80d7dfa4bc9a0caf665']
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--with-cxxrtlib="-lgcc_s -lstdc++"'  # for vt-mpi-unify
 
 dependencies = [('hwloc', '1.11.4')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -15,7 +15,6 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/d
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
 dependencies = [('hwloc', '1.11.3')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.0-GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.0-GCC-5.2.0.eb
@@ -17,7 +17,6 @@ dependencies = [('hwloc', '1.11.3')]
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
@@ -17,7 +17,6 @@ dependencies = [('hwloc', '1.11.4')]
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-iccifort-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-iccifort-2017.1.132-GCC-5.4.0-2.26.eb
@@ -17,7 +17,6 @@ dependencies = [('hwloc', '1.11.4')]
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27-opa.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27-opa.eb
@@ -19,7 +19,6 @@ dependencies = [('hwloc', '1.11.5')]
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-psm2 '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-psm2

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27.eb
@@ -18,7 +18,6 @@ dependencies = [('hwloc', '1.11.5')]
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-iccifort-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-iccifort-2017.1.132-GCC-6.3.0-2.27.eb
@@ -17,7 +17,6 @@ dependencies = [('hwloc', '1.11.5')]
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.0-GCC-6.3.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.0-GCC-6.3.0-2.28.eb
@@ -18,7 +18,6 @@ dependencies = [('hwloc', '1.11.6')]
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-GCC-6.4.0-2.28.eb
@@ -17,7 +17,6 @@ dependencies = [('hwloc', '1.11.7')]
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # to enable SLURM integration (site-specific)

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-iccifort-2017.4.196-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-iccifort-2017.4.196-GCC-6.4.0-2.28.eb
@@ -19,7 +19,6 @@ dependencies = [('hwloc', '1.11.7')]
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-GCC-6.4.0-2.28.eb
@@ -17,7 +17,6 @@ dependencies = [('hwloc', '1.11.8')]
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # to enable SLURM integration (site-specific)

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-iccifort-2018.1.163-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-iccifort-2018.1.163-GCC-6.4.0-2.28.eb
@@ -19,7 +19,6 @@ dependencies = [('hwloc', '1.11.8')]
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.0.0-GCC-7.2.0-2.29.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.0.0-GCC-7.2.0-2.29.eb
@@ -23,7 +23,6 @@ dependencies = [
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # to enable SLURM integration (site-specific)


### PR DESCRIPTION
cfr. #5716

The use of `--disable-dlopen` was originally introduced in #186 to fix a problem with `Rmpi` (see also https://www.mail-archive.com/devel@lists.open-mpi.org/msg10852.html).

I retested the installation of `Rmpi` on top of both `foss/2017b` and `foss/2016a` after rebuilding the `OpenMPI` component of those toolchains *without* `--disable-dlopen`, and I could not reproduce the `Rmpi` problem, so it seems like our original motivation for including `--disable-dlopen` is no longer valid anyway...

cc @m0zes, @chrissamuel, @akesandgren