### PR TITLE
stop including GCCcore 6.4.0 as build dep for GCCcore 8.1.0

### DIFF
--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-8.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-8.1.0.eb
@@ -42,8 +42,6 @@ checksums = [
 builddependencies = [
     ('M4', '1.4.18'),
     ('binutils', '2.30'),
-    # a sufficiently recent GCC is required (needs to support -flto), so can't rely on system GCC
-    ('GCCcore', '6.4.0'),
 ]
 
 languages = ['c', 'c++', 'fortran']


### PR DESCRIPTION
requires https://github.com/easybuilders/easybuild-easyblocks/pull/1435 to not cause problems on CentOS 6.x

@migueldiascosta Please test this on top of https://github.com/easybuilders/easybuild-easyblocks/pull/1435 on CentOS 6.x?