### PR TITLE
stop setting 'full_sanity_check' in easyconfigs

### DIFF
--- a/easybuild/easyconfigs/a/ARCH/ARCH-4.5.0-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/a/ARCH/ARCH-4.5.0-intel-2018a-Python-3.6.4.eb
@@ -35,9 +35,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/a/Albacore/Albacore-2.0.2-intel-2017a-Python-3.6.1.eb
+++ b/easybuild/easyconfigs/a/Albacore/Albacore-2.0.2-intel-2017a-Python-3.6.1.eb
@@ -41,9 +41,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/full_1dsq_basecaller.py', 'bin/paired_read_basecaller.py', 'bin/read_fast5_basecaller.py'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/b/BDBag/BDBag-1.4.1-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/b/BDBag/BDBag-1.4.1-intel-2018a-Python-2.7.14.eb
@@ -36,10 +36,6 @@ exts_list = [
     }),
 ]
 
-
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/b/bat/bat-0.3.3-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/b/bat/bat-0.3.3-intel-2017b-Python-3.6.3.eb
@@ -42,9 +42,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages']

--- a/easybuild/easyconfigs/b/bokeh/bokeh-0.12.15-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/b/bokeh/bokeh-0.12.15-intel-2018a-Python-3.6.4.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/bokeh'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/b/bokeh/bokeh-0.12.3-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/b/bokeh/bokeh-0.12.3-intel-2016b-Python-2.7.12.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/bokeh', 'bin/bokeh-server'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/b/bokeh/bokeh-0.12.3-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/b/bokeh/bokeh-0.12.3-intel-2016b-Python-3.5.2.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/bokeh', 'bin/bokeh-server'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/b/bx-python/bx-python-0.7.4-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/b/bx-python/bx-python-0.7.4-foss-2016b-Python-2.7.12.eb
@@ -35,9 +35,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['bin', 'lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/b/bx-python/bx-python-0.7.4-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/b/bx-python/bx-python-0.7.4-intel-2017a-Python-2.7.13.eb
@@ -34,9 +34,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['bin', 'lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/b/bx-python/bx-python-0.8.1-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/b/bx-python/bx-python-0.8.1-intel-2018a-Python-2.7.14.eb
@@ -35,9 +35,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['bin', 'lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/c/CNVkit/CNVkit-0.9.2-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/c/CNVkit/CNVkit-0.9.2-intel-2017b-Python-2.7.14.eb
@@ -50,9 +50,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/cnvkit.py'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/c/CatMAP/CatMAP-20170927-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/c/CatMAP/CatMAP-20170927-intel-2017b-Python-2.7.14.eb
@@ -44,8 +44,6 @@ exts_list = [
     }),
 ]
 
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/c/Cookiecutter/Cookiecutter-1.4.0-goolf-1.7.20-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/c/Cookiecutter/Cookiecutter-1.4.0-goolf-1.7.20-Python-2.7.11.eb
@@ -68,9 +68,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['chardetect', 'cookiecutter', 'futurize', 'pasteurize']],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/c/cget/cget-0.1.6-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/c/cget/cget-0.1.6-foss-2018a-Python-3.6.4.eb
@@ -42,8 +42,6 @@ exts_list = [
     }),
 ]
 
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/cget'],
     'dirs': ['lib/python%(pyshortver)s/site-packages']

--- a/easybuild/easyconfigs/c/custodian/custodian-1.1.0-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/c/custodian/custodian-1.1.0-intel-2017a-Python-2.7.13.eb
@@ -26,9 +26,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/d/dammit/dammit-0.3.2-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/d/dammit/dammit-0.3.2-intel-2017a-Python-2.7.13.eb
@@ -77,9 +77,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/d/dask/dask-0.12.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/d/dask/dask-0.12.0-intel-2016b-Python-2.7.12.eb
@@ -24,9 +24,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/d/dask/dask-0.12.0-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/d/dask/dask-0.12.0-intel-2016b-Python-3.5.2.eb
@@ -24,9 +24,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/d/dask/dask-0.16.0-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/d/dask/dask-0.16.0-intel-2017b-Python-3.6.3.eb
@@ -26,9 +26,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/d/dask/dask-0.17.0-foss-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/d/dask/dask-0.17.0-foss-2017a-Python-2.7.13.eb
@@ -26,9 +26,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/d/dask/dask-0.17.2-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/d/dask/dask-0.17.2-intel-2018a-Python-3.6.4.eb
@@ -55,9 +55,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/dask-%s' % x for x in ['mpi', 'remote', 'scheduler', 'ssh', 'submit', 'worker']],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/d/dask/dask-0.19.4-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/d/dask/dask-0.19.4-foss-2018b-Python-3.6.6.eb
@@ -77,9 +77,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/dask-%s' % x for x in ['mpi', 'remote', 'scheduler', 'ssh', 'submit', 'worker']],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/d/dask/dask-0.19.4-intel-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/d/dask/dask-0.19.4-intel-2018b-Python-3.6.6.eb
@@ -77,9 +77,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/dask-%s' % x for x in ['mpi', 'remote', 'scheduler', 'ssh', 'submit', 'worker']],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/d/deepTools/deepTools-2.5.4-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/d/deepTools/deepTools-2.5.4-intel-2017b-Python-3.6.3.eb
@@ -35,9 +35,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/bamCompare', 'bin/bamCoverage', 'bin/bamPEFragmentSize', 'bin/computeGCBias', 'bin/computeMatrix',
               'bin/correctGCBias', 'bin/multiBamSummary', 'bin/plotCorrelation', 'bin/plotCoverage',

