### PR TITLE
Add patch to Python 3.6.1 - 3.6.3 that removes comment in comment.

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.6.1-foss-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.1-foss-2017a.eb
@@ -10,7 +10,12 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
-checksums = ['aa50b0143df7c89ce91be020fe41382613a817354b33acdc6641b44f8ced3828']
+patches = ['Python-3.6.1_fix_stupid_comment_in_comment.patch']
+checksums = [
+    'aa50b0143df7c89ce91be020fe41382613a817354b33acdc6641b44f8ced3828',  # Python-3.6.1.tgz
+    # Python-3.6.1_fix_stupid_comment_in_comment.patch
+    'c664b16ae9a2d2ef9dcca39a3b959a0e48c8d57258e5ab403d988e39b359b48e',
+]
 
 # python needs bzip2 to build the bz2 package
 dependencies = [
@@ -35,99 +40,133 @@ exts_list = [
     # note: more recent versions of setuptools (v34.x) can not be installed from source anymore,
     # see https://github.com/pypa/setuptools/issues/980
     ('setuptools', '33.1.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
         'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+        'checksums': ['6b20352ed60ba08c43b3611bdb502286f7a869fbfcf472f40d7279f1e77de145'],
     }),
     ('pip', '9.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
     }),
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
     }),
     ('numpy', '1.12.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/n/numpy'],
