### PR TITLE
fix missing dependencies for Perl modules included as extensions for Perl 5.26.1

### DIFF
--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.1-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.1-GCCcore-6.4.0.eb
@@ -13,6 +13,10 @@ checksums = ['e763aa485e8dc1a70483dbe6d615986bbf32b977f38016480d68c99237e701dd']
 
 builddependencies = [('binutils', '2.28')]
 
+dependencies = [
+    ('expat', '2.2.5'),  # for XML::Parser
+]
+
 # !! order of extensions is important !!
 # extensions updated on Jan 31st 2018
 exts_list = [
@@ -85,6 +89,11 @@ exts_list = [
         'source_tmpl': 'Test-Warnings-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
         'checksums': ['ae2b68b1b5616704598ce07f5118efe42dc4605834453b7b2be14e26f9cc9a08'],
+    }),
+    ('File::ShareDir', '1.116', {
+        'source_tmpl': 'File-ShareDir-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+        'checksums': ['59d90bfdf98c4656ff4173e62954ea8cf0de66565e35d108ecd7050596cb8328'],
     }),
     ('File::ShareDir::Install', '0.11', {
         'source_tmpl': 'File-ShareDir-Install-%(version)s.tar.gz',
@@ -261,6 +270,11 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
         'checksums': ['156b13f07764f766d8b45a43728f2439af81a3512625438deab783b7883eb533'],
     }),
+    ('Text::Aligner', '0.13', {
+        'source_tmpl': 'Text-Aligner-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
+        'checksums': ['e61c1c93cdefd9cc2a40f12fa8bfb12e64bb06d2375ba9e61534249865103eef'],
+    }),
     ('Text::Table', '1.133', {
         'source_tmpl': 'Text-Table-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
@@ -376,6 +390,11 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
         'checksums': ['aa12d1a4c0ac260b94d448fa01feba242a8a85cb6cbfdc66432e3b5b468add96'],
     }),
+    ('Net::SSLeay', '1.85', {
+        'source_tmpl': 'Net-SSLeay-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MI/MIKEM'],
+        'checksums': ['9d8188b9fb1cae3bd791979c20554925d5e94a138d00414f1a6814549927b0c8'],
+    }),
     ('IO::Socket::SSL', '2.054', {
         'source_tmpl': 'IO-Socket-SSL-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SU/SULLR'],
@@ -451,6 +470,11 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG'],
         'checksums': ['f8bbb625f8e963eabe05cff9048fdd72bdd26777404ff2c40bc690f558be91e1'],
     }),
+    ('Clone::Choose', '0.010', {
+        'source_tmpl': 'Clone-Choose-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/H/HE/HERMES'],
+        'checksums': ['5623481f58cee8edb96cd202aad0df5622d427e5f748b253851dfd62e5123632'],
+    }),
     ('Hash::Merge', '0.299', {
         'source_tmpl': 'Hash-Merge-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/H/HE/HERMES'],
@@ -495,6 +519,11 @@ exts_list = [
         'source_tmpl': 'Module-Install-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
         'checksums': ['1a53a78ddf3ab9e3c03fc5e354b436319a944cba4281baf0b904fa932a13011b'],
+    }),
+    ('Config::Tiny', '2.23', {
+        'source_tmpl': 'Config-Tiny-%(version)s.tgz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE'],
+        'checksums': ['9a8a66e3ed420cbc6585c43abeff788368309a46355cf69a64c2a47e1911e50c'],
     }),
     ('Test::ClassAPI', '1.07', {
         'source_tmpl': 'Test-ClassAPI-%(version)s.tar.gz',
@@ -666,6 +695,11 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DT/DTOWN'],
         'checksums': ['14c37bc1cbb3f3cdc7d6c13e0f27a859f14cdcfd5ea54a0467a88bc259b0b741'],
     }),
