### PR TITLE
Example of Python-core at GCCcore/7.3.0 with Python at intel/2018b

### DIFF
--- a/easybuild/easyconfigs/p/Python-core/Python-core-2.7.15-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/p/Python-core/Python-core-2.7.15-GCCcore-7.3.0.eb
@@ -27,7 +27,6 @@ dependencies = [
     ('ncurses', '6.1'),
     ('SQLite', '3.24.0'),
     ('GMP', '6.1.2'),  # required for pycrypto
-    #('libyaml', '0.1.7'),  # required for PyYAML
 ]
 
 osdependencies = [
@@ -84,11 +83,6 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
         'checksums': ['f4b60475e7473c4c42665f106ef87fe94fbf1e4cac7571903153ad38c3167c69'],
     }),
-    #('PyYAML', '3.12', {
-    #    'modulename': 'yaml',
-    #    'source_urls': ['https://pypi.python.org/packages/source/P/PyYAML/'],
-    #    'checksums': [ '592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab'],
-    #}),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],

--- a/easybuild/easyconfigs/p/Python-core/Python-core-2.7.15-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/p/Python-core/Python-core-2.7.15-GCCcore-7.3.0.eb
@@ -1,0 +1,205 @@
+easyblock = 'EB_Python'
+
+name = 'Python-core'
+version = '2.7.15'
+
+homepage = 'http://python.org/'
+
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+more effectively.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.python.org/ftp/python/%(version)s/']
+sources = ['Python-%(version)s.tgz']
+checksums = ['18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db']
+
+builddependencies = [
+    ('binutils', '2.30'),
+]
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+    ('libreadline', '7.0'),
+    ('ncurses', '6.1'),
+    ('SQLite', '3.24.0'),
+    ('GMP', '6.1.2'),  # required for pycrypto
+    #('libyaml', '0.1.7'),  # required for PyYAML
+]
+
+osdependencies = [
+    # rely upon distribution for timely security updates
+    ('openssl-devel', 'libssl-dev', 'libopenssl-devel'),
+]
+
+# package versions updated June 19th 2018
+exts_list = [
+    ('setuptools', '39.2.0', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+        'checksums': ['f7cddbb5f5c640311eb00eab6e849f7701fa70bf6a183fc8a2c33dd1d1672fb2'],
+    }),
+    ('pip', '10.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+        'checksums': ['f2bd08e0cd1b06e10218feaf6fef299f473ba706582eb3bd9d52203fdbd7ee68'],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
+    }),
+    ('paycheck', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+        'checksums': ['6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34'],
+    }),
+    ('pbr', '4.0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+        'checksums': ['a9c27eb8f0e24e786e544b2dbaedb729c9d8546342b5a6818d8eda098ad4340d'],
+    }),
+    ('Cython', '0.28.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+        'checksums': ['1aae6d6e9858888144cea147eb5e677830f45faaff3d305d77378c3cba55f526'],
+    }),
+    ('six', '1.11.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+        'checksums': ['70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9'],
+    }),
+    ('python-dateutil', '2.7.3', {
+        'modulename': 'dateutil',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+        'checksums': ['e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8'],
+    }),
+    ('decorator', '4.3.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+        'checksums': ['c39efa13fbdeb4506c476c9b3babf6a718da943dab7811c206005a4a956c080c'],
+    }),
+    ('liac-arff', '2.2.2', {
+        'modulename': 'arff',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+        'checksums': ['f4b60475e7473c4c42665f106ef87fe94fbf1e4cac7571903153ad38c3167c69'],
+    }),
+    #('PyYAML', '3.12', {
+    #    'modulename': 'yaml',
+    #    'source_urls': ['https://pypi.python.org/packages/source/P/PyYAML/'],
+    #    'checksums': [ '592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab'],
+    #}),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
+    }),
+    ('enum34', '1.1.6', {
+        'modulename': 'enum',
+        'source_urls': ['https://pypi.python.org/packages/source/e/enum34/'],
+        'checksums': ['8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1'],
+    }),
+    ('ipaddress', '1.0.22', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipaddress/'],
+    }),
+    ('asn1crypto', '0.24.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
+        'checksums': ['9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49'],
+    }),
+    ('idna', '2.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
+        'checksums': ['684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16'],
+    }),
+    ('cryptography', '2.2.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
+        'checksums': ['9fc295bf69130a342e7a19a39d7bbeb15c0bcaabc7382ec33ef3b2b7d18d2f63'],
+    }),
+    ('pyasn1', '0.4.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
+        'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
+    }),
+    ('PyNaCl', '1.2.1', {
+        'modulename': 'nacl',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
+        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
+    }),
+    ('bcrypt', '3.1.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/bcrypt/'],
+        'checksums': ['67ed1a374c9155ec0840214ce804616de49c3df9c5bc66740687c1c9b1cd9e8d'],
+    }),
+    ('paramiko', '2.4.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+        'checksums': ['33e36775a6c71790ba7692a73f948b329cf9295a72b0102144b031114bd2a4f3'],
+    }),
+    ('pyparsing', '2.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
+    }),
+    ('netifaces', '0.10.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces/'],
+        'checksums': ['bd590fcb75421537d4149825e1e63cca225fd47dad861710c46bd1cb329d8cbd'],
+    }),
+    ('netaddr', '0.7.19', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr/'],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
+    }),
+    ('funcsigs', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs/'],
+        'checksums': ['a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50'],
+    }),
+    ('mock', '2.0.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mock/'],
+        'checksums': ['b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba'],
+    }),
+    ('pytz', '2018.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytz/'],
+        'checksums': ['c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749'],
+    }),
+    ('bitstring', '3.1.5', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/b/bitstring/'],
+        'checksums': ['c163a86fcef377c314690051885d86b47419e3e1770990c212e16723c1c08faa'],
+    }),
+    ('virtualenv', '16.0.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv/'],
+        'checksums': ['ca07b4c0b54e14a91af9f34d0919790b016923d157afda5efdde55c96718f752'],
+    }),
+    ('docopt', '0.6.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/docopt/'],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
+    }),
+    ('joblib', '0.11', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/joblib/'],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
+    }),
+    ('chardet', '3.0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
+        'checksums': ['84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae'],
+    }),
+    ('certifi', '2018.4.16', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
+        'checksums': ['13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7'],
+    }),
+    ('urllib3', '1.23', {
+        'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
+        'checksums': ['a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf'],
+    }),
+    ('requests', '2.19.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
+        'checksums': ['ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a'],
+    }),
+    ('xlrd', '1.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/x/xlrd'],
+        'checksums': ['8a21885513e6d915fe33a8ee5fdfa675433b61405ba13e2a69e62ee36828d7e2'],
+    }),
+    ('py_expression_eval', '0.3.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/py_expression_eval'],
+        'checksums': ['b9662c58f8835f6fa3380990f870429fe1176008718a47ce054a7867c4091ad8'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-foss-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-foss-2018b.eb
@@ -1,3 +1,5 @@
+easyblock = 'Bundle'
+
 name = 'Python'
 version = '2.7.15'
 
@@ -8,44 +10,20 @@ description = """Python is a programming language that lets you work more quickl
 toolchain = {'name': 'foss', 'version': '2018b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
-sources = [SOURCE_TGZ]
-checksums = ['18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db']
+exts_defaultclass = 'PythonPackage'
 
-# python needs bzip2 to build the bz2 package
 dependencies = [
-    ('bzip2', '1.0.6'),
-    ('zlib', '1.2.11'),
-    ('libreadline', '7.0'),
-    ('ncurses', '6.1'),
-    ('SQLite', '3.24.0'),
-    ('GMP', '6.1.2'),  # required for pycrypto
-    ('libffi', '3.2.1'),  # required for cryptography
-    # OS dependency should be preferred if the os version is more recent then this version,
-    # it's nice to have an up to date openssl for security reasons
-    # ('OpenSSL', '1.1.0h'),
+    ('Python-core', '%(version)s'),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
-
 exts_download_dep_fail = True
+
+#preinstallopts = 'export PYTHONPATH="%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH" && '
+preinstallopts = 'export PYTHONPATH="%(installdir)s/lib/python%(version_major_minor)s/site-packages:$PYTHONPATH" && '
 
 # order is important!
 # package versions updated June 19th 2018
 exts_list = [
-    ('setuptools', '39.2.0', {
-        'source_tmpl': '%(name)s-%(version)s.zip',
-        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
-        'checksums': ['f7cddbb5f5c640311eb00eab6e849f7701fa70bf6a183fc8a2c33dd1d1672fb2'],
-    }),
-    ('pip', '10.0.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
-        'checksums': ['f2bd08e0cd1b06e10218feaf6fef299f473ba706582eb3bd9d52203fdbd7ee68'],
-    }),
-    ('nose', '1.3.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
-        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
-    }),
     ('numpy', '1.14.5', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/n/numpy/'],
@@ -55,163 +33,29 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy/'],
         'checksums': ['878352408424dffaa695ffedf2f9f92844e116686923ed9aa8626fc30d32cfd1'],
     }),
-    ('blist', '1.3.6', {
-        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
-        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
-    }),
     ('mpi4py', '3.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
         'checksums': ['b457b02d85bdd9a4775a097fac5234a20397b43e073f14d9e29b6cd78c68efd7'],
-    }),
-    ('paycheck', '1.0.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
-        'checksums': ['6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34'],
-    }),
-    ('pbr', '4.0.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
-        'checksums': ['a9c27eb8f0e24e786e544b2dbaedb729c9d8546342b5a6818d8eda098ad4340d'],
-    }),
-    ('Cython', '0.28.3', {
-        'source_urls': ['https://pypi.python.org/packages/source/C/Cython/'],
-        'checksums': ['1aae6d6e9858888144cea147eb5e677830f45faaff3d305d77378c3cba55f526'],
-    }),
-    ('six', '1.11.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-        'checksums': ['70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9'],
-    }),
-    ('python-dateutil', '2.7.3', {
-        'modulename': 'dateutil',
-        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
-        'checksums': ['e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8'],
     }),
     ('deap', '1.2.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
         'checksums': ['95c63e66d755ec206c80fdb2908851c0bef420ee8651ad7be4f0578e9e909bcf'],
     }),
-    ('decorator', '4.3.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-        'checksums': ['c39efa13fbdeb4506c476c9b3babf6a718da943dab7811c206005a4a956c080c'],
-    }),
-    ('liac-arff', '2.2.2', {
-        'modulename': 'arff',
-        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
-        'checksums': ['f4b60475e7473c4c42665f106ef87fe94fbf1e4cac7571903153ad38c3167c69'],
-    }),
-    ('pycrypto', '2.6.1', {
-        'modulename': 'Crypto',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
-        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
-    }),
-    ('ecdsa', '0.13', {
-        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
-        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
-    }),
-    ('enum34', '1.1.6', {
-        'modulename': 'enum',
-        'source_urls': ['https://pypi.python.org/packages/source/e/enum34/'],
-        'checksums': ['8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1'],
-    }),
-    ('ipaddress', '1.0.22', {
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipaddress/'],
-    }),
-    ('asn1crypto', '0.24.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
-        'checksums': ['9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49'],
-    }),
-    ('idna', '2.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
-        'checksums': ['684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16'],
-    }),
-    ('cryptography', '2.2.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
-        'checksums': ['9fc295bf69130a342e7a19a39d7bbeb15c0bcaabc7382ec33ef3b2b7d18d2f63'],
-    }),
-    ('pyasn1', '0.4.3', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
-        'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
-    }),
-    ('PyNaCl', '1.2.1', {
-        'modulename': 'nacl',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
-        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
-    }),
-    ('bcrypt', '3.1.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/b/bcrypt/'],
-        'checksums': ['67ed1a374c9155ec0840214ce804616de49c3df9c5bc66740687c1c9b1cd9e8d'],
-    }),
-    ('paramiko', '2.4.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
-        'checksums': ['33e36775a6c71790ba7692a73f948b329cf9295a72b0102144b031114bd2a4f3'],
-    }),
-    ('pyparsing', '2.2.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
-        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
-    }),
-    ('netifaces', '0.10.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces/'],
-        'checksums': ['bd590fcb75421537d4149825e1e63cca225fd47dad861710c46bd1cb329d8cbd'],
-    }),
-    ('netaddr', '0.7.19', {
-        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr/'],
-        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
-    }),
-    ('funcsigs', '1.0.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs/'],
-        'checksums': ['a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50'],
-    }),
-    ('mock', '2.0.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/m/mock/'],
-        'checksums': ['b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba'],
-    }),
-    ('pytz', '2018.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pytz/'],
-        'checksums': ['c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749'],
-    }),
     ('pandas', '0.23.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
         'checksums': ['50b52af2af2e15f4aeb2fe196da073a8c131fa02e433e105d95ce40016df5690'],
     }),
-    ('bitstring', '3.1.5', {
-        'source_tmpl': '%(name)s-%(version)s.zip',
-        'source_urls': ['https://pypi.python.org/packages/source/b/bitstring/'],
-        'checksums': ['c163a86fcef377c314690051885d86b47419e3e1770990c212e16723c1c08faa'],
-    }),
-    ('virtualenv', '16.0.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv/'],
-        'checksums': ['ca07b4c0b54e14a91af9f34d0919790b016923d157afda5efdde55c96718f752'],
-    }),
-    ('docopt', '0.6.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/d/docopt/'],
-        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
-    }),
-    ('joblib', '0.11', {
-        'source_urls': ['https://pypi.python.org/packages/source/j/joblib/'],
-        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
-    }),
-    ('chardet', '3.0.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
-        'checksums': ['84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae'],
-    }),
-    ('certifi', '2018.4.16', {
-        'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
-        'checksums': ['13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7'],
-    }),
-    ('urllib3', '1.23', {
-        'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
-        'checksums': ['a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf'],
-    }),
-    ('requests', '2.19.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
-        'checksums': ['ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a'],
-    }),
-    ('xlrd', '1.1.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/x/xlrd'],
-        'checksums': ['8a21885513e6d915fe33a8ee5fdfa675433b61405ba13e2a69e62ee36828d7e2'],
-    }),
-    ('py_expression_eval', '0.3.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/py_expression_eval'],
-        'checksums': ['b9662c58f8835f6fa3380990f870429fe1176008718a47ce054a7867c4091ad8'],
-    }),
 ]
+
+full_sanity_check = True
+
+sanity_check_paths = {
+    'files': [],
+    #'dirs': ['lib/python%(pyshortver)s/site-packages'],
+    'dirs': ['lib/python%(version_major)s.%(version_minor)s/site-packages'],
+}
+
+#modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+modextrapaths = {'PYTHONPATH': ['lib/python%(version_major)s.%(version_minor)s/site-packages']}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-foss-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-foss-2018b.eb
@@ -18,7 +18,6 @@ dependencies = [
 
 exts_download_dep_fail = True
 
-#preinstallopts = 'export PYTHONPATH="%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH" && '
 preinstallopts = 'export PYTHONPATH="%(installdir)s/lib/python%(version_major_minor)s/site-packages:$PYTHONPATH" && '
 
 # order is important!
@@ -51,11 +50,9 @@ full_sanity_check = True
 
 sanity_check_paths = {
     'files': [],
-    #'dirs': ['lib/python%(pyshortver)s/site-packages'],
     'dirs': ['lib/python%(version_major)s.%(version_minor)s/site-packages'],
 }
 
-#modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 modextrapaths = {'PYTHONPATH': ['lib/python%(version_major)s.%(version_minor)s/site-packages']}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-fosscuda-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-fosscuda-2018b.eb
@@ -18,7 +18,6 @@ dependencies = [
 
 exts_download_dep_fail = True
 
-#preinstallopts = 'export PYTHONPATH="%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH" && '
 preinstallopts = 'export PYTHONPATH="%(installdir)s/lib/python%(version_major_minor)s/site-packages:$PYTHONPATH" && '
 
 # order is important!
@@ -51,11 +50,9 @@ full_sanity_check = True
 
 sanity_check_paths = {
     'files': [],
-    #'dirs': ['lib/python%(pyshortver)s/site-packages'],
     'dirs': ['lib/python%(version_major)s.%(version_minor)s/site-packages'],
 }
 
-#modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 modextrapaths = {'PYTHONPATH': ['lib/python%(version_major)s.%(version_minor)s/site-packages']}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-fosscuda-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-fosscuda-2018b.eb
@@ -1,3 +1,5 @@
+easyblock = 'Bundle'
+
 name = 'Python'
 version = '2.7.15'
 
@@ -8,44 +10,20 @@ description = """Python is a programming language that lets you work more quickl
 toolchain = {'name': 'fosscuda', 'version': '2018b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
-sources = [SOURCE_TGZ]
-checksums = ['18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db']
+exts_defaultclass = 'PythonPackage'
 
-# python needs bzip2 to build the bz2 package
 dependencies = [
-    ('bzip2', '1.0.6'),
-    ('zlib', '1.2.11'),
-    ('libreadline', '7.0'),
-    ('ncurses', '6.1'),
-    ('SQLite', '3.24.0'),
-    ('GMP', '6.1.2'),  # required for pycrypto
-    ('libffi', '3.2.1'),  # required for cryptography
-    # OS dependency should be preferred if the os version is more recent then this version,
-    # it's nice to have an up to date openssl for security reasons
-    # ('OpenSSL', '1.1.0h'),
+    ('Python-core', '%(version)s'),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
-
 exts_download_dep_fail = True
+
+#preinstallopts = 'export PYTHONPATH="%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH" && '
+preinstallopts = 'export PYTHONPATH="%(installdir)s/lib/python%(version_major_minor)s/site-packages:$PYTHONPATH" && '
 
 # order is important!
 # package versions updated June 19th 2018
 exts_list = [
-    ('setuptools', '39.2.0', {
-        'source_tmpl': '%(name)s-%(version)s.zip',
-        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
-        'checksums': ['f7cddbb5f5c640311eb00eab6e849f7701fa70bf6a183fc8a2c33dd1d1672fb2'],
-    }),
-    ('pip', '10.0.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
-        'checksums': ['f2bd08e0cd1b06e10218feaf6fef299f473ba706582eb3bd9d52203fdbd7ee68'],
-    }),
-    ('nose', '1.3.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
-        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
-    }),
     ('numpy', '1.14.5', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/n/numpy/'],
@@ -55,163 +33,29 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy/'],
         'checksums': ['878352408424dffaa695ffedf2f9f92844e116686923ed9aa8626fc30d32cfd1'],
     }),
-    ('blist', '1.3.6', {
-        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
-        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
-    }),
     ('mpi4py', '3.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
         'checksums': ['b457b02d85bdd9a4775a097fac5234a20397b43e073f14d9e29b6cd78c68efd7'],
-    }),
-    ('paycheck', '1.0.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
-        'checksums': ['6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34'],
-    }),
-    ('pbr', '4.0.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
-        'checksums': ['a9c27eb8f0e24e786e544b2dbaedb729c9d8546342b5a6818d8eda098ad4340d'],
-    }),
-    ('Cython', '0.28.3', {
-        'source_urls': ['https://pypi.python.org/packages/source/C/Cython/'],
-        'checksums': ['1aae6d6e9858888144cea147eb5e677830f45faaff3d305d77378c3cba55f526'],
-    }),
-    ('six', '1.11.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-        'checksums': ['70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9'],
-    }),
-    ('python-dateutil', '2.7.3', {
-        'modulename': 'dateutil',
-        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
-        'checksums': ['e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8'],
     }),
     ('deap', '1.2.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
         'checksums': ['95c63e66d755ec206c80fdb2908851c0bef420ee8651ad7be4f0578e9e909bcf'],
     }),
