### PR TITLE
{vis}[foss/2018b] Mesa v18.1.1 - add expat dep

### DIFF
--- a/easybuild/easyconfigs/m/Mesa/Mesa-18.1.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-18.1.1-foss-2018b.eb
@@ -41,6 +41,7 @@ builddependencies = [
     ('pkg-config', '0.29.2'),
     ('Mako', '1.0.7', '-Python-2.7.15'),
     ('libxml2', '2.9.8'),
+    ('expat', '2.2.5'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/m/Mesa/Mesa-18.1.1-intel-2018b.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-18.1.1-intel-2018b.eb
@@ -41,6 +41,7 @@ builddependencies = [
     ('pkg-config', '0.29.2'),
     ('Mako', '1.0.7', '-Python-2.7.15'),
     ('libxml2', '2.9.8'),
+    ('expat', '2.2.5'),
 ]
 
 dependencies = [


### PR DESCRIPTION
Adding explicit expat build dependency.

If absent, Mesa v18.1.1 configure step fails on `centos-release-7-5.1804.1.el7.centos.x86_64`:
 
`...`
`checking for expat... no`
`checking for expat21... no`
`configure: error: Package requirements (expat21) were not met`
`...`
