### PR TITLE
{debugger}[foss/2018a] GDB v8.1

### DIFF
--- a/easybuild/easyconfigs/g/GDB/GDB-8.1-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/g/GDB/GDB-8.1-foss-2018a-Python-2.7.14.eb
@@ -1,0 +1,38 @@
+easyblock = 'ConfigureMake'
+
+name = 'GDB'
+version = '8.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.gnu.org/software/gdb/gdb.html'
+description = "The GNU Project Debugger"
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['af61a0263858e69c5dce51eab26662ff3d2ad9aa68da9583e8143b5426be4b34']
+
+builddependencies = [
+    ('texinfo', '6.5'),
+]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('libreadline', '7.0'),
+    ('ncurses', '6.0'),
+    ('expat', '2.2.5'),
+    ('Python', '2.7.14'),
+]
+
+configopts = '--with-system-zlib --with-python=$EBROOTPYTHON/bin/python --with-expat=$EBROOTEXPAT '
+configopts += '--with-system-readline --enable-tui --enable-plugins'
+
+parallel = 1
+
+sanity_check_paths = {
+    'files': ['bin/gdb', 'bin/gdbserver'],
+    'dirs': [],
+}
+
+moduleclass = 'debugger'


### PR DESCRIPTION
It was necessary to add a build dependency upon texinfo since the build failed without access to makeinfo which wasn't installed on our system.