### PR TITLE
{devel}[foss-2018b,intel-2018b] Boost v1.68.0 with Python support

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.68.0-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.68.0-foss-2018b-Python-2.7.15.eb
@@ -1,0 +1,24 @@
+name = 'Boost'
+version = '1.68.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.boost.org/'
+description = """Boost provides free peer-reviewed portable C++ source libraries."""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
+checksums = ['da3411ea45622579d419bfda66f45cd0f8c32a181d84adfa936f5688388995cf']
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+    ('Python', '2.7.15'),
+]
+
+# also build boost_mpi
+boost_mpi = True
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.68.0-foss-2018b-Python-3.7.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.68.0-foss-2018b-Python-3.7.0.eb
@@ -1,0 +1,28 @@
+name = 'Boost'
+version = '1.68.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.boost.org/'
+description = """Boost provides free peer-reviewed portable C++ source libraries."""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
+patches = ['Boost-1.65.1_fix-Python3.patch']
+checksums = [
+    'da3411ea45622579d419bfda66f45cd0f8c32a181d84adfa936f5688388995cf',  # boost_1_68_0.tar.gz
+    '5585f98fb67425ec465dcbe2878af046ccd2729a8cdb802acf5d71cfa4022c26',  # Boost-1.65.1_fix-Python3.patch
+]
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+    ('Python', '3.7.0'),
+]
+
+# also build boost_mpi
+boost_mpi = True
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.68.0-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.68.0-intel-2018b-Python-2.7.15.eb
@@ -1,0 +1,24 @@
+name = 'Boost'
+version = '1.68.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.boost.org/'
+description = """Boost provides free peer-reviewed portable C++ source libraries."""
+
+toolchain = {'name': 'intel', 'version': '2018b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
+checksums = ['da3411ea45622579d419bfda66f45cd0f8c32a181d84adfa936f5688388995cf']
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+    ('Python', '2.7.15'),
+]
+
+# also build boost_mpi
+boost_mpi = True
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.68.0-intel-2018b-Python-3.7.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.68.0-intel-2018b-Python-3.7.0.eb
@@ -1,0 +1,28 @@
+name = 'Boost'
+version = '1.68.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.boost.org/'
+description = """Boost provides free peer-reviewed portable C++ source libraries."""
+
+toolchain = {'name': 'intel', 'version': '2018b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
+patches = ['Boost-1.65.1_fix-Python3.patch']
+checksums = [
+    'da3411ea45622579d419bfda66f45cd0f8c32a181d84adfa936f5688388995cf',  # boost_1_68_0.tar.gz
+    '5585f98fb67425ec465dcbe2878af046ccd2729a8cdb802acf5d71cfa4022c26',  # Boost-1.65.1_fix-Python3.patch
+]
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+    ('Python', '3.7.0'),
+]
+
+# also build boost_mpi
+boost_mpi = True
+
+moduleclass = 'devel'


### PR DESCRIPTION
Configuration files for Boost 1.68.0 for foss/2018b and intel/2018b.  With Python 2/3 support.

Requires modified easyblock: https://github.com/easybuilders/easybuild-easyblocks/pull/1472