### PR TITLE
new: Python v3.6.6-GCCcore7.3.0-bare with Ninja v1.8.2 + Meson v0.49.0

### DIFF
--- a/easybuild/easyconfigs/m/Meson/Meson-0.49.0-GCCcore-7.3.0-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/m/Meson/Meson-0.49.0-GCCcore-7.3.0-Python-3.6.6.eb
@@ -1,0 +1,28 @@
+easyblock = 'PythonPackage'
+
+name = 'Meson'
+version = '0.49.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://mesonbuild.com'
+description = "Meson is a cross-platform build system designed to be both as fast and as user friendly as possible."
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+
+source_urls = [PYPI_LOWER_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a0cd55372208730eca5cd7cdff7948e439a006d8587c50c4445be1a0e88b2521']
+
+dependencies = [
+    ('Python', '3.6.6', '-bare'),
+    ('Ninja', '1.8.2'),
+]
+
+options = {'modulename': 'mesonbuild'}
+
+sanity_check_paths = {
+    'files': ['bin/meson'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/Meson/Meson-0.49.0-GCCcore-7.3.0-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/m/Meson/Meson-0.49.0-GCCcore-7.3.0-Python-3.6.6.eb
@@ -13,6 +13,10 @@ source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['a0cd55372208730eca5cd7cdff7948e439a006d8587c50c4445be1a0e88b2521']
 
+builddependencies = [
+    ('binutils', '2.30'),
+]
+
 dependencies = [
     ('Python', '3.6.6', '-bare'),
     ('Ninja', '1.8.2'),

--- a/easybuild/easyconfigs/n/Ninja/Ninja-1.8.2-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/n/Ninja/Ninja-1.8.2-GCCcore-7.3.0.eb
@@ -1,0 +1,29 @@
+easyblock = 'CmdCp'
+
+name = 'Ninja'
+version = '1.8.2'
+
+homepage = 'https://ninja-build.org/'
+description = "Ninja is a small build system with a focus on speed."
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+
+source_urls = ['https://github.com/ninja-build/ninja/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['86b8700c3d0880c2b44c2ff67ce42774aaf8c28cbf57725cb881569288c1c6f4']
+
+builddependencies = [
+    ('binutils', '2.30'),
+    ('Python', '2.7.15', '-bare'),
+]
+
+cmds_map = [('.*', "./configure.py --bootstrap")]
+
+files_to_copy = [(['ninja'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/ninja'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/Python/Python-3.6.6-GCCcore-7.3.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.6.6-GCCcore-7.3.0-bare.eb
@@ -1,0 +1,37 @@
+name = 'Python'
+version = '3.6.6'
+versionsuffix = '-bare'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+ more effectively."""
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+checksums = ['7d56dadf6c7d92a238702389e80cfe66fbfae73e584189ed6f89c75bbf3eda58']
+
+# python needs bzip2 to build the bz2 package
+
+builddependencies = [
+    ('binutils', '2.30'),
+]
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+    ('libreadline', '7.0'),
+    ('ncurses', '6.1'),
+    ('SQLite', '3.24.0'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    # ('OpenSSL', '1.1.0h'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+exts_list = []
+
+moduleclass = 'lang'


### PR DESCRIPTION
as discussed in case of #7397 (GTK+3 and co.), let's create clean dependency tree for it, just with GCCcore.

(created using `eb --new-pr`)
