### PR TITLE
Fix compiling Qt-4.8.7 with OpenSSL 1.1, also disable SSLv3 and update dependencies.

### DIFF
--- a/easybuild/easyconfigs/q/Qt/Qt-4.8.7-foss-2018b.eb
+++ b/easybuild/easyconfigs/q/Qt/Qt-4.8.7-foss-2018b.eb
@@ -1,0 +1,45 @@
+name = 'Qt'
+version = '4.8.7'
+
+homepage = 'http://qt.io/'
+description = "Qt is a comprehensive cross-platform C++ application framework."
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+toolchainopts = {'cstd': 'gnu++98'}
+
+source_urls = [
+    'http://download.qt.io/official_releases/qt/%(version_major_minor)s/%(version)s/',
+    'http://download.qt.io/archive/qt/%(version_major_minor)s/%(version)s/'
+]
+sources = ['%(namelower)s-everywhere-opensource-src-%(version)s.tar.gz']
+patches = [
+    'Qt-%(version)s_phonon-export.patch',
+    'Qt-%(version)s_no-ssl3.patch',
+    'Qt-%(version)s_openssl_1.1.patch',
+]
+checksums = [
+    'e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0',  # qt-everywhere-opensource-src-4.8.7.tar.gz
+    '3853c87c33695bfa57e207ffb0d94cb2565aa462eccdf44d2b2804fd44ecbad6',  # Qt-4.8.7_phonon-export.patch
+    '744514a2c7d1fb8c127ea91da7655911c13f72499127e0cc1bceba0c2551a0e2',  # Qt-4.8.7_no-ssl3.patch
+    'c658829a0149c58eb1245faf7171fbba1be5923915c89526cefe6e9ad6590f23',  # Qt-4.8.7_openssl_1.1.patch
+]
+
+builddependencies = [
+    ('pkg-config', '0.29.2'),
+    ('Bison', '3.0.5'),
+    ('flex', '2.6.4'),
+]
+
+dependencies = [
+    ('GLib', '2.54.3'),
+    ('libpng', '1.6.34'),
+    ('X11', '20180604'),
+    ('libGLU', '9.0.0'),
+    ('SQLite', '3.24.0'),
+    ('fontconfig', '2.13.0'),
+    ('libjpeg-turbo', '2.0.0'),
+]
+
+configopts = '-webkit -opensource '
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/q/Qt/Qt-4.8.7_no-ssl3.patch
+++ b/easybuild/easyconfigs/q/Qt/Qt-4.8.7_no-ssl3.patch
@@ -1,0 +1,66 @@
+Description: Do not use SSLv3 methods in Qt4
+ This patch makes the use of SSLv3 methods optional at compile time.
+ On Debian this means they will not be used and will return a null ctx
+ if the SSLv3 method is deliberately selected.
+Author:	Jon DeVree <nuxi@vault24.org>
+Origin: other, https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=806505
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=806505
+Forwarded: not-needed
+Reviewed-by: Lisandro Damián Nicanor Pérez Meyer <lisandro@debian.org>
+Last-Update: 2015-11-30
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+diff -Nru qt4-x11-4.8.7+dfsg.orig/src/network/ssl/qsslsocket_openssl.cpp qt4-x11-4.8.7+dfsg/src/network/ssl/qsslsocket_openssl.cpp
+--- qt4-x11-4.8.7+dfsg.orig/src/network/ssl/qsslsocket_openssl.cpp	2015-05-07 10:14:44.000000000 -0400
++++ qt4-x11-4.8.7+dfsg/src/network/ssl/qsslsocket_openssl.cpp	2015-11-27 20:49:36.768826857 -0500
+@@ -267,7 +267,11 @@
+ #endif
+         break;
+     case QSsl::SslV3:
++#ifndef OPENSSL_NO_SSL3_METHOD
+         ctx = q_SSL_CTX_new(client ? q_SSLv3_client_method() : q_SSLv3_server_method());
++#else
++        ctx = 0; // SSL 3 not supported by the system, but chosen deliberately -> error
++#endif
+         break;
+     case QSsl::SecureProtocols: // SslV2 will be disabled below
+     case QSsl::TlsV1SslV3: // SslV2 will be disabled below
+diff -Nru qt4-x11-4.8.7+dfsg.orig/src/network/ssl/qsslsocket_openssl_symbols.cpp qt4-x11-4.8.7+dfsg/src/network/ssl/qsslsocket_openssl_symbols.cpp
+--- qt4-x11-4.8.7+dfsg.orig/src/network/ssl/qsslsocket_openssl_symbols.cpp	2015-05-07 10:14:44.000000000 -0400
++++ qt4-x11-4.8.7+dfsg/src/network/ssl/qsslsocket_openssl_symbols.cpp	2015-11-27 20:49:48.061023402 -0500
+@@ -228,13 +228,17 @@
+ #ifndef OPENSSL_NO_SSL2
+ DEFINEFUNC(const SSL_METHOD *, SSLv2_client_method, DUMMYARG, DUMMYARG, return 0, return)
+ #endif
++#ifndef OPENSSL_NO_SSL3_METHOD
+ DEFINEFUNC(const SSL_METHOD *, SSLv3_client_method, DUMMYARG, DUMMYARG, return 0, return)
++#endif
+ DEFINEFUNC(const SSL_METHOD *, SSLv23_client_method, DUMMYARG, DUMMYARG, return 0, return)
+ DEFINEFUNC(const SSL_METHOD *, TLSv1_client_method, DUMMYARG, DUMMYARG, return 0, return)
+ #ifndef OPENSSL_NO_SSL2
+ DEFINEFUNC(const SSL_METHOD *, SSLv2_server_method, DUMMYARG, DUMMYARG, return 0, return)
+ #endif
++#ifndef OPENSSL_NO_SSL3_METHOD
+ DEFINEFUNC(const SSL_METHOD *, SSLv3_server_method, DUMMYARG, DUMMYARG, return 0, return)
++#endif
+ DEFINEFUNC(const SSL_METHOD *, SSLv23_server_method, DUMMYARG, DUMMYARG, return 0, return)
+ DEFINEFUNC(const SSL_METHOD *, TLSv1_server_method, DUMMYARG, DUMMYARG, return 0, return)
+ #else
+@@ -822,13 +826,17 @@
+ #ifndef OPENSSL_NO_SSL2
+     RESOLVEFUNC(SSLv2_client_method)
+ #endif
++#ifndef OPENSSL_NO_SSL3_METHOD
+     RESOLVEFUNC(SSLv3_client_method)
++#endif
+     RESOLVEFUNC(SSLv23_client_method)
+     RESOLVEFUNC(TLSv1_client_method)
+ #ifndef OPENSSL_NO_SSL2
+     RESOLVEFUNC(SSLv2_server_method)
+ #endif
++#ifndef OPENSSL_NO_SSL3_METHOD
+     RESOLVEFUNC(SSLv3_server_method)
++#endif
+     RESOLVEFUNC(SSLv23_server_method)
+     RESOLVEFUNC(TLSv1_server_method)
+     RESOLVEFUNC(X509_NAME_entry_count)

