### PR TITLE
{system}[GCCcore/5.4.0,GCCcore/6.4.0,GCCcore/7.3.0] Do not check if hwloc-dump-hwdata utility was installed

### DIFF
--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.10-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.10-GCCcore-7.3.0.eb
@@ -39,7 +39,7 @@ configopts = "--enable-libnuma=$EBROOTNUMACTL "
 configopts += "--disable-cairo --disable-opencl --disable-cuda --disable-nvml --disable-gl --disable-libudev "
 
 sanity_check_paths = {
-    'files': ['bin/lstopo', 'include/hwloc/linux.h', 'sbin/hwloc-dump-hwdata',
+    'files': ['bin/lstopo', 'include/hwloc/linux.h',
               'lib/libhwloc.%s' % SHLIB_EXT],
     'dirs': ['share/man/man3'],
 }

--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.7-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.7-GCCcore-5.4.0.eb
@@ -33,7 +33,7 @@ dependencies = [
 configopts = "--enable-libnuma=$EBROOTNUMACTL"
 
 sanity_check_paths = {
-    'files': ['bin/lstopo', 'include/hwloc/linux.h', 'sbin/hwloc-dump-hwdata',
+    'files': ['bin/lstopo', 'include/hwloc/linux.h',
               'lib/libhwloc.%s' % SHLIB_EXT],
     'dirs': ['share/man/man3'],
 }

--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.7-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.7-GCCcore-6.4.0.eb
@@ -33,7 +33,7 @@ dependencies = [
 configopts = "--enable-libnuma=$EBROOTNUMACTL"
 
 sanity_check_paths = {
-    'files': ['bin/lstopo', 'include/hwloc/linux.h', 'sbin/hwloc-dump-hwdata',
+    'files': ['bin/lstopo', 'include/hwloc/linux.h',
               'lib/libhwloc.%s' % SHLIB_EXT],
     'dirs': ['share/man/man3'],
 }

--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.8-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.8-GCCcore-6.4.0.eb
@@ -36,7 +36,7 @@ configopts = "--enable-libnuma=$EBROOTNUMACTL "
 configopts += "--disable-cairo --disable-opencl --disable-cuda --disable-nvml --disable-gl --disable-libudev "
 
 sanity_check_paths = {
-    'files': ['bin/lstopo', 'include/hwloc/linux.h', 'sbin/hwloc-dump-hwdata',
+    'files': ['bin/lstopo', 'include/hwloc/linux.h',
               'lib/libhwloc.%s' % SHLIB_EXT],
     'dirs': ['share/man/man3'],
 }

--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.8-GCCcore-7.2.0.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.8-GCCcore-7.2.0.eb
@@ -36,7 +36,7 @@ configopts = "--enable-libnuma=$EBROOTNUMACTL "
 configopts += "--disable-cairo --disable-opencl --disable-cuda --disable-nvml --disable-gl --disable-libudev "
 
 sanity_check_paths = {
-    'files': ['bin/lstopo', 'include/hwloc/linux.h', 'sbin/hwloc-dump-hwdata',
+    'files': ['bin/lstopo', 'include/hwloc/linux.h',
               'lib/libhwloc.%s' % SHLIB_EXT],
     'dirs': ['share/man/man3'],
 }

--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.8-intel-2017a.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.8-intel-2017a.eb
@@ -29,7 +29,7 @@ dependencies = [
 configopts = "--enable-libnuma=$EBROOTNUMACTL"
 
 sanity_check_paths = {
-    'files': ['bin/lstopo', 'include/hwloc/linux.h', 'sbin/hwloc-dump-hwdata',
+    'files': ['bin/lstopo', 'include/hwloc/linux.h',
               'lib/libhwloc.%s' % SHLIB_EXT],
     'dirs': ['share/man/man3'],
 }


### PR DESCRIPTION
This utility is only built on x86 architectures. I left the check for the intel toolchain, as in that case the sanity check should be fine.

edit (by @boegel): cfr. #6833