### PR TITLE
{lib} [GCCcore/6.4.0] libxcb v1.13

### DIFF
--- a/easybuild/easyconfigs/l/libXau/libXau-1.0.8-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libXau/libXau-1.0.8-GCCcore-6.4.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libXau'
 version = '1.0.8'
 
-homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+homepage = "https://www.freedesktop.org/wiki/Software/xlibs"
 description = """The libXau package contains a library implementing the X11 Authorization Protocol.
 This is useful for restricting client access to the display."""
 

--- a/easybuild/easyconfigs/l/libXau/libXau-1.0.8-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libXau/libXau-1.0.8-GCCcore-6.4.0.eb
@@ -9,8 +9,9 @@ This is useful for restricting client access to the display."""
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
-sources = [SOURCE_TAR_GZ]
 source_urls = [XORG_LIB_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['c343b4ef66d66a6b3e0e27aa46b37ad5cab0f11a5c565eafb4a1c7590bc71d7b']
 
 builddependencies = [
     ('binutils', '2.28'),

--- a/easybuild/easyconfigs/l/libXau/libXau-1.0.8-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libXau/libXau-1.0.8-GCCcore-6.4.0.eb
@@ -1,0 +1,27 @@
+easyblock = 'ConfigureMake'
+
+name = 'libXau'
+version = '1.0.8'
+
+homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+description = """The libXau package contains a library implementing the X11 Authorization Protocol.
+This is useful for restricting client access to the display."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = [XORG_LIB_SOURCE]
+
+builddependencies = [
+    ('binutils', '2.28'),
+    ('pkg-config', '0.29.2'),
+    ('xproto', '7.0.31'),
+    ('xorg-macros', '1.19.1'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/libXau.a', 'lib/libXau.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libXdmcp/libXdmcp-1.1.2-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libXdmcp/libXdmcp-1.1.2-GCCcore-6.4.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libXdmcp'
 version = '1.1.2'
 
-homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+homepage = "https://www.freedesktop.org/wiki/Software/xlibs"
 description = """The libXdmcp package contains a library implementing the X Display Manager Control Protocol. This is
 useful for allowing clients to interact with the X Display Manager.
 """

--- a/easybuild/easyconfigs/l/libXdmcp/libXdmcp-1.1.2-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libXdmcp/libXdmcp-1.1.2-GCCcore-6.4.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'libXdmcp'
+version = '1.1.2'
+
+homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+description = """The libXdmcp package contains a library implementing the X Display Manager Control Protocol. This is
+useful for allowing clients to interact with the X Display Manager.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = [XORG_LIB_SOURCE]
+
+builddependencies = [
+    ('binutils', '2.28'),
+    ('pkg-config', '0.29.2'),
+    ('xproto', '7.0.31'),
+    ('xorg-macros', '1.19.1'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a', 'lib/%%(name)s.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libXdmcp/libXdmcp-1.1.2-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libXdmcp/libXdmcp-1.1.2-GCCcore-6.4.0.eb
@@ -10,8 +10,9 @@ useful for allowing clients to interact with the X Display Manager.
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
-sources = [SOURCE_TAR_GZ]
 source_urls = [XORG_LIB_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['6f7c7e491a23035a26284d247779174dedc67e34e93cc3548b648ffdb6fc57c0']
 
 builddependencies = [
     ('binutils', '2.28'),

--- a/easybuild/easyconfigs/l/libxcb/libxcb-1.13-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libxcb/libxcb-1.13-GCCcore-6.4.0.eb
@@ -3,13 +3,13 @@ easyblock = 'ConfigureMake'
 name = 'libxcb'
 version = '1.13'
 
-homepage = 'http://xcb.freedesktop.org/'
+homepage = 'https://xcb.freedesktop.org/'
 description = """The X protocol C-language Binding (XCB) is a replacement for Xlib featuring a small footprint,
 latency hiding, direct access to the protocol, improved threading support, and extensibility."""
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
-source_urls = ['http://xcb.freedesktop.org/dist/']
+source_urls = ['https://xcb.freedesktop.org/dist/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['0bb3cfd46dbd90066bf4d7de3cad73ec1024c7325a4a0cbf5f4a0d4fa91155fb']
 

--- a/easybuild/easyconfigs/l/libxcb/libxcb-1.13-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libxcb/libxcb-1.13-GCCcore-6.4.0.eb
@@ -1,0 +1,36 @@
+easyblock = 'ConfigureMake'
+
+name = 'libxcb'
+version = '1.13'
+
+homepage = 'http://xcb.freedesktop.org/'
+description = """The X protocol C-language Binding (XCB) is a replacement for Xlib featuring a small footprint,
+latency hiding, direct access to the protocol, improved threading support, and extensibility."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
+
+source_urls = ['http://xcb.freedesktop.org/dist/']
+sources = [SOURCELOWER_TAR_GZ]
+
+builddependencies = [
+    ('binutils', '2.28'),
+    ('pkg-config', '0.29.2'),
+    ('xcb-proto', '1.13', '', True),
+    ('xproto', '7.0.31'),
+    ('libpthread-stubs', '0.4'),
+    ('xorg-macros', '1.19.1'),
+]
+dependencies = [
+    ('libXau', '1.0.8'),
+    ('libXdmcp', '1.1.2'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/libxcb%s.a' % x for x in ['', '-composite', '-damage', '-dpms', '-dri2', '-glx',
+                                             '-randr', '-record', '-render', '-res', '-screensaver',
+                                             '-shape', '-shm', '-sync', '-xf86dri', '-xfixes',
+                                             '-xinerama', '-xtest', '-xv', '-xvmc']],
+    'dirs': ['include/xcb', 'lib/pkgconfig'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxcb/libxcb-1.13-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libxcb/libxcb-1.13-GCCcore-6.4.0.eb
@@ -11,6 +11,7 @@ toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
 source_urls = ['http://xcb.freedesktop.org/dist/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['0bb3cfd46dbd90066bf4d7de3cad73ec1024c7325a4a0cbf5f4a0d4fa91155fb']
 
 builddependencies = [
     ('binutils', '2.28'),

--- a/easybuild/easyconfigs/x/xcb-proto/xcb-proto-1.13.eb
+++ b/easybuild/easyconfigs/x/xcb-proto/xcb-proto-1.13.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'xcb-proto'
 version = '1.13'
 
-homepage = 'http://xcb.freedesktop.org/'
+homepage = 'https://xcb.freedesktop.org/'
 description = """The X protocol C-language Binding (XCB) is a replacement for Xlib featuring a small footprint,
 latency hiding, direct access to the protocol, improved threading support, and extensibility."""
 
@@ -11,7 +11,7 @@ latency hiding, direct access to the protocol, improved threading support, and e
 # only .py files are installed using Python, and some .xlm flies copied, so OK to use dummy toolchain
 toolchain = SYSTEM
 
-source_urls = ['http://xcb.freedesktop.org/dist/']
+source_urls = ['https://xcb.freedesktop.org/dist/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['0698e8f596e4c0dbad71d3dc754d95eb0edbb42df5464e0f782621216fa33ba7']
 

--- a/easybuild/easyconfigs/x/xcb-proto/xcb-proto-1.13.eb
+++ b/easybuild/easyconfigs/x/xcb-proto/xcb-proto-1.13.eb
@@ -9,7 +9,7 @@ latency hiding, direct access to the protocol, improved threading support, and e
 
 # even though xcb-proto is installed with configure-make-make install, nothing is actually built;
 # only .py files are installed using Python, and some .xlm flies copied, so OK to use dummy toolchain
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = SYSTEM
 
 source_urls = ['http://xcb.freedesktop.org/dist/']
 sources = [SOURCELOWER_TAR_GZ]
@@ -17,11 +17,11 @@ checksums = ['0698e8f596e4c0dbad71d3dc754d95eb0edbb42df5464e0f782621216fa33ba7']
 
 allow_system_deps = [('Python', SYS_PYTHON_VERSION)]
 
-pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[0:2])
+local_pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[0:2])
 
 sanity_check_paths = {
     'files': ['lib/pkgconfig/xcb-proto.pc'],
-    'dirs': ['lib/python%s/site-packages/xcbgen' % pyshortver]
+    'dirs': ['lib/python%s/site-packages/xcbgen' % local_pyshortver]
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/x/xcb-proto/xcb-proto-1.13.eb
+++ b/easybuild/easyconfigs/x/xcb-proto/xcb-proto-1.13.eb
@@ -13,6 +13,7 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = ['http://xcb.freedesktop.org/dist/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['0698e8f596e4c0dbad71d3dc754d95eb0edbb42df5464e0f782621216fa33ba7']
 
 allow_system_deps = [('Python', SYS_PYTHON_VERSION)]
 

--- a/easybuild/easyconfigs/x/xcb-proto/xcb-proto-1.13.eb
+++ b/easybuild/easyconfigs/x/xcb-proto/xcb-proto-1.13.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'xcb-proto'
+version = '1.13'
+
+homepage = 'http://xcb.freedesktop.org/'
+description = """The X protocol C-language Binding (XCB) is a replacement for Xlib featuring a small footprint,
+latency hiding, direct access to the protocol, improved threading support, and extensibility."""
+
+# even though xcb-proto is installed with configure-make-make install, nothing is actually built;
+# only .py files are installed using Python, and some .xlm flies copied, so OK to use dummy toolchain
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+source_urls = ['http://xcb.freedesktop.org/dist/']
+sources = [SOURCELOWER_TAR_GZ]
+
+allow_system_deps = [('Python', SYS_PYTHON_VERSION)]
+
+pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[0:2])
+
+sanity_check_paths = {
+    'files': ['lib/pkgconfig/xcb-proto.pc'],
+    'dirs': ['lib/python%s/site-packages/xcbgen' % pyshortver]
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Note, I had to remove the sanity checks on `libxcb-xevie.a` and `libxcb-xprint.a` since I couldn't figure out why they weren't built :-(