### PR TITLE
{lang}[foss/2018a] R 3.4.4

### DIFF
--- a/easybuild/easyconfigs/g/GDAL/GDAL-2.2.3-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-2.2.3-foss-2018a-Python-3.6.4.eb
@@ -32,12 +32,14 @@ dependencies = [
     ('cURL', '7.58.0'),
     ('PCRE', '8.41'),
     ('PROJ', '5.0.0'),
+    ('libgeotiff', '1.4.2'),
 ]
 
 configopts = '--with-expat=$EBROOTEXPAT --with-libz=$EBROOTLIBZ --with-hdf5=$EBROOTHDF5 --with-netcdf=$EBROOTNETCDF'
 configopts += ' --with-xml2=$EBROOTLIBXML2 --with-geos=$EBROOTGEOS/bin/geos-config --with-jpeg=$EBROOTLIBJPEGMINTURBO'
 configopts += ' --with-png=$EBROOTLIBPNG --with-sqlite3=$EBROOTSQLITE --with-jasper=$EBROOTJASPER'
 configopts += ' --with-libtiff=$EBROOTLIBTIFF --with-pcre=$EBROOTPCRE --with-python=$EBROOTPYTHON/bin/python'
+configopts += ' --with-libgeotiff=$EBROOTLIBGEOTIFF'
 
 modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
 

--- a/easybuild/easyconfigs/l/libgeotiff/libgeotiff-1.4.2-foss-2018a.eb
+++ b/easybuild/easyconfigs/l/libgeotiff/libgeotiff-1.4.2-foss-2018a.eb
@@ -9,7 +9,7 @@ description = "Library for reading and writing coordinate system information fro
 toolchain = {'name': 'foss', 'version': '2018a'}
 
 source_urls = [
-    'http://download.osgeo.org/geotiff/libgeotiff/'
+    'http://download.osgeo.org/geotiff/libgeotiff/',
     'ftp://ftp.remotesensing.org/pub/libgeotiff/',
 ]
 
