### PR TITLE
don't include (ancient version of) Time::HiRes as Perl extension, since it's a core Perl module

### DIFF
--- a/easybuild/easyconfigs/p/Perl/Perl-5.22.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.22.1-foss-2016a.eb
@@ -888,10 +888,6 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.22.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.22.1-foss-2016b.eb
@@ -888,10 +888,6 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.22.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.22.1-intel-2016a.eb
@@ -889,10 +889,6 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.22.2-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.22.2-goolf-1.7.20.eb
@@ -887,10 +887,6 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.22.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.22.2-intel-2016a.eb
@@ -888,10 +888,6 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.0-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.0-GCC-5.4.0-2.26.eb
@@ -895,10 +895,6 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.0-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.0-GCCcore-4.9.3.eb
@@ -897,10 +897,6 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.0-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.0-GCCcore-5.4.0.eb
@@ -898,10 +898,6 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.0-foss-2016b.eb
@@ -895,10 +895,6 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.0-intel-2016b.eb
@@ -896,10 +896,6 @@ exts_list = [
         'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-01.02.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.1-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.1-GCCcore-6.3.0.eb
@@ -1126,11 +1126,6 @@ exts_list = [
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
         'checksums': ['6855ce5615fd3e1af4cfc451a9bf44ff29a3140b4e7130034f1f0af2511a94fb'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.1-foss-2017a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.1-foss-2017a.eb
@@ -1124,11 +1124,6 @@ exts_list = [
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
         'checksums': ['6855ce5615fd3e1af4cfc451a9bf44ff29a3140b4e7130034f1f0af2511a94fb'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.1-intel-2017a.eb
@@ -1125,11 +1125,6 @@ exts_list = [
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
         'checksums': ['6855ce5615fd3e1af4cfc451a9bf44ff29a3140b4e7130034f1f0af2511a94fb'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-GCCcore-6.4.0.eb
@@ -1146,11 +1146,6 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI'],
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
-    }),
     ('Math::CDF', '0.1', {
         'source_tmpl': 'Math-CDF-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/C/CA/CALLAHAN/'],

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-foss-2017b.eb
@@ -1144,11 +1144,6 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI'],
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
-    }),
     ('Math::CDF', '0.1', {
         'source_tmpl': 'Math-CDF-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/C/CA/CALLAHAN/'],

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2017b.eb
@@ -1148,11 +1148,6 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI'],
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
-    }),
     ('Math::CDF', '0.1', {
         'source_tmpl': 'Math-CDF-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/C/CA/CALLAHAN/'],

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2018.00.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2018.00.eb
@@ -1148,11 +1148,6 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI'],
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
-    }),
     ('Math::CDF', '0.1', {
         'source_tmpl': 'Math-CDF-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/C/CA/CALLAHAN/'],

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2018.01.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.0-intel-2018.01.eb
@@ -1148,11 +1148,6 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI'],
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
-    ('Time::HiRes', '01.02', {
-        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DE/DEWEG/'],
-        'checksums': ['c3d28ad479b14b803bea3ccb8e90cb4c6a2565ee70866a0e9cfe4d76d4d45352'],
-    }),
     ('Math::CDF', '0.1', {
         'source_tmpl': 'Math-CDF-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/C/CA/CALLAHAN/'],

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.1-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.1-GCCcore-6.4.0.eb
@@ -1146,11 +1146,6 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI'],
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
-    ('Time::HiRes', '1.9753', {
-        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
-        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JH/JHI'],
-        'checksums': ['0fbfd5f99cdd26011d5c0bc3a8e369dacc4a9e1d1658f4663ac6018f2cec4915'],
-    }),
     ('Math::CDF', '0.1', {
         'source_tmpl': 'Math-CDF-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/C/CA/CALLAHAN/'],

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.1-foss-2018a.eb
@@ -1144,11 +1144,6 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI'],
         'checksums': ['b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16'],
     }),
-    ('Time::HiRes', '1.9753', {
-        'source_tmpl': 'Time-HiRes-%(version)s.tar.gz',
-        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JH/JHI'],
-        'checksums': ['0fbfd5f99cdd26011d5c0bc3a8e369dacc4a9e1d1658f4663ac6018f2cec4915'],
-    }),
     ('Math::CDF', '0.1', {
         'source_tmpl': 'Math-CDF-%(version)s.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/C/CA/CALLAHAN/'],


### PR DESCRIPTION
This reverts #5616 .

Including `Time::HiRes` as extension doesn't make sense, since it's a core Perl module (that is, it's always available).

Moreover, the `Time::HiRes` version that was included in #5616 is an ancient version, or some kind of customised fork of the official `Time::HiRes`.

Some installations are currently failing because of this:

* `BioPerl`: `"tv_interval" is not exported by the Time::HiRes module`
* `proovread`: `"usleep" is not exported by the Time::HiRes module`

This change was done for `QUAST` (cfr. #5610), but `QUAST-4.6.0-foss-2016b-Python-3.5.2.eb` builds just fine on top of `Perl/5.24.0-foss-2016b` that doesn't include `Time::HiRes` as an extension...