### PR TITLE
also add missing cffi extension to Python 3.6.1 & 3.6.2 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.6.1-foss-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.1-foss-2017a.eb
@@ -132,6 +132,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
         'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('cryptography', '1.8.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
         'checksums': ['323524312bb467565ebca7e50c8ae5e9674e544951d28a2904a50012a8828190'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.1-intel-2017a.eb
@@ -136,6 +136,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
         'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('cryptography', '1.8.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
         'checksums': ['323524312bb467565ebca7e50c8ae5e9674e544951d28a2904a50012a8828190'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.2-foss-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.2-foss-2017b.eb
@@ -148,6 +148,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
         'checksums': ['a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('cryptography', '2.0.3', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
         'checksums': ['d04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2017b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2017b.eb
@@ -160,6 +160,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pyasn1/'],
         'checksums': ['fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('PyNaCl', '1.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pynacl/'],
         'checksums': ['e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2018.00.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.2-intel-2018.00.eb
@@ -152,6 +152,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
         'checksums': ['a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('cryptography', '2.0.3', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
         'checksums': ['d04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a'],

--- a/easybuild/easyconfigs/p/Python/Python-3.6.4-foss-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.4-foss-2017a.eb
@@ -173,6 +173,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
         'checksums': ['a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3'],
     }),
+    ('cffi', '1.11.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        'checksums': ['e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4'],
+    }),
     ('cryptography', '2.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
         'checksums': [


### PR DESCRIPTION
cfr. #7105

strictly required in case https://github.com/easybuilders/easybuild-easyblocks/pull/1567 gets merged, to avoid failing `pip check`