### PR TITLE
change back checksum for libdap 3.19.1

### DIFF
--- a/easybuild/easyconfigs/l/libdap/libdap-3.19.1-intel-2017b.eb
+++ b/easybuild/easyconfigs/l/libdap/libdap-3.19.1-intel-2017b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2017b'}
 
 source_urls = ['http://www.opendap.org/pub/source/']
 sources = [SOURCE_TAR_GZ]
-checksums = ['fb7014b6047cf3fa47d05c0faf258636f664c5fc232ff0886a78dfc5aae29f8f']
+checksums = ['5215434bacf385ba3f7445494ce400a5ade3995533d8d38bb97fcef1478ad33e']
 
 builddependencies = [
     ('Bison', '3.0.4'),


### PR DESCRIPTION
This reverts commit 19d037e91a2edbdd26f87a4797e972bcd50d29e4 (PR #5473), since apparently the original tarball was re-instated (on Dec 28th 2017, if the timestamp in https://www.opendap.org/pub/source/ can be trusted).