### PR TITLE
fix building of QtWebEngine in Qt5-5.10.1-intel-2018a.eb (WIP)

### DIFF
--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.10.1-intel-2018a.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.10.1-intel-2018a.eb
@@ -28,6 +28,7 @@ dependencies = [
     ('libGLU', '9.0.0'),
     ('NSS', '3.39'),
     ('DBus', '1.13.6'),
+    ('gperf', '3.1'),
 ]
 
 # qtgamepad needs recent kernel/libevdev (fails on RHEL 6.x)

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.10.1-intel-2018a.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.10.1-intel-2018a.eb
@@ -13,18 +13,27 @@ source_urls = [
     'http://download.qt.io/archive/qt/%(version_major_minor)s/%(version)s/single/'
 ]
 sources = ['qt-everywhere-src-%(version)s.tar.xz']
-checksums = ['05ffba7b811b854ed558abf2be2ddbd3bb6ddd0b60ea4b5da75d277ac15e740a']
+patches = ['Qt5-%(version)s_fix-QtWebEngine-intel.patch']
+checksums = [
+    '05ffba7b811b854ed558abf2be2ddbd3bb6ddd0b60ea4b5da75d277ac15e740a',  # qt-everywhere-src-5.10.1.tar.xz
+    'ce412b74528608721ac8fec9a2fa380fd4e92dc8b8186fea3aab32e2431db6cf',  # Qt5-5.10.1_fix-QtWebEngine-intel.patch
+]
 
 builddependencies = [('pkg-config', '0.29.2')]
-
-# qtgamepad needs recent kernel/libevdev (fails on RHEL 6.x)
-configopts = '-skip qtgamepad'
 
 dependencies = [
     ('GLib', '2.54.3'),
     ('libpng', '1.6.34'),
     ('X11', '20180131'),
     ('libGLU', '9.0.0'),
+    ('NSS', '3.39'),
+    ('DBus', '1.13.6'),
 ]
+
+# qtgamepad needs recent kernel/libevdev (fails on RHEL 6.x)
+configopts = '-skip qtgamepad'
+
+# make sure QtWebEngine component is being built & installed
+check_qtwebengine = True
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.10.1_fix-QtWebEngine-intel.patch
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.10.1_fix-QtWebEngine-intel.patch
@@ -1,0 +1,30 @@
+don't disable building of QtWebEngine when Intel compilers are used
+
+author: Kenneth Hoste (HPC-UGent)
+
+--- qt-everywhere-src-5.10.1/qtwebengine/mkspecs/features/platform.prf.orig	2018-10-12 13:34:32.026246699 +0200
++++ qt-everywhere-src-5.10.1/qtwebengine/mkspecs/features/platform.prf	2018-10-12 13:34:11.676384153 +0200
+@@ -14,9 +14,9 @@
+   linux {
+     if(!gcc:!clang)|intel_icc {
+-      skipBuild("Qt WebEngine on Linux requires clang or GCC.")
++      #skipBuild("Qt WebEngine on Linux requires clang or GCC.")
+-      return(false)
++      #return(false)
+     }
+-    gcc:!clang:!isGCCVersionSupported(): return(false)
++    #gcc:!clang:!isGCCVersionSupported(): return(false)
+   } else:win32 {
+     winrt {
+       skipBuild("WinRT is not supported.")
+--- qt-everywhere-src-5.10.1/qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/HeapAllocator.h.orig	2018-10-12 13:33:05.176796309 +0200
++++ qt-everywhere-src-5.10.1/qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/HeapAllocator.h	2018-10-12 13:33:44.096551263 +0200
+@@ -130,7 +130,7 @@
+         size, IsEagerlyFinalizedType<Metadata>::value));
+   }
+ 
+-#if defined(OS_WIN) && defined(COMPILER_MSVC)
++#if (defined(OS_WIN) && defined(COMPILER_MSVC)) || defined(__INTEL_COMPILER)
+   // MSVC eagerly instantiates the unused 'operator delete',
+   // provide a version that asserts and fails at run-time if
+   // used.


### PR DESCRIPTION
requires ~~#7005~~ (`NSS`, `NSPR`, `DBus`) (+ ~~https://github.com/easybuilders/easybuild-easyblocks/pull/1544~~, strictly speaking)

Still WIP since the installation currently fails with a spurious `undefined reference` error that I haven't figured out yet...

The patch is already sort of a sign of trouble though, since building with Intel compilers is clearly not (well) supported...