### PR TITLE
{vis}[foss/2018b] ATK v2.26.1 (GTK+3)

### DIFF
--- a/easybuild/easyconfigs/a/ATK/ATK-2.26.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/a/ATK/ATK-2.26.1-foss-2018b.eb
@@ -1,0 +1,38 @@
+easyblock = 'ConfigureMake'
+
+name = 'ATK'
+version = '2.26.1'
+
+homepage = 'https://developer.gnome.org/ATK/stable/'
+description = """
+ ATK provides the set of accessibility interfaces that are implemented by other
+ toolkits and applications. Using the ATK interfaces, accessibility tools have
+ full access to view and control running applications.
+"""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['ef00ff6b83851dddc8db38b4d9faeffb99572ba150b0664ee02e46f015ea97cb']
+
+builddependencies = [
+    ('GObject-Introspection', '1.54.1', '-Python-2.7.15'),
+]
+
+dependencies = [
+    ('GLib', '2.54.3')
+]
+
+configopts = "--enable-introspection=yes"
+
+modextrapaths = {
+    'XDG_DATA_DIRS': 'share',
+}
+
+sanity_check_paths = {
+    'files': ['lib/libatk-1.0.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
`ATK` is dependency of `GTK+3`.
As specified here, https://www.gtk.org/download/linux.php, `ATK 2.26` is the proper version for stable `GTK+ 3.22`.

(created using `eb --new-pr`)