### PR TITLE
add missing checksums for ipaddress Python extension (+ reformatting)

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2017b.eb
@@ -36,21 +36,15 @@ exts_list = [
     ('setuptools', '36.5.0', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
-        'checksums': [
-            'ce2007c1cea3359870b80657d634253a0765b0c7dc5a988d77ba803fc86f2c64',  # setuptools-36.5.0.zip
-        ],
+        'checksums': ['ce2007c1cea3359870b80657d634253a0765b0c7dc5a988d77ba803fc86f2c64'],
     }),
     ('pip', '9.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
-        'checksums': [
-            '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d',  # pip-9.0.1.tar.gz
-        ],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
     }),
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
-        'checksums': [
-            'f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98',  # nose-1.3.7.tar.gz
-        ],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
     }),
     ('numpy', '1.13.1', {
         'patches': ['numpy-1.12.0-mkl.patch'],
@@ -64,88 +58,63 @@ exts_list = [
     ('scipy', '0.19.1', {
         'source_tmpl': '%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
-        'checksums': [
-            'a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6',  # scipy-0.19.1.tar.gz
-        ],
+        'checksums': ['a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6'],
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
-        'checksums': [
-            '3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3',  # blist-1.3.6.tar.gz
-        ],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
     }),
     ('mpi4py', '2.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
-        'checksums': [
-            '6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81',  # mpi4py-2.0.0.tar.gz
-        ],
+        'checksums': ['6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81'],
     }),
     ('paycheck', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
-        'checksums': [
-            '6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34',  # paycheck-1.0.2.tar.gz
-        ],
+        'checksums': ['6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34'],
     }),
     ('pbr', '3.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
-        'checksums': [
-            '05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1',  # pbr-3.1.1.tar.gz
-        ],
+        'checksums': ['05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1'],
     }),
     ('Cython', '0.26.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
-        'checksums': [
-            'c2e63c4794161135adafa8aa4a855d6068073f421c83ffacc39369497a189dd5',  # Cython-0.26.1.tar.gz
-        ],
+        'checksums': ['c2e63c4794161135adafa8aa4a855d6068073f421c83ffacc39369497a189dd5'],
     }),
     ('six', '1.11.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-        'checksums': [
-            '70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9',  # six-1.11.0.tar.gz
-        ],
+        'checksums': ['70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9'],
     }),
     ('dateutil', '2.6.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
-        'checksums': [
-            '891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca',  # python-dateutil-2.6.1.tar.gz
-        ],
+        'checksums': ['891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca'],
     }),
     ('deap', '1.0.2', {
         'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
-        'checksums': [
-            'c52bd32b8f0143db3a0b90f2b976c920b588638d6999ca0d038d8b1c07f7950b',  # deap-1.0.2.post2.tar.gz
-        ],
+        'checksums': ['c52bd32b8f0143db3a0b90f2b976c920b588638d6999ca0d038d8b1c07f7950b'],
     }),
     ('decorator', '4.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-        'checksums': [
-            '7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5',  # decorator-4.1.2.tar.gz
-        ],
+        'checksums': ['7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5'],
     }),
     ('arff', '2.1.1', {
         'source_tmpl': 'liac-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
-        'checksums': [
-            'b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817',  # liac-arff-2.1.1.tar.gz
-        ],
+        'checksums': ['b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817'],
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
-        'checksums': [
-            'f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c',  # pycrypto-2.6.1.tar.gz
-        ],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
-        'checksums': [
-            '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
-        ],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
     ('ipaddress', '1.0.22', {
         'source_urls': ['https://pypi.python.org/packages/source/i/ipaddress/'],
+        'checksums': ['b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c'],
     }),
     ('asn1crypto', '0.24.0', {
         'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
@@ -179,77 +148,53 @@ exts_list = [
     }),
     ('paramiko', '2.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
-        'checksums': [
-            'ff94ae65379914ec3c960de731381f49092057b6dd1d24d18842ead5a2eb2277',  # paramiko-2.2.1.tar.gz
-        ],
+        'checksums': ['ff94ae65379914ec3c960de731381f49092057b6dd1d24d18842ead5a2eb2277'],
     }),
     ('pyparsing', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
-        'checksums': [
-            '0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04',  # pyparsing-2.2.0.tar.gz
-        ],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
     }),
     ('netifaces', '0.10.6', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
-        'checksums': [
-            '0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0',  # netifaces-0.10.6.tar.gz
-        ],
+        'checksums': ['0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0'],
     }),
     ('netaddr', '0.7.19', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
-        'checksums': [
-            '38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd',  # netaddr-0.7.19.tar.gz
-        ],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
     }),
     ('funcsigs', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs'],
-        'checksums': [
-            'a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50',  # funcsigs-1.0.2.tar.gz
-        ],
+        'checksums': ['a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50'],
     }),
     ('mock', '2.0.0', {
         'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
-        'checksums': [
-            'b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba',  # mock-2.0.0.tar.gz
-        ],
+        'checksums': ['b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba'],
     }),
     ('pytz', '2017.2', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
-        'checksums': [
-            'f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589',  # pytz-2017.2.zip
-        ],
+        'checksums': ['f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589'],
     }),
     ('pandas', '0.20.3', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
-        'checksums': [
-            'a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66',  # pandas-0.20.3.tar.gz
-        ],
+        'checksums': ['a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66'],
     }),
     ('bitstring', '3.1.5', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/b/bitstring'],
-        'checksums': [
-            'c163a86fcef377c314690051885d86b47419e3e1770990c212e16723c1c08faa',  # bitstring-3.1.5.zip
-        ],
+        'checksums': ['c163a86fcef377c314690051885d86b47419e3e1770990c212e16723c1c08faa'],
     }),
     ('virtualenv', '15.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
-        'checksums': [
-            '02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a',  # virtualenv-15.1.0.tar.gz
-        ],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
     }),
     ('docopt', '0.6.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
-        'checksums': [
-            '49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491',  # docopt-0.6.2.tar.gz
-        ],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
     }),
     ('joblib', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
-        'checksums': [
-            '7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085',  # joblib-0.11.tar.gz
-        ],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
     }),
     ('xlrd', '1.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/x/xlrd'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2017b.eb
@@ -36,21 +36,15 @@ exts_list = [
     ('setuptools', '36.5.0', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
-        'checksums': [
-            'ce2007c1cea3359870b80657d634253a0765b0c7dc5a988d77ba803fc86f2c64',  # setuptools-36.5.0.zip
-        ],
+        'checksums': ['ce2007c1cea3359870b80657d634253a0765b0c7dc5a988d77ba803fc86f2c64'],
     }),
     ('pip', '9.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
-        'checksums': [
-            '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d',  # pip-9.0.1.tar.gz
-        ],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
     }),
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
-        'checksums': [
-            'f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98',  # nose-1.3.7.tar.gz
-        ],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
     }),
     ('numpy', '1.13.1', {
         'patches': ['numpy-1.12.0-mkl.patch'],
@@ -64,88 +58,63 @@ exts_list = [
     ('scipy', '0.19.1', {
         'source_tmpl': '%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
-        'checksums': [
-            'a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6',  # scipy-0.19.1.tar.gz
-        ],
+        'checksums': ['a19a2ca7a7336495ec180adeaa0dfdcf41e96dbbee90d51c3ed828ba570884e6'],
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
-        'checksums': [
-            '3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3',  # blist-1.3.6.tar.gz
-        ],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
     }),
     ('mpi4py', '2.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
-        'checksums': [
-            '6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81',  # mpi4py-2.0.0.tar.gz
-        ],
+        'checksums': ['6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81'],
     }),
     ('paycheck', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
-        'checksums': [
-            '6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34',  # paycheck-1.0.2.tar.gz
-        ],
+        'checksums': ['6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34'],
     }),
     ('pbr', '3.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
-        'checksums': [
-            '05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1',  # pbr-3.1.1.tar.gz
-        ],
+        'checksums': ['05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1'],
     }),
     ('Cython', '0.26.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
-        'checksums': [
-            'c2e63c4794161135adafa8aa4a855d6068073f421c83ffacc39369497a189dd5',  # Cython-0.26.1.tar.gz
-        ],
+        'checksums': ['c2e63c4794161135adafa8aa4a855d6068073f421c83ffacc39369497a189dd5'],
     }),
     ('six', '1.11.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-        'checksums': [
-            '70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9',  # six-1.11.0.tar.gz
-        ],
+        'checksums': ['70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9'],
     }),
     ('dateutil', '2.6.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
-        'checksums': [
-            '891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca',  # python-dateutil-2.6.1.tar.gz
-        ],
+        'checksums': ['891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca'],
     }),
     ('deap', '1.0.2', {
         'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
-        'checksums': [
-            'c52bd32b8f0143db3a0b90f2b976c920b588638d6999ca0d038d8b1c07f7950b',  # deap-1.0.2.post2.tar.gz
-        ],
+        'checksums': ['c52bd32b8f0143db3a0b90f2b976c920b588638d6999ca0d038d8b1c07f7950b'],
     }),
     ('decorator', '4.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-        'checksums': [
-            '7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5',  # decorator-4.1.2.tar.gz
-        ],
+        'checksums': ['7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5'],
     }),
     ('arff', '2.1.1', {
         'source_tmpl': 'liac-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
-        'checksums': [
-            'b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817',  # liac-arff-2.1.1.tar.gz
-        ],
+        'checksums': ['b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817'],
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
-        'checksums': [
-            'f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c',  # pycrypto-2.6.1.tar.gz
-        ],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
-        'checksums': [
-            '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
-        ],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
     ('ipaddress', '1.0.22', {
         'source_urls': ['https://pypi.python.org/packages/source/i/ipaddress/'],
+        'checksums': ['b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c'],
     }),
     ('asn1crypto', '0.24.0', {
         'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
@@ -179,77 +148,53 @@ exts_list = [
     }),
     ('paramiko', '2.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
-        'checksums': [
-            'ff94ae65379914ec3c960de731381f49092057b6dd1d24d18842ead5a2eb2277',  # paramiko-2.2.1.tar.gz
-        ],
+        'checksums': ['ff94ae65379914ec3c960de731381f49092057b6dd1d24d18842ead5a2eb2277'],
     }),
     ('pyparsing', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
-        'checksums': [
-            '0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04',  # pyparsing-2.2.0.tar.gz
-        ],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
     }),
     ('netifaces', '0.10.6', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
-        'checksums': [
-            '0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0',  # netifaces-0.10.6.tar.gz
-        ],
+        'checksums': ['0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0'],
     }),
     ('netaddr', '0.7.19', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
-        'checksums': [
-            '38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd',  # netaddr-0.7.19.tar.gz
-        ],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
     }),
     ('funcsigs', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs'],
-        'checksums': [
-            'a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50',  # funcsigs-1.0.2.tar.gz
-        ],
+        'checksums': ['a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50'],
     }),
     ('mock', '2.0.0', {
         'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
-        'checksums': [
-            'b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba',  # mock-2.0.0.tar.gz
-        ],
+        'checksums': ['b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba'],
     }),
     ('pytz', '2017.2', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
-        'checksums': [
-            'f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589',  # pytz-2017.2.zip
-        ],
+        'checksums': ['f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589'],
     }),
     ('pandas', '0.20.3', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
-        'checksums': [
-            'a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66',  # pandas-0.20.3.tar.gz
-        ],
+        'checksums': ['a777e07633d83d546c55706420179551c8e01075b53c497dcf8ae4036766bc66'],
     }),
     ('bitstring', '3.1.5', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/b/bitstring'],
-        'checksums': [
-            'c163a86fcef377c314690051885d86b47419e3e1770990c212e16723c1c08faa',  # bitstring-3.1.5.zip
-        ],
+        'checksums': ['c163a86fcef377c314690051885d86b47419e3e1770990c212e16723c1c08faa'],
     }),
     ('virtualenv', '15.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
-        'checksums': [
-            '02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a',  # virtualenv-15.1.0.tar.gz
-        ],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
     }),
     ('docopt', '0.6.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
-        'checksums': [
-            '49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491',  # docopt-0.6.2.tar.gz
-        ],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
     }),
     ('joblib', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
-        'checksums': [
-            '7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085',  # joblib-0.11.tar.gz
-        ],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
     }),
     ('xlrd', '1.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/x/xlrd'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2018.01.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2018.01.eb
@@ -36,21 +36,15 @@ exts_list = [
     ('setuptools', '37.0.0', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
-        'checksums': [
-            '0b95db16abf74d435217f17774245fce1ea5a583e5ae8098d98f4ab0145491e3',  # setuptools-37.0.0.zip
-        ],
+        'checksums': ['0b95db16abf74d435217f17774245fce1ea5a583e5ae8098d98f4ab0145491e3'],
     }),
     ('pip', '9.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
-        'checksums': [
-            '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d',  # pip-9.0.1.tar.gz
-        ],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
     }),
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
-        'checksums': [
-            'f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98',  # nose-1.3.7.tar.gz
-        ],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
     }),
     ('numpy', '1.13.3', {
         'patches': ['numpy-1.12.0-mkl.patch'],
@@ -64,87 +58,62 @@ exts_list = [
     ('scipy', '1.0.0', {
         'source_tmpl': '%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
-        'checksums': [
-            '87ea1f11a0e9ec08c264dc64551d501fa307289460705f6fccd84cbfc7926d10',  # scipy-1.0.0.tar.gz
-        ],
+        'checksums': ['87ea1f11a0e9ec08c264dc64551d501fa307289460705f6fccd84cbfc7926d10'],
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
-        'checksums': [
-            '3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3',  # blist-1.3.6.tar.gz
-        ],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
     }),
     ('mpi4py', '3.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
-        'checksums': [
-            'b457b02d85bdd9a4775a097fac5234a20397b43e073f14d9e29b6cd78c68efd7',  # mpi4py-3.0.0.tar.gz
-        ],
+        'checksums': ['b457b02d85bdd9a4775a097fac5234a20397b43e073f14d9e29b6cd78c68efd7'],
     }),
     ('paycheck', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
-        'checksums': [
-            '6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34',  # paycheck-1.0.2.tar.gz
-        ],
+        'checksums': ['6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34'],
     }),
     ('pbr', '3.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
-        'checksums': [
-            '05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1',  # pbr-3.1.1.tar.gz
-        ],
+        'checksums': ['05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1'],
     }),
     ('Cython', '0.27.3', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
-        'checksums': [
-            '6a00512de1f2e3ce66ba35c5420babaef1fe2d9c43a8faab4080b0dbcc26bc64',  # Cython-0.27.3.tar.gz
-        ],
+        'checksums': ['6a00512de1f2e3ce66ba35c5420babaef1fe2d9c43a8faab4080b0dbcc26bc64'],
     }),
     ('six', '1.11.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-        'checksums': [
-            '70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9',  # six-1.11.0.tar.gz
-        ],
+        'checksums': ['70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9'],
     }),
     ('dateutil', '2.6.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
-        'checksums': [
-            '891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca',  # python-dateutil-2.6.1.tar.gz
-        ],
+        'checksums': ['891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca'],
     }),
     ('deap', '1.2.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
-        'checksums': [
-            '95c63e66d755ec206c80fdb2908851c0bef420ee8651ad7be4f0578e9e909bcf',  # deap-1.2.2.tar.gz
-        ],
+        'checksums': ['95c63e66d755ec206c80fdb2908851c0bef420ee8651ad7be4f0578e9e909bcf'],
     }),
     ('decorator', '4.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-        'checksums': [
-            '7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5',  # decorator-4.1.2.tar.gz
-        ],
+        'checksums': ['7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5'],
     }),
     ('arff', '2.1.1', {
         'source_tmpl': 'liac-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
-        'checksums': [
-            'b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817',  # liac-arff-2.1.1.tar.gz
-        ],
+        'checksums': ['b8ef2c64ae5318f6884dc0e20b8491b0b1c96151a40077a479e0f57257cab817'],
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
-        'checksums': [
-            'f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c',  # pycrypto-2.6.1.tar.gz
-        ],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
-        'checksums': [
-            '64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa',  # ecdsa-0.13.tar.gz
-        ],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
     ('ipaddress', '1.0.22', {
         'source_urls': ['https://pypi.python.org/packages/source/i/ipaddress/'],
+        'checksums': ['b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c'],
     }),
     ('asn1crypto', '0.24.0', {
         'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
@@ -178,77 +147,53 @@ exts_list = [
     }),
     ('paramiko', '2.4.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
-        'checksums': [
-            '486f637f0a33a4792e0e567be37426c287efaa8c4c4a45e3216f9ce7fd70b1fc',  # paramiko-2.4.0.tar.gz
-        ],
+        'checksums': ['486f637f0a33a4792e0e567be37426c287efaa8c4c4a45e3216f9ce7fd70b1fc'],
     }),
     ('pyparsing', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
-        'checksums': [
-            '0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04',  # pyparsing-2.2.0.tar.gz
-        ],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
     }),
     ('netifaces', '0.10.6', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
-        'checksums': [
-            '0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0',  # netifaces-0.10.6.tar.gz
-        ],
+        'checksums': ['0c4da523f36d36f1ef92ee183f2512f3ceb9a9d2a45f7d19cda5a42c6689ebe0'],
     }),
     ('netaddr', '0.7.19', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
-        'checksums': [
-            '38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd',  # netaddr-0.7.19.tar.gz
-        ],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
     }),
     ('funcsigs', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs'],
-        'checksums': [
-            'a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50',  # funcsigs-1.0.2.tar.gz
-        ],
+        'checksums': ['a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50'],
     }),
     ('mock', '2.0.0', {
         'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
-        'checksums': [
-            'b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba',  # mock-2.0.0.tar.gz
-        ],
+        'checksums': ['b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba'],
     }),
     ('pytz', '2017.3', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
-        'checksums': [
-            'fae4cffc040921b8a2d60c6cf0b5d662c1190fe54d718271db4eb17d44a185b7',  # pytz-2017.3.zip
-        ],
+        'checksums': ['fae4cffc040921b8a2d60c6cf0b5d662c1190fe54d718271db4eb17d44a185b7'],
     }),
     ('pandas', '0.21.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
-        'checksums': [
-            '5cd5cb30e72eeaf202f0e5e180780b897570e889d2db328c689a5a263405c559',  # pandas-0.21.0.tar.gz
-        ],
+        'checksums': ['5cd5cb30e72eeaf202f0e5e180780b897570e889d2db328c689a5a263405c559'],
     }),
     ('bitstring', '3.1.5', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/b/bitstring'],
-        'checksums': [
-            'c163a86fcef377c314690051885d86b47419e3e1770990c212e16723c1c08faa',  # bitstring-3.1.5.zip
-        ],
+        'checksums': ['c163a86fcef377c314690051885d86b47419e3e1770990c212e16723c1c08faa'],
     }),
     ('virtualenv', '15.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
-        'checksums': [
-            '02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a',  # virtualenv-15.1.0.tar.gz
-        ],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
     }),
     ('docopt', '0.6.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
-        'checksums': [
-            '49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491',  # docopt-0.6.2.tar.gz
-        ],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
     }),
     ('joblib', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
-        'checksums': [
-            '7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085',  # joblib-0.11.tar.gz
-        ],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
     }),
     ('xlrd', '1.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/x/xlrd'],


### PR DESCRIPTION
Somehow the missing checksum slipped through in #7022, even though the tests are supposed to catch missing checksums in easyconfigs being touched...

Works as expected with `--check-contrib` though, which uses the same code as the tests...

```
$ eb --check-contrib  easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2017b.eb --ignore-osdeps
== temporary log file in case of crash /Users/kehoste/work/TMP/eb-OW6INh/easybuild-5MuZoZ.log

Running style check on 1 easyconfig(s)...

[PASS] /Volumes/work/easybuild-easyconfigs/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2017b.eb

>> All style checks PASSed!

Checking for SHA256 checksums in 1 easyconfig(s)...

[FAIL] /Volumes/work/easybuild-easyconfigs/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2017b.eb
Checksums missing for one or more sources/patches of extension ipaddress in Python-2.7.14-foss-2017b.eb: found 1 sources + 0 patches vs 0 checksums

>> One or more SHA256 checksums checks FAILED!

ERROR: One or more contribution checks FAILED!
```