### PR TITLE
{math}[dummy/dummy] Eigen v3.3.5

### DIFF
--- a/easybuild/easyconfigs/c/CMake/CMake-3.12.1.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.12.1.eb
@@ -1,0 +1,33 @@
+easyblock = 'ConfigureMake'
+
+name = 'CMake'
+version = '3.12.1'
+
+homepage = 'http://www.cmake.org'
+
+description = """
+ CMake, the cross-platform, open-source build system.  CMake is a family of
+ tools designed to build, test and package software.
+"""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['c53d5c2ce81d7a957ee83e3e635c8cda5dfe20c9d501a4828ee28e1615e57ab2']
+
+# Use OS dependencies in order to ensure that CMake can build software that
+# depends on them
+osdependencies = [
+    ('openssl-devel', 'libssl-dev', 'libopenssl-devel'),
+    'ncurses-devel',
+]
+
+configopts = '-- -DCMAKE_USE_OPENSSL=1'
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.3.5.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.3.5.eb
@@ -1,0 +1,20 @@
+name = 'Eigen'
+version = '3.3.5'
+
+homepage = 'http://eigen.tuxfamily.org/index.php?title=Main_Page'
+
+description = """
+ Eigen is a C++ template library for linear algebra:
+ matrices, vectors, numerical solvers, and related algorithms.
+"""
+
+# only includes header files, so no need for a non-dummy toolchain
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = ['http://bitbucket.org/%(namelower)s/%(namelower)s/get']
+sources = ['%(version)s.tar.bz2']
+checksums = ['7352bff3ea299e4c7d7fbe31c504f8eb9149d7e685dec5a12fbaa26379f603e2']
+
+builddependencies = [('CMake', '3.12.1')]
+
+moduleclass = 'math'


### PR DESCRIPTION
config for the latest Eigen, with a new CMake 3.12.1, both to be installed with a dummy toolchain

requires https://github.com/easybuilders/easybuild-easyblocks/pull/1482, already merged.