### PR TITLE
fix installation of Libint 2.4.2 by building with -std=c++11

### DIFF
--- a/easybuild/easyconfigs/l/Libint/Libint-2.4.2-intel-2018a.eb
+++ b/easybuild/easyconfigs/l/Libint/Libint-2.4.2-intel-2018a.eb
@@ -6,7 +6,7 @@ description = """Libint library is used to evaluate the traditional (electron re
  matrix elements (integrals) over Cartesian Gaussian functions used in modern atomic and molecular theory."""
 
 toolchain = {'name': 'intel', 'version': '2018a'}
-toolchainopts = {'pic': True}
+toolchainopts = {'pic': True, 'cstd': 'c++11'}
 
 source_urls = ['https://github.com/evaleev/libint/archive']
 sources = ['v%(version)s.tar.gz']


### PR DESCRIPTION
Libint provides an optional C++11 interface which requires the use of `-std=c++11`, cfr. https://github.com/evaleev/libint/wiki/using-modern-CPlusPlus--interface-v22-or-later