### PR TITLE
add tclsh symlink to recent Tcl easyconfigs

### DIFF
--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-GCC-4.9.3-2.25.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'GCC', 'version': '4.9.3-2.25'}
 
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
+checksums = ['ce26d5b9c7504fc25d2f10ef0b82b14cf117315445b5afa9e673ed331830fb53']
 
 dependencies = [
     ('zlib', '1.2.8'),
@@ -22,5 +23,16 @@ configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
 runtest = 'test'
 
 start_dir = 'unix'
+
+postinstallcmds = [
+    'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh'
+]
+
+sanity_check_paths = {
+    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'bin/tclsh',
+              'include/tcl.h', 'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
+              'lib/tclConfig.sh', 'man/man1/tclsh.1'],
+    'dirs': ['share'],
+}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-GCC-5.4.0-2.26.eb
@@ -24,4 +24,15 @@ runtest = 'test'
 
 start_dir = 'unix'
 
+postinstallcmds = [
+    'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh'
+]
+
+sanity_check_paths = {
+    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'bin/tclsh',
+              'include/tcl.h', 'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
+              'lib/tclConfig.sh', 'man/man1/tclsh.1'],
+    'dirs': ['share'],
+}
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-GCCcore-6.3.0.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
 
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
+checksums = ['ce26d5b9c7504fc25d2f10ef0b82b14cf117315445b5afa9e673ed331830fb53']
 
 builddependencies = [
     ('binutils', '2.27'),
@@ -26,5 +27,16 @@ configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
 runtest = 'test'
 
 start_dir = 'unix'
+
+postinstallcmds = [
+    'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh'
+]
+
+sanity_check_paths = {
+    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'bin/tclsh',
+              'include/tcl.h', 'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
+              'lib/tclConfig.sh', 'man/man1/tclsh.1'],
+    'dirs': ['share'],
+}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-foss-2016.04.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-foss-2016.04.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'foss', 'version': '2016.04'}
 
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
+checksums = ['ce26d5b9c7504fc25d2f10ef0b82b14cf117315445b5afa9e673ed331830fb53']
 
 dependencies = [
     ('zlib', '1.2.8'),
@@ -22,5 +23,16 @@ configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
 runtest = 'test'
 
 start_dir = 'unix'
+
+postinstallcmds = [
+    'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh'
+]
+
+sanity_check_paths = {
+    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'bin/tclsh',
+              'include/tcl.h', 'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
+              'lib/tclConfig.sh', 'man/man1/tclsh.1'],
+    'dirs': ['share'],
+}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-foss-2016a.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-foss-2016a.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
+checksums = ['ce26d5b9c7504fc25d2f10ef0b82b14cf117315445b5afa9e673ed331830fb53']
 
 dependencies = [
     ('zlib', '1.2.8'),
@@ -22,5 +23,16 @@ configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
 runtest = 'test'
 
 start_dir = 'unix'
+
+postinstallcmds = [
+    'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh'
+]
+
+sanity_check_paths = {
+    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'bin/tclsh',
+              'include/tcl.h', 'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
+              'lib/tclConfig.sh', 'man/man1/tclsh.1'],
+    'dirs': ['share'],
+}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-foss-2016b.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-foss-2016b.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
+checksums = ['ce26d5b9c7504fc25d2f10ef0b82b14cf117315445b5afa9e673ed331830fb53']
 
 dependencies = [
     ('zlib', '1.2.8'),
@@ -22,5 +23,16 @@ configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
 runtest = 'test'
 
 start_dir = 'unix'
+
+postinstallcmds = [
+    'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh'
+]
+
+sanity_check_paths = {
+    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'bin/tclsh',
+              'include/tcl.h', 'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
+              'lib/tclConfig.sh', 'man/man1/tclsh.1'],
+    'dirs': ['share'],
+}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'iccifort', 'version': '2016.3.210-GCC-5.4.0-2.26'}
 
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
+checksums = ['ce26d5b9c7504fc25d2f10ef0b82b14cf117315445b5afa9e673ed331830fb53']
 
 dependencies = [
     ('zlib', '1.2.8'),
@@ -22,5 +23,16 @@ configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
 runtest = 'test'
 
 start_dir = 'unix'
+
+postinstallcmds = [
+    'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh'
+]
+
+sanity_check_paths = {
+    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'bin/tclsh',
+              'include/tcl.h', 'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
+              'lib/tclConfig.sh', 'man/man1/tclsh.1'],
+    'dirs': ['share'],
+}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-intel-2016b.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-intel-2016b.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
+checksums = ['ce26d5b9c7504fc25d2f10ef0b82b14cf117315445b5afa9e673ed331830fb53']
 
 dependencies = [
     ('zlib', '1.2.8'),
@@ -22,5 +23,16 @@ configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
 runtest = 'test'
 
 start_dir = 'unix'
+
+postinstallcmds = [
+    'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh'
+]
+
+sanity_check_paths = {
+    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'bin/tclsh',
+              'include/tcl.h', 'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
+              'lib/tclConfig.sh', 'man/man1/tclsh.1'],
+    'dirs': ['share'],
+}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.6-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.6-GCCcore-4.9.3.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
 
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
+checksums = ['a265409781e4b3edcc4ef822533071b34c3dc6790b893963809b9fe221befe07']
 
 builddependencies = [
     ('binutils', '2.25'),
@@ -26,5 +27,16 @@ configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
 runtest = 'test'
 
 start_dir = 'unix'
+
+postinstallcmds = [
+    'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh'
+]
+
+sanity_check_paths = {
+    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'bin/tclsh',
+              'include/tcl.h', 'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
+              'lib/tclConfig.sh', 'man/man1/tclsh.1'],
+    'dirs': ['share'],
+}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.6-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.6-GCCcore-6.3.0.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
 
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
+checksums = ['a265409781e4b3edcc4ef822533071b34c3dc6790b893963809b9fe221befe07']
 
 builddependencies = [
     ('binutils', '2.27'),
@@ -26,5 +27,16 @@ configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
 runtest = 'test'
 
 start_dir = 'unix'
+
+postinstallcmds = [
+    'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh'
+]
+
+sanity_check_paths = {
+    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'bin/tclsh',
+              'include/tcl.h', 'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
+              'lib/tclConfig.sh', 'man/man1/tclsh.1'],
+    'dirs': ['share'],
+}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.7-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.7-GCCcore-6.4.0.eb
@@ -31,12 +31,15 @@ runtest = 'test'
 
 start_dir = 'unix'
 
