### PR TITLE
{lib} [GCCcore/6.4.0, intel/2018a] FANN v2.2.0

### DIFF
--- a/easybuild/easyconfigs/f/FANN/FANN-2.2.0-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/f/FANN/FANN-2.2.0-GCCcore-6.4.0.eb
@@ -1,0 +1,27 @@
+easyblock = 'CMakeMake'
+
+name = 'FANN'
+version = '2.2.0'
+
+homepage = 'http://leenissen.dk'
+description = """Fast Artificial Neural Network Library is a free open source neural network library,
+ which implements multilayer artificial neural networks in C with support for both fully connected
+ and sparsely connected networks."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
+
+source_urls = ['https://github.com/lib%(namelower)s/%(namelower)s/archive']
+sources = ['%(version)s.tar.gz']
+checksums = ['f31c92c1589996f97d855939b37293478ac03d24b4e1c08ff21e0bd093449c3c']
+
+builddependencies = [
+    ('binutils', '2.28'),
+    ('CMake', '3.9.5'),
+]
+
+sanity_check_paths = {
+    'files': ['include/fann.h', 'lib/libfann.%s' % SHLIB_EXT],
+    'dirs': ['include', 'lib'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/f/FANN/FANN-2.2.0-intel-2018a.eb
+++ b/easybuild/easyconfigs/f/FANN/FANN-2.2.0-intel-2018a.eb
@@ -1,0 +1,24 @@
+easyblock = 'CMakeMake'
+
+name = 'FANN'
+version = '2.2.0'
+
+homepage = 'http://leenissen.dk'
+description = """Fast Artificial Neural Network Library is a free open source neural network library,
+ which implements multilayer artificial neural networks in C with support for both fully connected
+ and sparsely connected networks."""
+
+toolchain = {'name': 'intel', 'version': '2018a'}
+
+source_urls = ['https://github.com/lib%(namelower)s/%(namelower)s/archive']
+sources = ['%(version)s.tar.gz']
+checksums = ['f31c92c1589996f97d855939b37293478ac03d24b4e1c08ff21e0bd093449c3c']
+
+builddependencies = [('CMake', '3.9.5')]
+
+sanity_check_paths = {
+    'files': ['include/fann.h', 'lib/libfann.%s' % SHLIB_EXT],
+    'dirs': ['include', 'lib'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
I'm not sure both an intel/2018a flavour and a GCCcore/6.4.0 one is needed, so I can remove the intel one if that's thought to be better practice.