### PR TITLE
libdrm: add `pkg-config` as build dependency

### DIFF
--- a/easybuild/easyconfigs/l/libdrm/libdrm-2.4.88-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libdrm/libdrm-2.4.88-GCCcore-6.4.0.eb
@@ -12,7 +12,10 @@ source_urls = ['http://dri.freedesktop.org/libdrm/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['a8b458db6a73c717baee2e249d39511fb6f5c0f5f24dee2770935eddeda1a017']
 
-builddependencies = [('binutils', '2.28')]
+builddependencies = [
+    ('binutils', '2.28'),
+    ('pkg-config', '0.29.2'),
+]
 dependencies = [('X11', '20171023')]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libdrm/libdrm-2.4.91-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libdrm/libdrm-2.4.91-GCCcore-6.4.0.eb
@@ -12,7 +12,10 @@ source_urls = ['http://dri.freedesktop.org/libdrm/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['c8ea3343d5bfc356550f0b5632403359d050fa09cf05d61e96e73adba0c407a9']
 
-builddependencies = [('binutils', '2.28')]
+builddependencies = [
+    ('binutils', '2.28'),
+    ('pkg-config', '0.29.2'),
+]
 dependencies = [('X11', '20180131')]
 
 sanity_check_paths = {


### PR DESCRIPTION
As discussed during yesterday's conf call, `libdrm` fails to build on systems where `pkg-config` isn't available through the OS.  Thus, adding it as a build dependency.

I've only touched `libdrm-2.4.88-GCCcore-6.4.0.eb` and `libdrm-2.4.91-GCCcore-6.4.0.eb` as I don't have all the other toolchains available.  However, older versions are likely to also be affected.