### PR TITLE
{cae}[foss/2018a] OpenFOAM-5.0 

### DIFF
--- a/easybuild/easyconfigs/c/CGAL/CGAL-4.11.1-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/c/CGAL/CGAL-4.11.1-foss-2018a-Python-2.7.14.eb
@@ -1,0 +1,37 @@
+name = 'CGAL'
+version = '4.11.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.cgal.org/'
+description = """The goal of the CGAL Open Source Project is to provide easy access to efficient
+ and reliable geometric algorithms in the form of a C++ library."""
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+toolchainopts = {'strict': True}
+
+source_urls = ['https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-%(version)s']
+sources = [SOURCE_TAR_XZ]
+checksums = ['fb152fc30f007e5911922913f8dc38e0bb969b534373ca0fbe85b4d872300e8b']
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('Python', '2.7.14'),
+    ('Boost', '1.66.0'),
+    ('MPFR', '4.0.1'),
+    ('GMP', '6.1.2'),
+    ('libGLU', '9.0.0'),
+    ('Qt5', '5.10.1'),
+]
+
+builddependencies = [
+    ('CMake', '3.10.2'),
+    ('Eigen', '3.3.4', '', True),
+]
+
+configopts = "-DOPENGL_INCLUDE_DIR=$EBROOTMESA/include\;$EBROOTLIBGLU/include "
+configopts += "-DOPENGL_gl_LIBRARY=$EBROOTMESA/lib/libGL.%s " % SHLIB_EXT
+configopts += "-DOPENGL_glu_LIBRARY=$EBROOTLIBGLU/lib/libGLU.%s " % SHLIB_EXT
+configopts += "-DWITH_ZLIB=ON -DWITH_MPFR=ON -DWITH_OpenGL=ON -DWITH_Eigen3=ON "
+configopts += "-DWITH_GMPXX=ON -DWITH_LAPACK=ON -DWITH_BLAS=ON "
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-5.0-20180108-foss-2018a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-5.0-20180108-foss-2018a.eb
@@ -1,0 +1,45 @@
+name = 'OpenFOAM'
+# bugfix release of OpenFOAM 5.0, see also https://openfoam.org/news/v5-0-patch/
+# https://github.com/OpenFOAM/OpenFOAM-5.x/commit/c409ae7d90966250bb3be9cfbc2a0538bc8e288d
+version = '5.0-20180108'
+commit = 'c409ae7'
+
+homepage = 'http://www.openfoam.org/'
+description = """OpenFOAM is a free, open source CFD software package.
+ OpenFOAM has an extensive range of features to solve anything from complex fluid flows
+ involving chemical reactions, turbulence and heat transfer,
+ to solid dynamics and electromagnetics."""
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+toolchainopts = {'cstd': 'c++11'}
+
+source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version_major)s.x/archive']
+sources = [{'download_filename': '%s.tar.gz' % commit, 'filename': SOURCE_TAR_GZ}]
+patches = [
+    'OpenFOAM-%(version)s_cleanup.patch',
+    'OpenFOAM-%(version)s_fix-decomposedBlockData.patch',
+]
+checksums = [
+    'bc805137ce65674c9067257ab239e1f2f820b12edfaf40a4d7c6de260dc6ad25',  # OpenFOAM-5.0-20180108.tar.gz
+    'f5768f5dbc422fc2f4183fd288dc6afb2370115384f3e8b9b0e155c943868989',  # OpenFOAM-5.0-20180108_cleanup.patch
+    # OpenFOAM-5.0-20180108_fix-decomposedBlockData.patch
+    '62c1585a43503c7550355ec6417fbfd28c22e750f559eaf72785d2bb630a4005',
+]
+
+dependencies = [
+    ('libreadline', '7.0'),
+    ('ncurses', '6.0'),
+    # OpenFOAM requires 64 bit METIS using 32 bit indexes (array indexes)
+    ('METIS', '5.1.0'),
+    ('SCOTCH', '6.0.5'),
+    ('CGAL', '4.11.1', '-Python-2.7.14'),
+    ('ParaView', '5.4.1', '-mpi'),
+]
+
+builddependencies = [
+    ('CMake', '3.10.2'),
+    ('Bison', '3.0.4'),
+    ('flex', '2.6.4'),
+]
+
+moduleclass = 'cae'

--- a/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.5-foss-2018a.eb
+++ b/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.5-foss-2018a.eb
@@ -1,0 +1,19 @@
+name = 'SCOTCH'
+version = '6.0.5'
+
+homepage = 'http://gforge.inria.fr/projects/scotch/'
+description = """Software package and libraries for sequential and parallel graph partitioning,
+static mapping, and sparse matrix block ordering, and sequential mesh and hypergraph partitioning."""
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://gforge.inria.fr/frs/download.php/file/34618/']
+sources = ['%(namelower)s_%(version)s.tar.gz']
+checksums = ['f53f4d71a8345ba15e2dd4e102a35fd83915abf50ea73e1bf6efe1bc2b4220c7']
+
+dependencies = [
+    ('zlib', '1.2.11'),
+]
+
+moduleclass = 'math'


### PR DESCRIPTION
@boegel it seems to be the case that ParaView is able to build with Qt5, which means that Qt4 from #6394 can be removed again? Also should the intel version of ParaView also adapt to use Qt5?
If you prefer to stay with using Qt4 it is also fine for me.

The documentation of Paraview also states:
> ParaView can still be built with Qt4, though it is not recommended.