### PR TITLE
rename 'Canu' to 'canu' for v1.7

### DIFF
--- a/easybuild/easyconfigs/c/canu/canu-1.7-intel-2018a.eb
+++ b/easybuild/easyconfigs/c/canu/canu-1.7-intel-2018a.eb
@@ -1,6 +1,6 @@
 easyblock = 'MakeCp'
 
-name = 'Canu'
+name = 'canu'
 version = '1.7'
 
 homepage = 'http://canu.readthedocs.io'


### PR DESCRIPTION
Amendment to #6377

We already have easyconfigs for the same software under the name `canu`...