### PR TITLE
build hwloc 1.11.10 with -fno-tree-vectorize to avoid segfaulting lstopo on Intel Skylake

### DIFF
--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.10-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.10-GCCcore-7.3.0.eb
@@ -17,6 +17,9 @@ description = """
 """
 
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+# need to build with -fno-tree-vectorize to avoid segfaulting lstopo on Intel Skylake
+# cfr. https://github.com/open-mpi/hwloc/issues/315
+toolchainopts = {'vectorize': False}
 
 source_urls = ['https://www.open-mpi.org/software/hwloc/v%(version_major_minor)s/downloads/']
 sources = [SOURCE_TAR_GZ]
@@ -37,5 +40,6 @@ sanity_check_paths = {
               'lib/libhwloc.%s' % SHLIB_EXT],
     'dirs': ['share/man/man3'],
 }
+sanity_check_commands = ['lstopo']
 
 moduleclass = 'system'


### PR DESCRIPTION
see also https://github.com/easybuilders/easybuild-easyconfigs/pull/6424#issuecomment-397601063 and https://github.com/open-mpi/hwloc/issues/315