### PR TITLE
update SCOTCH 6.0.5 easyconfigs in-place to 6.0.6 to fix wrong download URL

### DIFF
--- a/easybuild/easyconfigs/d/DOLFIN/DOLFIN-2018.1.0.post1-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/d/DOLFIN/DOLFIN-2018.1.0.post1-foss-2018a-Python-3.6.4.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('FFC', '2018.1.0', versionsuffix),
     ('FIAT', '2018.1.0', versionsuffix),
     ('UFL', '2018.1.0', versionsuffix),
-    ('SCOTCH', '6.0.5'),
+    ('SCOTCH', '6.0.6'),
     ('SuiteSparse', '5.1.2', '-METIS-5.1.0'),
     ('CGAL', '4.11.1', versionsuffix),
     ('PETSc', '3.9.3'),

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-5.0-20180108-foss-2018a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-5.0-20180108-foss-2018a.eb
@@ -31,7 +31,7 @@ dependencies = [
     ('ncurses', '6.0'),
     # OpenFOAM requires 64 bit METIS using 32 bit indexes (array indexes)
     ('METIS', '5.1.0'),
-    ('SCOTCH', '6.0.5'),
+    ('SCOTCH', '6.0.6'),
     ('CGAL', '4.11.1', '-Python-2.7.14'),
     ('ParaView', '5.4.1', '-mpi'),
 ]

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-5.0-20180108-intel-2018a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-5.0-20180108-intel-2018a.eb
@@ -31,7 +31,7 @@ dependencies = [
     ('ncurses', '6.0'),
     # OpenFOAM requires 64 bit METIS using 32 bit indexes (array indexes)
     ('METIS', '5.1.0'),
-    ('SCOTCH', '6.0.5'),
+    ('SCOTCH', '6.0.6'),
     ('CGAL', '4.11.1', '-Python-2.7.14'),
     ('ParaView', '5.4.1', '-mpi'),
 ]

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-6-foss-2018b.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-6-foss-2018b.eb
@@ -23,7 +23,7 @@ dependencies = [
     ('ncurses', '6.1'),
     # OpenFOAM requires 64 bit METIS using 32 bit indexes (array indexes)
     ('METIS', '5.1.0'),
-    ('SCOTCH', '6.0.5'),
+    ('SCOTCH', '6.0.6'),
     ('CGAL', '4.11.1', '-Python-2.7.15'),
     ('ParaView', '5.4.1', '-mpi'),
 ]

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-6-intel-2018a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-6-intel-2018a.eb
@@ -23,7 +23,7 @@ dependencies = [
     ('ncurses', '6.0'),
     # OpenFOAM requires 64 bit METIS using 32 bit indexes (array indexes)
     ('METIS', '5.1.0'),
-    ('SCOTCH', '6.0.5'),
+    ('SCOTCH', '6.0.6'),
     ('CGAL', '4.11.1', '-Python-2.7.14'),
     ('ParaView', '5.4.1', '-mpi'),
 ]

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v1806-foss-2018b.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v1806-foss-2018b.eb
@@ -23,7 +23,7 @@ dependencies = [
     ('ncurses', '6.1'),
     # OpenFOAM requires 64 bit METIS using 32 bit indexes (array indexes)
     ('METIS', '5.1.0'),
-    ('SCOTCH', '6.0.5'),
+    ('SCOTCH', '6.0.6'),
     ('CGAL', '4.11.1', '-Python-2.7.15'),
     ('ParaView', '5.4.1', '-mpi'),
 ]

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.9.3-foss-2018a.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.9.3-foss-2018a.eb
@@ -26,7 +26,7 @@ dependencies = [
     ('Boost', '1.66.0'),
     ('METIS', '5.1.0'),
     ('ParMETIS', '4.0.3'),
-    ('SCOTCH', '6.0.5'),
+    ('SCOTCH', '6.0.6'),
     ('SuiteSparse', '5.1.2', '-METIS-5.1.0'),
     ('Hypre', '2.14.0'),
 ]

--- a/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.6-foss-2018a.eb
+++ b/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.6-foss-2018a.eb
@@ -1,16 +1,16 @@
 name = 'SCOTCH'