-        'source_tmpl': '%(name)s-%(version)s.zip',
         'patches': ['numpy-1.12.0-mkl.patch'],
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/n/numpy'],
+        'checksums': [
+            'a65266a4ad6ec8936a1bc85ce51f8600634a31a258b722c9274a80ff189d9542',  # numpy-1.12.1.zip
+            'f212296ed289eb1b4e3f703997499dee8a2cdd0af78b55e017477487b6377ca4',  # numpy-1.12.0-mkl.patch
+        ],
     }),
     ('scipy', '0.19.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
         'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
+        'checksums': ['4190d34bf9a09626cd42100bbb12e3d96b2daf1a8a3244e991263eb693732122'],
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
     }),
     ('mpi4py', '2.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
+        'checksums': ['6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81'],
     }),
     ('paycheck', '1.0.2', {
+        'patches': ['paycheck-1.0.2_setup-open-README-utf8.patch'],
         'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
-        'patches': [
-            'paycheck-1.0.2_setup-open-README-utf8.patch',
+        'checksums': [
+            '6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34',  # paycheck-1.0.2.tar.gz
+            # paycheck-1.0.2_setup-open-README-utf8.patch
+            'ceb7f08aebf016cdcd94ae41c1c76c8c120907f85cbfce240d3a112afb264d79',
         ],
     }),
     ('pbr', '2.0.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+        'checksums': ['0ccd2db529afd070df815b1521f01401d43de03941170f8a800e7531faba265d'],
     }),
     ('lockfile', '0.12.2', {
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
+        'checksums': ['6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799'],
     }),
     ('Cython', '0.25.2', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+        'checksums': ['f141d1f9c27a07b5a93f7dc5339472067e2d7140d1c5a9e20112a5665ca60306'],
     }),
     ('six', '1.10.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+        'checksums': ['105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a'],
     }),
     ('dateutil', '2.6.0', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+        'checksums': ['62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2'],
     }),
     ('deap', '1.0.2', {
+        'patches': ['deap-1.0.2_setup-open-README-utf8.patch'],
         'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
-        'patches': [
-            'deap-1.0.2_setup-open-README-utf8.patch',
+        'checksums': [
+            'c52bd32b8f0143db3a0b90f2b976c920b588638d6999ca0d038d8b1c07f7950b',  # deap-1.0.2.post2.tar.gz
+            # deap-1.0.2_setup-open-README-utf8.patch
+            '39a3a08359321189a1b27a382eb309dfd4470cba9101997a6d527a2fd3a0ce93',
         ],
     }),
     ('decorator', '4.0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+        'checksums': ['953d6bf082b100f43229cf547f4f97f97e970f5ad645ee7601d55ff87afdfe76'],
     }),
     ('arff', '2.1.0', {
         'source_tmpl': 'liac-%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+        'checksums': ['be6b5b76698d5fca1f24d75c98ed9c0ff5e24eb0d985d01cfd26c08a70f9654e'],
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
     ('cryptography', '1.8.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
+        'checksums': ['323524312bb467565ebca7e50c8ae5e9674e544951d28a2904a50012a8828190'],
     }),
     ('paramiko', '2.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+        'checksums': ['5fae49bed35e2e3d45c4f7b0db2d38b9ca626312d91119b3991d0ecf8125e310'],
     }),
     ('pyparsing', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
     }),
     ('netifaces', '0.10.5', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+        'checksums': ['59d8ad52dd3116fcb6635e175751b250dc783fb011adba539558bd764e5d628b'],
     }),
     ('netaddr', '0.7.19', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
     }),
     ('pandas', '0.19.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+        'checksums': ['6f0f4f598c2b16746803c8bafef7c721c57e4844da752d36240c0acf97658014'],
     }),
     ('virtualenv', '15.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
     }),
     ('docopt', '0.6.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
     }),
     ('joblib', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
     }),
     ('tabulate', '0.8.2', {
         'source_urls': ['https://pypi.python.org/packages/source/t/tabulate/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.1-intel-2017a.eb
@@ -10,7 +10,12 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
-checksums = ['aa50b0143df7c89ce91be020fe41382613a817354b33acdc6641b44f8ced3828']
+patches = ['Python-3.6.1_fix_stupid_comment_in_comment.patch']
+checksums = [
+    'aa50b0143df7c89ce91be020fe41382613a817354b33acdc6641b44f8ced3828',  # Python-3.6.1.tgz
+    # Python-3.6.1_fix_stupid_comment_in_comment.patch
+    'c664b16ae9a2d2ef9dcca39a3b959a0e48c8d57258e5ab403d988e39b359b48e',
+]
 
 # python needs bzip2 to build the bz2 package
 dependencies = [
@@ -39,99 +44,133 @@ exts_list = [
     # note: more recent versions of setuptools (v34.x) can not be installed from source anymore,
     # see https://github.com/pypa/setuptools/issues/980
     ('setuptools', '33.1.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
         'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+        'checksums': ['6b20352ed60ba08c43b3611bdb502286f7a869fbfcf472f40d7279f1e77de145'],
     }),
     ('pip', '9.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
     }),
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
     }),
     ('numpy', '1.12.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/n/numpy'],
-        'source_tmpl': '%(name)s-%(version)s.zip',
         'patches': ['numpy-1.12.0-mkl.patch'],
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/n/numpy'],
+        'checksums': [
+            'a65266a4ad6ec8936a1bc85ce51f8600634a31a258b722c9274a80ff189d9542',  # numpy-1.12.1.zip
+            'f212296ed289eb1b4e3f703997499dee8a2cdd0af78b55e017477487b6377ca4',  # numpy-1.12.0-mkl.patch
+        ],
     }),
     ('scipy', '0.19.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
         'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
+        'checksums': ['4190d34bf9a09626cd42100bbb12e3d96b2daf1a8a3244e991263eb693732122'],
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
     }),
     ('mpi4py', '2.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
+        'checksums': ['6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81'],
     }),
     ('paycheck', '1.0.2', {
+        'patches': ['paycheck-1.0.2_setup-open-README-utf8.patch'],
         'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
-        'patches': [
-            'paycheck-1.0.2_setup-open-README-utf8.patch',
+        'checksums': [
+            '6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34',  # paycheck-1.0.2.tar.gz
+            # paycheck-1.0.2_setup-open-README-utf8.patch
+            'ceb7f08aebf016cdcd94ae41c1c76c8c120907f85cbfce240d3a112afb264d79',
         ],
     }),
     ('pbr', '2.0.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+        'checksums': ['0ccd2db529afd070df815b1521f01401d43de03941170f8a800e7531faba265d'],
     }),
     ('lockfile', '0.12.2', {
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
+        'checksums': ['6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799'],
     }),
     ('Cython', '0.25.2', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+        'checksums': ['f141d1f9c27a07b5a93f7dc5339472067e2d7140d1c5a9e20112a5665ca60306'],
     }),
     ('six', '1.10.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+        'checksums': ['105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a'],
     }),
     ('dateutil', '2.6.0', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+        'checksums': ['62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2'],
     }),
     ('deap', '1.0.2', {
+        'patches': ['deap-1.0.2_setup-open-README-utf8.patch'],
         'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
-        'patches': [
-            'deap-1.0.2_setup-open-README-utf8.patch',
+        'checksums': [
+            'c52bd32b8f0143db3a0b90f2b976c920b588638d6999ca0d038d8b1c07f7950b',  # deap-1.0.2.post2.tar.gz
+            # deap-1.0.2_setup-open-README-utf8.patch
+            '39a3a08359321189a1b27a382eb309dfd4470cba9101997a6d527a2fd3a0ce93',
         ],
     }),
     ('decorator', '4.0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+        'checksums': ['953d6bf082b100f43229cf547f4f97f97e970f5ad645ee7601d55ff87afdfe76'],
     }),
     ('arff', '2.1.0', {
         'source_tmpl': 'liac-%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+        'checksums': ['be6b5b76698d5fca1f24d75c98ed9c0ff5e24eb0d985d01cfd26c08a70f9654e'],
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
     ('cryptography', '1.8.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
+        'checksums': ['323524312bb467565ebca7e50c8ae5e9674e544951d28a2904a50012a8828190'],
     }),
     ('paramiko', '2.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+        'checksums': ['5fae49bed35e2e3d45c4f7b0db2d38b9ca626312d91119b3991d0ecf8125e310'],
     }),
     ('pyparsing', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
     }),
     ('netifaces', '0.10.5', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+        'checksums': ['59d8ad52dd3116fcb6635e175751b250dc783fb011adba539558bd764e5d628b'],
     }),
     ('netaddr', '0.7.19', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
     }),
     ('pandas', '0.19.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+        'checksums': ['6f0f4f598c2b16746803c8bafef7c721c57e4844da752d36240c0acf97658014'],
     }),
     ('virtualenv', '15.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
     }),
     ('docopt', '0.6.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
     }),
     ('joblib', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
     }),
     ('tabulate', '0.8.2', {
         'source_urls': ['https://pypi.python.org/packages/source/t/tabulate/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.1_fix_stupid_comment_in_comment.patch
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.1_fix_stupid_comment_in_comment.patch
@@ -1,0 +1,29 @@
+# Don't do comment in comment. It doesn't work...
+# The original code fails on AMD CPUs with AVX+FMA4
+# Patch matches the code in Python 3.6.4
+#
+# Lars Viklund
+diff -ru Python-3.6.3.orig/Modules/_blake2/impl/blake2s-load-xop.h Python-3.6.3/Modules/_blake2/impl/blake2s-load-xop.h
+--- Python-3.6.3.orig/Modules/_blake2/impl/blake2s-load-xop.h	2017-10-03 07:52:02.000000000 +0200
++++ Python-3.6.3/Modules/_blake2/impl/blake2s-load-xop.h	2018-02-05 16:39:28.221091877 +0100
+@@ -18,8 +18,9 @@
+ 
+ #define TOB(x) ((x)*4*0x01010101 + 0x03020100) /* ..or not TOB */
+ 
++#if 0
+ /* Basic VPPERM emulation, for testing purposes */
+-/*static __m128i _mm_perm_epi8(const __m128i src1, const __m128i src2, const __m128i sel)
++static __m128i _mm_perm_epi8(const __m128i src1, const __m128i src2, const __m128i sel)
+ {
+    const __m128i sixteen = _mm_set1_epi8(16);
+    const __m128i t0 = _mm_shuffle_epi8(src1, sel);
+@@ -27,7 +28,8 @@
+    const __m128i mask = _mm_or_si128(_mm_cmpeq_epi8(sel, sixteen),
+                                      _mm_cmpgt_epi8(sel, sixteen)); /* (>=16) = 0xff : 00 */
+    return _mm_blendv_epi8(t0, s1, mask);
+-}*/
++}
++#endif
+ 
+ #define LOAD_MSG_0_1(buf) \
+ buf = _mm_perm_epi8(m0, m1, _mm_set_epi32(TOB(6),TOB(4),TOB(2),TOB(0)) );

--- a/easybuild/easyconfigs/p/Python/Python-3.6.2-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.2-foss-2017b.eb
@@ -10,7 +10,12 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
-checksums = ['7919489310a5f17f7acbab64d731e46dca0702874840dadce8bd4b2b3b8e7a82']
+patches = ['Python-3.6.1_fix_stupid_comment_in_comment.patch']
+checksums = [
+    '7919489310a5f17f7acbab64d731e46dca0702874840dadce8bd4b2b3b8e7a82',  # Python-3.6.2.tgz
+    # Python-3.6.1_fix_stupid_comment_in_comment.patch
+    'c664b16ae9a2d2ef9dcca39a3b959a0e48c8d57258e5ab403d988e39b359b48e',
+]
 
 # python needs bzip2 to build the bz2 package
 dependencies = [
@@ -35,21 +40,15 @@ exts_list = [
     ('setuptools', '36.3.0', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
-        'checksums': [
-            'e9fa391c1183b40fc6a1298bee02d554743f23c805a3b75dbb18def0f0755fb1',  # setuptools-36.3.0.zip
-        ],
+        'checksums': ['e9fa391c1183b40fc6a1298bee02d554743f23c805a3b75dbb18def0f0755fb1'],
     }),
     ('pip', '9.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
-        'checksums': [
-            '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d',  # pip-9.0.1.tar.gz
-        ],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
     }),
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
-        'checksums': [
-            'f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98',  # nose-1.3.7.tar.gz
-        ],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
     }),
     ('numpy', '1.13.1', {
         'patches': ['numpy-1.12.0-mkl.patch'],
@@ -63,21 +62,15 @@ exts_list = [
     ('scipy', '0.19.1', {
         'source_tmpl': '%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
-        'checksums': [
-            'a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6',  # scipy-0.19.1.tar.gz
-        ],
+        'checksums': ['a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6'],
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
-        'checksums': [
-            '3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3',  # blist-1.3.6.tar.gz
-        ],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
     }),
     ('mpi4py', '2.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
-        'checksums': [
-            '6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81',  # mpi4py-2.0.0.tar.gz
-        ],
+        'checksums': ['6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81'],
     }),
     ('paycheck', '1.0.2', {
         'patches': ['paycheck-1.0.2_setup-open-README-utf8.patch'],
@@ -90,34 +83,24 @@ exts_list = [
     }),
     ('pbr', '3.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
-        'checksums': [
-            '05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1',  # pbr-3.1.1.tar.gz
-        ],
+        'checksums': ['05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1'],
     }),
     ('lockfile', '0.12.2', {
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
-        'checksums': [
-            '6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799',  # lockfile-0.12.2.tar.gz
-        ],
+        'checksums': ['6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799'],
     }),
     ('Cython', '0.26.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
-        'checksums': [
-            'c2e63c4794161135adafa8aa4a855d6068073f421c83ffacc39369497a189dd5',  # Cython-0.26.1.tar.gz
-        ],
+        'checksums': ['c2e63c4794161135adafa8aa4a855d6068073f421c83ffacc39369497a189dd5'],
     }),
     ('six', '1.10.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-        'checksums': [
-            '105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a',  # six-1.10.0.tar.gz
-        ],
+        'checksums': ['105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a'],
     }),
     ('dateutil', '2.6.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
-        'checksums': [
-            '891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca',  # python-dateutil-2.6.1.tar.gz
-        ],
+        'checksums': ['891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca'],
     }),
     ('deap', '1.0.2', {
         'patches': ['deap-1.0.2_setup-open-README-utf8.patch'],
@@ -131,83 +114,57 @@ exts_list = [
     }),
     ('decorator', '4.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-        'checksums': [
-            '7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5',  # decorator-4.1.2.tar.gz
-        ],
+        'checksums': ['7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5'],
     }),
     ('arff', '2.1.1', {
         'source_tmpl': 'liac-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
-        'checksums': [
-            'b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817',  # liac-arff-2.1.1.tar.gz
-        ],
+        'checksums': ['b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817'],
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
-        'checksums': [
-            'f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c',  # pycrypto-2.6.1.tar.gz
-        ],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
-        'checksums': [
-            '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
-        ],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
     ('cryptography', '2.0.3', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
-        'checksums': [
-            'd04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a',  # cryptography-2.0.3.tar.gz
-        ],
+        'checksums': ['d04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a'],
     }),
     ('paramiko', '2.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
-        'checksums': [
-            'ff94ae65379914ec3c960de731381f49092057b6dd1d24d18842ead5a2eb2277',  # paramiko-2.2.1.tar.gz
-        ],
+        'checksums': ['ff94ae65379914ec3c960de731381f49092057b6dd1d24d18842ead5a2eb2277'],
     }),
     ('pyparsing', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
-        'checksums': [
-            '0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04',  # pyparsing-2.2.0.tar.gz
-        ],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
     }),
     ('netifaces', '0.10.6', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
-        'checksums': [
-            '0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0',  # netifaces-0.10.6.tar.gz
-        ],
+        'checksums': ['0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0'],
     }),
     ('netaddr', '0.7.19', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
-        'checksums': [
-            '38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd',  # netaddr-0.7.19.tar.gz
-        ],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
     }),
     ('pandas', '0.20.3', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
-        'checksums': [
-            'a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66',  # pandas-0.20.3.tar.gz
-        ],
+        'checksums': ['a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66'],
     }),
     ('virtualenv', '15.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
-        'checksums': [
-            '02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a',  # virtualenv-15.1.0.tar.gz
-        ],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
     }),
     ('docopt', '0.6.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
-        'checksums': [
-            '49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491',  # docopt-0.6.2.tar.gz
-        ],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
     }),
     ('joblib', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
-        'checksums': [
-            '7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085',  # joblib-0.11.tar.gz
-        ],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
     }),
     ('tabulate', '0.8.2', {
         'source_urls': ['https://pypi.python.org/packages/source/t/tabulate/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2017b.eb
@@ -10,7 +10,12 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
-checksums = ['7919489310a5f17f7acbab64d731e46dca0702874840dadce8bd4b2b3b8e7a82']
+patches = ['Python-3.6.1_fix_stupid_comment_in_comment.patch']
+checksums = [
+    '7919489310a5f17f7acbab64d731e46dca0702874840dadce8bd4b2b3b8e7a82',  # Python-3.6.2.tgz
+    # Python-3.6.1_fix_stupid_comment_in_comment.patch
+    'c664b16ae9a2d2ef9dcca39a3b959a0e48c8d57258e5ab403d988e39b359b48e',
+]
 
 # python needs bzip2 to build the bz2 package
 dependencies = [
@@ -39,21 +44,15 @@ exts_list = [
     ('setuptools', '36.3.0', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
-        'checksums': [
-            'e9fa391c1183b40fc6a1298bee02d554743f23c805a3b75dbb18def0f0755fb1',  # setuptools-36.3.0.zip
-        ],
+        'checksums': ['e9fa391c1183b40fc6a1298bee02d554743f23c805a3b75dbb18def0f0755fb1'],
     }),
     ('pip', '9.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
-        'checksums': [
-            '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d',  # pip-9.0.1.tar.gz
-        ],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
     }),
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
-        'checksums': [
-            'f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98',  # nose-1.3.7.tar.gz
-        ],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
     }),
     ('numpy', '1.13.1', {
         'patches': ['numpy-1.12.0-mkl.patch'],
@@ -67,21 +66,15 @@ exts_list = [
     ('scipy', '0.19.1', {
         'source_tmpl': '%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
-        'checksums': [
-            'a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6',  # scipy-0.19.1.tar.gz
-        ],
+        'checksums': ['a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6'],
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
-        'checksums': [
-            '3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3',  # blist-1.3.6.tar.gz
-        ],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
     }),
     ('mpi4py', '2.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
-        'checksums': [
-            '6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81',  # mpi4py-2.0.0.tar.gz
-        ],
+        'checksums': ['6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81'],
     }),
     ('paycheck', '1.0.2', {
         'patches': ['paycheck-1.0.2_setup-open-README-utf8.patch'],
@@ -94,34 +87,24 @@ exts_list = [
     }),
     ('pbr', '3.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
-        'checksums': [
-            '05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1',  # pbr-3.1.1.tar.gz
-        ],
+        'checksums': ['05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1'],
     }),
     ('lockfile', '0.12.2', {
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
-        'checksums': [
-            '6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799',  # lockfile-0.12.2.tar.gz
-        ],
+        'checksums': ['6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799'],
     }),
     ('Cython', '0.26.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
-        'checksums': [
-            'c2e63c4794161135adafa8aa4a855d6068073f421c83ffacc39369497a189dd5',  # Cython-0.26.1.tar.gz
-        ],
+        'checksums': ['c2e63c4794161135adafa8aa4a855d6068073f421c83ffacc39369497a189dd5'],
     }),
     ('six', '1.10.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-        'checksums': [
-            '105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a',  # six-1.10.0.tar.gz
-        ],
+        'checksums': ['105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a'],
     }),
     ('dateutil', '2.6.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
-        'checksums': [
-            '891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca',  # python-dateutil-2.6.1.tar.gz
-        ],
+        'checksums': ['891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca'],
     }),
     ('deap', '1.0.2', {
         'patches': ['deap-1.0.2_setup-open-README-utf8.patch'],
@@ -135,83 +118,57 @@ exts_list = [
     }),
     ('decorator', '4.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-        'checksums': [
-            '7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5',  # decorator-4.1.2.tar.gz
-        ],
+        'checksums': ['7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5'],
     }),
     ('arff', '2.1.1', {
         'source_tmpl': 'liac-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
-        'checksums': [
-            'b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817',  # liac-arff-2.1.1.tar.gz
-        ],
+        'checksums': ['b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817'],
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
-        'checksums': [
-            'f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c',  # pycrypto-2.6.1.tar.gz
-        ],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
-        'checksums': [
-            '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
-        ],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
     ('cryptography', '2.0.3', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
-        'checksums': [
-            'd04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a',  # cryptography-2.0.3.tar.gz
-        ],
+        'checksums': ['d04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a'],
     }),
     ('paramiko', '2.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
-        'checksums': [
-            'ff94ae65379914ec3c960de731381f49092057b6dd1d24d18842ead5a2eb2277',  # paramiko-2.2.1.tar.gz
-        ],
+        'checksums': ['ff94ae65379914ec3c960de731381f49092057b6dd1d24d18842ead5a2eb2277'],
     }),
     ('pyparsing', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
-        'checksums': [
-            '0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04',  # pyparsing-2.2.0.tar.gz
-        ],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
     }),
     ('netifaces', '0.10.6', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
-        'checksums': [
-            '0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0',  # netifaces-0.10.6.tar.gz
-        ],
+        'checksums': ['0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0'],
     }),
     ('netaddr', '0.7.19', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
-        'checksums': [
-            '38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd',  # netaddr-0.7.19.tar.gz
-        ],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
     }),
     ('pandas', '0.20.3', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
-        'checksums': [
-            'a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66',  # pandas-0.20.3.tar.gz
-        ],
+        'checksums': ['a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66'],
     }),
     ('virtualenv', '15.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
-        'checksums': [
-            '02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a',  # virtualenv-15.1.0.tar.gz
-        ],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
     }),
     ('docopt', '0.6.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
-        'checksums': [
-            '49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491',  # docopt-0.6.2.tar.gz
-        ],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
     }),
     ('joblib', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
-        'checksums': [
-            '7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085',  # joblib-0.11.tar.gz
-        ],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
     }),
     ('tabulate', '0.8.2', {
         'source_urls': ['https://pypi.python.org/packages/source/t/tabulate/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2018.00.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2018.00.eb
@@ -10,7 +10,12 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
-checksums = ['7919489310a5f17f7acbab64d731e46dca0702874840dadce8bd4b2b3b8e7a82']
+patches = ['Python-3.6.1_fix_stupid_comment_in_comment.patch']
+checksums = [
+    '7919489310a5f17f7acbab64d731e46dca0702874840dadce8bd4b2b3b8e7a82',  # Python-3.6.2.tgz
+    # Python-3.6.1_fix_stupid_comment_in_comment.patch
+    'c664b16ae9a2d2ef9dcca39a3b959a0e48c8d57258e5ab403d988e39b359b48e',
+]
 
 # python needs bzip2 to build the bz2 package
 dependencies = [
@@ -39,21 +44,15 @@ exts_list = [
     ('setuptools', '36.3.0', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
-        'checksums': [
-            'e9fa391c1183b40fc6a1298bee02d554743f23c805a3b75dbb18def0f0755fb1',  # setuptools-36.3.0.zip
-        ],
+        'checksums': ['e9fa391c1183b40fc6a1298bee02d554743f23c805a3b75dbb18def0f0755fb1'],
     }),
     ('pip', '9.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
-        'checksums': [
-            '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d',  # pip-9.0.1.tar.gz
-        ],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
     }),
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
-        'checksums': [
-            'f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98',  # nose-1.3.7.tar.gz
-        ],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
     }),
     ('numpy', '1.13.1', {
         'patches': ['numpy-1.12.0-mkl.patch'],
@@ -67,21 +66,15 @@ exts_list = [
     ('scipy', '0.19.1', {
         'source_tmpl': '%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
-        'checksums': [
-            'a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6',  # scipy-0.19.1.tar.gz
-        ],
+        'checksums': ['a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6'],
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
-        'checksums': [
-            '3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3',  # blist-1.3.6.tar.gz
-        ],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
     }),
     ('mpi4py', '2.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
-        'checksums': [
-            '6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81',  # mpi4py-2.0.0.tar.gz
-        ],
+        'checksums': ['6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81'],
     }),
     ('paycheck', '1.0.2', {
         'patches': ['paycheck-1.0.2_setup-open-README-utf8.patch'],
@@ -94,34 +87,24 @@ exts_list = [
     }),
     ('pbr', '3.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
-        'checksums': [
-            '05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1',  # pbr-3.1.1.tar.gz
-        ],
+        'checksums': ['05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1'],
     }),
     ('lockfile', '0.12.2', {
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
-        'checksums': [
-            '6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799',  # lockfile-0.12.2.tar.gz
-        ],
+        'checksums': ['6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799'],
     }),
     ('Cython', '0.26.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
-        'checksums': [
-            'c2e63c4794161135adafa8aa4a855d6068073f421c83ffacc39369497a189dd5',  # Cython-0.26.1.tar.gz
-        ],
+        'checksums': ['c2e63c4794161135adafa8aa4a855d6068073f421c83ffacc39369497a189dd5'],
     }),
     ('six', '1.10.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-        'checksums': [
-            '105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a',  # six-1.10.0.tar.gz
-        ],
+        'checksums': ['105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a'],
     }),
     ('dateutil', '2.6.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
-        'checksums': [
-            '891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca',  # python-dateutil-2.6.1.tar.gz
-        ],
+        'checksums': ['891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca'],
     }),
     ('deap', '1.0.2', {
         'patches': ['deap-1.0.2_setup-open-README-utf8.patch'],
@@ -135,83 +118,57 @@ exts_list = [
     }),
     ('decorator', '4.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-        'checksums': [
-            '7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5',  # decorator-4.1.2.tar.gz
-        ],
+        'checksums': ['7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5'],
     }),
     ('arff', '2.1.1', {
         'source_tmpl': 'liac-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
-        'checksums': [
-            'b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817',  # liac-arff-2.1.1.tar.gz
-        ],
+        'checksums': ['b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817'],
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
-        'checksums': [
-            'f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c',  # pycrypto-2.6.1.tar.gz
-        ],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
-        'checksums': [
-            '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
-        ],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
     ('cryptography', '2.0.3', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
-        'checksums': [
-            'd04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a',  # cryptography-2.0.3.tar.gz
-        ],
+        'checksums': ['d04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a'],
     }),
     ('paramiko', '2.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
-        'checksums': [
-            'ff94ae65379914ec3c960de731381f49092057b6dd1d24d18842ead5a2eb2277',  # paramiko-2.2.1.tar.gz
-        ],
+        'checksums': ['ff94ae65379914ec3c960de731381f49092057b6dd1d24d18842ead5a2eb2277'],
     }),
     ('pyparsing', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
-        'checksums': [
-            '0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04',  # pyparsing-2.2.0.tar.gz
-        ],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
     }),
     ('netifaces', '0.10.6', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
-        'checksums': [
-            '0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0',  # netifaces-0.10.6.tar.gz
-        ],
+        'checksums': ['0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0'],
     }),
     ('netaddr', '0.7.19', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
-        'checksums': [
-            '38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd',  # netaddr-0.7.19.tar.gz
-        ],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
     }),
     ('pandas', '0.20.3', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
-        'checksums': [
-            'a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66',  # pandas-0.20.3.tar.gz
-        ],
+        'checksums': ['a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66'],
     }),
     ('virtualenv', '15.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
-        'checksums': [
-            '02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a',  # virtualenv-15.1.0.tar.gz
-        ],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
     }),
     ('docopt', '0.6.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
-        'checksums': [
-            '49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491',  # docopt-0.6.2.tar.gz
-        ],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
     }),
     ('joblib', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
-        'checksums': [
-            '7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085',  # joblib-0.11.tar.gz
-        ],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
     }),
     ('tabulate', '0.8.2', {
         'source_urls': ['https://pypi.python.org/packages/source/t/tabulate/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-foss-2017b.eb
@@ -10,7 +10,12 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
-checksums = ['ab6193af1921b30f587b302fe385268510e80187ca83ca82d2bfe7ab544c6f91']
+patches = ['Python-3.6.1_fix_stupid_comment_in_comment.patch']
+checksums = [
+    'ab6193af1921b30f587b302fe385268510e80187ca83ca82d2bfe7ab544c6f91',  # Python-3.6.3.tgz
+    # Python-3.6.1_fix_stupid_comment_in_comment.patch
+    'c664b16ae9a2d2ef9dcca39a3b959a0e48c8d57258e5ab403d988e39b359b48e',
+]
 
 # python needs bzip2 to build the bz2 package
 dependencies = [
@@ -35,21 +40,15 @@ exts_list = [
     ('setuptools', '36.6.0', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
-        'checksums': [
-            '62074589522a798da243f47348f38020d55b6c945652e2f2c09d3a96299812b7',  # setuptools-36.6.0.zip
-        ],
+        'checksums': ['62074589522a798da243f47348f38020d55b6c945652e2f2c09d3a96299812b7'],
     }),
     ('pip', '9.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
-        'checksums': [
-            '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d',  # pip-9.0.1.tar.gz
-        ],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
     }),
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
-        'checksums': [
-            'f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98',  # nose-1.3.7.tar.gz
-        ],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
     }),
     ('numpy', '1.13.3', {
         'patches': ['numpy-1.12.0-mkl.patch'],
@@ -63,21 +62,15 @@ exts_list = [
     ('scipy', '0.19.1', {
         'source_tmpl': '%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
-        'checksums': [
-            'a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6',  # scipy-0.19.1.tar.gz
-        ],
+        'checksums': ['a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6'],
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
-        'checksums': [
-            '3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3',  # blist-1.3.6.tar.gz
-        ],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
     }),
     ('mpi4py', '2.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
-        'checksums': [
-            '6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81',  # mpi4py-2.0.0.tar.gz
-        ],
+        'checksums': ['6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81'],
     }),
     ('paycheck', '1.0.2', {
         'patches': ['paycheck-1.0.2_setup-open-README-utf8.patch'],
@@ -90,34 +83,24 @@ exts_list = [
     }),
     ('pbr', '3.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
-        'checksums': [
-            '05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1',  # pbr-3.1.1.tar.gz
-        ],
+        'checksums': ['05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1'],
     }),
     ('lockfile', '0.12.2', {
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
-        'checksums': [
-            '6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799',  # lockfile-0.12.2.tar.gz
-        ],
+        'checksums': ['6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799'],
     }),
     ('Cython', '0.27.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
-        'checksums': [
-            'e6840a2ba2704f4ffb40e454c36f73aeb440a4005453ee8d7ff6a00d812ba176',  # Cython-0.27.1.tar.gz
-        ],
+        'checksums': ['e6840a2ba2704f4ffb40e454c36f73aeb440a4005453ee8d7ff6a00d812ba176'],
     }),
     ('six', '1.11.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-        'checksums': [
-            '70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9',  # six-1.11.0.tar.gz
-        ],
+        'checksums': ['70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9'],
     }),
     ('dateutil', '2.6.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
-        'checksums': [
-            '891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca',  # python-dateutil-2.6.1.tar.gz
-        ],
+        'checksums': ['891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca'],
     }),
     ('deap', '1.0.2', {
         'patches': ['deap-1.0.2_setup-open-README-utf8.patch'],
@@ -131,83 +114,57 @@ exts_list = [
     }),
     ('decorator', '4.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-        'checksums': [
-            '7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5',  # decorator-4.1.2.tar.gz
-        ],
+        'checksums': ['7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5'],
     }),
     ('arff', '2.1.1', {
         'source_tmpl': 'liac-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
-        'checksums': [
-            'b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817',  # liac-arff-2.1.1.tar.gz
-        ],
+        'checksums': ['b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817'],
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
-        'checksums': [
-            'f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c',  # pycrypto-2.6.1.tar.gz
-        ],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
-        'checksums': [
-            '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
-        ],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
     ('cryptography', '2.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
-        'checksums': [
-            '2699ed21e1f73dd1bdb7b0b22a517295de07809d535b23e200dd22166037fe6f',  # cryptography-2.1.1.tar.gz
-        ],
+        'checksums': ['2699ed21e1f73dd1bdb7b0b22a517295de07809d535b23e200dd22166037fe6f'],
     }),
     ('paramiko', '2.3.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
-        'checksums': [
-            'fa6b4f5c9d88f27c60fd9578146ff24e99d4b9f63391ff1343305bfd766c4660',  # paramiko-2.3.1.tar.gz
-        ],
+        'checksums': ['fa6b4f5c9d88f27c60fd9578146ff24e99d4b9f63391ff1343305bfd766c4660'],
     }),
     ('pyparsing', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
-        'checksums': [
-            '0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04',  # pyparsing-2.2.0.tar.gz
-        ],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
     }),
     ('netifaces', '0.10.6', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
-        'checksums': [
-            '0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0',  # netifaces-0.10.6.tar.gz
-        ],
+        'checksums': ['0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0'],
     }),
     ('netaddr', '0.7.19', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
-        'checksums': [
-            '38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd',  # netaddr-0.7.19.tar.gz
-        ],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
     }),
     ('pandas', '0.20.3', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
-        'checksums': [
-            'a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66',  # pandas-0.20.3.tar.gz
-        ],
+        'checksums': ['a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66'],
     }),
     ('virtualenv', '15.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
-        'checksums': [
-            '02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a',  # virtualenv-15.1.0.tar.gz
-        ],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
     }),
     ('docopt', '0.6.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
-        'checksums': [
-            '49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491',  # docopt-0.6.2.tar.gz
-        ],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
     }),
     ('joblib', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
-        'checksums': [
-            '7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085',  # joblib-0.11.tar.gz
-        ],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
     }),
     ('xlrd', '1.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/x/xlrd'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-goolfc-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-goolfc-2017b.eb
@@ -10,7 +10,12 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
-checksums = ['ab6193af1921b30f587b302fe385268510e80187ca83ca82d2bfe7ab544c6f91']
+patches = ['Python-3.6.1_fix_stupid_comment_in_comment.patch']
+checksums = [
+    'ab6193af1921b30f587b302fe385268510e80187ca83ca82d2bfe7ab544c6f91',  # Python-3.6.3.tgz
+    # Python-3.6.1_fix_stupid_comment_in_comment.patch
+    'c664b16ae9a2d2ef9dcca39a3b959a0e48c8d57258e5ab403d988e39b359b48e',
+]
 
 # python needs bzip2 to build the bz2 package
 dependencies = [
@@ -35,21 +40,15 @@ exts_list = [
     ('setuptools', '36.6.0', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
-        'checksums': [
-            '62074589522a798da243f47348f38020d55b6c945652e2f2c09d3a96299812b7',  # setuptools-36.6.0.zip
-        ],
+        'checksums': ['62074589522a798da243f47348f38020d55b6c945652e2f2c09d3a96299812b7'],
     }),
     ('pip', '9.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
-        'checksums': [
-            '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d',  # pip-9.0.1.tar.gz
-        ],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
     }),
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
-        'checksums': [
-            'f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98',  # nose-1.3.7.tar.gz
-        ],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
     }),
     ('numpy', '1.13.3', {
         'patches': ['numpy-1.12.0-mkl.patch'],
@@ -63,21 +62,15 @@ exts_list = [
     ('scipy', '0.19.1', {
         'source_tmpl': '%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
-        'checksums': [
-            'a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6',  # scipy-0.19.1.tar.gz
-        ],
+        'checksums': ['a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6'],
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
-        'checksums': [
-            '3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3',  # blist-1.3.6.tar.gz
-        ],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
     }),
     ('mpi4py', '2.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
-        'checksums': [
-            '6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81',  # mpi4py-2.0.0.tar.gz
-        ],
+        'checksums': ['6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81'],
     }),
     ('paycheck', '1.0.2', {
         'patches': ['paycheck-1.0.2_setup-open-README-utf8.patch'],
@@ -90,34 +83,24 @@ exts_list = [
     }),
     ('pbr', '3.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
-        'checksums': [
-            '05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1',  # pbr-3.1.1.tar.gz
-        ],
+        'checksums': ['05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1'],
     }),
     ('lockfile', '0.12.2', {
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
-        'checksums': [
-            '6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799',  # lockfile-0.12.2.tar.gz
-        ],
+        'checksums': ['6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799'],
     }),
     ('Cython', '0.27.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
-        'checksums': [
-            'e6840a2ba2704f4ffb40e454c36f73aeb440a4005453ee8d7ff6a00d812ba176',  # Cython-0.27.1.tar.gz
-        ],
+        'checksums': ['e6840a2ba2704f4ffb40e454c36f73aeb440a4005453ee8d7ff6a00d812ba176'],
     }),
     ('six', '1.11.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-        'checksums': [
-            '70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9',  # six-1.11.0.tar.gz
-        ],
+        'checksums': ['70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9'],
     }),
     ('dateutil', '2.6.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
-        'checksums': [
-            '891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca',  # python-dateutil-2.6.1.tar.gz
-        ],
+        'checksums': ['891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca'],
     }),
     ('deap', '1.0.2', {
         'patches': ['deap-1.0.2_setup-open-README-utf8.patch'],
@@ -131,83 +114,57 @@ exts_list = [
     }),
     ('decorator', '4.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-        'checksums': [
-            '7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5',  # decorator-4.1.2.tar.gz
-        ],
+        'checksums': ['7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5'],
     }),
     ('arff', '2.1.1', {
         'source_tmpl': 'liac-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
-        'checksums': [
-            'b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817',  # liac-arff-2.1.1.tar.gz
-        ],
+        'checksums': ['b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817'],
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
-        'checksums': [
-            'f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c',  # pycrypto-2.6.1.tar.gz
-        ],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
-        'checksums': [
-            '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
-        ],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
     ('cryptography', '2.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
-        'checksums': [
-            '2699ed21e1f73dd1bdb7b0b22a517295de07809d535b23e200dd22166037fe6f',  # cryptography-2.1.1.tar.gz
-        ],
+        'checksums': ['2699ed21e1f73dd1bdb7b0b22a517295de07809d535b23e200dd22166037fe6f'],
     }),
     ('paramiko', '2.3.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
-        'checksums': [
-            'fa6b4f5c9d88f27c60fd9578146ff24e99d4b9f63391ff1343305bfd766c4660',  # paramiko-2.3.1.tar.gz
-        ],
+        'checksums': ['fa6b4f5c9d88f27c60fd9578146ff24e99d4b9f63391ff1343305bfd766c4660'],
     }),
     ('pyparsing', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
-        'checksums': [
-            '0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04',  # pyparsing-2.2.0.tar.gz
-        ],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
     }),
     ('netifaces', '0.10.6', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
-        'checksums': [
-            '0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0',  # netifaces-0.10.6.tar.gz
-        ],
+        'checksums': ['0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0'],
     }),
     ('netaddr', '0.7.19', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
-        'checksums': [
-            '38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd',  # netaddr-0.7.19.tar.gz
-        ],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
     }),
     ('pandas', '0.20.3', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
-        'checksums': [
-            'a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66',  # pandas-0.20.3.tar.gz
-        ],
+        'checksums': ['a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66'],
     }),
     ('virtualenv', '15.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
-        'checksums': [
-            '02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a',  # virtualenv-15.1.0.tar.gz
-        ],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
     }),
     ('docopt', '0.6.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
-        'checksums': [
-            '49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491',  # docopt-0.6.2.tar.gz
-        ],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
     }),
     ('joblib', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
-        'checksums': [
-            '7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085',  # joblib-0.11.tar.gz
-        ],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
     }),
     ('xlrd', '1.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/x/xlrd'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2017b.eb
@@ -10,7 +10,12 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
-checksums = ['ab6193af1921b30f587b302fe385268510e80187ca83ca82d2bfe7ab544c6f91']
+patches = ['Python-3.6.1_fix_stupid_comment_in_comment.patch']
+checksums = [
+    'ab6193af1921b30f587b302fe385268510e80187ca83ca82d2bfe7ab544c6f91',  # Python-3.6.3.tgz
+    # Python-3.6.1_fix_stupid_comment_in_comment.patch
+    'c664b16ae9a2d2ef9dcca39a3b959a0e48c8d57258e5ab403d988e39b359b48e',
+]
 
 # python needs bzip2 to build the bz2 package
 dependencies = [
@@ -43,21 +48,15 @@ exts_list = [
     ('setuptools', '36.6.0', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
-        'checksums': [
-            '62074589522a798da243f47348f38020d55b6c945652e2f2c09d3a96299812b7',  # setuptools-36.6.0.zip
-        ],
+        'checksums': ['62074589522a798da243f47348f38020d55b6c945652e2f2c09d3a96299812b7'],
     }),
     ('pip', '9.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
-        'checksums': [
-            '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d',  # pip-9.0.1.tar.gz
-        ],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
     }),
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
-        'checksums': [
-            'f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98',  # nose-1.3.7.tar.gz
-        ],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
     }),
     ('numpy', '1.13.3', {
         'patches': ['numpy-1.12.0-mkl.patch'],
@@ -71,21 +70,15 @@ exts_list = [
     ('scipy', '0.19.1', {
         'source_tmpl': '%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
-        'checksums': [
-            'a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6',  # scipy-0.19.1.tar.gz
-        ],
+        'checksums': ['a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6'],
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
-        'checksums': [
-            '3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3',  # blist-1.3.6.tar.gz
-        ],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
     }),
     ('mpi4py', '2.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
-        'checksums': [
-            '6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81',  # mpi4py-2.0.0.tar.gz
-        ],
+        'checksums': ['6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81'],
     }),
     ('paycheck', '1.0.2', {
         'patches': ['paycheck-1.0.2_setup-open-README-utf8.patch'],
@@ -98,34 +91,24 @@ exts_list = [
     }),
     ('pbr', '3.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
-        'checksums': [
-            '05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1',  # pbr-3.1.1.tar.gz
-        ],
+        'checksums': ['05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1'],
     }),
     ('lockfile', '0.12.2', {
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
-        'checksums': [
-            '6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799',  # lockfile-0.12.2.tar.gz
-        ],
+        'checksums': ['6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799'],
     }),
     ('Cython', '0.27.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
-        'checksums': [
-            'e6840a2ba2704f4ffb40e454c36f73aeb440a4005453ee8d7ff6a00d812ba176',  # Cython-0.27.1.tar.gz
-        ],
+        'checksums': ['e6840a2ba2704f4ffb40e454c36f73aeb440a4005453ee8d7ff6a00d812ba176'],
     }),
     ('six', '1.11.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-        'checksums': [
-            '70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9',  # six-1.11.0.tar.gz
-        ],
+        'checksums': ['70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9'],
     }),
     ('dateutil', '2.6.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
-        'checksums': [
-            '891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca',  # python-dateutil-2.6.1.tar.gz
-        ],
+        'checksums': ['891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca'],
     }),
     ('deap', '1.0.2', {
         'patches': ['deap-1.0.2_setup-open-README-utf8.patch'],
@@ -139,83 +122,57 @@ exts_list = [
     }),
     ('decorator', '4.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-        'checksums': [
-            '7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5',  # decorator-4.1.2.tar.gz
-        ],
+        'checksums': ['7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5'],
     }),
     ('arff', '2.1.1', {
         'source_tmpl': 'liac-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
-        'checksums': [
-            'b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817',  # liac-arff-2.1.1.tar.gz
-        ],
+        'checksums': ['b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817'],
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
-        'checksums': [
-            'f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c',  # pycrypto-2.6.1.tar.gz
-        ],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
-        'checksums': [
-            '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
-        ],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
     ('cryptography', '2.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
-        'checksums': [
-            '2699ed21e1f73dd1bdb7b0b22a517295de07809d535b23e200dd22166037fe6f',  # cryptography-2.1.1.tar.gz
-        ],
+        'checksums': ['2699ed21e1f73dd1bdb7b0b22a517295de07809d535b23e200dd22166037fe6f'],
     }),
     ('paramiko', '2.3.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
-        'checksums': [
-            'fa6b4f5c9d88f27c60fd9578146ff24e99d4b9f63391ff1343305bfd766c4660',  # paramiko-2.3.1.tar.gz
-        ],
+        'checksums': ['fa6b4f5c9d88f27c60fd9578146ff24e99d4b9f63391ff1343305bfd766c4660'],
     }),
     ('pyparsing', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
-        'checksums': [
-            '0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04',  # pyparsing-2.2.0.tar.gz
-        ],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
     }),
     ('netifaces', '0.10.6', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
-        'checksums': [
-            '0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0',  # netifaces-0.10.6.tar.gz
-        ],
+        'checksums': ['0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0'],
     }),
     ('netaddr', '0.7.19', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
-        'checksums': [
-            '38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd',  # netaddr-0.7.19.tar.gz
-        ],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
     }),
     ('pandas', '0.20.3', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
-        'checksums': [
-            'a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66',  # pandas-0.20.3.tar.gz
-        ],
+        'checksums': ['a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66'],
     }),
     ('virtualenv', '15.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
-        'checksums': [
-            '02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a',  # virtualenv-15.1.0.tar.gz
-        ],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
     }),
     ('docopt', '0.6.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
-        'checksums': [
-            '49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491',  # docopt-0.6.2.tar.gz
-        ],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
     }),
     ('joblib', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
-        'checksums': [
-            '7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085',  # joblib-0.11.tar.gz
-        ],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
     }),
     ('xlrd', '1.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/x/xlrd'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2018.01.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2018.01.eb
@@ -10,7 +10,12 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
-checksums = ['ab6193af1921b30f587b302fe385268510e80187ca83ca82d2bfe7ab544c6f91']
+patches = ['Python-3.6.1_fix_stupid_comment_in_comment.patch']
+checksums = [
+    'ab6193af1921b30f587b302fe385268510e80187ca83ca82d2bfe7ab544c6f91',  # Python-3.6.3.tgz
+    # Python-3.6.1_fix_stupid_comment_in_comment.patch
+    'c664b16ae9a2d2ef9dcca39a3b959a0e48c8d57258e5ab403d988e39b359b48e',
+]
 
 # python needs bzip2 to build the bz2 package
 dependencies = [
@@ -39,21 +44,15 @@ exts_list = [
     ('setuptools', '37.0.0', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
-        'checksums': [
-            '0b95db16abf74d435217f17774245fce1ea5a583e5ae8098d98f4ab0145491e3',  # setuptools-37.0.0.zip
-        ],
+        'checksums': ['0b95db16abf74d435217f17774245fce1ea5a583e5ae8098d98f4ab0145491e3'],
     }),
     ('pip', '9.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
-        'checksums': [
-            '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d',  # pip-9.0.1.tar.gz
-        ],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
     }),
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
-        'checksums': [
-            'f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98',  # nose-1.3.7.tar.gz
-        ],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
     }),
     ('numpy', '1.13.3', {
         'patches': ['numpy-1.12.0-mkl.patch'],
@@ -67,21 +66,15 @@ exts_list = [
     ('scipy', '1.0.0', {
         'source_tmpl': '%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
-        'checksums': [
-            '87ea1f11a0e9ec08c264dc64551d501fa307289460705f6fccd84cbfc7926d10',  # scipy-1.0.0.tar.gz
-        ],
+        'checksums': ['87ea1f11a0e9ec08c264dc64551d501fa307289460705f6fccd84cbfc7926d10'],
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
-        'checksums': [
-            '3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3',  # blist-1.3.6.tar.gz
-        ],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
     }),
     ('mpi4py', '3.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
-        'checksums': [
-            'b457b02d85bdd9a4775a097fac5234a20397b43e073f14d9e29b6cd78c68efd7',  # mpi4py-3.0.0.tar.gz
-        ],
+        'checksums': ['b457b02d85bdd9a4775a097fac5234a20397b43e073f14d9e29b6cd78c68efd7'],
     }),
     ('paycheck', '1.0.2', {
         'patches': ['paycheck-1.0.2_setup-open-README-utf8.patch'],
@@ -94,121 +87,83 @@ exts_list = [
     }),
     ('pbr', '3.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
-        'checksums': [
-            '05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1',  # pbr-3.1.1.tar.gz
-        ],
+        'checksums': ['05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1'],
     }),
     ('lockfile', '0.12.2', {
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
-        'checksums': [
-            '6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799',  # lockfile-0.12.2.tar.gz
-        ],
+        'checksums': ['6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799'],
     }),
     ('Cython', '0.27.3', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
-        'checksums': [
-            '6a00512de1f2e3ce66ba35c5420babaef1fe2d9c43a8faab4080b0dbcc26bc64',  # Cython-0.27.3.tar.gz
-        ],
+        'checksums': ['6a00512de1f2e3ce66ba35c5420babaef1fe2d9c43a8faab4080b0dbcc26bc64'],
     }),
     ('six', '1.11.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-        'checksums': [
-            '70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9',  # six-1.11.0.tar.gz
-        ],
+        'checksums': ['70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9'],
     }),
     ('dateutil', '2.6.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
-        'checksums': [
-            '891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca',  # python-dateutil-2.6.1.tar.gz
-        ],
+        'checksums': ['891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca'],
     }),
     ('deap', '1.2.2', {
         'source_tmpl': '%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
-        'checksums': [
-            '95c63e66d755ec206c80fdb2908851c0bef420ee8651ad7be4f0578e9e909bcf',  # deap-1.2.2.tar.gz
-        ],
+        'checksums': ['95c63e66d755ec206c80fdb2908851c0bef420ee8651ad7be4f0578e9e909bcf'],
     }),
     ('decorator', '4.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-        'checksums': [
-            '7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5',  # decorator-4.1.2.tar.gz
-        ],
+        'checksums': ['7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5'],
     }),
     ('arff', '2.1.1', {
         'source_tmpl': 'liac-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
-        'checksums': [
-            'b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817',  # liac-arff-2.1.1.tar.gz
-        ],
+        'checksums': ['b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817'],
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
-        'checksums': [
-            'f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c',  # pycrypto-2.6.1.tar.gz
-        ],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
-        'checksums': [
-            '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
-        ],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
     ('cryptography', '2.1.3', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
-        'checksums': [
-            '68a26c353627163d74ee769d4749f2ee243866e9dac43c93bb33ebd8fbed1199',  # cryptography-2.1.3.tar.gz
-        ],
+        'checksums': ['68a26c353627163d74ee769d4749f2ee243866e9dac43c93bb33ebd8fbed1199'],
     }),
     ('paramiko', '2.4.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
-        'checksums': [
-            '486f637f0a33a4792e0e567be37426c287efaa8c4c4a45e3216f9ce7fd70b1fc',  # paramiko-2.4.0.tar.gz
-        ],
+        'checksums': ['486f637f0a33a4792e0e567be37426c287efaa8c4c4a45e3216f9ce7fd70b1fc'],
     }),
     ('pyparsing', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
-        'checksums': [
-            '0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04',  # pyparsing-2.2.0.tar.gz
-        ],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
     }),
     ('netifaces', '0.10.6', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
-        'checksums': [
-            '0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0',  # netifaces-0.10.6.tar.gz
-        ],
+        'checksums': ['0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0'],
     }),
     ('netaddr', '0.7.19', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
-        'checksums': [
-            '38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd',  # netaddr-0.7.19.tar.gz
-        ],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
     }),
     ('pandas', '0.21.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
-        'checksums': [
-            '5cd5cb30e72eeaf202f0e5e180780b897570e889d2db328c689a5a263405c559',  # pandas-0.21.0.tar.gz
-        ],
+        'checksums': ['5cd5cb30e72eeaf202f0e5e180780b897570e889d2db328c689a5a263405c559'],
     }),
     ('virtualenv', '15.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
-        'checksums': [
-            '02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a',  # virtualenv-15.1.0.tar.gz
-        ],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
     }),
     ('docopt', '0.6.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
-        'checksums': [
-            '49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491',  # docopt-0.6.2.tar.gz
-        ],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
     }),
     ('joblib', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
-        'checksums': [
-            '7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085',  # joblib-0.11.tar.gz
-        ],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
     }),
     ('xlrd', '1.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/x/xlrd'],


### PR DESCRIPTION
The patch matches the code from Python 3.6.4 and reduces the problem with building hashlib.

Also ran --inject-checksum --force causing exts_list to get a lot of changes.