+    ('XML::Filter::BufferText', '1.01', {
+        'source_tmpl': 'XML-Filter-BufferText-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RB/RBERJON'],
+        'checksums': ['8fd2126d3beec554df852919f4739e689202cbba6a17506e9b66ea165841a75c'],
+    }),
     ('XML::SAX::Writer', '0.57', {
         'source_tmpl': 'XML-SAX-Writer-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PERIGRIN'],
@@ -695,11 +729,6 @@ exts_list = [
         'source_tmpl': 'Package-Stash-XS-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DO/DOY'],
         'checksums': ['23d8c5c25768ef1dc0ce53b975796762df0d6e244445d06e48d794886c32d486'],
-    }),
-    ('GD::Graph', '1.54', {
-        'source_tmpl': 'GDGraph-%(version)s.tar.gz',
-        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RU/RUZ'],
-        'checksums': ['b96f5c10b656c17d16ab65a1777c908297b028d3b6815f6d54b2337f006bfa4f'],
     }),
     ('Set::Array', '0.30', {
         'source_tmpl': 'Set-Array-%(version)s.tgz',
@@ -750,6 +779,11 @@ exts_list = [
         'source_tmpl': 'Carp-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
         'checksums': ['a5a9ce3cbb959dfefa8c2dd16552567199b286d39b0e55053ca247c038977101'],
+    }),
+    ('XML::Parser', '2.44_01', {
+        'source_tmpl': 'XML-Parser-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TODDR'],
+        'checksums': ['5310ea5c8c707f387589bba8934ab9112463a452f828adf2755792d968b9ac7e'],
     }),
     ('XML::XPath', '1.42', {
         'source_tmpl': 'XML-XPath-%(version)s.tar.gz',
@@ -860,6 +894,16 @@ exts_list = [
         'source_tmpl': 'Class-DBI-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TM/TMTM'],
         'checksums': ['541354fe361c56850cb11261f6ca089a14573fa764792447444ff736ae626206'],
+    }),
+    ('List::SomeUtils', '0.56', {
+        'source_tmpl': 'List-SomeUtils-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+        'checksums': ['eaa7d99ce86380c0389876474c8eb84acc0a6bfeef1b0fc23a292592de6f89f7'],
+    }),
+    ('List::UtilsBy', '0.11', {
+        'source_tmpl': 'List-UtilsBy-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PEVANS'],
+        'checksums': ['faddf43b4bc21db8e4c0e89a26e5f23fe626cde3491ec651b6aa338627f5775a'],
     }),
     ('List::AllUtils', '0.14', {
         'source_tmpl': 'List-AllUtils-%(version)s.tar.gz',
@@ -1080,6 +1124,11 @@ exts_list = [
         'source_tmpl': 'Data-OptList-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
         'checksums': ['366117cb2966473f2559f2f4575ff6ae69e84c69a0f30a0773e1b51a457ef5c3'],
+    }),
+    ('Package::Constants', '0.06', {
+        'source_tmpl': 'Package-Constants-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+        'checksums': ['0b58be78706ccc4e4bd9bbad41767470427fd7b2cfad749489de101f85bc5df5'],
     }),
     ('CPANPLUS', '0.9172', {
         'source_tmpl': 'CPANPLUS-%(version)s.tar.gz',
@@ -1371,6 +1420,26 @@ exts_list = [
         'source_tmpl': 'Config-INI-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
         'checksums': ['628bf76d5b91f89dde22d4813ec033026ebf71b772bb61ccda909da00c869732'],
+    }),
+    ('String::Truncate', '1.100602', {
+        'source_tmpl': 'String-Truncate-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['aaa3d4eec01136921484139133eb75d5c571fe51b0ad329f089e6d469a235f6e'],
+    }),
+    ('Pod::Eventual', '0.094001', {
+        'source_tmpl': 'Pod-Eventual-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['be9fb8910b108e5d1a66f002b659ad22576e88d779b703dff9d15122c3f80834'],
+    }),
+    ('Pod::Elemental', '0.103004', {
+        'source_tmpl': 'Pod-Elemental-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['43625cde7241fb174ad9c7eb45387fba410dc141d7de2323855eeab3590072c9'],
+    }),
+    ('Pod::Weaver', '4.015', {
+        'source_tmpl': 'Pod-Weaver-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['5af25b29a55783e495a9df5ef6293240e2c9ab02764613d79f1ed50b12dec5ae'],
     }),
     ('Dist::Zilla', '6.012', {
         'source_tmpl': 'Dist-Zilla-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.1-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.1-GCCcore-6.4.0.eb
@@ -14,6 +14,7 @@ checksums = ['e763aa485e8dc1a70483dbe6d615986bbf32b977f38016480d68c99237e701dd']
 builddependencies = [('binutils', '2.28')]
 
 dependencies = [
+    ('zlib', '1.2.11'),  # for Net::SSLeay
     ('expat', '2.2.5'),  # for XML::Parser
 ]
 

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.1-foss-2018a.eb
@@ -11,6 +11,10 @@ source_urls = ['http://www.cpan.org/src/%(version_major)s.0']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['e763aa485e8dc1a70483dbe6d615986bbf32b977f38016480d68c99237e701dd']
 
+dependencies = [
+    ('expat', '2.2.5'),  # for XML::Parser
+]
+
 # !! order of extensions is important !!
 # extensions updated on Jan 31st 2018
 exts_list = [
@@ -83,6 +87,11 @@ exts_list = [
         'source_tmpl': 'Test-Warnings-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
         'checksums': ['ae2b68b1b5616704598ce07f5118efe42dc4605834453b7b2be14e26f9cc9a08'],
+    }),
+    ('File::ShareDir', '1.116', {
+        'source_tmpl': 'File-ShareDir-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+        'checksums': ['59d90bfdf98c4656ff4173e62954ea8cf0de66565e35d108ecd7050596cb8328'],
     }),
     ('File::ShareDir::Install', '0.11', {
         'source_tmpl': 'File-ShareDir-Install-%(version)s.tar.gz',
@@ -259,6 +268,11 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
         'checksums': ['156b13f07764f766d8b45a43728f2439af81a3512625438deab783b7883eb533'],
     }),
+    ('Text::Aligner', '0.13', {
+        'source_tmpl': 'Text-Aligner-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
+        'checksums': ['e61c1c93cdefd9cc2a40f12fa8bfb12e64bb06d2375ba9e61534249865103eef'],
+    }),
     ('Text::Table', '1.133', {
         'source_tmpl': 'Text-Table-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
@@ -374,6 +388,11 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
         'checksums': ['aa12d1a4c0ac260b94d448fa01feba242a8a85cb6cbfdc66432e3b5b468add96'],
     }),
+    ('Net::SSLeay', '1.85', {
+        'source_tmpl': 'Net-SSLeay-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MI/MIKEM'],
+        'checksums': ['9d8188b9fb1cae3bd791979c20554925d5e94a138d00414f1a6814549927b0c8'],
+    }),
     ('IO::Socket::SSL', '2.054', {
         'source_tmpl': 'IO-Socket-SSL-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SU/SULLR'],
@@ -449,6 +468,11 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG'],
         'checksums': ['f8bbb625f8e963eabe05cff9048fdd72bdd26777404ff2c40bc690f558be91e1'],
     }),
+    ('Clone::Choose', '0.010', {
+        'source_tmpl': 'Clone-Choose-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/H/HE/HERMES'],
+        'checksums': ['5623481f58cee8edb96cd202aad0df5622d427e5f748b253851dfd62e5123632'],
+    }),
     ('Hash::Merge', '0.299', {
         'source_tmpl': 'Hash-Merge-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/H/HE/HERMES'],
@@ -493,6 +517,11 @@ exts_list = [
         'source_tmpl': 'Module-Install-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
         'checksums': ['1a53a78ddf3ab9e3c03fc5e354b436319a944cba4281baf0b904fa932a13011b'],
+    }),
+    ('Config::Tiny', '2.23', {
+        'source_tmpl': 'Config-Tiny-%(version)s.tgz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE'],
+        'checksums': ['9a8a66e3ed420cbc6585c43abeff788368309a46355cf69a64c2a47e1911e50c'],
     }),
     ('Test::ClassAPI', '1.07', {
         'source_tmpl': 'Test-ClassAPI-%(version)s.tar.gz',
@@ -664,6 +693,11 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DT/DTOWN'],
         'checksums': ['14c37bc1cbb3f3cdc7d6c13e0f27a859f14cdcfd5ea54a0467a88bc259b0b741'],
     }),
