### PR TITLE
disable building of OpenColorIO Python bindings since Python is not included as a dependency

### DIFF
--- a/easybuild/easyconfigs/o/OpenColorIO/OpenColorIO-1.1.0-foss-2018b.eb
+++ b/easybuild/easyconfigs/o/OpenColorIO/OpenColorIO-1.1.0-foss-2018b.eb
@@ -21,6 +21,9 @@ builddependencies = [('CMake', '3.12.1')]
 
 separate_build_dir = True
 
+# don't build Python bindings since Python is not included as a dependency
+configopts = "-DOCIO_BUILD_PYGLUE=OFF"
+
 sanity_check_paths = {
     'files': ['bin/ociobakelut', 'bin/ociocheck', 'lib/libOpenColorIO.%s' % SHLIB_EXT],
     'dirs': ['include/OpenColorIO', 'share'],


### PR DESCRIPTION
(fix for problem reported by @JackPerdue in #7342)

I tested this in an environment where `python-devel` (and hence `Python.h`) is not available, which led to the same problem as reported in #7342.

Building of Python bindings is enabled by default, but they shouldn't be unless Python is included as a dependency.