### PR TITLE
{bio}[GCCcore/7.3.0] Add DCMTK v3.6.3

### DIFF
--- a/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.3-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.3-GCCcore-7.3.0.eb
@@ -1,0 +1,38 @@
+easyblock = 'CMakeMake'
+
+name = 'DCMTK'
+version = '3.6.3'
+
+homepage = 'https://dicom.offis.de/dcmtk'
+description = """DCMTK is a collection of libraries and applications implementing large parts the DICOM standard.
+It includes software for examining, constructing and converting DICOM image files, handling offline media, sending
+and receiving images over a network connection, as well as demonstrative image storage and worklist servers."""
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://dicom.offis.de/download/dcmtk/dcmtk%s/' % version.replace('.', '')]
+sources = ['%(namelower)s-%(version)s.tar.gz']
+checksums = ['63c373929f610653f10cbb8218ec643804eec6f842d3889d2b46a227da1ed530']
+
+builddependencies = [
+    # use same binutils version that was used when building GCC toolchain
+    ('binutils', '2.30', '', True),
+    ('CMake', '3.11.4')
+]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('libjpeg-turbo', '2.0.0'),
+    ('LibTIFF', '4.0.9'),
+    ('libpng', '1.6.34'),
+    ('libxml2', '2.9.8'),
+    ('libiconv', '1.15'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/dcmdump', 'bin/dcmj2pnm'],
+    'dirs': ['lib'],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.3-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.3-GCCcore-7.3.0.eb
@@ -16,8 +16,7 @@ sources = ['%(namelower)s-%(version)s.tar.gz']
 checksums = ['63c373929f610653f10cbb8218ec643804eec6f842d3889d2b46a227da1ed530']
 
 builddependencies = [
-    # use same binutils version that was used when building GCC toolchain
-    ('binutils', '2.30', '', True),
+    ('binutils', '2.30'),
     ('CMake', '3.11.4')
 ]
 
@@ -35,4 +34,4 @@ sanity_check_paths = {
     'dirs': ['lib'],
 }
 
-moduleclass = 'bio'
+moduleclass = 'data'

--- a/easybuild/easyconfigs/l/libiconv/libiconv-1.15-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/l/libiconv/libiconv-1.15-GCCcore-7.3.0.eb
@@ -12,8 +12,7 @@ source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178']
 
-# use same binutils version that was used when building GCC toolchain
-builddependencies = [('binutils', '2.30', '', True)]
+builddependencies = [('binutils', '2.30')]
 
 sanity_check_paths = {
     'files': ['bin/iconv', 'include/iconv.h', 'include/libcharset.h', 'include/localcharset.h',

--- a/easybuild/easyconfigs/l/libiconv/libiconv-1.15-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/l/libiconv/libiconv-1.15-GCCcore-7.3.0.eb
@@ -1,0 +1,24 @@
+easyblock = 'ConfigureMake'
+
+name = 'libiconv'
+version = '1.15'
+
+homepage = 'https://www.gnu.org/software/libiconv'
+description = "Libiconv converts from one character encoding to another through Unicode conversion"
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178']
+
+# use same binutils version that was used when building GCC toolchain
+builddependencies = [('binutils', '2.30', '', True)]
+
+sanity_check_paths = {
+    'files': ['bin/iconv', 'include/iconv.h', 'include/libcharset.h', 'include/localcharset.h',
+              'lib/libcharset.a', 'lib/libcharset.%s' % SHLIB_EXT, 'lib/libiconv.%s' % SHLIB_EXT],
+    'dirs': ['share'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
This PR adds DCMTK v3.6.3 and adds libiconv-1.15 for GCCcore/7.3.0.

> DCMTK is a collection of libraries and applications implementing large parts the DICOM standard. It includes software for examining, constructing and converting DICOM image files, handling offline media, sending and receiving images over a network connection, as well as demonstrative image storage and worklist servers.