+    ('XML::Filter::BufferText', '1.01', {
+        'source_tmpl': 'XML-Filter-BufferText-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RB/RBERJON'],
+        'checksums': ['8fd2126d3beec554df852919f4739e689202cbba6a17506e9b66ea165841a75c'],
+    }),
     ('XML::SAX::Writer', '0.57', {
         'source_tmpl': 'XML-SAX-Writer-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PERIGRIN'],
@@ -693,11 +727,6 @@ exts_list = [
         'source_tmpl': 'Package-Stash-XS-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DO/DOY'],
         'checksums': ['23d8c5c25768ef1dc0ce53b975796762df0d6e244445d06e48d794886c32d486'],
-    }),
-    ('GD::Graph', '1.54', {
-        'source_tmpl': 'GDGraph-%(version)s.tar.gz',
-        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RU/RUZ'],
-        'checksums': ['b96f5c10b656c17d16ab65a1777c908297b028d3b6815f6d54b2337f006bfa4f'],
     }),
     ('Set::Array', '0.30', {
         'source_tmpl': 'Set-Array-%(version)s.tgz',
@@ -748,6 +777,11 @@ exts_list = [
         'source_tmpl': 'Carp-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
         'checksums': ['a5a9ce3cbb959dfefa8c2dd16552567199b286d39b0e55053ca247c038977101'],
+    }),
+    ('XML::Parser', '2.44_01', {
+        'source_tmpl': 'XML-Parser-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TODDR'],
+        'checksums': ['5310ea5c8c707f387589bba8934ab9112463a452f828adf2755792d968b9ac7e'],
     }),
     ('XML::XPath', '1.42', {
         'source_tmpl': 'XML-XPath-%(version)s.tar.gz',
@@ -858,6 +892,16 @@ exts_list = [
         'source_tmpl': 'Class-DBI-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TM/TMTM'],
         'checksums': ['541354fe361c56850cb11261f6ca089a14573fa764792447444ff736ae626206'],
+    }),
+    ('List::SomeUtils', '0.56', {
+        'source_tmpl': 'List-SomeUtils-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+        'checksums': ['eaa7d99ce86380c0389876474c8eb84acc0a6bfeef1b0fc23a292592de6f89f7'],
+    }),
+    ('List::UtilsBy', '0.11', {
+        'source_tmpl': 'List-UtilsBy-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PEVANS'],
+        'checksums': ['faddf43b4bc21db8e4c0e89a26e5f23fe626cde3491ec651b6aa338627f5775a'],
     }),
     ('List::AllUtils', '0.14', {
         'source_tmpl': 'List-AllUtils-%(version)s.tar.gz',
@@ -1078,6 +1122,11 @@ exts_list = [
         'source_tmpl': 'Data-OptList-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
         'checksums': ['366117cb2966473f2559f2f4575ff6ae69e84c69a0f30a0773e1b51a457ef5c3'],
+    }),
+    ('Package::Constants', '0.06', {
+        'source_tmpl': 'Package-Constants-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+        'checksums': ['0b58be78706ccc4e4bd9bbad41767470427fd7b2cfad749489de101f85bc5df5'],
     }),
     ('CPANPLUS', '0.9172', {
         'source_tmpl': 'CPANPLUS-%(version)s.tar.gz',
@@ -1369,6 +1418,26 @@ exts_list = [
         'source_tmpl': 'Config-INI-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
         'checksums': ['628bf76d5b91f89dde22d4813ec033026ebf71b772bb61ccda909da00c869732'],
+    }),
+    ('String::Truncate', '1.100602', {
+        'source_tmpl': 'String-Truncate-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['aaa3d4eec01136921484139133eb75d5c571fe51b0ad329f089e6d469a235f6e'],
+    }),
+    ('Pod::Eventual', '0.094001', {
+        'source_tmpl': 'Pod-Eventual-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['be9fb8910b108e5d1a66f002b659ad22576e88d779b703dff9d15122c3f80834'],
+    }),
+    ('Pod::Elemental', '0.103004', {
+        'source_tmpl': 'Pod-Elemental-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['43625cde7241fb174ad9c7eb45387fba410dc141d7de2323855eeab3590072c9'],
+    }),
+    ('Pod::Weaver', '4.015', {
+        'source_tmpl': 'Pod-Weaver-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+        'checksums': ['5af25b29a55783e495a9df5ef6293240e2c9ab02764613d79f1ed50b12dec5ae'],
     }),
     ('Dist::Zilla', '6.012', {
         'source_tmpl': 'Dist-Zilla-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/p/Perl/Perl-5.26.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.26.1-foss-2018a.eb
@@ -12,6 +12,7 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['e763aa485e8dc1a70483dbe6d615986bbf32b977f38016480d68c99237e701dd']
 
 dependencies = [
+    ('zlib', '1.2.11'),  # for Net::SSLeay
     ('expat', '2.2.5'),  # for XML::Parser
 ]
 


### PR DESCRIPTION
(cfr. https://github.com/easybuilders/easybuild-easyblocks/pull/1449)