### PR TITLE
add missing extensions to Python 2.7.14 easyconfigs using toolchain of 2017b generation

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2017b.eb
@@ -155,11 +155,14 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
         'checksums': ['684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16'],
     }),
+    ('enum34', '1.1.6', {
+        'modulename': 'enum',
+        'source_urls': ['https://pypi.python.org/packages/source/e/enum34'],
+        'checksums': ['8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1'],
+    }),
     ('cryptography', '2.0.3', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
-        'checksums': [
-            'd04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a',  # cryptography-2.0.3.tar.gz
-        ],
+        'checksums': ['d04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a'],
     }),
     ('pyasn1', '0.4.3', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
@@ -221,13 +224,6 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
         'checksums': [
             'a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66',  # pandas-0.20.3.tar.gz
-        ],
-    }),
-    ('enum34', '1.1.6', {
-        'modulename': 'enum',
-        'source_urls': ['https://pypi.python.org/packages/source/e/enum34'],
-        'checksums': [
-            '8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1',  # enum34-1.1.6.tar.gz
         ],
     }),
     ('bitstring', '3.1.5', {

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2017b.eb
@@ -28,6 +28,8 @@ dependencies = [
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
+exts_download_dep_fail = True
+
 # order is important!
 # package versions updated September 18th 2017
 exts_list = [
@@ -142,11 +144,35 @@ exts_list = [
             '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
         ],
     }),
+    ('ipaddress', '1.0.22', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipaddress/'],
+    }),
+    ('asn1crypto', '0.24.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
+        'checksums': ['9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49'],
+    }),
+    ('idna', '2.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
+        'checksums': ['684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16'],
+    }),
     ('cryptography', '2.0.3', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
         'checksums': [
             'd04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a',  # cryptography-2.0.3.tar.gz
         ],
+    }),
+    ('pyasn1', '0.4.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
+        'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
+    }),
+    ('PyNaCl', '1.2.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
+        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
+        'modulename': 'nacl',
+    }),
+    ('bcrypt', '3.1.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/bcrypt/'],
+        'checksums': ['67ed1a374c9155ec0840214ce804616de49c3df9c5bc66740687c1c9b1cd9e8d'],
     }),
     ('paramiko', '2.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2017b.eb
@@ -155,11 +155,14 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
         'checksums': ['684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16'],
     }),
+    ('enum34', '1.1.6', {
+        'modulename': 'enum',
+        'source_urls': ['https://pypi.python.org/packages/source/e/enum34'],
+        'checksums': ['8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1'],
+    }),
     ('cryptography', '2.0.3', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
-        'checksums': [
-            'd04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a',  # cryptography-2.0.3.tar.gz
-        ],
+        'checksums': ['d04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a'],
     }),
     ('pyasn1', '0.4.3', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
@@ -221,13 +224,6 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
         'checksums': [
             'a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66',  # pandas-0.20.3.tar.gz
-        ],
-    }),
-    ('enum34', '1.1.6', {
-        'modulename': 'enum',
-        'source_urls': ['https://pypi.python.org/packages/source/e/enum34'],
-        'checksums': [
-            '8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1',  # enum34-1.1.6.tar.gz
         ],
     }),
     ('bitstring', '3.1.5', {

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2017b.eb
@@ -28,6 +28,8 @@ dependencies = [
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
+exts_download_dep_fail = True
+
 # order is important!
 # package versions updated September 18th 2017
 exts_list = [
@@ -142,11 +144,35 @@ exts_list = [
             '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
         ],
     }),
+    ('ipaddress', '1.0.22', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipaddress/'],
+    }),
+    ('asn1crypto', '0.24.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
+        'checksums': ['9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49'],
+    }),
+    ('idna', '2.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
+        'checksums': ['684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16'],
+    }),
     ('cryptography', '2.0.3', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
         'checksums': [
             'd04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a',  # cryptography-2.0.3.tar.gz
         ],
+    }),
+    ('pyasn1', '0.4.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
+        'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
+    }),
+    ('PyNaCl', '1.2.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
+        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
+        'modulename': 'nacl',
+    }),
+    ('bcrypt', '3.1.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/bcrypt/'],
+        'checksums': ['67ed1a374c9155ec0840214ce804616de49c3df9c5bc66740687c1c9b1cd9e8d'],
     }),
     ('paramiko', '2.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2018.01.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2018.01.eb
@@ -154,11 +154,14 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
         'checksums': ['684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16'],
     }),
+    ('enum34', '1.1.6', {
+        'modulename': 'enum',
+        'source_urls': ['https://pypi.python.org/packages/source/e/enum34'],
+        'checksums': ['8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1'],
+    }),
     ('cryptography', '2.1.3', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
-        'checksums': [
-            '68a26c353627163d74ee769d4749f2ee243866e9dac43c93bb33ebd8fbed1199',  # cryptography-2.1.3.tar.gz
-        ],
+        'checksums': ['68a26c353627163d74ee769d4749f2ee243866e9dac43c93bb33ebd8fbed1199'],
     }),
     ('pyasn1', '0.4.3', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
@@ -220,13 +223,6 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
         'checksums': [
             '5cd5cb30e72eeaf202f0e5e180780b897570e889d2db328c689a5a263405c559',  # pandas-0.21.0.tar.gz
-        ],
-    }),
-    ('enum34', '1.1.6', {
-        'modulename': 'enum',
-        'source_urls': ['https://pypi.python.org/packages/source/e/enum34'],
-        'checksums': [
-            '8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1',  # enum34-1.1.6.tar.gz
         ],
     }),
     ('bitstring', '3.1.5', {

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2018.01.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2018.01.eb
@@ -28,6 +28,8 @@ dependencies = [
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
+exts_download_dep_fail = True
+
 # order is important!
 # package versions updated September 18th 2017
 exts_list = [
@@ -141,11 +143,35 @@ exts_list = [
             '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
         ],
     }),
+    ('ipaddress', '1.0.22', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipaddress/'],
+    }),
+    ('asn1crypto', '0.24.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
+        'checksums': ['9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49'],
+    }),
+    ('idna', '2.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
+        'checksums': ['684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16'],
+    }),
     ('cryptography', '2.1.3', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
         'checksums': [
             '68a26c353627163d74ee769d4749f2ee243866e9dac43c93bb33ebd8fbed1199',  # cryptography-2.1.3.tar.gz
         ],
+    }),
+    ('pyasn1', '0.4.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
+        'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
+    }),
+    ('PyNaCl', '1.2.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
+        'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],
+        'modulename': 'nacl',
+    }),
+    ('bcrypt', '3.1.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/bcrypt/'],
+        'checksums': ['67ed1a374c9155ec0840214ce804616de49c3df9c5bc66740687c1c9b1cd9e8d'],
     }),
     ('paramiko', '2.4.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],


### PR DESCRIPTION
This is mainly done because picking up the most recent `PyNaCl` version (1.3.0) is problematic with this generation of Intel compilers (cfr. #6971)