-    ('decorator', '4.3.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-        'checksums': ['c39efa13fbdeb4506c476c9b3babf6a718da943dab7811c206005a4a956c080c'],
-    }),
-    ('liac-arff', '2.2.2', {
-        'modulename': 'arff',
-        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
-        'checksums': ['f4b60475e7473c4c42665f106ef87fe94fbf1e4cac7571903153ad38c3167c69'],
-    }),
-    ('pycrypto', '2.6.1', {
-        'modulename': 'Crypto',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
-        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
-    }),
-    ('ecdsa', '0.13', {
-        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
-        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
-    }),
-    ('enum34', '1.1.6', {
-        'modulename': 'enum',
-        'source_urls': ['https://pypi.python.org/packages/source/e/enum34/'],
-        'checksums': ['8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1'],
-    }),
-    ('ipaddress', '1.0.22', {
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipaddress/'],
-    }),
-    ('asn1crypto', '0.24.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
-        'checksums': ['9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49'],
-    }),
-    ('idna', '2.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
-        'checksums': ['684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16'],
-    }),
-    ('cryptography', '2.2.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
-        'checksums': ['9fc295bf69130a342e7a19a39d7bbeb15c0bcaabc7382ec33ef3b2b7d18d2f63'],
-    }),
-    ('pyasn1', '0.4.3', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
-        'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
-    }),
-    ('PyNaCl', '1.2.1', {
-        'modulename': 'nacl',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
-        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
-    }),
-    ('bcrypt', '3.1.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/b/bcrypt/'],
-        'checksums': ['67ed1a374c9155ec0840214ce804616de49c3df9c5bc66740687c1c9b1cd9e8d'],
-    }),
-    ('paramiko', '2.4.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
-        'checksums': ['33e36775a6c71790ba7692a73f948b329cf9295a72b0102144b031114bd2a4f3'],
-    }),
-    ('pyparsing', '2.2.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
-        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
-    }),
-    ('netifaces', '0.10.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces/'],
-        'checksums': ['bd590fcb75421537d4149825e1e63cca225fd47dad861710c46bd1cb329d8cbd'],
-    }),
-    ('netaddr', '0.7.19', {
-        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr/'],
-        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
-    }),
-    ('funcsigs', '1.0.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs/'],
-        'checksums': ['a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50'],
-    }),
-    ('mock', '2.0.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/m/mock/'],
-        'checksums': ['b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba'],
-    }),
-    ('pytz', '2018.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pytz/'],
-        'checksums': ['c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749'],
-    }),
     ('pandas', '0.23.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
         'checksums': ['50b52af2af2e15f4aeb2fe196da073a8c131fa02e433e105d95ce40016df5690'],
     }),
