### PR TITLE
fix broken installation for Python 3.6.2 & 3.6.3 with PyNaCl as dep for paramiko extension by explicitely including previous PyNaCl version as extension

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.6.2-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.2-foss-2017b.eb
@@ -161,6 +161,11 @@ exts_list = [
             'd04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a',  # cryptography-2.0.3.tar.gz
         ],
     }),
+    ('PyNaCl', '1.2.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
+        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
+        'modulename': 'nacl',
+    }),
     ('paramiko', '2.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
         'checksums': [

--- a/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2017b.eb
@@ -165,6 +165,11 @@ exts_list = [
             'd04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a',  # cryptography-2.0.3.tar.gz
         ],
     }),
+    ('PyNaCl', '1.2.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
+        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
+        'modulename': 'nacl',
+    }),
     ('paramiko', '2.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
         'checksums': [

--- a/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2018.00.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2018.00.eb
@@ -165,6 +165,11 @@ exts_list = [
             'd04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a',  # cryptography-2.0.3.tar.gz
         ],
     }),
+    ('PyNaCl', '1.2.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
+        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
+        'modulename': 'nacl',
+    }),
     ('paramiko', '2.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
         'checksums': [

--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-foss-2017b.eb
@@ -161,6 +161,11 @@ exts_list = [
             '2699ed21e1f73dd1bdb7b0b22a517295de07809d535b23e200dd22166037fe6f',  # cryptography-2.1.1.tar.gz
         ],
     }),
+    ('PyNaCl', '1.2.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
+        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
+        'modulename': 'nacl',
+    }),
     ('paramiko', '2.3.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
         'checksums': [

--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-goolfc-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-goolfc-2017b.eb
@@ -161,6 +161,11 @@ exts_list = [
             '2699ed21e1f73dd1bdb7b0b22a517295de07809d535b23e200dd22166037fe6f',  # cryptography-2.1.1.tar.gz
         ],
     }),
+    ('PyNaCl', '1.2.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
+        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
+        'modulename': 'nacl',
+    }),
     ('paramiko', '2.3.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
         'checksums': [

--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2017b.eb
@@ -169,6 +169,11 @@ exts_list = [
             '2699ed21e1f73dd1bdb7b0b22a517295de07809d535b23e200dd22166037fe6f',  # cryptography-2.1.1.tar.gz
         ],
     }),
+    ('PyNaCl', '1.2.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
+        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
+        'modulename': 'nacl',
+    }),
     ('paramiko', '2.3.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
         'checksums': [

--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2018.01.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2018.01.eb
@@ -162,6 +162,11 @@ exts_list = [
             '68a26c353627163d74ee769d4749f2ee243866e9dac43c93bb33ebd8fbed1199',  # cryptography-2.1.3.tar.gz
         ],
     }),
+    ('PyNaCl', '1.2.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
+        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
+        'modulename': 'nacl',
+    }),
     ('paramiko', '2.4.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
         'checksums': [


### PR DESCRIPTION
The installation of Python 3.6.2 & 3.6.3 with `intel` toolchain is broken because of a new `PyNaCl` release (1.3.0) that gets pulled in via `paramiko` which is listed as an extension, see failing test reports in #6946

This wasn't an issue before when the previous `PyNaCl` release was being pulled in, and as such it's a clear example of why we should start enforcing `download_dep_fail = True` in Python easyconfigs.

`PyNaCl` is already listed as extension in newer Python 3.x easyconfigs, and for Python 3.6.1 & older an older version of `paramiko` is included where the problem doesn't pop up