### PR TITLE
fix source URL for ADMIXTURE (no https) + add SHA256 checksum

### DIFF
--- a/easybuild/easyconfigs/a/ADMIXTURE/ADMIXTURE-1.3.0.eb
+++ b/easybuild/easyconfigs/a/ADMIXTURE/ADMIXTURE-1.3.0.eb
@@ -10,8 +10,9 @@ more rapidly using a fast numerical optimization algorithm."""
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-source_urls = ['https://www.genetics.ucla.edu/software/%(namelower)s/binaries/']
+source_urls = ['http://www.genetics.ucla.edu/software/%(namelower)s/binaries/']
 sources = ['%(namelower)s_linux-%(version)s.tar.gz']
+checksums = ['41f209817a17981a717c9a4aa3d799da718ed080f3386e703927628c74ca6ca6']
 
 sanity_check_paths = {
     'files': ['admixture', 'admixture32'],


### PR DESCRIPTION
correct download URL is (unfortunately) `http://` rather than `https://`

SHA256 checksum matches what I downloaded on Aug 10th 2016