### PR TITLE
add patch for GCCcore 6.4.0 to fix compilation problems on glibc 2.26 systems

### DIFF
--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.4.0.eb
@@ -24,7 +24,6 @@ source_urls = [
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies
     'http://isl.gforge.inria.fr/',  # original HTTP source for ISL
 ]
-
 sources = [
     'gcc-%(version)s.tar.gz',
     'gmp-6.1.2.tar.bz2',
@@ -32,17 +31,11 @@ sources = [
     'mpc-1.0.3.tar.gz',
     'isl-0.16.1.tar.bz2',
 ]
-
-builddependencies = [
-    ('M4', '1.4.18'),
-    ('binutils', '2.28'),
-]
-
 patches = [
     ('mpfr-%s-allpatches-20170606.patch' % mpfr_version, '../mpfr-%s' % mpfr_version),
     'GCCcore-6.2.0-fix-find-isl.patch',
+    'GCCcore-%(version)s_fix-linux-unwind-fix-ucontext.patch',
 ]
-
 checksums = [
     '4715f02413f8a91d02d967521c084990c99ce1a671b8a450a80fbd4245f4b728',  # gcc-6.4.0.tar.gz
     '5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2',  # gmp-6.1.2.tar.bz2
@@ -51,6 +44,13 @@ checksums = [
     '412538bb65c799ac98e17e8cfcdacbb257a57362acfaaff254b0fcae970126d2',  # isl-0.16.1.tar.bz2
     '137108952139486755e8c1bee30314ffa9233cc05cddfd848aa85503a6fea9d7',  # mpfr-3.1.5-allpatches-20170606.patch
     '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68',  # GCCcore-6.2.0-fix-find-isl.patch
+    # GCCcore-6.4.0_fix-linux-unwind-fix-ucontext.patch
+    'af893036033bfcdbc60d59c58f5bf190e38c75bec970d02d8873a9a751028fcb',
+]
+
+builddependencies = [
+    ('M4', '1.4.18'),
+    ('binutils', '2.28'),
 ]
 
 languages = ['c', 'c++', 'fortran']

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.4.0_fix-linux-unwind-fix-ucontext.patch
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.4.0_fix-linux-unwind-fix-ucontext.patch
@@ -1,0 +1,23 @@
+fix compilation of GCC on system with glibc 2.26
+see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81712
+patch taken from https://gcc.gnu.org/viewcvs/gcc?limit_changes=0&view=revision&revision=249957
+--- libgcc/config/i386/linux-unwind.h	2017/07/04 10:22:56	249956
++++ libgcc/config/i386/linux-unwind.h	2017/07/04 10:23:57	249957
+@@ -58,7 +58,7 @@
+   if (*(unsigned char *)(pc+0) == 0x48
+       && *(unsigned long long *)(pc+1) == RT_SIGRETURN_SYSCALL)
+     {
+-      struct ucontext *uc_ = context->cfa;
++      ucontext_t *uc_ = context->cfa;
+       /* The void * cast is necessary to avoid an aliasing warning.
+          The aliasing warning is correct, but should not be a problem
+          because it does not alias anything.  */
+@@ -138,7 +138,7 @@
+ 	siginfo_t *pinfo;
+ 	void *puc;
+ 	siginfo_t info;
+-	struct ucontext uc;
++	ucontext_t uc;
+       } *rt_ = context->cfa;
+       /* The void * cast is necessary to avoid an aliasing warning.
+          The aliasing warning is correct, but should not be a problem


### PR DESCRIPTION
cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/6374#issuecomment-392257938

cc @geimer