### PR TITLE
use empty toolchain version in picard easyconfigs to ensure Java dependency is loaded during installation

### DIFF
--- a/easybuild/easyconfigs/p/picard/picard-2.10.1-Java-1.8.0_131.eb
+++ b/easybuild/easyconfigs/p/picard/picard-2.10.1-Java-1.8.0_131.eb
@@ -21,7 +21,7 @@ versionsuffix = '-Java-%(javaver)s'
 homepage = 'http://sourceforge.net/projects/picard'
 description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['https://github.com/broadinstitute/picard/releases/download/%(version)s']
 sources = [{

--- a/easybuild/easyconfigs/p/picard/picard-2.18.11-Java-1.8.0_162.eb
+++ b/easybuild/easyconfigs/p/picard/picard-2.18.11-Java-1.8.0_162.eb
@@ -25,7 +25,7 @@ versionsuffix = '-Java-%(javaver)s'
 homepage = 'http://sourceforge.net/projects/picard'
 description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['https://github.com/broadinstitute/picard/releases/download/%(version)s']
 sources = [{

--- a/easybuild/easyconfigs/p/picard/picard-2.18.5-Java-1.8.0_162.eb
+++ b/easybuild/easyconfigs/p/picard/picard-2.18.5-Java-1.8.0_162.eb
@@ -21,7 +21,7 @@ versionsuffix = '-Java-%(javaver)s'
 homepage = 'http://sourceforge.net/projects/picard'
 description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['https://github.com/broadinstitute/picard/releases/download/%(version)s']
 sources = [{

--- a/easybuild/easyconfigs/p/picard/picard-2.2.4-Java-1.8.0_92.eb
+++ b/easybuild/easyconfigs/p/picard/picard-2.2.4-Java-1.8.0_92.eb
@@ -14,7 +14,7 @@ version = '2.2.4'
 homepage = 'http://sourceforge.net/projects/picard'
 description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['https://github.com/broadinstitute/picard/releases/download/%(version)s']
 sources = ['%(name)s-tools-%(version)s.zip']

--- a/easybuild/easyconfigs/p/picard/picard-2.2.4-Java-1.8.0_92.eb
+++ b/easybuild/easyconfigs/p/picard/picard-2.2.4-Java-1.8.0_92.eb
@@ -18,6 +18,7 @@ toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['https://github.com/broadinstitute/picard/releases/download/%(version)s']
 sources = ['%(name)s-tools-%(version)s.zip']
+checksums = ['233b16ce282fb4612c32b9d255e5cdf19f10685c5c76cb357fad49fd5d80d5bb']
 
 java = 'Java'
 javaver = '1.8.0_92'

--- a/easybuild/easyconfigs/p/picard/picard-2.6.0-Java-1.8.0_131.eb
+++ b/easybuild/easyconfigs/p/picard/picard-2.6.0-Java-1.8.0_131.eb
@@ -20,7 +20,7 @@ versionsuffix = '-Java-%(javaver)s'
 homepage = 'http://sourceforge.net/projects/picard'
 description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['https://github.com/broadinstitute/picard/releases/download/%(version)s']
 sources = ['%(name)s.jar']


### PR DESCRIPTION
see also https://easybuild.readthedocs.io/en/latest/Writing_easyconfig_files.html#loading-of-modules-for-dependencies-with-a-dummy-toolchain