### PR TITLE
fix source spec for networkx 2.1 extension in scikit-image easyconfig

### DIFF
--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.1-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.1-foss-2018a-Python-3.6.4.eb
@@ -24,8 +24,9 @@ dependencies = [
 
 exts_list = [
     ('networkx', '2.1', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/n/networkx'],
-        'checksums': ['46aab610cdf15e680d944cafbf926a1d638f0cd2f1336b0f978b768a37d037f4'],
+        'checksums': ['64272ca418972b70a196cb15d9c85a5a6041f09a2f32e0d30c0255f25d458bb1'],
     }),
     (name, version, {
         'modulename': 'skimage',


### PR DESCRIPTION
fix for #6246 reported by @hajgato

It seems like the `network-2.1.tar.gz` source tarball is no longer available on PyPI.
Cfr. https://pypi.org/project/networkx/#files

This may be related to the recent switch to new PyPI, but maybe the `.tar.gz` never was available...

cc @RvDijk (since this relates to an easyconfig he added in #5925)