### PR TITLE
consistently specify 'intel-mkl' component in recent Intel MKL easyconfigs

### DIFF
--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-4.9.3-2.25.eb
@@ -16,6 +16,8 @@ checksums = ['f72546df27f5ebb0941b5d21fd804e34']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-5.3.0-2.26.eb
@@ -16,6 +16,8 @@ checksums = ['f72546df27f5ebb0941b5d21fd804e34']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iimpi-2016.03-GCC-5.4.0-2.26.eb
@@ -16,6 +16,8 @@ checksums = ['f72546df27f5ebb0941b5d21fd804e34']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-pompi-2016.04.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-pompi-2016.04.eb
@@ -16,6 +16,8 @@ checksums = ['f72546df27f5ebb0941b5d21fd804e34']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.0.098-iimpi-2017.00-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.0.098-iimpi-2017.00-GCC-5.4.0-2.26.eb
@@ -16,6 +16,8 @@ checksums = ['3cdcb739ab5ab1e047eb130b9ffdd8d0']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-gimpi-2017a.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-gimpi-2017a.eb
@@ -14,6 +14,8 @@ checksums = ['7911c0f777c4cb04225bf4518088939e']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iimpi-2017.01-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iimpi-2017.01-GCC-5.4.0-2.26.eb
@@ -16,6 +16,8 @@ checksums = ['7911c0f777c4cb04225bf4518088939e']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iimpi-2017a.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iimpi-2017a.eb
@@ -16,6 +16,8 @@ checksums = ['7911c0f777c4cb04225bf4518088939e']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iompi-2017.01.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iompi-2017.01.eb
@@ -16,6 +16,8 @@ checksums = ['7911c0f777c4cb04225bf4518088939e']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iompi-2017a.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.1.132-iompi-2017a.eb
@@ -16,6 +16,8 @@ checksums = ['7911c0f777c4cb04225bf4518088939e']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.2.174-iimpi-2017.02-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.2.174-iimpi-2017.02-GCC-6.3.0-2.27.eb
@@ -16,6 +16,8 @@ checksums = ['ef39a12dcbffe5f4a0ef141b8759208c']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 interfaces = True
 
 postinstallcmds = [

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.3.196-gompi-2017b.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.3.196-gompi-2017b.eb
@@ -16,6 +16,8 @@ checksums = ['fd7295870fa164d6138c9818304f25f2bb263c814a6c6539c9fe4e104055f1ca']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.3.196-iimpi-2017b.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.3.196-iimpi-2017b.eb
@@ -14,6 +14,8 @@ checksums = ['fd7295870fa164d6138c9818304f25f2bb263c814a6c6539c9fe4e104055f1ca']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 interfaces = True
 
 postinstallcmds = [

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.3.196-iompi-2017b.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.3.196-iompi-2017b.eb
@@ -16,6 +16,8 @@ checksums = ['fd7295870fa164d6138c9818304f25f2bb263c814a6c6539c9fe4e104055f1ca']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.4.239-iimpi-2017.09.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.4.239-iimpi-2017.09.eb
@@ -14,6 +14,8 @@ checksums = ['dcac591ed1e95bd72357fd778edba215a7eab9c6993236373231cc16c200c92a']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 interfaces = True
 
 postinstallcmds = [

--- a/easybuild/easyconfigs/i/imkl/imkl-2018.0.128-iimpi-2018.00.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2018.0.128-iimpi-2018.00.eb
@@ -16,6 +16,8 @@ checksums = ['c368baa40ca88057292512534d7fad59fa24aef06da038ea0248e7cd1e280cec']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-2018.1.163-iimpi-2018.01.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2018.1.163-iimpi-2018.01.eb
@@ -16,6 +16,8 @@ checksums = ['f6dc263fc6f3c350979740a13de1b1e8745d9ba0d0f067ece503483b9189c2ca']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-2018.1.163-iimpi-2018a.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2018.1.163-iimpi-2018a.eb
@@ -16,6 +16,8 @@ checksums = ['f6dc263fc6f3c350979740a13de1b1e8745d9ba0d0f067ece503483b9189c2ca']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-2018.1.163-iompi-2018a.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2018.1.163-iompi-2018a.eb
@@ -16,6 +16,8 @@ checksums = ['f6dc263fc6f3c350979740a13de1b1e8745d9ba0d0f067ece503483b9189c2ca']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-2018.2.199-iimpi-2018.02.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2018.2.199-iimpi-2018.02.eb
@@ -16,6 +16,8 @@ checksums = ['e28d12173bef9e615b0ded2f95f59a42b3e9ad0afa713a79f8801da2bfb31936']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True

--- a/easybuild/easyconfigs/i/imkl/imkl-2018.2.199-iompi-2018.02.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2018.2.199-iompi-2018.02.eb
@@ -16,6 +16,8 @@ checksums = ['e28d12173bef9e615b0ded2f95f59a42b3e9ad0afa713a79f8801da2bfb31936']
 
 dontcreateinstalldir = 'True'
 
+components = ['intel-mkl']
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 interfaces = True


### PR DESCRIPTION
`components = ['intel-mkl']` is already included in some (older) `imkl` easyconfigs, but not consistently

Having this there helps with avoiding problems when people use an alternate installation tarball, cfr. https://github.com/easybuilders/easybuild-framework/issues/2469