### PR TITLE
stop using lowopt in libxc 4.2.3 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/l/libxc/libxc-4.2.3-foss-2017b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.2.3-foss-2017b.eb
@@ -8,8 +8,6 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'foss', 'version': '2017b'}
-# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
-toolchainopts = {'lowopt': True}
 
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-4.2.3-foss-2018a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.2.3-foss-2018a.eb
@@ -8,8 +8,6 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'foss', 'version': '2018a'}
-# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
-toolchainopts = {'lowopt': True}
 
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-4.2.3-foss-2018b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.2.3-foss-2018b.eb
@@ -8,8 +8,6 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'foss', 'version': '2018b'}
-# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
-toolchainopts = {'lowopt': True}
 
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-4.2.3-gimkl-2017a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.2.3-gimkl-2017a.eb
@@ -8,6 +8,8 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'gimkl', 'version': '2017a'}
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-4.2.3-gimkl-2017a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.2.3-gimkl-2017a.eb
@@ -8,8 +8,6 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'gimkl', 'version': '2017a'}
-# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
-toolchainopts = {'lowopt': True}
 
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-4.2.3-intel-2018a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.2.3-intel-2018a.eb
@@ -8,9 +8,6 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2018a'}
-# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
-# Tests also fail with Intel Compilers on Haswell when optarch is enabled.
-toolchainopts = {'lowopt': True, 'optarch': False}
 
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
 sources = [SOURCE_TAR_GZ]


### PR DESCRIPTION
It seems like the enforcing `lowopt` for recent `libxc` versions, which was added in #4199, is no longer required with `libxc` 4.2.3.

~~We're not~~ We are running `make check`, which should be sufficient to catch any problems with compiling with `-O2` (`defaultopt`) rather than `-O1` (`lowopt`).

cc @akesandgren, @tovrstra (cfr. #4199), @migueldiascosta (cfr. #5250)