### PR TITLE
avoid that Nipype downloads dependencies for included extensions

### DIFF
--- a/easybuild/easyconfigs/l/lxml/lxml-4.2.0-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/l/lxml/lxml-4.2.0-intel-2018a-Python-3.6.4.eb
@@ -1,0 +1,27 @@
+easyblock = 'PythonPackage'
+
+name = 'lxml'
+version = '4.2.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://lxml.de/'
+description = """The lxml XML toolkit is a Pythonic binding for the C libraries libxml2 and libxslt."""
+
+toolchain = {'name': 'intel', 'version': '2018a'}
+
+source_urls = ['http://lxml.de/files/']
+sources = [SOURCE_TGZ]
+checksums = ['7d96fbb5f23a62300aa9bef7d286cd61aca8902357619c8708c0290aba5df73f']
+
+dependencies = [
+    ('Python', '3.6.4'),
+    ('libxml2', '2.9.7'),
+    ('libxslt', '1.1.32'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/Nipype/Nipype-1.0.2-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/n/Nipype/Nipype-1.0.2-intel-2018a-Python-3.6.4.eb
@@ -12,8 +12,7 @@ toolchain = {'name': 'intel', 'version': '2018a'}
 
 dependencies = [
     ('Python', '3.6.4'),
-    ('libxml2', '2.9.7'),
-    ('libxslt', '1.1.32'),
+    ('lxml', '4.2.0', versionsuffix),
     ('NiBabel', '2.2.1', versionsuffix),
 ]
 
@@ -34,6 +33,64 @@ exts_list = [
     ('future', '0.16.0', {
         'source_urls': ['https://pypi.python.org/packages/source/f/future'],
         'checksums': ['e39ced1ab767b5936646cedba8bcce582398233d6a627067d4c6a454c90cfedb'],
+    }),
+    ('packaging', '17.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/packaging'],
+        'checksums': ['f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b'],
+    }),
+    ('pydot', '1.2.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pydot'],
+        'checksums': ['92d2e2d15531d00710f2d6fb5540d2acabc5399d464f2f20d5d21073af241eb6'],
+    }),
+    ('pydotplus', '2.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pydotplus'],
+        'checksums': ['91e85e9ee9b85d2391ead7d635e3d9c7f5f44fd60a60e59b13e2403fa66505c4'],
+    }),
+    ('pluggy', '0.6.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pluggy'],
+        'checksums': ['7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff'],
+    }),
+    ('more-itertools', '4.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/more-itertools'],
+        'checksums': ['c9ce7eccdcb901a2c75d326ea134e0886abfbea5f93e91cc95de9507c0816c44'],
+        'modulename': 'more_itertools',
+    }),
+    ('attrs', '17.4.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/a/attrs'],
+        'checksums': ['1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9'],
+        'modulename': 'attr',
+    }),
+    ('py', '1.5.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/py'],
+        'checksums': ['29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881'],
+    }),
+    ('pytest', '3.5.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytest'],
+        'checksums': ['54713b26c97538db6ff0703a12b19aeaeb60b5e599de542e7fca0ec83b9038e8'],
+    }),
+    ('funcsigs', version, {
+        'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs'],
+        'checksums': ['a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50'],
+    }),
+    ('click', '6.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/click'],
+        'checksums': ['f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b'],
+    }),
+    ('isodate', '0.6.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/isodate'],
+        'checksums': ['2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8'],
+    }),
+    ('rdflib', '4.2.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/r/rdflib'],
+        'checksums': ['da1df14552555c5c7715d8ce71c08f404c988c58a1ecd38552d0da4fc261280d'],
+    }),
+    ('prov', '1.5.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/prov'],
+        'checksums': ['96a74efa1b3324961ff66246539ed7bdc06245dcbeef538688c755a0ad5777ee'],
+    }),
+    ('simplejson', '3.14.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/simplejson'],
+        'checksums': ['1ebbd84c2d7512f7ba65df0b9cc3cbc1bbd6ef9eab39fc9389dfe7e3681f7bd2'],
     }),
     ('nipype', version, {
         'source_urls': ['https://pypi.python.org/packages/source/n/nipype'],


### PR DESCRIPTION
Since this easyconfigs set `exts_download_dep_fail = True`, the download detection added in https://github.com/easybuilders/easybuild-easyblocks/pull/1377 will trigger a sanity check failure without listing these additional extensions explicitly...  