### PR TITLE
fix installation of scikit-image 0.13.x by including missing required PyWavelets extension

### DIFF
--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.0-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.0-foss-2017b-Python-3.6.3.eb
@@ -12,9 +12,6 @@ It strives to be simple and efficient, accessible to everybody, and reusable in 
 
 toolchain = {'name': 'foss', 'version': '2017b'}
 
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
 dependencies = [
     ('Python', '3.6.3'),
     ('Qhull', '2015.2'),
@@ -22,10 +19,22 @@ dependencies = [
     ('Pillow', '4.3.0', versionsuffix),
 ]
 
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'download_dep_fail': True,
+    'use_pip': True,
+}
+exts_filter = ("python -c 'import %(ext_name)s'", '')
+
 exts_list = [
     ('networkx', '1.11', {
         'source_urls': ['https://pypi.python.org/packages/source/n/networkx'],
         'checksums': ['0d0e70e10dfb47601cbb3425a00e03e2a2e97477be6f80638fef91d54dd1e4b8'],
+    }),
+    ('PyWavelets', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/P/PyWavelets'],
+        'checksums': ['3c5cece36d4e17d395be6e9ac6b80ce7b774a1f71c251756c6163e63b6d878dc'],
+        'modulename': 'pywt',
     }),
     (name, version, {
         'modulename': 'skimage',

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.0-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.0-intel-2017a-Python-2.7.13.eb
@@ -12,20 +12,28 @@ It strives to be simple and efficient, accessible to everybody, and reusable in 
 
 toolchain = {'name': 'intel', 'version': '2017a'}
 
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
 dependencies = [
     ('Python', '2.7.13'),
     ('Qhull', '2015.2'),
     ('matplotlib', '2.0.2', versionsuffix + '-libpng-1.6.29'),
     ('Pillow', '4.3.0', versionsuffix),
 ]
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'download_dep_fail': True,
+    'use_pip': True,
+}
+exts_filter = ("python -c 'import %(ext_name)s'", '')
 
 exts_list = [
     ('networkx', '1.11', {
         'source_urls': ['https://pypi.python.org/packages/source/n/networkx'],
         'checksums': ['0d0e70e10dfb47601cbb3425a00e03e2a2e97477be6f80638fef91d54dd1e4b8'],
+    }),
+    ('PyWavelets', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/P/PyWavelets'],
+        'checksums': ['3c5cece36d4e17d395be6e9ac6b80ce7b774a1f71c251756c6163e63b6d878dc'],
+        'modulename': 'pywt',
     }),
     (name, version, {
         'modulename': 'skimage',

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.0-intel-2017a-Python-3.6.1.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.0-intel-2017a-Python-3.6.1.eb
@@ -12,9 +12,6 @@ It strives to be simple and efficient, accessible to everybody, and reusable in 
 
 toolchain = {'name': 'intel', 'version': '2017a'}
 
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
 dependencies = [
     ('Python', '3.6.1'),
     ('Qhull', '2015.2'),
@@ -22,10 +19,22 @@ dependencies = [
     ('Pillow', '4.2.1', versionsuffix),
 ]
 
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'download_dep_fail': True,
+    'use_pip': True,
+}
+exts_filter = ("python -c 'import %(ext_name)s'", '')
+
 exts_list = [
     ('networkx', '1.11', {
         'source_urls': ['https://pypi.python.org/packages/source/n/networkx'],
         'checksums': ['0d0e70e10dfb47601cbb3425a00e03e2a2e97477be6f80638fef91d54dd1e4b8'],
+    }),
+    ('PyWavelets', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/P/PyWavelets'],
+        'checksums': ['3c5cece36d4e17d395be6e9ac6b80ce7b774a1f71c251756c6163e63b6d878dc'],
+        'modulename': 'pywt',
     }),
     (name, version, {
         'modulename': 'skimage',

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.1-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.1-foss-2017b-Python-3.6.3.eb
@@ -12,9 +12,6 @@ It strives to be simple and efficient, accessible to everybody, and reusable in 
 
 toolchain = {'name': 'foss', 'version': '2017b'}
 
-exts_defaultclass = 'PythonPackage'
-exts_filter = ("python -c 'import %(ext_name)s'", '')
-
 dependencies = [
     ('Python', '3.6.3'),
     ('Qhull', '2015.2'),
@@ -22,10 +19,22 @@ dependencies = [
     ('Pillow', '4.3.0', versionsuffix),
 ]
 
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'download_dep_fail': True,
+    'use_pip': True,
+}
+exts_filter = ("python -c 'import %(ext_name)s'", '')
+
 exts_list = [
     ('networkx', '1.11', {
         'source_urls': ['https://pypi.python.org/packages/source/n/networkx'],
         'checksums': ['0d0e70e10dfb47601cbb3425a00e03e2a2e97477be6f80638fef91d54dd1e4b8'],
+    }),
+    ('PyWavelets', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/P/PyWavelets'],
+        'checksums': ['3c5cece36d4e17d395be6e9ac6b80ce7b774a1f71c251756c6163e63b6d878dc'],
+        'modulename': 'pywt',
     }),
     (name, version, {
         'modulename': 'skimage',

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.1-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.1-foss-2018a-Python-3.6.4.eb
@@ -13,6 +13,10 @@ It strives to be simple and efficient, accessible to everybody, and reusable in 
 toolchain = {'name': 'foss', 'version': '2018a'}
 
 exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'download_dep_fail': True,
+    'use_pip': True,
+}
 exts_filter = ("python -c 'import %(ext_name)s'", '')
 
 dependencies = [
@@ -27,6 +31,11 @@ exts_list = [
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/n/networkx'],
         'checksums': ['64272ca418972b70a196cb15d9c85a5a6041f09a2f32e0d30c0255f25d458bb1'],
+    }),
+    ('PyWavelets', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/P/PyWavelets'],
+        'checksums': ['3c5cece36d4e17d395be6e9ac6b80ce7b774a1f71c251756c6163e63b6d878dc'],
+        'modulename': 'pywt',
     }),
     (name, version, {
         'modulename': 'skimage',

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.1-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.1-intel-2017b-Python-2.7.14.eb
@@ -12,9 +12,6 @@ It strives to be simple and efficient, accessible to everybody, and reusable in 
 
 toolchain = {'name': 'intel', 'version': '2017b'}
 
-exts_defaultclass = 'PythonPackage'
-exts_filter = ("python -c 'import %(ext_name)s'", '')
-
 dependencies = [
     ('Python', '2.7.14'),
     ('Qhull', '2015.2'),
@@ -22,10 +19,22 @@ dependencies = [
     ('Pillow', '4.3.0', versionsuffix),
 ]
 
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'download_dep_fail': True,
+    'use_pip': True,
+}
+exts_filter = ("python -c 'import %(ext_name)s'", '')
+
 exts_list = [
     ('networkx', '1.11', {
         'source_urls': ['https://pypi.python.org/packages/source/n/networkx'],
         'checksums': ['0d0e70e10dfb47601cbb3425a00e03e2a2e97477be6f80638fef91d54dd1e4b8'],
+    }),
+    ('PyWavelets', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/P/PyWavelets'],
+        'checksums': ['3c5cece36d4e17d395be6e9ac6b80ce7b774a1f71c251756c6163e63b6d878dc'],
+        'modulename': 'pywt',
     }),
     (name, version, {
         'modulename': 'skimage',


### PR DESCRIPTION
installation now fails with a weird error like:

```
Processing dependencies for scikit-image==0.13.1
Searching for PyWavelets>=0.4.0
Reading https://pypi.python.org/simple/PyWavelets/
Downloading https://files.pythonhosted.org/packages/b4/42/074c6adcd1586926650d8365bcc3e1ab42f81a68c620c4242aa9297b01d9/PyWavelets-1.0.1.tar.gz#sha256=3c5cece36d4e17d395be6e9ac6b80ce7b774a1f71c251756c6163e63b6d878dc
Best match: PyWavelets 1.0.1
Processing PyWavelets-1.0.1.tar.gz
Writing /tmp/eb-9U_o_7/easy_install-8hzs3oix/PyWavelets-1.0.1/setup.cfg
Running PyWavelets-1.0.1/setup.py -q bdist_egg --dist-dir /tmp/eb-9U_o_7/easy_install-8hzs3oix/PyWavelets-1.0.1/egg-dist-tmp-o5hds8fq
Partial import of skimage during the build process.
Traceback (most recent call last):
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software/Python/3.6.4-foss-2018a/lib/python3.6/site-packages/setuptools/sandbox.py", line 157, in save_modules
    yield saved
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software/Python/3.6.4-foss-2018a/lib/python3.6/site-packages/setuptools/sandbox.py", line 198, in setup_context
    yield
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software/Python/3.6.4-foss-2018a/lib/python3.6/site-packages/setuptools/sandbox.py", line 248, in run_setup
    DirectorySandbox(setup_dir).run(runner)
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software/Python/3.6.4-foss-2018a/lib/python3.6/site-packages/setuptools/sandbox.py", line 278, in run
    return func()
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software/Python/3.6.4-foss-2018a/lib/python3.6/site-packages/setuptools/sandbox.py", line 246, in runner
    _execfile(setup_script, ns)
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software/Python/3.6.4-foss-2018a/lib/python3.6/site-packages/setuptools/sandbox.py", line 47, in _execfile
    exec(code, globals, locals)
  File "/tmp/eb-9U_o_7/easy_install-8hzs3oix/PyWavelets-1.0.1/setup.py", line 453, in <module>
  File "/tmp/eb-9U_o_7/easy_install-8hzs3oix/PyWavelets-1.0.1/setup.py", line 427, in setup_package
  File "/tmp/eb-9U_o_7/easy_install-8hzs3oix/PyWavelets-1.0.1/setup.py", line 359, in parse_setuppy_commands
NameError: name 'warnings' is not defined
```

This problem does not occur when we install `PyWavelets` ourselves rather than having it pulled in from PyPI...

It seems like this only pops up now with `PyWavelets` 1.0.1 which was released recently, it didn't pop up when `PyWavelets` 1.0.0 was the latest available version.