### PR TITLE
{chem}[iomkl/2018a] PLUMED v 2.4.1

### DIFF
--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.4.0-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.4.0-intel-2017b.eb
@@ -18,6 +18,7 @@ toolchainopts = {'usempi': 'True'}
 
 source_urls = ['https://github.com/plumed/plumed2/releases/download/v%(version)s/']
 sources = [SOURCE_TGZ]
+checksums = ['bcd54a2e910fa474dff14c6419a420b96ac697aaebfcd8591ec23426f702e41c']
 
 dependencies = [
     ('zlib', '1.2.11'),

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.4.0-intel-2018a.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.4.0-intel-2018a.eb
@@ -18,6 +18,7 @@ toolchainopts = {'usempi': 'True'}
 
 source_urls = ['https://github.com/plumed/plumed2/releases/download/v%(version)s/']
 sources = [SOURCE_TGZ]
+checksums = ['bcd54a2e910fa474dff14c6419a420b96ac697aaebfcd8591ec23426f702e41c']
 
 dependencies = [
     ('zlib', '1.2.11'),

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.4.1-iomkl-2018a.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.4.1-iomkl-2018a.eb
@@ -1,9 +1,10 @@
 # by Ward Poelmans <wpoely86@gmail.com>
+# modified for iomkl by Joachim Hein <joachim.hein@lunarc.lu.se>
 
 easyblock = 'ConfigureMake'
 
 name = 'PLUMED'
-version = '2.4.0'
+version = '2.4.1'
 
 homepage = 'http://www.plumed-code.org'
 description = """PLUMED is an open source library for free energy calculations in molecular systems which
@@ -13,12 +14,12 @@ description = """PLUMED is an open source library for free energy calculations i
  The software, written in C++, can be easily interfaced with both fortran and C/C++ codes.
 """
 
-toolchain = {'name': 'foss', 'version': '2018a'}
+toolchain = {'name': 'iomkl', 'version': '2018a'}
 toolchainopts = {'usempi': 'True'}
 
 source_urls = ['https://github.com/plumed/plumed2/releases/download/v%(version)s/']
 sources = [SOURCE_TGZ]
-checksums = ['bcd54a2e910fa474dff14c6419a420b96ac697aaebfcd8591ec23426f702e41c']
+checksums = ['77ed5159c1d25eeb9d89c311c73111d6fc731415e0acd2f092434e345f701e38']
 
 dependencies = [
     ('zlib', '1.2.11'),


### PR DESCRIPTION
PLUMED 2.4.1 in iomkl toolchain and checksum included for PLUMED 2.4.0
easy-configs.  2.4.0 configs completely lacked the checksum tests.