### PR TITLE
fix source URL in Doxygen easyconfigs

### DIFF
--- a/easybuild/easyconfigs/__archive__/d/Doxygen/Doxygen-1.8.1.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/__archive__/d/Doxygen/Doxygen-1.8.1.1-goalf-1.1.0-no-OFED.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'goalf', 'version': '1.1.0-no-OFED'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['d2c754d2387c8794da35196462a9b4492007a3dad9d40f69f3e658766c8de8d6']
 
 builddependencies = [
     ('flex', '2.5.35'),

--- a/easybuild/easyconfigs/__archive__/d/Doxygen/Doxygen-1.8.1.1-ictce-3.2.2.u3.eb
+++ b/easybuild/easyconfigs/__archive__/d/Doxygen/Doxygen-1.8.1.1-ictce-3.2.2.u3.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '3.2.2.u3'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['d2c754d2387c8794da35196462a9b4492007a3dad9d40f69f3e658766c8de8d6']
 
 builddependencies = [
     ('flex', '2.5.35'),

--- a/easybuild/easyconfigs/__archive__/d/Doxygen/Doxygen-1.8.1.1-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/__archive__/d/Doxygen/Doxygen-1.8.1.1-ictce-4.0.6.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '4.0.6'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['d2c754d2387c8794da35196462a9b4492007a3dad9d40f69f3e658766c8de8d6']
 
 builddependencies = [
     ('flex', '2.5.35'),

--- a/easybuild/easyconfigs/__archive__/d/Doxygen/Doxygen-1.8.1.1-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/__archive__/d/Doxygen/Doxygen-1.8.1.1-ictce-4.1.13.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '4.1.13'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['d2c754d2387c8794da35196462a9b4492007a3dad9d40f69f3e658766c8de8d6']
 
 builddependencies = [
     ('flex', '2.5.35'),

--- a/easybuild/easyconfigs/__archive__/d/Doxygen/Doxygen-1.8.2-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/__archive__/d/Doxygen/Doxygen-1.8.2-ictce-4.1.13.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '4.1.13'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['5258244e3e225511dbacbbc58be958f114c11e35461a893473d356182b949d54']
 
 builddependencies = [
     ('flex', '2.5.37'),

--- a/easybuild/easyconfigs/__archive__/d/Doxygen/Doxygen-1.8.3.1-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/__archive__/d/Doxygen/Doxygen-1.8.3.1-ictce-4.1.13.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '4.1.13'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['0c749f68101b6c04ccb0d9696dd37836a6ba62cd8002add275058a975ee72b55']
 
 builddependencies = [
     ('flex', '2.5.37'),

--- a/easybuild/easyconfigs/__archive__/d/Doxygen/Doxygen-1.8.3.1-iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/__archive__/d/Doxygen/Doxygen-1.8.3.1-iqacml-3.7.3.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'iqacml', 'version': '3.7.3'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['0c749f68101b6c04ccb0d9696dd37836a6ba62cd8002add275058a975ee72b55']
 
 builddependencies = [
     ('flex', '2.5.37'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.1.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.1.1-goolf-1.4.10.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['d2c754d2387c8794da35196462a9b4492007a3dad9d40f69f3e658766c8de8d6']
 
 builddependencies = [
     ('flex', '2.5.35'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.1.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.1.1-ictce-5.3.0.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['d2c754d2387c8794da35196462a9b4492007a3dad9d40f69f3e658766c8de8d6']
 
 builddependencies = [
     ('flex', '2.5.35'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.1.1-ictce-5.4.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.1.1-ictce-5.4.0.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '5.4.0'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['d2c754d2387c8794da35196462a9b4492007a3dad9d40f69f3e658766c8de8d6']
 
 builddependencies = [
     ('flex', '2.5.35'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.10-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.10-GNU-4.9.3-2.25.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'GNU', 'version': '4.9.3-2.25'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['cedf78f6d213226464784ecb999b54515c97eab8a2f9b82514292f837cf88b93']
 
 builddependencies = [
     ('flex', '2.5.39'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.10-foss-2015b.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.10-foss-2015b.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'foss', 'version': '2015b'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['cedf78f6d213226464784ecb999b54515c97eab8a2f9b82514292f837cf88b93']
 
 builddependencies = [
     ('CMake', '3.4.1'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.10-intel-2015b.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.10-intel-2015b.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'intel', 'version': '2015b'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['cedf78f6d213226464784ecb999b54515c97eab8a2f9b82514292f837cf88b93']
 
 builddependencies = [
     ('CMake', '3.4.1'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.10-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.10-intel-2016.02-GCC-4.9.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['cedf78f6d213226464784ecb999b54515c97eab8a2f9b82514292f837cf88b93']
 
 builddependencies = [
     ('CMake', '3.4.1'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-GCC-4.9.2.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'GCC', 'version': '4.9.2'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['65d08b46e48bd97186aef562dc366681045b119e00f83c5b61d05d37ea154049']
 
 builddependencies = [
     ('CMake', '3.4.1'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-GCCcore-5.4.0.eb
@@ -7,7 +7,7 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'GCCcore', 'version': '5.4.0'}
 
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
 checksums = ['65d08b46e48bd97186aef562dc366681045b119e00f83c5b61d05d37ea154049']
 

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-foss-2015a.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-foss-2015a.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'foss', 'version': '2015a'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['65d08b46e48bd97186aef562dc366681045b119e00f83c5b61d05d37ea154049']
 
 builddependencies = [
     ('CMake', '3.4.1'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-foss-2016a.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-foss-2016a.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'foss', 'version': '2016a'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['65d08b46e48bd97186aef562dc366681045b119e00f83c5b61d05d37ea154049']
 
 builddependencies = [
     ('CMake', '3.4.3'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-foss-2016b.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-foss-2016b.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'foss', 'version': '2016b'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['65d08b46e48bd97186aef562dc366681045b119e00f83c5b61d05d37ea154049']
 
 builddependencies = [
     ('CMake', '3.5.2'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-intel-2016a.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-intel-2016a.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'intel', 'version': '2016a'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['65d08b46e48bd97186aef562dc366681045b119e00f83c5b61d05d37ea154049']
 
 builddependencies = [
     ('CMake', '3.4.3'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-intel-2016b.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-intel-2016b.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'intel', 'version': '2016b'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['65d08b46e48bd97186aef562dc366681045b119e00f83c5b61d05d37ea154049']
 
 builddependencies = [
     ('CMake', '3.5.2'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-iomkl-2016.07.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-iomkl-2016.07.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'iomkl', 'version': '2016.07'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['65d08b46e48bd97186aef562dc366681045b119e00f83c5b61d05d37ea154049']
 
 builddependencies = [
     ('flex', '2.6.0'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.11-iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'iomkl', 'version': '2016.09-GCC-4.9.3-2.25'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['65d08b46e48bd97186aef562dc366681045b119e00f83c5b61d05d37ea154049']
 
 builddependencies = [
     ('flex', '2.6.0'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.13-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.13-GCCcore-6.3.0.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['af667887bd7a87dc0dbf9ac8d86c96b552dfb8ca9c790ed1cbffaa6131573f6b']
 
 builddependencies = [
     # use same binutils version that was used when building GCC toolchain

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.13-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.13-GCCcore-6.4.0.eb
@@ -11,7 +11,7 @@ description = """
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
 checksums = ['af667887bd7a87dc0dbf9ac8d86c96b552dfb8ca9c790ed1cbffaa6131573f6b']
 

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.13-gimkl-2017a.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.13-gimkl-2017a.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'gimkl', 'version': '2017a'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['af667887bd7a87dc0dbf9ac8d86c96b552dfb8ca9c790ed1cbffaa6131573f6b']
 
 builddependencies = [
     ('CMake', '3.6.1'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.14-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.14-GCCcore-6.4.0.eb
@@ -11,7 +11,7 @@ description = """
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
 checksums = ['d1757e02755ef6f56fd45f1f4398598b920381948d6fcfa58f5ca6aa56f59d4d']
 

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.14-GCCcore-7.2.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.14-GCCcore-7.2.0.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'GCCcore', 'version': '7.2.0'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['d1757e02755ef6f56fd45f1f4398598b920381948d6fcfa58f5ca6aa56f59d4d']
 
 builddependencies = [
     ('binutils', '2.29'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.14-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.14-GCCcore-7.3.0.eb
@@ -11,7 +11,7 @@ description = """
 
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
 checksums = ['d1757e02755ef6f56fd45f1f4398598b920381948d6fcfa58f5ca6aa56f59d4d']
 

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.2-ictce-5.3.0.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['5258244e3e225511dbacbbc58be958f114c11e35461a893473d356182b949d54']
 
 builddependencies = [
     ('flex', '2.5.37'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.3.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.3.1-goolf-1.4.10.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['0c749f68101b6c04ccb0d9696dd37836a6ba62cd8002add275058a975ee72b55']
 
 builddependencies = [
     ('flex', '2.5.37'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.3.1-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.3.1-goolf-1.5.14.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'goolf', 'version': '1.5.14'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['0c749f68101b6c04ccb0d9696dd37836a6ba62cd8002add275058a975ee72b55']
 
 builddependencies = [
     ('flex', '2.5.37'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.3.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.3.1-ictce-5.3.0.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['0c749f68101b6c04ccb0d9696dd37836a6ba62cd8002add275058a975ee72b55']
 
 dependencies = [
     ('flex', '2.5.37'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.3.1-ictce-5.4.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.3.1-ictce-5.4.0.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '5.4.0'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['0c749f68101b6c04ccb0d9696dd37836a6ba62cd8002add275058a975ee72b55']
 
 builddependencies = [
     ('flex', '2.5.37'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.3.1-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.3.1-ictce-5.5.0.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['0c749f68101b6c04ccb0d9696dd37836a6ba62cd8002add275058a975ee72b55']
 
 builddependencies = [
     ('flex', '2.5.37'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.3.1-ictce-6.1.5.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.3.1-ictce-6.1.5.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '6.1.5'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['0c749f68101b6c04ccb0d9696dd37836a6ba62cd8002add275058a975ee72b55']
 
 dependencies = [
     ('flex', '2.5.37'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.5-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.5-ictce-5.5.0.eb
@@ -7,8 +7,9 @@ IDL (Corba and Microsoft flavors), Fortran, VHDL, PHP, C#, and to some extent D.
 
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['243a8b67db12ad68d6ea5b51c6f60dc2cc3a34fa47abf1b5b4499196c3d7cc25']
 
 dependencies = [
     ('flex', '2.5.37'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.5-intel-2014b.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.5-intel-2014b.eb
@@ -7,8 +7,9 @@ IDL (Corba and Microsoft flavors), Fortran, VHDL, PHP, C#, and to some extent D.
 
 toolchain = {'name': 'intel', 'version': '2014b'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['243a8b67db12ad68d6ea5b51c6f60dc2cc3a34fa47abf1b5b4499196c3d7cc25']
 
 dependencies = [
     ('flex', '2.5.37'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.6-ictce-5.4.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.6-ictce-5.4.0.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '5.4.0'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['6a718625f0c0c1eb3dee78ec1f83409b49e790f4c6c47fd44cd51cb92695535f']
 
 builddependencies = [
     ('flex', '2.5.37'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.6-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.6-ictce-5.5.0.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['6a718625f0c0c1eb3dee78ec1f83409b49e790f4c6c47fd44cd51cb92695535f']
 
 builddependencies = [
     ('flex', '2.5.37'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.7-foss-2014b.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.7-foss-2014b.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'foss', 'version': '2014b'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['c6eac6b6e82148ae15ec5aecee4631547359f284af1ce94474d046ebca6ee3d9']
 
 builddependencies = [
     ('flex', '2.5.39'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.7-foss-2015a.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.7-foss-2015a.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'foss', 'version': '2015a'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['c6eac6b6e82148ae15ec5aecee4631547359f284af1ce94474d046ebca6ee3d9']
 
 builddependencies = [
     ('flex', '2.5.39'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.7-intel-2014b.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.7-intel-2014b.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'intel', 'version': '2014b'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['c6eac6b6e82148ae15ec5aecee4631547359f284af1ce94474d046ebca6ee3d9']
 
 builddependencies = [
     ('flex', '2.5.39'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.7-intel-2015a.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.7-intel-2015a.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'intel', 'version': '2015a'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['c6eac6b6e82148ae15ec5aecee4631547359f284af1ce94474d046ebca6ee3d9']
 
 builddependencies = [
     ('flex', '2.5.39'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.8-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.8-ictce-7.1.2.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'ictce', 'version': '7.1.2'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['d1f978350527a2338199c9abb78f76f10746520de5dc4ae4cdd27fc9df9b19b8']
 
 builddependencies = [
     ('flex', '2.5.39'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.8-intel-2014b.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.8-intel-2014b.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'intel', 'version': '2014b'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['d1f978350527a2338199c9abb78f76f10746520de5dc4ae4cdd27fc9df9b19b8']
 
 builddependencies = [
     ('flex', '2.5.39'),

--- a/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.9.1-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/d/Doxygen/Doxygen-1.8.9.1-GCC-4.9.2.eb
@@ -7,8 +7,9 @@ description = """Doxygen is a documentation system for C++, C, Java, Objective-C
 
 toolchain = {'name': 'GCC', 'version': '4.9.2'}
 
+source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(namelower)s-%(version)s.src.tar.gz']
-source_urls = ['http://ftp.stack.nl/pub/users/dimitri/']
+checksums = ['d4ab6e28d4d45d8956cad17470aade3fbe2356e8f64b92167e738c1887feccec']
 
 builddependencies = [
     ('flex', '2.5.39'),


### PR DESCRIPTION
Switch to downloading doxygen from doxygen.nl as ftp.stack.nl is dead.

See Issue #7280.