### PR TITLE
stick to ncurses 6.0 as dependency for CMake built with GCCcore/6.4.0

### DIFF
--- a/easybuild/easyconfigs/c/CMake/CMake-3.11.4-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.11.4-GCCcore-6.4.0.eb
@@ -21,7 +21,7 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('ncurses', '6.1'),
+    ('ncurses', '6.0'),
     # OS dependency should be preferred if the os version is more recent then this version,
     # it's nice to have an up to date openssl for security reasons
     # ('OpenSSL', '1.1.0g'),

--- a/easybuild/easyconfigs/c/CMake/CMake-3.12.1-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.12.1-GCCcore-6.4.0.eb
@@ -21,7 +21,7 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('ncurses', '6.1'),
+    ('ncurses', '6.0'),
     # OS dependency should be preferred if the os version is more recent then this version,
     # it's nice to have an up to date openssl for security reasons
     # ('OpenSSL', '1.1.0g'),


### PR DESCRIPTION
for compatibility with easyconfigs using a */2017b or */2018a toolchain

see https://github.com/easybuilders/easybuild-easyconfigs/pull/6724/files#r212670349