### PR TITLE
Bazel 0.16.0 with GCCcore 6.4.0

### DIFF
--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.16.0-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.16.0-GCCcore-6.4.0.eb
@@ -1,0 +1,21 @@
+name = 'Bazel'
+version = '0.16.0'
+
+homepage = 'http://bazel.io/'
+description = """Bazel is a build tool that builds code quickly and reliably. 
+It is used to build the majority of Google's software."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
+
+source_urls = ['https://github.com/bazelbuild/bazel/releases/download/%(version)s']
+sources = ['%(namelower)s-%(version)s-dist.zip']
+patches = ['%(name)s-%(version)s_remove_define_DATE.patch']
+checksums = [
+    'c730593916ef0ba62f3d113cc3a268e45f7e8039daf7b767c8641b6999bd49b1',  # bazel-0.16.0-dist.zip
+    'e2ac95693835f71518133b664747365cc1cf1cd90fffa9b585799db967b1c951',  # Bazel-0.16.0_remove_define_DATE.patch
+]
+
+builddependencies = [('binutils', '2.28')]
+dependencies = [('Java', '1.8.0_162', '', True)]
+
+moduleclass = 'devel'


### PR DESCRIPTION
A updated version of Bazel to make sure that a newer TensorFlow builds without issues.