### PR TITLE
add missing cffi & pycparser extensions to recent Python easyconfigs

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.13-foss-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.13-foss-2017a.eb
@@ -91,6 +91,14 @@ exts_list = [
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
     }),
+    ('pycparser', '2.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        'checksums': ['99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226'],
+    }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('cryptography', '1.8.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
     }),

--- a/easybuild/easyconfigs/p/Python/Python-2.7.13-foss-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.13-foss-2017a.eb
@@ -10,6 +10,7 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
+checksums = ['a4f05a0720ce0fd92626f0278b6b433eee9a6173ddf2bced7957dfb599a5ece1']
 
 # python needs bzip2 to build the bz2 package
 dependencies = [
@@ -35,61 +36,81 @@ exts_list = [
     ('setuptools', '33.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
         'source_tmpl': '%(name)s-%(version)s.zip',
+        'checksums': ['6b20352ed60ba08c43b3611bdb502286f7a869fbfcf472f40d7279f1e77de145'],
     }),
     ('pip', '9.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
     }),
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
     }),
     ('numpy', '1.12.1', {
         'source_urls': ['https://pypi.python.org/packages/source/n/numpy'],
         'source_tmpl': '%(name)s-%(version)s.zip',
         'patches': ['numpy-1.12.0-mkl.patch'],
+        'checksums': [
+            'a65266a4ad6ec8936a1bc85ce51f8600634a31a258b722c9274a80ff189d9542',  # numpy-1.12.1.zip
+            'f212296ed289eb1b4e3f703997499dee8a2cdd0af78b55e017477487b6377ca4',  # numpy-1.12.0-mkl.patch
+        ],
     }),
     ('scipy', '0.19.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
         'source_tmpl': '%(name)s-%(version)s.zip',
+        'checksums': ['4190d34bf9a09626cd42100bbb12e3d96b2daf1a8a3244e991263eb693732122'],
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
     }),
     ('mpi4py', '2.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
+        'checksums': ['6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81'],
     }),
     ('paycheck', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+        'checksums': ['6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34'],
     }),
     ('pbr', '2.0.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+        'checksums': ['0ccd2db529afd070df815b1521f01401d43de03941170f8a800e7531faba265d'],
     }),
     ('Cython', '0.25.2', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+        'checksums': ['f141d1f9c27a07b5a93f7dc5339472067e2d7140d1c5a9e20112a5665ca60306'],
     }),
     ('six', '1.10.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+        'checksums': ['105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a'],
     }),
     ('dateutil', '2.6.0', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+        'checksums': ['62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2'],
     }),
     ('deap', '1.0.2', {
         'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+        'checksums': ['c52bd32b8f0143db3a0b90f2b976c920b588638d6999ca0d038d8b1c07f7950b'],
     }),
     ('decorator', '4.0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+        'checksums': ['953d6bf082b100f43229cf547f4f97f97e970f5ad645ee7601d55ff87afdfe76'],
     }),
     ('arff', '2.1.0', {
         'source_tmpl': 'liac-%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+        'checksums': ['be6b5b76698d5fca1f24d75c98ed9c0ff5e24eb0d985d01cfd26c08a70f9654e'],
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
     ('pycparser', '2.18', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
@@ -101,48 +122,62 @@ exts_list = [
     }),
     ('cryptography', '1.8.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
+        'checksums': ['323524312bb467565ebca7e50c8ae5e9674e544951d28a2904a50012a8828190'],
     }),
     ('paramiko', '2.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+        'checksums': ['5fae49bed35e2e3d45c4f7b0db2d38b9ca626312d91119b3991d0ecf8125e310'],
     }),
     ('pyparsing', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
     }),
     ('netifaces', '0.10.5', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+        'checksums': ['59d8ad52dd3116fcb6635e175751b250dc783fb011adba539558bd764e5d628b'],
     }),
     ('netaddr', '0.7.19', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
     }),
     ('funcsigs', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs'],
+        'checksums': ['a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50'],
     }),
     ('mock', '2.0.0', {
         'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
+        'checksums': ['b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba'],
     }),
     ('pytz', '2017.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
         'source_tmpl': '%(name)s-%(version)s.zip',
+        'checksums': ['f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589'],
     }),
     ('pandas', '0.19.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+        'checksums': ['6f0f4f598c2b16746803c8bafef7c721c57e4844da752d36240c0acf97658014'],
     }),
     ('enum34', '1.1.6', {
         'modulename': 'enum',
         'source_urls': ['https://pypi.python.org/packages/source/e/enum34'],
+        'checksums': ['8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1'],
     }),
     ('bitstring', '3.1.5', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/b/bitstring'],
+        'checksums': ['c163a86fcef377c314690051885d86b47419e3e1770990c212e16723c1c08faa'],
     }),
     ('virtualenv', '15.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
     }),
     ('docopt', '0.6.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
     }),
     ('joblib', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
     }),
     ('xlrd', '1.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/x/xlrd'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.13-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.13-intel-2017a.eb
@@ -91,6 +91,14 @@ exts_list = [
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
     }),
