### PR TITLE
fix checksums for pkgmaker/rngtools/RWeka/RcppProgress extensions in R 3.4.4 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
@@ -8,8 +8,8 @@ description = """R is a free software environment for statistical computing and 
 
 toolchain = {'name': 'foss', 'version': '2018a'}
 
-sources = [SOURCE_TAR_GZ]
 source_urls = ['https://cloud.r-project.org/src/base/R-%(version_major)s']
+sources = [SOURCE_TAR_GZ]
 checksums = ['b3e97d2fab7256d1c655c4075934725ba1cd7cb9237240a11bb22ccdad960337']
 
 builddependencies = [
@@ -717,10 +717,10 @@ exts_list = [
         'checksums': ['5d8be59ba791987b2400e9e8eaaac614cd544c1aece785ec4782ea6d5ea00efb'],
     }),
     ('pkgmaker', '0.22', {
-        'checksums': ['19ad78c16bd5757333e7abbd5eebcec081deb494c9a4b6eec6919a3747b3386f'],
+        'checksums': ['05da8b6c0e6828676aeb3faa05ea6e1025b95efffde4820e9ae2b938dbb3027e'],
     }),
     ('rngtools', '1.2.4', {
-        'checksums': ['27019835b750f470b13dbb7fecd3b839a61b52774e23fffa191f919533768fb9'],
+        'checksums': ['17409ada52a2405efa931b5895254cac0e28518a0d41f05012ba3f8af8af3556'],
     }),
     ('doParallel', '1.0.11', {
         'checksums': ['4ccbd2eb46d3e4f5251b0c3de4d93d9168b02bb0be493656d6aea236667ff76a'],
@@ -900,9 +900,7 @@ exts_list = [
         'checksums': ['55403252d8bae9627476d1f553236ea5dc7aa6e54da6980526a6cdc66924e155'],
     }),
     ('bigmemory', '4.5.33', {
-        'checksums': [
-            '7237d9785d8ce3eab4e36ad3ce2c95cbae926326031661b4f237b7517f4b9479',  # bigmemory_4.5.33.tar.gz
-        ],
+        'checksums': ['7237d9785d8ce3eab4e36ad3ce2c95cbae926326031661b4f237b7517f4b9479'],
     }),
     ('calibrate', '1.7.2', {
         'checksums': ['78066a564f57f2110f1752d681d6b97915cf73135134330587fff8b46c581604'],
@@ -995,7 +993,7 @@ exts_list = [
         'checksums': ['0e6c00ea2a0798dec828a3a3eb61fbcf43da305f1664f62774fbdb8e473dd600'],
     }),
     ('RWeka', '0.4-37', {
-        'checksums': ['fc0a3bb09b9d4dfefd7c3ada038d5d6b03c5091e1206e88ef7f045c18f8f19e0'],
+        'checksums': ['bf9b54e0a871d0b6f3e703fe9d996c7d5917371677889bc14a31e20ca990d9af'],
     }),
     ('slam', '0.1-42', {
         'checksums': ['7206b0189544c9878b83005f80f89626cc2c53cfe3e640aeaa9c3da1f07675df'],
@@ -1133,9 +1131,7 @@ exts_list = [
         'checksums': ['2ef4c2e36ba13e32f66000e84281a3616584c86b255bca8643ff3fe4f78ed704'],
     }),
     ('kohonen', '3.0.4', {
-        'checksums': [
-            '429864d72858c29d4187bed48ac1c17cf2ecb08f18090b6bf44dff55174609ab',  # kohonen_3.0.4.tar.gz
-        ],
+        'checksums': ['429864d72858c29d4187bed48ac1c17cf2ecb08f18090b6bf44dff55174609ab'],
     }),
     ('base64', '2.0', {
         'checksums': ['8e259c2b12446197d1152b83a81bab84ccb5a5b77021a9b5645dd4c63c804bd1'],
@@ -1183,9 +1179,7 @@ exts_list = [
         'checksums': ['36727bc330c281dab8a028fab2dde92d032345974b15e3dde920ee16dc6db363'],
     }),
     ('forecast', '8.2', {
-        'checksums': [
-            'eb3fab64ed139d068e7d026cd3880f1b623f4153a832fb71845488fa75e8b812',  # forecast_8.2.tar.gz
-        ],
+        'checksums': ['eb3fab64ed139d068e7d026cd3880f1b623f4153a832fb71845488fa75e8b812'],
     }),
     ('fma', '2.3', {
         'checksums': ['f516eff79e14d4ffefcdc2db06d97ae57f998e37e871264457078f671384fafc'],
@@ -1378,9 +1372,7 @@ exts_list = [
         'checksums': ['75de3d2237f67f9e58a36e80a6bbf7e796d43eb46789f2dd1311270007bf5f62'],
     }),
     ('multicool', '0.1-10', {
-        'checksums': [
-            '5bb0cb0d9eb64420c862877247a79bb0afadacfe23262ec8c3fa26e5e34d6ff9',  # multicool_0.1-10.tar.gz
-        ],
+        'checksums': ['5bb0cb0d9eb64420c862877247a79bb0afadacfe23262ec8c3fa26e5e34d6ff9'],
     }),
     ('plot3D', '1.1.1', {
         'checksums': ['f6fe4a001387132626fc553ed1d5720d448b8064eb5a6917458a798e1d381632'],
@@ -1519,9 +1511,7 @@ exts_list = [
         'checksums': ['2d45ddd1ee0eb7482d5d4a9cfe41b3aa645de8af89295b4b205d73b19ac6d821'],
     }),
     ('imager', '0.40.2', {
-        'checksums': [
-            '12be25495c32883961e2503c8064aa90473fc36046630f582ae28c1c06995c9d',  # imager_0.40.2.tar.gz
-        ],
+        'checksums': ['12be25495c32883961e2503c8064aa90473fc36046630f582ae28c1c06995c9d'],
     }),
     ('signal', '0.7-6', {
         'checksums': ['6b60277b07cf0167f8272059b128cc82f27a9bab1fd33d74c2a9e1f2abca5def'],
@@ -1572,9 +1562,7 @@ exts_list = [
         'checksums': ['fa33e29cc82bf241ad94fbbf5bb4dd6c9fe01803ba389957a4194d81e5979351'],
     }),
     ('Rtsne', '0.13', {
-        'checksums': [
-            '1c3bffe3bd11733ee4fe01749c293669daafda1af2ec74f9158f6080625b999d',  # Rtsne_0.13.tar.gz
-        ],
+        'checksums': ['1c3bffe3bd11733ee4fe01749c293669daafda1af2ec74f9158f6080625b999d'],
     }),
     ('cowplot', '0.9.2', {
         'checksums': ['8b92ce7f92937fde06b0cfb86c7634a39b3b2101e362cc55c4bec6b3fde1d28f'],
@@ -1586,7 +1574,7 @@ exts_list = [
         'checksums': ['cdfdaf9b8aecbe48daac858aecaf65a766b74a363d1eb7cd6ebf27c0549f6552'],
     }),
     ('RcppProgress', '0.4', {
-        'checksums': ['3b1ecc82ced98eb481819a28737dac3658586e11ad16a92abd14c4649ae15e25'],
+        'checksums': ['706e14360dbc5976db05c2ac6692c3279c0f8c95e72bf9d4becd9e1348025e3e'],
     }),
     ('sn', '1.5-1', {
         'checksums': ['fcfc077a2c1eb35b1ed875fea296b225540aefb05564cbb54477f266a0a2f850'],

--- a/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
@@ -717,10 +717,10 @@ exts_list = [
         'checksums': ['5d8be59ba791987b2400e9e8eaaac614cd544c1aece785ec4782ea6d5ea00efb'],
     }),
     ('pkgmaker', '0.22', {
-        'checksums': ['19ad78c16bd5757333e7abbd5eebcec081deb494c9a4b6eec6919a3747b3386f'],
+        'checksums': ['05da8b6c0e6828676aeb3faa05ea6e1025b95efffde4820e9ae2b938dbb3027e'],
     }),
     ('rngtools', '1.2.4', {
-        'checksums': ['27019835b750f470b13dbb7fecd3b839a61b52774e23fffa191f919533768fb9'],
+        'checksums': ['17409ada52a2405efa931b5895254cac0e28518a0d41f05012ba3f8af8af3556'],
     }),
     ('doParallel', '1.0.11', {
         'checksums': ['4ccbd2eb46d3e4f5251b0c3de4d93d9168b02bb0be493656d6aea236667ff76a'],
@@ -997,7 +997,7 @@ exts_list = [
         'checksums': ['0e6c00ea2a0798dec828a3a3eb61fbcf43da305f1664f62774fbdb8e473dd600'],
     }),
     ('RWeka', '0.4-37', {
-        'checksums': ['fc0a3bb09b9d4dfefd7c3ada038d5d6b03c5091e1206e88ef7f045c18f8f19e0'],
+        'checksums': ['bf9b54e0a871d0b6f3e703fe9d996c7d5917371677889bc14a31e20ca990d9af'],
     }),
     ('slam', '0.1-42', {
         'checksums': ['7206b0189544c9878b83005f80f89626cc2c53cfe3e640aeaa9c3da1f07675df'],
@@ -1602,7 +1602,7 @@ exts_list = [
         'checksums': ['cdfdaf9b8aecbe48daac858aecaf65a766b74a363d1eb7cd6ebf27c0549f6552'],
     }),
     ('RcppProgress', '0.4', {
-        'checksums': ['3b1ecc82ced98eb481819a28737dac3658586e11ad16a92abd14c4649ae15e25'],
+        'checksums': ['706e14360dbc5976db05c2ac6692c3279c0f8c95e72bf9d4becd9e1348025e3e'],
     }),
     ('sn', '1.5-1', {
         'checksums': ['fcfc077a2c1eb35b1ed875fea296b225540aefb05564cbb54477f266a0a2f850'],

--- a/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
@@ -717,10 +717,10 @@ exts_list = [
         'checksums': ['5d8be59ba791987b2400e9e8eaaac614cd544c1aece785ec4782ea6d5ea00efb'],
     }),
     ('pkgmaker', '0.22', {
-        'checksums': ['19ad78c16bd5757333e7abbd5eebcec081deb494c9a4b6eec6919a3747b3386f'],
+        'checksums': ['05da8b6c0e6828676aeb3faa05ea6e1025b95efffde4820e9ae2b938dbb3027e'],
     }),
     ('rngtools', '1.2.4', {
-        'checksums': ['27019835b750f470b13dbb7fecd3b839a61b52774e23fffa191f919533768fb9'],
+        'checksums': ['17409ada52a2405efa931b5895254cac0e28518a0d41f05012ba3f8af8af3556'],
     }),
     ('doParallel', '1.0.11', {
         'checksums': ['4ccbd2eb46d3e4f5251b0c3de4d93d9168b02bb0be493656d6aea236667ff76a'],
@@ -997,7 +997,7 @@ exts_list = [
         'checksums': ['0e6c00ea2a0798dec828a3a3eb61fbcf43da305f1664f62774fbdb8e473dd600'],
     }),
     ('RWeka', '0.4-37', {
-        'checksums': ['fc0a3bb09b9d4dfefd7c3ada038d5d6b03c5091e1206e88ef7f045c18f8f19e0'],
+        'checksums': ['bf9b54e0a871d0b6f3e703fe9d996c7d5917371677889bc14a31e20ca990d9af'],
     }),
     ('slam', '0.1-42', {
         'checksums': ['7206b0189544c9878b83005f80f89626cc2c53cfe3e640aeaa9c3da1f07675df'],
@@ -1602,7 +1602,7 @@ exts_list = [
         'checksums': ['cdfdaf9b8aecbe48daac858aecaf65a766b74a363d1eb7cd6ebf27c0549f6552'],
     }),
     ('RcppProgress', '0.4', {
-        'checksums': ['3b1ecc82ced98eb481819a28737dac3658586e11ad16a92abd14c4649ae15e25'],
+        'checksums': ['706e14360dbc5976db05c2ac6692c3279c0f8c95e72bf9d4becd9e1348025e3e'],
     }),
     ('sn', '1.5-1', {
         'checksums': ['fcfc077a2c1eb35b1ed875fea296b225540aefb05564cbb54477f266a0a2f850'],


### PR DESCRIPTION
No idea what happened, but when downloading the following files from CRAN now, the checksums are different than before.

That's strange, especially for `pkgmaker_0.22.tar.gz` and `rngtools_1.2.4.tar.gz`, both of which were downloaded on Jan 16th 2015 and haven't changed since (until now, that is).