-version = '6.0.5'
+version = '6.0.6'
 
 homepage = 'http://gforge.inria.fr/projects/scotch/'
 description = """Software package and libraries for sequential and parallel graph partitioning,
 static mapping, and sparse matrix block ordering, and sequential mesh and hypergraph partitioning."""
 
-toolchain = {'name': 'intel', 'version': '2018a'}
+toolchain = {'name': 'foss', 'version': '2018a'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://gforge.inria.fr/frs/download.php/file/34618/']
+source_urls = ['https://gforge.inria.fr/frs/download.php/file/37622/']
 sources = ['%(namelower)s_%(version)s.tar.gz']
-checksums = ['f53f4d71a8345ba15e2dd4e102a35fd83915abf50ea73e1bf6efe1bc2b4220c7']
+checksums = ['686f0cad88d033fe71c8b781735ff742b73a1d82a65b8b1586526d69729ac4cf']
 
 dependencies = [
     ('zlib', '1.2.11'),

--- a/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.6-foss-2018b.eb
+++ b/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.6-foss-2018b.eb
@@ -1,5 +1,5 @@
 name = 'SCOTCH'
-version = '6.0.5'
+version = '6.0.6'
 
 homepage = 'http://gforge.inria.fr/projects/scotch/'
 description = """Software package and libraries for sequential and parallel graph partitioning,
@@ -8,9 +8,9 @@ static mapping, and sparse matrix block ordering, and sequential mesh and hyperg
 toolchain = {'name': 'foss', 'version': '2018b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://gforge.inria.fr/frs/download.php/file/34618/']
+source_urls = ['https://gforge.inria.fr/frs/download.php/file/37622/']
 sources = ['%(namelower)s_%(version)s.tar.gz']
-checksums = ['f53f4d71a8345ba15e2dd4e102a35fd83915abf50ea73e1bf6efe1bc2b4220c7']
+checksums = ['686f0cad88d033fe71c8b781735ff742b73a1d82a65b8b1586526d69729ac4cf']
 
 dependencies = [
     ('zlib', '1.2.11'),

--- a/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.6-intel-2018a.eb
+++ b/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.6-intel-2018a.eb
@@ -1,16 +1,16 @@
 name = 'SCOTCH'
-version = '6.0.5'
+version = '6.0.6'
 
 homepage = 'http://gforge.inria.fr/projects/scotch/'
 description = """Software package and libraries for sequential and parallel graph partitioning,
 static mapping, and sparse matrix block ordering, and sequential mesh and hypergraph partitioning."""
 
-toolchain = {'name': 'foss', 'version': '2018a'}
+toolchain = {'name': 'intel', 'version': '2018a'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://gforge.inria.fr/frs/download.php/file/34618/']
+source_urls = ['https://gforge.inria.fr/frs/download.php/file/37622/']
 sources = ['%(namelower)s_%(version)s.tar.gz']
-checksums = ['f53f4d71a8345ba15e2dd4e102a35fd83915abf50ea73e1bf6efe1bc2b4220c7']
+checksums = ['686f0cad88d033fe71c8b781735ff742b73a1d82a65b8b1586526d69729ac4cf']
 
 dependencies = [
     ('zlib', '1.2.11'),

--- a/easybuild/easyconfigs/t/Trilinos/Trilinos-12.12.1-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/t/Trilinos/Trilinos-12.12.1-foss-2018a-Python-3.6.4.eb
@@ -38,7 +38,7 @@ dependencies = [
     ('Python', '3.6.4'),
     ('Boost', '1.66.0'),
     ('Boost.Python', '1.66.0', versionsuffix),
-    ('SCOTCH', '6.0.5'),
+    ('SCOTCH', '6.0.6'),
     ('SuiteSparse', '5.1.2', '-METIS-5.1.0'),
     ('ParMETIS', '4.0.3'),
     ('netCDF', '4.6.0'),


### PR DESCRIPTION
fix for problem reported by @smoors in #7154

see also enhanced `SCOTCH` easyblock in ~~https://github.com/easybuilders/easybuild-easyblocks/pull/1580~~

WIP since needs thorough testing (which is under way); test reports welcome!