### PR TITLE
iomkl-2018.02.eb and deps

### DIFF
--- a/easybuild/easyconfigs/i/imkl/imkl-2018.2.199-iompi-2018.02.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2018.2.199-iompi-2018.02.eb
@@ -1,0 +1,36 @@
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
+
+name = 'imkl'
+version = '2018.2.199'
+
+homepage = 'http://software.intel.com/en-us/intel-mkl/'
+description = """Intel Math Kernel Library is a library of highly optimized,
+ extensively threaded math routines for science, engineering, and financial
+ applications that require maximum performance. Core math functions include
+ BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
+
+toolchain = {'name': 'iompi', 'version': '2018.02'}
+
+sources = ['l_mkl_%(version)s.tgz']
+checksums = ['e28d12173bef9e615b0ded2f95f59a42b3e9ad0afa713a79f8801da2bfb31936']
+
+dontcreateinstalldir = 'True'
+
+license_file = HOME + '/licenses/intel/license.lic'
+
+interfaces = True
+
+postinstallcmds = [
+    # extract the examples
+    'tar xvzf %(installdir)s/mkl/examples/examples_cluster_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_cluster_f.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_f.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_f95.tgz -C %(installdir)s/mkl/examples/',
+]
+
+modextravars = {
+    'MKL_EXAMPLES': '%(installdir)s/mkl/examples/',
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/i/iomkl/iomkl-2018.02.eb
+++ b/easybuild/easyconfigs/i/iomkl/iomkl-2018.02.eb
@@ -1,0 +1,24 @@
+easyblock = "Toolchain"
+
+name = 'iomkl'
+version = '2018.02'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Intel Cluster Toolchain Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MKL &
+ OpenMPI."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+compver = '2018.2.199'
+gccver = '6.4.0'
+binutilsver = '2.28'
+gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+
+dependencies = [
+    ('icc', compver, gccsuff),
+    ('ifort', compver, gccsuff),
+    ('OpenMPI', '2.1.3', '', ('iccifort', '%s%s' % (compver, gccsuff))),
+    ('imkl', compver, '', ('iompi', version)),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iompi/iompi-2018.02.eb
+++ b/easybuild/easyconfigs/i/iompi/iompi-2018.02.eb
@@ -1,0 +1,21 @@
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
+easyblock = "Toolchain"
+
+name = 'iompi'
+version = '2018.02'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Intel C/C++ and Fortran compilers, alongside Open MPI."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+compver = '2018.2.199'
+compversuff = '-GCC-6.4.0-2.28'
+
+dependencies = [
+    ('icc', compver, compversuff),
+    ('ifort', compver, compversuff),
+    ('OpenMPI', '2.1.3', '', ('iccifort', '%s%s' % (compver, compversuff))),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.3-iccifort-2018.2.199-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.3-iccifort-2018.2.199-GCC-6.4.0-2.28.eb
@@ -1,0 +1,35 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = '2.1.3'
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-2 implementation."""
+
+toolchain = {'name': 'iccifort', 'version': '2018.2.199-GCC-6.4.0-2.28'}
+
+sources = [SOURCELOWER_TAR_GZ]
+
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['3e2f7b349b7d28a85c88d65f71327fcc2300a56c1fb6cd9ff0647d806523435e']
+
+dependencies = [('hwloc', '1.11.8')]
+
+configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
+configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
+
+# needed for --with-verbs
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
+
+libs = ["mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
+    'dirs': [],
+}
+
+moduleclass = 'mpi'


### PR DESCRIPTION
After asking my users they requested to include OpenMPI 2.1.3 with this toolchain because they haven't tried openmpi-3.0.0 yet and they don't have the time right now to test it

Feel free to keep this PR on hold or modify it to include a different OpenMPI version