### PR TITLE
Add iso_c_binding support to arpack-ng 3.6.2

### DIFF
--- a/easybuild/easyconfigs/a/arpack-ng/arpack-ng-3.6.2-intel-2018a.eb
+++ b/easybuild/easyconfigs/a/arpack-ng/arpack-ng-3.6.2-intel-2018a.eb
@@ -16,7 +16,7 @@ checksums = ['673c8202de996fd3127350725eb1818e534db4e79de56d5dcee8c00768db599a']
 builddependencies = [('Autotools', '20170619')]
 
 preconfigopts = "sh bootstrap && "
-configopts = '--with-pic --with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK"'
+configopts = '--enable-icb --with-pic --with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK"'
 
 sanity_check_paths = {
     'files': ["lib/libarpack.a", "lib/libarpack.%s" % SHLIB_EXT],


### PR DESCRIPTION
So then `arpack` libraries can be linked not only from `Fortran` but from `C` and `C++` , see https://github.com/opencollab/arpack-ng point 4.