### PR TITLE
Fix builing GCCcore-6.3.0 by backporting patches from 6.4.0

### DIFF
--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.3.0.eb
@@ -20,7 +20,6 @@ source_urls = [
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies
     'http://isl.gforge.inria.fr/',  # original HTTP source for ISL
 ]
-
 sources = [
     'gcc-%(version)s.tar.bz2',
     'gmp-6.1.1.tar.bz2',
@@ -28,12 +27,6 @@ sources = [
     'mpc-1.0.3.tar.gz',
     'isl-0.16.1.tar.bz2',
 ]
-
-builddependencies = [
-    ('M4', '1.4.17'),
-    ('binutils', '2.27'),
-]
-
 patches = [
     ('mpfr-%s-allpatches-20161215.patch' % mpfr_version, '../mpfr-%s' % mpfr_version),
     'GCCcore-6.2.0-fix-find-isl.patch',
@@ -41,13 +34,23 @@ patches = [
     'GCCcore-6.3.0_fix-linux-unwind-fix-ucontext.patch',
     'GCCcore-6.3.0_fix-sanitizer_linux.patch'
 ]
-
 checksums = [
-    '677a7623c7ef6ab99881bc4e048debb6',     # gcc-6.3.0.tar.bz2
-    '4c175f86e11eb32d8bf9872ca3a8e11d',     # gmp-6.1.1.tar.bz2
-    'b1d23a55588e3b2a13e3be66bc69fd8d',     # mpfr-3.1.5.tar.gz
-    'd6a1d5f8ddea3abd2cc3e98f58352d26',     # mpc-1.0.3.tar.gz
-    'ac1f25a0677912952718a51f5bc20f32',     # isl-0.16.1.tar.bz2
+    'f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f',  # gcc-6.3.0.tar.bz2
+    'a8109865f2893f1373b0a8ed5ff7429de8db696fc451b1036bd7bdf95bbeffd6',  # gmp-6.1.1.tar.bz2
+    'ca498c1c7a74dd37a576f353312d1e68d490978de4395fa28f1cbd46a364e658',  # mpfr-3.1.5.tar.bz2
+    '617decc6ea09889fb08ede330917a00b16809b8db88c29c31bfbb49cbf88ecc3',  # mpc-1.0.3.tar.gz
+    '412538bb65c799ac98e17e8cfcdacbb257a57362acfaaff254b0fcae970126d2',  # isl-0.16.1.tar.bz2
+    '1621958531f863152971a55bfc6fd7bebbf55b390ac472d1168c8b87efc56cc9',  # mpfr-3.1.5-allpatches-20161215.patch
+    '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68',  # GCCcore-6.2.0-fix-find-isl.patch
+    'a021bdc9da72438475168639d71dcbd8953becef8230eabd46bc5719519c164e',  # GCCcore-6.x-fix-ubsan.patch
+    # GCCcore-6.3.0_fix-linux-unwind-fix-ucontext.patch
+    'f16f7be8e42605b4d476289f7b8bf38fa7553b282392d21649d91ef5d5ecb3fc',
+    '650e903af7399b6dca82bb606560a5d9bfe06f794a73d3ada9018bdc8ab497a3',  # GCCcore-6.3.0_fix-sanitizer_linux.patch
+]
+
+builddependencies = [
+    ('M4', '1.4.17'),
+    ('binutils', '2.27'),
 ]
 
 languages = ['c', 'c++', 'fortran']

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.3.0.eb
@@ -38,6 +38,8 @@ patches = [
     ('mpfr-%s-allpatches-20161215.patch' % mpfr_version, '../mpfr-%s' % mpfr_version),
     'GCCcore-6.2.0-fix-find-isl.patch',
     'GCCcore-6.x-fix-ubsan.patch',
+    'GCCcore-6.3.0_fix-linux-unwind-fix-ucontext.patch',
+    'GCCcore-6.3.0_fix-sanitizer_linux.patch'
 ]
 
 checksums = [

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.3.0_fix-linux-unwind-fix-ucontext.patch
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.3.0_fix-linux-unwind-fix-ucontext.patch
@@ -1,0 +1,141 @@
+Taken from https://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/recipes-devtools/gcc/gcc-6.3/0055-unwind_h-glibc26.patch?id=4cb2af5af804393c80ed4d76b2ff34187d5a4d5b
+
+Backport and edit of patches from:
+https://gcc.gnu.org/viewcvs/gcc?limit_changes=0&view=revision&revision=249957
+by jsm28 (Joseph Myers)
+
+Current glibc no longer gives the ucontext_t type the tag struct
+ucontext, to conform with POSIX namespace rules.  This requires
+various linux-unwind.h files in libgcc, that were previously using
+struct ucontext, to be fixed to use ucontext_t instead.  This is
+similar to the removal of the struct siginfo tag from siginfo_t some
+years ago.
+
+This patch changes those files to use ucontext_t instead.  As the
+standard name that should be unconditionally safe, so this is not
+restricted to architectures supported by glibc, or conditioned on the
+glibc version.
+
+Upstream-Status: Backport
+
+Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>
+
+--- branches/gcc-6-branch/libgcc/config/aarch64/linux-unwind.h	2017/07/04 10:22:56	249956
++++ branches/gcc-6-branch/libgcc/config/aarch64/linux-unwind.h	2017/07/04 10:23:57	249957
+@@ -52,7 +52,7 @@
+   struct rt_sigframe
+   {
+     siginfo_t info;
+-    struct ucontext uc;
++    ucontext_t uc;
+   };
+ 
+   struct rt_sigframe *rt_;
+--- branches/gcc-6-branch/libgcc/config/alpha/linux-unwind.h	2017/07/04 10:22:56	249956
++++ branches/gcc-6-branch/libgcc/config/alpha/linux-unwind.h	2017/07/04 10:23:57	249957
+@@ -51,7 +51,7 @@
+     {
+       struct rt_sigframe {
+ 	siginfo_t info;
+-	struct ucontext uc;
++	ucontext_t uc;
+       } *rt_ = context->cfa;
+       sc = &rt_->uc.uc_mcontext;
+     }
+--- branches/gcc-6-branch/libgcc/config/bfin/linux-unwind.h	2017/07/04 10:22:56	249956
++++ branches/gcc-6-branch/libgcc/config/bfin/linux-unwind.h	2017/07/04 10:23:57	249957
+@@ -52,7 +52,7 @@
+ 	void *puc;
+ 	char retcode[8];
+ 	siginfo_t info;
+-	struct ucontext uc;
++	ucontext_t uc;
+       } *rt_ = context->cfa;
+ 
+       /* The void * cast is necessary to avoid an aliasing warning.
+--- branches/gcc-6-branch/libgcc/config/i386/linux-unwind.h	2017/07/04 10:22:56	249956
++++ branches/gcc-6-branch/libgcc/config/i386/linux-unwind.h	2017/07/04 10:23:57	249957
+@@ -58,7 +58,7 @@
+   if (*(unsigned char *)(pc+0) == 0x48
+       && *(unsigned long long *)(pc+1) == RT_SIGRETURN_SYSCALL)
+     {
+-      struct ucontext *uc_ = context->cfa;
++      ucontext_t *uc_ = context->cfa;
+       /* The void * cast is necessary to avoid an aliasing warning.
+          The aliasing warning is correct, but should not be a problem
+          because it does not alias anything.  */
+@@ -138,7 +138,7 @@
+ 	siginfo_t *pinfo;
+ 	void *puc;
+ 	siginfo_t info;
+-	struct ucontext uc;
++	ucontext_t uc;
+       } *rt_ = context->cfa;
+       /* The void * cast is necessary to avoid an aliasing warning.
+          The aliasing warning is correct, but should not be a problem
+--- branches/gcc-6-branch/libgcc/config/m68k/linux-unwind.h	2017/07/04 10:22:56	249956
++++ branches/gcc-6-branch/libgcc/config/m68k/linux-unwind.h	2017/07/04 10:23:57	249957
+@@ -33,7 +33,7 @@
+ /* <sys/ucontext.h> is unfortunately broken right now.  */
+ struct uw_ucontext {
+ 	unsigned long	  uc_flags;
+-	struct ucontext  *uc_link;
++	ucontext_t	 *uc_link;
+ 	stack_t		  uc_stack;
+ 	mcontext_t	  uc_mcontext;
+ 	unsigned long	  uc_filler[80];
+--- branches/gcc-6-branch/libgcc/config/nios2/linux-unwind.h	2017/07/04 10:22:56	249956
++++ branches/gcc-6-branch/libgcc/config/nios2/linux-unwind.h	2017/07/04 10:23:57	249957
+@@ -38,7 +38,7 @@
+ 
+ struct nios2_ucontext {
+   unsigned long uc_flags;
+-  struct ucontext *uc_link;
++  ucontext_t *uc_link;
+   stack_t uc_stack;
+   struct nios2_mcontext uc_mcontext;
+   sigset_t uc_sigmask;	/* mask last for extensibility */
+--- branches/gcc-6-branch/libgcc/config/pa/linux-unwind.h	2017/07/04 10:22:56	249956
++++ branches/gcc-6-branch/libgcc/config/pa/linux-unwind.h	2017/07/04 10:23:57	249957
+@@ -80,7 +80,7 @@
+   struct sigcontext *sc;
+   struct rt_sigframe {
+     siginfo_t info;
+-    struct ucontext uc;
++    ucontext_t uc;
+   } *frame;
+ 
+   /* rt_sigreturn trampoline:
+--- branches/gcc-6-branch/libgcc/config/sh/linux-unwind.h	2017/07/04 10:22:56	249956
++++ branches/gcc-6-branch/libgcc/config/sh/linux-unwind.h	2017/07/04 10:23:57	249957
+@@ -180,7 +180,7 @@
+     {
+       struct rt_sigframe {
+ 	siginfo_t info;
+-	struct ucontext uc;
++	ucontext_t uc;
+       } *rt_ = context->cfa;
+       /* The void * cast is necessary to avoid an aliasing warning.
+          The aliasing warning is correct, but should not be a problem
+--- branches/gcc-6-branch/libgcc/config/tilepro/linux-unwind.h	2017/07/04 10:22:56	249956
++++ branches/gcc-6-branch/libgcc/config/tilepro/linux-unwind.h	2017/07/04 10:23:57	249957
+@@ -61,7 +61,7 @@
+   struct rt_sigframe {
+     unsigned char save_area[C_ABI_SAVE_AREA_SIZE];
+     siginfo_t info;
+-    struct ucontext uc;
++    ucontext_t uc;
+   } *rt_;
+ 
+   /* Return if this is not a signal handler.  */
+--- branches/gcc-6-branch/libgcc/config/xtensa/linux-unwind.h	2017/07/04 10:22:56	249956
++++ branches/gcc-6-branch/libgcc/config/xtensa/linux-unwind.h	2017/07/04 10:23:57	249957
+@@ -67,7 +67,7 @@
+ 
+   struct rt_sigframe {
+     siginfo_t info;
+-    struct ucontext uc;
++    ucontext_t uc;
+   } *rt_;
+ 
+   /* movi a2, __NR_rt_sigreturn; syscall */

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.3.0_fix-sanitizer_linux.patch
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.3.0_fix-sanitizer_linux.patch
@@ -1,0 +1,86 @@
+Taken from https://github.com/gcc-mirror/gcc/commit/72edc2c02f8b4768ad660f46a1c7e2400c0a8e06.patch
+
+From 72edc2c02f8b4768ad660f46a1c7e2400c0a8e06 Mon Sep 17 00:00:00 2001
+From: jakub <jakub@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date: Mon, 17 Jul 2017 19:41:08 +0000
+Subject: [PATCH] 	Backported from mainline 	2017-07-14  Jakub
+ Jelinek  <jakub@redhat.com>
+
+	PR sanitizer/81066
+	* sanitizer_common/sanitizer_linux.h: Cherry-pick upstream r307969.
+	* sanitizer_common/sanitizer_linux.cc: Likewise.
+	* sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cc: Likewise.
+	* tsan/tsan_platform_linux.cc: Likewise.
+
+
+git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/branches/gcc-7-branch@250287 138bc75d-0d04-0410-961f-82ee72b054a4
+---
+ libsanitizer/ChangeLog                                | 11 +++++++++++
+ libsanitizer/sanitizer_common/sanitizer_linux.cc      |  3 +--
+ libsanitizer/sanitizer_common/sanitizer_linux.h       |  4 +---
+ .../sanitizer_stoptheworld_linux_libcdep.cc           |  2 +-
+ libsanitizer/tsan/tsan_platform_linux.cc              |  2 +-
+ 5 files changed, 15 insertions(+), 7 deletions(-)
+
+diff --git a/libsanitizer/sanitizer_common/sanitizer_linux.cc b/libsanitizer/sanitizer_common/sanitizer_linux.cc
+index 806fcd5e2847..5b6f18602e7d 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_linux.cc
++++ b/libsanitizer/sanitizer_common/sanitizer_linux.cc
+@@ -605,8 +605,7 @@ uptr internal_prctl(int option, uptr arg2, uptr arg3, uptr arg4, uptr arg5) {
+ }
+ #endif
+ 
+-uptr internal_sigaltstack(const struct sigaltstack *ss,
+-                         struct sigaltstack *oss) {
++uptr internal_sigaltstack(const void *ss, void *oss) {
+   return internal_syscall(SYSCALL(sigaltstack), (uptr)ss, (uptr)oss);
+ }
+ 
+diff --git a/libsanitizer/sanitizer_common/sanitizer_linux.h b/libsanitizer/sanitizer_common/sanitizer_linux.h
+index 895bfc18195c..a42df5764052 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_linux.h
++++ b/libsanitizer/sanitizer_common/sanitizer_linux.h
+@@ -19,7 +19,6 @@
+ #include "sanitizer_platform_limits_posix.h"
+ 
+ struct link_map;  // Opaque type returned by dlopen().
+-struct sigaltstack;
+ 
+ namespace __sanitizer {
+ // Dirent structure for getdents(). Note that this structure is different from
+@@ -28,8 +27,7 @@ struct linux_dirent;
+ 
+ // Syscall wrappers.
+ uptr internal_getdents(fd_t fd, struct linux_dirent *dirp, unsigned int count);
+-uptr internal_sigaltstack(const struct sigaltstack* ss,
+-                          struct sigaltstack* oss);
++uptr internal_sigaltstack(const void* ss, void* oss);
+ uptr internal_sigprocmask(int how, __sanitizer_sigset_t *set,
+     __sanitizer_sigset_t *oldset);
+ 
+diff --git a/libsanitizer/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cc b/libsanitizer/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cc
+index 891386dc0ba7..234e8c652c67 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cc
++++ b/libsanitizer/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cc
+@@ -273,7 +273,7 @@ static int TracerThread(void* argument) {
+ 
+   // Alternate stack for signal handling.
+   InternalScopedBuffer<char> handler_stack_memory(kHandlerStackSize);
+-  struct sigaltstack handler_stack;
++  stack_t handler_stack;
+   internal_memset(&handler_stack, 0, sizeof(handler_stack));
+   handler_stack.ss_sp = handler_stack_memory.data();
+   handler_stack.ss_size = kHandlerStackSize;
+diff --git a/libsanitizer/tsan/tsan_platform_linux.cc b/libsanitizer/tsan/tsan_platform_linux.cc
+index 2ed5718a12e3..6f972ab0dd64 100644
+--- a/libsanitizer/tsan/tsan_platform_linux.cc
++++ b/libsanitizer/tsan/tsan_platform_linux.cc
+@@ -287,7 +287,7 @@ void InitializePlatform() {
+ int ExtractResolvFDs(void *state, int *fds, int nfd) {
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+   int cnt = 0;
+-  __res_state *statp = (__res_state*)state;
++  struct __res_state *statp = (struct __res_state*)state;
+   for (int i = 0; i < MAXNS && cnt < nfd; i++) {
+     if (statp->_u._ext.nsaddrs[i] && statp->_u._ext.nssocks[i] != -1)
+       fds[cnt++] = statp->_u._ext.nssocks[i];

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.3.0_fix-sanitizer_linux.patch
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.3.0_fix-sanitizer_linux.patch
@@ -1,4 +1,13 @@
-Taken from https://github.com/gcc-mirror/gcc/commit/72edc2c02f8b4768ad660f46a1c7e2400c0a8e06.patch
+The following error was encountered when building GCCcore-6.3.0:
+
+../../../../libsanitizer/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cc: In function ‘int __sanitizer::TracerThread(void*)’:
+../../../../libsanitizer/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cc:270:22: error: aggregate ‘sigaltstack handler_stack’ has incomplete type and cannot be defined
+   struct sigaltstack handler_stack;
+
+This happened due to a glibc patch: https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=7553131847151d04d58a02300673f13d73861cbb
+
+The bug was been fixed upstream and was cherry picked in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81066 back to 6.3.0.
+Patch taken from: https://github.com/gcc-mirror/gcc/commit/72edc2c02f8b4768ad660f46a1c7e2400c0a8e06.patch
 
 From 72edc2c02f8b4768ad660f46a1c7e2400c0a8e06 Mon Sep 17 00:00:00 2001
 From: jakub <jakub@138bc75d-0d04-0410-961f-82ee72b054a4>


### PR DESCRIPTION
Fixes issue #5758 by using backported patches from 6.4.0:

- https://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/recipes-devtools/gcc/gcc-6.3/0055-unwind_h-glibc26.patch?id=4cb2af5af804393c80ed4d76b2ff34187d5a4d5b
- https://github.com/gcc-mirror/gcc/commit/72edc2c02f8b4768ad660f46a1c7e2400c0a8e06.patch