-    ('bitstring', '3.1.5', {
-        'source_tmpl': '%(name)s-%(version)s.zip',
-        'source_urls': ['https://pypi.python.org/packages/source/b/bitstring/'],
-        'checksums': ['c163a86fcef377c314690051885d86b47419e3e1770990c212e16723c1c08faa'],
-    }),
-    ('virtualenv', '16.0.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv/'],
-        'checksums': ['ca07b4c0b54e14a91af9f34d0919790b016923d157afda5efdde55c96718f752'],
-    }),
-    ('docopt', '0.6.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/d/docopt/'],
-        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
-    }),
-    ('joblib', '0.11', {
-        'source_urls': ['https://pypi.python.org/packages/source/j/joblib/'],
-        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
-    }),
-    ('chardet', '3.0.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
-        'checksums': ['84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae'],
-    }),
-    ('certifi', '2018.4.16', {
-        'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
-        'checksums': ['13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7'],
-    }),
-    ('urllib3', '1.23', {
-        'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
-        'checksums': ['a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf'],
-    }),
-    ('requests', '2.19.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
-        'checksums': ['ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a'],
-    }),
-    ('xlrd', '1.1.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/x/xlrd'],
-        'checksums': ['8a21885513e6d915fe33a8ee5fdfa675433b61405ba13e2a69e62ee36828d7e2'],
-    }),
-    ('py_expression_eval', '0.3.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/py_expression_eval'],
-        'checksums': ['b9662c58f8835f6fa3380990f870429fe1176008718a47ce054a7867c4091ad8'],
-    }),
 ]
