### PR TITLE
Add missing dep for Szip in 2017b builds of netCDF.

### DIFF
--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.4.1.1-foss-2017b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.4.1.1-foss-2017b.eb
@@ -16,6 +16,7 @@ checksums = ['7f040a0542ed3f6d27f3002b074e509614e18d6c515b2005d1537fec01b24909']
 dependencies = [
     ('HDF5', '1.10.1'),
     ('cURL', '7.56.0'),
+    ('Szip', '2.1.1'),
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.4.1.1-intel-2017b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.4.1.1-intel-2017b.eb
@@ -16,6 +16,7 @@ checksums = ['7f040a0542ed3f6d27f3002b074e509614e18d6c515b2005d1537fec01b24909']
 dependencies = [
     ('HDF5', '1.10.1'),
     ('cURL', '7.56.0'),
+    ('Szip', '2.1.1'),
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.5.0-intel-2017b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.5.0-intel-2017b.eb
@@ -16,6 +16,7 @@ checksums = ['f7d1cb2a82100b9bf9a1130a50bc5c7baf0de5b5022860ac3e09a0a32f83cf4a']
 dependencies = [
     ('HDF5', '1.10.1'),
     ('cURL', '7.56.1'),
+    ('Szip', '2.1.1'),
 ]
 
 builddependencies = [


### PR DESCRIPTION
Some 2017b easyconfigs for netCDF was missing the Szip dependency.