### PR TITLE
also install shared libraries for LZO

### DIFF
--- a/easybuild/easyconfigs/l/LZO/LZO-2.06-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.06-goolf-1.4.10.eb
@@ -25,6 +25,8 @@ sanity_check_paths = {
     'dirs': ['lib', 'include']
 }
 
+configopts = '--enable-shared'
+
 runtest = 'test'
 
 parallel = 1    # this is a very conservative choice

--- a/easybuild/easyconfigs/l/LZO/LZO-2.06-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.06-goolf-1.4.10.eb
@@ -15,8 +15,9 @@ version = '2.06'
 homepage = 'http://www.oberhumer.com/opensource/lzo/'
 description = "LZO-2.06: Portable lossless data compression library"
 
-sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage + 'download/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['ff79e6f836d62d3f86ef6ce893ed65d07e638ef4d3cb952963471b4234d43e73']
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 

--- a/easybuild/easyconfigs/l/LZO/LZO-2.06-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.06-goolf-1.4.10.eb
@@ -21,15 +21,15 @@ checksums = ['ff79e6f836d62d3f86ef6ce893ed65d07e638ef4d3cb952963471b4234d43e73']
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
+configopts = '--enable-shared'
+
+parallel = 1    # this is a very conservative choice
+
+runtest = 'test'
+
 sanity_check_paths = {
     'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
     'dirs': ['include']
 }
-
-configopts = '--enable-shared'
-
-runtest = 'test'
-
-parallel = 1    # this is a very conservative choice
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.06-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.06-goolf-1.4.10.eb
@@ -21,7 +21,7 @@ source_urls = [homepage + 'download/']
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 sanity_check_paths = {
-    'files': [],
+    'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
     'dirs': ['lib', 'include']
 }
 

--- a/easybuild/easyconfigs/l/LZO/LZO-2.06-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.06-goolf-1.4.10.eb
@@ -23,7 +23,7 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 sanity_check_paths = {
     'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
-    'dirs': ['lib', 'include']
+    'dirs': ['include']
 }
 
 configopts = '--enable-shared'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.06-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.06-ictce-5.3.0.eb
@@ -15,8 +15,9 @@ version = '2.06'
 homepage = 'http://www.oberhumer.com/opensource/lzo/'
 description = "LZO-2.06: Portable lossless data compression library"
 
-sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage + 'download/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['ff79e6f836d62d3f86ef6ce893ed65d07e638ef4d3cb952963471b4234d43e73']
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 

--- a/easybuild/easyconfigs/l/LZO/LZO-2.06-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.06-ictce-5.3.0.eb
@@ -23,7 +23,7 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
 sanity_check_paths = {
     'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
-    'dirs': ['lib', 'include']
+    'dirs': ['include']
 }
 
 runtest = 'test'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.06-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.06-ictce-5.3.0.eb
