### PR TITLE
Add golf-2018a toolchain + FFTW dep and Python-3.6.4 built with it.

### DIFF
--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.7-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.7-GCC-6.4.0-2.28.eb
@@ -1,0 +1,19 @@
+name = 'FFTW'
+version = '3.3.7'
+
+homepage = 'http://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+ in one or more dimensions, of arbitrary input size, and of both real and complex data."""
+
+toolchain = {'name': 'GCC', 'version': '6.4.0-2.28'}
+toolchainopts = {'pic': True}
+
+source_urls = [homepage]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['3b609b7feba5230e8f6dd8d245ddbefac324c5a6ae4186947670d9ac2cd25573']
+
+with_mpi = False
+
+runtest = 'check'
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/g/golf/golf-2018a.eb
+++ b/easybuild/easyconfigs/g/golf/golf-2018a.eb
@@ -1,0 +1,24 @@
+easyblock = 'Toolchain'
+
+name = 'golf'
+version = '2018a'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain, including
+ OpenBLAS (BLAS and LAPACK support) and FFTW."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+gccver = '6.4.0-2.28'
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.20'
+blas = '%s-%s' % (blaslib, blasver)
+
+dependencies = [
+    ('GCC', gccver),
+    (blaslib, blasver, '', ('GCC', gccver)),
+    ('FFTW', '3.3.7', '', ('GCC', gccver)),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/p/Python/Python-3.6.4-golf-2018a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.4-golf-2018a.eb
@@ -1,0 +1,208 @@
+name = 'Python'
+version = '3.6.4'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+ more effectively."""
+
+toolchain = {'name': 'golf', 'version': '2018a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+checksums = ['7dc453e1a93c083388eb1a23a256862407f8234a96dc4fae0fc7682020227486']
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+    ('libreadline', '7.0'),
+    ('ncurses', '6.0'),
+    ('SQLite', '3.21.0'),
+    ('XZ', '5.2.3'),
+    ('GMP', '6.1.2'),  # required for pycrypto
+    ('libffi', '3.2.1'),  # required for cryptography
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    # ('OpenSSL', '1.1.0g'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# workaround for "undefined symbol: __stack_chk_guard"
+# see also https://software.intel.com/en-us/forums/intel-c-compiler/topic/610514
+buildopts = 'LDFLAGS="$LDFLAGS -lssp"'
+
+# order is important!
+# package versions updated January 12th 2018
+exts_list = [
+    ('setuptools', '38.4.0', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+        'checksums': ['6501fc32f505ec5b3ed36ec65ba48f1b975f52cf2ea101c7b73a08583fd12f75'],
+    }),
+    ('pip', '9.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
+    }),
+    ('numpy', '1.14.0', {
+        'patches': ['numpy-1.12.0-mkl.patch'],
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/n/numpy/'],
+        'checksums': [
+            '3de643935b212307b420248018323a44ec51987a336d1d747c1322afc3c099fb',  # numpy-1.14.0.zip
+            'f212296ed289eb1b4e3f703997499dee8a2cdd0af78b55e017477487b6377ca4',  # numpy-1.12.0-mkl.patch
+        ],
+    }),
+    ('scipy', '1.0.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/scipy/'],
+        'checksums': ['87ea1f11a0e9ec08c264dc64551d501fa307289460705f6fccd84cbfc7926d10'],
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
+    }),
+    ('paycheck', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+        'checksums': ['6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34'],
+    }),
+    ('pbr', '3.1.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+        'checksums': ['05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1'],
+    }),
+    ('Cython', '0.27.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/C/Cython/'],
+        'checksums': ['6a00512de1f2e3ce66ba35c5420babaef1fe2d9c43a8faab4080b0dbcc26bc64'],
+    }),
+    ('six', '1.11.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+        'checksums': ['70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9'],
+    }),
+    ('python-dateutil', '2.6.1', {
+        'modulename': 'dateutil',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+        'checksums': ['891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca'],
+    }),
+    ('deap', '1.2.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+        'checksums': ['95c63e66d755ec206c80fdb2908851c0bef420ee8651ad7be4f0578e9e909bcf'],
+    }),
+    ('decorator', '4.1.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+        'checksums': ['7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5'],
+    }),
+    ('liac-arff', '2.1.1', {
+        'modulename': 'arff',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+        'checksums': ['b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817'],
+    }),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
+    }),
+    ('pycparser', '2.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        'checksums': ['99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226'],
+    }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
+    ('asn1crypto', '0.24.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
+        'checksums': ['9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49'],
+    }),
+    ('idna', '2.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
+        'checksums': ['2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f'],
+    }),
+    ('cryptography', '2.1.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
+        'checksums': ['e4d967371c5b6b2e67855066471d844c5d52d210c36c28d49a8507b96e2c5291'],
+    }),
+    ('pyasn1', '0.4.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
+        'checksums': ['d258b0a71994f7770599835249cece1caef3c70def868c4915e6e5ca49b67d15'],
+    }),
+    ('PyNaCl', '1.2.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
+        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
+    }),
+    ('bcrypt', '3.1.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/bcrypt/'],
+        'checksums': ['67ed1a374c9155ec0840214ce804616de49c3df9c5bc66740687c1c9b1cd9e8d'],
+    }),
+    ('paramiko', '2.4.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+        'checksums': ['486f637f0a33a4792e0e567be37426c287efaa8c4c4a45e3216f9ce7fd70b1fc'],
+    }),
+    ('pyparsing', '2.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
+    }),
+    ('netifaces', '0.10.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces/'],
+        'checksums': ['0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0'],
+    }),
+    ('netaddr', '0.7.19', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr/'],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
+    }),
+    ('mock', '2.0.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mock/'],
+        'checksums': ['b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba'],
+    }),
+    ('pytz', '2017.3', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytz/'],
+        'checksums': ['fae4cffc040921b8a2d60c6cf0b5d662c1190fe54d718271db4eb17d44a185b7'],
+    }),
+    ('pandas', '0.22.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
+        'checksums': ['44a94091dd71f05922eec661638ec1a35f26d573c119aa2fad964f10a2880e6c'],
+    }),
+    ('bitstring', '3.1.5', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/b/bitstring/'],
+        'checksums': ['c163a86fcef377c314690051885d86b47419e3e1770990c212e16723c1c08faa'],
+    }),
+    ('virtualenv', '15.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv/'],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
+    }),
+    ('docopt', '0.6.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/docopt/'],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
+    }),
+    ('joblib', '0.11', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/joblib/'],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
+    }),
+    ('chardet', '3.0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
+        'checksums': ['84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae'],
+    }),
+    ('certifi', '2018.1.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
+        'checksums': ['edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d'],
+    }),
+    ('urllib3', '1.22', {
+        'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
+        'checksums': ['cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f'],
+    }),
+    ('requests', '2.18.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
+        'checksums': ['9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e'],
+    }),
+]
+
+moduleclass = 'lang'


### PR DESCRIPTION
This Python is identical to Python-3.6.4-foss-2018a.eb except for
mpi4py, that is no MPI support. I did need to add some packages that
were downloaded previously though, that will be fixed in the foss
version too.

Depends on
https://github.com/easybuilders/easybuild-framework/pull/2458