--- a/easybuild/easyconfigs/d/distributed/distributed-1.14.3-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/d/distributed/distributed-1.14.3-intel-2016b-Python-2.7.12.eb
@@ -54,9 +54,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/dask-remote', 'bin/dask-scheduler', 'bin/dask-ssh', 'bin/dask-submit', 'bin/dask-worker',
               'bin/dcenter', 'bin/dcluster', 'bin/dscheduler', 'bin/dworker'],

--- a/easybuild/easyconfigs/d/distributed/distributed-1.14.3-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/d/distributed/distributed-1.14.3-intel-2016b-Python-3.5.2.eb
@@ -54,9 +54,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/dask-remote', 'bin/dask-scheduler', 'bin/dask-ssh', 'bin/dask-submit', 'bin/dask-worker',
               'bin/dcenter', 'bin/dcluster', 'bin/dscheduler', 'bin/dworker'],

--- a/easybuild/easyconfigs/d/distributed/distributed-1.21.6-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/d/distributed/distributed-1.21.6-intel-2018a-Python-3.6.4.eb
@@ -63,9 +63,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/dask-remote', 'bin/dask-scheduler', 'bin/dask-ssh', 'bin/dask-submit', 'bin/dask-worker'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/e/evmix/evmix-2.6-intel-2016b-R-3.3.1.eb
+++ b/easybuild/easyconfigs/e/evmix/evmix-2.6-intel-2016b-R-3.3.1.eb
@@ -27,9 +27,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['evmix', 'gsl'],

--- a/easybuild/easyconfigs/f/FSLeyes/FSLeyes-0.15.0-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/f/FSLeyes/FSLeyes-0.15.0-intel-2017a-Python-2.7.13.eb
@@ -69,9 +69,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/f/FireWorks/FireWorks-1.4.2-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/f/FireWorks/FireWorks-1.4.2-intel-2017a-Python-2.7.13.eb
@@ -47,9 +47,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/faceswap/faceswap-20180212-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/f/faceswap/faceswap-20180212-foss-2017b-Python-3.6.3.eb
@@ -50,9 +50,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/f/ffnet/ffnet-0.8.3-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/f/ffnet/ffnet-0.8.3-intel-2016a-Python-2.7.11.eb
@@ -26,9 +26,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/f/fullrmc/fullrmc-3.2.0-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/f/fullrmc/fullrmc-3.2.0-intel-2018a-Python-2.7.14.eb
@@ -49,9 +49,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': [('lib/python%(pyshortver)s/site-packages', 'lib64/python%(pyshortver)s/site-packages')],

--- a/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.2.3.eb
+++ b/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.2.3.eb
@@ -97,9 +97,6 @@ pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[:2])
 # on RHEL-based systems, some extensions get installed to lib, some to lib64
 modextrapaths = {'PYTHONPATH': ['lib/python%s/site-packages' % pyshortver, 'lib64/python%s/site-packages' % pyshortver]}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/gc3utils'],
     'dirs': ['lib/python%(pyver)s/site-packages/gc3pie-%%(version)s-py%(pyver)s.egg/gc3libs' % {'pyver': pyshortver}],

--- a/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.3.eb
+++ b/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.3.eb
@@ -97,9 +97,6 @@ pyver = '.'.join(SYS_PYTHON_VERSION.split('.')[:2])
 # on RHEL-based systems, some extensions get installed to lib, some to lib64
 modextrapaths = {'PYTHONPATH': ['lib/python%s/site-packages' % pyver, 'lib64/python%s/site-packages' % pyver]}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/gc3utils'],
     'dirs': [('lib/python%s/site-packages' % pyver, 'lib64/python%s/site-packages' % pyver)],