+postinstallcmds = [
+    'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh'
+]
+
 sanity_check_paths = {
-    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'include/tcl.h',
-              'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
+    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'bin/tclsh',
+              'include/tcl.h', 'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
               'lib/tclConfig.sh', 'man/man1/tclsh.1'],
     'dirs': ['share'],
 }
-
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.8-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.8-GCCcore-6.4.0.eb
@@ -31,12 +31,15 @@ runtest = 'test'
 
 start_dir = 'unix'
 
+postinstallcmds = [
+    'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh'
+]
+
 sanity_check_paths = {
-    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'include/tcl.h',
-              'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
+    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'bin/tclsh',
+              'include/tcl.h', 'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
               'lib/tclConfig.sh', 'man/man1/tclsh.1'],
     'dirs': ['share'],
 }
-
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.8-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.8-GCCcore-7.3.0.eb
@@ -31,12 +31,15 @@ runtest = 'test'
 
 start_dir = 'unix'
 
+postinstallcmds = [
+    'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh'
+]
+
 sanity_check_paths = {
-    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'include/tcl.h',
-              'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
+    'files': ['bin/tclsh%(version_major)s.%(version_minor)s', 'bin/tclsh',
+              'include/tcl.h', 'lib/libtcl%%(version_major)s.%%(version_minor)s.%s' % SHLIB_EXT,
               'lib/tclConfig.sh', 'man/man1/tclsh.1'],
     'dirs': ['share'],
 }
-
 
 moduleclass = 'lang'


### PR DESCRIPTION
The installation only provides the `tclsh8.6` executable. Scripts that call `tclsh` (e.g. building `FSL`'s `fslio`) will fail unless available from the underlying OS.

With this PR the symlink `tclsh -> tclsh8.6` is created in the binaries installation path.