### PR TITLE
{perf}[foss/2018a] Score-P 4.0 + Scalasca 2.4 + deps (WIP)

### DIFF
--- a/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.3-foss-2018a.eb
+++ b/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.3-foss-2018a.eb
@@ -1,0 +1,37 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2013-2018 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'OPARI2'
+version = '2.0.3'
+
+homepage = 'http://www.score-p.org'
+description = """OPARI2, the successor of Forschungszentrum Juelich's OPARI,
+ is a source-to-source instrumentation tool for OpenMP and hybrid codes.
+ It surrounds OpenMP directives and runtime library calls with calls to
+ the POMP2 measurement interface."""
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+
+source_urls = ['http://www.vi-hps.org/upload/packages/opari2/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '7e2efcfbc99152ee6e31454ef4fb747f77165691539d5d2c1df2abc4612de86c',  # opari2-2.0.3.tar.gz
+]
+
+sanity_check_paths = {
+    'files': ['bin/opari2', 'include/opari2/pomp2_lib.h'],
+    'dirs': [],
+}
+
+moduleclass = 'perf'


### PR DESCRIPTION
Full-toolchain versions (flat MNS) for foss/2018a.