### PR TITLE
Add libuuid (from util-linux 2.32.1) and update fontconfig-2.13.0 to depend on it

### DIFF
--- a/easybuild/easyconfigs/f/fontconfig/fontconfig-2.13.0-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/f/fontconfig/fontconfig-2.13.0-GCCcore-7.3.0.eb
@@ -26,7 +26,7 @@ builddependencies = [
 dependencies = [
     ('expat', '2.2.5'),
     ('freetype', '2.9.1'),
-    ('LibUUID', '1.0.3'),
+    ('LibUUID1', '2.32.1'),
 ]
 
 configopts = '--disable-docs '

--- a/easybuild/easyconfigs/l/LibUUID1/LibUUID1-2.32.1-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/l/LibUUID1/LibUUID1-2.32.1-GCCcore-7.3.0.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'LibUUID1'
+version = '2.32.1'
+
+homepage = 'http://www.kernel.org/pub/linux/utils/util-linux'
+
+description = "Set of Linux utilities, only compiling libuuid"
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['%s/v%%(version_major_minor)s' % homepage]
+sources = ['util-linux-%(version)s.tar.gz']
+checksums = ['3bbf9f3d4a33d6653cf0f7e4fc422091b6a38c3b1195c0ee716c67148a1a7122']
+
+configopts = "--disable-all-programs --enable-libuuid --disable-libsmartcols --disable-libfdisk "
+# disable building Python bindings (since we don't include Python as a dep)
+configopts += "--without-python "
+
+builddependencies = [
+    ('binutils', '2.30'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/libuuid.a'],
+    'dirs': [''],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
In ran into some problems on my Ubuntu Bionic release after compiling `LibUUID`. As soon, as that module was loaded, I ran into errors like to following one:

```(...)/LibUUID/1.0.3-GCCcore-7.3.0/lib/libuuid.so.1: version `UUID_1.0' not found (required by /usr/lib/rstudio-server/bin/rserver)```

Other tools, such as `wget`, were affected as well. I mitigated this problem by compiling `LibUUID`  only from `util-linux` 2.32.1 and depending on that. I got the idea from Debian providing a [libuuid1 package](https://packages.debian.org/stretch/libuuid1), but I am not sure this is the way to go.

The original LibUUID package on sf.net was last touched [~4 years ago](https://sourceforge.net/projects/libuuid/files/).