### PR TITLE
also include patch + use -mno-avx512f to fix TensorFlow 1.8.0 built with foss/2018a on Intel Skylake (AVX512)

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.8.0-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.8.0-foss-2018a-Python-3.6.4.eb
@@ -30,4 +30,6 @@ builddependencies = [
 
 dependencies = [('Python', '3.6.4')]
 
+preconfigopts = 'export CC_OPT_FLAGS="$CC_OPT_FLAGS -mno-avx512f" && '
+
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.8.0-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.8.0-foss-2018a-Python-3.6.4.eb
@@ -13,12 +13,14 @@ patches = [
     'TensorFlow-1.5.0_swig-env.patch',
     'TensorFlow-%(version)s_remove-msse-hardcoding.patch',
     'TensorFlow-1.8.0_lrt-flag.patch',
+    'TensorFlow-1.6.0_use_64b_alignment.patch',
 ]
 checksums = [
     '47646952590fd213b747247e6870d89bb4a368a95ae3561513d6c76e44f92a75',  # v1.8.0.tar.gz
     '53807290f1acb6a0f2a84f1a0ad9f917ee131c304b3e08679f3cbd335b22c7ef',  # TensorFlow-1.5.0_swig-env.patch
     '4d043bba84d19aa38e402ef4ddaa89df936ae792f82693a49ce8ae4a1d091f6d',  # TensorFlow-1.8.0_remove-msse-hardcoding.patch
     '3c499788266800c71fa9874d411df79f7331320b3a86bc7c79c74763ae04c143',  # TensorFlow-1.8.0_lrt-flag.patch
+    'bcff66b5cc7a98e2ae894df6940aac5e3dcec3700773d24a6c3a5a69128ef66f',  # TensorFlow-1.6.0_use_64b_alignment.patch
 ]
 
 builddependencies = [


### PR DESCRIPTION
cfr. #6286