### PR TITLE
fix checksum for foreign extension in R 3.4.3 and R 3.4.4 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.4.3-foss-2017b-X11-20171023.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.3-foss-2017b-X11-20171023.eb
@@ -488,7 +488,7 @@ exts_list = [
         'checksums': ['2557d5d59a45620ec9de340c2c25eec4cc478d3fc3f8b87979cf337c5bcfde11'],
     }),
     ('foreign', '0.8-69', {
-        'checksums': ['820e1409162fbd6418b80a0f5a4b50d649ee74f06d195a5210745619b16e1592'],
+        'checksums': ['13689f5ec1ab09e8973be81c7f1799b7de4313176072887a9fa0b5825aed3468'],
     }),
     ('gam', '1.14-4', {
         'checksums': ['6a65d7f707c4833bf2f0b51f959e1bf05d83a75848884b65f6b40787e737aa8e'],

--- a/easybuild/easyconfigs/r/R/R-3.4.3-intel-2017b-X11-20171023.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.3-intel-2017b-X11-20171023.eb
@@ -496,7 +496,7 @@ exts_list = [
         'checksums': ['2557d5d59a45620ec9de340c2c25eec4cc478d3fc3f8b87979cf337c5bcfde11'],
     }),
     ('foreign', '0.8-69', {
-        'checksums': ['820e1409162fbd6418b80a0f5a4b50d649ee74f06d195a5210745619b16e1592'],
+        'checksums': ['13689f5ec1ab09e8973be81c7f1799b7de4313176072887a9fa0b5825aed3468'],
     }),
     ('gam', '1.14-4', {
         'checksums': ['6a65d7f707c4833bf2f0b51f959e1bf05d83a75848884b65f6b40787e737aa8e'],

--- a/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
@@ -514,7 +514,7 @@ exts_list = [
         'checksums': ['d52b9e04b3291f9bda8a88c174678f520ddffc5f2edf9b3dfa6d97dca943ce9a'],
     }),
     ('foreign', '0.8-69', {
-        'checksums': ['820e1409162fbd6418b80a0f5a4b50d649ee74f06d195a5210745619b16e1592'],
+        'checksums': ['13689f5ec1ab09e8973be81c7f1799b7de4313176072887a9fa0b5825aed3468'],
     }),
     ('gam', '1.15', {
         'checksums': ['1e365f9f328e018955140b4d842a30a499f4877291cb88cb9f147be79b62d1f0'],

--- a/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
@@ -514,7 +514,7 @@ exts_list = [
         'checksums': ['d52b9e04b3291f9bda8a88c174678f520ddffc5f2edf9b3dfa6d97dca943ce9a'],
     }),
     ('foreign', '0.8-69', {
-        'checksums': ['820e1409162fbd6418b80a0f5a4b50d649ee74f06d195a5210745619b16e1592'],
+        'checksums': ['13689f5ec1ab09e8973be81c7f1799b7de4313176072887a9fa0b5825aed3468'],
     }),
     ('gam', '1.15', {
         'checksums': ['1e365f9f328e018955140b4d842a30a499f4877291cb88cb9f147be79b62d1f0'],


### PR DESCRIPTION
reported by @shahzebsiddiqui 

This is the 2nd occurrence of changed checksums for R packages in a short amount of time (cfr. #6118), maybe it's time we raise this with CRAN somehow?