### PR TITLE
{devel,vis}[foss/2018b] add missing gperf dep for Qt5 5.10.1 and new config for Qt5 5.11.2

### DIFF
--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.10.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.10.1-foss-2018a.eb
@@ -24,6 +24,7 @@ dependencies = [
     ('libGLU', '9.0.0'),
     ('NSS', '3.39'),
     ('DBus', '1.13.6'),
+    ('gperf', '3.1'),
 ]
 
 # qtgamepad needs recent kernel/libevdev (fails on RHEL 6.x)

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.11.2-foss-2018b.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.11.2-foss-2018b.eb
@@ -1,7 +1,7 @@
 easyblock = 'EB_Qt'
 
 name = 'Qt5'
-version = '5.10.1'
+version = '5.11.2'
 
 homepage = 'http://qt.io/'
 description = "Qt is a comprehensive cross-platform C++ application framework."
@@ -13,7 +13,7 @@ source_urls = [
     'http://download.qt.io/archive/qt/%(version_major_minor)s/%(version)s/single/'
 ]
 sources = ['qt-everywhere-src-%(version)s.tar.xz']
-checksums = ['05ffba7b811b854ed558abf2be2ddbd3bb6ddd0b60ea4b5da75d277ac15e740a']
+checksums = ['c6104b840b6caee596fa9a35bc5f57f67ed5a99d6a36497b6fe66f990a53ca81']
 
 builddependencies = [('pkg-config', '0.29.2')]
 


### PR DESCRIPTION
configs QT5.10.1 (bugfix) and QT5.11.2 (new) for foss/2018b

This replaces PR #7082, which got corrupted when attempting a merge conflict resolution.