### PR TITLE
{data} [intel/2018a] PnetCDF v1.9.0

### DIFF
--- a/easybuild/easyconfigs/p/PnetCDF/PnetCDF-1.9.0-intel-2018a.eb
+++ b/easybuild/easyconfigs/p/PnetCDF/PnetCDF-1.9.0-intel-2018a.eb
@@ -12,15 +12,11 @@ source_urls = ['http://cucis.ece.northwestern.edu/projects/PnetCDF/Release/']
 sources = ['parallel-netcdf-%(version)s.tar.gz']
 checksums = ['356e1e1fae14bc6c4236ec11435cfea0ff6bde2591531a4a329f9508a01fbe98']
 
-# configopts = '--enable-shared'
-
 sanity_check_paths = {
     'files': ['bin/pnetcdf_version'],
     'dirs': ['include', 'lib'],
 }
 
-modextravars = {
-    'PNETCDF': '%(installdir)s',
-}
+modextravars = {'PNETCDF': '%(installdir)s'}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/p/PnetCDF/PnetCDF-1.9.0-intel-2018a.eb
+++ b/easybuild/easyconfigs/p/PnetCDF/PnetCDF-1.9.0-intel-2018a.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'PnetCDF'
+version = '1.9.0'
+
+homepage = 'https://trac.mcs.anl.gov/projects/parallel-netcdf'
+description = """Parallel netCDF: A Parallel I/O Library for NetCDF File Access"""
+
+toolchain = {'name': 'intel', 'version': '2018a'}
+
+source_urls = ['http://cucis.ece.northwestern.edu/projects/PnetCDF/Release/']
+sources = ['parallel-netcdf-%(version)s.tar.gz']
+checksums = ['356e1e1fae14bc6c4236ec11435cfea0ff6bde2591531a4a329f9508a01fbe98']
+
+# configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/pnetcdf_version'],
+    'dirs': ['include', 'lib'],
+}
+
+modextravars = {
+    'PNETCDF': '%(installdir)s',
+}
+
+moduleclass = 'data'


### PR DESCRIPTION
Doesn't build with `configopts = '--enable-shared'` so only static libraries (as is also the case in the only other `PnetCDF` eb file).

