### PR TITLE
Fix missing comment from OpenBabel-2.4.1-fix-link-path-tests.patch

### DIFF
--- a/easybuild/easyconfigs/o/OpenBabel/OpenBabel-2.4.1-fix-link-path-tests.patch
+++ b/easybuild/easyconfigs/o/OpenBabel/OpenBabel-2.4.1-fix-link-path-tests.patch
@@ -1,3 +1,5 @@
+# This patch fixes the LD_LIBRARY_PATH for the tests. By default, it was overwritten.
+# By Ward Poelmans <wpoely86@gmail.com>
 --- openbabel-2.4.1/test/CMakeLists.txt.bk	2017-12-17 12:01:59.255142490 +0100
 +++ openbabel-2.4.1/test/CMakeLists.txt	2017-12-17 12:02:38.065471653 +0100
 @@ -148,7 +148,7 @@

--- a/easybuild/easyconfigs/o/OpenBabel/OpenBabel-2.4.1-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/o/OpenBabel/OpenBabel-2.4.1-intel-2017b-Python-2.7.14.eb
@@ -20,7 +20,7 @@ patches = [
 checksums = [
     '204136582cdfe51d792000b20202de8950218d617fd9c6e18cee36706a376dfc',  # openbabel-2.4.1.tar.gz
     '0db85c64f53862dce05ada9091a35d7b4c5c29a44aef76e0cb41cd679441a446',  # OpenBabel-2.3.2-use-xHost.patch
-    'c9425e7a06edcfdc69afce3b2f4f04f7f819501271257b87ab83378d329d0b46',  # OpenBabel-2.4.1-fix-link-path-tests.patch
+    'a6a1f687fc22e20a83b4f8c5e89e32e3eebefb1bb9440c9ca3848d23120bc458',  # OpenBabel-2.4.1-fix-link-path-tests.patch
 ]
 
 builddependencies = [('CMake', '3.10.0')]


### PR DESCRIPTION
Adjust checksum where needed.