### PR TITLE
{vis}[GCCcore/7.3.0] at-spi2-core v2.30.0 (GTK+3)

### DIFF
--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.30.0-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.30.0-GCCcore-7.3.0.eb
@@ -16,15 +16,15 @@ source_urls = [FTPGNOME_SOURCE]
 checksums = ['0175f5393d19da51f4c11462cba4ba6ef3fa042abf1611a70bdfed586b7bfb2b']
 
 builddependencies = [
-    ('Meson', '0.48.1','-Python-3.6.6',('foss','2018b')),
-    ('Ninja', '1.8.2','',('foss','2018b')),
+    ('Meson', '0.48.1', '-Python-3.6.6', ('foss', '2018b')),
+    ('Ninja', '1.8.2', '', ('foss', '2018b')),
     ('binutils', '2.30'),
 ]
 
 dependencies = [
-    ('DBus','1.13.6'),
-    ('X11','20180604'),
-    ('GLib','2.54.3'),
+    ('DBus', '1.13.6'),
+    ('X11', '20180604'),
+    ('GLib', '2.54.3'),
 ]
 
 configopts = ''

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.30.0-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.30.0-GCCcore-7.3.0.eb
@@ -1,0 +1,41 @@
+easyblock = 'MesonNinja'
+
+name = 'at-spi2-core'
+version = '2.30.0'
+
+homepage = 'https://www.freedesktop.org/wiki/Accessibility/AT-SPI2/'
+description = """
+At-Spi2-core includes the protocol definitions for the new D-Bus at-spi.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_XZ]
+source_urls = [FTPGNOME_SOURCE]
+checksums = ['0175f5393d19da51f4c11462cba4ba6ef3fa042abf1611a70bdfed586b7bfb2b']
+
+builddependencies = [
+    ('Meson', '0.48.1','-Python-3.6.6',('foss','2018b')),
+    ('Ninja', '1.8.2','',('foss','2018b')),
+    ('binutils', '2.30'),
+]
+
+dependencies = [
+    ('DBus','1.13.6'),
+    ('X11','20180604'),
+    ('GLib','2.54.3'),
+]
+
+configopts = ''
+
+sanity_check_paths = {
+    'files': [
+        'lib64/libatspi.so',
+    ],
+    'dirs': [
+        ''
+    ]
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
`at-spi2-core` is dependency of `at-spi2-atk`.
`2.30.0` is the last stable and compatible one with `at-spi2-atk 2.26.2`, needed by `GTK+3`.

(created using `eb --new-pr`)