### PR TITLE
drop '-mpi' versionsuffix for VTK 8.1.1

### DIFF
--- a/easybuild/easyconfigs/v/VTK/VTK-8.1.1-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-8.1.1-intel-2018a-Python-2.7.14.eb
@@ -14,7 +14,7 @@ easyblock = 'CMakeMake'
 
 name = 'VTK'
 version = '8.1.1'
-versionsuffix = '-Python-%(pyver)s-mpi'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://www.vtk.org'
 description = """The Visualization Toolkit (VTK) is an open-source, freely available software system for


### PR DESCRIPTION
#6404 was merged a bit prematurely...

We should always build VTK with MPI support enabled from now on imho.