### PR TITLE
add CMake build dep for Eigen 3.3.4

### DIFF
--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.3.4.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.3.4.eb
@@ -9,10 +9,12 @@ description = """
 """
 
 # only includes header files, so no need for a non-dummy toolchain
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['http://bitbucket.org/%(namelower)s/%(namelower)s/get']
 sources = ['%(version)s.tar.bz2']
 checksums = ['dd254beb0bafc695d0f62ae1a222ff85b52dbaa3a16f76e781dce22d0d20a4a6']
+
+builddependencies = [('CMake', '3.9.1')]
 
 moduleclass = 'math'


### PR DESCRIPTION
required because of change to `Eigen` easyblock, see https://github.com/easybuilders/easybuild-easyblocks/pull/1482