### PR TITLE
sync up easyconfig for IPython 5.7.0 w/ foss/2018a & Python 2.7.14 wi…

### DIFF
--- a/easybuild/easyconfigs/i/IPython/IPython-5.7.0-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-5.7.0-foss-2018a-Python-2.7.14.eb
@@ -16,23 +16,25 @@ toolchain = {'name': 'foss', 'version': '2018a'}
 
 dependencies = [
     ('Python', '2.7.14'),
-    ('PyZMQ', '17.0.0', '%s-zmq4' % versionsuffix),
+    ('ZeroMQ', '4.2.5'),
+    ('matplotlib', '2.1.2', versionsuffix),
 ]
 
 exts_defaultclass = 'PythonPackage'
+exts_filter = ("python -c 'import %(ext_name)s'", '')
 exts_download_dep_fail = True
 
 exts_list = [
-    ('nose', '1.3.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
-        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
+    ('pyzmq', '17.0.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyzmq/'],
+        'checksums': ['0145ae59139b41f65e047a3a9ed11bbc36e37d5e96c64382fcdff911c4d8c3f0'],
+        'modulename': 'zmq',
     }),
     ('nbformat', '4.4.0', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nbformat/'],
         'checksums': ['f7494ef0df60766b7cabe0a3651556345a963b74dbc16bc7c18479041170d402'],
     }),
     ('Pygments', '2.2.0', {
-        'modulename': 'pygments',
         'source_urls': ['https://pypi.python.org/packages/source/P/Pygments/'],
         'checksums': ['dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc'],
     }),
@@ -48,17 +50,20 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/b/backports_abc/'],
         'checksums': ['033be54514a03e255df75c5aee8f9e672f663f93abb723444caec8fe43437bde'],
     }),
-    ('tornado', '4.5.3', {
+    ('futures', '3.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/f/futures/'],
+        'checksums': ['9ec02aa7d674acb8618afb127e27fde7fc68994c0437ad759fa094a574adb265'],
+        'modulename': 'concurrent.futures',
+    }),
+    ('tornado', '5.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/t/tornado/'],
-        'checksums': ['6d14e47eab0e15799cf3cdcc86b0b98279da68522caace2bd7ce644287685f0a'],
+        'checksums': ['1b83d5c10550f2653380b4c77331d6f8850f287c4f67d7ce1e1c639d9222fbc7'],
     }),
     ('MarkupSafe', '1.0', {
-        'modulename': 'markupsafe',
         'source_urls': ['https://pypi.python.org/packages/source/M/MarkupSafe/'],
         'checksums': ['a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665'],
     }),
     ('Jinja2', '2.10', {
-        'modulename': 'jinja2',
         'source_urls': ['https://pypi.python.org/packages/source/J/Jinja2/'],
         'checksums': ['f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4'],
     }),
@@ -112,39 +117,30 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/t/traitlets/'],
         'checksums': ['9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835'],
     }),
-    ('notebook', '5.3.1', {
+    ('notebook', '5.4.1', {
         'source_urls': ['https://pypi.python.org/packages/source/n/notebook/'],
         'use_pip': True,
-        'checksums': ['380bbed63117accbb13e42d01d06153c72da6a386f75c81ae4c174eaa11e738b'],
+        'checksums': ['7d6143d10e9b026df888e0b2936ceff1827ef2f2087646b4dd475c8dcef58606'],
     }),
     ('jupyter_core', '4.4.0', {
         'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_core/'],
         'checksums': ['ba70754aa680300306c699790128f6fbd8c306ee5927976cbe48adacf240c0b7'],
     }),
-    ('pexpect', '4.3.1', {
+    ('pexpect', '4.5.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pexpect/'],
-        'checksums': ['8e287b171dbaf249d0b06b5f2e88cb7e694651d2d0b8c15bccb83170d3c55575'],
+        'checksums': ['9f8eb3277716a01faafaba553d629d3d60a1a624c7cf45daa600d2148c30020c'],
     }),
     ('pandocfilters', '1.4.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandocfilters/'],
         'checksums': ['b3dd70e169bb5449e6bc6ff96aea89c5eea8c5f6ab5e207fc2f521a2cf4a0da9'],
     }),
     ('configparser', '3.5.0', {
-        'patches': ['configparser-3.5.0_no-backports-namespace.patch'],
         'source_urls': ['https://pypi.python.org/packages/source/c/configparser/'],
-        'use_pip': True,
-        'checksums': [
-            '5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a',  # configparser-3.5.0.tar.gz
-            # configparser-3.5.0_no-backports-namespace.patch
-            '1d4541cf6401592a28c80962fbda155de2536c3031ede800cbc62178361596d6',
-        ],
+        'checksums': ['5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a'],
     }),
     ('entrypoints', '0.2.3', {
-        'source_tmpl': 'entrypoints-%(version)s-py2.py3-none-any.whl',
         'source_urls': ['https://pypi.python.org/packages/source/e/entrypoints/'],
-        'unpack_sources': False,
-        'use_pip': True,
-        'checksums': ['10ad569bb245e7e2ba425285b9fa3e8178a0dc92fc53b1e1c553805e15a8825b'],
+        'checksums': ['d2d587dde06f99545fb13a383d2cd336a8ff1f359c5839ce3a64c917d10c029f'],
     }),
     ('nbconvert', '5.3.1', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
@@ -156,35 +152,25 @@ exts_list = [
         'checksums': ['713e7a8228ae80341c70586d1cc0a8caa5207346927e23d09dcbcaf18eadec80'],
     }),
     ('testpath', '0.3.1', {
-        'source_tmpl': 'testpath-%(version)s-py2.py3-none-any.whl',
-        'source_urls': ['https://pypi.python.org/packages/py2.py3/t/testpath/'],
-        'unpack_sources': False,
-        'use_pip': True,
-        'checksums': ['039fa6a6c9fd3488f8336d23aebbfead5fa602c4a47d49d83845f55a595ec1b4'],
+        'source_urls': ['https://pypi.python.org/packages/source/t/testpath/'],
+        'checksums': ['0d5337839c788da5900df70f8e01015aec141aa3fe7936cb0d0a2953f7ac7609'],
     }),
     ('wcwidth', '0.1.7', {
-        'source_tmpl': 'wcwidth-%(version)s-py2.py3-none-any.whl',
         'source_urls': ['https://pypi.python.org/packages/source/w/wcwidth/'],
-        'unpack_sources': False,
-        'use_pip': True,
-        'checksums': ['f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c'],
+        'checksums': ['3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e'],
     }),
