### PR TITLE
add missing NSS/DBus dependencies to Qt 5.10.1 easyconfigs built with foss toolchain to ensure that QtWebEngine component gets installed

### DIFF
--- a/easybuild/easyconfigs/d/DBus/DBus-1.13.6-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/d/DBus/DBus-1.13.6-GCCcore-6.4.0.eb
@@ -1,0 +1,39 @@
+easyblock = 'ConfigureMake'
+
+name = 'DBus'
+version = '1.13.6'
+
+homepage = 'http://dbus.freedesktop.org/'
+
+description = """
+ D-Bus is a message bus system, a simple way for applications to talk
+ to one another.  In addition to interprocess communication, D-Bus helps
+ coordinate process lifecycle; it makes it simple and reliable to code
+ a "single instance" application or daemon, and to launch applications
+ and daemons on demand when their services are needed.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://dbus.freedesktop.org/releases/dbus']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['b533693232d36d608a09f70c15440c1816319bac3055433300d88019166c1ae4']
+
+builddependencies = [
+    ('binutils', '2.28'),
+]
+
+dependencies = [
+    ('expat', '2.2.5'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/dbus-%s' % x for x in
+              ['cleanup-sockets', 'daemon', 'launch', 'monitor',
+               'run-session', 'send', 'uuidgen']] +
+             ['lib/libdbus-1.%s' % x for x in ['a', SHLIB_EXT]],
+    'dirs': ['include', 'share'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/d/DBus/DBus-1.13.6-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/d/DBus/DBus-1.13.6-GCCcore-7.3.0.eb
@@ -1,0 +1,39 @@
+easyblock = 'ConfigureMake'
+
+name = 'DBus'
+version = '1.13.6'
+
+homepage = 'http://dbus.freedesktop.org/'
+
+description = """
+ D-Bus is a message bus system, a simple way for applications to talk
+ to one another.  In addition to interprocess communication, D-Bus helps
+ coordinate process lifecycle; it makes it simple and reliable to code
+ a "single instance" application or daemon, and to launch applications
+ and daemons on demand when their services are needed.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://dbus.freedesktop.org/releases/dbus']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['b533693232d36d608a09f70c15440c1816319bac3055433300d88019166c1ae4']
+
+builddependencies = [
+    ('binutils', '2.30'),
+]
+
+dependencies = [
+    ('expat', '2.2.5'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/dbus-%s' % x for x in
+              ['cleanup-sockets', 'daemon', 'launch', 'monitor',
+               'run-session', 'send', 'uuidgen']] +
+             ['lib/libdbus-1.%s' % x for x in ['a', SHLIB_EXT]],
+    'dirs': ['include', 'share'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/n/NSPR/NSPR-4.20-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/n/NSPR/NSPR-4.20-GCCcore-6.4.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'NSPR'
+version = '4.20'
+
+homepage = 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR'
+description = """Netscape Portable Runtime (NSPR) provides a platform-neutral API for system level
+ and libc-like functions."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
+
+source_urls = ['https://archive.mozilla.org/pub/nspr/releases/v%(version)s/src/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['2c8964913da89ffbaf464d49ce44d79e8804e1794ef9a8c52a7bff7224d1556e']
+
+builddependencies = [('binutils', '2.28')]
+
+configopts = "--disable-debug --enable-optimize --enable-64bit"
+
+sanity_check_paths = {
+    'files': ['bin/nspr-config', 'lib/libnspr%(version_major)s.a', 'lib/libnspr%%(version_major)s.%s' % SHLIB_EXT,
+              'lib/libplc%(version_major)s.a', 'lib/libplc%%(version_major)s.%s' % SHLIB_EXT,
+              'lib/libplds%(version_major)s.a', 'lib/libplds%%(version_major)s.%s' % SHLIB_EXT,
+              'lib/pkgconfig/nspr.pc'],
+    'dirs': ['include/nspr'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/NSPR/NSPR-4.20-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/n/NSPR/NSPR-4.20-GCCcore-7.3.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'NSPR'
+version = '4.20'
+
+homepage = 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR'
+description = """Netscape Portable Runtime (NSPR) provides a platform-neutral API for system level
+ and libc-like functions."""
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+
+source_urls = ['https://archive.mozilla.org/pub/nspr/releases/v%(version)s/src/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['2c8964913da89ffbaf464d49ce44d79e8804e1794ef9a8c52a7bff7224d1556e']
+
+builddependencies = [('binutils', '2.30')]
+
+configopts = "--disable-debug --enable-optimize --enable-64bit"
+
+sanity_check_paths = {
+    'files': ['bin/nspr-config', 'lib/libnspr%(version_major)s.a', 'lib/libnspr%%(version_major)s.%s' % SHLIB_EXT,
+              'lib/libplc%(version_major)s.a', 'lib/libplc%%(version_major)s.%s' % SHLIB_EXT,
+              'lib/libplds%(version_major)s.a', 'lib/libplds%%(version_major)s.%s' % SHLIB_EXT,
+              'lib/pkgconfig/nspr.pc'],
+    'dirs': ['include/nspr'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/NSS/NSS-3.39-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/n/NSS/NSS-3.39-GCCcore-6.4.0.eb
@@ -1,0 +1,40 @@
+easyblock = 'MakeCp'
+
+name = 'NSS'
+version = '3.39'
+
+homepage = 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS'
+description = """Network Security Services (NSS) is a set of libraries designed to support cross-platform development
+ of security-enabled client and server applications."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
+
+source_urls = ['https://ftp.mozilla.org/pub/security/nss/releases/NSS_%(version_major)s_%(version_minor)s_RTM/src/']
+sources = [SOURCELOWER_TAR_GZ]
+patches = ['NSS-%(version)s_pkgconfig.patch']
+checksums = [
+    '6be64dd76f212415cc8bc34343ac1e7389048db4db9a023a84873c411dc5864b',  # nss-3.39.tar.gz
+    '5c4b55842e5afd1e8e67b90635f6474510b89242963c4ac2622d3e3da9062774',  # NSS-3.39_pkgconfig.patch
+]
+
+builddependencies = [('binutils', '2.28')]
+dependencies = [('NSPR', '4.20')]
+
+# building in parallel fails
+parallel = 1
+
+# fix for not being able to find header files
+buildopts = 'BUILD_OPT=1 USE_64=1 CPATH="$EBROOTNSPR/include/nspr:$CPATH" && '
+# also install pkgconfig file (see patch)
+buildopts += "cd config && make PREFIX=%(installdir)s BUILD_OPT=1 USE_64=1 && cd -"
+
+files_to_copy = ['../dist/Linux*.OBJ/*', (['../dist/public/*'], 'include')]
+
+sanity_check_paths = {
+    'files': ['lib/libnss.a'],
+    'dirs': ['bin', 'include/dbm', 'include/nss'],
+}
+
+modextrapaths = {'CPATH': 'include/nss'}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/NSS/NSS-3.39-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/n/NSS/NSS-3.39-GCCcore-7.3.0.eb
@@ -1,0 +1,40 @@
+easyblock = 'MakeCp'
+
+name = 'NSS'
+version = '3.39'
+
+homepage = 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS'
+description = """Network Security Services (NSS) is a set of libraries designed to support cross-platform development
+ of security-enabled client and server applications."""
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+
+source_urls = ['https://ftp.mozilla.org/pub/security/nss/releases/NSS_%(version_major)s_%(version_minor)s_RTM/src/']
+sources = [SOURCELOWER_TAR_GZ]
+patches = ['NSS-%(version)s_pkgconfig.patch']
+checksums = [
+    '6be64dd76f212415cc8bc34343ac1e7389048db4db9a023a84873c411dc5864b',  # nss-3.39.tar.gz
+    '5c4b55842e5afd1e8e67b90635f6474510b89242963c4ac2622d3e3da9062774',  # NSS-3.39_pkgconfig.patch
+]
+
+builddependencies = [('binutils', '2.30')]
+dependencies = [('NSPR', '4.20')]
+
+# building in parallel fails
+parallel = 1
+
+# fix for not being able to find header files
+buildopts = 'BUILD_OPT=1 USE_64=1 CPATH="$EBROOTNSPR/include/nspr:$CPATH" && '
+# also install pkgconfig file (see patch)
+buildopts += "cd config && make PREFIX=%(installdir)s BUILD_OPT=1 USE_64=1 && cd -"
+
+files_to_copy = ['../dist/Linux*.OBJ/*', (['../dist/public/*'], 'include')]
+
+sanity_check_paths = {
+    'files': ['lib/libnss.a'],
+    'dirs': ['bin', 'include/dbm', 'include/nss'],
+}
+
+modextrapaths = {'CPATH': 'include/nss'}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/NSS/NSS-3.39_pkgconfig.patch
+++ b/easybuild/easyconfigs/n/NSS/NSS-3.39_pkgconfig.patch
@@ -1,0 +1,221 @@
+based on https://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/dev-libs/nss/files/nss-3.12.4-gentoo-fixups-1.diff
+
+updated/fixed for NSS 3.39 by Kenneth Hoste (HPC-UGent)
+
+diff -urN nss/manifest.mn nss-3.12.4/mozilla/security/nss/manifest.mn
+--- nss/manifest.mn	2008-04-04 15:36:59.000000000 -0500
++++ nss/manifest.mn	2009-09-14 21:45:45.703656167 -0500
+
+ RELEASE = nss
+
+-DIRS = coreconf lib cmd cpputil gtests
++DIRS = coreconf lib cmd cpputil gtests config
+diff -urN nss/config/Makefile nss-3.12.4/mozilla/security/nss/config/Makefile
+--- nss/config/Makefile	1969-12-31 18:00:00.000000000 -0600
++++ nss/config/Makefile	2009-09-14 21:45:45.619639265 -0500
+@@ -0,0 +1,40 @@
++CORE_DEPTH = ..
++DEPTH      = ../..
++
++include $(CORE_DEPTH)/coreconf/config.mk
++
++NSS_MAJOR_VERSION = `grep "NSS_VMAJOR" ../lib/nss/nss.h | awk '{print $$3}'`
++NSS_MINOR_VERSION = `grep "NSS_VMINOR" ../lib/nss/nss.h | awk '{print $$3}'`
++NSS_PATCH_VERSION = `grep "NSS_VPATCH" ../lib/nss/nss.h | awk '{print $$3}'`
++PREFIX = /usr
++
++all: export libs
++
++export:
++	# Create the nss.pc file
++	mkdir -p $(DIST)/lib/pkgconfig
++	sed -e "s,@prefix@,$(PREFIX)," \
++	    -e "s,@exec_prefix@,\$${prefix}/bin," \
++	    -e "s,@libdir@,\$${prefix}/lib," \
++	    -e "s,@includedir@,\$${prefix}/include/nss," \
++	    -e "s,@NSS_MAJOR_VERSION@,$(NSS_MAJOR_VERSION),g" \
++	    -e "s,@NSS_MINOR_VERSION@,$(NSS_MINOR_VERSION)," \
++	    -e "s,@NSS_PATCH_VERSION@,$(NSS_PATCH_VERSION)," \
++	    nss.pc.in > nss.pc
++	chmod 0644 nss.pc
++	ln -sf ../../../../nss/config/nss.pc $(DIST)/lib/pkgconfig
++
++	# Create the nss-config script
++	mkdir -p $(DIST)/bin
++	sed -e "s,@prefix@,$(PREFIX)," \
++	    -e "s,@NSS_MAJOR_VERSION@,$(NSS_MAJOR_VERSION)," \
++	    -e "s,@NSS_MINOR_VERSION@,$(NSS_MINOR_VERSION)," \
++	    -e "s,@NSS_PATCH_VERSION@,$(NSS_PATCH_VERSION)," \
++	    nss-config.in > nss-config
++	chmod 0755 nss-config
++	ln -sf ../../../nss/config/nss-config $(DIST)/bin
++
++libs:
++
++dummy: all export libs
++
+diff -urN nss/config/nss-config.in nss-3.12.4/mozilla/security/nss/config/nss-config.in
+--- nss/config/nss-config.in	1969-12-31 18:00:00.000000000 -0600
++++ nss/config/nss-config.in	2009-09-14 21:47:45.190638078 -0500
+@@ -0,0 +1,145 @@
++#!/bin/sh
++
++prefix=@prefix@
++
++major_version=@NSS_MAJOR_VERSION@
++minor_version=@NSS_MINOR_VERSION@
++patch_version=@NSS_PATCH_VERSION@
++
++usage()
++{
++	cat <<EOF
++Usage: nss-config [OPTIONS] [LIBRARIES]
++Options:
++	[--prefix[=DIR]]
++	[--exec-prefix[=DIR]]
++	[--includedir[=DIR]]
++	[--libdir[=DIR]]
++	[--version]
++	[--libs]
++	[--cflags]
++Dynamic Libraries:
++	nss
++	ssl
++	smime
++	nssutil
++EOF
++	exit $1
++}
++
++if test $# -eq 0; then
++	usage 1 1>&2
++fi
++
++lib_ssl=yes
++lib_smime=yes
++lib_nss=yes
++lib_nssutil=yes
++
++while test $# -gt 0; do
++  case "$1" in
++  -*=*) optarg=`echo "$1" | sed 's/[-_a-zA-Z0-9]*=//'` ;;
++  *) optarg= ;;
++  esac
++
++  case $1 in
++    --prefix=*)
++      prefix=$optarg
++      ;;
++    --prefix)
++      echo_prefix=yes
++      ;;
++    --exec-prefix=*)
++      exec_prefix=$optarg
++      ;;
++    --exec-prefix)
++      echo_exec_prefix=yes
++      ;;
++    --includedir=*)
++      includedir=$optarg
++      ;;
++    --includedir)
++      echo_includedir=yes
++      ;;
++    --libdir=*)
++      libdir=$optarg
++      ;;
++    --libdir)
++      echo_libdir=yes
++      ;;
++    --version)
++      echo ${major_version}.${minor_version}.${patch_version}
++      ;;
++    --cflags)
++      echo_cflags=yes
++      ;;
++    --libs)
++      echo_libs=yes
++      ;;
++    ssl)
++      lib_ssl=yes
++      ;;
++    smime)
++      lib_smime=yes
++      ;;
++    nss)
++      lib_nss=yes
++      ;;
++    nssutil)                                                      
++      lib_nssutil=yes                                             
++      ;;
++    *)
++      usage 1 1>&2
++      ;;
++  esac
++  shift
++done
++
++# Set variables that may be dependent upon other variables
++if test -z "$exec_prefix"; then
++    exec_prefix=`pkg-config --variable=exec_prefix nss`
++fi
++if test -z "$includedir"; then
++    includedir=`pkg-config --variable=includedir nss`
++fi
++if test -z "$libdir"; then
++    libdir=`pkg-config --variable=libdir nss`
++fi
++
++if test "$echo_prefix" = "yes"; then
++    echo $prefix
++fi
++
++if test "$echo_exec_prefix" = "yes"; then
++    echo $exec_prefix
++fi
++
++if test "$echo_includedir" = "yes"; then
++    echo $includedir
++fi
++
++if test "$echo_libdir" = "yes"; then
++    echo $libdir
++fi
++
++if test "$echo_cflags" = "yes"; then
++    echo -I$includedir
++fi
++
++if test "$echo_libs" = "yes"; then
++      libdirs="-Wl,-R$libdir -L$libdir"
++      if test -n "$lib_ssl"; then
++	libdirs="$libdirs -lssl${major_version}"
++      fi
++      if test -n "$lib_smime"; then
++	libdirs="$libdirs -lsmime${major_version}"
++      fi
++      if test -n "$lib_nss"; then
++	libdirs="$libdirs -lnss${major_version}"
++      fi
++      if test -n "$lib_nssutil"; then
++       libdirs="$libdirs -lnssutil${major_version}"
++      fi
++      echo $libdirs
++fi      
++
+diff -urN nss/config/nss.pc.in nss-3.12.4/mozilla/security/nss/config/nss.pc.in
+--- nss/config/nss.pc.in	1969-12-31 18:00:00.000000000 -0600
++++ nss/config/nss.pc.in	2009-09-14 21:45:45.653637310 -0500
+@@ -0,0 +1,12 @@
++prefix=@prefix@
++exec_prefix=@exec_prefix@
++libdir=@libdir@
++includedir=@includedir@
++
++Name: NSS
++Description: Network Security Services
++Version: @NSS_MAJOR_VERSION@.@NSS_MINOR_VERSION@.@NSS_PATCH_VERSION@
++Requires: nspr >= 4.8
++Libs: -L${libdir} -lssl3 -lsmime3 -lnssutil3 -lnss3 -Wl,-R${libdir}
++Cflags: -I${includedir}
++

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.10.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.10.1-foss-2018a.eb
@@ -17,14 +17,19 @@ checksums = ['05ffba7b811b854ed558abf2be2ddbd3bb6ddd0b60ea4b5da75d277ac15e740a']
 
 builddependencies = [('pkg-config', '0.29.2')]
 
