### PR TITLE
add missing XZ dep in Python 3.6.4 easyconfigs built with */2018a toolchain

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.6.4-foss-2018a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.4-foss-2018a.eb
@@ -19,6 +19,7 @@ dependencies = [
     ('libreadline', '7.0'),
     ('ncurses', '6.0'),
     ('SQLite', '3.21.0'),
+    ('XZ', '5.2.3'),
     ('GMP', '6.1.2'),  # required for pycrypto
     ('libffi', '3.2.1'),  # required for cryptography
     # OS dependency should be preferred if the os version is more recent then this version,

--- a/easybuild/easyconfigs/p/Python/Python-3.6.4-intel-2018a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.4-intel-2018a.eb
@@ -19,6 +19,7 @@ dependencies = [
     ('libreadline', '7.0'),
     ('ncurses', '6.0'),
     ('SQLite', '3.21.0'),
+    ('XZ', '5.2.3'),
     ('GMP', '6.1.2'),  # required for pycrypto
     ('libffi', '3.2.1'),  # required for cryptography
     # OS dependency should be preferred if the os version is more recent then this version,


### PR DESCRIPTION
These easyconfigs were contributed in #5678 with the `XZ` dependency missing, probably because they were based on Python 2.7.14 easyconfigs (where `XZ` is not required).