### PR TITLE
TensorFlow 1.10.1 for the foss(cuda) 2018a toolchain

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.10.1-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.10.1-foss-2018a-Python-2.7.14.eb
@@ -1,0 +1,31 @@
+name = 'TensorFlow'
+version = '1.10.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://www.tensorflow.org/'
+description = "An open-source software library for Machine Intelligence"
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/tensorflow/tensorflow/archive/']
+sources = ['v%(version)s.tar.gz']
+patches = [
+    'TensorFlow-1.10.0_swig-env.patch',
+    'TensorFlow-1.10.0_remove-msse-hardcoding.patch',
+]
+checksums = [
+    '83092d709800e2d93d4d4b1bcacaeb74f2f328962ed764cb35bbee20402879c6',  # v1.10.1.tar.gz
+    '75e33fe56c8002c162c5ebede58d5528e6eb6bc54ffabfa54250a862242351b8',  # TensorFlow-1.10.0_swig-env.patch
+    # TensorFlow-1.10.0_remove-msse-hardcoding.patch
+    'd7a37d6d2be6a35b262a27ad77d3c8a4746cc7b3ae8f93b979afd947821fd1a2',
+]
+
+builddependencies = [
+    ('Bazel', '0.16.0'),
+    ('wheel', '0.30.0', versionsuffix),
+]
+
+dependencies = [('Python', '2.7.14')]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.10.1-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.10.1-foss-2018a-Python-3.6.4.eb
@@ -1,0 +1,31 @@
+name = 'TensorFlow'
+version = '1.10.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://www.tensorflow.org/'
+description = "An open-source software library for Machine Intelligence"
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/tensorflow/tensorflow/archive/']
+sources = ['v%(version)s.tar.gz']
+patches = [
+    'TensorFlow-1.10.0_swig-env.patch',
+    'TensorFlow-1.10.0_remove-msse-hardcoding.patch',
+]
+checksums = [
+    '83092d709800e2d93d4d4b1bcacaeb74f2f328962ed764cb35bbee20402879c6',  # v1.10.1.tar.gz
+    '75e33fe56c8002c162c5ebede58d5528e6eb6bc54ffabfa54250a862242351b8',  # TensorFlow-1.10.0_swig-env.patch
+    # TensorFlow-1.10.0_remove-msse-hardcoding.patch
+    'd7a37d6d2be6a35b262a27ad77d3c8a4746cc7b3ae8f93b979afd947821fd1a2',
+]
+
+builddependencies = [
+    ('Bazel', '0.16.0'),
+    ('wheel', '0.30.0', versionsuffix),
+]
+
+dependencies = [('Python', '3.6.4')]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.10.1-fosscuda-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.10.1-fosscuda-2018a-Python-2.7.14.eb
@@ -1,0 +1,39 @@
+name = 'TensorFlow'
+version = '1.10.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://www.tensorflow.org/'
+description = "An open-source software library for Machine Intelligence"
+
+toolchain = {'name': 'fosscuda', 'version': '2018a'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/tensorflow/tensorflow/archive/']
+sources = ['v%(version)s.tar.gz']
+patches = [
+    '%(name)s-1.10.0_remove-msse-hardcoding.patch',
+    '%(name)s-1.10.0_swig-env.patch',
+    '%(name)s-1.10.0_dont_expand_cuda_cudnn_path.patch',
+]
+checksums = [
+    '83092d709800e2d93d4d4b1bcacaeb74f2f328962ed764cb35bbee20402879c6',  # v1.10.1.tar.gz
+    # TensorFlow-1.10.0_remove-msse-hardcoding.patch
+    'd7a37d6d2be6a35b262a27ad77d3c8a4746cc7b3ae8f93b979afd947821fd1a2',
+    '75e33fe56c8002c162c5ebede58d5528e6eb6bc54ffabfa54250a862242351b8',  # TensorFlow-1.10.0_swig-env.patch
+    # TensorFlow-1.10.0_dont_expand_cuda_cudnn_path.patch
+    'a32dc8b5601e588e29464847daeccb57ce5943e79642cf237fbd8b6ff25f40c0',
+]
+
+builddependencies = [
+    ('Bazel', '0.16.0'),
+    ('wheel', '0.31.0', versionsuffix),
+]
+
+dependencies = [
+    ('Python', '2.7.14'),
+    ('cuDNN', '7.0.5.15'),
+]
+
+cuda_compute_capabilities = ['3.0', '3.2', '3.5', '3.7', '5.0', '6.0', '7.0']
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.10.1-fosscuda-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.10.1-fosscuda-2018a-Python-3.6.4.eb
@@ -1,0 +1,39 @@
+name = 'TensorFlow'
+version = '1.10.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://www.tensorflow.org/'
+description = "An open-source software library for Machine Intelligence"
+
+toolchain = {'name': 'fosscuda', 'version': '2018a'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/tensorflow/tensorflow/archive/']
+sources = ['v%(version)s.tar.gz']
+patches = [
+    '%(name)s-1.10.0_remove-msse-hardcoding.patch',
+    '%(name)s-1.10.0_swig-env.patch',
+    '%(name)s-1.10.0_dont_expand_cuda_cudnn_path.patch',
+]
+checksums = [
+    '83092d709800e2d93d4d4b1bcacaeb74f2f328962ed764cb35bbee20402879c6',  # v1.10.1.tar.gz
+    # TensorFlow-1.10.0_remove-msse-hardcoding.patch
+    'd7a37d6d2be6a35b262a27ad77d3c8a4746cc7b3ae8f93b979afd947821fd1a2',
+    '75e33fe56c8002c162c5ebede58d5528e6eb6bc54ffabfa54250a862242351b8',  # TensorFlow-1.10.0_swig-env.patch
+    # TensorFlow-1.10.0_dont_expand_cuda_cudnn_path.patch
+    'a32dc8b5601e588e29464847daeccb57ce5943e79642cf237fbd8b6ff25f40c0',
+]
+
+builddependencies = [
+    ('Bazel', '0.16.0'),
+    ('wheel', '0.31.0', versionsuffix),
+]
+
+dependencies = [
+    ('Python', '3.6.4'),
+    ('cuDNN', '7.0.5.15'),
+]
+
+cuda_compute_capabilities = ['3.0', '3.2', '3.5', '3.7', '5.0', '6.0', '7.0']
+
+moduleclass = 'lib'


### PR DESCRIPTION
TensorFlow 1.10.1 for the foss(cuda) 2018a toolchain, including Python 2.7.14 and 3.6.4 versions.