@@ -27,8 +27,8 @@ configopts = ' --with-libtiff=$EBROOTLIBTIFF --with-proj=$EBROOTPROJ --with-zlib
 configopts += ' --with-jpeg=$EBROOTLIBJPEGMINTURBO'
 
 sanity_check_paths = {
-    'files': ['bin/listgeo'],
-    'dirs': [],
+    'files': ['bin/listgeo', 'lib/libgeotiff.a', 'lib/libgeotiff.%s' % SHLIB_EXT],
+    'dirs': ['include', 'share'],
 }
 
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libgeotiff/libgeotiff-1.4.2-foss-2018a.eb
+++ b/easybuild/easyconfigs/l/libgeotiff/libgeotiff-1.4.2-foss-2018a.eb
@@ -1,0 +1,33 @@
+easyblock = 'ConfigureMake'
+
+name = 'libgeotiff'
+version = '1.4.2'
+
+homepage = 'https://directory.fsf.org/wiki/Libgeotiff'
+description = "Library for reading and writing coordinate system information from/to GeoTIFF files"
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+
+source_urls = [
+    'http://download.osgeo.org/geotiff/libgeotiff/'
+    'ftp://ftp.remotesensing.org/pub/libgeotiff/',
+]
+
+sources = ['%(name)s-%(version)s.tar.gz']
+checksums = ['ad87048adb91167b07f34974a8e53e4ec356494c29f1748de95252e8f81a5e6e']
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('LibTIFF', '4.0.9'),
+    ('PROJ', '5.0.0'),
+    ('libjpeg-turbo', '1.5.3'),
+]
+
+configopts = ' --with-libtiff=$EBROOTLIBTIFF --with-proj=$EBROOTPROJ --with-zlib=$EBROOTZLIB --with-jpeg=$EBROOTLIBJPEGMINTURBO'
+
+sanity_check_paths = {
+    'files': ['bin/listgeo'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libgeotiff/libgeotiff-1.4.2-foss-2018a.eb
+++ b/easybuild/easyconfigs/l/libgeotiff/libgeotiff-1.4.2-foss-2018a.eb
@@ -23,7 +23,8 @@ dependencies = [
     ('libjpeg-turbo', '1.5.3'),
 ]
 
-configopts = ' --with-libtiff=$EBROOTLIBTIFF --with-proj=$EBROOTPROJ --with-zlib=$EBROOTZLIB --with-jpeg=$EBROOTLIBJPEGMINTURBO'
+configopts = ' --with-libtiff=$EBROOTLIBTIFF --with-proj=$EBROOTPROJ --with-zlib=$EBROOTZLIB'
+configopts += ' --with-jpeg=$EBROOTLIBJPEGMINTURBO'
 
 sanity_check_paths = {
     'files': ['bin/listgeo'],

--- a/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
@@ -514,7 +514,7 @@ exts_list = [
         'checksums': ['d52b9e04b3291f9bda8a88c174678f520ddffc5f2edf9b3dfa6d97dca943ce9a'],
     }),
     ('foreign', '0.8-69', {
-        'checksums': ['820e1409162fbd6418b80a0f5a4b50d649ee74f06d195a5210745619b16e1592'],
+        'checksums': ['13689f5ec1ab09e8973be81c7f1799b7de4313176072887a9fa0b5825aed3468'],
     }),
     ('gam', '1.15', {
         'checksums': ['1e365f9f328e018955140b4d842a30a499f4877291cb88cb9f147be79b62d1f0'],

--- a/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
@@ -1,0 +1,1811 @@
+name = 'R'
+version = '3.4.4'
+x11ver = '20180131'
+versionsuffix = '-X11-%s' % x11ver
+
+homepage = 'http://www.r-project.org/'
+description = """R is a free software environment for statistical computing and graphics."""
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['https://cloud.r-project.org/src/base/R-%(version_major)s']
+checksums = ['b3e97d2fab7256d1c655c4075934725ba1cd7cb9237240a11bb22ccdad960337']
+
+builddependencies = [
+    ('pkg-config', '0.29.2'),
+]
+dependencies = [
+    ('X11', x11ver),
+    ('Mesa', '17.3.6'),
+    ('libGLU', '9.0.0'),
+    ('cairo', '1.14.12'),
+    ('libreadline', '7.0'),
+    ('ncurses', '6.0'),
+    ('bzip2', '1.0.6'),
+    ('XZ', '5.2.3'),
+    ('zlib', '1.2.11'),
+    ('SQLite', '3.21.0'),
+    ('PCRE', '8.41'),
+    ('libpng', '1.6.34'),  # for plotting in R
+    ('libjpeg-turbo', '1.5.3'),  # for plottting in R
+    ('LibTIFF', '4.0.9'),
+    ('Java', '1.8.0_162', '', True),  # Java bindings are built if Java is found, might as well provide it
+    ('Tcl', '8.6.8'),  # for tcltk
+    ('Tk', '8.6.8'),  # for tcltk
+    ('cURL', '7.58.0'),  # for RCurl
+    ('libxml2', '2.9.7'),  # for XML
+    ('GDAL', '2.2.3', '-Python-3.6.4'),  # for rgdal
+    ('PROJ', '5.0.0'),  # for rgdal
+    ('GMP', '6.1.2'),  # for igraph
+    ('NLopt', '2.4.2'),  # for nloptr
+    ('FFTW', '3.3.7'),  # for fftw
+    ('libsndfile', '1.0.28'),  # for seewave
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    # ('OpenSSL', '1.0.2h'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
+
+exts_default_options = {
+    'source_urls': [
+        'http://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'http://cran.r-project.org/src/contrib/',  # current version of packages
+        'http://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+
+# !! order of packages is important !!
+# packages updated on Mar 15 2018
+exts_list = [
+    'base',
+    'datasets',
+    'graphics',
+    'grDevices',
+    'grid',
+    'methods',
+    'splines',
+    'stats',
+    'stats4',
+    'tools',
+    'utils',
+    ('Rmpi', '0.6-6', {
+        'patches': ['Rmpi-0.6-5_impi5.patch'],
+        'checksums': [
+            'd8fc09ad38264697caa86079885a7a1098921a3116d5a77a62022b9508f8a63a',  # Rmpi_0.6-6.tar.gz
+            'f753f0b6434295be70fe29d36edb2047c091e465b7ff0cab56b93d55883c8dd3',  # Rmpi-0.6-5_impi5.patch
+        ],
+    }),
+    ('abind', '1.4-5', {
+        'checksums': ['3a3ace5afbcb86e56889efcebf3bf5c3bb042a282ba7cc4412d450bb246a3f2c'],
+    }),
+    ('magic', '1.5-8', {
+        'checksums': ['7f8bc26e05003168e9d2dadf64eb9a34b51bc41beba482208874803dee7d6c20'],
+    }),
+    ('geometry', '0.3-6', {
+        'patches': ['geometry-0.3-4-icc.patch'],
+        'checksums': [
+            '2be231ac99171367635cd957f27da77705329df97520ab86f655839c41dc0968',  # geometry_0.3-6.tar.gz
+            'df0ea118e597f31561093e01d50698dac3345d40d082eee05360bb4f94378377',  # geometry-0.3-4-icc.patch
+        ],
+    }),
+    ('bit', '1.1-12', {
+        'checksums': ['ce281c87fb7602bf1a599e72f3e25f9ff7a13e390c124a4506087f69ad79d128'],
+    }),
+    ('filehash', '2.4-1', {
+        'checksums': ['d0e087d338d89372c251c18fc93b53fb24b1750ea154833216ff16aff3b1eaf4'],
+    }),
+    ('ff', '2.2-13', {
+        'checksums': ['8bfb08afe0651ef3c23aaad49208146d5f929af5af12a25262fe7743fa346ddb'],
+    }),
+    ('bnlearn', '4.3', {
+        'checksums': ['78bb1d45977801ffa64f04f4319fa6e1fe9b5268f42b197d33aac074dc46f787'],
+    }),
+    ('bootstrap', '2017.2', {
+        'checksums': ['44f118c90ee226730175c467a16ac8d5b3169d610424e613da4f73348fd79522'],
+    }),
+    ('combinat', '0.0-8', {
+        'checksums': ['1513cf6b6ed74865bfdd9f8ca58feae12b62f38965d1a32c6130bef810ca30c1'],
+    }),
+    ('deal', '1.2-37', {
+        'checksums': ['aadfadfd85792b129063d02d5604dbd1afa5aacd2a6ec7eff7458edf2b5dc2da'],
+    }),
+    ('fdrtool', '1.2.15', {
+        'checksums': ['65f964aa768d0703ceb7a199adc5e79ca79a6d29d7bc053a262eb533697686c0'],
+    }),
+    ('formatR', '1.5', {
+        'checksums': ['874c197ae3720ec11b44984a055655b99a698e1912104eb9034c11fdf6104da7'],
+    }),
+    ('gtools', '3.5.0', {
+        'checksums': ['86b6a51a92ddb3c78095e0c5dc20414c67f6e28f915bf0ee11406adad3e476f6'],
+    }),
+    ('gdata', '2.18.0', {
+        'checksums': ['4b287f59f5bbf5fcbf18db16477852faac4a605b10c5284c46b93fa6e9918d7f'],
+    }),
+    ('GSA', '1.03', {
+        'checksums': ['dfb84f92508765c74b170bb5bb2b206a11d10fdb4a74473821b0e51cec5d3ac0'],
+    }),
+    ('highr', '0.6', {
+        'checksums': ['43e152b2dea596df6e14c44398c74fcd438ece15eaae5bdb84aef8d61b213b59'],
+    }),
+    ('infotheo', '1.2.0', {
+        'checksums': ['9b47ebc3db5708c88dc014b4ffec6734053a9c255a9241fcede30fec3e63aaa3'],
+    }),
+    ('lars', '1.2', {
+        'checksums': ['64745b568f20b2cfdae3dad02fba92ebf78ffee466a71aaaafd4f48c3921922e'],
+    }),
+    ('lazy', '1.2-15', {
+        'checksums': ['7a4a33ad77ad5dc973413745b5626856485c1c63a984f2182ccf5d0cec7eb8dd'],
+    }),
+    ('kernlab', '0.9-25', {
+        'checksums': ['b9de072754bb03c02c4d6a5ca20f2290fd090de328b55ab334ac0b397ac2ca62'],
+    }),
+    ('mime', '0.5', {
+        'checksums': ['fcc72115afb0eb43237da872754464f37ae9ae097f332ec7984149b5e3a82145'],
+    }),
+    ('markdown', '0.8', {
+        'checksums': ['538fd912b2220f2df344c6cca58304ce11e0960de7bd7bd573b3385105d48fed'],
+    }),
+    ('mlbench', '2.1-1', {
+        'checksums': ['748141d56531a39dc4d37cf0a5165a40b653a04c507e916854053ed77119e0e6'],
+    }),
+    ('NLP', '0.1-11', {
+        'checksums': ['580551a463c14d7186f62e029504f2e95dd9cbbaaef3f979221ddffafb036597'],
+    }),
+    ('mclust', '5.4', {
+        'checksums': ['7363057845272a1c2b97c77c89704d9d21f3b4eb9b41b95d1c54018c110e7bc4'],
+    }),
+    ('RANN', '2.5.1', {
+        'checksums': ['75277e5d8a13ca01ff387f99d403268a8077862d4e95b076b74fb1b5538a8546'],
+    }),
+    ('rmeta', '2.16', {
+        'checksums': ['9efb9e4f1847b59d9cbc46c793c528cf1b79d961ab1e6636daad81390b0a76e8'],
+    }),
+    ('segmented', '0.5-3.0', {
+        'checksums': ['98f2f0c23693d49527b43e7b6eb0746f2be7cb25715d2679e43015ec5d99315b'],
+    }),
+    ('som', '0.3-5.1', {
+        'checksums': ['a6f4c0e5b36656b7a8ea144b057e3d7642a8b71972da387a7133f3dd65507fb9'],
+    }),
+    ('SuppDists', '1.1-9.4', {
+        'checksums': ['fcb571150af66b95dcf0627298c54f7813671d60521a00ed157f63fc2247ddb9'],
+    }),
+    ('stabledist', '0.7-1', {
+        'checksums': ['06c5704d3a3c179fa389675c537c39a006867bc6e4f23dd7e406476ed2c88a69'],
+    }),
+    ('survivalROC', '1.0.3', {
+        'checksums': ['1449e7038e048e6ad4d3f7767983c0873c9c7a7637ffa03a4cc7f0e25c31cd72'],
+    }),
+    ('pspline', '1.0-18', {
+        'checksums': ['f71cf293bd5462e510ac5ad16c4a96eda18891a0bfa6447dd881c65845e19ac7'],
+    }),
+    ('timeDate', '3043.102', {
+        'checksums': ['377cba03cddab8c6992e31d0683c1db3a73afa9834eee3e95b3b0723f02d7473'],
+    }),
+    ('longmemo', '1.0-0', {
+        'checksums': ['acfd7c55389ebce52c7805c55a4b3161102b534c9a50aec891dc77ee6c99ccca'],
+    }),
+    ('ADGofTest', '0.3', {
+        'checksums': ['9cd9313954f6ecd82480d373f6c5371ca84ab33e3f5c39d972d35cfcf1096846'],
+    }),
+    ('MASS', '7.3-49', {
+        'checksums': ['1a33f77d5571e97daae22d1b764f3696f088bd2b18a9c709e21b7c7283b44bfa'],
+    }),
+    ('ade4', '1.7-10', {
+        'checksums': ['865157b21d5c0db96504d36f4361640c81d66de0fe5f09985f0f0ceb410f687e'],
+    }),
+    ('AlgDesign', '1.1-7.3', {
+        'checksums': ['df0d56111401474b7f06eaf9ce7145a1cb73b3c5ec4817bad06f56db48af872e'],
+    }),
+    ('base64enc', '0.1-3', {
+        'checksums': ['6d856d8a364bcdc499a0bf38bfd283b7c743d08f0b288174fba7dbf0a04b688d'],
+    }),
+    ('BH', '1.66.0-1', {
+        'checksums': ['17d9eb5512d74aa7dd02ec98953408422e728b01ce63493a6a473070b9596a92'],
+    }),
+    ('brew', '1.0-6', {
+        'checksums': ['d70d1a9a01cf4a923b4f11e4374ffd887ad3ff964f35c6f9dc0f29c8d657f0ed'],
+    }),
+    ('Brobdingnag', '1.2-4', {
+        'checksums': ['6ab8afd7fb0751c6d24c9cfad9b986dfbf397e29da03be43284e0c2712515de9'],
+    }),
+    ('corpcor', '1.6.9', {
+        'checksums': ['2e4fabd1d3936fecea67fa365233590147ca50bb45cf80efb53a10345a8a23c2'],
+    }),
+    ('longitudinal', '1.1.12', {
+        'checksums': ['d4f894c38373ba105b1bdc89e3e7c1b215838e2fb6b4470b9f23768b84e603b5'],
+    }),
+    ('backports', '1.1.2', {
+        'checksums': ['e85b93675c6703e1da790dce1f8fb61f27b87e92722c7f0909273ed5074cb456'],
+    }),
+    ('checkmate', '1.8.5', {
+        'checksums': ['e94d2a3971908ce2a8252a9320ae7e030e0364b0ecd5385ab98e600aca7cd1e0'],
+    }),
+    ('Rcpp', '0.12.16', {
+        'checksums': ['d4e1636e53e2b656e173b49085b7abbb627981787cd63d63df325c713c83a8e6'],
+    }),
+    ('cubature', '1.3-11', {
+        'checksums': ['9398fae6e0f5fa62a06f41f4ed3a8b86941909fcbb439301ba629cb5b67ec619'],
+    }),
+    ('DEoptimR', '1.0-8', {
+        'checksums': ['846911c1b2561a9fae73a8c60a21a5680963ebb0050af3c1f1147ae9a121e5ef'],
+    }),
+    ('digest', '0.6.15', {
+        'checksums': ['882e74bb4f0722260bd912fd7f8a0fcefcf44c558f43ac8a03d63e53d25444c5'],
+    }),
+    ('fastmatch', '1.1-0', {
+        'checksums': ['20b51aa4838dbe829e11e951444a9c77257dcaf85130807508f6d7e76797007d'],
+    }),
+    ('ffbase', '0.12.3', {
+        'checksums': ['a52998ec589c2b519034757919565473273f8b73486d8333ba7ff6deec3ae9db'],
+    }),
+    ('iterators', '1.0.9', {
+        'checksums': ['de001e063805fdd124953b571ccb0ed2838c55e40cca2e9d283d8a90b0645e9b'],
+    }),
+    ('maps', '3.2.0', {
+        'checksums': ['437abeb4fa4ad4a36af6165d319634b89bfc6bf2b1827ca86c478d56d670e714'],
+    }),
+    ('nnls', '1.4', {
+        'checksums': ['0e5d77abae12bc50639d34354f96a8e079408c9d7138a360743b73bd7bce6c1f'],
+    }),
+    ('sendmailR', '1.2-1', {
+        'checksums': ['04feb08c6c763d9c58b2db24b1222febe01e28974eac4fe87670be6fb9bff17c'],
+    }),
+    ('dotCall64', '0.9-5.2', {
+        'checksums': ['738809d87ff13d1fa06ebe903645989b72fca24e3117016b943bda92b89f80cb'],
+    }),
+    ('spam', '2.1-2', {
+        'checksums': ['c2ef16eb239ffdd50003d423ab91954c14cfa2c1ee295ccc92984828a85a8219'],
+    }),
+    ('subplex', '1.5-2', {
+        'checksums': ['6f8c3ccadf1ccd7f11f3eae28cec16eed3695f14e351b864d807dbaba6cd3ded'],
+    }),
+    ('stringi', '1.1.7', {
+        'checksums': ['b475a8549fbaf8ee0e625a7cead9b3b478cd73864c785582cdb3d217850e9359'],
+    }),
+    ('magrittr', '1.5', {
+        'checksums': ['05c45943ada9443134caa0ab24db4a962b629f00b755ccf039a2a2a7b2c92ae8'],
+    }),
+    ('glue', '1.2.0', {
+        'checksums': ['19275b34ee6a1bcad05360b7eb996cebaa1402f189a5dfb084e695d423f2296e'],
+    }),
+    ('stringr', '1.3.0', {
+        'checksums': ['23b048d2344cafa10a3480f8d52ab818525c6fdf7210290635f3a10de772bb1d'],
+    }),
+    ('evaluate', '0.10.1', {
+        'checksums': ['c9a763895d3f460dbf87c43a6469e4b41a251a74477df8c5d7e7d2b66cdd1b1c'],
+    }),
+    ('logspline', '2.1.9', {
+        'checksums': ['7c9b051f5bf7f64fb7ab7923f60e14fde4496b59eb74989aa192adae58cca7cd'],
+    }),
+    ('ncbit', '2013.03.29', {
+        'checksums': ['4480271f14953615c8ddc2e0666866bb1d0964398ba0fab6cc29046436820738'],
+    }),
+    ('permute', '0.9-4', {
+        'checksums': ['a541a5f5636ddd67fd856d3e11224f15bc068e96e23aabe3e607a7e7c2fc1cf1'],
+    }),
+    ('plotrix', '3.7', {
+        'checksums': ['3e5f232546b05cbb92242ad595842389f94c57918ebd4bd60051b471930d8867'],
+    }),
+    ('randomForest', '4.6-12', {
+        'checksums': ['6e512f8f88a51c01a918360acba61f1f39432f6e690bc231b7864218558b83c4'],
+    }),
+    ('scatterplot3d', '0.3-41', {
+        'checksums': ['4c8326b70a3b2d37126ca806771d71e5e9fe1201cfbe5b0d5a0a83c3d2c75d94'],
+    }),
+    ('SparseM', '1.77', {
+        'checksums': ['a9329fef14ae4fc646df1f4f6e57efb0211811599d015f7bc04c04285495d45c'],
+    }),
+    ('tripack', '1.3-8', {
+        'checksums': ['6bb340292a9629a41a0e0664335ddd97be3ad46bca225034db5dfb6efe01c75d'],
+    }),
+    ('irace', '2.4', {
+        'checksums': ['64cecf6fd0807dacea55a4f029677de127e105807de8dc026e3203cc2479bf1f'],
+    }),
+    ('rJava', '0.9-9', {
+        'checksums': ['932b153f2b5c546d614bb5ac4124df3d103c9f8e09a608a14fd036dfe15e9146'],
+    }),
+    ('lattice', '0.20-35', {
+        'checksums': ['0829ab0f4dec55aac6a73bc3411af68441ddb1b5b078d680a7c2643abeaa965d'],
+    }),
+    ('RColorBrewer', '1.1-2', {
+        'checksums': ['f3e9781e84e114b7a88eb099825936cc5ae7276bbba5af94d35adb1b3ea2ccdd'],
+    }),
+    ('latticeExtra', '0.6-28', {
+        'checksums': ['780695323dfadac108fb27000011c734e2927b1e0f069f247d65d27994c67ec2'],
+    }),
+    ('Matrix', '1.2-12', {
+        'checksums': ['0d0e36e9742ea86355b2611ed94552946093b027e5eca2b8656abb4401838291'],
+    }),
+    ('png', '0.1-7', {
+        'checksums': ['e269ff968f04384fc9421d17cfc7c10cf7756b11c2d6d126e9776f5aca65553c'],
+    }),
+    ('RcppArmadillo', '0.8.400.0.0', {
+        'checksums': ['d917b66aa36779bb7ba6be8fd138ef181febfcd7e0cc093e73867f439c9ec287'],
+    }),
+    ('plyr', '1.8.4', {
+        'checksums': ['60b522d75961007658c9806f8394db27989f1154727cb0bb970062c96ec9eac5'],
+    }),
+    ('gtable', '0.2.0', {
+        'checksums': ['801e4869830ff3da1d38e41f5a2296a54fc10a7419c6ffb108582850c701e76f'],
+    }),
+    ('reshape2', '1.4.3', {
+        'checksums': ['8aff94c935e75032344b52407593392ddd4e16a88bb206984340c816d42c710e'],
+    }),
+    ('dichromat', '2.0-0', {
+        'checksums': ['31151eaf36f70bdc1172da5ff5088ee51cc0a3db4ead59c7c38c25316d580dd1'],
+    }),
+    ('colorspace', '1.3-2', {
+        'checksums': ['dd9fd2342b650456901d014e7ff6d2e201f8bec0b555be63b1a878d2e1513e34'],
+    }),
+    ('munsell', '0.4.3', {
+        'checksums': ['397c3c90af966f48eebe8f5d9e40c41b17541f0baaa102eec3ea4faae5a2bd49'],
+    }),
+    ('labeling', '0.3', {
+        'checksums': ['0d8069eb48e91f6f6d6a9148f4e2dc5026cabead15dd15fc343eff9cf33f538f'],
+    }),
+    ('R6', '2.2.2', {
+        'checksums': ['087756f471884c3b3ead80215a7cc5636a78b8a956e91675acfe2896426eae8f'],
+    }),
+    ('viridisLite', '0.3.0', {
+        'checksums': ['780ea12e7c4024d5ba9029f3a107321c74b8d6d9165262f6e64b79e00aa0c2af'],
+    }),
+    ('scales', '0.5.0', {
+        'checksums': ['dbfcc0817c4ab8b8777ec7d68ebfe220177c193cfb5bd0e8ba5d365dbfe3e97d'],
+    }),
+    ('rlang', '0.2.0', {
+        'checksums': ['4872a7d1b8e1e1a64a851dac707efb0c1dcbef69f6dadee417dac85b38740739'],
+    }),
+    ('assertthat', '0.2.0', {
+        'checksums': ['d73ef79b1e75293ed889a99571b237a95829c099f7da094d4763f83ea6fde5f2'],
+    }),
+    ('crayon', '1.3.4', {
+        'checksums': ['fc6e9bf990e9532c4fcf1a3d2ce22d8cf12d25a95e4779adfa17713ed836fa68'],
+    }),
+    ('cli', '1.0.0', {
+        'checksums': ['8fa3dbfc954ca61b8510f767ede9e8a365dac2ef95fe87c715a0f37d721b5a1d'],
+    }),
+    ('utf8', '1.1.3', {
+        'checksums': ['43b394c3274ba0f66719d28dc4a7babeb87187e766de8d8ca716e0548091440f'],
+    }),
+    ('pillar', '1.2.1', {
+        'checksums': ['6de997a43416f436039f2b8b47c46ea08d2508f8ad341e0e1fd878704a3dcde7'],
+    }),
+    ('tibble', '1.4.2', {
+        'checksums': ['11670353ff7059a55066dd075d1534d6a27bc5c3583fb9bc291bf750a75c5b17'],
+    }),
+    ('lazyeval', '0.2.1', {
+        'checksums': ['83b3a43e94c40fe7977e43eb607be0a3cd64c02800eae4f2774e7866d1e93f61'],
+    }),
+    ('ggplot2', '2.2.1', {
+        'checksums': ['5fbc89fec3160ad14ba90bd545b151c7a2e7baad021c0ab4b950ecd6043a8314'],
+    }),
+    ('pROC', '1.10.0', {
+        'checksums': ['4039fb71e531b1fcff319fc656657813465bf818476535d02a16f7271c44a066'],
+    }),
+    ('quadprog', '1.5-5', {
+        'checksums': ['d999620688354c283de5bb305203f5db70271b4dfdc23577cae8c2ba94c9e349'],
+    }),
+    ('BB', '2014.10-1', {
+        'checksums': ['a09f67e3a6ef36db660e4dc92832dfad4a7591ae9fadc2a265c8770ffb1e2fd2'],
+    }),
+    ('BBmisc', '1.11', {
+        'checksums': ['1ea48c281825349d8642a661bb447e23bfd651db3599bf72593bfebe17b101d2'],
+    }),
+    ('fail', '1.3', {
+        'checksums': ['ede8aa2a9f2371aff5874cd030ac625adb35c33954835b54ab4abf7aeb34d56d'],
+    }),
+    ('rlecuyer', '0.3-4', {
+        'checksums': ['c7378f1134e99abc9dfbde7906da430b34333e11aa98a03f87b638637f63b534'],
+    }),
+    ('snow', '0.4-2', {
+        'checksums': ['ee070187aea3607c9ca6235399b3db3e181348692405d038e962e06aefccabd7'],
+    }),
+    ('tree', '1.0-38', {
+        'checksums': ['fa0b9258261f1dadfb2baaf798bed8d758a02c8a12092c28383710b131d1fafd'],
+    }),
+    ('pls', '2.6-0', {
+        'checksums': ['3d8708fb7f45863d3861fd231e06955e6750bcbe717e1ccfcc6d66d0cb4d4596'],
+    }),
+    ('class', '7.3-14', {
+        'checksums': ['18b876dbc18bebe6a00890eab7d04ef72b903ba0049d5ce50731406a82426b9c'],
+    }),
+    ('e1071', '1.6-8', {
+        'checksums': ['f68601743b9b49e1d1f8b9ec9963d6500d66158417c53f65bf7232678d88c622'],
+    }),
+    ('nnet', '7.3-12', {
+        'checksums': ['2723523e8581cc0e2215435ac773033577a16087a3f41d111757dd96b8c5559d'],
+    }),
+    ('nlme', '3.1-131.1', {
+        'checksums': ['1e3c2d147df34d83b0f3ab50ac065371035f5d676a763c45595f26058e894ef5'],
+    }),
+    ('minqa', '1.2.4', {
+        'checksums': ['cfa193a4a9c55cb08f3faf4ab09c11b70412523767f19894e4eafc6e94cccd0c'],
+    }),
+    ('RcppEigen', '0.3.3.4.0', {
+        'checksums': ['11020c567b299b1eac95e8a4d57abf0315931286907823dc7b66c44d0dd6dad4'],
+    }),
+    ('MatrixModels', '0.4-1', {
+        'checksums': ['fe878e401e697992a480cd146421c3a10fa331f6b37a51bac83b5c1119dcce33'],
+    }),
+    ('quantreg', '5.35', {
+        'checksums': ['f57c75d3ab15cc1cb6a819200fa9239c976b2bfa5a7f580aae78051976c7c3a1'],
+    }),
+    ('mgcv', '1.8-23', {
+        'checksums': ['7771ac5581542904d569388e2e498d3e3b8b65f7a81737acbb45d8ef838359d3'],
+    }),
+    ('robustbase', '0.92-8', {
+        'checksums': ['bcbf894c7d3916fc92064f0f9152f6347560c9b98ec81d57b5705f8421b31e20'],
+    }),
+    ('sp', '1.2-7', {
+        'checksums': ['6d60e03e1abd30a7d4afe547d157ce3dd7a8c166fc5e407fd6d62ae99ff30460'],
+    }),
+    ('zoo', '1.8-1', {
+        'checksums': ['d93d88500374fce7f5c047f25240ac60483bcfd6fadf81df4eb2b879ad2ccc9a'],
+    }),
+    ('lmtest', '0.9-35', {
+        'checksums': ['2f4982f1b6cd133ef36fe9718f4ff2f4fa5c20716100fdd5ee5c947b68c8eb80'],
+    }),
+    ('vcd', '1.4-4', {
+        'checksums': ['a561adf120b5ce41b66e0c0c321542fcddc772eb12b3d7020d86e9cd014ce9d2'],
+    }),
+    ('snowfall', '1.84-6.1', {
+        'checksums': ['5c446df3a931e522a8b138cf1fb7ca5815cc82fcf486dbac964dcbc0690e248d'],
+    }),
+    ('rpart', '4.1-13', {
+        'checksums': ['8e11a6552224e0fbe23a85aba95acd21a0889a3fe48277f3d345de3147c7494c'],
+    }),
+    ('survival', '2.41-3', {
+        'checksums': ['f3797c344de93abd2ba8c89568770a13524a8b2694144ae55adec46921c8961d'],
+    }),
+    ('mice', '2.46.0', {
+        'checksums': ['5d3109ab3e9a84cb9ba60b0ab477d4e3ed9326fe4831fd99bbf1ed7fcca45bbe'],
+    }),
+    ('urca', '1.3-0', {
+        'checksums': ['621cc82398e25b58b4a16edf000ed0a1484d9a0bc458f734e97b6f371cc76aaa'],
+    }),
+    ('fracdiff', '1.4-2', {
+        'checksums': ['983781cedc2b4e3ba9fa020213957d5133ae9cd6710bc61d6225728e2f6e850e'],
+    }),
+    ('logistf', '1.22', {
+        'checksums': ['e866f02b1b40332e6e57c932201993725742e464f362e0053776bb8ce8c2fc5a'],
+    }),
+    ('akima', '0.6-2', {
+        'checksums': ['61da3e556553eea6d1f8db7c92218254441da31e365bdef82dfe5da188cc97ce'],
+    }),
+    ('bitops', '1.0-6', {
+        'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
+    }),
+    ('boot', '1.3-20', {
+        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+    }),
+    ('mixtools', '1.1.0', {
+        'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],
+    }),
+    ('cluster', '2.0.6', {
+        'checksums': ['b53bb0eed64b79767a6e0d203fdc82f9fdb5c9692f30316fbe1c5b196a62fd81'],
+    }),
+    ('gclus', '1.3.1', {
+        'checksums': ['d6994ee264b464503db005450153973d75eba502e4caaaa6ff99cb95e4376a09'],
+    }),
+    ('coda', '0.19-1', {
+        'checksums': ['d41ff5731da6805170769dba75dd011ab33f916d15b2336001f279e21a524491'],
+    }),
+    ('codetools', '0.2-15', {
+        'checksums': ['4e0798ed79281a614f8cdd199e25f2c1bd8f35ecec902b03016544bd7795fa40'],
+    }),
+    ('foreach', '1.4.4', {
+        'checksums': ['c0a71090d5b70b9a95a6936091dabae9c26e1fc6b9609bfe5fb6346033905e48'],
+    }),
+    ('doMC', '1.3.5', {
+        'checksums': ['792254596babd8cc074bb3c83c18672dd07a0c3246b4ebab08d8ebedf6f4d9ed'],
+    }),
+    ('DBI', '0.8', {
+        'checksums': ['d52b9e04b3291f9bda8a88c174678f520ddffc5f2edf9b3dfa6d97dca943ce9a'],
+    }),
+    ('foreign', '0.8-69', {
+        'checksums': ['820e1409162fbd6418b80a0f5a4b50d649ee74f06d195a5210745619b16e1592'],
+    }),
+    ('gam', '1.15', {
+        'checksums': ['1e365f9f328e018955140b4d842a30a499f4877291cb88cb9f147be79b62d1f0'],
+    }),
+    ('gamlss.data', '5.0-0', {
+        'checksums': ['3abc373d43698275361bfc3d61f5646e8ddf59019886bfd248bdea19493d1fd7'],
+    }),
+    ('gamlss.dist', '5.0-4', {
+        'checksums': ['2d1221db92be90b88f50e01e284c7e2218d35bb72af488e351b3d3ec4ca1b498'],
+    }),
+    ('hwriter', '1.3.2', {
+        'checksums': ['6b3531d2e7a239be9d6e3a1aa3256b2745eb68aa0bdffd2076d36552d0d7322b'],
+    }),
+    ('KernSmooth', '2.23-15', {
+        'checksums': ['8b72d23ed121a54af188b2cda4441e3ce2646359309885f6455b82c0275210f6'],
+    }),
+    ('xts', '0.10-2', {
+        'checksums': ['8155888319c38e874ed87300decd65570e77ea4a7575136f4690123d3f7321c4'],
+    }),
+    ('curl', '3.1', {
+        'checksums': ['270f2596be50a11fe43fe63bcacbf4a4aa9c75cc6ebc0d619ac2e52e9497cb95'],
+    }),
+    ('TTR', '0.23-3', {
+        'checksums': ['2136032c7a2cd2a82518a4412fc655ecb16597b123dbdebe5684caef9f15261f'],
+    }),
+    ('quantmod', '0.4-12', {
+        'checksums': ['18d61d869180670cd5e97bc6cc12ab2939b8b63ae720c89c6e1b041d2680ef78'],
+    }),
+    ('mnormt', '1.5-5', {
+        'checksums': ['ff78d5f935278935f1814a69e5a913d93d6dd2ac1b5681ba86b30c6773ef64ac'],
+    }),
+    ('mvtnorm', '1.0-7', {
+        'checksums': ['d063b0dec57c2f588da4ac35fcd479dc2ab83cb473e4a6fee6cbb6e7a9fbf038'],
+    }),
+    ('pcaPP', '1.9-73', {
+        'checksums': ['ca4566b0babfbe83ef9418283b08a12b3420dc362f93c6562f265df7926b53fc'],
+    }),
+    ('numDeriv', '2016.8-1', {
+        'checksums': ['1b681d273697dc780a3ac5bedabb4a257785732d9ca4ef68e4e4aac8b328d11e'],
+    }),
+    ('SQUAREM', '2017.10-1', {
+        'checksums': ['9b89905b436f1cf3faa9e3dabc585a76299e729e85ca659bfddb4b7cba11b283'],
+    }),
+    ('lava', '1.6', {
+        'checksums': ['bf05dafeeeac86b7d64ea7c2a0986fb727f139019efb82ed4b5f6564522bae0b'],
+    }),
+    ('prodlim', '1.6.1', {
+        'checksums': ['3f2665257118a3db8682731a500b1ae4d669af344672dc2037f987bee3cca154'],
+    }),
+    ('pscl', '1.5.2', {
+        'checksums': ['2c9fe648485c6b54c6f95a54b6e00ffe3cf06fa8c5c68f1d669664a7b91a0ede'],
+    }),
+    ('memoise', '1.1.0', {
+        'checksums': ['b276f9452a26aeb79e12dd7227fcc8712832781a42f92d70e86040da0573980c'],
+    }),
+    ('plogr', '0.1-1', {
+        'checksums': ['22755c93c76c26252841f43195df31681ea865e91aa89726010bd1b9288ef48f'],
+    }),
+    ('bit64', '0.9-7', {
+        'checksums': ['7b9aaa7f971198728c3629f9ba1a1b24d53db5c7e459498b0fdf86bbd3dff61f'],
+    }),
+    ('blob', '1.1.0', {
+        'checksums': ['16d6603df3ddba177f0ac4d9469c938f89131c4bf8834345db838defd9ffea16'],
+    }),
+    ('pkgconfig', '2.0.1', {
+        'checksums': ['ab02b2a4b639ba94dcba882a059fe9cddae5498a4309841f764b62ec46ba5a40'],
+    }),
+    ('RSQLite', '2.0', {
+        'patches': ['RSQLite-2.0-icc.patch'],
+        'checksums': [
+            '7f0fe629f34641c6af1e8a34412f3089ee2d184853843209d97ffe29430ceff6',  # RSQLite_2.0.tar.gz
+            '828dd9aeb4f8aaff7bccb8671bee757b8001e049ed349d655044e9c916d1860d',  # RSQLite-2.0-icc.patch
+        ],
+    }),
+    ('data.table', '1.10.4-3', {
+        'checksums': ['ba8b4f1b96b16e7f9765fc49c5028f21ef2210fc46cf962f4f7ea7901f9d8a89'],
+    }),
+    ('BatchJobs', '1.7', {
+        'checksums': ['49ef69adfb42f085c7ed143a80d78566d55d794ee9a1e1c83d85dbac2a2aa60c'],
+    }),
+    ('sandwich', '2.4-0', {
+        'checksums': ['34315b9ced76a3ed109aead7b8f77eea6398a6eb2e1ad71515a48bed9808ccc0'],
+    }),
+    ('sfsmisc', '1.1-2', {
+        'checksums': ['808734644863d102263134634b89dc856dbaadc4d54c32ae697f3e1b0214f831'],
+    }),
+    ('spatial', '7.3-11', {
+        'checksums': ['624448d2ac22e1798097d09fc5dc4605908a33f490b8ec971fc6ea318a445c11'],
+    }),
+    ('VGAM', '1.0-5', {
+        'checksums': ['01acf530b011b8f04e1698742c51ea0682d7c9fcdf814fc65ba44869b6e76346'],
+    }),
+    ('waveslim', '1.7.5', {
+        'checksums': ['31b698f7b19aadcdc02068ee69bf7676cd9dea2913420ce3caa7e507e3a41a53'],
+    }),
+    ('xtable', '1.8-2', {
+        'checksums': ['1623a1cde2e130fedb46f98840c3a882f1cbb167b292ef2bd86d70baefc4280d'],
+    }),
+    ('profileModel', '0.5-9', {
+        'checksums': ['c94f25d222521867ddc86021bd0b9a6b9f7b055212985652a8511054b24c2bdd'],
+    }),
+    ('brglm', '0.6.1', {
+        'checksums': ['b786db50edc703b1b6a986b1ce13d31aab76fd3c672a6540161b25f5cd57239f'],
+    }),
+    ('deSolve', '1.20', {
+        'checksums': ['56e945835b0c66d36ebc4ec8b55197b616e387d990788a2e52e924ce551ddda2'],
+    }),
+    ('tseriesChaos', '0.1-13', {
+        'checksums': ['efabf9c59548e2d22aa9763b340789d8e46e88c741ed4a831e52b1ed3bf35038'],
+    }),
+    ('tseries', '0.10-43', {
+        'checksums': ['c27912f45d6bbd723c8055b345936a3c96ccdc7bd919fad9cf57dc408f845dfa'],
+    }),
+    ('fastICA', '1.2-1', {
+        'checksums': ['6f2997dd766a544be3a3de2780df48ca67242ac7790a4a2882c417bfaa171f81'],
+    }),
+    ('R.methodsS3', '1.7.1', {
+        'checksums': ['44b840399266cd27f8f9157777b4d9d85ab7bd31bfdc143b3fc45079a2d8e687'],
+    }),
+    ('R.oo', '1.21.0', {
+        'checksums': ['645ceec2f815ed39650ca72db87fb4ece7357857875a4ec73e18bfaf647f431c'],
+    }),
+    ('cgdsr', '1.2.10', {
+        'checksums': ['43bc02fb33c371464f9407d5e5e6419527e9360e3e394343862cca0aebe1d0f7'],
+    }),
+    ('R.utils', '2.6.0', {
+        'checksums': ['5d64993d1209b512a4e97f2edecdbc185f4a369ee5fa2e334ed2cf017486470e'],
+    }),
+    ('R.matlab', '3.6.1', {
+        'checksums': ['1032579fd152d419eaf1f69bf6035fba7a71ef26e76136c48a6fc619e3887804'],
+    }),
+    ('gbm', '2.1.3', {
+        'checksums': ['eaf24be931d762f1ccca4f90e15997719d01005f152160a3d20d858a0bbed92b'],
+    }),
+    ('Formula', '1.2-2', {
+        'checksums': ['8def4600fb7457d38db8083733477501b54528974aa216e4adf8871bff4aa429'],
+    }),
+    ('acepack', '1.4.1', {
+        'checksums': ['82750507926f02a696f6cc03693e8d4a5ee7e92500c8c15a16a9c12addcd28b9'],
+    }),
+    ('proto', '1.0.0', {
+        'checksums': ['9294d9a3b2b680bb6fac17000bfc97453d77c87ef68cfd609b4c4eb6d11d04d1'],
+    }),
+    ('gridExtra', '2.3', {
+        'checksums': ['81b60ce6f237ec308555471ae0119158b115463df696d2eca9b177ded8988e3b'],
+    }),
+    ('chron', '2.3-52', {
+        'checksums': ['c47fcf4abb635babe6337604c876d4853d8a24639a98b71523746c56ce75b4a0'],
+    }),
+    ('viridis', '0.5.0', {
+        'checksums': ['fea477172c1e11be40554545260b36d6ddff3fe6bc3bbed87813ffb77c5546cd'],
+    }),
+    ('yaml', '2.1.18', {
+        'checksums': ['1bb54d5f28f0adc24a5f3cfbf5cda4a71ca2ad7922a687f756e0619767c1a496'],
+    }),
+    ('jsonlite', '1.5', {
+        'checksums': ['6490371082a387cb1834048ad8cdecacb8b6b6643751b50298c741490c798e02'],
+    }),
+    ('htmltools', '0.3.6', {
+        'checksums': ['44affb82f9c2fd76c9e2b58f9229adb003217932b68c3fdbf1327c8d74c868a2'],
+    }),
+    ('htmlwidgets', '1.0', {
+        'checksums': ['9973fe7a0271d1f39317fad58edee818eae8df26d037f0341024d032e0af9326'],
+    }),
+    ('knitr', '1.20', {
+        'checksums': ['7b2409056af001970d1ed502a25fd84536aca4a21039479998507556446d0890'],
+    }),
+    ('rstudioapi', '0.7', {
+        'checksums': ['a541bc76ef082d2c27e42fd683f8262cb195b1497af3509178d2642870397a8c'],
+    }),
+    ('bindr', '0.1.1', {
+        'checksums': ['7c785ca77ceb3ab9282148bcecf64d1857d35f5b800531d49483622fe67505d0'],
+    }),
+    ('bindrcpp', '0.2', {
+        'checksums': ['d0efa1313cb8148880f7902a4267de1dcedae916f28d9a0ef5911f44bf103450'],
+    }),
+    ('dplyr', '0.7.4', {
+        'checksums': ['7b1fc90750fbb46483423da6721832c545d37b157f4f3355784a65e50fada8c2'],
+    }),
+    ('purrr', '0.2.4', {
+        'checksums': ['ed8d0f69d29b95c2289ae52be08a0e65f8171abb6d2587de7b57328bf3b2eb71'],
+    }),
+    ('tidyselect', '0.2.4', {
+        'checksums': ['5cb30e56ad5c1ac59786969edc8d542a7a1735a129a474f585a141aefe6a2295'],
+    }),
+    ('tidyr', '0.8.0', {
+        'checksums': ['0b7fb3e4ee7c6c8bb9894825c7f16db967abb57aceac0609b7866fa1825c57e2'],
+    }),
+    ('htmlTable', '1.11.2', {
+        'checksums': ['64a273b1cdf07a7c57b9031315ca665f95d78e70b4320d020f64a139278877d1'],
+    }),
+    ('Hmisc', '4.1-1', {
+        'checksums': ['991db21cdf73ffbf5b0239a4876b2e76fd243ea33528afd88dc968792f281498'],
+    }),
+    ('fastcluster', '1.1.24', {
+        'checksums': ['82c939b79dbaf00c79b01f19b09a8fadb9a949397b8f65bc861c552e0485b995'],
+    }),
+    ('registry', '0.5', {
+        'checksums': ['5d8be59ba791987b2400e9e8eaaac614cd544c1aece785ec4782ea6d5ea00efb'],
+    }),
+    ('pkgmaker', '0.22', {
+        'checksums': ['19ad78c16bd5757333e7abbd5eebcec081deb494c9a4b6eec6919a3747b3386f'],
+    }),
+    ('rngtools', '1.2.4', {
+        'checksums': ['27019835b750f470b13dbb7fecd3b839a61b52774e23fffa191f919533768fb9'],
+    }),
+    ('doParallel', '1.0.11', {
+        'checksums': ['4ccbd2eb46d3e4f5251b0c3de4d93d9168b02bb0be493656d6aea236667ff76a'],
+    }),
+    ('gridBase', '0.4-7', {
+        'checksums': ['be8718d24cd10f6e323dce91b15fc40ed88bccaa26acf3192d5e38fe33e15f26'],
+    }),
+    ('NMF', '0.21.0', {
+        'checksums': ['3b30c81c66066fab4a63c5611a0313418b840d8b63414db31ef0e932872d02e3'],
+    }),
+    ('irlba', '2.3.2', {
+        'checksums': ['3fdf2d8fefa6ab14cd0992740de7958f9f501c71aca93229f5eb03c54558fc38'],
+    }),
+    ('igraph', '1.2.1', {
+        'checksums': ['55341848f85a436c32d60f59a4db485238d535f2e8afe0d5a360804fc33299c1'],
+    }),
+    ('GeneNet', '1.2.13', {
+        'checksums': ['3798caac3bef7dc87f97b3628eb29eb12365d571ce0837b5b6285b0be655a270'],
+    }),
+    ('ape', '5.0', {
+        'checksums': ['c32ed22e350b3d7c7ef3de9334155ab1f3086922b5ec9a1643897cae7abda960'],
+    }),
+    ('RJSONIO', '1.3-0', {
+        'checksums': ['119334b7761c6c1c3cec52fa17dbc1b72eaebb520c53e68d873dea147cf48fb7'],
+    }),
+    ('caTools', '1.17.1', {
+        'checksums': ['d32a73febf00930355cc00f3e4e71357412e0f163faae6a4bf7f552cacfe9af4'],
+    }),
+    ('gplots', '3.0.1', {
+        'checksums': ['343df84327ac3d03494992e79ee3afc78ba3bdc08af9a305ee3fb0a38745cb0a'],
+    }),
+    ('ROCR', '1.0-7', {
+        'checksums': ['e7ef710f847e441a48b20fdc781dbc1377f5a060a5ee635234053f7a2a435ec9'],
+    }),
+    ('httpuv', '1.3.6.2', {
+        'checksums': ['8e8ca2f15529089846695abdab229cbc9812f0b2710855fb0a41ac720a9f7040'],
+    }),
+    ('rjson', '0.2.15', {
+        'checksums': ['77d00d8f6a1c936329b46f3b8b0be79a165f8c5f1989497f942ecc53dcf6f2ef'],
+    }),
+    ('sourcetools', '0.1.6', {
+        'checksums': ['c9f48d2f0b7f7ed0e7fecdf8e730b0b80c4d567f0e1e880d118b0944b1330c51'],
+    }),
+    ('shiny', '1.0.5', {
+        'checksums': ['20e25f3f72f3608a2151663f7836f2e0c6da32683a555d7541063ae7a935fa42'],
+    }),
+    ('seqinr', '3.4-5', {
+        'checksums': ['162a347495fd52cbb62e8187a4692e7c50b9fa62123c5ef98f2744c98a05fb9f'],
+    }),
+    ('LearnBayes', '2.15', {
+        'checksums': ['45c91114b4aaa0314feeb4311dbe78f5b75a3b76bb2d1ca0f8adb2e0f1cbe233'],
+    }),
+    ('deldir', '0.1-14', {
+        'checksums': ['89d365a980ef8589971e5d311c6bd59fe32c48dbac8000a880b9655032c99289'],
+    }),
+    ('gmodels', '2.16.2', {
+        'checksums': ['ab018894bdb376c5bd6bc4fbc4fe6e86590f4106795a586ef196fbb6699ec47d'],
+    }),
+    ('expm', '0.999-2', {
+        'checksums': ['38f1e5bfa90f794486789695d0d9e49158c7eb9445dc171dd83dec3d8fa130d6'],
+    }),
+    ('spData', '0.2.8.1', {
+        'checksums': ['64e389474bd45f39b2cdf4ba8e5bf872a6f52cbf83deca10111df1000e7b7951'],
+    }),
+    ('spdep', '0.7-4', {
+        'checksums': ['9643f1e509e0107c8f8d949b0a6cbb6a274c7ca1e9ba4d474ce42235696653c7'],
+    }),
+    ('vegan', '2.4-6', {
+        'checksums': ['dc9c1b0832835e1dd9e0ed3d9066e0834f4b15f2330f771f4abed72a48c6b59c'],
+    }),
+    ('adegenet', '2.1.1', {
+        'checksums': ['3043fe5d731a38ff0e266f090dcda448640c3d0fd61934c76da32d082e5dce7a'],
+    }),
+    ('prettyunits', '1.0.2', {
+        'checksums': ['35a4980586c20650538ae1e4fed4d80fdde3f212b98546fc3c7d9469a1207f5c'],
+    }),
+    ('progress', '1.1.2', {
+        'checksums': ['a9f4abfd9579b80967cd681041643fe9dfcc4eb3beeba45391bb64e9209baabb'],
+    }),
+    ('rncl', '0.8.2', {
+        'checksums': ['80e1aa00cab4af0093198d0d902c973eb31dbdf4628e229ee9c136a9cc9c369e'],
+    }),
+    ('XML', '3.98-1.10', {
+        'checksums': ['a19e04178e420c0cbf8a2d55513ea568c7c13aa53a6c1f1c3de652ba56525fb9'],
+    }),
+    ('praise', '1.0.0', {
+        'checksums': ['5c035e74fd05dfa59b03afe0d5f4c53fbf34144e175e90c53d09c6baedf5debd'],
+    }),
+    ('withr', '2.1.1', {
+        'checksums': ['bd5fae3846b8f89081a0991375402266dccf49bfa5d614690deea1b03ba5eb9e'],
+    }),
+    ('testthat', '2.0.0', {
+        'checksums': ['3bc047ad1c4522104023d4fbbfc9aceed14d316fdb16865a514f26b3e628b494'],
+    }),
+    ('rprojroot', '1.3-2', {
+        'checksums': ['df5665834941d8b0e377a8810a04f98552201678300f168de5f58a587b73238b'],
+    }),
+    ('rmarkdown', '1.9', {
+        'checksums': ['cbb7da80b514c148b48b8d4b6d497ec8edf6d2f6be3c483c836eec99e19a0673'],
+    }),
+    ('openssl', '1.0.1', {
+        'checksums': ['605c05868e26c5d3cbea9748d400371612bcf082322b1cea5c08397e5fa1d8e3'],
+    }),
+    ('httr', '1.3.1', {
+        'checksums': ['22134d7426b2eba37f0cc34b99285499b8bac9fe75a7bc3222fbad179bf8f258'],
+    }),
+    ('reshape', '0.8.7', {
+        'checksums': ['2fa6c87d1e89f182e51bc5a4fcda3d42d83b8fb4474ca525fa7a8db5081f3992'],
+    }),
+    ('xml2', '1.2.0', {
+        'checksums': ['0a7a916fe9c5da9ac45aeb4c6b6b25d33c07652d422b9f2bb570f2e8f4ac9494'],
+    }),
+    ('triebeard', '0.3.0', {
+        'checksums': ['bf1dd6209cea1aab24e21a85375ca473ad11c2eff400d65c6202c0fb4ef91ec3'],
+    }),
+    ('urltools', '1.7.0', {
+        'checksums': ['b4272fce4de28c6abb15ff6c192a889cf99d96a777fcb19de712b94c2429bb4f'],
+    }),
+    ('httpcode', '0.2.0', {
+        'checksums': ['fbc1853db742a2cc1df11285cf27ce2ea43bc0ba5f7d393ee96c7e0ee328681a'],
+    }),
+    ('crul', '0.5.2', {
+        'checksums': ['e01b25606dd113941537a9399d90370fa8de133ae7b2d8c82aa8979525dad269'],
+    }),
+    ('bold', '0.5.0', {
+        'checksums': ['f40963b847667cf8d69ba7ba3bd479bc117e1bc4df8bd1482a975dadff58b53d'],
+    }),
+    ('rredlist', '0.4.0', {
+        'checksums': ['9e59d3c5830322ed85762bbb3273b59befe59c3feabfe7d2f32de96fc4525048'],
+    }),
+    ('rentrez', '1.2.1', {
+        'checksums': ['74cf6dbe1b229518c25221534b20437b53cb663f1473cf9df5a59ca76b76ae84'],
+    }),
+    ('rotl', '3.0.3', {
+        'checksums': ['049a417ee10203339b3543fd97116b59de467344493f234d0d01c4b6ad7fd75d'],
+    }),
+    ('solrium', '1.0.0', {
+        'checksums': ['0e362d4f3b700997bc417ea3ca21301ddbd7978ab3394affbe6861eb27308ee6'],
+    }),
+    ('ritis', '0.7.0', {
+        'checksums': ['bb3a3243f83083e7dd874624e8dfb57953c8aea38df16b3e5c0163857e875d38'],
+    }),
+    ('worrms', '0.2.0', {
+        'checksums': ['66f6238988b3deeecc1dee628979727c98b3db072b046e316ff8962192141bd7'],
+    }),
+    ('natserv', '0.1.4', {
+        'checksums': ['07501608a2e79b20940cd0e22aca9db6150942eed5b6dad184ec957e153d8e63'],
+    }),
+    ('WikipediR', '1.5.0', {
+        'checksums': ['f8d0e6f04fb65f7ad9c1c068852a6a8b699ffe8d39edf1f3fa07d32d087e8ff0'],
+    }),
+    ('WikidataR', '1.4.0', {
+        'checksums': ['64b1d53d7023249b73a77a7146adc3a8957b7bf3d808ebd6734795e9f58f4b2a'],
+    }),
+    ('wikitaxa', '0.2.0', {
+        'checksums': ['944523717b2571af02a6bf15a58100dfb69530f702ab919f1c5fd3d263588c19'],
+    }),
+    ('taxize', '0.9.2', {
+        'checksums': ['15aacbdd61a77b27a6faa8e0c6fd05b2e96cba51eb94cefd623f29428c4cbb97'],
+    }),
+    ('uuid', '0.1-2', {
+        'checksums': ['dd71704dc336b0857981b92a75ed9877d4ca47780b1682def28839304cd3b1be'],
+    }),
+    ('RNeXML', '2.0.8', {
+        'checksums': ['b2bc118a3982866d12aa880823a17e0247915a0fa265163a383bc26981d96d46'],
+    }),
+    ('phylobase', '0.8.4', {
+        'checksums': ['d7c1a972c266ffe80345c7150608a85e6e2def4a3f079ac964ad9dbce2281002'],
+    }),
+    ('adephylo', '1.1-11', {
+        'checksums': ['154bf2645eac4493b85877933b9445442524ca4891aefe4e80c294c398cff61a'],
+    }),
+    ('animation', '2.5', {
+        'checksums': ['b232fef1b318c79710e5e1923d87baba4c85ffe2c77ddb188130e0911d8cb55f'],
+    }),
+    ('bigmemory.sri', '0.1.3', {
+        'checksums': ['55403252d8bae9627476d1f553236ea5dc7aa6e54da6980526a6cdc66924e155'],
+    }),
+    ('bigmemory', '4.5.33', {
+        'checksums': [
+            '7237d9785d8ce3eab4e36ad3ce2c95cbae926326031661b4f237b7517f4b9479',  # bigmemory_4.5.33.tar.gz
+        ],
+    }),
+    ('calibrate', '1.7.2', {
+        'checksums': ['78066a564f57f2110f1752d681d6b97915cf73135134330587fff8b46c581604'],
+    }),
+    ('clusterGeneration', '1.3.4', {
+        'checksums': ['7c591ad95a8a9d7fb0e4d5d80dfd78f7d6a63cf7d11eb53dd3c98fdfb5b868aa'],
+    }),
+    ('raster', '2.6-7', {
+        'checksums': ['fb91804fd465a4a6d9d9858e29fd05f41a99b8efdcc5cf4370ea253b68e42b01'],
+    }),
+    ('dismo', '1.1-4', {
+        'checksums': ['f2110f716cd9e4cca5fd2b22130c6954658aaf61361d2fe688ba22bbfdfa97c8'],
+    }),
+    ('extrafontdb', '1.0', {
+        'checksums': ['faa1bafee5d4fbc24d03ed237f29f1179964ebac6e3a46ac25b0eceda020b684'],
+    }),
+    ('Rttf2pt1', '1.3.6', {
+        'checksums': ['4eb1f3e0e5bcb11f8e2f6fa7d5ecb3410287291ba538f615872ab78fac20f1a2'],
+    }),
+    ('extrafont', '0.17', {
+        'checksums': ['2f6d7d79a890424b56ddbdced361f8b9ddede5edd33e090b816b88a99315332d'],
+    }),
+    ('fields', '9.6', {
+        'checksums': ['410424d74861ad0ba16f26e2b44bd63a9b590a190cc98c048dac55891422ffec'],
+    }),
+    ('shapefiles', '0.7', {
+        'checksums': ['eeb18ea4165119519a978d4a2ba1ecbb47649deb96a7f617f5b3100d63b3f021'],
+    }),
+    ('fossil', '0.3.7', {
+        'checksums': ['3feba6ceecaa6f2f68fdc1ceb0019395ccfadb0cf033e1709dddb690c7f210a1'],
+    }),
+    ('geiger', '2.0.6', {
+        'checksums': ['e13b2c526378eaf9356b00bbe21b3c2c956327f8062fed638ccc1f49591c3eff'],
+    }),
+    ('glmnet', '2.0-13', {
+        'checksums': ['f3288dcaddb2f7014d42b755bede6563f73c17bc87f8292c2ef7776cb9b9b8fd'],
+    }),
+    ('crosstalk', '1.0.0', {
+        'checksums': ['b31eada24cac26f24c9763d9a8cbe0adfd87b264cf57f8725027fe0c7742ca51'],
+    }),
+    ('rgl', '0.99.9', {
+        'checksums': ['b5bdc24ba7f86b940158ad72ac9069e7b80067f103493fc916a6af3a007e64e7'],
+    }),
+    ('labdsv', '1.8-0', {
+        'checksums': ['dfaeb03a6e1bab6cfd384c00671235b22f2b4254cac1129b24a348cb353b6e65'],
+    }),
+    ('stabs', '0.6-3', {
+        'checksums': ['e961ae21d45babc1162b6eeda874c4e3677fc286fd06f5427f071ad7a5064a9f'],
+    }),
+    ('modeltools', '0.2-21', {
+        'checksums': ['07b331475625674ab00e6ddfc479cbdbf0b22d5d237e8c25d83ddf3e0ad1cd7a'],
+    }),
+    ('strucchange', '1.5-1', {
+        'checksums': ['740e2e20477b9fceeef767ae1002adc5ec397cb0f7daba5289a2c23b0dddaf31'],
+    }),
+    ('TH.data', '1.0-8', {
+        'checksums': ['478f109fcc1226500ead8e3bd6e047cecde2294fde4df8ec216d38313db79a9d'],
+    }),
+    ('multcomp', '1.4-8', {
+        'checksums': ['a20876619312310e9523d67e9090af501383ce49dc6113c6b4ca30f9c943a73a'],
+    }),
+    ('coin', '1.2-2', {
+        'checksums': ['d518065d3e1eb00121cb4e0200e1e4ae6b68eca6e249afc38bbffa35d24105bb'],
+    }),
+    ('party', '1.2-4', {
+        'checksums': ['6c1d3ee9ce6f1ce8e33eefc3d28a504406be6470cac4da6dd4aab09166ff2182'],
+    }),
+    ('mboost', '2.8-1', {
+        'checksums': ['96a8b7daf5c6bc9240ad2e398867834ec18918c6cbdf64804ddc100a9b717798'],
+    }),
+    ('msm', '1.6.6', {
+        'checksums': ['fd12512d3cdca5fab634bf6222d896482bd1876192939da475f251b3a873a71a'],
+    }),
+    ('nor1mix', '1.2-3', {
+        'checksums': ['435e6519e832ef5229c51ccb2619640e6b50dfc7470f70f0c938d18a114273af'],
+    }),
+    ('np', '0.60-6', {
+        'checksums': ['59c37424161cfac331d1c8b6feec747010445f18f3c72e3c7bac269964e9e2f8'],
+    }),
+    ('polynom', '1.3-9', {
+        'checksums': ['d35a50925cc5552a6aac0816a91dbc03e9fd77da47e06d27572fde9dcbee9de8'],
+    }),
+    ('polspline', '1.1.12', {
+        'checksums': ['fc6bd2e0cca8c13cf099c54fe1e740730e26bb9793d439c395cf16ec8c2b0f32'],
+    }),
+    ('rms', '5.1-2', {
+        'checksums': ['f1cfeef466ac436105756679353a3468027d97a600e3be755b819aef30ed9207'],
+    }),
+    ('RWekajars', '3.9.2-1', {
+        'checksums': ['0e6c00ea2a0798dec828a3a3eb61fbcf43da305f1664f62774fbdb8e473dd600'],
+    }),
+    ('RWeka', '0.4-37', {
+        'checksums': ['fc0a3bb09b9d4dfefd7c3ada038d5d6b03c5091e1206e88ef7f045c18f8f19e0'],
+    }),
+    ('slam', '0.1-42', {
+        'checksums': ['7206b0189544c9878b83005f80f89626cc2c53cfe3e640aeaa9c3da1f07675df'],
+    }),
+    ('tm', '0.7-3', {
+        'checksums': ['f3c3e151e621ffb0c82048b5bf9c2a34c8fb34cf5d2943544979b4fcc2cc1c11'],
+    }),
+    ('TraMineR', '2.0-8', {
+        'checksums': ['394d4481707dfd8a4b0e28681097948ab36934dbe4084cf0917ae5f3e0bb9774'],
+    }),
+    ('chemometrics', '1.4.2', {
+        'checksums': ['b705832fa167dc24b52b642f571ed1efd24c5f53ba60d02c7797986481b6186a'],
+    }),
+    ('FNN', '1.1', {
+        'checksums': ['b2a2e97af14aa50ef4dce15a170e1d7329aebb7643bab4a6cf35609555acccce'],
+    }),
+    ('ipred', '0.9-6', {
+        'checksums': ['b8d36438eb9b7209d27b85738dcad03b2e535dcb2f4191432780d9cbf00d3cef'],
+    }),
+    ('statmod', '1.4.30', {
+        'checksums': ['9d2c1722a85f53623a9ee9f73d835119ae22ae2b8ec7b50d675401e314ea641f'],
+    }),
+    ('miscTools', '0.6-22', {
+        'checksums': ['d00bb2602d1d31e9e1e13c8868cfe69d432bbe15afa8d4bbb83b3c9e0b9dcfea'],
+    }),
+    ('maxLik', '1.3-4', {
+        'checksums': ['181ab87721b1e6e3859c60d12eea2f67a7135bfa679db73c20a9ef76d82c4b4a'],
+    }),
+    ('mlogit', '0.2-4', {
+        'checksums': ['5d9f5d20efd9d654e15875d813d9da3e756c7b8f25d8bb1f5d689a128fa7cd96'],
+    }),
+    ('getopt', '1.20.2', {
+        'checksums': ['3d6c12d32d6cd4b2909be626e570e158b3ed960e4739510e3a251e7f172de38e'],
+    }),
+    ('gsalib', '2.1', {
+        'checksums': ['e1b23b986c18b89a94c58d9db45e552d1bce484300461803740dacdf7c937fcc'],
+    }),
+    ('optparse', '1.4.4', {
+        'checksums': ['0b1f1d336f1be386260fb5bbdf74f01787c09176d69febf8d563e5af75e5c4b9'],
+    }),
+    ('miniUI', '0.1.1', {
+        'checksums': ['9c92032071ee75ee9c26c4cfd3115877fbcb15de2fd2023109c670784b51cce1'],
+    }),
+    ('hms', '0.4.2', {
+        'checksums': ['a57820b3e3221e973cba9500b4ad7953730110ee398693d150af833f26d5d0bc'],
+    }),
+    ('readr', '1.1.1', {
+        'checksums': ['1a29b99009a06f2cee18d08bc6201fd4985b6d45c76cefca65084dcc1a2f7cb3'],
+    }),
+    ('forcats', '0.3.0', {
+        'checksums': ['95814610ec18b8a8830eba63751954387f9d21400d6ab40394ed0ff22c0cb657'],
+    }),
+    ('haven', '1.1.1', {
+        'checksums': ['5f7bf6dbee431b4e64771d9d97ee2c3da5b8f66a5e81fd1ec78a236eb3de6cba'],
+    }),
+    ('labelled', '1.0.1', {
+        'checksums': ['9b7f1c5644f0e30496c291c84c52204b47d2b7da9aaefa332898aaae3226bfa2'],
+    }),
+    ('classInt', '0.1-24', {
+        'checksums': ['f3dc9084450ea3da07e1ea5eeb097fd2fedc7e29e5d7794b418bcb438c4fcfa2'],
+    }),
+    ('questionr', '0.6.2', {
+        'checksums': ['1dcad3c980548352f3a775ec089359b3f7737762e97c2a97c9a39cda4de54f56'],
+    }),
+    ('klaR', '0.6-13', {
+        'checksums': ['56b9689fc7ed5ece159056bcea181c9e670205a570095e76779a2a03d156171b'],
+    }),
+    ('neuRosim', '0.2-12', {
+        'checksums': ['f4f718c7bea2f4b61a914023015f4c71312f8a180124dcbc2327b71b7be256c3'],
+    }),
+    ('locfit', '1.5-9.1', {
+        'checksums': ['f524148fdb29aac3a178618f88718d3d4ac91283014091aa11a01f1c70cd4e51'],
+    }),
+    ('GGally', '1.3.2', {
+        'checksums': ['f4143f45254fed794be991180aeffe459f6756bfa08acad963707d8e843cfd0a'],
+    }),
+    ('beanplot', '1.2', {
+        'checksums': ['49da299139a47171c5b4ccdea79ffbbc152894e05d552e676f135147c0c9b372'],
+    }),
+    ('clValid', '0.6-6', {
+        'checksums': ['c13ef1b6258e34ba53615b78f39dbe4d8ba47b976b3c24a3eedaecf5ffba19ed'],
+    }),
+    ('matrixStats', '0.53.1', {
+        'checksums': ['df70bc9fb64716a7a633b5d0c2a2422b2c8d93ac5e64574528a325505df9712e'],
+    }),
+    ('DiscriMiner', '0.1-29', {
+        'checksums': ['5aab7671086ef9940e030324651976456f0e84dab35edb7048693ade885228c6'],
+    }),
+    ('ellipse', '0.4.1', {
+        'checksums': ['1a9a9c52195b26c2b4d51ad159ab98aff7aa8ca25fdc6b2198818d1a0adb023d'],
+    }),
+    ('leaps', '3.0', {
+        'checksums': ['55a879cdad5a4c9bc3b5697dd4d364b3a094a49d8facb6692f5ce6af82adf285'],
+    }),
+    ('nloptr', '1.0.4', {
+        'checksums': ['84225b993cb1ef7854edda9629858662cc8592b0d1344baadea4177486ece1eb'],
+    }),
+    ('lme4', '1.1-15', {
+        'checksums': ['7d9fd6309aae9cfa691236b3841a60f88ec70110faf2c1dabcbdff18e1ce8669'],
+    }),
+    ('pbkrtest', '0.4-7', {
+        'checksums': ['5cbb03ad2b2468720a5a610a0ebda48ac08119a34fca77810a85f554225c23ea'],
+    }),
+    ('car', '2.1-6', {
+        'checksums': ['d2426a66f63324d9db34dc89becb728d2d4b6d5f183f2efe02cbf683646a8492'],
+    }),
+    ('flashClust', '1.01-2', {
+        'checksums': ['48a7849bb86530465ff3fbfac1c273f0df4b846e67d5eee87187d250c8bf9450'],
+    }),
+    ('FactoMineR', '1.39', {
+        'checksums': ['b0bb1d6d7d1f3cb11a4b63c377321e10078a36f29bc78dfa3b80c7c149f4a08a'],
+    }),
+    ('flexclust', '1.3-5', {
+        'checksums': ['dbf49969c93a7b314d9dc3299a0764ed9a804ba7dcbdc08a1235f244f4b85059'],
+    }),
+    ('flexmix', '2.3-14', {
+        'checksums': ['837c7f175a211b3c484b2c7b81ec9729889a614c5c6e7d70c95a2c1d60ff846a'],
+    }),
+    ('prabclus', '2.2-6', {
+        'checksums': ['41792980e40ba18204fab92d85120dcd468860e2204e52fb42636c6f7aee5a62'],
+    }),
+    ('diptest', '0.75-7', {
+        'checksums': ['462900100ca598ef21dbe566bf1ab2ce7c49cdeab6b7a600a50489b05f61b61b'],
+    }),
+    ('trimcluster', '0.1-2', {
+        'checksums': ['622fb61580cc19b9061c6ee28ffd751250a127f07904b45a0e1c5438d25b4f53'],
+    }),
+    ('fpc', '2.1-11', {
+        'checksums': ['5975b31b63ad1e7b9c081ae42414e3d4de7a45e1a80100c2931aae5716d65411'],
+    }),
+    ('BiasedUrn', '1.07', {
+        'checksums': ['2377c2e59d68e758a566452d7e07e88663ae61a182b9ee455d8b4269dda3228e'],
+    }),
+    ('TeachingDemos', '2.10', {
+        'checksums': ['2ef4c2e36ba13e32f66000e84281a3616584c86b255bca8643ff3fe4f78ed704'],
+    }),
+    ('kohonen', '3.0.4', {
+        'checksums': [
+            '429864d72858c29d4187bed48ac1c17cf2ecb08f18090b6bf44dff55174609ab',  # kohonen_3.0.4.tar.gz
+        ],
+    }),
+    ('base64', '2.0', {
+        'checksums': ['8e259c2b12446197d1152b83a81bab84ccb5a5b77021a9b5645dd4c63c804bd1'],
+    }),
+    ('doRNG', '1.6.6', {
+        'checksums': ['939c2282c72c0b89fc7510f4bff901a4e99007dc006f46762c8f594c0ecbd876'],
+    }),
+    ('nleqslv', '3.3.1', {
+        'checksums': ['87eee7dad496539ede21bdb02bb0bc3793c9a390c000b0cd2bcd9b41ce5d3ad8'],
+    }),
+    ('Deriv', '3.8.4', {
+        'checksums': ['de4b7dfd4653dec9ae49987b8588c5ecfd7ef59081d9a1c55834da94bb5342d1'],
+    }),
+    ('RGCCA', '2.1.2', {
+        'checksums': ['20f341fca8f616c556699790814debdf2ac7aa4dd9ace2071100c66af1549d7d'],
+    }),
+    ('pheatmap', '1.0.8', {
+        'checksums': ['51468765380119c302ee9afd52d0483123c0670297f4b906edc79235939960c6'],
+    }),
+    ('openxlsx', '4.0.17', {
+        'checksums': ['116b9829c5a85ab1b7368d9f7f34a2248436f54bbf6ad635186c8a70b5a204d7'],
+    }),
+    ('pvclust', '2.0-0', {
+        'checksums': ['1a4615214992307fd7c786cf4607a3ae2af5c0d4067f5053e1c195798a70d741'],
+    }),
+    ('RCircos', '1.2.0', {
+        'checksums': ['7fd06e2efc33b5c30fc4ba3945b04021f255ba4ffcc394348df7488b9394444a'],
+    }),
+    ('lambda.r', '1.2', {
+        'checksums': ['7dc4188ce1d4a6b026a1b128719ff60234ae1e3ffa583941bbcd8473ad18146f'],
+    }),
+    ('futile.options', '1.0.0', {
+        'checksums': ['ee84ece359397fbb63f145d11af678f5c8618570971e78cc64ac60dc0d14e8c2'],
+    }),
+    ('futile.logger', '1.4.3', {
+        'checksums': ['5e8b32d65f77a86d17d90fd8690fc085aa0612df8018e4d6d6c1a60fa65776e4'],
+    }),
+    ('VennDiagram', '1.6.19', {
+        'checksums': ['c2baf466e072878643a28e971f11691dc830610ae8e7077d1adbd0be73e11338'],
+    }),
+    ('xlsxjars', '0.6.1', {
+        'checksums': ['37c1517f95f8bca6e3514429394d2457b9e62383305eba288416fb53ab2e6ae6'],
+    }),
+    ('xlsx', '0.5.7', {
+        'checksums': ['36727bc330c281dab8a028fab2dde92d032345974b15e3dde920ee16dc6db363'],
+    }),
+    ('forecast', '8.2', {
+        'checksums': [
+            'eb3fab64ed139d068e7d026cd3880f1b623f4153a832fb71845488fa75e8b812',  # forecast_8.2.tar.gz
+        ],
+    }),
+    ('fma', '2.3', {
+        'checksums': ['f516eff79e14d4ffefcdc2db06d97ae57f998e37e871264457078f671384fafc'],
+    }),
+    ('expsmooth', '2.3', {
+        'checksums': ['ac7da36347f983d6ec71715daefd2797fe2fc505c019f4965cff9f77ce79982a'],
+    }),
+    ('fpp', '0.5', {
+        'checksums': ['9c87dd8591b8a87327cae7a03fd362a5492495a96609e5845ccbeefb96e916cb'],
+    }),
+    ('maptools', '0.9-2', {
+        'checksums': ['3bf88cd06f69168d169727ca90d378dfedca77d80ebd26380b2708b3c6aab41c'],
+    }),
+    ('tensor', '1.5', {
+        'checksums': ['e1dec23e3913a82e2c79e76313911db9050fb82711a0da227f94fc6df2d3aea6'],
+    }),
+    ('polyclip', '1.6-1', {
+        'checksums': ['c33aac743f1a4c35d37791486a6628838f5fbff51001b4270aba813163e1bd1f'],
+    }),
+    ('goftest', '1.1-1', {
+        'checksums': ['db6cb1ff6e18520b172e93fca5d7d953bd2d06f4af73bf90aa0a09df8cad71a0'],
+    }),
+    ('spatstat.utils', '1.8-0', {
+        'checksums': ['cf412cb4ef44af63e8c9e01ca2aa86d665788cdb128fba5a0d9c499beb317214'],
+    }),
+    ('spatstat.data', '1.2-0', {
+        'checksums': ['f5f1da10a19b1eb3911d56aadea294e1c428d332076cf2ca8ad50c1b832ffc5b'],
+    }),
+    ('spatstat', '1.55-0', {
+        'checksums': ['6392b947a2c970dc3d1787d077398c67e0b8ab053061e4d8a4ad12de3ee0b716'],
+    }),
+    ('rgdal', '1.2-16', {
+        'checksums': ['017fefea4f9a6d4540d128c707197b7025b55e4aff98fc763065366b025b03c9'],
+    }),
+    ('gdalUtils', '2.0.1.7', {
+        'checksums': ['931138a03b37678f47a41a27dca4ba1938bed07a8a3e869f42feaa76aa380c59'],
+    }),
+    ('pracma', '2.1.4', {
+        'checksums': ['0ccaef86c1446971ca244e6dbcc605222c2f652b23a5db921070e37a6240f5f9'],
+    }),
+    ('RCurl', '1.95-4.10', {
+        'checksums': ['6f8324f1cb2de6ca818851bd9b83be33083f8752e76ce4187b7c39bda781fe0a'],
+    }),
+    ('bio3d', '2.3-3', {
+        'checksums': ['f4b45847eb8a4175dacea659f30a8075769ec1ae19daec6842b0d72227b48633'],
+    }),
+    ('AUC', '0.3.0', {
+        'checksums': ['e705f2c63d336249d19187f3401120d738d42d323fce905f3e157c2c56643766'],
+    }),
+    ('interpretR', '0.2.4', {
+        'checksums': ['4c08a6dffd6fd5764f27812f3a085c53e6a21d59ae82d903c9c0da93fd1dd059'],
+    }),
+    ('cvAUC', '1.1.0', {
+        'checksums': ['c4d8ed53b93869650aa2f666cf6d1076980cbfea7fa41f0b8227595be849738d'],
+    }),
+    ('SuperLearner', '2.0-23', {
+        'checksums': ['846c01080256d4c1d4570535599662ee8bcd95ceff753f2bcaaff0cf5a7f7a11'],
+    }),
+    ('lpSolve', '5.6.13', {
+        'checksums': ['d5d41c53212dead4fd8e6425a9d3c5767cdc5feb19d768a4704116d791cf498d'],
+    }),
+    ('mediation', '4.4.6', {
+        'checksums': ['b17784c001305d5f3b84573a673cef31475520d9baec972e42431be193bf305f'],
+    }),
+    ('ModelMetrics', '1.1.0', {
+        'checksums': ['487d53fda57da4b29f83a927dda8b1ae6655ab044ee3eec33c38aeb27eed3d85'],
+    }),
+    ('CVST', '0.2-1', {
+        'checksums': ['a27fd2bfa778fce9b9a68d2b9206c66af27b3c36a973dd45ce673886a267aa9f'],
+    }),
+    ('DRR', '0.0.3', {
+        'checksums': ['7493389c1fb9ddc4d4261e15bf2d4198603227275688b1d3e3994d47e976a1f9'],
+    }),
+    ('dimRed', '0.1.0', {
+        'checksums': ['fb0cef7a21b8a5219c74e5227a282168599dd63e904130366f3d2fed8a625a39'],
+    }),
+    ('lubridate', '1.7.3', {
+        'checksums': ['2cffbf54afce1d068e65241fb876a77b10ee907d5a19d2ffa84d5ba8a2c3f3df'],
+    }),
+    ('ddalpha', '1.3.1.1', {
+        'checksums': ['fe70c65758fc75365ac6ee537010777b24cb49fb830c5c899a19a0964b8e888f'],
+    }),
+    ('gower', '0.1.2', {
+        'checksums': ['eb91b2d2784d237c7055abcf3cfa4fc0b2226b855a0c29fc5a4e8eaa689079d5'],
+    }),
+    ('RcppRoll', '0.2.2', {
+        'checksums': ['51c76812687e2a8572c6037b0c095c0a30ee6a24783edf2c7c717d547ddfbfa7'],
+    }),
+    ('psych', '1.7.8', {
+        'checksums': ['f328ea602e22b0e7e5f310a8d19f305d8e0a3a86040cdfb64863b68b56d55135'],
+    }),
+    ('broom', '0.4.3', {
+        'checksums': ['2e261b40006432e787dc208c2a8943c6ae714968879dd3361ba1ee6ea5603785'],
+    }),
+    ('recipes', '0.1.2', {
+        'checksums': ['891a30cce1529e29a832f3aab92b38c9a0ef959a6fb144c0bf07595c871a59b1'],
+    }),
+    ('caret', '6.0-78', {
+        'checksums': ['dea8799853b9b0843d994b4dad09d1535547f36752ff70a956004111e3ef3640'],
+    }),
+    ('adabag', '4.2', {
+        'checksums': ['47019eb8cefc8372996fbb2642f64d4a91d7cedc192690a8d8be6e7e03cd3c81'],
+    }),
+    ('parallelMap', '1.3', {
+        'checksums': ['a52d93572c1b85281e41d8e3c2db97dda5fce96c222e04171b4489ec5000cd08'],
+    }),
+    ('ParamHelpers', '1.10', {
+        'checksums': ['80629ba62e93b0b706bf2e451578b94fbb9c5b95ff109ecfb5b011bfe0a0fa5b'],
+    }),
+    ('ggvis', '0.4.3', {
+        'checksums': ['34d517783016aaa1c4bef8972f4c06df5cd9ca0568035b647e60a8369043ecdc'],
+    }),
+    ('mlr', '2.12', {
+        'checksums': ['cfe00089ae4cd88c6d03826eda43d4fe29e467e3a7c95d103fafca8308f5c161'],
+    }),
+    ('unbalanced', '2.0', {
+        'checksums': ['9be32b1ce9d972f1abfff2fbe18f5bb5ba9c3f4fb1282063dc410b82ad4d1ea2'],
+    }),
+    ('RSNNS', '0.4-10', {
+        'checksums': ['f00d34a62e67ec14a7c1963f9f7f0f01c94fcf79ec7a5774a2fa49e475d81ace'],
+    }),
+    ('abc.data', '1.0', {
+        'checksums': ['b242f43c3d05de2e8962d25181c6b1bb6ca1852d4838868ae6241ca890b161af'],
+    }),
+    ('abc', '2.1', {
+        'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
+    }),
+    ('lhs', '0.16', {
+        'checksums': ['9cd199c3b5b2be1736d585ef0fd39a00e31fc015a053333a7a319668d0809425'],
+    }),
+    ('tensorA', '0.36', {
+        'checksums': ['97b3e72f26ca3a756d045008764d787a32c68f0a276fb7a29b6e1b4592fdecf6'],
+    }),
+    ('EasyABC', '1.5', {
+        'checksums': ['1dd7b1383a7c891cafb34d9cec65d92f1511a336cff1b219e63c0aa791371b9f'],
+    }),
+    ('shape', '1.4.4', {
+        'checksums': ['f4cb1b7d7c84cf08d2fa97f712ea7eb53ed5fa16e5c7293b820bceabea984d41'],
+    }),
+    ('whisker', '0.3-2', {
+        'checksums': ['484836510fcf123a66ddd13cdc8f32eb98e814cad82ed30c0294f55742b08c7c'],
+    }),
+    ('commonmark', '1.4', {
+        'checksums': ['865ecf9432763393ca9de52d0106a58c4be9e8d5196da60e068eed0b67ca68ed'],
+    }),
+    ('desc', '1.1.1', {
+        'checksums': ['32ff99b658db3bf0172cf30d15b7f34021144ffc08a5896afd3d30055fc4074c'],
+    }),
+    ('roxygen2', '6.0.1', {
+        'checksums': ['d22ddc05cd5308a48b8359b932e1f7f4c23fdf0c857ac8e52c42381b6bfcff76'],
+    }),
+    ('git2r', '0.21.0', {
+        'checksums': ['0480e4c47394ad1724c80982eff3be5ce34168046939340bf22cc1df6b6baf87'],
+    }),
+    ('rversions', '1.0.3', {
+        'checksums': ['21d0809f46505de89a2be7be9449e39c39cff5bc77e584dec976ee6c0b884f44'],
+    }),
+    ('devtools', '1.13.5', {
+        'checksums': ['fa59488415d7b601dc743cf6080834e6fbd49dda6ecd60629cca0fd8ced47cf4'],
+    }),
+    ('Rook', '1.1-1', {
+        'checksums': ['00f4ecfa4c5c57018acbb749080c07154549a6ecaa8d4130dd9de79427504903'],
+    }),
+    ('Cairo', '1.5-9', {
+        'patches': ['Cairo-1.5-9.patch'],
+        'checksums': [
+            '2a867b6cae96671d6bc3acf9334d6615dc01f6ecf1953a27cde8a43c724a38f4',  # Cairo_1.5-9.tar.gz
+            '3efa99888503949eefe586faf3f6f80566674c5a8cfb2c62b648b42f22466dfa',  # Cairo-1.5-9.patch
+        ],
+    }),
+    ('RMTstat', '0.3', {
+        'checksums': ['81eb4c5434d04cb66c749a434c33ceb1c07d92ba79765d4e9233c13a092ec2da'],
+    }),
+    ('Lmoments', '1.2-3', {
+        'checksums': ['e974b65d6116d540bc2c934c40c5552f64d7781b77c259a5b7724b1338c9e08e'],
+    }),
+    ('distillery', '1.0-4', {
+        'checksums': ['3d3a8445471b19a6b652761ca783994b2d2108b64ff539b0597a9db9697d17d4'],
+    }),
+    ('extRemes', '2.0-8', {
+        'checksums': ['d53d50d0feb6295f72c4f646242e1506ca51911c026f881d443d65f1c68ad75e'],
+    }),
+    ('pixmap', '0.4-11', {
+        'checksums': ['6fa010749a59cdf56aad9f81271473b7d55697036203f2cd5d81372bcded7412'],
+    }),
+    ('tkrplot', '0.0-23', {
+        'checksums': ['87a4323ce3bc6c852c2dae4727639b9a1c30724327a812379f21d73cecd7deb2'],
+    }),
+    ('misc3d', '0.8-4', {
+        'checksums': ['75de3d2237f67f9e58a36e80a6bbf7e796d43eb46789f2dd1311270007bf5f62'],
+    }),
+    ('multicool', '0.1-10', {
+        'checksums': [
+            '5bb0cb0d9eb64420c862877247a79bb0afadacfe23262ec8c3fa26e5e34d6ff9',  # multicool_0.1-10.tar.gz
+        ],
+    }),
+    ('plot3D', '1.1.1', {
+        'checksums': ['f6fe4a001387132626fc553ed1d5720d448b8064eb5a6917458a798e1d381632'],
+    }),
+    ('plot3Drgl', '1.0.1', {
+        'checksums': ['466d428d25c066c9c96d892f24da930513d42b1bdf76d3b53628c3ba13c3e48a'],
+    }),
+    ('OceanView', '1.0.4', {
+        'checksums': ['e67f6f376737e1e5cf22fdfe2769a8f674e90c886b0e43942e97d9a3e6924f1c'],
+    }),
+    ('ks', '1.11.0', {
+        'checksums': ['648e23578445049e4f73238b1c4b3a07e365c55577a9d8172cc69eaaf1377cf1'],
+    }),
+    ('logcondens', '2.1.5', {
+        'checksums': ['72e61abc1f3eb28830266fbe5b0da0999eb5520586000a3024e7c26be93c02eb'],
+    }),
+    ('Iso', '0.0-17', {
+        'checksums': ['c007d6eaf6335a15c1912b0804276ff39abce27b7a61539a91b8fda653629252'],
+    }),
+    ('penalized', '0.9-50', {
+        'checksums': ['c12b3259e019f91c7bd02827ea3a27f842d9c15950fa6cc114dff23c89c297d1'],
+    }),
+    ('clusterRepro', '0.5-1.1', {
+        'checksums': ['b7fcb9db0c762a2e6e22a0a0689affd73504c56f13c13b04272a946630334e6f'],
+    }),
+    ('randomForestSRC', '2.5.1', {
+        'checksums': ['ad45878dab93cdf5fbdd88cbcf5e6cdcceb7fae6b9dd8d2ccddac2d6ce2faadc'],
+    }),
+    ('sm', '2.2-5.4', {
+        'checksums': ['49f26c52728ac9dd2152d80ef1d3d59b98269bdc81616f81548fa4ed842ed842'],
+    }),
+    ('pbivnorm', '0.6.0', {
+        'checksums': ['07c37d507cb8f8d2d9ae51a9a6d44dfbebd8a53e93c242c4378eaddfb1cc5f16'],
+    }),
+    ('lavaan', '0.5-23.1097', {
+        'checksums': ['9aa7c3278f08f46b91fb0357dbdb9539936ba54e11d270d7febce0049efc9d87'],
+    }),
+    ('matrixcalc', '1.0-3', {
+        'checksums': ['17e6caeeecd596b850a6caaa257984398de9ec5d2b41ce83c428f112614b9cb0'],
+    }),
+    ('arm', '1.9-3', {
+        'checksums': ['1cefcc1d82431f1b3ed014ff04dd087fd0da3396df5a25144ffa80a8d01fe700'],
+    }),
+    ('mi', '1.0', {
+        'checksums': ['34f44353101e8c3cb6bf59c5f4ff5b2391d884dcbb9d23066a11ee756b9987c0'],
+    }),
+    ('visNetwork', '2.0.3', {
+        'checksums': ['bc2e75cf4cc1410d8eb528a38870666117e674f1b9ba5fa1ff769b8ab2e2462f'],
+    }),
+    ('rgexf', '0.15.3', {
+        'checksums': ['2e8a7978d1fb977318e6310ba65b70a9c8890185c819a7951ac23425c6dc8147'],
+    }),
+    ('influenceR', '0.1.0', {
+        'checksums': ['4fc9324179bd8896875fc0e879a8a96b9ef2a6cf42a296c3b7b4d9098519e98a'],
+    }),
+    ('downloader', '0.4', {
+        'checksums': ['1890e75b028775154023f2135cafb3e3eed0fe908138ab4f7eff1fc1b47dafab'],
+    }),
+    ('DiagrammeR', '1.0.0', {
+        'checksums': ['2b186dae1b19018681b979e9444bf16559c42740d8382676fbaf3b0f8a44337e'],
+    }),
+    ('sem', '3.1-9', {
+        'checksums': ['4a33780202506543da85877cd2813250114420d6ec5e75457bc67477cd332cb9'],
+    }),
+    ('jpeg', '0.1-8', {
+        'checksums': ['d032befeb3a414cefdbf70ba29a6c01541c54387cc0a1a98a4022d86cbe60a16'],
+    }),
+    ('network', '1.13.0', {
+        'checksums': ['7a04ea89261cdf32ccb52222810699d5fca59a849053e306b5ec9dd5c1184f87'],
+    }),
+    ('statnet.common', '4.0.0', {
+        'checksums': ['206e1967df661b277c6fde68f8b0bf4589508f569ff94f1ec5126c4c56a1867b'],
+    }),
+    ('sna', '2.4', {
+        'checksums': ['2292b3190e8d879e494527ae9d9d1174c31cb4183749ecb455aedd8d534048cf'],
+    }),
+    ('glasso', '1.8', {
+        'patches': [('glasso-1.8-ifort-no-fixed.patch', 1)],
+        'checksums': [
+            'fc9ba74519388c194e14bae39d41f3fec8c2aade0177df364f61753f0fbf8a3d',  # glasso_1.8.tar.gz
+            '87e966b6651c2d9ccd8a2c2ba842eef8dcbeaa3fdd25085bb1d5aff6e79f409c',  # glasso-1.8-ifort-no-fixed.patch
+        ],
+    }),
+    ('huge', '1.2.7', {
+        'checksums': ['042b771c334cf4d1a92c5c546ca025238919f772a50457594b7e0bd243498d8c'],
+    }),
+    ('d3Network', '0.5.2.1', {
+        'checksums': ['5c798dc0c87c6d574abb7c1f1903346e6b0fec8adfd1df7aef5e4f9e7e3a09be'],
+    }),
+    ('ggm', '2.3', {
+        'checksums': ['832ffe81ff87c6f1a6644e689ebbfb172924b4c4584ac8108d1244d153219ed8'],
+    }),
+    ('BDgraph', '2.44', {
+        'checksums': ['06c3cbe72024d6f38329bed1393ef1e8c877fe2343cabe0c8cd8bd8b9cacb714'],
+    }),
+    ('qgraph', '1.4.4', {
+        'checksums': ['f62a908a4185f30c2f6924a69f1a569a636fa3053de1e92288367b498b93f841'],
+    }),
+    ('HWxtest', '1.1.7', {
+        'checksums': ['7cfcf7860d655945f9d3bbda4590374d3100bb5da6b49956f2e701b910a20e0c'],
+    }),
+    ('diveRsity', '1.9.90', {
+        'checksums': ['b8f49cdbfbd82805206ad293fcb2dad65b962fb5523059a3e3aecaedf5c0ee86'],
+    }),
+    ('doSNOW', '1.0.16', {
+        'checksums': ['161434ecd55f04d6b070da784b222a7686c914b73de558eef6048a229022398e'],
+    }),
+    ('phangorn', '2.4.0', {
+        'checksums': ['31d0ea035b48d3940013f369e514351db19f9f92b2832c53f09f752b4a998875'],
+    }),
+    ('geepack', '1.2-1', {
+        'checksums': ['7effe67381129a48154c445704490ea3b5f2e1adedb66cb65f61369dd1f8d38d'],
+    }),
+    ('biom', '0.3.12', {
+        'checksums': ['4ad17f7811c7346dc4923bd6596a007c177eebb1944a9f46e5674afcc5fdd5a1'],
+    }),
+    ('pim', '2.0.1', {
+        'checksums': ['174568a01f68b9601a4ea89ca5857bf4888242f00e4212bfb7a422d6292300d5'],
+    }),
+    ('minpack.lm', '1.2-1', {
+        'checksums': ['14cb7dba3ef2b46da0479b46d46c76198e129a31f6157cd8b37f178adb15d5a3'],
+    }),
+    ('rootSolve', '1.7', {
+        'checksums': ['08b3bb63f04fc0b065cb615b6ca1ef95eb6df7a813eb9eb625bc15c6de332c22'],
+    }),
+    ('diagram', '1.6.4', {
+        'checksums': ['7c2bc5d5d634c3b8ca7fea79fb463e412962d88f47a77a74c811cc62f375ce38'],
+    }),
+    ('FME', '1.3.5', {
+        'checksums': ['3619d88df2a41ca8819b93bb7dff3b8233f76ff8ab0ca67c664f530f835935e4'],
+    }),
+    ('bmp', '0.3', {
+        'checksums': ['bdf790249b932e80bc3a188a288fef079d218856cf64ffb88428d915423ea649'],
+    }),
+    ('readbitmap', '0.1-4', {
+        'checksums': ['2d45ddd1ee0eb7482d5d4a9cfe41b3aa645de8af89295b4b205d73b19ac6d821'],
+    }),
+    ('imager', '0.40.2', {
+        'checksums': [
+            '12be25495c32883961e2503c8064aa90473fc36046630f582ae28c1c06995c9d',  # imager_0.40.2.tar.gz
+        ],
+    }),
+    ('signal', '0.7-6', {
+        'checksums': ['6b60277b07cf0167f8272059b128cc82f27a9bab1fd33d74c2a9e1f2abca5def'],
+    }),
+    ('tuneR', '1.3.2', {
+        'checksums': ['4aafd7d6330572711c117fa2d6e21e14485f695db38a7ebf5c7b3ba8723666f6'],
+    }),
+    ('pastecs', '1.3-18', {
+        'checksums': ['5188662294bf91545d0c2e4d7de113296f5a8c2cbf38bdc2a90f3f7d03b3b447'],
+    }),
+    ('audio', '0.1-5', {
+        'checksums': ['b4e229457a0a399b14136ac145e65bb007d9c8d46e421ae79fd26461450164c3'],
+    }),
+    ('fftw', '1.0-4', {
+        'checksums': ['80413901ce751c0700ac53283366cfcfe3cbeec2982d29721a0275f9fb9de204'],
+    }),
+    ('seewave', '2.1.0', {
+        'checksums': ['5ea4fd79fe99f094c6bb9092e6048490175e9bedcd6d6e97badc1143df861f44'],
+    }),
+    ('gsw', '1.0-5', {
+        'checksums': ['eb468918ee91e429b47fbcac43269eca627b7f64b61520de5bbe8fa223e96453'],
+    }),
+    ('oce', '0.9-23', {
+        'checksums': ['390fd082710ee1586074ff20df61208df4c76b9f2dc0c9b1125aade4c934b04c'],
+    }),
+    ('ineq', '0.2-13', {
+        'checksums': ['e0876403f59a3dfc2ea7ffc0d965416e1ecfdecf154e5856e5f54800b3efda25'],
+    }),
+    ('soundecology', '1.3.3', {
+        'checksums': ['276164d5eb92c78726c647be16232d2443acbf7061371ddde2672b4fdb7a069a'],
+    }),
+    ('memuse', '4.0-0', {
+        'checksums': ['fbf8716a1388692ee439f69ac99643fa427eb100027d8911ff0fbfdcb5b6c3bc'],
+    }),
+    ('pinfsc50', '1.1.0', {
+        'checksums': ['b6b9b6365a3f408533264d7ec820494f57eccaf362553e8478a46a8e5b474aba'],
+    }),
+    ('vcfR', '1.7.0', {
+        'checksums': ['ba6bce3861d1c87d2746984e736a0cbb977fd5ac450995f143b322887ed1a4ef'],
+    }),
+    ('glmmML', '1.0.2', {
+        'checksums': ['abc9ded054787f5459e0e419697927eb031f221be8e0cfdbf306f776d4b9bb59'],
+    }),
+    ('ucminf', '1.1-4', {
+        'checksums': ['a2eb382f9b24e949d982e311578518710f8242070b3aa3314a331c1e1e7f6f07'],
+    }),
+    ('ordinal', '2015.6-28', {
+        'checksums': ['fa33e29cc82bf241ad94fbbf5bb4dd6c9fe01803ba389957a4194d81e5979351'],
+    }),
+    ('Rtsne', '0.13', {
+        'checksums': [
+            '1c3bffe3bd11733ee4fe01749c293669daafda1af2ec74f9158f6080625b999d',  # Rtsne_0.13.tar.gz
+        ],
+    }),
+    ('cowplot', '0.9.2', {
+        'checksums': ['8b92ce7f92937fde06b0cfb86c7634a39b3b2101e362cc55c4bec6b3fde1d28f'],
+    }),
+    ('tsne', '0.1-3', {
+        'checksums': ['66fdf5d73e69594af529a9c4f261d972872b9b7bffd19f85c1adcd66afd80c69'],
+    }),
+    ('pbapply', '1.3-4', {
+        'checksums': ['cdfdaf9b8aecbe48daac858aecaf65a766b74a363d1eb7cd6ebf27c0549f6552'],
+    }),
+    ('RcppProgress', '0.4', {
+        'checksums': ['3b1ecc82ced98eb481819a28737dac3658586e11ad16a92abd14c4649ae15e25'],
+    }),
+    ('sn', '1.5-1', {
+        'checksums': ['fcfc077a2c1eb35b1ed875fea296b225540aefb05564cbb54477f266a0a2f850'],
+    }),
+    ('tclust', '1.3-1', {
+        'checksums': ['fe4479a73b947d8f6c1cc63587283a8b6223d430d39eee4e5833a06d3d1726d2'],
+    }),
+    ('ranger', '0.9.0', {
+        'checksums': ['17ecc45dae291f07c9a579bf05effe9d39dc70c75eefe4f5035422da6f9134de'],
+    }),
+    ('hexbin', '1.27.2', {
+        'checksums': ['46d47b1efef75d6f126af686a4dd614228b60418b9a5bde9e9e5d11200a0ee52'],
+    }),
+    ('pryr', '0.1.4', {
+        'checksums': ['d39834316504c49ecd4936cbbcaf3ee3dae6ded287af42475bf38c9e682f721b'],
+    }),
+    ('moments', '0.14', {
+        'checksums': ['2a3b81e60dafdd092d2bdd3513d7038855ca7d113dc71df1229f7518382a3e39'],
+    }),
+    ('laeken', '0.4.6', {
+        'checksums': ['465174263f2d495162bf1ee8ab35b362dae8088e458c162ce517813267d813e6'],
+    }),
+    ('VIM', '4.7.0', {
+        'checksums': ['cdd64cbdca23c097efa8d5084bfc1c0d1449744e90a41680a5246db979d14cee'],
+    }),
+    ('proxy', '0.4-21', {
+        'checksums': ['607770418758c7cb856c2e5da1e877270a60adc4a1f588588127edeff44330ee'],
+    }),
+    ('smoother', '1.1', {
+        'checksums': ['91b55b82f805cfa1deedacc0a4e844a2132aa59df593f3b05676954cf70a195b'],
+    }),
+    ('dynamicTreeCut', '1.63-1', {
+        'checksums': ['831307f64eddd68dcf01bbe2963be99e5cde65a636a13ce9de229777285e4db9'],
+    }),
+    ('DT', '0.4', {
+        'checksums': ['3daa96b819ca54e5fbc2c7d78cb3637982a2d44be58cea0683663b71cfc7fa19'],
+    }),
+    ('beeswarm', '0.2.3', {
+        'checksums': ['0115425e210dced05da8e162c8455526a47314f72e441ad2a33dcab3f94ac843'],
+    }),
+    ('vipor', '0.4.5', {
+        'checksums': ['7d19251ac37639d6a0fed2d30f1af4e578785677df5e53dcdb2a22771a604f84'],
+    }),
+    ('ggbeeswarm', '0.6.0', {
+        'checksums': ['bbac8552f67ff1945180fbcda83f7f1c47908f27ba4e84921a39c45d6e123333'],
+    }),
+    ('shinydashboard', '0.6.1', {
+        'checksums': ['1ee38f257433d24455426bc9d85c36f588735a54fbf6143935fed9cccb3bf193'],
+    }),
+    ('rrcov', '1.4-3', {
+        'checksums': ['d89631e0dfb39777af9fe303cc0537bbc82c6f3d2a1ed360de950c13dfc34f4d'],
+    }),
+    ('WriteXLS', '4.0.0', {
+        'checksums': ['a0541da45e16bc4bf994cdf3f07a0e202c38d52386460c64e27fe6c1cd889d5b'],
+    }),
+    ('bst', '0.3-14', {
+        'checksums': ['08013994d3ac79ffc78585cb2831d4d2e52f39423ba880f84c6224e4c6b6360b'],
+    }),
+    ('mpath', '0.3-4', {
+        'checksums': ['2a77539924c1aaf9eece2277b415f1df7146c44f04886b4e96d2d9ad32b6c262'],
+    }),
+    ('timereg', '1.9.2', {
+        'checksums': ['b0b969807e72003cc537c979f01b62e6199fa335baca4cf92473babcd19cac35'],
+    }),
+    ('peperr', '1.1-7', {
+        'checksums': ['73e0422c71f2df59cd4a0f820c87dd828f2952b60df2d6c58f62a35559d74605'],
+    }),
+    ('heatmap3', '1.1.1', {
+        'checksums': ['055e30a2fee0e8b6e499cdc5ccb7e37e5615ed3d52cc7058fc5ca5fc808cf393'],
+    }),
+    ('GlobalOptions', '0.0.12', {
+        'checksums': ['c09da3f9b1646d0f815056cdbeb5fff7dda29f7dd8742d245f5f6dc7066077a9'],
+    }),
+    ('circlize', '0.4.3', {
+        'checksums': ['ca768f40123262db745046a6209e59023cfd50af4d99bddc8ccffb3cdf21e95d'],
+    }),
+    ('GetoptLong', '0.1.6', {
+        'checksums': ['f526f006e3ed8507f1f236430ac9e97341c1ee9c207fbb68f936dd4d377b28b5'],
+    }),
+    ('dendextend', '1.7.0', {
+        'checksums': ['ad50970790561a661f0035e8f5e50943191755ff7c1d8a4befa3406b9bc23bcf'],
+    }),
+    ('RInside', '0.2.14', {
+        'checksums': ['8de5340993fe879ca00fa559c5b1b27b408ba78bfc5f67d36d6f0b8d8e8649cf'],
+    }),
+    ('limSolve', '1.5.5.3', {
+        'checksums': ['2f27c03411e0d771ad50d5412125bf4fa0ba461051610edc77e20d28488e86d2'],
+    }),
+    ('dbplyr', '1.2.1', {
+        'checksums': ['b348e7a02623f037632c85fb11be16c40c01755ae6ca02c8c189cdc192a699db'],
+    }),
+    ('modelr', '0.1.1', {
+        'checksums': ['25b95198d6aa23e28a0bd97dcdc78264ef168ae403928bff01e1ee81ca021ce7'],
+    }),
+    ('rematch', '1.0.1', {
+        'checksums': ['a409dec978cd02914cdddfedc974d9b45bd2975a124d8870d52cfd7d37d47578'],
+    }),
+    ('cellranger', '1.1.0', {
+        'checksums': ['5d38f288c752bbb9cea6ff830b8388bdd65a8571fd82d8d96064586bd588cf99'],
+    }),
+    ('readxl', '1.0.0', {
+        'checksums': ['fbd62f07fed7946363698a57be88f4ef3fa254ecf456ef292535849c787fc7ad'],
+    }),
+    ('debugme', '1.1.0', {
+        'checksums': ['4dae0e2450d6689a6eab560e36f8a7c63853abbab64994028220b8fd4b793ab1'],
+    }),
+    ('callr', '2.0.2', {
+        'checksums': ['778595e3f0b08f4e33a3103bd8e84a183945074f9e7404cdee8d72b7d3b8a154'],
+    }),
+    ('clipr', '0.4.0', {
+        'checksums': ['44a2f1ab4fde53e4fe81cf5800aa6ad45b72b5da93d6fe4d3661d7397220e8af'],
+    }),
+    ('reprex', '0.1.2', {
+        'checksums': ['7a6fc5f2a8f48ca5c6829811b899671b861f3d17cbe98bf87d343a5cf54ead80'],
+    }),
+    ('selectr', '0.3-2', {
+        'checksums': ['5e222b462b6d0ced877897da5cf2385128010c143979911e349f3c9c8991b94d'],
+    }),
+    ('rvest', '0.3.2', {
+        'checksums': ['0d6e8837fb1df79b1c83e7b48d8f1e6245f34a10c4bb6952e7bec7867e4abb12'],
+    }),
+    ('tidyverse', '1.2.1', {
+        'checksums': ['ad67a27bb4e89417a15338fe1a40251a7b5dedba60e9b72637963d3de574c37b'],
+    }),
+    ('R.cache', '0.13.0', {
+        'checksums': ['d3d4a99a676734ea53e96747d87857fa69615e59858804e92f8ad9ddcf62c5c1'],
+    }),
+    ('R.rsp', '0.42.0', {
+        'checksums': ['a02ebd3857849896f30993ed8306c88b03116250261d9d85dcee48103f0498fd'],
+    }),
+    ('listenv', '0.7.0', {
+        'checksums': ['6126020b111870baea08b36afa82777cd578e88c17db5435cd137f11b3964555'],
+    }),
+    ('globals', '0.11.0', {
+        'checksums': ['ac285bd040d02ddc230486a193f76fad78bb6f013577c702b0b58e9af6f3579f'],
+    }),
+    ('future', '1.7.0', {
+        'checksums': ['382a2a7c5840ea86ba0c995fbbef37b9bde9e0e5754aa8a39e8bb4f047e1df51'],
+    }),
+    ('gdistance', '1.2-1', {
+        'checksums': ['c1a74a86e31c26b6b1cd49c151c2e0ba362565667ec9971c08efc4194167cff3'],
+    }),
+    ('vioplot', '0.2', {
+        'checksums': ['601f043630999e0498f0fba213d3d3fefd6ff0abf8fdb22119199b3d8d58939b'],
+    }),
+    ('emulator', '1.2-15', {
+        'checksums': ['e221f185f610ca34d169c42dc560209094825ed0a4fe35db97892ca4ffc1e7e6'],
+    }),
+    ('gmm', '1.6-1', {
+        'checksums': ['c1d6ac78cfa302895934fbefbf6d073bfdd5c0c92708bfe4a46fb7775804383e'],
+    }),
+    ('tmvtnorm', '1.4-10', {
+        'checksums': ['1a9f35e9b4899672e9c0b263affdc322ecb52ec198b2bb015af9d022faad73f0'],
+    }),
+    ('IDPmisc', '1.1.17', {
+        'checksums': ['18ec9db0aab1de526b8e57ac1f0223811806a814777149b793722b999e6f7c59'],
+    }),
+    ('gap', '1.1-21', {
+        'checksums': ['fa94b64e3a9c77ff3b4bd5ef0faeb42e647bbaedf3127933bef30568cc5c546f'],
+    }),
+    ('qrnn', '2.0.2', {
+        'checksums': ['a4f786f767c02d65e6200ed0688c4e99e415815f44a6e980103dbb695ffc8f70'],
+    }),
+    ('DHARMa', '0.1.5', {
+        'checksums': ['97e3ad80583eb6612f59e225100a10364e39d23076e9a295c5f75c4aa1bffbd5'],
+    }),
+    ('bridgesampling', '0.4-0', {
+        'checksums': ['9577b535535b46022d06a7372ee309e2eb2ef0d045d65e2f3ed507f9b88062bf'],
+    }),
+    ('BayesianTools', '0.1.4', {
+        'checksums': ['ed0b68020a9f1b10eda4135a0734e2c88a09e7d3d1fd7b83772cdec1b680358e'],
+    }),
+    ('gomms', '1.0', {
+        'checksums': ['52828c6fe9b78d66bde5474e45ff153efdb153f2bd9f0e52a20a668e842f2dc5'],
+    }),
+    ('feather', '0.3.1', {
+        'checksums': ['f1069bf920e9bc3da6bf43542a3a7ccc3142544d759945115ecade69dd5ccde0'],
+    }),
+    ('tidyverse', '1.2.1', {
+        'checksums': ['ad67a27bb4e89417a15338fe1a40251a7b5dedba60e9b72637963d3de574c37b'],
+    }),
+    ('dummies', '1.5.6', {
+        'checksums': ['7551bc2df0830b98c53582cac32145d5ce21f5a61d97e2bb69fd848e3323c805'],
+    }),
+    ('SimSeq', '1.4.0', {
+        'checksums': ['5ab9d4fe2cb1b7634432ff125a9e04d2f574fed06246a93859f8004e10790f19'],
+    }),
+    ('fdrtool', '1.2.15', {
+        'checksums': ['65f964aa768d0703ceb7a199adc5e79ca79a6d29d7bc053a262eb533697686c0'],
+    }),
+    ('uniqueAtomMat', '0.1-3-2', {
+        'checksums': ['f7024e73274e1e76a870ce5e26bd58f76e8f6df0aa9775c631b861d83f4f53d7'],
+    }),
+    ('PoissonSeq', '1.1.2', {
+        'checksums': ['6f3dc30ad22e33e4fcfa37b3427c093d591c02f1b89a014d85e63203f6031dc2'],
+    }),
+    ('aod', '1.3', {
+        'checksums': ['e377effe345987850ece985eabf79750ca1979d75469d17a323c21515ad1dda8'],
+    }),
+    ('cghFLasso', '0.2-1', {
+        'checksums': ['6e697959b35a3ceb2baa1542ef81f0335006a5a9c937f0173c6483979cb4302c'],
+    }),
+    ('svd', '0.4.1', {
+        'checksums': ['6f585cb622cc52e2b7f3efddb7a363e91771bff80b8facb554755c2b33b7f402'],
+    }),
+    ('Rssa', '1.0', {
+        'checksums': ['9cc20a7101d8dff4c6cfb789f9bdc14e2b3bb128d7613a67b0f9633cf006902a'],
+    }),
+    ('JBTools', '0.7.2.9', {
+        'checksums': ['b33cfa17339df7113176ad1832cbb0533acf5d25c36b95e888f561d586c5d62f'],
+    }),
+    ('RUnit', '0.4.31', {
+        'checksums': ['9d764092216391c9d7e13bbe1585f5d00c357ed8b04c7e66ed82d229c34119cb'],
+    }),
+    ('DistributionUtils', '0.5-1', {
+        'checksums': ['e92a29003d5e5974f53e40bdb8417e2bdabe784304e21360d7a1cbec7818853f'],
+    }),
+    ('gapfill', '0.9.6', {
+        'checksums': ['850d0be9d05e3f3620f0f5143496321f1004ed966299bffd6a67a9abd8d9040d'],
+    }),
+]
+
+moduleclass = 'lang'


### PR DESCRIPTION
libgeotiff depedency was added to the GDAL module, since the R package `rgdal` was linking to `/usr/lib64/libgeotiff.so`, which resulted in errors. 