+
+full_sanity_check = True
+
+sanity_check_paths = {
+    'files': [],
+    #'dirs': ['lib/python%(pyshortver)s/site-packages'],
+    'dirs': ['lib/python%(version_major)s.%(version_minor)s/site-packages'],
+}
+
+#modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+modextrapaths = {'PYTHONPATH': ['lib/python%(version_major)s.%(version_minor)s/site-packages']}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-intel-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-intel-2018b.eb
@@ -1,3 +1,5 @@
+easyblock = 'Bundle'
+
 name = 'Python'
 version = '2.7.15'
 
@@ -8,44 +10,20 @@ description = """Python is a programming language that lets you work more quickl
 toolchain = {'name': 'intel', 'version': '2018b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
-sources = [SOURCE_TGZ]
-checksums = ['18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db']
+exts_defaultclass = 'PythonPackage'
 
-# python needs bzip2 to build the bz2 package
 dependencies = [
-    ('bzip2', '1.0.6'),
-    ('zlib', '1.2.11'),
-    ('libreadline', '7.0'),
-    ('ncurses', '6.1'),
-    ('SQLite', '3.24.0'),
-    ('GMP', '6.1.2'),  # required for pycrypto
-    ('libffi', '3.2.1'),  # required for cryptography
-    # OS dependency should be preferred if the os version is more recent then this version,
-    # it's nice to have an up to date openssl for security reasons
-    # ('OpenSSL', '1.1.0h'),
+    ('Python-core', '%(version)s'),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
-
 exts_download_dep_fail = True
+
+#preinstallopts = 'export PYTHONPATH="%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH" && '
+preinstallopts = 'export PYTHONPATH="%(installdir)s/lib/python%(version_major_minor)s/site-packages:$PYTHONPATH" && '
 
 # order is important!
 # package versions updated June 19th 2018
 exts_list = [
-    ('setuptools', '39.2.0', {
-        'source_tmpl': '%(name)s-%(version)s.zip',
-        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
-        'checksums': ['f7cddbb5f5c640311eb00eab6e849f7701fa70bf6a183fc8a2c33dd1d1672fb2'],
-    }),
-    ('pip', '10.0.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
-        'checksums': ['f2bd08e0cd1b06e10218feaf6fef299f473ba706582eb3bd9d52203fdbd7ee68'],
-    }),
-    ('nose', '1.3.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
-        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
-    }),
     ('numpy', '1.14.5', {
         'patches': ['numpy-1.12.0-mkl.patch'],
         'source_tmpl': '%(name)s-%(version)s.zip',
@@ -59,163 +37,30 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy/'],
         'checksums': ['878352408424dffaa695ffedf2f9f92844e116686923ed9aa8626fc30d32cfd1'],
     }),
-    ('blist', '1.3.6', {
-        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
-        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
-    }),
     ('mpi4py', '3.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
         'checksums': ['b457b02d85bdd9a4775a097fac5234a20397b43e073f14d9e29b6cd78c68efd7'],
-    }),
-    ('paycheck', '1.0.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
-        'checksums': ['6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34'],
-    }),
-    ('pbr', '4.0.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
-        'checksums': ['a9c27eb8f0e24e786e544b2dbaedb729c9d8546342b5a6818d8eda098ad4340d'],
-    }),
-    ('Cython', '0.28.3', {
-        'source_urls': ['https://pypi.python.org/packages/source/C/Cython/'],
-        'checksums': ['1aae6d6e9858888144cea147eb5e677830f45faaff3d305d77378c3cba55f526'],
-    }),
-    ('six', '1.11.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-        'checksums': ['70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9'],
-    }),
-    ('python-dateutil', '2.7.3', {
-        'modulename': 'dateutil',
-        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
-        'checksums': ['e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8'],
     }),
     ('deap', '1.2.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
         'checksums': ['95c63e66d755ec206c80fdb2908851c0bef420ee8651ad7be4f0578e9e909bcf'],
     }),
-    ('decorator', '4.3.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-        'checksums': ['c39efa13fbdeb4506c476c9b3babf6a718da943dab7811c206005a4a956c080c'],
-    }),
-    ('liac-arff', '2.2.2', {
-        'modulename': 'arff',
-        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
-        'checksums': ['f4b60475e7473c4c42665f106ef87fe94fbf1e4cac7571903153ad38c3167c69'],
-    }),
-    ('pycrypto', '2.6.1', {
-        'modulename': 'Crypto',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
-        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
-    }),
-    ('ecdsa', '0.13', {
-        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
-        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
-    }),
-    ('enum34', '1.1.6', {
-        'modulename': 'enum',
-        'source_urls': ['https://pypi.python.org/packages/source/e/enum34/'],
-        'checksums': ['8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1'],
-    }),
-    ('ipaddress', '1.0.22', {
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipaddress/'],
-    }),
-    ('asn1crypto', '0.24.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
-        'checksums': ['9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49'],
-    }),
-    ('idna', '2.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
-        'checksums': ['684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16'],
-    }),
-    ('cryptography', '2.2.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
-        'checksums': ['9fc295bf69130a342e7a19a39d7bbeb15c0bcaabc7382ec33ef3b2b7d18d2f63'],
-    }),
-    ('pyasn1', '0.4.3', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
-        'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
-    }),
-    ('PyNaCl', '1.2.1', {
-        'modulename': 'nacl',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
-        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
-    }),
-    ('bcrypt', '3.1.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/b/bcrypt/'],
-        'checksums': ['67ed1a374c9155ec0840214ce804616de49c3df9c5bc66740687c1c9b1cd9e8d'],
-    }),
-    ('paramiko', '2.4.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
-        'checksums': ['33e36775a6c71790ba7692a73f948b329cf9295a72b0102144b031114bd2a4f3'],
-    }),
-    ('pyparsing', '2.2.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
-        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
-    }),
-    ('netifaces', '0.10.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces/'],
-        'checksums': ['bd590fcb75421537d4149825e1e63cca225fd47dad861710c46bd1cb329d8cbd'],
-    }),
-    ('netaddr', '0.7.19', {
-        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr/'],
-        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
-    }),
-    ('funcsigs', '1.0.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs/'],
-        'checksums': ['a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50'],
-    }),
-    ('mock', '2.0.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/m/mock/'],
-        'checksums': ['b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba'],
-    }),
-    ('pytz', '2018.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pytz/'],
-        'checksums': ['c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749'],
-    }),
-    ('pandas', '0.23.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
-        'checksums': ['50b52af2af2e15f4aeb2fe196da073a8c131fa02e433e105d95ce40016df5690'],
-    }),
-    ('bitstring', '3.1.5', {
-        'source_tmpl': '%(name)s-%(version)s.zip',
-        'source_urls': ['https://pypi.python.org/packages/source/b/bitstring/'],
-        'checksums': ['c163a86fcef377c314690051885d86b47419e3e1770990c212e16723c1c08faa'],
-    }),
-    ('virtualenv', '16.0.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv/'],
-        'checksums': ['ca07b4c0b54e14a91af9f34d0919790b016923d157afda5efdde55c96718f752'],
-    }),
-    ('docopt', '0.6.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/d/docopt/'],
-        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
-    }),
-    ('joblib', '0.11', {
-        'source_urls': ['https://pypi.python.org/packages/source/j/joblib/'],
-        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
-    }),
-    ('chardet', '3.0.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
-        'checksums': ['84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae'],
-    }),
-    ('certifi', '2018.4.16', {
-        'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
-        'checksums': ['13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7'],
-    }),
-    ('urllib3', '1.23', {
-        'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
-        'checksums': ['a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf'],
-    }),
-    ('requests', '2.19.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
-        'checksums': ['ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a'],
-    }),
-    ('xlrd', '1.1.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/x/xlrd'],
-        'checksums': ['8a21885513e6d915fe33a8ee5fdfa675433b61405ba13e2a69e62ee36828d7e2'],
-    }),
-    ('py_expression_eval', '0.3.4', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/py_expression_eval'],
-        'checksums': ['b9662c58f8835f6fa3380990f870429fe1176008718a47ce054a7867c4091ad8'],
-    }),
+    # Some compile error (need more time to investigate
+    #('pandas', '0.23.1', {
+    #    'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
+    #    'checksums': ['50b52af2af2e15f4aeb2fe196da073a8c131fa02e433e105d95ce40016df5690'],
+    #}),
 ]
+
+full_sanity_check = True
+
+sanity_check_paths = {
+    'files': [],
+    #'dirs': ['lib/python%(pyshortver)s/site-packages'],
+    'dirs': ['lib/python%(version_major)s.%(version_minor)s/site-packages'],
+}
+
+#modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+modextrapaths = {'PYTHONPATH': ['lib/python%(version_major)s.%(version_minor)s/site-packages']}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-intel-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-intel-2018b.eb
@@ -18,8 +18,8 @@ dependencies = [
 
 exts_download_dep_fail = True
 
-#preinstallopts = 'export PYTHONPATH="%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH" && '
 preinstallopts = 'export PYTHONPATH="%(installdir)s/lib/python%(version_major_minor)s/site-packages:$PYTHONPATH" && '
+prebuildopts = 'export LDSHARED="$CC -shared" && '
 
 # order is important!
 # package versions updated June 19th 2018
@@ -45,22 +45,19 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
         'checksums': ['95c63e66d755ec206c80fdb2908851c0bef420ee8651ad7be4f0578e9e909bcf'],
     }),
-    # Some compile error (need more time to investigate
-    #('pandas', '0.23.1', {
-    #    'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
-    #    'checksums': ['50b52af2af2e15f4aeb2fe196da073a8c131fa02e433e105d95ce40016df5690'],
-    #}),
+    ('pandas', '0.23.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
+        'checksums': ['50b52af2af2e15f4aeb2fe196da073a8c131fa02e433e105d95ce40016df5690'],
+    }),
 ]
 
 full_sanity_check = True
 
 sanity_check_paths = {
     'files': [],
-    #'dirs': ['lib/python%(pyshortver)s/site-packages'],
     'dirs': ['lib/python%(version_major)s.%(version_minor)s/site-packages'],
 }
 
-#modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 modextrapaths = {'PYTHONPATH': ['lib/python%(version_major)s.%(version_minor)s/site-packages']}
 
 moduleclass = 'lang'


### PR DESCRIPTION
I created this PR by modifying #6479 to exemplify how I think we should split Python-core and Python. I have built this, and it does work great. There was a single numpy test that failed, though, the build was accepted anyway (perhaps it's know to fail?). There definitely doesn't seem to be anything to to worry about having a libpython+interpreter built with gcc and a numpy/scipy build with icc. 

1. Nothing fancy, no hidden packages,  no shadowing (so no ABI worries)
2. No duplicated packages (even more important as more toolchains of various pop up, iomkl, goolfc, cuda, and all the other permutations of the usual suspects. So *a lot* less stuff to compile.
3. Removes the need for a Python-*-bare
4. Most critically; will allow us to move even more dependencies to GCCcore;
Mesa, Tkinter, PyGTK, PyQt, Tk, Swig, etc. etc. etc.

So this means a lot less work maintaining easyconfigs, a lot less stuff to (re-)compile, and vastly larger module availability in less popular toolchains,

I'm not really very concerned how the configs are implemented. We can have numpy/scipy/pandas as a standalone config, doesn't matter. But I can't see any reason why at least the interpreter and libpython wouldn't **exclusively** be built at GCCcore.
I fail to see any downside to this. If there is a critical piece of information I have managed to neglect, please let me know.