### PR TITLE
add missing (dummy) sklearn extension in NeuroKit easyconfig

### DIFF
--- a/easybuild/easyconfigs/n/NeuroKit/NeuroKit-0.2.7-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/n/NeuroKit/NeuroKit-0.2.7-intel-2018a-Python-3.6.4.eb
@@ -55,6 +55,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/m/mne'],
         'checksums': ['c166b19aed189409c23af25b29038cbdd4ea55349212057fda575cc24a6e19d9'],
     }),
+    ('sklearn', '0.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/sklearn'],
+        'checksums': ['e23001573aa194b834122d2b9562459bf5ae494a2d59ca6b8aa22c85a44c0e31'],
+    }),
     (name, version, {
         'source_tmpl': '5dfa41d.tar.gz',
         'source_urls': ['https://github.com/neuropsychology/NeuroKit.py/archive/'],


### PR DESCRIPTION
strictly required if https://github.com/easybuilders/easybuild-easyblocks/pull/1567 gets merged to avoid `pip check` failure..