--- a/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.4.0.eb
+++ b/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.4.0.eb
@@ -97,9 +97,6 @@ pyver = '.'.join(SYS_PYTHON_VERSION.split('.')[:2])
 # on RHEL-based systems, some extensions get installed to lib, some to lib64
 modextrapaths = {'PYTHONPATH': ['lib/python%s/site-packages' % pyver, 'lib64/python%s/site-packages' % pyver]}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/gc3utils'],
     'dirs': [('lib/python%s/site-packages' % pyver, 'lib64/python%s/site-packages' % pyver)],

--- a/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.4.1.eb
+++ b/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.4.1.eb
@@ -97,9 +97,6 @@ pyver = '.'.join(SYS_PYTHON_VERSION.split('.')[:2])
 # on RHEL-based systems, some extensions get installed to lib, some to lib64
 modextrapaths = {'PYTHONPATH': ['lib/python%s/site-packages' % pyver, 'lib64/python%s/site-packages' % pyver]}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/gc3utils'],
     'dirs': [('lib/python%s/site-packages' % pyver, 'lib64/python%s/site-packages' % pyver)],

--- a/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.4.2.eb
+++ b/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.4.2.eb
@@ -97,9 +97,6 @@ pyver = '.'.join(SYS_PYTHON_VERSION.split('.')[:2])
 # on RHEL-based systems, some extensions get installed to lib, some to lib64
 modextrapaths = {'PYTHONPATH': ['lib/python%s/site-packages' % pyver, 'lib64/python%s/site-packages' % pyver]}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/gc3utils'],
     'dirs': [('lib/python%s/site-packages' % pyver, 'lib64/python%s/site-packages' % pyver)],

--- a/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.5.0.eb
+++ b/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.5.0.eb
@@ -155,9 +155,6 @@ pyver = '.'.join(SYS_PYTHON_VERSION.split('.')[:2])
 # on RHEL-based systems, some extensions get installed to lib, some to lib64
 modextrapaths = {'PYTHONPATH': ['lib/python%s/site-packages' % pyver, 'lib64/python%s/site-packages' % pyver]}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/gc3utils'],
     'dirs': [('lib/python%s/site-packages' % pyver, 'lib64/python%s/site-packages' % pyver)],

--- a/easybuild/easyconfigs/g/gdc-client/gdc-client-1.0.1-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/g/gdc-client/gdc-client-1.0.1-intel-2016b-Python-2.7.12.eb
@@ -46,9 +46,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/gdc-client'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/g/gdc-client/gdc-client-1.3.0-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/g/gdc-client/gdc-client-1.3.0-foss-2018a-Python-2.7.14.eb
@@ -123,9 +123,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/gdc-client'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/g/gdc-client/gdc-client-1.3.0-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/g/gdc-client/gdc-client-1.3.0-intel-2017b-Python-2.7.14.eb
@@ -123,9 +123,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/gdc-client'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/g/gensim/gensim-0.13.2-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/g/gensim/gensim-0.13.2-foss-2016a-Python-2.7.11.eb
@@ -36,9 +36,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/h/HiC-Pro/HiC-Pro-2.9.0-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/h/HiC-Pro/HiC-Pro-2.9.0-foss-2016b-Python-2.7.12.eb
@@ -53,9 +53,6 @@ modextrapaths = {
     'SCRIPTS': ['scripts']
 }
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/ice', 'config-system.txt', 'scripts/build_matrix', 'scripts/cutsite_trimming', 'bin/HiC-Pro'],
     'dirs': ['lib/python%(pyshortver)s/site-packages', 'scripts', 'bin/utils'],

--- a/easybuild/easyconfigs/h/hyperspy/hyperspy-1.1.1-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/h/hyperspy/hyperspy-1.1.1-intel-2016b-Python-3.5.2.eb
@@ -60,9 +60,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/'],

--- a/easybuild/easyconfigs/i/IPython/IPython-4.0.0-intel-2015a-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-4.0.0-intel-2015a-Python-2.7.10.eb
@@ -56,9 +56,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/ipython'],
     'dirs': ['lib/python%(pyshortver)s/site-packages/IPython'],

