### PR TITLE
Guile 1.8.8: added necessary compiler flag

### DIFF
--- a/easybuild/easyconfigs/g/Guile/Guile-1.8.8-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/g/Guile/Guile-1.8.8-GCCcore-6.4.0.eb
@@ -24,7 +24,7 @@ dependencies = [
     ('GMP', '6.1.2'),
 ]
 
-configopts = 'CFLAGS="$CFLAGS -Wno-unused-but-set-variable -Wno-misleading-indentation"'
+configopts = 'CFLAGS="$CFLAGS -Wno-unused-but-set-variable -Wno-misleading-indentation -Wno-error=maybe-uninitialized"'
 
 sanity_check_paths = {
     'files': ['bin/guile', 'bin/guile-config', 'bin/guile-snarf', 'bin/guile-tools',


### PR DESCRIPTION
Because -Werror is added, building this fails with
   ramap.c:704:7: error: ‘ras’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
I have added -Wno-error=maybe-uninitialized to circumvent this.