### PR TITLE
Update gromacs 2016.3 for nvml patches

### DIFF
--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-foss-2016b-GPU-enabled.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-foss-2016b-GPU-enabled.eb
@@ -28,13 +28,16 @@ toolchainopts = {'openmp': True, 'usempi': True}
 
 source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
 sources = [SOURCELOWER_TAR_GZ]
-
-checksums = [
-    '7bf00e74a9d38b7cef9356141d20e4ba9387289cbbfd4d11be479ef932d77d27',     # gromacs-2016.3.tar.gz
-]
-
 patches = [
+    'GROMACS-%(version)s_fix_search_for_nvml_include.patch',
     'GROMACS-%(version)s_amend_search_for_nvml_lib.patch',
+]
+checksums = [
+    '7bf00e74a9d38b7cef9356141d20e4ba9387289cbbfd4d11be479ef932d77d27',  # gromacs-2016.3.tar.gz
+    # GROMACS-2016.3_fix_search_for_nvml_include.patch
+    'bb5975862501f64c1f836b79f9f17f8a5a7068caf4933e9e5acd0c1bbc59b6d6',
+    # GROMACS-2016.3_amend_search_for_nvml_lib.patch
+    'd74f00b28a7fb0d1892cfd20c7f1314dc1716fccbfdf9ed9b540e7304684e77a',
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-goolfc-2017.01.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3-goolfc-2017.01.eb
@@ -28,12 +28,15 @@ toolchainopts = {'openmp': True, 'usempi': True}
 source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
 sources = [SOURCELOWER_TAR_GZ]
 patches = [
+    'GROMACS-%(version)s_fix_search_for_nvml_include.patch',
     'GROMACS-%(version)s_amend_search_for_nvml_lib.patch',
 ]
 checksums = [
     '7bf00e74a9d38b7cef9356141d20e4ba9387289cbbfd4d11be479ef932d77d27',  # gromacs-2016.3.tar.gz
+    # GROMACS-2016.3_fix_search_for_nvml_include.patch
+    'bb5975862501f64c1f836b79f9f17f8a5a7068caf4933e9e5acd0c1bbc59b6d6',
     # GROMACS-2016.3_amend_search_for_nvml_lib.patch
-    '6f29fde4e7d905843cccf16e4b2a341d74ef5ad8602a5cf56f3760def30816f7',
+    'd74f00b28a7fb0d1892cfd20c7f1314dc1716fccbfdf9ed9b540e7304684e77a',
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3_amend_search_for_nvml_lib.patch
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3_amend_search_for_nvml_lib.patch
@@ -1,14 +1,15 @@
 # The NVML library location depends on driver version on Ubuntu
-# Åke Sandgren, 2016-10-14
-diff -ru gromacs-2016.orig/cmake/FindNVML.cmake gromacs-2016/cmake/FindNVML.cmake
---- gromacs-2016.orig/cmake/FindNVML.cmake	2016-07-09 02:55:38.000000000 +0200
-+++ gromacs-2016/cmake/FindNVML.cmake	2016-10-14 21:44:08.143648879 +0200
-@@ -96,7 +96,7 @@
+# Åke Sandgren, 2017-12-07
+diff -ru gromacs-2016.3.orig/cmake/FindNVML.cmake gromacs-2016.3/cmake/FindNVML.cmake
+--- gromacs-2016.3.orig/cmake/FindNVML.cmake	2016-07-09 02:55:38.000000000 +0200
++++ gromacs-2016.3/cmake/FindNVML.cmake	2017-12-07 19:56:19.702407170 +0100
+@@ -96,7 +96,8 @@
    # reasonably set GPU_DEPLOYMENT_KIT_ROOT_DIR to the value they
    # passed to the installer, or the root where they later found the
    # kit to be installed. Below, we cater for both possibilities.
 -  set( NVML_LIB_PATHS /usr/lib64 )
-+  set( NVML_LIB_PATHS /usr/lib64 /usr/lib64/nvidia /usr/lib/nvidia-367 /usr/lib/nvidia-375)
++  file(GLOB NVIDIA_DIRS /usr/lib/nvidia-*)
++  set( NVML_LIB_PATHS /usr/lib64 ${NVIDIA_DIRS})
    if(GPU_DEPLOYMENT_KIT_ROOT_DIR)
        list(APPEND NVML_LIB_PATHS
            "${GPU_DEPLOYMENT_KIT_ROOT_DIR}/src/gdk/nvml/lib"

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3_fix_search_for_nvml_include.patch
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.3_fix_search_for_nvml_include.patch
@@ -1,0 +1,18 @@
+# Use CMake builtin search path for include files, i.e.
+# CMAKE_INCLUDE_PATH 
+#
+# Needed to find NVML from EB built CUDA.
+#
+# Åke Sandgren, 20180705
+diff -ru gromacs-2016.3.orig/cmake/FindNVML.cmake gromacs-2016.3/cmake/FindNVML.cmake
+--- gromacs-2016.3.orig/cmake/FindNVML.cmake	2016-07-09 02:55:38.000000000 +0200
++++ gromacs-2016.3/cmake/FindNVML.cmake	2017-08-14 14:07:04.176338240 +0200
+@@ -116,7 +116,7 @@
+ 
+ find_library(NVML_LIBRARY NAMES ${NVML_NAMES} PATHS ${NVML_LIB_PATHS} )
+ 
+-find_path(NVML_INCLUDE_DIR nvml.h PATHS ${NVML_INC_PATHS})
++find_path(NVML_INCLUDE_DIR nvml.h)
+ 
+ # handle the QUIETLY and REQUIRED arguments and set NVML_FOUND to TRUE if
+ # all listed variables are TRUE


### PR DESCRIPTION
Update GROMACS 2016.3 easyconfigs with nvml include search patch.
Update GROMACS-2016.3 nvml lib search patch to be more generic.
Add nmvl include search patch.
Update checksums.
