### PR TITLE
Add med2image-1.1.2 and updates dependencies

### DIFF
--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-foss-2018b-Python-3.6.6.eb
@@ -1,0 +1,59 @@
+easyblock = 'Bundle'
+
+name = 'matplotlib'
+version = '2.2.3'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://matplotlib.org'
+description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
+ hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
+ and ipython shell, web application servers, and six graphical user interface toolkits."""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+# this is a bundle of Python packages
+exts_defaultclass = 'PythonPackage'
+
+builddependencies = [
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('Python', '3.6.6'),
+    ('libpng', '1.6.34'),
+    ('freetype', '2.9.1'),
+    ('Tkinter', '%(pyver)s', versionsuffix),
+]
+
+exts_list = [
+    ('Cycler', '0.10.0', {
+        'modulename': 'cycler',
+        'source_tmpl': 'cycler-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/C/Cycler'],
+        'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
+    }),
+    (name, version, {
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
+        'checksums': ['7355bf757ecacd5f0ac9dd9523c8e1a1103faadf8d33c22664178e17533f8ce5'],
+    }),
+]
+
+# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
+full_sanity_check = True
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+# use non-interactive plotting backend as default
+# see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
+modextravars = {'MPLBACKEND': 'Agg'}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/med2image/med2image-1.1.2-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/m/med2image/med2image-1.1.2-foss-2018b-Python-3.6.6.eb
@@ -1,0 +1,36 @@
+easyblock = 'PythonPackage'
+
+name = 'med2image'
+version = '1.1.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/FNNDSC/med2image'
+description = "Converts medical images to more displayable formats, e.g. NIfTI to jpg."
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+source_urls = ['https://github.com/FNNDSC/med2image/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = [
+    '1e4fb8021380c1ead501578b29b037898ce7ed3b97ed796514b096567b53f25d',  # 1.1.2.tar.gz
+]
+
+dependencies = [
+    ('Python', '3.6.6'),
+    ('numpy', '1.15.1', versionsuffix),
+    ('NiBabel', '2.3.0', versionsuffix),
+    ('pydicom', '1.1.0', versionsuffix),
+    ('matplotlib', '2.2.3', versionsuffix),
+    ('Pillow', '5.2.0', versionsuffix),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [('python', "-c 'import %(namelower)s'")]
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/n/NiBabel/NiBabel-2.3.0-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/n/NiBabel/NiBabel-2.3.0-foss-2018b-Python-3.6.6.eb
@@ -1,0 +1,47 @@
+easyblock = 'Bundle'
+
+name = 'NiBabel'
+version = '2.3.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://nipy.github.io/nibabel'
+description = """NiBabel provides read/write access to some common medical and neuroimaging file formats,
+ including: ANALYZE (plain, SPM99, SPM2 and later), GIFTI, NIfTI1, NIfTI2, MINC1, MINC2, MGH and ECAT
+ as well as Philips PAR/REC. We can read and write Freesurfer geometry, and read Freesurfer morphometry and
+ annotation files. There is some very limited support for DICOM. NiBabel is the successor of PyNIfTI."""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+dependencies = [
+    ('Python', '3.6.6'),
+    ('Pillow', '5.2.0', versionsuffix),
+]
+
+# raise an error when auto-downloading of dependency packages is detected
+exts_download_dep_fail = True
+
+exts_defaultclass = 'PythonPackage'
+exts_list = [
+    ('pydicom', '1.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pydicom'],
+        'start_dir': 'source',
+        'checksums': ['9e3cb1d4e2f46203bf2785cf26d3897868e40e167110e4559603b20eff9bc1ec'],
+    }),
+    (name, version, {
+        'source_tmpl': 'nibabel-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/n/nibabel'],
+        'checksums': ['bf34aeb0f7ca52dc528ae4f842607cea307b334163857ff1d64d43068f637ada'],
+    }),
+]
+
+# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
+full_sanity_check = True
+
+sanity_check_paths = {
+    'files': ['bin/nib-dicomfs', 'bin/nib-ls', 'bin/nib-nifti-dx', 'bin/parrec2nii'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/nibabel', 'lib/python%(pyshortver)s/site-packages/nisext'],
+}
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/n/numpy/numpy-1.15.1-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/n/numpy/numpy-1.15.1-foss-2018b-Python-3.6.6.eb
@@ -1,0 +1,26 @@
+name = 'numpy'
+version = '1.15.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.numpy.org'
+description = """NumPy is the fundamental package for scientific computing with Python. It contains among other things:
+ a powerful N-dimensional array object, sophisticated (broadcasting) functions, tools for integrating C/C++ and Fortran
+ code, useful linear algebra, Fourier transform, and random number capabilities. Besides its obvious scientific uses,
+ NumPy can also be used as an efficient multi-dimensional container of generic data. Arbitrary data-types can be 
+ defined. This allows NumPy to seamlessly and speedily integrate with a wide variety of databases."""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_ZIP]
+checksums = ['7b9e37f194f8bcdca8e9e6af92e2cbad79e360542effc2dd6b98d63955d8d8a3']
+
+builddependencies = [
+    ('pytest', '3.7.2', versionsuffix),
+]
+
+dependencies = [
+    ('Python', '3.6.6'),
+]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/Pillow/Pillow-5.2.0-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/p/Pillow/Pillow-5.2.0-foss-2018b-Python-3.6.6.eb
@@ -1,0 +1,33 @@
+easyblock = 'PythonPackage'
+
+name = 'Pillow'
+version = '5.2.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://pillow.readthedocs.org/'
+description = """Pillow is the 'friendly PIL fork' by Alex Clark and Contributors.
+ PIL is the Python Imaging Library by Fredrik Lundh and Contributors."""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['f8b3d413c5a8f84b12cd4c5df1d8e211777c9852c6be3ee9c094b626644d3eab']
+
+dependencies = [
+    ('Python', '3.6.6'),
+    ('libjpeg-turbo', '2.0.0'),
+    ('libpng', '1.6.34'),
+    ('zlib', '1.2.11'),
+    ('LibTIFF', '4.0.9'),
+    ('freetype', '2.9.1')
+]
+
+options = {'modulename': 'PIL'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/py/py-1.5.4-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/p/py/py-1.5.4-foss-2018b-Python-3.6.6.eb
@@ -1,0 +1,25 @@
+easyblock = "PythonPackage"
+
+name = 'py'
+version = '1.5.4'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = ' http://pylib.readthedocs.org/'
+description = """library with cross-python path, ini-parsing, io, code, log facilities"""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7']
+
+dependencies = [
+    ('Python', '3.6.6'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/pydicom/pydicom-1.1.0-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/p/pydicom/pydicom-1.1.0-foss-2018b-Python-3.6.6.eb
@@ -1,0 +1,23 @@
+easyblock = 'PythonPackage'
+
+name = 'pydicom'
+version = '1.1.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/darcymason/pydicom'
+description = """Read, modify and write DICOM files with python code"""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+source_urls = ['https://github.com/darcymason/pydicom/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['8bf70268a684659a59d4f02a93976867abdb675d4b12b3667e564194418ebe23']
+
+dependencies = [('Python', '3.6.6')]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/pydicom-%(version)s-py%(pyshortver)s.egg'],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/p/pytest/pytest-3.7.2-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/p/pytest/pytest-3.7.2-foss-2018b-Python-3.6.6.eb
@@ -1,0 +1,26 @@
+easyblock = "PythonPackage"
+
+name = 'pytest'
+version = '3.7.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://pytest.org'
+description = """pytest: simple powerful testing with Python"""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['3459a123ad5532852d36f6f4501dfe1acf4af1dd9541834a164666aa40395b02']
+
+dependencies = [
+    ('Python', '3.6.6'),
+    ('py', '1.5.4', versionsuffix),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/t/Tkinter/Tkinter-3.6.6-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/t/Tkinter/Tkinter-3.6.6-foss-2018b-Python-3.6.6.eb
@@ -1,0 +1,21 @@
+name = 'Tkinter'
+version = '3.6.6'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://python.org/'
+description = """Tkinter module, built with the Python buildsystem"""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.python.org/ftp/python/%(version)s/']
+sources = ['Python-%(version)s.tgz']
+checksums = ['7d56dadf6c7d92a238702389e80cfe66fbfae73e584189ed6f89c75bbf3eda58']
+
+dependencies = [
+    ('Python', version),
+    ('Tk', '8.6.8'),
+    ('zlib', '1.2.11'),
+]
+
+moduleclass = 'lang'


### PR DESCRIPTION
This adds [med2image](https://github.com/FNNDSC/med2image) v1.1.2

> Converts medical images to more displayable formats, e.g. NIfTI to jpg.

Dependencies were updated:
- m/matplotlib/matplotlib-2.2.3-foss-2018b-Python-3.6.6.eb
- n/NiBabel/NiBabel-2.3.0-foss-2018b-Python-3.6.6.eb
- n/numpy/numpy-1.15.1-foss-2018b-Python-3.6.6.eb
- p/Pillow/Pillow-5.2.0-foss-2018b-Python-3.6.6.eb
- p/py/py-1.5.4-foss-2018b-Python-3.6.6.eb
- p/pydicom/pydicom-1.1.0-foss-2018b-Python-3.6.6.eb
- p/pytest/pytest-3.7.2-foss-2018b-Python-3.6.6.eb
- Tkinter/Tkinter-3.6.6-foss-2018b-Python-3.6.6.eb