### PR TITLE
fix source_urls in bzip2 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-CrayGNU-2015.06.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-CrayGNU-2015.06.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'CrayGNU', 'version': '2015.06'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-CrayGNU-2015.06.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-CrayGNU-2015.06.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-CrayGNU-2015.11.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'CrayGNU', 'version': '2015.11'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-CrayGNU-2015.11.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-CrayGNU-2016.03.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-CrayGNU-2016.03.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'CrayGNU', 'version': '2016.03'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-CrayGNU-2016.03.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-CrayGNU-2016.03.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.8.1.eb
@@ -9,7 +9,11 @@ compressors), whilst being around twice as fast at compression and six times fas
 toolchain = {'name': 'GCC', 'version': '4.8.1'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s/']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.8.1.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically 
 compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical 
 compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.8.2.eb
@@ -9,7 +9,11 @@ compressors), whilst being around twice as fast at compression and six times fas
 toolchain = {'name': 'GCC', 'version': '4.8.2'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s/']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.8.2.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically 
 compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical 
 compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.8.4.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'GCC', 'version': '4.8.4'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.8.4.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.9.2.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'GCC', 'version': '4.9.2'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.9.2.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.9.3-2.25.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'GCC', 'version': '4.9.3-2.25'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-4.9.3-2.25.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-5.4.0-2.26.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-5.4.0-2.26.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-4.9.3.eb
@@ -9,8 +9,12 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 builddependencies = [
     ('binutils', '2.25'),

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-4.9.3.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-5.4.0.eb
@@ -9,7 +9,10 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'GCCcore', 'version': '5.4.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.bzip.org/%(version)s']
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
 checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-5.4.0.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-6.3.0.eb
@@ -9,8 +9,12 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 # use same binutils version that was used when building GCCcore toolchain
 builddependencies = [('binutils', '2.27', '', True)]

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-6.3.0.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-6.4.0.eb
@@ -12,10 +12,13 @@ description = """
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 toolchainopts = {'pic': True}
-checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
-source_urls = ['http://www.bzip.org/%(version)s']
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 builddependencies = [
     ('binutils', '2.28'),

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-6.4.0.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 
 description = """
  bzip2 is a freely available, patent free, high-quality data compressor. It

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-7.2.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-7.2.0.eb
@@ -13,7 +13,10 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '7.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.bzip.org/%(version)s']
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
 checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-7.2.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-7.2.0.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 
 description = """
  bzip2 is a freely available, patent free, high-quality data compressor. It

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-7.3.0.eb
@@ -12,10 +12,13 @@ description = """
 
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 toolchainopts = {'pic': True}
-checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
-source_urls = ['http://www.bzip.org/%(version)s']
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 builddependencies = [
     ('binutils', '2.30'),

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-7.3.0.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 
 description = """
  bzip2 is a freely available, patent free, high-quality data compressor. It

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GNU-4.9.3-2.25.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'GNU', 'version': '4.9.3-2.25'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GNU-4.9.3-2.25.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2014b.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2014b.eb
@@ -9,7 +9,11 @@ compressors), whilst being around twice as fast at compression and six times fas
 toolchain = {'name': 'foss', 'version': '2014b'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s/']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2014b.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2014b.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
 compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
 compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2015.05.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2015.05.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'foss', 'version': '2015.05'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2015.05.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2015.05.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2015a.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2015a.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'foss', 'version': '2015a'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2015a.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2015a.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2015b.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2015b.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'foss', 'version': '2015b'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2015b.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2015b.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016.04.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016.04.eb
@@ -10,7 +10,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'foss', 'version': '2016.04'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016.04.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016.04.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor.
  It typically compresses files to within 10% to 15% of the best available techniques (the
  PPM family of statistical compressors), whilst being around twice as fast at compression

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016a.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016a.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'foss', 'version': '2016a'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016a.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016a.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016b.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016b.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'foss', 'version': '2016b'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016b.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016b.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-gimkl-2.11.5.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'gimkl', 'version': '2.11.5'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-gimkl-2.11.5.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-gimkl-2017a.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-gimkl-2017a.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'version': '2017a', 'name': 'gimkl'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-gimkl-2017a.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-gimkl-2017a.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-gompi-1.5.16.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-gompi-1.5.16.eb
@@ -9,7 +9,11 @@ compressors), whilst being around twice as fast at compression and six times fas
 toolchain = {'name': 'gompi', 'version': '1.5.16'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s/']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-gompi-1.5.16.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-gompi-1.5.16.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically 
 compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical 
 compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.4.10.eb
@@ -9,7 +9,11 @@ compressors), whilst being around twice as fast at compression and six times fas
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s/']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.4.10.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically 
 compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical 
 compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.5.14.eb
@@ -9,7 +9,11 @@ compressors), whilst being around twice as fast at compression and six times fas
 toolchain = {'name': 'goolf', 'version': '1.5.14'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s/']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.5.14.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically 
 compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical 
 compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.5.16.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.5.16.eb
@@ -9,7 +9,11 @@ compressors), whilst being around twice as fast at compression and six times fas
 toolchain = {'name': 'goolf', 'version': '1.5.16'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s/']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.5.16.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.5.16.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically 
 compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical 
 compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.7.20.eb
@@ -9,7 +9,11 @@ compressors), whilst being around twice as fast at compression and six times fas
 toolchain = {'name': 'goolf', 'version': '1.7.20'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.bzip.org/%(version)s/']
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-goolf-1.7.20.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically 
 compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical 
 compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.2.0.eb
@@ -9,7 +9,11 @@ compressors), whilst being around twice as fast at compression and six times fas
 toolchain = {'name': 'ictce', 'version': '5.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.bzip.org/%(version)s/']
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.2.0.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
 compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
 compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.3.0.eb
@@ -6,11 +6,14 @@ description = """bzip2 is a freely available, patent free, high-quality data com
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""
 
-
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.3.0.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.4.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.4.0.eb
@@ -6,11 +6,14 @@ description = """bzip2 is a freely available, patent free, high-quality data com
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""
 
-
 toolchain = {'name': 'ictce', 'version': '5.4.0'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.4.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.4.0.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.5.0.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-5.5.0.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-6.2.5.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'ictce', 'version': '6.2.5'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-6.2.5.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-7.1.2.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'ictce', 'version': '7.1.2'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-ictce-7.1.2.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2014.06.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2014.06.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'intel', 'version': '2014.06'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2014.06.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2014.06.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2014b.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2014b.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'intel', 'version': '2014b'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2014b.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2014b.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2015a.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2015a.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'intel', 'version': '2015a'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2015a.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2015a.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2015b.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2015b.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'intel', 'version': '2015b'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2015b.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2015b.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2016.02-GCC-4.9.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2016.02-GCC-4.9.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2016a.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2016a.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'intel', 'version': '2016a'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2016a.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2016a.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2016b.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2016b.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'intel', 'version': '2016b'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2016b.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2016b.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-iomkl-2016.07.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-iomkl-2016.07.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'iomkl', 'version': '2016.07'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-iomkl-2016.07.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-iomkl-2016.07.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -9,7 +9,11 @@ description = """bzip2 is a freely available, patent free, high-quality data com
 toolchain = {'name': 'iomkl', 'version': '2016.09-GCC-4.9.3-2.25'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
  compressors), whilst being around twice as fast at compression and six times faster at decompression."""

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6.eb
@@ -9,8 +9,12 @@ compressors), whilst being around twice as fast at compression and six times fas
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 toolchainopts = {'pic': True}
 
+source_urls = [
+    'https://fossies.org/linux/misc/',
+    'http://www.bzip.org/%(version)s/',
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.bzip.org/%(version)s/']
+checksums = ['a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd']
 
 buildopts = "CC=gcc CFLAGS='-Wall -Winline -O3 -fPIC -g $(BIGFILES)'"
 

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6.eb
@@ -1,7 +1,7 @@
 name = 'bzip2'
 version = '1.0.6'
 
-homepage = 'http://www.bzip.org/'
+homepage = 'https://sourceware.org/bzip2'
 description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically 
 compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical 
 compressors), whilst being around twice as fast at compression and six times faster at decompression."""


### PR DESCRIPTION
It seems like the http://bzip.org/ domain has expired, and is up for sale...

The only seemingly reliable/appropriate alternative I could find for downloading `bzip2-1.0.6.tar.gz` is `https://fossies.org/linux/misc`...