### PR TITLE
add wish -> wish8.6 symlink to Tk

### DIFF
--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.8-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.8-GCCcore-6.4.0.eb
@@ -26,6 +26,9 @@ dependencies = [
 
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib CFLAGS="-I$EBROOTTCL/include"'
 
+version_major_minor = version.split('.')[:2]
+postinstallcmds = ["ln -s wish%(version_major_minor)s %(installdir)s/bin/wish"]
+
 start_dir = 'unix'
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.8-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.8-GCCcore-6.4.0.eb
@@ -26,7 +26,6 @@ dependencies = [
 
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib CFLAGS="-I$EBROOTTCL/include"'
 
-version_major_minor = version.split('.')[:2]
 postinstallcmds = ["ln -s wish%(version_major_minor)s %(installdir)s/bin/wish"]
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.8-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.8-GCCcore-7.3.0.eb
@@ -26,6 +26,9 @@ dependencies = [
 
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib CFLAGS="-I$EBROOTTCL/include"'
 
+version_major_minor = version.split('.')[:2]
+postinstallcmds = ["ln -s wish%(version_major_minor)s %(installdir)s/bin/wish"]
+
 start_dir = 'unix'
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.8-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.8-GCCcore-7.3.0.eb
@@ -26,7 +26,6 @@ dependencies = [
 
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib CFLAGS="-I$EBROOTTCL/include"'
 
-version_major_minor = version.split('.')[:2]
 postinstallcmds = ["ln -s wish%(version_major_minor)s %(installdir)s/bin/wish"]
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.8-foss-2018a.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.8-foss-2018a.eb
@@ -25,6 +25,8 @@ dependencies = [
 
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib CFLAGS="-I$EBROOTTCL/include"'
 
+postinstallcmds = ["ln -s wish%(version_major_minor)s %(installdir)s/bin/wish"]
+
 start_dir = 'unix'
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.8-iomkl-2018a.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.8-iomkl-2018a.eb
@@ -25,6 +25,8 @@ dependencies = [
 
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib CFLAGS="-I$EBROOTTCL/include"'
 
+postinstallcmds = ["ln -s wish%(version_major_minor)s %(installdir)s/bin/wish"]
+
 start_dir = 'unix'
 
 moduleclass = 'vis'


### PR DESCRIPTION
Tk only installs an executable named "wish8.6", but other software (e.g. FSL) usually looks for just "wish" without the version number. OS packages from e.g. RHEL also install a "wish" executable instead of the versioned one, so with this change, the EasyConfig creates a symlink in the bin dir from "wish" -> "wish8.6".