### PR TITLE
remove Python dependency from BLAST+ 2.7.1 easyconfig using foss/2018a toolchain

### DIFF
--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.7.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.7.1-foss-2018a.eb
@@ -14,7 +14,6 @@ easyblock = 'ConfigureMake'
 
 name = 'BLAST+'
 version = '2.7.1'
-versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://blast.ncbi.nlm.nih.gov/'
 description = """Basic Local Alignment Search Tool, or BLAST, is an algorithm
@@ -36,7 +35,6 @@ dependencies = [
     ('zlib', '1.2.11'),
     ('bzip2', '1.0.6'),
     ('PCRE', '8.41'),
-    ('Python', '2.7.14'),
     ('Boost', '1.66.0'),
     ('GMP', '6.1.2'),
     ('libpng', '1.6.34'),

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.7.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.7.1-foss-2018a.eb
@@ -43,7 +43,7 @@ dependencies = [
 ]
 
 configopts = "--with-64 --with-z=$EBROOTZLIB --with-bz2=$EBROOTBZIP2 --with-pcre=$EBROOTPCRE "
-configopts += "--with-python=$EBROOTPYTHON --with-boost=$EBROOTBOOST --with-gmp=$EBROOTGMP --with-png=$EBROOTLIBPNG "
+configopts += "--with-boost=$EBROOTBOOST --with-gmp=$EBROOTGMP --with-png=$EBROOTLIBPNG "
 configopts += "--with-jpeg=$EBROOTLIBJPEGMINTURBO --with-lmdb=$EBROOTLMDB"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.7.1-intel-2018a.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.7.1-intel-2018a.eb
@@ -14,7 +14,6 @@ easyblock = 'ConfigureMake'
 
 name = 'BLAST+'
 version = '2.7.1'
-versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://blast.ncbi.nlm.nih.gov/'
 description = """Basic Local Alignment Search Tool, or BLAST, is an algorithm
@@ -40,7 +39,6 @@ dependencies = [
     ('zlib', '1.2.11'),
     ('bzip2', '1.0.6'),
     ('PCRE', '8.41'),
-    ('Python', '2.7.14'),
     ('Boost', '1.66.0'),
     ('GMP', '6.1.2'),
     ('libpng', '1.6.34'),
@@ -49,7 +47,7 @@ dependencies = [
 ]
 
 configopts = "--with-64 --with-z=$EBROOTZLIB --with-bz2=$EBROOTBZIP2 --with-pcre=$EBROOTPCRE "
-configopts += "--with-python=$EBROOTPYTHON --with-boost=$EBROOTBOOST --with-gmp=$EBROOTGMP --with-png=$EBROOTLIBPNG "
+configopts += "--with-boost=$EBROOTBOOST --with-gmp=$EBROOTGMP --with-png=$EBROOTLIBPNG "
 configopts += "--with-jpeg=$EBROOTLIBJPEGMINTURBO --with-lmdb=$EBROOTLMDB"
 
 # configure script uses -openmp with Intel compilers, which is no longer valid (-fopenmp is more generic than -qopenmp)


### PR DESCRIPTION
After running into a version conflict on `Python` when combining `BLAST+` (which currently includes `Python` `2.7.14` as a dependency) with `R` (which indirectly depends on `Python` `3.6.4`), in the context of `Roary`, cfr. #6284), I looked into why we actually have `Python` listed as a dependency for `BLAST+`...

The only reason I could find is the `windowmasker_2.2.22_adapter.py`, which actually has `#!/usr/bin/python` hardcoded (so the `Python` we provide as a dependency is not used).
Moreover, I doubt the script is very relevant, can't seem to find much about it when searching the BLAST+ documentation... Note that there's also a `windowmasker` binary.

So, I propose we drop `Python` as a dependency to `BLAST+`, and rename the easyconfig accordingly. That way, we can also use this easyconfig in a situation where `Python` `3.6.4` is also pulled in.
The obvious other alternative is adding `BLAST+-2.7.1-*-2018a-Python-3.6.4.eb` easyconfigs, but that's silly imho, since i) the `python` we provide isn't used given the hardcoding, and ii) the `windowmasker_2.2.22_adapter.py` script is not compatible with Python 3.x...

We can easily do this for the easyconfig for `BLAST+` `2.7.1` built with `foss/2018` (which was added very recently in #6015), since that's not used as a dependency anywhere yet and it's not included in an EasyBuild release.
Doing the same for `BLAST+-2.7.1-intel-2017b-Python-2.7.14.eb` is a lot more painful, and since the dependency issue hasn't popped up there, I suggest we leave it as is (not worth the trouble) and only change this going forward.

I'd like to (also) hear @Serpens 's thoughts on this, since he contributed the easyconfig being changed here (cfr. #6015)...

If this gets merged, I'll update #6283 accordingly