### PR TITLE
Eliminate dependency on problematic LibUUID library.

### DIFF
--- a/easybuild/easyconfigs/f/fontconfig/fontconfig-2.13.0-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/f/fontconfig/fontconfig-2.13.0-GCCcore-6.4.0.eb
@@ -26,7 +26,7 @@ builddependencies = [
 dependencies = [
     ('expat', '2.2.5'),
     ('freetype', '2.9'),
-    ('LibUUID', '1.0.3'),
+    ('util-linux', '2.32.1'),
 ]
 
 configopts = '--disable-docs '

--- a/easybuild/easyconfigs/f/fontconfig/fontconfig-2.13.0-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/f/fontconfig/fontconfig-2.13.0-GCCcore-6.4.0.eb
@@ -26,7 +26,7 @@ builddependencies = [
 dependencies = [
     ('expat', '2.2.5'),
     ('freetype', '2.9'),
-    ('util-linux', '2.32.1'),
+    ('util-linux', '2.31.1'),
 ]
 
 configopts = '--disable-docs '

--- a/easybuild/easyconfigs/f/fontconfig/fontconfig-2.13.0-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/f/fontconfig/fontconfig-2.13.0-GCCcore-7.3.0.eb
@@ -26,7 +26,7 @@ builddependencies = [
 dependencies = [
     ('expat', '2.2.5'),
     ('freetype', '2.9.1'),
-    ('LibUUID', '1.0.3'),
+    ('util-linux', '2.32.1'),
 ]
 
 configopts = '--disable-docs '

--- a/easybuild/easyconfigs/f/fontconfig/fontconfig-2.13.0-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/f/fontconfig/fontconfig-2.13.0-GCCcore-7.3.0.eb
@@ -26,7 +26,7 @@ builddependencies = [
 dependencies = [
     ('expat', '2.2.5'),
     ('freetype', '2.9.1'),
-    ('util-linux', '2.32.1'),
+    ('util-linux', '2.32'),
 ]
 
 configopts = '--disable-docs '


### PR DESCRIPTION
This removes LibUUID which causes several system programs to fail, see discussion on the mailing list:
https://lists.ugent.be/wws/arc/easybuild/2018-10/msg00011.html

The dependency of LibUUID is replaced by util-linux.  The change only affects fontconfig-2.13.0 as older versions do not depend on LibUUID.  Rebuilding this module is enough to solve the issues, no need to rebuild the entire X11 stack.

CC: @OleHolmNielsen 
