### PR TITLE
{bio}[foss/2018b] GATK-4.0.10.0 w/ Python 3.6.6

### DIFF
--- a/easybuild/easyconfigs/g/GATK/GATK-4.0.10.0-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-4.0.10.0-foss-2018b-Python-3.6.6.eb
@@ -21,8 +21,6 @@ easyblock = 'Tarball'
 name = 'GATK'
 version = '4.0.10.0'
 versionsuffix = '-Python-%(pyver)s'
-pyver = '3.6.6'
-javaver = '1.8.0_181'
 
 homepage = 'http://www.broadinstitute.org/gatk/'
 description = """The Genome Analysis Toolkit or GATK is a software package
@@ -40,8 +38,8 @@ sources = ['gatk-%(version)s.zip']
 checksums = ['6a149750dfcdb250e07198cf1726d2f0958d2b8f257618b3b585194c4c392283']
 
 dependencies = [
-    ('Python', pyver),
-    ('Java', javaver, '', True),
+    ('Python', '3.6.6'),
+    ('Java', '1.8', '', True),
 ]
 
 modextrapaths = {'PATH': ''}

--- a/easybuild/easyconfigs/g/GATK/GATK-4.0.10.0-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-4.0.10.0-foss-2018b-Python-3.6.6.eb
@@ -1,0 +1,55 @@
+##
+# EasyBuild Easyconfig 
+#
+# Copyright:: Copyright 2012-2013 Cyprus Institute /
+# CaSToRC, University of Luxembourg / LCSB
+# Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>,
+#             Fotis Georgatos <fotis.georgatos@uni.lu>,
+#             Kenneth Hoste (UGent)
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component 
+# of the policy: http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-94.html
+# Modified by: Adam Huffman, Jonas Demeulemeester
+# The Francis Crick Institute
+# Modified for version 4.0.5.1 by: Ruben van Dijk, University of Groningen
+##
+
+easyblock = 'Tarball'
+
+name = 'GATK'
+version = '4.0.10.0'
+versionsuffix = '-Python-%(pyver)s'
+pyver = '3.6.6'
+javaver = '1.8.0_181'
+
+homepage = 'http://www.broadinstitute.org/gatk/'
+description = """The Genome Analysis Toolkit or GATK is a software package
+developed at the Broad Institute to analyse next-generation resequencing
+data. The toolkit offers a wide variety of tools, with a primary focus on
+variant discovery and genotyping as well as strong emphasis on data quality
+assurance. Its robust architecture, powerful processing engine and
+high-performance computing features make it capable of taking on projects
+of any size."""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+source_urls = ['https://github.com/broadinstitute/gatk/releases/download/%(version)s/']
+sources = ['gatk-%(version)s.zip']
+checksums = ['6a149750dfcdb250e07198cf1726d2f0958d2b8f257618b3b585194c4c392283']
+
+dependencies = [
+    ('Python', pyver),
+    ('Java', javaver, '', True),
+]
+
+modextrapaths = {'PATH': ''}
+
+sanity_check_paths = {
+    'files': ['gatk'],
+    'dirs': [],
+}
+sanity_check_commands = ["gatk --help"]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GATK/GATK-4.0.10.0-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-4.0.10.0-foss-2018b-Python-3.6.6.eb
@@ -1,5 +1,5 @@
 ##
-# EasyBuild Easyconfig 
+# EasyBuild Easyconfig
 #
 # Copyright:: Copyright 2012-2013 Cyprus Institute /
 # CaSToRC, University of Luxembourg / LCSB
@@ -9,7 +9,7 @@
 # License::   MIT/GPL
 # $Id$
 #
-# This work implements a part of the HPCBIOS project and is a component 
+# This work implements a part of the HPCBIOS project and is a component
 # of the policy: http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-94.html
 # Modified by: Adam Huffman, Jonas Demeulemeester
 # The Francis Crick Institute


### PR DESCRIPTION
GATK-4.0.10.0 - Edited to make pep8 compliant, added javaver, pyver.
Update GATK for 2018b, using Java 1.8.0_181 with 2018b