### PR TITLE
{vis}[foss/2018b] Pango v1.40.14 (GTK+3)

### DIFF
--- a/easybuild/easyconfigs/p/Pango/Pango-1.40.14-foss-2018b.eb
+++ b/easybuild/easyconfigs/p/Pango/Pango-1.40.14-foss-2018b.eb
@@ -17,10 +17,10 @@ sources = [SOURCELOWER_TAR_XZ]
 checksums = ['90af1beaa7bf9e4c52db29ec251ec4fd0a8f2cc185d521ad1f88d01b3a6a17e3']
 
 dependencies = [
-    ('X11', '20180604','',('GCCcore','7.3.0')),
-    ('GLib', '2.54.3','',('GCCcore','7.3.0')),
-    ('cairo', '1.14.12','',('GCCcore','7.3.0')),
-    ('HarfBuzz', '2.2.0' ),
+    ('X11', '20180604', '', ('GCCcore', '7.3.0')),
+    ('GLib', '2.54.3', '', ('GCCcore', '7.3.0')),
+    ('cairo', '1.14.12', '', ('GCCcore', '7.3.0')),
+    ('HarfBuzz', '2.2.0'),
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/p/Pango/Pango-1.40.14-foss-2018b.eb
+++ b/easybuild/easyconfigs/p/Pango/Pango-1.40.14-foss-2018b.eb
@@ -1,0 +1,38 @@
+easyblock = 'ConfigureMake'
+
+name = 'Pango'
+version = '1.40.14'
+
+homepage = 'http://www.pango.org/'
+description = """
+Pango is a library for laying out and rendering of text, with an emphasis on internationalization.
+Pango can be used anywhere that text layout is needed, though most of the work on Pango so far has been done in the
+context of the GTK+ widget toolkit. Pango forms the core of text and font handling for GTK+-2.x.
+"""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['90af1beaa7bf9e4c52db29ec251ec4fd0a8f2cc185d521ad1f88d01b3a6a17e3']
+
+dependencies = [
+    ('X11', '20180604','',('GCCcore','7.3.0')),
+    ('GLib', '2.54.3','',('GCCcore','7.3.0')),
+    ('cairo', '1.14.12','',('GCCcore','7.3.0')),
+    ('HarfBuzz', '2.2.0' ),
+]
+
+builddependencies = [
+    ('GObject-Introspection', '1.54.1', '-Python-2.7.15'),
+    ('pkg-config', '0.29.2'),
+    ('FriBidi', '1.0.5'),
+]
+
+configopts = "--disable-silent-rules --enable-introspection=yes --enable-static --enable-shared "
+
+modextrapaths = {
+    'XDG_DATA_DIRS': 'share',
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
`Pango` is dependency of `GTK+3`.
As specified here, https://www.gtk.org/download/linux.php, `1.40` is the proper `Pango` version for stable `GTK+ 3.22`.

(created using `eb --new-pr`)