### PR TITLE
{bio} [intel/2018a] PANDASeq 2.11

### DIFF
--- a/easybuild/easyconfigs/p/PANDAseq/PANDAseq-2.11-intel-2018a.eb
+++ b/easybuild/easyconfigs/p/PANDAseq/PANDAseq-2.11-intel-2018a.eb
@@ -14,12 +14,14 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['6e3e35d88c95f57d612d559e093656404c1d48c341a8baa6bef7bb0f09fc8f82']
 
 dependencies = [
-    ('libtool', '2.4.6'),
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.11'),
 ]
 
-builddependencies = [('Autoconf', '2.69')]
+builddependencies = [
+    ('Autotools', '20170619'),
+    ('pkg-config', '0.29.2'),
+]
 
 preconfigopts = "./autogen.sh &&"
 

--- a/easybuild/easyconfigs/p/PANDAseq/PANDAseq-2.11-intel-2018a.eb
+++ b/easybuild/easyconfigs/p/PANDAseq/PANDAseq-2.11-intel-2018a.eb
@@ -4,16 +4,14 @@ name = 'PANDAseq'
 version = '2.11'
 
 homepage = 'https://github.com/neufeld/pandaseq'
-description = """PANDASEQ is a program to align Illumina reads, optionally with PCR primers embedded in the sequence, and reconstruct an overlapping sequence."""
+description = """PANDASEQ is a program to align Illumina reads, optionally with PCR primers embedded
+    in the sequence, and reconstruct an overlapping sequence."""
 
 toolchain = {'name': 'intel', 'version': '2018a'}
 
-# download from https://github.com/neufeld/pandaseq/archive/v2.11.tar.gz
 source_urls = ['https://github.com/neufeld/%(namelower)s/archive/v%(version)s']
 sources = [SOURCELOWER_TAR_GZ]
-
-checksums = [('sha512', '1c37b8f777b698fe02df0248b9352c9550af7da0c739d0186f9973d4b4fcc30febc9c6345b098bd96ffb5dce703ccd201850fc543caad3e9da09b0e38fec4396')]
-
+checksums = ['6e3e35d88c95f57d612d559e093656404c1d48c341a8baa6bef7bb0f09fc8f82']
 
 dependencies = [
     ('libtool', '2.4.6'),
@@ -21,12 +19,12 @@ dependencies = [
     ('zlib', '1.2.11'),
 ]
 
-builddependencies = [('Autoconf', '2.69','',('GCCcore','6.4.0'))]
+builddependencies = [('Autoconf', '2.69')]
 
 preconfigopts = "./autogen.sh &&"
 
 sanity_check_paths = {
-    'files': ['bin/pandaseq', 'bin/pandaseq-checkid', 'bin/pandaseq-hang', 'bin/pandaxs','bin/pandaseq-diff',
+    'files': ['bin/pandaseq', 'bin/pandaseq-checkid', 'bin/pandaseq-hang', 'bin/pandaxs', 'bin/pandaseq-diff',
               'lib/libpandaseq.%s' % SHLIB_EXT, 'lib/libpandaseq.a', 'lib/pkgconfig/pandaseq-%(version_major)s.pc'],
     'dirs': ['include/pandaseq-%(version_major)s'],
 }

--- a/easybuild/easyconfigs/p/PANDAseq/PANDAseq-2.11-intel-2018a.eb
+++ b/easybuild/easyconfigs/p/PANDAseq/PANDAseq-2.11-intel-2018a.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'PANDAseq'
+version = '2.11'
+
+homepage = 'https://github.com/neufeld/pandaseq'
+description = """PANDASEQ is a program to align Illumina reads, optionally with PCR primers embedded in the sequence, and reconstruct an overlapping sequence."""
+
+toolchain = {'name': 'intel', 'version': '2018a'}
+
+# download from https://github.com/neufeld/pandaseq/archive/v2.11.tar.gz
+source_urls = ['https://github.com/neufeld/%(namelower)s/archive/v%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+
+checksums = [('sha512', '1c37b8f777b698fe02df0248b9352c9550af7da0c739d0186f9973d4b4fcc30febc9c6345b098bd96ffb5dce703ccd201850fc543caad3e9da09b0e38fec4396')]
+
+
+dependencies = [
+    ('libtool', '2.4.6'),
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+]
+
+builddependencies = [('Autoconf', '2.69','',('GCCcore','6.4.0'))]
+
+preconfigopts = "./autogen.sh &&"
+
+sanity_check_paths = {
+    'files': ['bin/pandaseq', 'bin/pandaseq-checkid', 'bin/pandaseq-hang', 'bin/pandaxs','bin/pandaseq-diff',
+              'lib/libpandaseq.%s' % SHLIB_EXT, 'lib/libpandaseq.a', 'lib/pkgconfig/pandaseq-%(version_major)s.pc'],
+    'dirs': ['include/pandaseq-%(version_major)s'],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
A slight adaption of `PANDAseq-2.5-goolf-1.4.10.eb` to install a newer version of PANDASeq with the intel toolchain.