### PR TITLE
create default configuration for RTG-Tools

### DIFF
--- a/easybuild/easyconfigs/r/RTG-Tools/RTG-Tools-3.9.1-Java-1.8.eb
+++ b/easybuild/easyconfigs/r/RTG-Tools/RTG-Tools-3.9.1-Java-1.8.eb
@@ -23,6 +23,9 @@ cmds_map = [('.*', comp_cmd)]
 
 files_to_copy = ['rtg-tools-%(version)s-unknown/*']
 
+# add default configuration: no crash reporting, no usage logging
+postinstallcmds = ["echo 'RTG_TALKBACK=false\nRTG_USAGE=' > %(installdir)s/rtg.cfg"]
+
 modextrapaths = {'PATH': ['']}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/r/RTG-Tools/RTG-Tools-3.9.1-Java-1.8.eb
+++ b/easybuild/easyconfigs/r/RTG-Tools/RTG-Tools-3.9.1-Java-1.8.eb
@@ -29,7 +29,7 @@ postinstallcmds = ["echo 'RTG_TALKBACK=false\nRTG_USAGE=' > %(installdir)s/rtg.c
 modextrapaths = {'PATH': ['']}
 
 sanity_check_paths = {
-    'files': ['rtg', 'RTG.jar'],
+    'files': ['rtg', 'rtg.cfg', 'RTG.jar'],
     'dirs': [],
 }
 


### PR DESCRIPTION
addition for #6862

Without this, the user is prompted with interactive Q&A when running `rtg`, which tries to create `rtg.cfg` in the installation directory, which usually fails because of permission problems...

cc @smoors