### PR TITLE
change fastStructure easyconfig to use custom easyblock

### DIFF
--- a/easybuild/easyconfigs/f/fastStructure/fastStructure-1.0-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/f/fastStructure/fastStructure-1.0-foss-2016a-Python-2.7.11.eb
@@ -2,9 +2,10 @@
 # integrates with some C code using Cython. This
 # easyconfig calls setup.py to build the Cython code and
 # copies the whole tree over to the installation directory.
-# The '#!/bin/env python' header is added to structure.py,
-# and it is made executable in order for the users to be able
-# to use it without having to refer to its full path.
+# The '#!/bin/env python' header is added to the Python scripts
+# in the installation directory, and they are made executable
+# in order for the users to be able to use them without having
+# to refer to its full path.
 easyblock = 'CmdCp'
 
 name = 'fastStructure'
@@ -34,8 +35,10 @@ cmds_map = [('.*', 'cd vars && python setup.py build_ext --inplace && cd .. && p
 files_to_copy = ['*']
 
 postinstallcmds = [
-    'echo "#!/bin/env python" | cat - %(installdir)s/structure.py > temp && mv temp %(installdir)s/structure.py',
-    'chmod +x %(installdir)s/structure.py'
+    'for pyfile in %(installdir)s/*.py; do ' + 
+    'echo "#!/bin/env python" | cat - ${pyfile} > temp && mv temp ${pyfile}; ' +
+    'chmod +x ${pyfile}; ' +
+    'done'
 ]
 
 modextrapaths = {'PATH': ['']}

--- a/easybuild/easyconfigs/f/fastStructure/fastStructure-1.0-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/f/fastStructure/fastStructure-1.0-foss-2016a-Python-2.7.11.eb
@@ -27,6 +27,7 @@ checksums = ['f1bfb24bb5ecd108bc3a90145fad232012165c1e60608003f1c87d200f867b81']
 
 dependencies = [
     ('Python', '2.7.11'),
+    ('matplotlib', '1.5.1', '-Python-%(pyver)s'),
     ('GSL', '2.1'),
 ]
 

--- a/easybuild/easyconfigs/f/fastStructure/fastStructure-1.0-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/f/fastStructure/fastStructure-1.0-foss-2016a-Python-2.7.11.eb
@@ -1,13 +1,3 @@
-# fastStructure is a Python program structure.py, which 
-# integrates with some C code using Cython. This
-# easyconfig calls setup.py to build the Cython code and
-# copies the whole tree over to the installation directory.
-# The '#!/bin/env python' header is added to the Python scripts
-# in the installation directory, and they are made executable
-# in order for the users to be able to use them without having
-# to refer to its full path.
-easyblock = 'CmdCp'
-
 name = 'fastStructure'
 version = '1.0'
 versionsuffix = '-Python-%(pyver)s'
@@ -30,23 +20,5 @@ dependencies = [
     ('matplotlib', '1.5.1', '-Python-%(pyver)s'),
     ('GSL', '2.1'),
 ]
-
-cmds_map = [('.*', 'cd vars && python setup.py build_ext --inplace && cd .. && python setup.py build_ext --inplace')]
-
-files_to_copy = ['*']
-
-postinstallcmds = [
-    'for pyfile in %(installdir)s/*.py; do ' +
-    'echo "#!/bin/env python" | cat - ${pyfile} > temp && mv temp ${pyfile}; ' +
-    'chmod +x ${pyfile}; ' +
-    'done'
-]
-
-modextrapaths = {'PATH': ['']}
-
-sanity_check_paths = {
-    'files': ['structure.py'],
-    'dirs': ['vars'],
-}
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/f/fastStructure/fastStructure-1.0-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/f/fastStructure/fastStructure-1.0-foss-2016a-Python-2.7.11.eb
@@ -35,7 +35,7 @@ cmds_map = [('.*', 'cd vars && python setup.py build_ext --inplace && cd .. && p
 files_to_copy = ['*']
 
 postinstallcmds = [
-    'for pyfile in %(installdir)s/*.py; do ' + 
+    'for pyfile in %(installdir)s/*.py; do ' +
     'echo "#!/bin/env python" | cat - ${pyfile} > temp && mv temp ${pyfile}; ' +
     'chmod +x ${pyfile}; ' +
     'done'


### PR DESCRIPTION
The current fastStructure easyconfig only makes the main script (structure.py) executable. This PR also makes the additional scripts (chooseK.py, distruct.py, see https://rajanil.github.io/fastStructure/#choosing-model-complexity) executable, so they can be easily run without having to prefix them with the installation path.

edit: now requires https://github.com/easybuilders/easybuild-easyblocks/pull/1529