### PR TITLE
add various additional extensions to recent R easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
@@ -1887,6 +1887,9 @@ exts_list = [
     ('bayesm', '3.1-0.1', {
         'checksums': ['5879823b7fb6e6df0c0fe98faabc1044a4149bb65989062df4ade64e19d26411'],
     }),
+    ('energy', '1.7-5', {
+        'checksums': ['24c2cf080939f8f56cd9cda06d2dfc30d0389cd3ec7250af4f9a09a4c06b6996'],
+    }),
     ('compositions', '1.40-2', {
         'checksums': ['110d71ae000561987cb73fc76cd953bd69d37562cb401ed3c36dca137d01b78a'],
     }),

--- a/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
@@ -1884,6 +1884,12 @@ exts_list = [
     ('pulsar', '0.3.4', {
         'checksums': ['d7230b2286d0fbfa59bbd4f7314ee6e7b77f929f41a8b42bd95af0a7e354cb1c'],
     }),
+    ('bayesm', '3.1-0.1', {
+        'checksums': ['5879823b7fb6e6df0c0fe98faabc1044a4149bb65989062df4ade64e19d26411'],
+    }),
+    ('compositions', '1.40-2', {
+        'checksums': ['110d71ae000561987cb73fc76cd953bd69d37562cb401ed3c36dca137d01b78a'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
@@ -42,6 +42,7 @@ dependencies = [
     ('FFTW', '3.3.7'),  # for fftw
     ('libsndfile', '1.0.28'),  # for seewave
     ('ICU', '61.1'),  # for rJava & gdsfmt
+    ('HDF5', '1.10.1'),  # for hdf5r
     # OS dependency should be preferred if the os version is more recent then this version,
     # it's nice to have an up to date openssl for security reasons
     # ('OpenSSL', '1.0.2h'),
@@ -1827,6 +1828,61 @@ exts_list = [
     }),
     ('KODAMA', '1.4', {
         'checksums': ['126bc85c5fe08c06fe1d4dda230da2d7574d57bda3b8fa36b2a87d498d7cf763'],
+    }),
+    ('locfdr', '1.1-8', {
+        'checksums': ['42d6e12593ae6d541e6813a140b92591dabeb1df94432a515507fc2eee9a54b9'],
+    }),
+    ('ica', '1.0-2', {
+        'checksums': ['e721596fc6175d3270a60d5e0b5b98be103a8fd0dd93ef16680af21fe0b54179'],
+    }),
+    ('dtw', '1.20-1', {
+        'checksums': ['43ca1a47a7c81a2b5d5054da1be8b8af79a85d6f9ce7b4512e9ed91f790f60f0'],
+    }),
+    ('SDMTools', '1.1-221', {
+        'checksums': ['a6da297a670f756ee964ffd99c3b212c55c297d385583fd0e767435dd5cd4ccd'],
+    }),
+    ('later', '0.7.4', {
+        'checksums': ['c4d49aa91f5154ef54ea0498b17f230b8bf99da62541b64417e0c8971261bf88'],
+    }),
+    ('promises', '1.0.1', {
+        'checksums': ['c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558'],
+    }),
+    ('ggridges', '0.5.0', {
+        'checksums': ['124bc84044e56728fa965682f8232fc868f2af7d3eb7276f6b0df53be8d2dbfe'],
+    }),
+    ('bibtex', '0.4.2', {
+        'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
+    }),
+    ('gbRd', '0.4-11', {
+        'checksums': ['0251f6dd6ca987a74acc4765838b858f1edb08b71dbad9e563669b58783ea91b'],
+    }),
+    ('Rdpack', '0.9-0', {
+        'checksums': ['2bb4f64c416f89166d3d2433257da2dbf981a8550d956ed99f10a83f0d07fc18'],
+    }),
+    ('metap', '1.0', {
+        'checksums': ['50a014cd52c30d55cf219cc37864323c4d1b44c3c26ff948b10e4dff1dde3fa3'],
+    }),
+    ('lsei', '1.2-0', {
+        'checksums': ['4781ebd9ef93880260d5d5f23066580ac06061e95c1048fb25e4e838963380f6'],
+    }),
+    ('npsurv', '0.4-0', {
+        'checksums': ['404cf7135dc40a04e9b81224a543307057a8278e11109ba1fcaa28e87c6204f3'],
+    }),
+    ('fitdistrplus', '1.0-11', {
+        'checksums': ['861b986529d21a1c5de3e7e22848167704848f60b3f31770827fc8e2c79b0c8a'],
+    }),
+    ('reticulate', '1.10', {
+        'checksums': ['58e36d3b8a67d01194c4e5099499657d017f77fc2081213633964b1d57a7e32f'],
+    }),
+    ('hdf5r', '1.0.0', {
+        'checksums': ['6a5fb0c4ac7129405e993ce461db908d51bc0ea2b717e8ca306c26902423d7e8'],
+        'preinstallopts': "unset LIBS && ",
+    }),
+    ('DTRreg', '1.3', {
+        'checksums': ['835df542d0ec55368834bc4173dc4aa90f1c0ff146ab243d6e377bba309b8484'],
+    }),
+    ('pulsar', '0.3.4', {
+        'checksums': ['d7230b2286d0fbfa59bbd4f7314ee6e7b77f929f41a8b42bd95af0a7e354cb1c'],
     }),
 ]
 

--- a/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
@@ -1916,6 +1916,12 @@ exts_list = [
     ('pulsar', '0.3.4', {
         'checksums': ['d7230b2286d0fbfa59bbd4f7314ee6e7b77f929f41a8b42bd95af0a7e354cb1c'],
     }),
+    ('bayesm', '3.1-0.1', {
+        'checksums': ['5879823b7fb6e6df0c0fe98faabc1044a4149bb65989062df4ade64e19d26411'],
+    }),
+    ('compositions', '1.40-2', {
+        'checksums': ['110d71ae000561987cb73fc76cd953bd69d37562cb401ed3c36dca137d01b78a'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
@@ -42,6 +42,7 @@ dependencies = [
     ('FFTW', '3.3.7'),  # for fftw
     ('libsndfile', '1.0.28'),  # for seewave
     ('ICU', '61.1'),  # for rJava & gdsfmt
+    ('HDF5', '1.10.1'),  # for hdf5r
     # OS dependency should be preferred if the os version is more recent then this version,
     # it's nice to have an up to date openssl for security reasons
     # ('OpenSSL', '1.0.2h'),
@@ -1859,6 +1860,61 @@ exts_list = [
     }),
     ('KODAMA', '1.4', {
         'checksums': ['126bc85c5fe08c06fe1d4dda230da2d7574d57bda3b8fa36b2a87d498d7cf763'],
+    }),
+    ('locfdr', '1.1-8', {
+        'checksums': ['42d6e12593ae6d541e6813a140b92591dabeb1df94432a515507fc2eee9a54b9'],
+    }),
+    ('ica', '1.0-2', {
+        'checksums': ['e721596fc6175d3270a60d5e0b5b98be103a8fd0dd93ef16680af21fe0b54179'],
+    }),
+    ('dtw', '1.20-1', {
+        'checksums': ['43ca1a47a7c81a2b5d5054da1be8b8af79a85d6f9ce7b4512e9ed91f790f60f0'],
+    }),
+    ('SDMTools', '1.1-221', {
+        'checksums': ['a6da297a670f756ee964ffd99c3b212c55c297d385583fd0e767435dd5cd4ccd'],
+    }),
+    ('later', '0.7.4', {
+        'checksums': ['c4d49aa91f5154ef54ea0498b17f230b8bf99da62541b64417e0c8971261bf88'],
+    }),
+    ('promises', '1.0.1', {
+        'checksums': ['c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558'],
+    }),
+    ('ggridges', '0.5.0', {
+        'checksums': ['124bc84044e56728fa965682f8232fc868f2af7d3eb7276f6b0df53be8d2dbfe'],
+    }),
+    ('bibtex', '0.4.2', {
+        'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
+    }),
+    ('gbRd', '0.4-11', {
+        'checksums': ['0251f6dd6ca987a74acc4765838b858f1edb08b71dbad9e563669b58783ea91b'],
+    }),
+    ('Rdpack', '0.9-0', {
+        'checksums': ['2bb4f64c416f89166d3d2433257da2dbf981a8550d956ed99f10a83f0d07fc18'],
+    }),
+    ('metap', '1.0', {
+        'checksums': ['50a014cd52c30d55cf219cc37864323c4d1b44c3c26ff948b10e4dff1dde3fa3'],
+    }),
+    ('lsei', '1.2-0', {
+        'checksums': ['4781ebd9ef93880260d5d5f23066580ac06061e95c1048fb25e4e838963380f6'],
+    }),
+    ('npsurv', '0.4-0', {
+        'checksums': ['404cf7135dc40a04e9b81224a543307057a8278e11109ba1fcaa28e87c6204f3'],
+    }),
+    ('fitdistrplus', '1.0-11', {
+        'checksums': ['861b986529d21a1c5de3e7e22848167704848f60b3f31770827fc8e2c79b0c8a'],
+    }),
+    ('reticulate', '1.10', {
+        'checksums': ['58e36d3b8a67d01194c4e5099499657d017f77fc2081213633964b1d57a7e32f'],
+    }),
+    ('hdf5r', '1.0.0', {
+        'checksums': ['6a5fb0c4ac7129405e993ce461db908d51bc0ea2b717e8ca306c26902423d7e8'],
+        'preinstallopts': "unset LIBS && ",
+    }),
+    ('DTRreg', '1.3', {
+        'checksums': ['835df542d0ec55368834bc4173dc4aa90f1c0ff146ab243d6e377bba309b8484'],
+    }),
+    ('pulsar', '0.3.4', {
+        'checksums': ['d7230b2286d0fbfa59bbd4f7314ee6e7b77f929f41a8b42bd95af0a7e354cb1c'],
     }),
 ]
 

--- a/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
@@ -1919,6 +1919,9 @@ exts_list = [
     ('bayesm', '3.1-0.1', {
         'checksums': ['5879823b7fb6e6df0c0fe98faabc1044a4149bb65989062df4ade64e19d26411'],
     }),
+    ('energy', '1.7-5', {
+        'checksums': ['24c2cf080939f8f56cd9cda06d2dfc30d0389cd3ec7250af4f9a09a4c06b6996'],
+    }),
     ('compositions', '1.40-2', {
         'checksums': ['110d71ae000561987cb73fc76cd953bd69d37562cb401ed3c36dca137d01b78a'],
     }),

--- a/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
@@ -1860,6 +1860,61 @@ exts_list = [
     ('KODAMA', '1.4', {
         'checksums': ['126bc85c5fe08c06fe1d4dda230da2d7574d57bda3b8fa36b2a87d498d7cf763'],
     }),
+    ('locfdr', '1.1-8', {
+        'checksums': ['42d6e12593ae6d541e6813a140b92591dabeb1df94432a515507fc2eee9a54b9'],
+    }),
+    ('ica', '1.0-2', {
+        'checksums': ['e721596fc6175d3270a60d5e0b5b98be103a8fd0dd93ef16680af21fe0b54179'],
+    }),
+    ('dtw', '1.20-1', {
+        'checksums': ['43ca1a47a7c81a2b5d5054da1be8b8af79a85d6f9ce7b4512e9ed91f790f60f0'],
+    }),
+    ('SDMTools', '1.1-221', {
+        'checksums': ['a6da297a670f756ee964ffd99c3b212c55c297d385583fd0e767435dd5cd4ccd'],
+    }),
+    ('later', '0.7.4', {
+        'checksums': ['c4d49aa91f5154ef54ea0498b17f230b8bf99da62541b64417e0c8971261bf88'],
+    }),
+    ('promises', '1.0.1', {
+        'checksums': ['c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558'],
+    }),
+    ('ggridges', '0.5.0', {
+        'checksums': ['124bc84044e56728fa965682f8232fc868f2af7d3eb7276f6b0df53be8d2dbfe'],
+    }),
+    ('bibtex', '0.4.2', {
+        'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
+    }),
+    ('gbRd', '0.4-11', {
+        'checksums': ['0251f6dd6ca987a74acc4765838b858f1edb08b71dbad9e563669b58783ea91b'],
+    }),
+    ('Rdpack', '0.9-0', {
+        'checksums': ['2bb4f64c416f89166d3d2433257da2dbf981a8550d956ed99f10a83f0d07fc18'],
+    }),
+    ('metap', '1.0', {
+        'checksums': ['50a014cd52c30d55cf219cc37864323c4d1b44c3c26ff948b10e4dff1dde3fa3'],
+    }),
+    ('lsei', '1.2-0', {
+        'checksums': ['4781ebd9ef93880260d5d5f23066580ac06061e95c1048fb25e4e838963380f6'],
+    }),
+    ('npsurv', '0.4-0', {
+        'checksums': ['404cf7135dc40a04e9b81224a543307057a8278e11109ba1fcaa28e87c6204f3'],
+    }),
+    ('fitdistrplus', '1.0-11', {
+        'checksums': ['861b986529d21a1c5de3e7e22848167704848f60b3f31770827fc8e2c79b0c8a'],
+    }),
+    ('reticulate', '1.10', {
+        'checksums': ['58e36d3b8a67d01194c4e5099499657d017f77fc2081213633964b1d57a7e32f'],
+    }),
+    ('hdf5r', '1.0.0', {
+        'checksums': ['6a5fb0c4ac7129405e993ce461db908d51bc0ea2b717e8ca306c26902423d7e8'],
+        'preinstallopts': "unset LIBS && ",
+    }),
+    ('DTRreg', '1.3', {
+        'checksums': ['835df542d0ec55368834bc4173dc4aa90f1c0ff146ab243d6e377bba309b8484'],
+    }),
+    ('pulsar', '0.3.4', {
+        'checksums': ['d7230b2286d0fbfa59bbd4f7314ee6e7b77f929f41a8b42bd95af0a7e354cb1c'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
@@ -1916,6 +1916,12 @@ exts_list = [
     ('pulsar', '0.3.4', {
         'checksums': ['d7230b2286d0fbfa59bbd4f7314ee6e7b77f929f41a8b42bd95af0a7e354cb1c'],
     }),
+    ('bayesm', '3.1-0.1', {
+        'checksums': ['5879823b7fb6e6df0c0fe98faabc1044a4149bb65989062df4ade64e19d26411'],
+    }),
+    ('compositions', '1.40-2', {
+        'checksums': ['110d71ae000561987cb73fc76cd953bd69d37562cb401ed3c36dca137d01b78a'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
@@ -42,6 +42,7 @@ dependencies = [
     ('FFTW', '3.3.7'),  # for fftw
     ('libsndfile', '1.0.28'),  # for seewave
     ('ICU', '61.1'),  # for rJava & gdsfmt
+    ('HDF5', '1.10.1'),  # for hdf5r
     # OS dependency should be preferred if the os version is more recent then this version,
     # it's nice to have an up to date openssl for security reasons
     # ('OpenSSL', '1.0.2h'),

--- a/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
@@ -1919,6 +1919,9 @@ exts_list = [
     ('bayesm', '3.1-0.1', {
         'checksums': ['5879823b7fb6e6df0c0fe98faabc1044a4149bb65989062df4ade64e19d26411'],
     }),
+    ('energy', '1.7-5', {
+        'checksums': ['24c2cf080939f8f56cd9cda06d2dfc30d0389cd3ec7250af4f9a09a4c06b6996'],
+    }),
     ('compositions', '1.40-2', {
         'checksums': ['110d71ae000561987cb73fc76cd953bd69d37562cb401ed3c36dca137d01b78a'],
     }),

--- a/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
@@ -1907,6 +1907,61 @@ exts_list = [
     ('KODAMA', '1.4', {
         'checksums': ['126bc85c5fe08c06fe1d4dda230da2d7574d57bda3b8fa36b2a87d498d7cf763'],
     }),
+    ('locfdr', '1.1-8', {
+        'checksums': ['42d6e12593ae6d541e6813a140b92591dabeb1df94432a515507fc2eee9a54b9'],
+    }),
+    ('ica', '1.0-2', {
+        'checksums': ['e721596fc6175d3270a60d5e0b5b98be103a8fd0dd93ef16680af21fe0b54179'],
+    }),
+    ('dtw', '1.20-1', {
+        'checksums': ['43ca1a47a7c81a2b5d5054da1be8b8af79a85d6f9ce7b4512e9ed91f790f60f0'],
+    }),
+    ('SDMTools', '1.1-221', {
+        'checksums': ['a6da297a670f756ee964ffd99c3b212c55c297d385583fd0e767435dd5cd4ccd'],
+    }),
+    ('later', '0.7.4', {
+        'checksums': ['c4d49aa91f5154ef54ea0498b17f230b8bf99da62541b64417e0c8971261bf88'],
+    }),
+    ('promises', '1.0.1', {
+        'checksums': ['c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558'],
+    }),
+    ('ggridges', '0.5.0', {
+        'checksums': ['124bc84044e56728fa965682f8232fc868f2af7d3eb7276f6b0df53be8d2dbfe'],
+    }),
+    ('bibtex', '0.4.2', {
+        'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
+    }),
+    ('gbRd', '0.4-11', {
+        'checksums': ['0251f6dd6ca987a74acc4765838b858f1edb08b71dbad9e563669b58783ea91b'],
+    }),
+    ('Rdpack', '0.9-0', {
+        'checksums': ['2bb4f64c416f89166d3d2433257da2dbf981a8550d956ed99f10a83f0d07fc18'],
+    }),
+    ('metap', '1.0', {
+        'checksums': ['50a014cd52c30d55cf219cc37864323c4d1b44c3c26ff948b10e4dff1dde3fa3'],
+    }),
+    ('lsei', '1.2-0', {
+        'checksums': ['4781ebd9ef93880260d5d5f23066580ac06061e95c1048fb25e4e838963380f6'],
+    }),
+    ('npsurv', '0.4-0', {
+        'checksums': ['404cf7135dc40a04e9b81224a543307057a8278e11109ba1fcaa28e87c6204f3'],
+    }),
+    ('fitdistrplus', '1.0-11', {
+        'checksums': ['861b986529d21a1c5de3e7e22848167704848f60b3f31770827fc8e2c79b0c8a'],
+    }),
+    ('reticulate', '1.10', {
+        'checksums': ['58e36d3b8a67d01194c4e5099499657d017f77fc2081213633964b1d57a7e32f'],
+    }),
+    ('hdf5r', '1.0.0', {
+        'checksums': ['6a5fb0c4ac7129405e993ce461db908d51bc0ea2b717e8ca306c26902423d7e8'],
+        'preinstallopts': "unset LIBS && ",
+    }),
+    ('DTRreg', '1.3', {
+        'checksums': ['835df542d0ec55368834bc4173dc4aa90f1c0ff146ab243d6e377bba309b8484'],
+    }),
+    ('pulsar', '0.3.4', {
+        'checksums': ['d7230b2286d0fbfa59bbd4f7314ee6e7b77f929f41a8b42bd95af0a7e354cb1c'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
@@ -8,8 +8,8 @@ description = """R is a free software environment for statistical computing and 
 
 toolchain = {'name': 'iomkl', 'version': '2018a'}
 
-sources = [SOURCE_TAR_GZ]
 source_urls = ['https://cloud.r-project.org/src/base/R-%(version_major)s']
+sources = [SOURCE_TAR_GZ]
 checksums = ['fd1725535e21797d3d9fea8963d99be0ba4c3aecadcf081b43e261458b416870']
 
 builddependencies = [
@@ -1965,6 +1965,9 @@ exts_list = [
     }),
     ('bayesm', '3.1-0.1', {
         'checksums': ['5879823b7fb6e6df0c0fe98faabc1044a4149bb65989062df4ade64e19d26411'],
+    }),
+    ('energy', '1.7-5', {
+        'checksums': ['24c2cf080939f8f56cd9cda06d2dfc30d0389cd3ec7250af4f9a09a4c06b6996'],
     }),
     ('compositions', '1.40-2', {
         'checksums': ['110d71ae000561987cb73fc76cd953bd69d37562cb401ed3c36dca137d01b78a'],

--- a/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
@@ -1963,6 +1963,12 @@ exts_list = [
     ('pulsar', '0.3.4', {
         'checksums': ['d7230b2286d0fbfa59bbd4f7314ee6e7b77f929f41a8b42bd95af0a7e354cb1c'],
     }),
+    ('bayesm', '3.1-0.1', {
+        'checksums': ['5879823b7fb6e6df0c0fe98faabc1044a4149bb65989062df4ade64e19d26411'],
+    }),
+    ('compositions', '1.40-2', {
+        'checksums': ['110d71ae000561987cb73fc76cd953bd69d37562cb401ed3c36dca137d01b78a'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
@@ -42,6 +42,7 @@ dependencies = [
     ('FFTW', '3.3.7'),  # for fftw
     ('libsndfile', '1.0.28'),  # for seewave
     ('ICU', '61.1'),  # for rJava & gdsfmt
+    ('HDF5', '1.10.1'),  # for hdf5r
     # OS dependency should be preferred if the os version is more recent then this version,
     # it's nice to have an up to date openssl for security reasons
     # ('OpenSSL', '1.0.2h'),

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
@@ -1953,6 +1953,9 @@ exts_list = [
     ('bayesm', '3.1-0.1', {
         'checksums': ['5879823b7fb6e6df0c0fe98faabc1044a4149bb65989062df4ade64e19d26411'],
     }),
+    ('energy', '1.7-5', {
+        'checksums': ['24c2cf080939f8f56cd9cda06d2dfc30d0389cd3ec7250af4f9a09a4c06b6996'],
+    }),
     ('compositions', '1.40-2', {
         'checksums': ['110d71ae000561987cb73fc76cd953bd69d37562cb401ed3c36dca137d01b78a'],
     }),

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
@@ -1890,6 +1890,61 @@ exts_list = [
     ('KODAMA', '1.4', {
         'checksums': ['126bc85c5fe08c06fe1d4dda230da2d7574d57bda3b8fa36b2a87d498d7cf763'],
     }),
+    ('locfdr', '1.1-8', {
+        'checksums': ['42d6e12593ae6d541e6813a140b92591dabeb1df94432a515507fc2eee9a54b9'],
+    }),
+    ('ica', '1.0-2', {
+        'checksums': ['e721596fc6175d3270a60d5e0b5b98be103a8fd0dd93ef16680af21fe0b54179'],
+    }),
+    ('dtw', '1.20-1', {
+        'checksums': ['43ca1a47a7c81a2b5d5054da1be8b8af79a85d6f9ce7b4512e9ed91f790f60f0'],
+    }),
+    ('SDMTools', '1.1-221', {
+        'checksums': ['a6da297a670f756ee964ffd99c3b212c55c297d385583fd0e767435dd5cd4ccd'],
+    }),
+    ('later', '0.7.4', {
+        'checksums': ['c4d49aa91f5154ef54ea0498b17f230b8bf99da62541b64417e0c8971261bf88'],
+    }),
+    ('promises', '1.0.1', {
+        'checksums': ['c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558'],
+    }),
+    ('ggridges', '0.5.0', {
+        'checksums': ['124bc84044e56728fa965682f8232fc868f2af7d3eb7276f6b0df53be8d2dbfe'],
+    }),
+    ('bibtex', '0.4.2', {
+        'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
+    }),
+    ('gbRd', '0.4-11', {
+        'checksums': ['0251f6dd6ca987a74acc4765838b858f1edb08b71dbad9e563669b58783ea91b'],
+    }),
+    ('Rdpack', '0.9-0', {
+        'checksums': ['2bb4f64c416f89166d3d2433257da2dbf981a8550d956ed99f10a83f0d07fc18'],
+    }),
+    ('metap', '1.0', {
+        'checksums': ['50a014cd52c30d55cf219cc37864323c4d1b44c3c26ff948b10e4dff1dde3fa3'],
+    }),
+    ('lsei', '1.2-0', {
+        'checksums': ['4781ebd9ef93880260d5d5f23066580ac06061e95c1048fb25e4e838963380f6'],
+    }),
+    ('npsurv', '0.4-0', {
+        'checksums': ['404cf7135dc40a04e9b81224a543307057a8278e11109ba1fcaa28e87c6204f3'],
+    }),
+    ('fitdistrplus', '1.0-11', {
+        'checksums': ['861b986529d21a1c5de3e7e22848167704848f60b3f31770827fc8e2c79b0c8a'],
+    }),
+    ('reticulate', '1.10', {
+        'checksums': ['58e36d3b8a67d01194c4e5099499657d017f77fc2081213633964b1d57a7e32f'],
+    }),
+    ('hdf5r', '1.0.0', {
+        'checksums': ['6a5fb0c4ac7129405e993ce461db908d51bc0ea2b717e8ca306c26902423d7e8'],
+        'preinstallopts': "unset LIBS && ",
+    }),
+    ('DTRreg', '1.3', {
+        'checksums': ['835df542d0ec55368834bc4173dc4aa90f1c0ff146ab243d6e377bba309b8484'],
+    }),
+    ('pulsar', '0.3.4', {
+        'checksums': ['d7230b2286d0fbfa59bbd4f7314ee6e7b77f929f41a8b42bd95af0a7e354cb1c'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
@@ -39,6 +39,7 @@ dependencies = [
     ('FFTW', '3.3.8'),  # for fftw
     ('libsndfile', '1.0.28'),  # for seewave
     ('ICU', '61.1'),  # for rJava & gdsfmt
+    ('HDF5', '1.10.2'),  # for hdf5r
     # OS dependency should be preferred if the os version is more recent then this version,
     # it's nice to have an up to date openssl for security reasons
     # ('OpenSSL', '1.0.2h'),

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
@@ -1937,8 +1937,12 @@ exts_list = [
         'checksums': ['58e36d3b8a67d01194c4e5099499657d017f77fc2081213633964b1d57a7e32f'],
     }),
     ('hdf5r', '1.0.0', {
-        'checksums': ['6a5fb0c4ac7129405e993ce461db908d51bc0ea2b717e8ca306c26902423d7e8'],
+        'patches': ['hdf5r-1.0.0_fix-HDF5-1.10.2.patch'],
         'preinstallopts': "unset LIBS && ",
+        'checksums': [
+            '6a5fb0c4ac7129405e993ce461db908d51bc0ea2b717e8ca306c26902423d7e8',  # hdf5r_1.0.0.tar.gz
+            'a01ffc5aa37dc3df375638c78ac02bb7e518eb0e41447a25e77a6da6f4e92608',  # hdf5r-1.0.0_fix-HDF5-1.10.2.patch
+        ],
     }),
     ('DTRreg', '1.3', {
         'checksums': ['835df542d0ec55368834bc4173dc4aa90f1c0ff146ab243d6e377bba309b8484'],

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
@@ -1950,6 +1950,12 @@ exts_list = [
     ('pulsar', '0.3.4', {
         'checksums': ['d7230b2286d0fbfa59bbd4f7314ee6e7b77f929f41a8b42bd95af0a7e354cb1c'],
     }),
+    ('bayesm', '3.1-0.1', {
+        'checksums': ['5879823b7fb6e6df0c0fe98faabc1044a4149bb65989062df4ade64e19d26411'],
+    }),
+    ('compositions', '1.40-2', {
+        'checksums': ['110d71ae000561987cb73fc76cd953bd69d37562cb401ed3c36dca137d01b78a'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/hdf5r-1.0.0_fix-HDF5-1.10.2.patch
+++ b/easybuild/easyconfigs/r/R/hdf5r-1.0.0_fix-HDF5-1.10.2.patch
@@ -1,0 +1,39 @@
+fix compilation error: error: 'H5D_MPIO_FILTERS' undeclared
+internal constant H5D_MPIO_FILTERS was renamed to H5D_MPIO_NO_COLLECTIVE_MAX_CAUSE in HDF5 1.10.2
+see also https://github.com/hhoeflin/hdf5r/issues/97
+author: Kenneth Hoste (HPC-UGent)
+diff -ru hdf5r.orig/MD5 hdf5r/MD5
+--- hdf5r.orig/MD5	2017-10-25 11:45:44.000000000 +0200
++++ hdf5r/MD5	2018-09-18 19:06:10.131472405 +0200
+@@ -179,7 +179,7 @@
+ ca5d483c11c1eabe73aa58e464e003ed *src/1_10_0/Wrapper_auto_H5Z.h
+ 786e8111cf97a17f3e186c23138a3a51 *src/1_10_0/const_export.c
+ 197c5a485540fb6a9b10b881b00805cc *src/1_10_0/const_export.h
+-a0febd83da74edb5693bccd325ab9d79 *src/1_10_0/datatype_export.c
++54cfea23947efa6f83952e934ecdd811 *src/1_10_0/datatype_export.c
+ 93630a5e8c69fb2b041b0a60d04ef8cf *src/1_10_0/datatype_export.h
+ 0ba59b04936519e01219d12465a35b85 *src/1_10_0/export_auto.h
+ 4cf5cc29d1987c24b8a34a7f08f7574c *src/1_8_12/HelperStructs.h
+diff -ru hdf5r.orig/src/1_10_0/datatype_export.c hdf5r/src/1_10_0/datatype_export.c
+--- hdf5r.orig/src/1_10_0/datatype_export.c	2017-10-23 21:39:29.000000000 +0200
++++ hdf5r/src/1_10_0/datatype_export.c	2018-09-18 19:05:00.690794603 +0200
+@@ -1474,7 +1474,7 @@
+   return(dtype_id);
+ }
+ 
+-/* typedef enum H5D_mpio_no_collective_cause_t { H5D_MPIO_COLLECTIVE = 0x00, H5D_MPIO_SET_INDEPENDENT = 0x01, H5D_MPIO_DATATYPE_CONVERSION = 0x02, H5D_MPIO_DATA_TRANSFORMS = 0x04, H5D_MPIO_MPI_OPT_TYPES_ENV_VAR_DISABLED = 0x08, H5D_MPIO_NOT_SIMPLE_OR_SCALAR_DATASPACES = 0x10, H5D_MPIO_NOT_CONTIGUOUS_OR_CHUNKED_DATASET = 0x20, H5D_MPIO_FILTERS = 0x40} H5D_mpio_no_collective_cause_t; */
++/* typedef enum H5D_mpio_no_collective_cause_t { H5D_MPIO_COLLECTIVE = 0x00, H5D_MPIO_SET_INDEPENDENT = 0x01, H5D_MPIO_DATATYPE_CONVERSION = 0x02, H5D_MPIO_DATA_TRANSFORMS = 0x04, H5D_MPIO_MPI_OPT_TYPES_ENV_VAR_DISABLED = 0x08, H5D_MPIO_NOT_SIMPLE_OR_SCALAR_DATASPACES = 0x10, H5D_MPIO_NOT_CONTIGUOUS_OR_CHUNKED_DATASET = 0x20, H5D_MPIO_NO_COLLECTIVE_MAX_CAUSE = 0x40} H5D_mpio_no_collective_cause_t; */
+ hid_t create_DT_H5D_mpio_no_collective_cause_t(void) {
+   enum H5D_mpio_no_collective_cause_t myenum;
+   hid_t base_type = get_h5_equiv(sizeof(enum H5D_mpio_no_collective_cause_t), issigned(enum H5D_mpio_no_collective_cause_t));
+@@ -1493,8 +1493,8 @@
+   H5Tenum_insert(dtype_id, "H5D_MPIO_NOT_SIMPLE_OR_SCALAR_DATASPACES", &myenum);
+   myenum = H5D_MPIO_NOT_CONTIGUOUS_OR_CHUNKED_DATASET;
+   H5Tenum_insert(dtype_id, "H5D_MPIO_NOT_CONTIGUOUS_OR_CHUNKED_DATASET", &myenum);
+-  myenum = H5D_MPIO_FILTERS;
+-  H5Tenum_insert(dtype_id, "H5D_MPIO_FILTERS", &myenum);
++  myenum = H5D_MPIO_NO_COLLECTIVE_MAX_CAUSE;
++  H5Tenum_insert(dtype_id, "H5D_MPIO_NO_COLLECTIVE_MAX_CAUSE", &myenum);
+   return(dtype_id);
+ }
+ 


### PR DESCRIPTION
requires https://github.com/easybuilders/easybuild-easyblocks/pull/1513 to ensure that `preinstallopts` for `hdf5r` is picked up