### PR TITLE
remove useless definition of TORCH_CUDA_ARCH_LIST in PyTorch easyconfig that doesn't use CUDA

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-0.3.1-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-0.3.1-intel-2018a-Python-3.6.4.eb
@@ -83,10 +83,6 @@ dependencies = [
 # This environment is needed to prevent setup.py from invoking git to determine version.
 prebuildopts = 'PYTORCH_BUILD_VERSION=%(version)s PYTORCH_BUILD_NUMBER=1'
 
-# you can choice here: either give a list of CUDA cc version or tell it All
-# by default it does autodetect of the GPU on the local machine
-prebuildopts += ' TORCH_CUDA_ARCH_LIST="3.0 3.2 3.5 3.7 5.0 5.2 5.3 6.0 6.1 7.0"'
-
 runtest = 'export PYTHONPATH=%(builddir)s/%(namelower)s-%(version)s/build/lib.linux-x86_64-%(pyshortver)s:$PYTHONPATH '
 runtest += '&& cd test && bash run_test.sh'
 


### PR DESCRIPTION
This was inherited from `PyTorch-0.3.1-foss-2018a-Python-3.6.4-CUDA-9.1.85.eb` via #6152, but it doesn't make any sense to have it there...

cc @wpoely86, @smoors, @zao