### PR TITLE
promote FriBiDi to runtime dep of Pango rather than only build dep

### DIFF
--- a/easybuild/easyconfigs/p/Pango/Pango-1.41.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/p/Pango/Pango-1.41.1-foss-2018a.eb
@@ -19,12 +19,12 @@ dependencies = [
     ('GLib', '2.54.3'),
     ('cairo', '1.14.12'),
     ('HarfBuzz', '1.7.5'),
+    ('FriBidi', '1.0.1'),
 ]
 
 builddependencies = [
     ('GObject-Introspection', '1.54.1', '-Python-2.7.14'),
     ('pkg-config', '0.29.2'),
-    ('FriBidi', '1.0.1'),
 ]
 
 configopts = "--disable-silent-rules --enable-introspection=yes --enable-static --enable-shared "

--- a/easybuild/easyconfigs/p/Pango/Pango-1.41.1-intel-2018a.eb
+++ b/easybuild/easyconfigs/p/Pango/Pango-1.41.1-intel-2018a.eb
@@ -19,12 +19,12 @@ dependencies = [
     ('GLib', '2.54.3'),
     ('cairo', '1.14.12'),
     ('HarfBuzz', '1.7.5'),
+    ('FriBidi', '1.0.1'),
 ]
 
 builddependencies = [
     ('GObject-Introspection', '1.54.1', '-Python-2.7.14'),
     ('pkg-config', '0.29.2'),
-    ('FriBidi', '1.0.1'),
 ]
 
 configopts = "--disable-silent-rules --enable-introspection=yes --enable-static --enable-shared "

--- a/easybuild/easyconfigs/p/Pango/Pango-1.42.4-foss-2018b.eb
+++ b/easybuild/easyconfigs/p/Pango/Pango-1.42.4-foss-2018b.eb
@@ -19,12 +19,12 @@ dependencies = [
     ('GLib', '2.54.3'),
     ('cairo', '1.14.12'),
     ('HarfBuzz', '2.2.0'),
+    ('FriBidi', '1.0.5'),
 ]
 
 builddependencies = [
     ('GObject-Introspection', '1.54.1', '-Python-2.7.15'),
     ('pkg-config', '0.29.2'),
-    ('FriBidi', '1.0.5'),
 ]
 
 configopts = "--disable-silent-rules --enable-introspection=yes --enable-static --enable-shared "


### PR DESCRIPTION
Without this change, I saw problem when building `gnuplot` (cfr. #7332) which includes `Pango` as a dependency:

```
configure:14448: checking for CAIROPDF
configure:14456: $PKG_CONFIG --exists --print-errors "       cairo >= 1.2 cairo-pdf >= 1.2 pango >= 1.22 pangocairo >= 1.10 glib-2.0 >= 2.28"
Package fribidi was not found in the pkg-config search path
Perhaps you should add the directory containing `fribidi.pc'
to the PKG_CONFIG_PATH environment variable
...
Package 'fribidi', required by 'pango', not found
...
configure:14558: WARNING: The cairo terminals will not be compiled.
```

Which causes problems with the use of gnuplot:

```
set terminal pdf font "Helvetica,11" size 2.5,2
             ^
"./test", line 3: unknown or ambiguous terminal type; type just 'set terminal' for a list
```