### PR TITLE
also check for multiple dependency variants in easyconfigs using GCCcore 7.3.0 & newer

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -221,7 +221,8 @@ class EasyConfigTest(TestCase):
             return res
 
         # restrict to checking dependencies of easyconfigs using common toolchains (start with 2018a)
-        for pattern in ['201[89][ab]', '20[2-9][0-9][ab]']:
+        # and GCCcore subtoolchain for common toolchains, starting with GCCcore 7.x
+        for pattern in ['201[89][ab]', '20[2-9][0-9][ab]', 'GCCcore-[7-9]\.[0-9]']:
             all_deps = {}
             regex = re.compile('^.*-(?P<tc_gen>%s).*\.eb$' % pattern)
 


### PR DESCRIPTION
Since `GCCcore` 7.3.0 is most likely going to become the base for the `2018b` common toolchains, we should extend the "dependency variants" we're doing for easyconfigs using a common toolchain to also check easyconfigs using a recent version of the `GCCcore` toolchain

cc @hajgato 