+    ('pycparser', '2.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        'checksums': ['99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226'],
+    }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('cryptography', '1.8.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
     }),

--- a/easybuild/easyconfigs/p/Python/Python-2.7.13-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.13-intel-2017a.eb
@@ -10,6 +10,7 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
+checksums = ['a4f05a0720ce0fd92626f0278b6b433eee9a6173ddf2bced7957dfb599a5ece1']
 
 # python needs bzip2 to build the bz2 package
 dependencies = [
@@ -35,61 +36,81 @@ exts_list = [
     ('setuptools', '33.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
         'source_tmpl': '%(name)s-%(version)s.zip',
+        'checksums': ['6b20352ed60ba08c43b3611bdb502286f7a869fbfcf472f40d7279f1e77de145'],
     }),
     ('pip', '9.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+        'checksums': ['09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'],
     }),
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
     }),
     ('numpy', '1.12.1', {
         'source_urls': ['https://pypi.python.org/packages/source/n/numpy'],
         'source_tmpl': '%(name)s-%(version)s.zip',
         'patches': ['numpy-1.12.0-mkl.patch'],
+        'checksums': [
+            'a65266a4ad6ec8936a1bc85ce51f8600634a31a258b722c9274a80ff189d9542',  # numpy-1.12.1.zip
+            'f212296ed289eb1b4e3f703997499dee8a2cdd0af78b55e017477487b6377ca4',  # numpy-1.12.0-mkl.patch
+        ],
     }),
     ('scipy', '0.19.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
         'source_tmpl': '%(name)s-%(version)s.zip',
+        'checksums': ['4190d34bf9a09626cd42100bbb12e3d96b2daf1a8a3244e991263eb693732122'],
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
     }),
     ('mpi4py', '2.0.0', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
+        'checksums': ['6543a05851a7aa1e6d165e673d422ba24e45c41e4221f0993fe1e5924a00cb81'],
     }),
     ('paycheck', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+        'checksums': ['6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34'],
     }),
     ('pbr', '2.0.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+        'checksums': ['0ccd2db529afd070df815b1521f01401d43de03941170f8a800e7531faba265d'],
     }),
     ('Cython', '0.25.2', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+        'checksums': ['f141d1f9c27a07b5a93f7dc5339472067e2d7140d1c5a9e20112a5665ca60306'],
     }),
     ('six', '1.10.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+        'checksums': ['105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a'],
     }),
     ('dateutil', '2.6.0', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+        'checksums': ['62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2'],
     }),
     ('deap', '1.0.2', {
         'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+        'checksums': ['c52bd32b8f0143db3a0b90f2b976c920b588638d6999ca0d038d8b1c07f7950b'],
     }),
     ('decorator', '4.0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+        'checksums': ['953d6bf082b100f43229cf547f4f97f97e970f5ad645ee7601d55ff87afdfe76'],
     }),
     ('arff', '2.1.0', {
         'source_tmpl': 'liac-%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+        'checksums': ['be6b5b76698d5fca1f24d75c98ed9c0ff5e24eb0d985d01cfd26c08a70f9654e'],
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
         'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
     ('pycparser', '2.18', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
@@ -101,48 +122,62 @@ exts_list = [
     }),
     ('cryptography', '1.8.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
+        'checksums': ['323524312bb467565ebca7e50c8ae5e9674e544951d28a2904a50012a8828190'],
     }),
     ('paramiko', '2.1.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+        'checksums': ['5fae49bed35e2e3d45c4f7b0db2d38b9ca626312d91119b3991d0ecf8125e310'],
     }),
     ('pyparsing', '2.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+        'checksums': ['0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04'],
     }),
     ('netifaces', '0.10.5', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+        'checksums': ['59d8ad52dd3116fcb6635e175751b250dc783fb011adba539558bd764e5d628b'],
     }),
     ('netaddr', '0.7.19', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
     }),
     ('funcsigs', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs'],
+        'checksums': ['a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50'],
     }),
     ('mock', '2.0.0', {
         'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
+        'checksums': ['b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba'],
     }),
     ('pytz', '2017.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
         'source_tmpl': '%(name)s-%(version)s.zip',
+        'checksums': ['f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589'],
     }),
     ('pandas', '0.19.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+        'checksums': ['6f0f4f598c2b16746803c8bafef7c721c57e4844da752d36240c0acf97658014'],
     }),
     ('enum34', '1.1.6', {
         'modulename': 'enum',
         'source_urls': ['https://pypi.python.org/packages/source/e/enum34'],
+        'checksums': ['8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1'],
     }),
     ('bitstring', '3.1.5', {
         'source_tmpl': '%(name)s-%(version)s.zip',
         'source_urls': ['https://pypi.python.org/packages/source/b/bitstring'],
+        'checksums': ['c163a86fcef377c314690051885d86b47419e3e1770990c212e16723c1c08faa'],
     }),
     ('virtualenv', '15.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
+        'checksums': ['02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a'],
     }),
     ('docopt', '0.6.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
     }),
     ('joblib', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
+        'checksums': ['7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085'],
     }),
     ('xlrd', '1.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/x/xlrd'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2017b.eb
@@ -137,6 +137,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
         'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2017b.eb
@@ -137,6 +137,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('pycparser', '2.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        'checksums': ['99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226'],
+    }),
     ('cffi', '1.11.5', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
         'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2018a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2018a.eb
@@ -135,6 +135,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
         'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2018a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-foss-2018a.eb
@@ -135,6 +135,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('pycparser', '2.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        'checksums': ['99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226'],
+    }),
     ('cffi', '1.11.5', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
         'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-fosscuda-2018a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-fosscuda-2018a.eb
@@ -135,6 +135,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
         'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-fosscuda-2018a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-fosscuda-2018a.eb
@@ -135,6 +135,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('pycparser', '2.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        'checksums': ['99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226'],
+    }),
     ('cffi', '1.11.5', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
         'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2017b.eb
@@ -137,6 +137,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
         'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2017b.eb
@@ -137,6 +137,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('pycparser', '2.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        'checksums': ['99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226'],
+    }),
     ('cffi', '1.11.5', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
         'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2018.01.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2018.01.eb
@@ -136,6 +136,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
         'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2018.01.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2018.01.eb
@@ -136,6 +136,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('pycparser', '2.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        'checksums': ['99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226'],
+    }),
     ('cffi', '1.11.5', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
         'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2018a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2018a.eb
@@ -135,6 +135,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
         'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2018a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-intel-2018a.eb
@@ -135,6 +135,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('pycparser', '2.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        'checksums': ['99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226'],
+    }),
     ('cffi', '1.11.5', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
         'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-iomkl-2018a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-iomkl-2018a.eb
@@ -135,6 +135,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
         'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-iomkl-2018a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-iomkl-2018a.eb
@@ -135,6 +135,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('pycparser', '2.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        'checksums': ['99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226'],
+    }),
     ('cffi', '1.11.5', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
         'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-foss-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-foss-2018b.eb
@@ -131,6 +131,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('pycparser', '2.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        'checksums': ['99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226'],
+    }),
     ('cffi', '1.11.5', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
         'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-foss-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-foss-2018b.eb
@@ -131,6 +131,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'modulename': 'nacl',
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-fosscuda-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-fosscuda-2018b.eb
@@ -131,6 +131,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('pycparser', '2.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        'checksums': ['99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226'],
+    }),
     ('cffi', '1.11.5', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
         'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-fosscuda-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-fosscuda-2018b.eb
@@ -131,6 +131,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'modulename': 'nacl',
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-intel-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-intel-2018b.eb
@@ -135,6 +135,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'modulename': 'nacl',
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-intel-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-intel-2018b.eb
@@ -135,6 +135,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('pycparser', '2.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        'checksums': ['99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226'],
+    }),
     ('cffi', '1.11.5', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
         'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-iomkl-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-iomkl-2018b.eb
@@ -135,6 +135,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'modulename': 'nacl',
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-iomkl-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-iomkl-2018b.eb
@@ -135,6 +135,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('pycparser', '2.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        'checksums': ['99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226'],
+    }),
     ('cffi', '1.11.5', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
         'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-foss-2017b.eb
@@ -156,6 +156,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
         'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-goolfc-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-goolfc-2017b.eb
@@ -156,6 +156,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
         'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2017b.eb
@@ -164,6 +164,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
         'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2018.01.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.3-intel-2018.01.eb
@@ -155,6 +155,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
         'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],


### PR DESCRIPTION
`pip check` reports that `PyNacl`, `bcrypt` and `cryptography` require `cffi` to be installed, but it's not...

This isn't picked up by `download_dep_fail` for some reason, but `pip check` does pick up on it (cfr. #1565), for example:

```
pynacl 1.2.1 requires cffi, which is not installed.
bcrypt 3.1.4 requires cffi, which is not installed.
cryptography 2.2.2 requires cffi, which is not installed.
```