### PR TITLE
fix source_urls in CP2K easyconfigs (for official releases)

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-2.4.0-goolf-1.4.10-ipi.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-2.4.0-goolf-1.4.10-ipi.eb
@@ -10,14 +10,18 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-source_urls = ['http://sourceforge.net/projects/cp2k/files/']
-
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s/']
 sources = [SOURCELOWER_TAR_BZ2]
-
 patches = [
     'CP2K-%(version)s_ipi.patch',
     'CP2K-%(version)s-fix_compile_date_lastsvn.patch',
     'do_regtest_nocompile.patch'
+]
+checksums = [
+    '9208af877b0854456ec4b550d75d96bdff087406dfed8b38f95028a1f108392d',  # cp2k-2.4.0.tar.bz2
+    'bef229e946555f90b8adcba96f19adbbc86a94665059895cf9668fc7a42525d1',  # CP2K-2.4.0_ipi.patch
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
+    'b34bf3116c2564bba037cbee89d7ad29ebecaea8b8ea01f83d1718881c6e3475',  # do_regtest_nocompile.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-2.4.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-2.4.0-goolf-1.4.10.eb
@@ -9,13 +9,16 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-source_urls = ['http://sourceforge.net/projects/cp2k/files/']
-
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s/']
 sources = [SOURCELOWER_TAR_BZ2]
-
 patches = [
     'CP2K-%(version)s-fix_compile_date_lastsvn.patch',
     'do_regtest_nocompile.patch'
+]
+checksums = [
+    '9208af877b0854456ec4b550d75d96bdff087406dfed8b38f95028a1f108392d',  # cp2k-2.4.0.tar.bz2
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
+    'b34bf3116c2564bba037cbee89d7ad29ebecaea8b8ea01f83d1718881c6e3475',  # do_regtest_nocompile.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-2.4.0-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-2.4.0-ictce-5.5.0.eb
@@ -10,13 +10,18 @@ classical pair and many-body potentials. """
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 toolchainopts = {'pic': True}
 
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s/']
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
-
 patches = [
     'do_regtest_nocompile.patch',
     'CP2K-20131211-ifort-compiler-bug-fix.patch',
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+checksums = [
+    '9208af877b0854456ec4b550d75d96bdff087406dfed8b38f95028a1f108392d',  # cp2k-2.4.0.tar.bz2
+    'b34bf3116c2564bba037cbee89d7ad29ebecaea8b8ea01f83d1718881c6e3475',  # do_regtest_nocompile.patch
+    'decf3208e9ae96e2f9d22d0c964608ac40540ddfb3e381175cb3be6ce94d2882',  # CP2K-20131211-ifort-compiler-bug-fix.patch
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-2.5.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-2.5.1-intel-2014b.eb
@@ -10,12 +10,16 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'intel', 'version': '2014b'}
 toolchainopts = {'pic': True}
 
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s/']
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
-
 patches = [
     'CP2K-20131211-ifort-compiler-bug-fix.patch',
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+checksums = [
+    '0e6f12834176feb94b7266b328e61e9c60a2d4c2ea6c5e7d853a648da29ec5b0',  # cp2k-2.5.1.tar.bz2
+    'decf3208e9ae96e2f9d22d0c964608ac40540ddfb3e381175cb3be6ce94d2882',  # CP2K-20131211-ifort-compiler-bug-fix.patch
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-2.6.0-CrayGNU-2015.06.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-2.6.0-CrayGNU-2015.06.eb
@@ -10,12 +10,16 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'CrayGNU', 'version': '2015.06'}
 toolchainopts = {'pic': True}
 
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s/']
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
-
 patches = [
     'CP2K-2.6.0-ifort-compiler-bug-fix.patch',
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+checksums = [
+    '7d224a92eb8c767c7dcfde54a1b22e2c83b7cabb3ce00633e94bbd4b0d06a784',  # cp2k-2.6.0.tar.bz2
+    'b6d4e2ef29de13e93edd18b51d4bca530ad2fd405f730de3b07dafc83853e7f4',  # CP2K-2.6.0-ifort-compiler-bug-fix.patch
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-2.6.0-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-2.6.0-CrayGNU-2015.11.eb
@@ -10,12 +10,16 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'CrayGNU', 'version': '2015.11'}
 toolchainopts = {'pic': True}
 
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s/']
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
-
 patches = [
     'CP2K-2.6.0-ifort-compiler-bug-fix.patch',
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+checksums = [
+    '7d224a92eb8c767c7dcfde54a1b22e2c83b7cabb3ce00633e94bbd4b0d06a784',  # cp2k-2.6.0.tar.bz2
+    'b6d4e2ef29de13e93edd18b51d4bca530ad2fd405f730de3b07dafc83853e7f4',  # CP2K-2.6.0-ifort-compiler-bug-fix.patch
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-2.6.0-intel-2015a.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-2.6.0-intel-2015a.eb
@@ -10,12 +10,16 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'intel', 'version': '2015a'}
 toolchainopts = {'pic': True}
 
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s/']
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
-
 patches = [
     'CP2K-2.6.0-ifort-compiler-bug-fix.patch',
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+checksums = [
+    '7d224a92eb8c767c7dcfde54a1b22e2c83b7cabb3ce00633e94bbd4b0d06a784',  # cp2k-2.6.0.tar.bz2
+    'b6d4e2ef29de13e93edd18b51d4bca530ad2fd405f730de3b07dafc83853e7f4',  # CP2K-2.6.0-ifort-compiler-bug-fix.patch
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-2.6.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-2.6.1-foss-2015b.eb
@@ -10,12 +10,16 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'foss', 'version': '2015b'}
 toolchainopts = {'pic': True}
 
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s/']
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
-
 patches = [
     'CP2K-2.6.0-ifort-compiler-bug-fix.patch',
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+checksums = [
+    '26bef0718f84efb5197bb4d13211d2b7ad2103eced413dd2652d9b11a97868f5',  # cp2k-2.6.1.tar.bz2
+    'b6d4e2ef29de13e93edd18b51d4bca530ad2fd405f730de3b07dafc83853e7f4',  # CP2K-2.6.0-ifort-compiler-bug-fix.patch
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-2.6.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-2.6.1-intel-2015b.eb
@@ -10,12 +10,16 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'intel', 'version': '2015b'}
 toolchainopts = {'pic': True}
 
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s/']
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
-
 patches = [
     'CP2K-2.6.0-ifort-compiler-bug-fix.patch',
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+checksums = [
+    '26bef0718f84efb5197bb4d13211d2b7ad2103eced413dd2652d9b11a97868f5',  # cp2k-2.6.1.tar.bz2
+    'b6d4e2ef29de13e93edd18b51d4bca530ad2fd405f730de3b07dafc83853e7f4',  # CP2K-2.6.0-ifort-compiler-bug-fix.patch
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-3.0-CrayGNU-2015.11-cuda-7.0.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-3.0-CrayGNU-2015.11-cuda-7.0.eb
@@ -13,12 +13,16 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'CrayGNU', 'version': '2015.11'}
 toolchainopts = {'pic': True}
 
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s.0/']
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
-
 patches = [
     'CP2K-2.6.0-ifort-compiler-bug-fix.patch',
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+checksums = [
+    '1acfacef643141045b7cbade7006f9b7538476d861eeecd9658c9e468dc61151',  # cp2k-3.0.tar.bz2
+    'b6d4e2ef29de13e93edd18b51d4bca530ad2fd405f730de3b07dafc83853e7f4',  # CP2K-2.6.0-ifort-compiler-bug-fix.patch
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-3.0-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-3.0-CrayGNU-2015.11.eb
@@ -11,12 +11,16 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'CrayGNU', 'version': '2015.11'}
 toolchainopts = {'pic': True}
 
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s.0/']
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
-
 patches = [
     'CP2K-2.6.0-ifort-compiler-bug-fix.patch',
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+checksums = [
+    '1acfacef643141045b7cbade7006f9b7538476d861eeecd9658c9e468dc61151',  # cp2k-3.0.tar.bz2
+    'b6d4e2ef29de13e93edd18b51d4bca530ad2fd405f730de3b07dafc83853e7f4',  # CP2K-2.6.0-ifort-compiler-bug-fix.patch
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-3.0-intel-2016a.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-3.0-intel-2016a.eb
@@ -10,12 +10,16 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'intel', 'version': '2016a'}
 toolchainopts = {'pic': True}
 
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s.0/']
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
-
 patches = [
     'CP2K-2.6.0-ifort-compiler-bug-fix.patch',
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+checksums = [
+    '1acfacef643141045b7cbade7006f9b7538476d861eeecd9658c9e468dc61151',  # cp2k-3.0.tar.bz2
+    'b6d4e2ef29de13e93edd18b51d4bca530ad2fd405f730de3b07dafc83853e7f4',  # CP2K-2.6.0-ifort-compiler-bug-fix.patch
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-3.0-intel-2016b-psmp.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-3.0-intel-2016b-psmp.eb
@@ -11,12 +11,16 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'intel', 'version': '2016b'}
 toolchainopts = {'pic': True}
 
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s.0/']
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
-
 patches = [
     'CP2K-2.6.0-ifort-compiler-bug-fix.patch',
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+checksums = [
+    '1acfacef643141045b7cbade7006f9b7538476d861eeecd9658c9e468dc61151',  # cp2k-3.0.tar.bz2
+    'b6d4e2ef29de13e93edd18b51d4bca530ad2fd405f730de3b07dafc83853e7f4',  # CP2K-2.6.0-ifort-compiler-bug-fix.patch
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-3.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-3.0-intel-2016b.eb
@@ -10,12 +10,16 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'intel', 'version': '2016b'}
 toolchainopts = {'pic': True}
 
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s.0/']
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
-
 patches = [
     'CP2K-2.6.0-ifort-compiler-bug-fix.patch',
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+checksums = [
+    '1acfacef643141045b7cbade7006f9b7538476d861eeecd9658c9e468dc61151',  # cp2k-3.0.tar.bz2
+    'b6d4e2ef29de13e93edd18b51d4bca530ad2fd405f730de3b07dafc83853e7f4',  # CP2K-2.6.0-ifort-compiler-bug-fix.patch
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-3.0-intel-2017b.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-3.0-intel-2017b.eb
@@ -10,7 +10,7 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'intel', 'version': '2017b'}
 toolchainopts = {'pic': True}
 
-source_urls = [SOURCEFORGE_SOURCE]
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s.0/']
 sources = [SOURCELOWER_TAR_BZ2]
 patches = [
     'CP2K-2.6.0-ifort-compiler-bug-fix.patch',

--- a/easybuild/easyconfigs/c/CP2K/CP2K-3.0-intel-2018a.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-3.0-intel-2018a.eb
@@ -10,7 +10,7 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'intel', 'version': '2018a'}
 toolchainopts = {'pic': True}
 
-source_urls = [SOURCEFORGE_SOURCE]
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s.0/']
 sources = [SOURCELOWER_TAR_BZ2]
 patches = [
     'CP2K-2.6.0-ifort-compiler-bug-fix.patch',

--- a/easybuild/easyconfigs/c/CP2K/CP2K-4.1-foss-2016b-psmp.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-4.1-foss-2016b-psmp.eb
@@ -11,11 +11,14 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'foss', 'version': '2016b'}
 toolchainopts = {'pic': True, 'openmp': True}
 
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s.0/']
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
-
 patches = [
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+checksums = [
+    '4a3e4a101d8a35ebd80a9e9ecb02697fb8256364f1eccdbe4e5a85d31fe21343',  # cp2k-4.1.tar.bz2
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-4.1-intel-2016b.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-4.1-intel-2016b.eb
@@ -10,11 +10,14 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'intel', 'version': '2016b'}
 toolchainopts = {'pic': True}
 
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s.0/']
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
-
 patches = [
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+checksums = [
+    '4a3e4a101d8a35ebd80a9e9ecb02697fb8256364f1eccdbe4e5a85d31fe21343',  # cp2k-4.1.tar.bz2
+    '02475cbe24c8d4ba27037c826adf8a534cad634c3c4e02c21d743f5284516bda',  # CP2K-2.4.0-fix_compile_date_lastsvn.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/c/CP2K/CP2K-5.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-5.1-foss-2018a.eb
@@ -10,7 +10,7 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'foss', 'version': '2018a'}
 toolchainopts = {'pic': True}
 
-source_urls = [SOURCEFORGE_SOURCE]
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s.0/']
 sources = [SOURCELOWER_TAR_BZ2]
 patches = [
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',

--- a/easybuild/easyconfigs/c/CP2K/CP2K-5.1-intel-2017b.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-5.1-intel-2017b.eb
@@ -10,7 +10,7 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'intel', 'version': '2017b'}
 toolchainopts = {'pic': True}
 
-source_urls = [SOURCEFORGE_SOURCE]
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s.0/']
 sources = [SOURCELOWER_TAR_BZ2]
 patches = [
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',

--- a/easybuild/easyconfigs/c/CP2K/CP2K-5.1-intel-2018a.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-5.1-intel-2018a.eb
@@ -10,7 +10,7 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'intel', 'version': '2018a'}
 toolchainopts = {'pic': True}
 
-source_urls = [SOURCEFORGE_SOURCE]
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s.0/']
 sources = [SOURCELOWER_TAR_BZ2]
 patches = [
     'CP2K-2.4.0-fix_compile_date_lastsvn.patch',


### PR DESCRIPTION
fix for #7239 reported by @sassy-crick

The source tarballs that can be downloaded from GitHub are exactly the same as the ones that used to be on SourceForge (same SHA256 checksums).