### PR TITLE
osdeps for git +last git eb 2.19.1

### DIFF
--- a/easybuild/easyconfigs/g/git/git-2.12.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/g/git/git-2.12.2-foss-2016b.eb
@@ -22,6 +22,9 @@ dependencies = [
     ('Perl', '5.24.0', '-bare'),
 ]
 
+# asciidoc and xmlto are required for git man/doc build
+osdependencies = ['asciidoc', 'xmlto']
+
 preconfigopts = 'make configure && '
 
 # Work around git build system bug.  If LIBS contains -lpthread, then configure

--- a/easybuild/easyconfigs/g/git/git-2.13.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/g/git/git-2.13.1-foss-2016b.eb
@@ -23,6 +23,9 @@ dependencies = [
     ('Perl', '5.24.0', '-bare'),
 ]
 
+# asciidoc and xmlto are required for git man/doc build
+osdependencies = ['asciidoc', 'xmlto']
+
 preconfigopts = 'make configure && '
 
 # Work around git build system bug.  If LIBS contains -lpthread, then configure

--- a/easybuild/easyconfigs/g/git/git-2.14.1-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/g/git/git-2.14.1-GCCcore-6.4.0.eb
@@ -24,6 +24,9 @@ dependencies = [
     ('Perl', '5.26.0'),
 ]
 
+# asciidoc and xmlto are required for git man/doc build
+osdependencies = ['asciidoc', 'xmlto']
+
 preconfigopts = 'make configure && '
 
 # Work around git build system bug.  If LIBS contains -lpthread, then configure

--- a/easybuild/easyconfigs/g/git/git-2.16.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/g/git/git-2.16.1-foss-2018a.eb
@@ -23,6 +23,9 @@ dependencies = [
     ('Perl', '5.26.1'),
 ]
 
+# asciidoc and xmlto are required for git man/doc build
+osdependencies = ['asciidoc', 'xmlto']
+
 preconfigopts = 'make configure && '
 
 # Work around git build system bug.  If LIBS contains -lpthread, then configure

--- a/easybuild/easyconfigs/g/git/git-2.18.0-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/g/git/git-2.18.0-GCCcore-7.3.0.eb
@@ -24,6 +24,9 @@ dependencies = [
     ('Perl', '5.28.0'),
 ]
 
+# asciidoc and xmlto are required for git man/doc build
+osdependencies = ['asciidoc', 'xmlto']
+
 preconfigopts = 'make configure && '
 
 # Work around git build system bug.  If LIBS contains -lpthread, then configure

--- a/easybuild/easyconfigs/g/git/git-2.19.1-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/g/git/git-2.19.1-GCCcore-7.3.0.eb
@@ -1,0 +1,45 @@
+easyblock = 'ConfigureMake'
+
+name = 'git'
+version = '2.19.1'
+
+homepage = 'http://git-scm.com/'
+description = """Git is a free and open source distributed version control system designed
+to handle everything from small to very large projects with speed and efficiency."""
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+
+sources = ['v%(version)s.tar.gz']
+source_urls = ['https://github.com/git/git/archive']
+checksums = ['ba2fed9d02e424b735e035c4f2b0bdb168ef0df7e35156b5051d900dc7247787']
+
+builddependencies = [
+    ('binutils', '2.30'),
+    ('Autotools', '20180311'),
+]
+dependencies = [
+    ('cURL', '7.60.0'),
+    ('expat', '2.2.5'),
+    ('gettext', '0.19.8.1'),
+    ('Perl', '5.28.0'),
+]
+
+# asciidoc and xmlto are required for git man/doc build
+osdependencies = ['asciidoc', 'xmlto']
+
+preconfigopts = 'make configure && '
+
+# Work around git build system bug.  If LIBS contains -lpthread, then configure
+# will not append -lpthread to LDFLAGS, but Makefile ignores LIBS.
+configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
+
+# required to also install documentation
+buildopts = "doc"
+installopts = "install-doc"
+
+sanity_check_paths = {
+    'files': ['bin/git'],
+    'dirs': ['share/man'],
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
+missing osdeps for git documentation build as mentioned in https://github.com/jose-d/easybuild-easyconfigs/commit/50ab4fa71d2654abbb54dc382c56b6e9dd1b6dab#commitcomment-30863442. 