### PR TITLE
enable checking/setting of unlimited stack limit in Python 3.6.x easyconfigs using an 'intel' toolchain

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.6.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.1-intel-2017a.eb
@@ -29,6 +29,10 @@ dependencies = [
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
+# try and make sure stack limit is set to unlimited, to avoid compilation errors for hashlib with Intel compilers
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/6484
+ulimit_unlimited = True
+
 # order is important!
 # package versions updated May 28th 2015
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2017b.eb
@@ -29,6 +29,10 @@ dependencies = [
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
+# try and make sure stack limit is set to unlimited, to avoid compilation errors for hashlib with Intel compilers
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/6484
+ulimit_unlimited = True
+
 # order is important!
 # package versions updated August 31st 2017
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2018.00.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2018.00.eb
@@ -29,6 +29,10 @@ dependencies = [
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
+# try and make sure stack limit is set to unlimited, to avoid compilation errors for hashlib with Intel compilers
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/6484
+ulimit_unlimited = True
+
 # order is important!
 # package versions updated August 31st 2017
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2017b.eb
@@ -29,6 +29,10 @@ dependencies = [
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
+# try and make sure stack limit is set to unlimited, to avoid compilation errors for hashlib with Intel compilers
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/6484
+ulimit_unlimited = True
+
 # workaround for "undefined symbol: __stack_chk_guard"
 # see also https://software.intel.com/en-us/forums/intel-c-compiler/topic/610514
 buildopts = 'LDFLAGS="$LDFLAGS -lssp"'

--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2018.01.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2018.01.eb
@@ -29,6 +29,10 @@ dependencies = [
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
+# try and make sure stack limit is set to unlimited, to avoid compilation errors for hashlib with Intel compilers
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/6484
+ulimit_unlimited = True
+
 # order is important!
 # package versions updated November 24th 2017
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-3.6.4-intel-2018a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.4-intel-2018a.eb
@@ -29,6 +29,10 @@ dependencies = [
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
+# try and make sure stack limit is set to unlimited, to avoid compilation errors for hashlib with Intel compilers
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/6484
+ulimit_unlimited = True
+
 # workaround for "undefined symbol: __stack_chk_guard"
 # see also https://software.intel.com/en-us/forums/intel-c-compiler/topic/610514
 buildopts = 'LDFLAGS="$LDFLAGS -lssp"'


### PR DESCRIPTION
fix for #6484

requires https://github.com/easybuilders/easybuild-easyblocks/pull/1441