### PR TITLE
fix ImageMagick source URLs: use launchpad.net for old versions, switch to GitHub for 7.0.8-* onwards

### DIFF
--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.5-10-foss-2016b.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.5-10-foss-2016b.eb
@@ -12,9 +12,9 @@ description = """ImageMagick is a software suite to create, edit, compose, or co
 
 toolchain = {'name': 'foss', 'version': '2016b'}
 
+source_urls = ['https://launchpad.net/imagemagick/main/%(version)s/+download/']
 sources = [SOURCE_TAR_GZ]
-source_urls = ['https://www.imagemagick.org/download/releases/']
-checksums = ['43912034c69171882536b359a7b84f9f']
+checksums = ['a64f5ed292cbdd329de3db95bfa78fbb136df606d50cd7b0a6cb39a17d357377']
 
 dependencies = [
     ('bzip2', '1.0.6'),

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.5-4-intel-2017a.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.5-4-intel-2017a.eb
@@ -12,9 +12,9 @@ description = """ImageMagick is a software suite to create, edit, compose, or co
 
 toolchain = {'name': 'intel', 'version': '2017a'}
 
+source_urls = ['https://launchpad.net/imagemagick/main/%(version)s/+download/']
 sources = [SOURCE_TAR_GZ]
-source_urls = ['https://www.imagemagick.org/download/releases/']
-checksums = ['473a1e7ae37548eb6fe9cf2b1fb78011']
+checksums = ['4ebe4a4cbe9ead3a5aa6e1f7f72fc6ad75a83e7598d6d196809f4179ad204564']
 
 dependencies = [
     ('bzip2', '1.0.6'),

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-14-foss-2017b.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-14-foss-2017b.eb
@@ -12,8 +12,8 @@ description = """ImageMagick is a software suite to create, edit, compose, or co
 
 toolchain = {'name': 'foss', 'version': '2017b'}
 
+source_urls = ['https://launchpad.net/imagemagick/main/%(version)s/+download/']
 sources = [SOURCE_TAR_GZ]
-source_urls = ['https://www.imagemagick.org/download/releases/']
 checksums = ['5d7faa0e0e11095f3f748b3a87061287f6f605da137195aafac9a98c48ff193f']
 
 dependencies = [

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-14-intel-2017b.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-14-intel-2017b.eb
@@ -12,8 +12,8 @@ description = """ImageMagick is a software suite to create, edit, compose, or co
 
 toolchain = {'name': 'intel', 'version': '2017b'}
 
+source_urls = ['https://launchpad.net/imagemagick/main/%(version)s/+download/']
 sources = [SOURCE_TAR_GZ]
-source_urls = ['https://www.imagemagick.org/download/releases/']
 checksums = ['5d7faa0e0e11095f3f748b3a87061287f6f605da137195aafac9a98c48ff193f']
 
 dependencies = [

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-15-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-15-GCCcore-6.4.0.eb
@@ -12,8 +12,8 @@ description = """ImageMagick is a software suite to create, edit, compose, or co
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
+source_urls = ['https://launchpad.net/imagemagick/main/%(version)s/+download/']
 sources = [SOURCE_TAR_GZ]
-source_urls = ['https://www.imagemagick.org/download/releases/']
 checksums = ['4d8e3549bd5974fe7d00856fe30ccb3793dab0d3c629ed6bac6d5bf9964bace3']
 
 dependencies = [

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-26-foss-2018a.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-26-foss-2018a.eb
@@ -12,8 +12,8 @@ description = """ImageMagick is a software suite to create, edit, compose, or co
 
 toolchain = {'name': 'foss', 'version': '2018a'}
 
+source_urls = ['https://launchpad.net/imagemagick/main/%(version)s/+download/']
 sources = [SOURCE_TAR_GZ]
-source_urls = ['https://www.imagemagick.org/download/releases/']
 checksums = ['0b94b2c86ddb52ecc99a9ad2b811a42e69e1b7fc1fd6bcd2aea12aee6f8b6615']
 
 dependencies = [

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-30-GCCcore-6.4.0-Ghostscript-9.22-cairo-1.14.12.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-30-GCCcore-6.4.0-Ghostscript-9.22-cairo-1.14.12.eb
@@ -15,7 +15,7 @@ description = """ImageMagick is a software suite to create, edit, compose, or co
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
-source_urls = ['https://www.imagemagick.org/download/releases/']
+source_urls = ['https://launchpad.net/imagemagick/main/%(version)s/+download/']
 sources = [SOURCE_TAR_GZ]
 checksums = ['8d3aca87b13dc1c17d28f83326201529e5a2936e9b8ee289377a247c615f272c']
 

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-30-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-30-GCCcore-6.4.0.eb
@@ -12,7 +12,7 @@ description = """ImageMagick is a software suite to create, edit, compose, or co
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
-source_urls = ['https://www.imagemagick.org/download/releases/']
+source_urls = ['https://launchpad.net/imagemagick/main/%(version)s/+download/']
 sources = [SOURCE_TAR_GZ]
 checksums = ['8d3aca87b13dc1c17d28f83326201529e5a2936e9b8ee289377a247c615f272c']
 

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-39-GCCcore-6.4.0-Ghostscript-9.23-cairo-1.14.12.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-39-GCCcore-6.4.0-Ghostscript-9.23-cairo-1.14.12.eb
@@ -15,9 +15,9 @@ description = """ImageMagick is a software suite to create, edit, compose, or co
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
-source_urls = ['https://www.imagemagick.org/download/releases/']
-sources = [SOURCE_TAR_XZ]
-checksums = ['978d260eb033debafeb43948d8c6d16e1fbd43e6e133f607890e75335d910d6a']
+source_urls = ['https://launchpad.net/imagemagick/main/%(version)s/+download/']
+sources = [SOURCE_TAR_GZ]
+checksums = ['9ca867e8553cab32760a96452b7997b7595cc1db045b6b76c545d3bd3ca350aa']
 
 dependencies = [
     ('bzip2', '1.0.6'),

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-8-intel-2017a-JasPer-1.900.1.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.7-8-intel-2017a-JasPer-1.900.1.eb
@@ -14,9 +14,9 @@ description = """ImageMagick is a software suite to create, edit, compose, or co
 
 toolchain = {'name': 'intel', 'version': '2017a'}
 
+source_urls = ['https://launchpad.net/imagemagick/main/%(version)s/+download/']
 sources = [SOURCE_TAR_GZ]
-source_urls = ['https://www.imagemagick.org/download/releases/']
-checksums = ['8dbd544640bc074541f441c911e2b3b9045695083d2ccdc694ec9a62181e5823']
+checksums = ['ce3bf2a4e2adcbd75c1a9bd5bf7beb20baf625385eb36c7b9701b766e2388c57']
 
 dependencies = [
     ('bzip2', '1.0.6'),

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.8-11-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.8-11-GCCcore-7.3.0.eb
@@ -12,9 +12,9 @@ description = """ImageMagick is a software suite to create, edit, compose, or co
 
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 
-source_urls = ['https://www.imagemagick.org/download/releases/']
-sources = [SOURCE_TAR_XZ]
-checksums = ['c15f14c054b4fde417e7b82c23950047203f81e582de7f1270cf3bdfa8a38a03']
+source_urls = ['https://github.com/ImageMagick/ImageMagick/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['95e4da5fa109bc8b59b5e7a54cdfcf1af3230067c95adf608ff21c08eca1de20']
 
 dependencies = [
     ('bzip2', '1.0.6'),


### PR DESCRIPTION
fix for #7274, based on the feedback in https://imagemagick.org/discourse-server/viewtopic.php?f=2&t=35150

There's little point in using https://www.imagemagick.org/download/releases/ as source URL, since source tarballs disappear there when new releases are available.

For versions prior to and including 7.0.8-5, original tarballs can be downloaded from https://launchpad.net/imagemagick/+download.

For newer version, we can use the tags from GitHub, see https://github.com/ImageMagick/ImageMagick/releases/

cc @sassy-crick 