### PR TITLE
add svd, Rssa, JBTools, RUnit, DistributionUtils and gapfill extensions for R 3.4.4

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
@@ -1800,6 +1800,24 @@ exts_list = [
     ('cghFLasso', '0.2-1', {
         'checksums': ['6e697959b35a3ceb2baa1542ef81f0335006a5a9c937f0173c6483979cb4302c'],
     }),
+    ('svd', '0.4.1', {
+        'checksums': ['6f585cb622cc52e2b7f3efddb7a363e91771bff80b8facb554755c2b33b7f402'],
+    }),
+    ('Rssa', '1.0', {
+        'checksums': ['9cc20a7101d8dff4c6cfb789f9bdc14e2b3bb128d7613a67b0f9633cf006902a'],
+    }),
+    ('JBTools', '0.7.2.9', {
+        'checksums': ['b33cfa17339df7113176ad1832cbb0533acf5d25c36b95e888f561d586c5d62f'],
+    }),
+    ('RUnit', '0.4.31', {
+        'checksums': ['9d764092216391c9d7e13bbe1585f5d00c357ed8b04c7e66ed82d229c34119cb'],
+    }),
+    ('DistributionUtils', '0.5-1', {
+        'checksums': ['e92a29003d5e5974f53e40bdb8417e2bdabe784304e21360d7a1cbec7818853f'],
+    }),
+    ('gapfill', '0.9.6', {
+        'checksums': ['850d0be9d05e3f3620f0f5143496321f1004ed966299bffd6a67a9abd8d9040d'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
@@ -1800,6 +1800,24 @@ exts_list = [
     ('cghFLasso', '0.2-1', {
         'checksums': ['6e697959b35a3ceb2baa1542ef81f0335006a5a9c937f0173c6483979cb4302c'],
     }),
+    ('svd', '0.4.1', {
+        'checksums': ['6f585cb622cc52e2b7f3efddb7a363e91771bff80b8facb554755c2b33b7f402'],
+    }),
+    ('Rssa', '1.0', {
+        'checksums': ['9cc20a7101d8dff4c6cfb789f9bdc14e2b3bb128d7613a67b0f9633cf006902a'],
+    }),
+    ('JBTools', '0.7.2.9', {
+        'checksums': ['b33cfa17339df7113176ad1832cbb0533acf5d25c36b95e888f561d586c5d62f'],
+    }),
+    ('RUnit', '0.4.31', {
+        'checksums': ['9d764092216391c9d7e13bbe1585f5d00c357ed8b04c7e66ed82d229c34119cb'],
+    }),
+    ('DistributionUtils', '0.5-1', {
+        'checksums': ['e92a29003d5e5974f53e40bdb8417e2bdabe784304e21360d7a1cbec7818853f'],
+    }),
+    ('gapfill', '0.9.6', {
+        'checksums': ['137286aff194b33b1bcd21fdcb5908308a23628e66b62ce5fbe1a70ff5668cc3'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
@@ -1816,7 +1816,7 @@ exts_list = [
         'checksums': ['e92a29003d5e5974f53e40bdb8417e2bdabe784304e21360d7a1cbec7818853f'],
     }),
     ('gapfill', '0.9.6', {
-        'checksums': ['137286aff194b33b1bcd21fdcb5908308a23628e66b62ce5fbe1a70ff5668cc3'],
+        'checksums': ['850d0be9d05e3f3620f0f5143496321f1004ed966299bffd6a67a9abd8d9040d'],
     }),
 ]
 


### PR DESCRIPTION
to sync up with recent changes in R 3.4.3 easyconfigs, cfr. #6099