### PR TITLE
bump Pysam dep for MAJIQ to 0.14.1 to fix compatibility with other 2018a easyconfigs

### DIFF
--- a/easybuild/easyconfigs/m/MAJIQ/MAJIQ-1.1.1-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/m/MAJIQ/MAJIQ-1.1.1-intel-2018a-Python-3.6.4.eb
@@ -20,7 +20,7 @@ builddependencies = [
 ]
 dependencies = [
     ('Python', '3.6.4'),
-    ('Pysam', '0.14', versionsuffix),
+    ('Pysam', '0.14.1', versionsuffix),
     ('matplotlib', '2.1.2', versionsuffix),
     ('h5py', '2.7.1', versionsuffix),
 ]

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.14.1-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.14.1-intel-2018a-Python-3.6.4.eb
@@ -1,0 +1,38 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# Author: Pablo Escobar Lopez
+# sciCORE - University of Basel
+# SIB Swiss Institute of Bioinformatics 
+# 0.9.1.4:
+# Modified by: Adam Huffman
+# The Francis Crick Institute
+# Modified by: Erich Birngruber
+# Gregor Mendel Institute
+
+easyblock = 'PythonPackage'
+
+name = 'Pysam'
+version = '0.14.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/pysam-developers/pysam'
+description = """Pysam is a python module for reading and manipulating Samfiles. 
+ It's a lightweight wrapper of the samtools C-API. Pysam also includes an interface for tabix."""
+
+toolchain = {'name': 'intel', 'version': '2018a'}
+
+source_urls = ['https://github.com/pysam-developers/pysam/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['d2bb40cd083c1357768e4683377f03471d160cfe8421136630bfa47f5adb3219']
+
+dependencies = [
+    ('Python', '3.6.4'),
+    ('ncurses', '6.0'),
+    ('cURL', '7.58.0'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
follow-up for #5983, tests fail because of multiple variants of Pysam being found without this