### PR TITLE
bump up build dependency of flex-2.6.4 from Bison-3.0.4 to Bison-3.0.5

### DIFF
--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.5-GCCcore-5.5.0.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.5-GCCcore-5.5.0.eb
@@ -7,7 +7,7 @@ homepage = 'http://www.gnu.org/software/bison'
 description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
  into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
 
-toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+toolchain = {'name': 'GCCcore', 'version': '5.5.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
@@ -16,7 +16,7 @@ checksums = ['cd399d2bee33afa712bac4b1f4434e20379e9b4099bce47189e09a7675a2d566']
 builddependencies = [
     ('M4', '1.4.18'),
     # use same binutils version that was used when building GCCcore toolchain
-    ('binutils', '2.30', '', True),
+    ('binutils', '2.26', '', True),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.5-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.5-GCCcore-6.3.0.eb
@@ -7,7 +7,7 @@ homepage = 'http://www.gnu.org/software/bison'
 description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
  into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
 
-toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
@@ -16,7 +16,7 @@ checksums = ['cd399d2bee33afa712bac4b1f4434e20379e9b4099bce47189e09a7675a2d566']
 builddependencies = [
     ('M4', '1.4.18'),
     # use same binutils version that was used when building GCCcore toolchain
-    ('binutils', '2.30', '', True),
+    ('binutils', '2.27', '', True),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.5-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.5-GCCcore-6.4.0.eb
@@ -4,10 +4,14 @@ name = 'Bison'
 version = '3.0.5'
 
 homepage = 'http://www.gnu.org/software/bison'
-description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
- into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
 
-toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+description = """
+ Bison is a general-purpose parser generator that converts an annotated
+ context-free grammar into a deterministic LR or generalized LR (GLR) parser
+ employing LALR(1) parser tables.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
@@ -16,7 +20,7 @@ checksums = ['cd399d2bee33afa712bac4b1f4434e20379e9b4099bce47189e09a7675a2d566']
 builddependencies = [
     ('M4', '1.4.18'),
     # use same binutils version that was used when building GCCcore toolchain
-    ('binutils', '2.30', '', True),
+    ('binutils', '2.28', '', True),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.5-GCCcore-7.2.0.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.5-GCCcore-7.2.0.eb
@@ -7,7 +7,7 @@ homepage = 'http://www.gnu.org/software/bison'
 description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
  into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
 
-toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+toolchain = {'name': 'GCCcore', 'version': '7.2.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
@@ -16,7 +16,7 @@ checksums = ['cd399d2bee33afa712bac4b1f4434e20379e9b4099bce47189e09a7675a2d566']
 builddependencies = [
     ('M4', '1.4.18'),
     # use same binutils version that was used when building GCCcore toolchain
-    ('binutils', '2.30', '', True),
+    ('binutils', '2.29', '', True),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.5-GCCcore-8.1.0.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.5-GCCcore-8.1.0.eb
@@ -7,7 +7,7 @@ homepage = 'http://www.gnu.org/software/bison'
 description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
  into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
 
-toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+toolchain = {'name': 'GCCcore', 'version': '8.1.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.5-GCCcore-system.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.5-GCCcore-system.eb
@@ -7,17 +7,18 @@ homepage = 'http://www.gnu.org/software/bison'
 description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
  into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
 
-toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+toolchain = {'name': 'GCCcore', 'version': 'system'}
+# Can't rely on binutils in this case (since this is a dep) so switch off architecture optimisations
+toolchainopts = {'optarch': False}
 
-source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
 checksums = ['cd399d2bee33afa712bac4b1f4434e20379e9b4099bce47189e09a7675a2d566']
 
 builddependencies = [
     ('M4', '1.4.18'),
-    # use same binutils version that was used when building GCCcore toolchain
-    ('binutils', '2.30', '', True),
 ]
+
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['bison', 'yacc']] + [('lib/liby.a', 'lib64/liby.a')],

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-5.5.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-5.5.0.eb
@@ -17,7 +17,7 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995']
 
 builddependencies = [
-    ('Bison', '3.0.4'),
+    ('Bison', '3.0.5'),
     ('help2man', '1.47.5'),
     # use same binutils version that was used when building GCC toolchain
     ('binutils', '2.26', '', True),

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-6.3.0.eb
@@ -15,7 +15,7 @@ checksums = ['2882e3179748cc9f9c23ec593d6adc8d']
 
 dependencies = [('M4', '1.4.18')]
 builddependencies = [
-    ('Bison', '3.0.4'),
+    ('Bison', '3.0.5'),
     ('help2man', '1.47.4'),
     # use same binutils version that was used when building GCC toolchain
     ('binutils', '2.27', '', True),

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-6.3.0.eb
@@ -11,7 +11,7 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['https://github.com/westes/flex/releases/download/v%(version)s/']
 
-checksums = ['2882e3179748cc9f9c23ec593d6adc8d']
+checksums = ['e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995'']
 
 dependencies = [('M4', '1.4.18')]
 builddependencies = [

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-6.3.0.eb
@@ -11,7 +11,7 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['https://github.com/westes/flex/releases/download/v%(version)s/']
 
-checksums = ['e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995'']
+checksums = ['e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995']
 
 dependencies = [('M4', '1.4.18')]
 builddependencies = [

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-6.4.0.eb
@@ -17,7 +17,7 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995']
 
 builddependencies = [
-    ('Bison', '3.0.4'),
+    ('Bison', '3.0.5'),
     ('help2man', '1.47.4'),
     # use same binutils version that was used when building GCC toolchain
     ('binutils', '2.28', '', True),

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-7.2.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-7.2.0.eb
@@ -17,7 +17,7 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995']
 
 builddependencies = [
-    ('Bison', '3.0.4'),
+    ('Bison', '3.0.5'),
     ('help2man', '1.47.4'),
     # use same binutils version that was used when building GCC toolchain
     ('binutils', '2.29', '', True),

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-7.3.0.eb
@@ -17,7 +17,7 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995']
 
 builddependencies = [
-    ('Bison', '3.0.4'),
+    ('Bison', '3.0.5'),
     ('help2man', '1.47.4'),
     # use same binutils version that was used when building GCC toolchain
     ('binutils', '2.30', '', True),

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-8.1.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-8.1.0.eb
@@ -17,7 +17,7 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995']
 
 builddependencies = [
-    ('Bison', '3.0.4'),
+    ('Bison', '3.0.5'),
     ('help2man', '1.47.6'),
     # use same binutils version that was used when building GCC toolchain
     ('binutils', '2.30', '', True),

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-system.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-system.eb
@@ -18,7 +18,7 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995']
 
 builddependencies = [
-    ('Bison', '3.0.4'),
+    ('Bison', '3.0.5'),
     ('help2man', '1.47.4'),
 ]
 


### PR DESCRIPTION
Currently flex-2.6.4.eb has Bison-3.0.4.eb as a build dependency.  Bison-3.0.4.eb has M4-1.4.17.eb as a build dependency. 
However,  flex-2.6.4.eb also has M4-1.4.18.eb as a regular dependency.
Hence, the present PR proposes to bump the buiild dependency of flex-2.6.4.eb from  Bison-3.0.4 to  Bison-3.0.5. This would on the one hand remove the implicit dependency on M4-1.4.17.eb.
On the other hand M4-1.4.18 and Bison-3.0.4 do not compile on systems with the recent glibc 2.28.
As M4-1.4.18 is the most recent version of M4, a patch is required and has been proposed in PR https://github.com/easybuilders/easybuild-easyconfigs/pull/7384.
In contrast, Bison-3.0.5 compiles fine on glibc 2.28 and we do not require a patch but a change from  Bison-3.0.4 to Bison-3.0.5 would automatically also solve this issue.