--- a/easybuild/easyconfigs/i/i-cisTarget/i-cisTarget-20160602-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/i-cisTarget/i-cisTarget-20160602-intel-2016a-Python-2.7.11.eb
@@ -48,9 +48,6 @@ dependencies = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['ctx-convert', 'ctx-db2r', 'ctx-gt', 'ctx-r2db', 'ctx-rcc']],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/i/ipyrad/ipyrad-0.6.15-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/i/ipyrad/ipyrad-0.6.15-intel-2017a-Python-2.7.13.eb
@@ -99,9 +99,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/ipyrad'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/l/LMfit/LMfit-0.9.9-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/l/LMfit/LMfit-0.9.9-intel-2018a-Python-3.6.4.eb
@@ -26,9 +26,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/MACS2/MACS2-2.1.0.20150731-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/MACS2/MACS2-2.1.0.20150731-goolf-1.4.10-Python-2.7.3.eb
@@ -20,6 +20,7 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
+checksums = ['5c87df78a89b15b2c3c8be54ce8216e3e0e28ffd1025d437697102016a64db8b']
 
 python = 'Python'
 pyver = '2.7.3'

--- a/easybuild/easyconfigs/m/MACS2/MACS2-2.1.0.20150731-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/MACS2/MACS2-2.1.0.20150731-goolf-1.4.10-Python-2.7.3.eb
@@ -34,9 +34,6 @@ dependencies = [
 
 options = {'modulename': name}
 
-# specify that this asyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/macs2', '%s/%s-%s-py%s-linux-x86_64.egg' % (pylibdir, name, version, pyshortver)],
     'dirs': [],

--- a/easybuild/easyconfigs/m/MACS2/MACS2-2.1.1.20160309-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/MACS2/MACS2-2.1.1.20160309-intel-2017b-Python-2.7.14.eb
@@ -27,9 +27,6 @@ dependencies = [('Python', '2.7.14')]
 
 options = {'modulename': name}
 
-# specify that this asyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/macs2'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/MultiQC/MultiQC-1.2-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/MultiQC/MultiQC-1.2-intel-2017b-Python-2.7.14.eb
@@ -123,8 +123,6 @@ exts_list = [
     }),
 ]
 
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/multiqc'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.4.3-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.4.3-intel-2016b-Python-2.7.12.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-CrayGNU-2015.11-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-CrayGNU-2015.11-Python-2.7.11.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2015b-Python-2.7.10.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2016a-Python-2.7.11-freetype-2.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2016a-Python-2.7.11-freetype-2.6.3.eb
@@ -34,9 +34,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2016a-Python-2.7.11.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2016a-Python-3.5.1.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-goolf-1.7.20-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-goolf-1.7.20-Python-2.7.11.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2015b-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2015b-Python-2.7.11.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016a-Python-2.7.11-freetype-2.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016a-Python-2.7.11-freetype-2.6.3.eb
@@ -34,9 +34,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016a-Python-2.7.11.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016a-Python-3.5.1.eb
@@ -33,9 +33,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016b-Python-2.7.12.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016b-Python-3.5.2.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.2-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.2-foss-2016b-Python-2.7.12.eb
@@ -31,9 +31,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.2-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.2-intel-2016b-Python-2.7.12.eb
@@ -31,9 +31,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.2-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.2-intel-2016b-Python-3.5.2.eb
@@ -31,9 +31,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.3-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.3-foss-2016b-Python-2.7.12.eb
@@ -31,9 +31,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.3-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.3-foss-2016b-Python-3.5.2.eb
@@ -31,9 +31,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.3-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.3-intel-2016b-Python-2.7.12.eb
@@ -31,9 +31,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.3-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.3-intel-2016b-Python-3.5.2.eb
@@ -31,9 +31,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.0-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.0-foss-2016b-Python-2.7.12.eb
@@ -31,9 +31,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.0-intel-2016b-Python-2.7.12.eb
@@ -31,9 +31,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.0-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.0-intel-2017a-Python-2.7.13.eb
@@ -31,9 +31,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.1-intel-2017a-Python-3.6.1.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.1-intel-2017a-Python-3.6.1.eb
@@ -31,9 +31,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-foss-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-foss-2017a-Python-2.7.13.eb
@@ -36,9 +36,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-foss-2017a-Python-3.6.1.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-foss-2017a-Python-3.6.1.eb
@@ -36,9 +36,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-2.7.13-Qt-4.8.7.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-2.7.13-Qt-4.8.7.eb
@@ -34,9 +34,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-2.7.13-libpng-1.6.29.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-2.7.13-libpng-1.6.29.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-2.7.13.eb
@@ -31,9 +31,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-3.6.1-libpng-1.6.29.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.0.2-intel-2017a-Python-3.6.1-libpng-1.6.29.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.2.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.2.eb
@@ -38,9 +38,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.3.eb
@@ -38,9 +38,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-2.7.14.eb
@@ -42,9 +42,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-3.6.3.eb
@@ -34,9 +34,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-foss-2017b-Python-3.6.3.eb
@@ -34,9 +34,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-2.7.14.eb
@@ -34,9 +34,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-3.6.3.eb
@@ -34,9 +34,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-foss-2018a-Python-2.7.14.eb
@@ -40,9 +40,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-foss-2018a-Python-3.6.4.eb
@@ -40,9 +40,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-intel-2018a-Python-2.7.14.eb
@@ -40,9 +40,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-intel-2018a-Python-3.6.4.eb
@@ -40,9 +40,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-iomkl-2018.02-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-iomkl-2018.02-Python-3.6.4.eb
@@ -40,9 +40,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-iomkl-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-iomkl-2018a-Python-3.6.4.eb
@@ -40,9 +40,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-foss-2018b-Python-2.7.15.eb
@@ -40,9 +40,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-intel-2018b-Python-2.7.15.eb
@@ -40,9 +40,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-3.0.0-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-3.0.0-foss-2018b-Python-3.6.6.eb
@@ -48,9 +48,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-3.0.0-intel-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-3.0.0-intel-2018b-Python-3.6.6.eb
@@ -48,9 +48,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-3.0.0-iomkl-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-3.0.0-iomkl-2018b-Python-3.6.6.eb
@@ -48,9 +48,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/mayavi/mayavi-4.4.4-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/mayavi/mayavi-4.4.4-intel-2016a-Python-2.7.11.eb
@@ -48,9 +48,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/mayavi2'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/meshio/meshio-2.0.2-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/meshio/meshio-2.0.2-intel-2018a-Python-2.7.14.eb
@@ -35,9 +35,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/meshio-convert'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/meshio/meshio-2.0.2-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/m/meshio/meshio-2.0.2-intel-2018a-Python-3.6.4.eb
@@ -35,9 +35,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/meshio-convert'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/m/mordecai/mordecai-2.0.1-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/m/mordecai/mordecai-2.0.1-foss-2018a-Python-3.6.4.eb
@@ -113,9 +113,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['chardetect', 'freeze_graph', 'get_objgraph',
                                      'markdown_py', 'plac_runner.py', 'saved_model_cli',

--- a/easybuild/easyconfigs/m/mypy/mypy-0.4.5-intel-2016b.eb
+++ b/easybuild/easyconfigs/m/mypy/mypy-0.4.5-intel-2016b.eb
@@ -24,9 +24,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/n/NeuroKit/NeuroKit-0.2.7-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/n/NeuroKit/NeuroKit-0.2.7-intel-2018a-Python-3.6.4.eb
@@ -62,9 +62,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/n/NiBabel/NiBabel-2.1.0-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/n/NiBabel/NiBabel-2.1.0-intel-2017a-Python-2.7.13.eb
@@ -38,9 +38,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/nib-dicomfs', 'bin/nib-ls', 'bin/nib-nifti-dx', 'bin/parrec2nii'],
     'dirs': ['lib/python%(pyshortver)s/site-packages/nibabel', 'lib/python%(pyshortver)s/site-packages/nisext'],

--- a/easybuild/easyconfigs/n/NiBabel/NiBabel-2.2.1-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/n/NiBabel/NiBabel-2.2.1-intel-2018a-Python-3.6.4.eb
@@ -34,9 +34,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/nib-dicomfs', 'bin/nib-ls', 'bin/nib-nifti-dx', 'bin/parrec2nii'],
     'dirs': ['lib/python%(pyshortver)s/site-packages/nibabel', 'lib/python%(pyshortver)s/site-packages/nisext'],

--- a/easybuild/easyconfigs/n/NiBabel/NiBabel-2.3.0-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/n/NiBabel/NiBabel-2.3.0-foss-2018b-Python-3.6.6.eb
@@ -35,9 +35,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/nib-dicomfs', 'bin/nib-ls', 'bin/nib-nifti-dx', 'bin/parrec2nii'],
     'dirs': ['lib/python%(pyshortver)s/site-packages/nibabel', 'lib/python%(pyshortver)s/site-packages/nisext'],

--- a/easybuild/easyconfigs/n/Nipype/Nipype-1.0.2-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/n/Nipype/Nipype-1.0.2-intel-2018a-Python-3.6.4.eb
@@ -98,9 +98,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/nipypecli'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/n/Nipype/Nipype-1.1.3-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/n/Nipype/Nipype-1.1.3-foss-2018b-Python-3.6.6.eb
@@ -123,9 +123,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/nipypecli'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/n/nanonet/nanonet-2.0.0-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/n/nanonet/nanonet-2.0.0-intel-2017a-Python-2.7.13.eb
@@ -56,9 +56,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/nanonet2d', 'bin/nanonetcall', 'bin/nanonettrain'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/n/nd2reader/nd2reader-3.0.6-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/n/nd2reader/nd2reader-3.0.6-intel-2017b-Python-2.7.14.eb
@@ -28,9 +28,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/n/numba/numba-0.22.1-intel-2015b-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.22.1-intel-2015b-Python-2.7.11.eb
@@ -29,9 +29,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 pyshortver = '.'.join(pyver.split('.')[:2])
 sanity_check_paths = {
     'files': ['bin/numba', 'bin/pycc'],

--- a/easybuild/easyconfigs/n/numba/numba-0.24.0-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.24.0-intel-2016a-Python-2.7.11.eb
@@ -28,9 +28,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/numba', 'bin/pycc'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/n/numba/numba-0.24.0-intel-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.24.0-intel-2016a-Python-3.5.1.eb
@@ -28,9 +28,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/numba', 'bin/pycc'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/n/numba/numba-0.26.0-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.26.0-intel-2016a-Python-2.7.11.eb
@@ -28,9 +28,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/numba', 'bin/pycc'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/n/numba/numba-0.32.0-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.32.0-intel-2017a-Python-2.7.13.eb
@@ -27,9 +27,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/numba', 'bin/pycc'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/n/numba/numba-0.37.0-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.37.0-intel-2017b-Python-2.7.14.eb
@@ -36,9 +36,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/numba', 'bin/pycc'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/n/numba/numba-0.37.0-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.37.0-intel-2018a-Python-3.6.4.eb
@@ -38,9 +38,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/numba', 'bin/pycc'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/p/PIMS/PIMS-0.4.1-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/p/PIMS/PIMS-0.4.1-intel-2017b-Python-2.7.14.eb
@@ -60,9 +60,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/p/pandas-datareader/pandas-datareader-0.7.0-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/p/pandas-datareader/pandas-datareader-0.7.0-intel-2018a-Python-3.6.4.eb
@@ -32,9 +32,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/p/pymatgen-db/pymatgen-db-0.6.5-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/p/pymatgen-db/pymatgen-db-0.6.5-intel-2017a-Python-2.7.13.eb
@@ -28,9 +28,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/pymatgen/pymatgen-2017.10.16-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/p/pymatgen/pymatgen-2017.10.16-intel-2017b-Python-2.7.14.eb
@@ -102,9 +102,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/pymatgen/pymatgen-2017.10.16-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/p/pymatgen/pymatgen-2017.10.16-intel-2017b-Python-3.6.3.eb
@@ -97,9 +97,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/pymatgen/pymatgen-4.7.3-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/p/pymatgen/pymatgen-4.7.3-intel-2017a-Python-2.7.13.eb
@@ -46,9 +46,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/q/Quandl/Quandl-3.4.2-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/q/Quandl/Quandl-3.4.2-intel-2018a-Python-3.6.4.eb
@@ -33,9 +33,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/s/Scoary/Scoary-1.6.16-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/s/Scoary/Scoary-1.6.16-intel-2018a-Python-2.7.14.eb
@@ -39,9 +39,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/scoary', 'bin/scoary_GUI', 'bin/vcf2scoary'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/s/Sphinx/Sphinx-1.3.3-intel-2015b-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/s/Sphinx/Sphinx-1.3.3-intel-2015b-Python-2.7.11.eb
@@ -57,9 +57,6 @@ postinstallcmds = [' && '.join([
     "PYTHONPATH=%%(installdir)s/lib/python%s/site-packages/:$PYTHONPATH make test" % pyshortver,
 ])]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/sphinx-%s' % x for x in ['apidoc', 'autogen', 'build', 'quickstart']],
     'dirs': ['lib/python%s/site-packages' % pyshortver],

--- a/easybuild/easyconfigs/s/Sphinx/Sphinx-1.4.8-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/s/Sphinx/Sphinx-1.4.8-foss-2016a-Python-2.7.11.eb
@@ -61,9 +61,6 @@ postinstallcmds = [' && '.join([
     "PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages/:$PYTHONPATH make test",
 ])]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/sphinx-%s' % x for x in ['apidoc', 'autogen', 'build', 'quickstart']],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/s/Sphinx/Sphinx-1.4.8-foss-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/s/Sphinx/Sphinx-1.4.8-foss-2016a-Python-3.5.1.eb
@@ -61,9 +61,6 @@ postinstallcmds = [' && '.join([
     "PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages/:$PYTHONPATH make test",
 ])]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/sphinx-%s' % x for x in ['apidoc', 'autogen', 'build', 'quickstart']],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/s/Sphinx/Sphinx-1.8.1-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/s/Sphinx/Sphinx-1.8.1-foss-2018b-Python-3.6.6.eb
@@ -80,9 +80,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/sphinx-%s' % x for x in ['apidoc', 'autogen', 'build', 'quickstart']],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/s/Spyder/Spyder-3.1.4-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/s/Spyder/Spyder-3.1.4-intel-2017a-Python-2.7.13.eb
@@ -104,9 +104,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/spyder'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.12.3-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.12.3-foss-2016b-Python-3.5.2.eb
@@ -36,9 +36,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/'],

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.12.3-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.12.3-intel-2016b-Python-2.7.12.eb
@@ -34,9 +34,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/'],

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.12.3-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.12.3-intel-2016b-Python-3.5.2.eb
@@ -34,9 +34,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/'],

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.0-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.0-foss-2017b-Python-3.6.3.eb
@@ -45,9 +45,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/'],

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.0-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.0-intel-2017a-Python-2.7.13.eb
@@ -44,9 +44,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/'],

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.0-intel-2017a-Python-3.6.1.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.0-intel-2017a-Python-3.6.1.eb
@@ -45,9 +45,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/'],

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.1-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.1-foss-2017b-Python-3.6.3.eb
@@ -45,9 +45,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/'],

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.1-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.1-foss-2018a-Python-3.6.4.eb
@@ -46,9 +46,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/'],

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.1-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.13.1-intel-2017b-Python-2.7.14.eb
@@ -45,9 +45,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/'],

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.14.1-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.14.1-foss-2018b-Python-3.6.6.eb
@@ -47,9 +47,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/'],

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.14.1-intel-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.14.1-intel-2018b-Python-3.6.6.eb
@@ -47,9 +47,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/'],

--- a/easybuild/easyconfigs/s/snakemake/snakemake-5.2.2-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/s/snakemake/snakemake-5.2.2-intel-2018a-Python-3.6.4.eb
@@ -55,9 +55,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/snakemake'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/s/snakemake/snakemake-5.2.4-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/s/snakemake/snakemake-5.2.4-foss-2018b-Python-3.6.6.eb
@@ -56,9 +56,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/snakemake'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/s/statsmodels/statsmodels-0.6.1-foss-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/s/statsmodels/statsmodels-0.6.1-foss-2017a-Python-2.7.13.eb
@@ -28,8 +28,6 @@ exts_list = [
     }),
 ]
 
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/s/statsmodels/statsmodels-0.6.1-intel-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/s/statsmodels/statsmodels-0.6.1-intel-2016a-Python-3.5.1.eb
@@ -27,9 +27,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/t/TVB-deps/TVB-deps-20160618-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/t/TVB-deps/TVB-deps-20160618-intel-2016a-Python-2.7.11.eb
@@ -78,9 +78,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.2.0-intel-2017a-Python-3.6.1.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.2.0-intel-2017a-Python-3.6.1.eb
@@ -35,9 +35,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/tensorboard'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.2.1-foss-2016b-GPU-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.2.1-foss-2016b-GPU-Python-3.5.2.eb
@@ -51,9 +51,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/tensorboard'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.2.1-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.2.1-foss-2016b-Python-3.5.2.eb
@@ -48,9 +48,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/tensorboard'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.3.0-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.3.0-intel-2017a-Python-2.7.13.eb
@@ -36,9 +36,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/tensorboard'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.3.0-intel-2017a-Python-3.6.1.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.3.0-intel-2017a-Python-3.6.1.eb
@@ -36,9 +36,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/tensorboard'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.3.0-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.3.0-intel-2017b-Python-3.6.3.eb
@@ -36,9 +36,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/tensorboard'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/t/ToFu/ToFu-1.3.17-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/t/ToFu/ToFu-1.3.17-foss-2018a-Python-2.7.14.eb
@@ -45,9 +45,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/t/ToFu/ToFu-1.3.17-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/t/ToFu/ToFu-1.3.17-foss-2018a-Python-3.6.4.eb
@@ -45,9 +45,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/x/X11/X11-20160819-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20160819-GCCcore-5.4.0.eb
@@ -200,9 +200,6 @@ pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[0:2])
 
 preconfigopts = "if [ ! -f configure ]; then ./autogen.sh; fi && "
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['include/X11/Xlib.h', 'include/X11/Xutil.h'],
     'dirs': ['include/GL', 'include/X11', 'include/X11/extensions', 'lib',

--- a/easybuild/easyconfigs/x/X11/X11-20160819-foss-2015a.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20160819-foss-2015a.eb
@@ -124,9 +124,6 @@ pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[0:2])
 
 preconfigopts = "if [ ! -f configure ]; then ./autogen.sh; fi && "
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['include/X11/Xlib.h', 'include/X11/Xutil.h'],
     'dirs': ['include/GL', 'include/X11', 'include/X11/extensions', 'lib',

--- a/easybuild/easyconfigs/x/X11/X11-20160819-foss-2016b.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20160819-foss-2016b.eb
@@ -124,9 +124,6 @@ pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[0:2])
 
 preconfigopts = "if [ ! -f configure ]; then ./autogen.sh; fi && "
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['include/X11/Xlib.h', 'include/X11/Xutil.h'],
     'dirs': ['include/GL', 'include/X11', 'include/X11/extensions', 'lib',

--- a/easybuild/easyconfigs/x/X11/X11-20160819-intel-2016b.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20160819-intel-2016b.eb
@@ -124,9 +124,6 @@ pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[0:2])
 
 preconfigopts = "if [ ! -f configure ]; then ./autogen.sh; fi && "
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['include/X11/Xlib.h', 'include/X11/Xutil.h'],
     'dirs': ['include/GL', 'include/X11', 'include/X11/extensions', 'lib',

--- a/easybuild/easyconfigs/x/X11/X11-20170129-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20170129-GCCcore-6.3.0.eb
@@ -127,9 +127,6 @@ pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[0:2])
 
 preconfigopts = "if [ ! -f configure ]; then ./autogen.sh; fi && "
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['include/X11/Xlib.h', 'include/X11/Xutil.h'],
     'dirs': ['include/GL', 'include/X11', 'include/X11/extensions', 'lib',

--- a/easybuild/easyconfigs/x/X11/X11-20170129-gimkl-2017a.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20170129-gimkl-2017a.eb
@@ -126,9 +126,6 @@ pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[0:2])
 
 preconfigopts = "if [ ! -f configure ]; then ./autogen.sh; fi && "
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['include/X11/Xlib.h', 'include/X11/Xutil.h'],
     'dirs': ['include/GL', 'include/X11', 'include/X11/extensions', 'lib',

--- a/easybuild/easyconfigs/x/X11/X11-20170314-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20170314-GCCcore-6.3.0.eb
@@ -127,9 +127,6 @@ pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[0:2])
 
 preconfigopts = "if [ ! -f configure ]; then ./autogen.sh; fi && "
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['include/X11/Xlib.h', 'include/X11/Xutil.h'],
     'dirs': ['include/GL', 'include/X11', 'include/X11/extensions', 'lib',

--- a/easybuild/easyconfigs/x/X11/X11-20171023-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20171023-GCCcore-6.4.0.eb
@@ -124,9 +124,6 @@ components = [
 
 preconfigopts = "if [ ! -f configure ]; then ./autogen.sh; fi && "
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['include/X11/Xlib.h', 'include/X11/Xutil.h'],
     'dirs': ['include/GL', 'include/X11', 'include/X11/extensions', 'lib/pkgconfig',

--- a/easybuild/easyconfigs/x/X11/X11-20180131-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20180131-GCCcore-6.4.0.eb
@@ -280,9 +280,6 @@ components = [
 
 preconfigopts = "if [ ! -f configure ]; then ./autogen.sh; fi && "
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['include/X11/Xlib.h', 'include/X11/Xutil.h'],
     'dirs': ['include/GL', 'include/X11', 'include/X11/extensions', 'lib/pkgconfig',

--- a/easybuild/easyconfigs/x/X11/X11-20180604-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20180604-GCCcore-7.3.0.eb
@@ -275,9 +275,6 @@ components = [
 
 preconfigopts = "if [ ! -f configure ]; then ./autogen.sh; fi && "
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['include/X11/Xlib.h', 'include/X11/Xutil.h'],
     'dirs': ['include/GL', 'include/X11', 'include/X11/extensions', 'lib/pkgconfig',

--- a/easybuild/easyconfigs/x/xonsh/xonsh-0.3.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/x/xonsh/xonsh-0.3.2-intel-2016a.eb
@@ -35,9 +35,6 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': ['bin/xonsh'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],


### PR DESCRIPTION
Setting `full_sanity_check` is useless since it was removed as a custom easyconfig parameter for the `Bundle` easyblock years ago (cfr. https://github.com/easybuilders/easybuild-easyblocks/commit/07f9c5b686bf6e99b5d435d541c25b660f8f8b4e, which was included in EasyBuild v2.2.0 via https://github.com/easybuilders/easybuild-easyblocks/pull/627).

Instead, we check whether extensions are listed or whether `sanity_check_paths` or `sanity_check_commands` are specified to determine whether or not a full sanity check should be performed.

As such, removing the `full_sanity_check = True` lines basically has no effect on the installation procedure...