### PR TITLE
Update the GROMACS-2016.3 nvml lib search patch to be more generic.

### DIFF
--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3_amend_search_for_nvml_lib.patch
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3_amend_search_for_nvml_lib.patch
@@ -1,14 +1,15 @@
 # The NVML library location depends on driver version on Ubuntu
-# Åke Sandgren, 2016-10-14
-diff -ru gromacs-2016.orig/cmake/FindNVML.cmake gromacs-2016/cmake/FindNVML.cmake
---- gromacs-2016.orig/cmake/FindNVML.cmake	2016-07-09 02:55:38.000000000 +0200
-+++ gromacs-2016/cmake/FindNVML.cmake	2016-10-14 21:44:08.143648879 +0200
-@@ -96,7 +96,7 @@
+# Åke Sandgren, 2017-12-07
+diff -ru gromacs-2016.3.orig/cmake/FindNVML.cmake gromacs-2016.3/cmake/FindNVML.cmake
+--- gromacs-2016.3.orig/cmake/FindNVML.cmake	2016-07-09 02:55:38.000000000 +0200
++++ gromacs-2016.3/cmake/FindNVML.cmake	2017-12-07 19:56:19.702407170 +0100
+@@ -96,7 +96,8 @@
    # reasonably set GPU_DEPLOYMENT_KIT_ROOT_DIR to the value they
    # passed to the installer, or the root where they later found the
    # kit to be installed. Below, we cater for both possibilities.
 -  set( NVML_LIB_PATHS /usr/lib64 )
-+  set( NVML_LIB_PATHS /usr/lib64 /usr/lib64/nvidia /usr/lib/nvidia-367 /usr/lib/nvidia-375)
++  file(GLOB NVIDIA_DIRS /usr/lib/nvidia-*)
++  set( NVML_LIB_PATHS /usr/lib64 ${NVIDIA_DIRS})
    if(GPU_DEPLOYMENT_KIT_ROOT_DIR)
        list(APPEND NVML_LIB_PATHS
            "${GPU_DEPLOYMENT_KIT_ROOT_DIR}/src/gdk/nvml/lib"


### PR DESCRIPTION
And match the GROMACS 2018 patch.