### PR TITLE
{lib}[intel/2018b] CFITSIO v3.45

### DIFF
--- a/easybuild/easyconfigs/c/CFITSIO/CFITSIO-3.45-intel-2018b.eb
+++ b/easybuild/easyconfigs/c/CFITSIO/CFITSIO-3.45-intel-2018b.eb
@@ -26,7 +26,7 @@ sanity_check_paths = {
         'lib/libcfitsio.a',
         'lib/libcfitsio.so',
         'lib/libcfitsio.so.7.%(version)s'
-        ],
+    ],
     'dirs': ['include'],
 }
 

--- a/easybuild/easyconfigs/c/CFITSIO/CFITSIO-3.45-intel-2018b.eb
+++ b/easybuild/easyconfigs/c/CFITSIO/CFITSIO-3.45-intel-2018b.eb
@@ -1,0 +1,33 @@
+easyblock = 'ConfigureMake'
+
+name = 'CFITSIO'
+version = '3.45'
+
+homepage = 'http://heasarc.gsfc.nasa.gov/fitsio/'
+description = """CFITSIO is a library of C and Fortran subroutines for reading and writing data files in
+FITS (Flexible Image Transport System) data format."""
+
+toolchain = {'name': 'intel', 'version': '2018b'}
+toolchainopts = {'pic': True}
+
+# curl for HTTPs support
+dependencies = [('cURL', '7.60.0')]
+
+# standard make would create just static libcfitsio.a
+buildopts = '&& make shared'
+
+srcversion = '%s0' % version.replace('.', '')
+source_urls = ['http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/']
+sources = ['%%(namelower)s%s.tar.gz' % srcversion]
+checksums = ['bf6012dbe668ecb22c399c4b7b2814557ee282c74a7d5dc704eb17c30d9fb92e']
+
+sanity_check_paths = {
+    'files': [
+        'lib/libcfitsio.a',
+        'lib/libcfitsio.so',
+        'lib/libcfitsio.so.7.%(version)s'
+        ],
+    'dirs': ['include'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
- recent cfitsio from `https://heasarc.gsfc.nasa.gov/fitsio/` built with intel2018b toolchain
- added dependency to current cURL for HTTPs support in cfitsio
- added `make shared` statement to produce shared lib too