-# qtgamepad needs recent kernel/libevdev (fails on RHEL 6.x)
-configopts = '-skip qtgamepad'
-
 dependencies = [
     ('GLib', '2.54.3'),
     ('libpng', '1.6.34'),
     ('X11', '20180131'),
     ('libGLU', '9.0.0'),
+    ('NSS', '3.39'),
+    ('DBus', '1.13.6'),
 ]
+
+# qtgamepad needs recent kernel/libevdev (fails on RHEL 6.x)
+configopts = '-skip qtgamepad'
+
+# make sure QtWebEngine component is being built & installed
+check_qtwebengine = True
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.10.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.10.1-foss-2018b.eb
@@ -17,14 +17,19 @@ checksums = ['05ffba7b811b854ed558abf2be2ddbd3bb6ddd0b60ea4b5da75d277ac15e740a']
 
 builddependencies = [('pkg-config', '0.29.2')]
 
-# qtgamepad needs recent kernel/libevdev (fails on RHEL 6.x)
-configopts = '-skip qtgamepad'
-
 dependencies = [
     ('GLib', '2.54.3'),
     ('libpng', '1.6.34'),
     ('X11', '20180604'),
     ('libGLU', '9.0.0'),
+    ('NSS', '3.39'),
+    ('DBus', '1.13.6'),
 ]
+
+# qtgamepad needs recent kernel/libevdev (fails on RHEL 6.x)
+configopts = '-skip qtgamepad'
+
+# make sure QtWebEngine component is being built & installed
+check_qtwebengine = True
 
 moduleclass = 'devel'


### PR DESCRIPTION
(strictly speaking requires https://github.com/easybuilders/easybuild-easyblocks/pull/1544)

cfr. #5600

note: similar fix for `Qt5-5.10.1-intel-2018a.eb` is more complex, it also involves some patches, will open a separate PR for that