### PR TITLE
Make SCOTCH 6.0.5 install version 6.0.5 (instead 6.0.4)

### DIFF
--- a/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.5-foss-2018a.eb
+++ b/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.5-foss-2018a.eb
@@ -8,9 +8,12 @@ static mapping, and sparse matrix block ordering, and sequential mesh and hyperg
 toolchain = {'name': 'foss', 'version': '2018a'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://gforge.inria.fr/frs/download.php/file/34618/']
+source_urls = ['http://gforge.inria.fr/frs/download.php/file/37401/']
 sources = ['%(namelower)s_%(version)s.tar.gz']
-checksums = ['f53f4d71a8345ba15e2dd4e102a35fd83915abf50ea73e1bf6efe1bc2b4220c7']
+# The previous version of SCHOTCH 6.0.5 easyconfig installed version 6.0.4
+# This is actually version 6.0.5a, since 6.0.5 is not publicly accessible.
+# This is in general not a proiblem, because all 6.0.5 versions were installing 6.0.4
+checksums = ['5b21b95e33acd5409d682fa7253cefbdffa8db82875549476c006d8cbe7c556f']
 
 dependencies = [
     ('zlib', '1.2.11'),

--- a/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.5-foss-2018b.eb
+++ b/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.5-foss-2018b.eb
@@ -8,9 +8,12 @@ static mapping, and sparse matrix block ordering, and sequential mesh and hyperg
 toolchain = {'name': 'foss', 'version': '2018b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://gforge.inria.fr/frs/download.php/file/34618/']
+source_urls = ['http://gforge.inria.fr/frs/download.php/file/37401/']
 sources = ['%(namelower)s_%(version)s.tar.gz']
-checksums = ['f53f4d71a8345ba15e2dd4e102a35fd83915abf50ea73e1bf6efe1bc2b4220c7']
+# The previous version of SCHOTCH 6.0.5 easyconfig installed version 6.0.4
+# This is actually version 6.0.5a, since 6.0.5 is not publicly accessible.
+# This is in general not a proiblem, because all 6.0.5 versions were installing 6.0.4
+checksums = ['5b21b95e33acd5409d682fa7253cefbdffa8db82875549476c006d8cbe7c556f']
 
 dependencies = [
     ('zlib', '1.2.11'),

--- a/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.5-intel-2018a.eb
+++ b/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.5-intel-2018a.eb
@@ -8,9 +8,12 @@ static mapping, and sparse matrix block ordering, and sequential mesh and hyperg
 toolchain = {'name': 'intel', 'version': '2018a'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://gforge.inria.fr/frs/download.php/file/34618/']
+source_urls = ['http://gforge.inria.fr/frs/download.php/file/37401/']
 sources = ['%(namelower)s_%(version)s.tar.gz']
-checksums = ['f53f4d71a8345ba15e2dd4e102a35fd83915abf50ea73e1bf6efe1bc2b4220c7']
+# The previous version of SCHOTCH 6.0.5 easyconfig installed version 6.0.4
+# This is actually version 6.0.5a, since 6.0.5 is not publicly accessible.
+# This is in general not a proiblem, because all 6.0.5 versions were installing 6.0.4
+checksums = ['5b21b95e33acd5409d682fa7253cefbdffa8db82875549476c006d8cbe7c556f']
 
 dependencies = [
     ('zlib', '1.2.11'),


### PR DESCRIPTION
Just for reference, this is `SCOTCH` `6.0.5a` as `6.0.5` download link is not publicly accessible. Since all previous `6.0.5` versions installed version `6.0.4`, it should not be a problem.

Just for a record, `6.0.5` can be downloaded from https://gforge.inria.fr/frs/download.php/file/37396/scotch_6.0.5.tar.gz