### PR TITLE
Use -D_GNU_SOURCE for flex-2.6.4-GCCcore-7.3.0 as well

### DIFF
--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-5.5.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-5.5.0.eb
@@ -27,4 +27,8 @@ dependencies = [
     ('M4', '1.4.18'),
 ]
 
+# glibc 2.26 requires _GNU_SOURCE defined to expose reallocarray in the correct
+# header, see https://github.com/westes/flex/issues/241
+preconfigopts = 'export CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE" && '
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-6.3.0.eb
@@ -21,4 +21,8 @@ builddependencies = [
     ('binutils', '2.27', '', True),
 ]
 
+# glibc 2.26 requires _GNU_SOURCE defined to expose reallocarray in the correct
+# header, see https://github.com/westes/flex/issues/241
+preconfigopts = 'export CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE" && '
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-6.4.0.eb
@@ -27,4 +27,8 @@ dependencies = [
     ('M4', '1.4.18'),
 ]
 
+# glibc 2.26 requires _GNU_SOURCE defined to expose reallocarray in the correct
+# header, see https://github.com/westes/flex/issues/241
+preconfigopts = 'export CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE" && '
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-7.2.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-7.2.0.eb
@@ -27,4 +27,8 @@ dependencies = [
     ('M4', '1.4.18'),
 ]
 
+# glibc 2.26 requires _GNU_SOURCE defined to expose reallocarray in the correct
+# header, see https://github.com/westes/flex/issues/241
+preconfigopts = 'export CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE" && '
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-7.3.0.eb
@@ -27,4 +27,8 @@ dependencies = [
     ('M4', '1.4.18'),
 ]
 
+# glibc 2.26 requires _GNU_SOURCE defined to expose reallocarray in the correct
+# header, see https://github.com/westes/flex/issues/241
+preconfigopts = 'export CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE" && '
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-8.1.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-8.1.0.eb
@@ -27,4 +27,8 @@ dependencies = [
     ('M4', '1.4.18'),
 ]
 
+# glibc 2.26 requires _GNU_SOURCE defined to expose reallocarray in the correct
+# header, see https://github.com/westes/flex/issues/241
+preconfigopts = 'export CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE" && '
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-system.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-system.eb
@@ -26,4 +26,8 @@ dependencies = [
     ('M4', '1.4.18'),
 ]
 
+# glibc 2.26 requires _GNU_SOURCE defined to expose reallocarray in the correct
+# header, see https://github.com/westes/flex/issues/241
+preconfigopts = 'export CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE" && '
+
 moduleclass = 'lang'


### PR DESCRIPTION
Now that I built Doxygen, which depends on flex, I found that we need to add `-D_GNU_SOURCE` to `preconfigopts` not only for the dummy flex, but also the `GCCcore-7.3.0` flex. Otherwise, flex will segfault when building Doxygen.

Please refer to #5792.

Should we add the `preconfigopts` to the other `flex-2.6.4-GCCcore-*.eb` as well?