### PR TITLE
{vis}[GCCcore/7.3.0] libepoxy v1.5.3 (GTK+3)

### DIFF
--- a/easybuild/easyconfigs/l/libepoxy/libepoxy-1.5.3-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/l/libepoxy/libepoxy-1.5.3-GCCcore-7.3.0.eb
@@ -16,8 +16,8 @@ source_urls = [FTPGNOME_SOURCE]
 checksums = ['002958c5528321edd53440235d3c44e71b5b1e09b9177e8daf677450b6c4433d']
 
 builddependencies = [
-    ('Meson', '0.48.1','-Python-3.6.6',('foss','2018b')),
-    ('Ninja', '1.8.2','',('foss','2018b')),
+    ('Meson', '0.48.1', '-Python-3.6.6', ('foss', '2018b')),
+    ('Ninja', '1.8.2', '', ('foss', '2018b')),
     ('binutils', '2.30'),
 ]
 

--- a/easybuild/easyconfigs/l/libepoxy/libepoxy-1.5.3-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/l/libepoxy/libepoxy-1.5.3-GCCcore-7.3.0.eb
@@ -1,0 +1,38 @@
+easyblock = 'MesonNinja'
+
+name = 'libepoxy'
+version = '1.5.3'
+
+homepage = 'https://github.com/anholt/libepoxy'
+description = """
+(lib)Epoxy is a library for handling OpenGL function pointer management for you.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_XZ]
+source_urls = [FTPGNOME_SOURCE]
+checksums = ['002958c5528321edd53440235d3c44e71b5b1e09b9177e8daf677450b6c4433d']
+
+builddependencies = [
+    ('Meson', '0.48.1','-Python-3.6.6',('foss','2018b')),
+    ('Ninja', '1.8.2','',('foss','2018b')),
+    ('binutils', '2.30'),
+]
+
+dependencies = []
+
+# in easybuild Mesa there is disabled egl. So let's disable it here too:
+configopts = '-Degl=no'
+
+sanity_check_paths = {
+    'files': [
+        'lib64/libepoxy.so',
+    ],
+    'dirs': [
+        'include/epoxy'
+    ]
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
`libepoxy` is needed for `GTK+3`.
`v1.5.3` is latest stable one.

(created using `eb --new-pr`)