-    ('prompt-toolkit', '1.0.15', {
-        'modulename': 'prompt_toolkit',
-        'source_tmpl': 'prompt_toolkit-%(version)s-py2-none-any.whl',
+    ('prompt_toolkit', '1.0.15', {
         'source_urls': ['https://pypi.python.org/packages/source/p/prompt_toolkit/'],
-        'unpack_sources': False,
-        'use_pip': True,
-        'checksums': ['3f473ae040ddaa52b52f97f6b4a493cfa9f5920c255a12dc56a7d34397a398a4'],
+        'checksums': ['858588f1983ca497f1cf4ffde01d978a3ea02b01c8a26a8bbc5cd2e66d816917'],
     }),
     ('ipython', version, {
-        'modulename': 'IPython',
         'source_urls': ['https://pypi.python.org/packages/source/i/ipython/'],
         'checksums': ['8db43a7fb7619037c98626613ff08d03dda9d5d12c84814a4504c78c0da8323c'],
+        'modulename': 'IPython',
     }),
-    ('ipykernel', '4.8.0', {
+    ('ipykernel', '4.8.2', {
         'source_urls': ['https://pypi.python.org/packages/source/i/ipykernel/'],
-        'checksums': ['dedc199df6a38725c732986dfa606c245fb8fe0fe999b33a0c305b73d80c6774'],
+        'checksums': ['c091449dd0fad7710ddd9c4a06e8b9e15277da306590bc07a3a1afa6b4453c8f'],
     }),
     ('ipywidgets', '7.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/i/ipywidgets/'],
@@ -202,13 +188,25 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/h/html5lib/'],
         'checksums': ['66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736'],
     }),
-    ('bleach', '2.1.2', {
+    ('bleach', '2.1.3', {
         'source_urls': ['https://pypi.python.org/packages/source/b/bleach/'],
-        'checksums': ['38fc8cbebea4e787d8db55d6f324820c7f74362b70db9142c1ac7920452d1a19'],
+        'checksums': ['eb7386f632349d10d9ce9d4a838b134d4731571851149f9cc2c05a9a837a9a44'],
     }),
     ('widgetsnbextension', '3.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/w/widgetsnbextension/'],
         'checksums': ['5417789ee6064ff515fd10be24870660af3561c02d3d48b26f6f44285d0f70cc'],
+    }),
+    ('parso', '0.1.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/parso/'],
+        'checksums': ['5815f3fe254e5665f3c5d6f54f086c2502035cb631a91341591b5a564203cffb'],
+    }),
+    ('jedi', '0.11.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/jedi/'],
+        'checksums': ['d6e799d04d1ade9459ed0f20de47c32f2285438956a677d083d3c98def59fa97'],
+    }),
+    ('backcall', '0.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/backcall/'],
+        'checksums': ['38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4'],
     }),
 ]
 
@@ -220,10 +218,9 @@ sanity_check_paths = {
 }
 
 sanity_check_commands = [
-    ('ipython -h', ''),
-    ('ipython notebook --help', ''),
-    ('iptest', ''),
-    ('iptest2', ''),
+    "ipython -h",
+    "ipython notebook --help",
+    "iptest",
 ]
 
 moduleclass = 'tools'


### PR DESCRIPTION
…th equivalent using intel/2018a toolchain

see discussion in #6776

I would be nice to get this merged before #6776 (since reviewing #6676 then becomes trivial, there's literally no other difference than the toolchain name anymore...).

@smoors Please review (since this is tweaking the easyconfig you contributed in #6415, let me know if you have any concerns.