### PR TITLE
Move zstd from GCCcore to foss

### DIFF
--- a/easybuild/easyconfigs/z/zstd/zstd-1.3.4-foss-2016b.eb
+++ b/easybuild/easyconfigs/z/zstd/zstd-1.3.4-foss-2016b.eb
@@ -9,13 +9,11 @@ description = """Zstandard is a real-time compression algorithm, providing high 
  It also offers a special mode for small data, called dictionary compression, and can create dictionaries
  from any sample set."""
 
-toolchain = {'name': 'GCCcore', 'version': '5.4.0'}
+toolchain = {'name': 'foss', 'version': '2016b'}
 
 source_urls = ['https://github.com/facebook/zstd/archive/']
 sources = ['v%(version)s.tar.gz']
 checksums = ['92e41b6e8dd26bbd46248e8aa1d86f1551bc221a796277ae9362954f26d605a9']
-
-builddependencies = [('binutils', '2.26')]
 
 dependencies = [
     ('zlib', '1.2.8'),


### PR DESCRIPTION
For this old toolchain there may be issues related to Lmod loading the same `zlib` version from both `GCCcore` and `foss`. For example see #6450 
The issue is solved by promoting `zstd` from `GCCcore` to `foss`.