### PR TITLE
add missing 'patsy' extension in ARCH easyconfig + switch to using PythonBundle easyblock

### DIFF
--- a/easybuild/easyconfigs/a/ARCH/ARCH-4.5.0-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/a/ARCH/ARCH-4.5.0-intel-2018a-Python-3.6.4.eb
@@ -1,4 +1,4 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'ARCH'
 version = '4.5.0'
@@ -15,14 +15,13 @@ dependencies = [
     ('numba', '0.37.0', versionsuffix),
 ]
 
-exts_defaultclass = 'PythonPackage'
-exts_default_options = {
-    'download_dep_fail': True,
-    'use_pip': True,
-}
-
+use_pip = True
 
 exts_list = [
+    ('patsy', '0.5.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/patsy'],
+        'checksums': ['f115cec4201e1465cd58b9866b0b0e7b941caafec129869057405bfe5b5e3991'],
+    }),
     ('statsmodels', '0.9.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/statsmodels'],
         'checksums': ['6461f93a842c649922c2c9a9bc9d9c4834110b89de8c4af196a791ab8f42ba3b'],
@@ -34,12 +33,5 @@ exts_list = [
         'installopts': "--install-option '--no-binary'",
     }),
 ]
-
-sanity_check_paths = {
-    'files': [],
-    'dirs': ['lib/python%(pyshortver)s/site-packages'],
-}
-
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'lib'


### PR DESCRIPTION
strictly required in case https://github.com/easybuilders/easybuild-easyblocks/pull/1567 gets merged, to avoid failing `pip check`