### PR TITLE
Fix building flex 2.6.4 on glibc 2.26+

### DIFF
--- a/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-GCCcore-7.3.0.eb
@@ -20,8 +20,9 @@ source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969']
 
+# use same binutils version that was used when building GCC toolchain
 builddependencies = [
-    ('binutils', '2.30'),
+    ('binutils', '2.30', '', True),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GCCcore-7.3.0.eb
@@ -1,0 +1,41 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'Automake'
+version = "1.15"
+
+homepage = 'http://www.gnu.org/software/automake/automake.html'
+description = "Automake: GNU Standards-compliant Makefile generator"
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+patches = ['Automake-%(version)s-fix-brace.patch']
+checksums = [
+    '7946e945a96e28152ba5a6beb0625ca715c6e32ac55f2e353ef54def0c8ed924',  # automake-1.15.tar.gz
+    '9f72b339934d546ba8f8486d3ca601601a298963b66a20474245df524acaf0d7',  # Automake-1.15-fix-brace.patch
+]
+
+dependencies = [('Autoconf', '2.69')]
+
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.30', '', True)]
+
+sanity_check_paths = {
+    'files': ['bin/automake', 'bin/aclocal'],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15.eb
@@ -22,7 +22,11 @@ toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['7946e945a96e28152ba5a6beb0625ca715c6e32ac55f2e353ef54def0c8ed924']
+patches = ['Automake-%(version)s-fix-brace.patch']
+checksums = [
+    '7946e945a96e28152ba5a6beb0625ca715c6e32ac55f2e353ef54def0c8ed924',  # automake-1.15.tar.gz
+    '9f72b339934d546ba8f8486d3ca601601a298963b66a20474245df524acaf0d7',  # Automake-1.15-fix-brace.patch
+]
 
 dependencies = [('Autoconf', '2.69')]
 

--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.5.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.5.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'Bison'
+version = '3.0.5'
+
+homepage = 'http://www.gnu.org/software/bison'
+description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
+ into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['cd399d2bee33afa712bac4b1f4434e20379e9b4099bce47189e09a7675a2d566']
+
+builddependencies = [
+    ('M4', '1.4.18'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['bison', 'yacc']] + [('lib/liby.a', 'lib64/liby.a')],
+    'dirs': [],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-7.3.0.eb
@@ -14,7 +14,11 @@ toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/westes/flex/releases/download/v%(version)s/']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995']
+patches = ['flex-2.6.4_system_extension.patch']
+checksums = [
+    'e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995',  # flex-2.6.4.tar.gz
+    '4bb26cc1a92a3b10872548ad7db43aa7b82517d850a6803147d0fc2637cd6910',  # flex-2.6.4_system_extension.patch
+]
 
 builddependencies = [
     ('Bison', '3.0.4'),

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-7.3.0.eb
@@ -17,12 +17,13 @@ sources = [SOURCELOWER_TAR_GZ]
 patches = ['flex-2.6.4_system_extension.patch']
 checksums = [
     'e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995',  # flex-2.6.4.tar.gz
-    '4bb26cc1a92a3b10872548ad7db43aa7b82517d850a6803147d0fc2637cd6910',  # flex-2.6.4_system_extension.patch
+    '2975201c6ec3687219cb1b7f85f04aee227ea67f0491ba16d50f0384a8e02630',  # flex-2.6.4_system_extension.patch
 ]
 
 builddependencies = [
-    ('Bison', '3.0.4'),
-    ('help2man', '1.47.4'),
+    ('Bison', '3.0.5'),
+    ('help2man', '1.47.6'),
+    ('Automake', '1.15'),
     # use same binutils version that was used when building GCC toolchain
     ('binutils', '2.30', '', True),
 ]

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4.eb
@@ -14,7 +14,11 @@ toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/westes/flex/releases/download/v%(version)s/']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995']
+patches = ['flex-2.6.4_system_extension.patch']
+checksums = [
+    'e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995',  # flex-2.6.4.tar.gz
+    '4bb26cc1a92a3b10872548ad7db43aa7b82517d850a6803147d0fc2637cd6910',  # flex-2.6.4_system_extension.patch
+]
 
 builddependencies = [
     ('Bison', '3.0.4'),

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4.eb
@@ -17,12 +17,12 @@ sources = [SOURCELOWER_TAR_GZ]
 patches = ['flex-2.6.4_system_extension.patch']
 checksums = [
     'e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995',  # flex-2.6.4.tar.gz
-    '4bb26cc1a92a3b10872548ad7db43aa7b82517d850a6803147d0fc2637cd6910',  # flex-2.6.4_system_extension.patch
+    '2975201c6ec3687219cb1b7f85f04aee227ea67f0491ba16d50f0384a8e02630',  # flex-2.6.4_system_extension.patch
 ]
 
 builddependencies = [
-    ('Bison', '3.0.4'),
-    ('help2man', '1.47.4'),
+    ('Bison', '3.0.5'),
+    ('help2man', '1.47.6'),
     ('Automake', '1.15'),
 ]
 

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4.eb
@@ -23,6 +23,7 @@ checksums = [
 builddependencies = [
     ('Bison', '3.0.4'),
     ('help2man', '1.47.4'),
+    ('Automake', '1.15'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4_system_extension.patch
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4_system_extension.patch
@@ -1,0 +1,46 @@
+When building with glibc 2.26+, reallocarray() needs to be enabled, otherwise a segfault will occur during building.
+
+Error without this patch:
+
+[...]
+gcc -DHAVE_CONFIG_H -I.  -DLOCALEDIR=\"/software/easybuild/software/flex/2.6.4/share/locale\"   -g -O2 -MT stage1flex-yylex.o -MD -MP -MF .deps/stage1flex-yylex.Tpo -c -o stage1flex-yylex.o `test -f 'yylex.c' || echo './'`yylex.c
+misc.c: In function ‘allocate_array’:
+misc.c:147:8: warning: implicit declaration of function ‘reallocarray’; did you mean ‘reallocate_array’? [-Wimplicit-function-declaration]
+  mem = reallocarray(NULL, (size_t) size, element_size);
+        ^~~~~~~~~~~~
+        reallocate_array
+misc.c:147:6: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
+  mem = reallocarray(NULL, (size_t) size, element_size);
+      ^
+misc.c: In function ‘reallocate_array’:
+misc.c:664:12: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
+  new_array = reallocarray(array, (size_t) size, element_size);
+            ^
+misc.c: In function ‘allocate_array’:
+misc.c:147:8: warning: implicit declaration of function ‘reallocarray’; did you mean ‘reallocate_array’? [-Wimplicit-function-declaration]
+  mem = reallocarray(NULL, (size_t) size, element_size);
+        ^~~~~~~~~~~~
+        reallocate_array
+misc.c:147:6: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
+  mem = reallocarray(NULL, (size_t) size, element_size);
+      ^
+misc.c: In function ‘reallocate_array’:
+misc.c:664:12: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
+  new_array = reallocarray(array, (size_t) size, element_size);
+            ^
+
+diff --git a/configure.ac b/configure.ac
+index c6f12d64..3c977a4e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -25,8 +25,10 @@
+ # autoconf requirements and initialization
+ 
+ AC_INIT([the fast lexical analyser generator],[2.6.4],[flex-help@lists.sourceforge.net],[flex])
++AC_PREREQ([2.60])
+ AC_CONFIG_SRCDIR([src/scan.l])
+ AC_CONFIG_AUX_DIR([build-aux])
++AC_USE_SYSTEM_EXTENSIONS
+ LT_INIT
+ AM_INIT_AUTOMAKE([1.15 -Wno-portability foreign std-options dist-lzip parallel-tests subdir-objects])
+ AC_CONFIG_HEADER([src/config.h])

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4_system_extension.patch
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4_system_extension.patch
@@ -29,6 +29,10 @@ misc.c:664:12: warning: assignment makes pointer from integer without a cast [-W
   new_array = reallocarray(array, (size_t) size, element_size);
             ^
 
+Taken from:
+https://github.com/westes/flex/issues/241
+https://github.com/westes/flex/commit/c5a26b1
+
 diff --git a/configure.ac b/configure.ac
 index c6f12d64..3c977a4e 100644
 --- a/configure.ac

--- a/easybuild/easyconfigs/h/help2man/help2man-1.47.6-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/h/help2man/help2man-1.47.6-GCCcore-7.3.0.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'help2man'
+version = '1.47.6'
+
+homepage = 'https://www.gnu.org/software/help2man/'
+description = """help2man produces simple manual pages from the '--help' and '--version' output of other commands."""
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_XZ]
+checksums = ['d91b0295b72a638e4a564f643e4e6d1928779131f628c00f356c13bf336de46f']
+
+builddependencies = [
+    # use same binutils version that was used when building GCC toolchain
+    ('binutils', '2.30', '', True),
+]
+
+sanity_check_paths = {
+    'files': ['bin/help2man'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/help2man/help2man-1.47.6.eb
+++ b/easybuild/easyconfigs/h/help2man/help2man-1.47.6.eb
@@ -1,0 +1,20 @@
+easyblock = 'ConfigureMake'
+
+name = 'help2man'
+version = '1.47.6'
+
+homepage = 'https://www.gnu.org/software/help2man/'
+description = """help2man produces simple manual pages from the '--help' and '--version' output of other commands."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_XZ]
+checksums = ['d91b0295b72a638e4a564f643e4e6d1928779131f628c00f356c13bf336de46f']
+
+sanity_check_paths = {
+    'files': ['bin/help2man'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
flex 2.6.4 fails to build with glibc 2.26+, since `reallocarray()` needs to be enabled, otherwise a segfault will occur during building, with the following errors during compiling:

```
gcc -DHAVE_CONFIG_H -I.  -DLOCALEDIR=\"/software/easybuild/software/flex/2.6.4/share/locale\"   -g -O2 -MT stage1flex-yylex.o -MD -MP -MF .deps/stage1flex-yylex.Tpo -c -o stage1flex-yylex.o `test -f 'yylex.c' || echo './'`yylex.c
misc.c: In function ‘allocate_array’:
misc.c:147:8: warning: implicit declaration of function ‘reallocarray’; did you mean ‘reallocate_array’? [-Wimplicit-function-declaration]
  mem = reallocarray(NULL, (size_t) size, element_size);
        ^~~~~~~~~~~~
        reallocate_array
misc.c:147:6: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
  mem = reallocarray(NULL, (size_t) size, element_size);
      ^
misc.c: In function ‘reallocate_array’:
misc.c:664:12: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
  new_array = reallocarray(array, (size_t) size, element_size);
            ^
misc.c: In function ‘allocate_array’:
misc.c:147:8: warning: implicit declaration of function ‘reallocarray’; did you mean ‘reallocate_array’? [-Wimplicit-function-declaration]
  mem = reallocarray(NULL, (size_t) size, element_size);
        ^~~~~~~~~~~~
        reallocate_array
misc.c:147:6: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
  mem = reallocarray(NULL, (size_t) size, element_size);
      ^
misc.c: In function ‘reallocate_array’:
misc.c:664:12: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
  new_array = reallocarray(array, (size_t) size, element_size);
            ^
```

Fix is taken from https://github.com/westes/flex/commit/c5a26b1 (issue and discussion: https://github.com/westes/flex/issues/241).

In the process, `Automake-1.15` needed to be added to the `flex-2.6.4` and `flex-2.6.4-GCCcore-7.3.0` easyblocks, which caused a dependency loop, until `binutils-2.30` was set to use the same binutils version that was used when building GCC toolchain in `Autoconf-2.69-GCCcore-7.3.0`.

The `Automake-1.15s-fix-brace.patch` was also added to `Automake-1.15.eb` (already in the other Automake EBs).

`Bison` and `help2man` dependencies were updated in the process.

I hope this is not too much squashed into a single PR.