--- a/easybuild/easyconfigs/q/Qt/Qt-4.8.7_openssl_1.1.patch
+++ b/easybuild/easyconfigs/q/Qt/Qt-4.8.7_openssl_1.1.patch
@@ -1,0 +1,673 @@
+Description: Compile with openssl-1.1.0
+ * Most changes are related to openssl structures are now opaque. 
+ * The network/ssl threading setup has been disabled because the
+   old openssl threading model has been removed and is apparently
+   no longer needed.
+ * A number of new functions had to be imported (see changes to
+   src/network/ssl/qsslsocket_openssl_symbols.cpp) 
+Author: Gert Wollny  <gw.fossdev@gmail.com>
+Author: Dmitry Eremin-Solenikov <dbaryshkov@gmail.com>
+Last-Update: 2017-11-07
+Bug-Debian: http://bugs.debian.org/828522
+
+---
+ src/network/ssl/qsslcertificate.cpp            |   25 +++--
+ src/network/ssl/qsslkey.cpp                    |   11 ++
+ src/network/ssl/qsslsocket_openssl.cpp         |   27 ++++-
+ src/network/ssl/qsslsocket_openssl_p.h         |    4 
+ src/network/ssl/qsslsocket_openssl_symbols.cpp |  118 +++++++++++++++++++++++++
+ src/network/ssl/qsslsocket_openssl_symbols_p.h |   76 ++++++++++++++++
+ 6 files changed, 249 insertions(+), 12 deletions(-)
+
+--- a/src/network/ssl/qsslcertificate.cpp
++++ b/src/network/ssl/qsslcertificate.cpp
+@@ -259,10 +259,10 @@ void QSslCertificate::clear()
+ QByteArray QSslCertificate::version() const
+ {
+     QMutexLocker lock(QMutexPool::globalInstanceGet(d.data()));
+-    if (d->versionString.isEmpty() && d->x509)
++    if (d->versionString.isEmpty() && d->x509) {
+         d->versionString =
+-            QByteArray::number(qlonglong(q_ASN1_INTEGER_get(d->x509->cert_info->version)) + 1);
+-
++	    QByteArray::number(qlonglong(q_X509_get_version(d->x509)) + 1);
++    }
+     return d->versionString;
+ }
+ 
+@@ -276,7 +276,7 @@ QByteArray QSslCertificate::serialNumber
+ {
+     QMutexLocker lock(QMutexPool::globalInstanceGet(d.data()));
+     if (d->serialNumberString.isEmpty() && d->x509) {
+-        ASN1_INTEGER *serialNumber = d->x509->cert_info->serialNumber;
++        ASN1_INTEGER *serialNumber = q_X509_get_serialNumber(d->x509);
+         // if we cannot convert to a long, just output the hexadecimal number
+         if (serialNumber->length > 4) {
+             QByteArray hexString;
+@@ -489,24 +489,33 @@ QSslKey QSslCertificate::publicKey() con
+     QSslKey key;
+ 
+     key.d->type = QSsl::PublicKey;
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     X509_PUBKEY *xkey = d->x509->cert_info->key;
++#else
++    X509_PUBKEY *xkey = q_X509_get_X509_PUBKEY(d->x509);
++#endif
+     EVP_PKEY *pkey = q_X509_PUBKEY_get(xkey);
+     Q_ASSERT(pkey);
+ 
+-    if (q_EVP_PKEY_type(pkey->type) == EVP_PKEY_RSA) {
++    int key_id;
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++    key_id = q_EVP_PKEY_type(pkey->type);
++#else
++    key_id = q_EVP_PKEY_base_id(pkey);
++#endif
++    if (key_id == EVP_PKEY_RSA) {
+         key.d->rsa = q_EVP_PKEY_get1_RSA(pkey);
+         key.d->algorithm = QSsl::Rsa;
+         key.d->isNull = false;
+-    } else if (q_EVP_PKEY_type(pkey->type) == EVP_PKEY_DSA) {
++    } else if (key_id == EVP_PKEY_DSA) {
+         key.d->dsa = q_EVP_PKEY_get1_DSA(pkey);
+         key.d->algorithm = QSsl::Dsa;
+         key.d->isNull = false;
+-    } else if (q_EVP_PKEY_type(pkey->type) == EVP_PKEY_DH) {
++    } else if (key_id == EVP_PKEY_DH) {
+         // DH unsupported
+     } else {
+         // error?
+     }
+-
+     q_EVP_PKEY_free(pkey);
+     return key;
+ }
+--- a/src/network/ssl/qsslkey.cpp
++++ b/src/network/ssl/qsslkey.cpp
+@@ -321,8 +321,19 @@ int QSslKey::length() const
+ {
+     if (d->isNull)
+         return -1;
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     return (d->algorithm == QSsl::Rsa)
+            ? q_BN_num_bits(d->rsa->n) : q_BN_num_bits(d->dsa->p);
++#else
++    if (d->algorithm == QSsl::Rsa) {
++        return q_RSA_bits(d->rsa);
++    }else{
++        BIGNUM *p = NULL;
++        q_DSA_get0_pqg(d->dsa, &p, NULL, NULL);
++	return q_BN_num_bits(p);
++    }
++#endif
++
+ }
+ 
+ /*!
+--- a/src/network/ssl/qsslsocket_openssl.cpp
++++ b/src/network/ssl/qsslsocket_openssl.cpp
+@@ -93,6 +93,7 @@ bool QSslSocketPrivate::s_libraryLoaded
+ bool QSslSocketPrivate::s_loadedCiphersAndCerts = false;
+ bool QSslSocketPrivate::s_loadRootCertsOnDemand = false;
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ /* \internal
+ 
+     From OpenSSL's thread(3) manual page:
+@@ -174,6 +175,8 @@ static unsigned long id_function()
+ }
+ } // extern "C"
+ 
++#endif //OPENSSL_VERSION_NUMBER >= 0x10100000L
++
+ QSslSocketBackendPrivate::QSslSocketBackendPrivate()
+     : ssl(0),
+       ctx(0),
+@@ -222,9 +225,12 @@ QSslCipher QSslSocketBackendPrivate::QSs
+             ciph.d->encryptionMethod = descriptionList.at(4).mid(4);
+         ciph.d->exportable = (descriptionList.size() > 6 && descriptionList.at(6) == QLatin1String("export"));
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+         ciph.d->bits = cipher->strength_bits;
+         ciph.d->supportedBits = cipher->alg_bits;
+-
++#else
++	ciph.d->bits = q_SSL_CIPHER_get_bits(cipher, &ciph.d->supportedBits);
++#endif
+     }
+     return ciph;
+ }
+@@ -367,7 +373,7 @@ init_context:
+         //
+         // See also: QSslContext::fromConfiguration()
+         if (caCertificate.expiryDate() >= QDateTime::currentDateTime()) {
+-            q_X509_STORE_add_cert(ctx->cert_store, (X509 *)caCertificate.handle());
++	  q_X509_STORE_add_cert(q_SSL_CTX_get_cert_store(ctx), (X509 *)caCertificate.handle());
+         }
+     }
+ 
+@@ -504,8 +510,10 @@ void QSslSocketBackendPrivate::destroySs
+ */
+ void QSslSocketPrivate::deinitialize()
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     q_CRYPTO_set_id_callback(0);
+     q_CRYPTO_set_locking_callback(0);
++#endif
+ }
+ 
+ /*!
+@@ -526,13 +534,17 @@ bool QSslSocketPrivate::ensureLibraryLoa
+         return false;
+ 
+     // Check if the library itself needs to be initialized.
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     QMutexLocker locker(openssl_locks()->initLock());
++#endif
+     if (!s_libraryLoaded) {
+         s_libraryLoaded = true;
+ 
+         // Initialize OpenSSL.
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+         q_CRYPTO_set_id_callback(id_function);
+         q_CRYPTO_set_locking_callback(locking_function);
++#endif
+         if (q_SSL_library_init() != 1)
+             return false;
+         q_SSL_load_error_strings();
+@@ -571,7 +583,9 @@ bool QSslSocketPrivate::ensureLibraryLoa
+ 
+ void QSslSocketPrivate::ensureCiphersAndCertsLoaded()
+ {
+-    QMutexLocker locker(openssl_locks()->initLock());
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++  QMutexLocker locker(openssl_locks()->initLock());
++#endif
+     if (s_loadedCiphersAndCerts)
+         return;
+     s_loadedCiphersAndCerts = true;
+@@ -663,13 +677,18 @@ void QSslSocketPrivate::resetDefaultCiph
+     STACK_OF(SSL_CIPHER) *supportedCiphers = q_SSL_get_ciphers(mySsl);
+     for (int i = 0; i < q_sk_SSL_CIPHER_num(supportedCiphers); ++i) {
+         if (SSL_CIPHER *cipher = q_sk_SSL_CIPHER_value(supportedCiphers, i)) {
+-            if (cipher->valid) {
++
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++	  if (cipher->valid) {
++#endif
+                 QSslCipher ciph = QSslSocketBackendPrivate::QSslCipher_from_SSL_CIPHER(cipher);
+                 if (!ciph.isNull()) {
+                     if (!ciph.name().toLower().startsWith(QLatin1String("adh")))
+                         ciphers << ciph;
+                 }
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+             }
++#endif
+         }
+     }
+ 
+--- a/src/network/ssl/qsslsocket_openssl_symbols_p.h
++++ b/src/network/ssl/qsslsocket_openssl_symbols_p.h
+@@ -213,9 +213,15 @@ int q_BIO_read(BIO *a, void *b, int c);
+ BIO_METHOD *q_BIO_s_mem();
+ int q_BIO_write(BIO *a, const void *b, int c);
+ int q_BN_num_bits(const BIGNUM *a);
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ int q_CRYPTO_num_locks();
+ void q_CRYPTO_set_locking_callback(void (*a)(int, int, const char *, int));
+ void q_CRYPTO_set_id_callback(unsigned long (*a)());
++#else
++#define q_CRYPTO_num_locks() 1
++#define q_CRYPTO_set_locking_callback(a)
++#define q_CRYPTO_set_id_callback(a)
++#endif
+ void q_CRYPTO_free(void *a);
+ void q_DSA_free(DSA *a);
+ #if OPENSSL_VERSION_NUMBER >= 0x00908000L
+@@ -258,6 +264,7 @@ int q_PEM_write_bio_RSA_PUBKEY(BIO *a, R
+ void q_RAND_seed(const void *a, int b);
+ int q_RAND_status();
+ void q_RSA_free(RSA *a);
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ int q_sk_num(STACK *a);
+ void q_sk_pop_free(STACK *a, void (*b)(void *));
+ #if OPENSSL_VERSION_NUMBER >= 0x10000000L
+@@ -267,6 +274,16 @@ void * q_sk_value(STACK *a, int b);
+ void q_sk_free(STACK *a);
+ char * q_sk_value(STACK *a, int b);
+ #endif
++#else
++int q_OPENSSL_sk_num(STACK *a);
++void q_OPENSSL_sk_pop_free(STACK *a, void (*b)(void *));
++void q_OPENSSL_sk_free(_STACK *a);
++void * q_OPENSSL_sk_value(STACK *a, int b);
++#define q_sk_num q_OPENSSL_sk_num
++#define q_sk_pop_free q_OPENSSL_sk_pop_free
++#define q_sk_free q_OPENSSL_sk_free
++#define q_sk_value q_OPENSSL_sk_value
++#endif
+ int q_SSL_accept(SSL *a);
+ int q_SSL_clear(SSL *a);
+ char *q_SSL_CIPHER_description(SSL_CIPHER *a, char *b, int c);
+@@ -314,8 +331,14 @@ long q_SSL_get_verify_result(const SSL *
+ #else
+ long q_SSL_get_verify_result(SSL *a);
+ #endif
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ int q_SSL_library_init();
+ void q_SSL_load_error_strings();
++#else
++int q_OPENSSL_init_ssl(uint64_t opts, void *settings);
++#define q_SSL_library_init() q_OPENSSL_init_ssl(0, NULL)
++#define q_SSL_load_error_strings() q_OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL)
++#endif
+ SSL *q_SSL_new(SSL_CTX *a);
+ #if OPENSSL_VERSION_NUMBER >= 0x0090806fL && !defined(OPENSSL_NO_TLSEXT)
+ long q_SSL_ctrl(SSL *ssl,int cmd, long larg, void *parg);
+@@ -328,11 +351,21 @@ int q_SSL_shutdown(SSL *a);
+ #if OPENSSL_VERSION_NUMBER >= 0x10000000L
+ const SSL_METHOD *q_SSLv2_client_method();
+ const SSL_METHOD *q_SSLv3_client_method();
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ const SSL_METHOD *q_SSLv23_client_method();
++#else
++const SSL_METHOD *q_TLS_client_method();
++#define q_SSLv23_client_method q_TLS_client_method
++#endif
+ const SSL_METHOD *q_TLSv1_client_method();
+ const SSL_METHOD *q_SSLv2_server_method();
+ const SSL_METHOD *q_SSLv3_server_method();
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ const SSL_METHOD *q_SSLv23_server_method();
++#else
++const SSL_METHOD *q_TLS_server_method();
++#define q_SSLv23_server_method q_TLS_server_method
++#endif
+ const SSL_METHOD *q_TLSv1_server_method();
+ #else
+ SSL_METHOD *q_SSLv2_client_method();
+@@ -377,7 +410,12 @@ int q_X509_STORE_CTX_set_purpose(X509_ST
+ int q_X509_STORE_CTX_get_error(X509_STORE_CTX *ctx);
+ int q_X509_STORE_CTX_get_error_depth(X509_STORE_CTX *ctx);
+ X509 *q_X509_STORE_CTX_get_current_cert(X509_STORE_CTX *ctx);
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ STACK_OF(X509) *q_X509_STORE_CTX_get_chain(X509_STORE_CTX *ctx);
++#else
++STACK_OF(X509) *q_X509_STORE_CTX_get0_chain(X509_STORE_CTX *ctx);
++#define q_X509_STORE_CTX_get_chain q_X509_STORE_CTX_get0_chain
++#endif
+ 
+ #define q_BIO_get_mem_data(b, pp) (int)q_BIO_ctrl(b,BIO_CTRL_INFO,0,(char *)pp)
+ #define q_BIO_pending(b) (int)q_BIO_ctrl(b,BIO_CTRL_PENDING,0,NULL)
+@@ -399,7 +437,25 @@ DSA *q_d2i_DSAPrivateKey(DSA **a, unsign
+ 		PEM_ASN1_write_bio((int (*)(void*, unsigned char**))q_i2d_DSAPrivateKey,PEM_STRING_DSA,\
+ 			bp,(char *)x,enc,kstr,klen,cb,u)
+ #endif
++
++X509_STORE * q_SSL_CTX_get_cert_store(const SSL_CTX *ctx);
++ASN1_INTEGER * q_X509_get_serialNumber(X509 *x);
++
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ #define q_SSL_CTX_set_options(ctx,op) q_SSL_CTX_ctrl((ctx),SSL_CTRL_OPTIONS,(op),NULL)
++#define q_X509_get_version(x) X509_get_version(x)
++#else
++int q_EVP_PKEY_id(const EVP_PKEY *pkey);
++int q_EVP_PKEY_base_id(const EVP_PKEY *pkey);
++int q_SSL_CIPHER_get_bits(const SSL_CIPHER *cipher, int *alg_bits);
++long q_SSL_CTX_set_options(SSL_CTX *ctx, long options);
++long q_X509_get_version(X509 *x);
++X509_PUBKEY * q_X509_get_X509_PUBKEY(X509 *x);
++int q_RSA_bits(const RSA *rsa);
++int q_DSA_security_bits(const DSA *dsa);
++void q_DSA_get0_pqg(const DSA *d, BIGNUM **p, BIGNUM **q, BIGNUM **g);
++#endif
++
+ #define q_SKM_sk_num(type, st) ((int (*)(const STACK_OF(type) *))q_sk_num)(st)
+ #define q_SKM_sk_value(type, st,i) ((type * (*)(const STACK_OF(type) *, int))q_sk_value)(st, i)
+ #define q_sk_GENERAL_NAME_num(st) q_SKM_sk_num(GENERAL_NAME, (st))
+@@ -410,8 +466,17 @@ DSA *q_d2i_DSAPrivateKey(DSA **a, unsign
+ #define q_sk_SSL_CIPHER_value(st, i) q_SKM_sk_value(SSL_CIPHER, (st), (i))
+ #define q_SSL_CTX_add_extra_chain_cert(ctx,x509) \
+         q_SSL_CTX_ctrl(ctx,SSL_CTRL_EXTRA_CHAIN_CERT,0,(char *)x509)
++
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ #define q_X509_get_notAfter(x) X509_get_notAfter(x)
+ #define q_X509_get_notBefore(x) X509_get_notBefore(x)
++#else
++ASN1_TIME *q_X509_getm_notAfter(X509 *x);
++ASN1_TIME *q_X509_getm_notBefore(X509 *x);
++#define q_X509_get_notAfter(x) q_X509_getm_notAfter(x)
++#define q_X509_get_notBefore(x) q_X509_getm_notBefore(x)
++#endif
++
+ #define q_EVP_PKEY_assign_RSA(pkey,rsa) q_EVP_PKEY_assign((pkey),EVP_PKEY_RSA,\
+ 					(char *)(rsa))
+ #define q_EVP_PKEY_assign_DSA(pkey,dsa) q_EVP_PKEY_assign((pkey),EVP_PKEY_DSA,\
+@@ -421,10 +486,21 @@ DSA *q_d2i_DSAPrivateKey(DSA **a, unsign
+ #else
+ #define q_OpenSSL_add_all_algorithms() q_OPENSSL_add_all_algorithms_noconf()
+ #endif
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ void q_OPENSSL_add_all_algorithms_noconf();
+ void q_OPENSSL_add_all_algorithms_conf();
++#else
++int q_OPENSSL_init_crypto(uint64_t opts, void *settings);
++#define q_OPENSSL_add_all_algorithms_conf() q_OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS | OPENSSL_INIT_LOAD_CONFIG, NULL)
++#  define q_OPENSSL_add_all_algorithms_noconf() q_OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS, NULL)
++#endif
+ int q_SSL_CTX_load_verify_locations(SSL_CTX *ctx, const char *CAfile, const char *CApath);
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ long q_SSLeay();
++#else
++unsigned long q_OpenSSL_version_num();
++#define q_SSLeay q_OpenSSL_version_num
++#endif
+ 
+ // Helper function
+ class QDateTime;
+--- a/src/network/ssl/qsslsocket_openssl_symbols.cpp
++++ b/src/network/ssl/qsslsocket_openssl_symbols.cpp
+@@ -117,9 +117,11 @@ DEFINEFUNC3(int, BIO_read, BIO *a, a, vo
+ DEFINEFUNC(BIO_METHOD *, BIO_s_mem, void, DUMMYARG, return 0, return)
+ DEFINEFUNC3(int, BIO_write, BIO *a, a, const void *b, b, int c, c, return -1, return)
+ DEFINEFUNC(int, BN_num_bits, const BIGNUM *a, a, return 0, return)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ DEFINEFUNC(int, CRYPTO_num_locks, DUMMYARG, DUMMYARG, return 0, return)
+ DEFINEFUNC(void, CRYPTO_set_locking_callback, void (*a)(int, int, const char *, int), a, return, DUMMYARG)
+ DEFINEFUNC(void, CRYPTO_set_id_callback, unsigned long (*a)(), a, return, DUMMYARG)
++#endif
+ DEFINEFUNC(void, CRYPTO_free, void *a, a, return, DUMMYARG)
+ DEFINEFUNC(void, DSA_free, DSA *a, a, return, DUMMYARG)
+ #if  OPENSSL_VERSION_NUMBER < 0x00908000L
+@@ -157,6 +159,7 @@ DEFINEFUNC2(int, PEM_write_bio_RSA_PUBKE
+ DEFINEFUNC2(void, RAND_seed, const void *a, a, int b, b, return, DUMMYARG)
+ DEFINEFUNC(int, RAND_status, void, DUMMYARG, return -1, return)
+ DEFINEFUNC(void, RSA_free, RSA *a, a, return, DUMMYARG)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ DEFINEFUNC(int, sk_num, STACK *a, a, return -1, return)
+ DEFINEFUNC2(void, sk_pop_free, STACK *a, a, void (*b)(void*), b, return, DUMMYARG)
+ #if OPENSSL_VERSION_NUMBER >= 0x10000000L
+@@ -166,6 +169,12 @@ DEFINEFUNC2(void *, sk_value, STACK *a,
+ DEFINEFUNC(void, sk_free, STACK *a, a, return, DUMMYARG)
+ DEFINEFUNC2(char *, sk_value, STACK *a, a, int b, b, return 0, return)
+ #endif
++#else
++DEFINEFUNC(int, OPENSSL_sk_num, STACK *a, a, return -1, return)
++DEFINEFUNC2(void, OPENSSL_sk_pop_free, STACK *a, a, void (*b)(void*), b, return, DUMMYARG)
++DEFINEFUNC(void, OPENSSL_sk_free, _STACK *a, a, return, DUMMYARG)
++DEFINEFUNC2(void *, OPENSSL_sk_value, STACK *a, a, int b, b, return 0, return)
++#endif
+ DEFINEFUNC(int, SSL_accept, SSL *a, a, return -1, return)
+ DEFINEFUNC(int, SSL_clear, SSL *a, a, return -1, return)
+ DEFINEFUNC3(char *, SSL_CIPHER_description, SSL_CIPHER *a, a, char *b, b, int c, c, return 0, return)
+@@ -213,8 +222,12 @@ DEFINEFUNC(long, SSL_get_verify_result,
+ #else
+ DEFINEFUNC(long, SSL_get_verify_result, SSL *a, a, return -1, return)
+ #endif
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ DEFINEFUNC(int, SSL_library_init, void, DUMMYARG, return -1, return)
+ DEFINEFUNC(void, SSL_load_error_strings, void, DUMMYARG, return, DUMMYARG)
++#else
++DEFINEFUNC2(int, OPENSSL_init_ssl, uint64_t opts, opts, void *settings, settings, return -1, return)
++#endif
+ DEFINEFUNC(SSL *, SSL_new, SSL_CTX *a, a, return 0, return)
+ #if OPENSSL_VERSION_NUMBER >= 0x0090806fL && !defined(OPENSSL_NO_TLSEXT)
+ DEFINEFUNC4(long, SSL_ctrl, SSL *a, a, int cmd, cmd, long larg, larg, void *parg, parg, return -1, return)
+@@ -231,7 +244,11 @@ DEFINEFUNC(const SSL_METHOD *, SSLv2_cli
+ #ifndef OPENSSL_NO_SSL3_METHOD
+ DEFINEFUNC(const SSL_METHOD *, SSLv3_client_method, DUMMYARG, DUMMYARG, return 0, return)
+ #endif
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ DEFINEFUNC(const SSL_METHOD *, SSLv23_client_method, DUMMYARG, DUMMYARG, return 0, return)
++#else
++DEFINEFUNC(const SSL_METHOD *, TLS_client_method, DUMMYARG, DUMMYARG, return 0, return)
++#endif
+ DEFINEFUNC(const SSL_METHOD *, TLSv1_client_method, DUMMYARG, DUMMYARG, return 0, return)
+ #ifndef OPENSSL_NO_SSL2
+ DEFINEFUNC(const SSL_METHOD *, SSLv2_server_method, DUMMYARG, DUMMYARG, return 0, return)
+@@ -239,7 +256,11 @@ DEFINEFUNC(const SSL_METHOD *, SSLv2_ser
+ #ifndef OPENSSL_NO_SSL3_METHOD
+ DEFINEFUNC(const SSL_METHOD *, SSLv3_server_method, DUMMYARG, DUMMYARG, return 0, return)
+ #endif
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ DEFINEFUNC(const SSL_METHOD *, SSLv23_server_method, DUMMYARG, DUMMYARG, return 0, return)
++#else
++DEFINEFUNC(const SSL_METHOD *, TLS_server_method, DUMMYARG, DUMMYARG, return 0, return)
++#endif
+ DEFINEFUNC(const SSL_METHOD *, TLSv1_server_method, DUMMYARG, DUMMYARG, return 0, return)
+ #else
+ DEFINEFUNC(SSL_METHOD *, SSLv2_client_method, DUMMYARG, DUMMYARG, return 0, return)
+@@ -278,7 +299,11 @@ DEFINEFUNC2(int, X509_STORE_CTX_set_purp
+ DEFINEFUNC(int, X509_STORE_CTX_get_error, X509_STORE_CTX *a, a, return -1, return)
+ DEFINEFUNC(int, X509_STORE_CTX_get_error_depth, X509_STORE_CTX *a, a, return -1, return)
+ DEFINEFUNC(X509 *, X509_STORE_CTX_get_current_cert, X509_STORE_CTX *a, a, return 0, return)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ DEFINEFUNC(STACK_OF(X509) *, X509_STORE_CTX_get_chain, X509_STORE_CTX *a, a, return 0, return)
++#else
++DEFINEFUNC(STACK_OF(X509) *, X509_STORE_CTX_get0_chain, X509_STORE_CTX *a, a, return 0, return)
++#endif
+ DEFINEFUNC(X509_STORE_CTX *, X509_STORE_CTX_new, DUMMYARG, DUMMYARG, return 0, return)
+ #ifdef SSLEAY_MACROS
+ DEFINEFUNC2(int, i2d_DSAPrivateKey, const DSA *a, a, unsigned char **b, b, return -1, return)
+@@ -286,10 +311,39 @@ DEFINEFUNC2(int, i2d_RSAPrivateKey, cons
+ DEFINEFUNC3(RSA *, d2i_RSAPrivateKey, RSA **a, a, unsigned char **b, b, long c, c, return 0, return)
+ DEFINEFUNC3(DSA *, d2i_DSAPrivateKey, DSA **a, a, unsigned char **b, b, long c, c, return 0, return)
+ #endif
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ DEFINEFUNC(void, OPENSSL_add_all_algorithms_noconf, void, DUMMYARG, return, DUMMYARG)
+ DEFINEFUNC(void, OPENSSL_add_all_algorithms_conf, void, DUMMYARG, return, DUMMYARG)
++#else
++DEFINEFUNC2(int, OPENSSL_init_crypto, uint64_t opts, opts, void *settings, settings, return -1, return)
++#endif
+ DEFINEFUNC3(int, SSL_CTX_load_verify_locations, SSL_CTX *ctx, ctx, const char *CAfile, CAfile, const char *CApath, CApath, return 0, return)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ DEFINEFUNC(long, SSLeay, void, DUMMYARG, return 0, return)
++#else
++DEFINEFUNC(unsigned long, OpenSSL_version_num, void, DUMMYARG, return 0, return)
++#endif
++DEFINEFUNC(X509_STORE *, SSL_CTX_get_cert_store, const SSL_CTX *ctx, ctx, return 0, return)
++
++DEFINEFUNC(ASN1_INTEGER *, X509_get_serialNumber, X509 *x, x, return 0, return)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++DEFINEFUNC(int, EVP_PKEY_id, const EVP_PKEY *pkey, pkey, return 0, return)
++DEFINEFUNC(int, EVP_PKEY_base_id, const EVP_PKEY *pkey, pkey, return 0, return)
++DEFINEFUNC2(int, SSL_CIPHER_get_bits, const SSL_CIPHER *cipher, cipher, int *alg_bits, alg_bits, return 0, return)
++DEFINEFUNC2(long, SSL_CTX_set_options, SSL_CTX *ctx, ctx, long options, options, return 0, return)
++DEFINEFUNC(long, X509_get_version, X509 *x, x, return 0, return)
++DEFINEFUNC(X509_PUBKEY *, X509_get_X509_PUBKEY, X509 *x, x, return 0, return)
++DEFINEFUNC(int, RSA_bits,  const RSA *rsa, rsa, return 0, return)
++DEFINEFUNC(int, DSA_security_bits, const DSA *dsa, dsa, return 0, return)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++DEFINEFUNC(ASN1_TIME *, X509_get_notAfter, X509 *x, x, return 0, return)
++DEFINEFUNC(ASN1_TIME *, X509_get_notBefore, X509 *x, x, return 0, return)
++#else
++DEFINEFUNC(ASN1_TIME *, X509_getm_notAfter, X509 *x, x, return 0, return)
++DEFINEFUNC(ASN1_TIME *, X509_getm_notBefore, X509 *x, x, return 0, return)
++#endif
++DEFINEFUNC4(void, DSA_get0_pqg, const DSA *d, d, BIGNUM **p, p, BIGNUM **q, q, BIGNUM **g, g, return, return)
++#endif
+ 
+ #ifdef Q_OS_SYMBIAN
+ #define RESOLVEFUNC(func, ordinal, lib) \
+@@ -584,7 +638,11 @@ bool q_resolveOpenSslSymbols()
+     static volatile bool symbolsResolved = false;
+     static volatile bool triedToResolveSymbols = false;
+ #ifndef QT_NO_THREAD
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     QMutexLocker locker(QMutexPool::globalInstanceGet((void *)&q_SSL_library_init));
++#else
++    QMutexLocker locker(QMutexPool::globalInstanceGet((void *)&q_OPENSSL_init_ssl));
++#endif
+ #endif
+     if (symbolsResolved)
+         return true;
+@@ -618,9 +676,11 @@ bool q_resolveOpenSslSymbols()
+     RESOLVEFUNC(BIO_write, 269, libs.second )
+     RESOLVEFUNC(BN_num_bits, 387, libs.second )
+     RESOLVEFUNC(CRYPTO_free, 469, libs.second )
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     RESOLVEFUNC(CRYPTO_num_locks, 500, libs.second )
+     RESOLVEFUNC(CRYPTO_set_id_callback, 513, libs.second )
+     RESOLVEFUNC(CRYPTO_set_locking_callback, 516, libs.second )
++#endif
+     RESOLVEFUNC(DSA_free, 594, libs.second )
+     RESOLVEFUNC(ERR_error_string, 744, libs.second )
+     RESOLVEFUNC(ERR_get_error, 749, libs.second )
+@@ -678,8 +738,10 @@ bool q_resolveOpenSslSymbols()
+     RESOLVEFUNC(SSL_get_peer_cert_chain, 117, libs.first )
+     RESOLVEFUNC(SSL_get_peer_certificate, 118, libs.first )
+     RESOLVEFUNC(SSL_get_verify_result, 132, libs.first )
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     RESOLVEFUNC(SSL_library_init, 137, libs.first )
+     RESOLVEFUNC(SSL_load_error_strings, 139, libs.first )
++#endif
+     RESOLVEFUNC(SSL_new, 140, libs.first )
+ #if OPENSSL_VERSION_NUMBER >= 0x0090806fL && !defined(OPENSSL_NO_TLSEXT)
+     RESOLVEFUNC(SSL_ctrl, 95, libs.first )
+@@ -751,9 +813,11 @@ bool q_resolveOpenSslSymbols()
+     RESOLVEFUNC(BIO_write)
+     RESOLVEFUNC(BN_num_bits)
+     RESOLVEFUNC(CRYPTO_free)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     RESOLVEFUNC(CRYPTO_num_locks)
+     RESOLVEFUNC(CRYPTO_set_id_callback)
+     RESOLVEFUNC(CRYPTO_set_locking_callback)
++#endif
+     RESOLVEFUNC(DSA_free)
+     RESOLVEFUNC(ERR_error_string)
+     RESOLVEFUNC(ERR_get_error)
+@@ -783,10 +847,17 @@ bool q_resolveOpenSslSymbols()
+     RESOLVEFUNC(RAND_seed)
+     RESOLVEFUNC(RAND_status)
+     RESOLVEFUNC(RSA_free)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     RESOLVEFUNC(sk_free)
+     RESOLVEFUNC(sk_num)
+     RESOLVEFUNC(sk_pop_free)
+     RESOLVEFUNC(sk_value)
++#else
++    RESOLVEFUNC(OPENSSL_sk_free)
++    RESOLVEFUNC(OPENSSL_sk_num)
++    RESOLVEFUNC(OPENSSL_sk_pop_free)
++    RESOLVEFUNC(OPENSSL_sk_value)
++#endif
+     RESOLVEFUNC(SSL_CIPHER_description)
+     RESOLVEFUNC(SSL_CTX_check_private_key)
+     RESOLVEFUNC(SSL_CTX_ctrl)
+@@ -801,6 +872,7 @@ bool q_resolveOpenSslSymbols()
+     RESOLVEFUNC(SSL_CTX_use_PrivateKey)
+     RESOLVEFUNC(SSL_CTX_use_RSAPrivateKey)
+     RESOLVEFUNC(SSL_CTX_use_PrivateKey_file)
++    RESOLVEFUNC(SSL_CTX_get_cert_store)
+     RESOLVEFUNC(SSL_accept)
+     RESOLVEFUNC(SSL_clear)
+     RESOLVEFUNC(SSL_connect)
+@@ -811,8 +883,12 @@ bool q_resolveOpenSslSymbols()
+     RESOLVEFUNC(SSL_get_peer_cert_chain)
+     RESOLVEFUNC(SSL_get_peer_certificate)
+     RESOLVEFUNC(SSL_get_verify_result)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     RESOLVEFUNC(SSL_library_init)
+     RESOLVEFUNC(SSL_load_error_strings)
++#else
++    RESOLVEFUNC(OPENSSL_init_ssl)
++#endif
+     RESOLVEFUNC(SSL_new)
+ #if OPENSSL_VERSION_NUMBER >= 0x0090806fL && !defined(OPENSSL_NO_TLSEXT)
+     RESOLVEFUNC(SSL_ctrl)
+@@ -823,13 +899,39 @@ bool q_resolveOpenSslSymbols()
+     RESOLVEFUNC(SSL_set_connect_state)
+     RESOLVEFUNC(SSL_shutdown)
+     RESOLVEFUNC(SSL_write)
++
++    RESOLVEFUNC(X509_get_serialNumber)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++    RESOLVEFUNC(SSL_CTX_ctrl)
++    RESOLVEFUNC(EVP_PKEY_id)
++    RESOLVEFUNC(EVP_PKEY_base_id)
++    RESOLVEFUNC(SSL_CIPHER_get_bits)
++    RESOLVEFUNC(SSL_CTX_set_options)
++    RESOLVEFUNC(X509_get_version)
++    RESOLVEFUNC(X509_get_X509_PUBKEY)
++    RESOLVEFUNC(RSA_bits)
++    RESOLVEFUNC(DSA_security_bits)
++    RESOLVEFUNC(DSA_get0_pqg)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++    RESOLVEFUNC(X509_get_notAfter)
++    RESOLVEFUNC(X509_get_notBefore)
++#else
++    RESOLVEFUNC(X509_getm_notAfter)
++    RESOLVEFUNC(X509_getm_notBefore)
++#endif
++#endif
++
+ #ifndef OPENSSL_NO_SSL2
+     RESOLVEFUNC(SSLv2_client_method)
+ #endif
+ #ifndef OPENSSL_NO_SSL3_METHOD
+     RESOLVEFUNC(SSLv3_client_method)
+ #endif
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     RESOLVEFUNC(SSLv23_client_method)
++#else
++    RESOLVEFUNC(TLS_client_method)
++#endif
+     RESOLVEFUNC(TLSv1_client_method)
+ #ifndef OPENSSL_NO_SSL2
+     RESOLVEFUNC(SSLv2_server_method)
+@@ -837,7 +939,11 @@ bool q_resolveOpenSslSymbols()
+ #ifndef OPENSSL_NO_SSL3_METHOD
+     RESOLVEFUNC(SSLv3_server_method)
+ #endif
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     RESOLVEFUNC(SSLv23_server_method)
++#else
++    RESOLVEFUNC(TLS_server_method)
++#endif
+     RESOLVEFUNC(TLSv1_server_method)
+     RESOLVEFUNC(X509_NAME_entry_count)
+     RESOLVEFUNC(X509_NAME_get_entry)
+@@ -854,7 +960,11 @@ bool q_resolveOpenSslSymbols()
+     RESOLVEFUNC(X509_STORE_CTX_get_error)
+     RESOLVEFUNC(X509_STORE_CTX_get_error_depth)
+     RESOLVEFUNC(X509_STORE_CTX_get_current_cert)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     RESOLVEFUNC(X509_STORE_CTX_get_chain)
++#else
++    RESOLVEFUNC(X509_STORE_CTX_get0_chain)
++#endif
+     RESOLVEFUNC(X509_cmp)
+ #ifndef SSLEAY_MACROS
+     RESOLVEFUNC(X509_dup)
+@@ -875,10 +985,18 @@ bool q_resolveOpenSslSymbols()
+     RESOLVEFUNC(d2i_DSAPrivateKey)
+     RESOLVEFUNC(d2i_RSAPrivateKey)
+ #endif
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     RESOLVEFUNC(OPENSSL_add_all_algorithms_noconf)
+     RESOLVEFUNC(OPENSSL_add_all_algorithms_conf)
++#else
++    RESOLVEFUNC(OPENSSL_init_crypto)
++#endif
+     RESOLVEFUNC(SSL_CTX_load_verify_locations)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     RESOLVEFUNC(SSLeay)
++#else
++    RESOLVEFUNC(OpenSSL_version_num)
++#endif
+ #endif // Q_OS_SYMBIAN
+     symbolsResolved = true;
+     delete libs.first;
+--- a/src/network/ssl/qsslsocket_openssl_p.h
++++ b/src/network/ssl/qsslsocket_openssl_p.h
+@@ -84,6 +84,10 @@
+ #include <openssl/tls1.h>
+ #endif
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#define OPENSSL_NO_SSL2
++#endif
++
+ #if OPENSSL_VERSION_NUMBER >= 0x10000000L
+ typedef _STACK STACK;
+ #endif


### PR DESCRIPTION
This fixes compiling Qt-4.8.7 with OpenSSL 1.1 (previously it only built with OpenSSL 1.0, also see #6644). Also this PR disables SSLv3 in Qt4 for security reasons and updates dependencies.

Patches were adapted from:
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=806505
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=828522