### PR TITLE
use sortable version for coevol

### DIFF
--- a/easybuild/easyconfigs/c/coevol/coevol-20180201-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/c/coevol/coevol-20180201-goolf-1.7.20.eb
@@ -6,8 +6,8 @@
 easyblock = 'ConfigureMake'
 
 name = 'coevol'
-commit_id = '5d7fc52'
-version = '%s-02012018' % commit_id
+commit = '5d7fc52'
+version = '20180201'
 
 homepage = 'https://github.com/bayesiancook/coevol'
 description = 'Correlated evolution of substitution rates and quantitative traits'
@@ -15,7 +15,7 @@ description = 'Correlated evolution of substitution rates and quantitative trait
 toolchain = {'name': 'goolf', 'version': '1.7.20'}
 
 source_urls = ['https://github.com/bayesiancook/coevol/archive/']
-sources = ['%s.tar.gz' % commit_id]
+sources = [{'download_filename': '%s.tar.gz' % commit, 'filename': SOURCE_TAR_GZ}]
 checksums = ['e2cb1227f452c4f781faf8ec60e483ca27ffd288380bcfa483886f445a775bb6']
 
 unpack_options = '--strip-components=1'
@@ -33,7 +33,7 @@ buildopts = 'all PROGSDIR=%(installdir)s/bin/'
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['ancov', 'coevol', 'readancov', 'readcoevol',
                                      'readtipcoevol', 'tipcoevol']],
-    'dirs': []
+    'dirs': ['data']
 }
 
 moduleclass = 'bio'


### PR DESCRIPTION
follow-up for #6589 

@pescobar `20180201` matches date of used commit (Feb 1st 2018), and sorts properly