### PR TITLE
Fix gtest 1.8.0 - compile gtest

### DIFF
--- a/easybuild/easyconfigs/g/gtest/gtest-1.8.0-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/g/gtest/gtest-1.8.0-GCCcore-6.3.0.eb
@@ -8,7 +8,10 @@ description = "Google's framework for writing C++ tests on a variety of platform
 
 toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
 
-builddependencies = [('CMake', '3.8.2')]
+builddependencies = [
+    ('CMake', '3.8.2'),
+    ('binutils', '2.27'),
+]
 
 sources = ['release-%(version)s.tar.gz']
 source_urls = ['https://github.com/google/googletest/archive/']

--- a/easybuild/easyconfigs/g/gtest/gtest-1.8.0-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/g/gtest/gtest-1.8.0-GCCcore-6.3.0.eb
@@ -1,4 +1,4 @@
-easyblock = "Tarball"
+easyblock = "CMakeMake"
 
 name = 'gtest'
 version = '1.8.0'
@@ -8,12 +8,15 @@ description = "Google's framework for writing C++ tests on a variety of platform
 
 toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
 
+builddependencies = [('CMake', '3.10.2')]
+
 sources = ['release-%(version)s.tar.gz']
 source_urls = ['https://github.com/google/googletest/archive/']
+checksums = ['58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8']
 
 sanity_check_paths = {
-    'files': ['CMakeLists.txt', ],
-    'dirs': ['googletest/include', 'googletest/src'],
+    'files': ['lib/libgtest.a', 'lib/libgmock.a'],
+    'dirs': ['include'],
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/g/gtest/gtest-1.8.0-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/g/gtest/gtest-1.8.0-GCCcore-6.3.0.eb
@@ -8,7 +8,7 @@ description = "Google's framework for writing C++ tests on a variety of platform
 
 toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
 
-builddependencies = [('CMake', '3.10.2')]
+builddependencies = [('CMake', '3.8.2')]
 
 sources = ['release-%(version)s.tar.gz']
 source_urls = ['https://github.com/google/googletest/archive/']

--- a/easybuild/easyconfigs/g/gtest/gtest-1.8.0-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/g/gtest/gtest-1.8.0-GCCcore-6.4.0.eb
@@ -10,7 +10,7 @@ toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
 builddependencies = [
     ('CMake', '3.10.2'),
-    ('binutils' '2.28'),
+    ('binutils', '2.28'),
 ]
 
 source_urls = ['https://github.com/google/googletest/archive/']

--- a/easybuild/easyconfigs/g/gtest/gtest-1.8.0-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/g/gtest/gtest-1.8.0-GCCcore-6.4.0.eb
@@ -1,4 +1,4 @@
-easyblock = "Tarball"
+easyblock = "CMakeMake"
 
 name = 'gtest'
 version = '1.8.0'
@@ -8,13 +8,15 @@ description = "Google's framework for writing C++ tests on a variety of platform
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
+builddependencies = [('CMake', '3.10.2')]
+
 source_urls = ['https://github.com/google/googletest/archive/']
 sources = ['release-%(version)s.tar.gz']
 checksums = ['58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8']
 
 sanity_check_paths = {
-    'files': ['CMakeLists.txt', ],
-    'dirs': ['googletest/include', 'googletest/src'],
+    'files': ['lib/libgtest.a', 'lib/libgmock.a'],
+    'dirs': ['include'],
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/g/gtest/gtest-1.8.0-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/g/gtest/gtest-1.8.0-GCCcore-6.4.0.eb
@@ -8,7 +8,10 @@ description = "Google's framework for writing C++ tests on a variety of platform
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
-builddependencies = [('CMake', '3.10.2')]
+builddependencies = [
+    ('CMake', '3.10.2'),
+    ('binutils' '2.28'),
+]
 
 source_urls = ['https://github.com/google/googletest/archive/']
 sources = ['release-%(version)s.tar.gz']


### PR DESCRIPTION
Previous versions were installed as binary, `1.8.0` is a source version, so it have to be compiled.