### PR TITLE
switch to Python 3.6.6 (instead of 3.7.0) for 2018b toolchain generation

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.68.0-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.68.0-foss-2018b-Python-3.6.6.eb
@@ -5,7 +5,7 @@ versionsuffix = '-Python-%(pyver)s'
 homepage = 'http://www.boost.org/'
 description = """Boost provides free peer-reviewed portable C++ source libraries."""
 
-toolchain = {'name': 'intel', 'version': '2018b'}
+toolchain = {'name': 'foss', 'version': '2018b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = [SOURCEFORGE_SOURCE]
@@ -19,7 +19,7 @@ checksums = [
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.11'),
-    ('Python', '3.7.0'),
+    ('Python', '3.6.6'),
 ]
 
 # also build boost_mpi

--- a/easybuild/easyconfigs/b/Boost/Boost-1.68.0-intel-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.68.0-intel-2018b-Python-3.6.6.eb
@@ -5,7 +5,7 @@ versionsuffix = '-Python-%(pyver)s'
 homepage = 'http://www.boost.org/'
 description = """Boost provides free peer-reviewed portable C++ source libraries."""
 
-toolchain = {'name': 'foss', 'version': '2018b'}
+toolchain = {'name': 'intel', 'version': '2018b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = [SOURCEFORGE_SOURCE]
@@ -19,7 +19,7 @@ checksums = [
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.11'),
-    ('Python', '3.7.0'),
+    ('Python', '3.6.6'),
 ]
 
 # also build boost_mpi

--- a/easybuild/easyconfigs/h/h5py/h5py-2.8.0-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.8.0-foss-2018b-Python-3.6.6.eb
@@ -20,7 +20,7 @@ checksums = ['e626c65a8587921ebc7fb8d31a49addfdd0b9a9aa96315ea484c09803337b955']
 prebuildopts = ' python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
 
 dependencies = [
-    ('Python', '3.7.0'),
+    ('Python', '3.6.6'),
     ('HDF5', '1.10.2'),
     ('pkgconfig', '1.3.1', '-Python-%(pyver)s'),
 ]

--- a/easybuild/easyconfigs/h/h5py/h5py-2.8.0-intel-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.8.0-intel-2018b-Python-3.6.6.eb
@@ -20,7 +20,7 @@ checksums = ['e626c65a8587921ebc7fb8d31a49addfdd0b9a9aa96315ea484c09803337b955']
 prebuildopts = ' python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
 
 dependencies = [
-    ('Python', '3.7.0'),
+    ('Python', '3.6.6'),
     ('HDF5', '1.10.2'),
     ('pkgconfig', '1.3.1', '-Python-%(pyver)s'),
 ]

--- a/easybuild/easyconfigs/p/pkgconfig/pkgconfig-1.3.1-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/p/pkgconfig/pkgconfig-1.3.1-foss-2018b-Python-3.6.6.eb
@@ -7,7 +7,7 @@ versionsuffix = '-Python-%(pyver)s'
 homepage = 'http://github.com/matze/pkgconfig'
 description = """pkgconfig is a Python module to interface with the pkg-config command line tool"""
 
-toolchain = {'name': 'intel', 'version': '2018b'}
+toolchain = {'name': 'foss', 'version': '2018b'}
 toolchainopts = {'usempi': True}
 
 source_urls = [PYPI_SOURCE]
@@ -15,7 +15,7 @@ sources = [SOURCE_TAR_GZ]
 checksums = ['0bc77e955a5990b466b7277234a88dc6a62f1f4388ac1e95469051c82a17fd80']
 
 dependencies = [
-    ('Python', '3.7.0'),
+    ('Python', '3.6.6'),
     ('pkg-config', '0.29.2'),
 ]
 

--- a/easybuild/easyconfigs/p/pkgconfig/pkgconfig-1.3.1-intel-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/p/pkgconfig/pkgconfig-1.3.1-intel-2018b-Python-3.6.6.eb
@@ -7,7 +7,7 @@ versionsuffix = '-Python-%(pyver)s'
 homepage = 'http://github.com/matze/pkgconfig'
 description = """pkgconfig is a Python module to interface with the pkg-config command line tool"""
 
-toolchain = {'name': 'foss', 'version': '2018b'}
+toolchain = {'name': 'intel', 'version': '2018b'}
 toolchainopts = {'usempi': True}
 
 source_urls = [PYPI_SOURCE]
@@ -15,7 +15,7 @@ sources = [SOURCE_TAR_GZ]
 checksums = ['0bc77e955a5990b466b7277234a88dc6a62f1f4388ac1e95469051c82a17fd80']
 
 dependencies = [
-    ('Python', '3.7.0'),
+    ('Python', '3.6.6'),
     ('pkg-config', '0.29.2'),
 ]
 


### PR DESCRIPTION
cfr. #6682