@@ -27,6 +27,8 @@ sanity_check_paths = {
 
 runtest = 'test'
 
+configopts = '--enable-shared'
+
 parallel = 1    # this is a very conservative choice
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.06-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.06-ictce-5.3.0.eb
@@ -21,7 +21,7 @@ source_urls = [homepage + 'download/']
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
 sanity_check_paths = {
-    'files': [],
+    'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
     'dirs': ['lib', 'include']
 }
 

--- a/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2016b.eb
@@ -28,7 +28,7 @@ runtest = 'test'
 
 sanity_check_paths = {
     'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
-    'dirs': ['lib', 'include']
+    'dirs': ['include']
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2016b.eb
@@ -21,6 +21,8 @@ source_urls = [homepage + 'download/']
 toolchain = {'name': 'intel', 'version': '2016b'}
 toolchainopts = {'pic': True}
 
+configopts = '--enable-shared'
+
 runtest = 'test'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2016b.eb
@@ -15,8 +15,9 @@ version = '2.09'
 homepage = 'http://www.oberhumer.com/opensource/lzo/'
 description = "LZO-2.06: Portable lossless data compression library"
 
-sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage + 'download/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['f294a7ced313063c057c504257f437c8335c41bfeed23531ee4e6a2b87bcb34c']
 
 toolchain = {'name': 'intel', 'version': '2016b'}
 toolchainopts = {'pic': True}

--- a/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2016b.eb
@@ -26,7 +26,7 @@ configopts = '--enable-shared'
 runtest = 'test'
 
 sanity_check_paths = {
-    'files': [],
+    'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
     'dirs': ['lib', 'include']
 }
 

--- a/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2017b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2017b.eb
@@ -28,7 +28,7 @@ runtest = 'test'
 
 sanity_check_paths = {
     'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
-    'dirs': ['lib', 'include']
+    'dirs': ['include']
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2017b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2017b.eb
@@ -27,7 +27,7 @@ configopts = '--enable-shared'
 runtest = 'test'
 
 sanity_check_paths = {
-    'files': [],
+    'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
     'dirs': ['lib', 'include']
 }
 

--- a/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2017b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.09-intel-2017b.eb
@@ -22,6 +22,8 @@ checksums = ['f294a7ced313063c057c504257f437c8335c41bfeed23531ee4e6a2b87bcb34c']
 toolchain = {'name': 'intel', 'version': '2017b'}
 toolchainopts = {'pic': True}
 
+configopts = '--enable-shared'
+
 runtest = 'test'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-GCCcore-6.4.0.eb
@@ -24,6 +24,8 @@ toolchainopts = {'pic': True}
 
 builddependencies = [('binutils', '2.28')]
 
+configopts = '--enable-shared'
+
 runtest = 'test'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-GCCcore-6.4.0.eb
@@ -30,7 +30,7 @@ runtest = 'test'
 
 sanity_check_paths = {
     'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
-    'dirs': ['lib', 'include']
+    'dirs': ['include']
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-GCCcore-6.4.0.eb
@@ -29,7 +29,7 @@ configopts = '--enable-shared'
 runtest = 'test'
 
 sanity_check_paths = {
-    'files': [],
+    'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
     'dirs': ['lib', 'include']
 }
 

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2016a.eb
@@ -31,7 +31,7 @@ runtest = 'test'
 
 sanity_check_paths = {
     'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
-    'dirs': ['lib', 'include']
+    'dirs': ['include']
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2016a.eb
@@ -25,6 +25,8 @@ checksums = ['c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072']
 toolchain = {'name': 'foss', 'version': '2016a'}
 toolchainopts = {'pic': True}
 
+configopts = '--enable-shared'
+
 runtest = 'test'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2016a.eb
@@ -30,7 +30,7 @@ configopts = '--enable-shared'
 runtest = 'test'
 
 sanity_check_paths = {
-    'files': [],
+    'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
     'dirs': ['lib', 'include']
 }
 

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2016b.eb
@@ -25,6 +25,8 @@ checksums = ['c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072']
 toolchain = {'name': 'foss', 'version': '2016b'}
 toolchainopts = {'pic': True}
 
+configopts = '--enable-shared'
+
 runtest = 'test'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2016b.eb
@@ -31,7 +31,7 @@ runtest = 'test'
 
 sanity_check_paths = {
     'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
-    'dirs': ['lib', 'include']
+    'dirs': ['include']
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2016b.eb
@@ -30,7 +30,7 @@ configopts = '--enable-shared'
 runtest = 'test'
 
 sanity_check_paths = {
-    'files': [],
+    'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
     'dirs': ['lib', 'include']
 }
 

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2017a.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2017a.eb
@@ -31,7 +31,7 @@ runtest = 'test'
 
 sanity_check_paths = {
     'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
-    'dirs': ['lib', 'include']
+    'dirs': ['include']
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2017a.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2017a.eb
@@ -25,6 +25,8 @@ source_urls = [homepage + 'download/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072']
 
+configopts = '--enable-shared'
+
 runtest = 'test'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2017a.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2017a.eb
@@ -30,7 +30,7 @@ configopts = '--enable-shared'
 runtest = 'test'
 
 sanity_check_paths = {
-    'files': [],
+    'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
     'dirs': ['lib', 'include']
 }
 

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2018a.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2018a.eb
@@ -31,7 +31,7 @@ runtest = 'test'
 
 sanity_check_paths = {
     'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
-    'dirs': ['lib', 'include']
+    'dirs': ['include']
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2018a.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2018a.eb
@@ -25,6 +25,8 @@ source_urls = [homepage + 'download/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072']
 
+configopts = '--enable-shared'
+
 runtest = 'test'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2018a.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2018a.eb
@@ -30,7 +30,7 @@ configopts = '--enable-shared'
 runtest = 'test'
 
 sanity_check_paths = {
-    'files': [],
+    'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
     'dirs': ['lib', 'include']
 }
 

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2018b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2018b.eb
@@ -31,7 +31,7 @@ runtest = 'test'
 
 sanity_check_paths = {
     'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
-    'dirs': ['lib', 'include']
+    'dirs': ['include']
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2018b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2018b.eb
@@ -25,6 +25,8 @@ source_urls = [homepage + 'download/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072']
 
+configopts = '--enable-shared'
+
 runtest = 'test'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2018b.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-foss-2018b.eb
@@ -30,7 +30,7 @@ configopts = '--enable-shared'
 runtest = 'test'
 
 sanity_check_paths = {
-    'files': [],
+    'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
     'dirs': ['lib', 'include']
 }
 

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-intel-2017a.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-intel-2017a.eb
@@ -17,6 +17,7 @@ description = "Portable lossless data compression library"
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage + 'download/']
+checksums = ['c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072']
 
 toolchain = {'name': 'intel', 'version': '2017a'}
 toolchainopts = {'pic': True}

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-intel-2017a.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-intel-2017a.eb
@@ -27,7 +27,7 @@ runtest = 'test'
 
 sanity_check_paths = {
     'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
-    'dirs': ['lib', 'include']
+    'dirs': ['include']
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-intel-2017a.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-intel-2017a.eb
@@ -21,6 +21,8 @@ source_urls = [homepage + 'download/']
 toolchain = {'name': 'intel', 'version': '2017a'}
 toolchainopts = {'pic': True}
 
+configopts = '--enable-shared'
+
 runtest = 'test'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-intel-2017a.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-intel-2017a.eb
@@ -26,7 +26,7 @@ configopts = '--enable-shared'
 runtest = 'test'
 
 sanity_check_paths = {
-    'files': [],
+    'files': ['lib/liblzo2.a', 'lib/liblzo2.so'],
     'dirs': ['lib', 'include']
 }
 


### PR DESCRIPTION
while installing an application that needs the dynamic library `liblzo2.so.2` I realized that the easyconfig for LZO only provides static libraries because that's the default in the build system provided by LZO

```
lzo-2.10]$ ./configure --help |grep -i shared
  --enable-shared[=PKGS]  build shared libraries [default=no]
```

I have enabled the dynamic build for all the easyconfigs and extended the sanity check

@boegel I guess you are the only one who has all these toolchains installed. Can you trigger a test build please?

