### PR TITLE
fix typo in Nipype & NiBabel causing failure in test suite due to triggering typo detection

### DIFF
--- a/easybuild/easyconfigs/n/NiBabel/NiBabel-2.2.1-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/n/NiBabel/NiBabel-2.2.1-intel-2018a-Python-3.6.4.eb
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 # raise an error when auto-downloading of dependency packages is detected
-download_dep_fail = True
+exts_download_dep_fail = True
 
 exts_defaultclass = 'PythonPackage'
 exts_list = [

--- a/easybuild/easyconfigs/n/Nipype/Nipype-1.0.2-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/n/Nipype/Nipype-1.0.2-intel-2018a-Python-3.6.4.eb
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 # raise an error when auto-downloading of dependency packages is detected
-download_dep_fail = True
+exts_download_dep_fail = True
 
 exts_defaultclass = 'PythonPackage'
 exts_list = [


### PR DESCRIPTION
This started occurring after https://github.com/easybuilders/easybuild-framework/pull/2493 was merged:

```
ERROR: Test for parsing of easyconfig NiBabel-2.2.1-intel-2018a-Python-3.6.4.eb
----------------------------------------------------------------------
Traceback (most recent call last):
  File "<string>", line 1, in innertest
  File "/home/travis/build/easybuilders/easybuild-easyconfigs/test/easyconfigs/easyconfigs.py", line 297, in template_easyconfig_test
    ecs = process_easyconfig(spec)
  File "/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/easybuild_framework-3.6.1.dev0-py2.6.egg/easybuild/framework/easyconfig/easyconfig.py", line 1263, in process_easyconfig
    raise EasyBuildError("Failed to process easyconfig %s: %s", spec, err.msg)
EasyBuildError: 'Failed to process easyconfig /home/travis/build/easybuilders/easybuild-easyconfigs/easybuild/easyconfigs/n/NiBabel/NiBabel-2.2.1-intel-2018a-Python-3.6.4.eb: You may have some typos in your easyconfig file: download_dep_fail -> exts_download_dep_fail'

======================================================================
ERROR: Test for parsing of easyconfig Nipype-1.0.2-intel-2018a-Python-3.6.4.eb
----------------------------------------------------------------------
Traceback (most recent call last):
  File "<string>", line 1, in innertest
  File "/home/travis/build/easybuilders/easybuild-easyconfigs/test/easyconfigs/easyconfigs.py", line 297, in template_easyconfig_test
    ecs = process_easyconfig(spec)
  File "/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/easybuild_framework-3.6.1.dev0-py2.6.egg/easybuild/framework/easyconfig/easyconfig.py", line 1263, in process_easyconfig
    raise EasyBuildError("Failed to process easyconfig %s: %s", spec, err.msg)
EasyBuildError: 'Failed to process easyconfig /home/travis/build/easybuilders/easybuild-easyconfigs/easybuild/easyconfigs/n/Nipype/Nipype-1.0.2-intel-2018a-Python-3.6.4.eb: You may have some typos in your easyconfig file: download_dep_fail -> exts_download_dep_fail'

----------------------------------------------------------------------
Ran 8867 tests in 265.390s

FAILED (errors=2)
ERROR: Not all tests were successful.
```

The errors produced are genuine: `download_dep_fail` is not a known easyconfig parameter in general (it will be a known custom one for the `PythonPackage` easyblock when https://github.com/easybuilders/easybuild-easyblocks/pull/1377 gets merged), while `exts_download_dep_fail` is.