### PR TITLE
add missing build dependencies in old Harfbuzz/Pango easyconfigs (2016a generation)

### DIFF
--- a/easybuild/easyconfigs/h/HarfBuzz/HarfBuzz-1.2.7-foss-2016a.eb
+++ b/easybuild/easyconfigs/h/HarfBuzz/HarfBuzz-1.2.7-foss-2016a.eb
@@ -10,6 +10,7 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 
 source_urls = ['http://www.freedesktop.org/software/harfbuzz/release/']
 sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['bba0600ae08b84384e6d2d7175bea10b5fc246c4583dc841498d01894d479026']
 
 glibver = '2.48.0'
 dependencies = [

--- a/easybuild/easyconfigs/h/HarfBuzz/HarfBuzz-1.2.7-foss-2016a.eb
+++ b/easybuild/easyconfigs/h/HarfBuzz/HarfBuzz-1.2.7-foss-2016a.eb
@@ -21,6 +21,11 @@ dependencies = [
 
 builddependencies = [
     ('pkg-config', '0.29.1'),
+    ('libpthread-stubs', '0.3'),
+    ('xproto', '7.0.28'),
+    ('renderproto', '0.11'),
+    ('kbproto', '1.0.7'),
+    ('xextproto', '7.3.0'),
 ]
 
 configopts = "--enable-introspection=yes --with-gobject=yes --enable-static --enable-shared --with-cairo "

--- a/easybuild/easyconfigs/h/HarfBuzz/HarfBuzz-1.2.7-intel-2016a.eb
+++ b/easybuild/easyconfigs/h/HarfBuzz/HarfBuzz-1.2.7-intel-2016a.eb
@@ -10,6 +10,7 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 
 source_urls = ['http://www.freedesktop.org/software/harfbuzz/release/']
 sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['bba0600ae08b84384e6d2d7175bea10b5fc246c4583dc841498d01894d479026']
 
 glibver = '2.48.0'
 dependencies = [

--- a/easybuild/easyconfigs/h/HarfBuzz/HarfBuzz-1.2.7-intel-2016a.eb
+++ b/easybuild/easyconfigs/h/HarfBuzz/HarfBuzz-1.2.7-intel-2016a.eb
@@ -21,6 +21,11 @@ dependencies = [
 
 builddependencies = [
     ('pkg-config', '0.29.1'),
+    ('libpthread-stubs', '0.3'),
+    ('xproto', '7.0.28'),
+    ('renderproto', '0.11'),
+    ('kbproto', '1.0.7'),
+    ('xextproto', '7.3.0'),
 ]
 
 configopts = "--enable-introspection=yes --with-gobject=yes --enable-static --enable-shared --with-cairo "

--- a/easybuild/easyconfigs/p/Pango/Pango-1.40.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/Pango/Pango-1.40.1-foss-2016a.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 
 source_urls = [FTPGNOME_SOURCE]
 sources = [SOURCELOWER_TAR_XZ]
+checksums = ['e27af54172c72b3ac6be53c9a4c67053e16c905e02addcf3a603ceb2005c1a40']
 
 glibver = '2.48.0'
 dependencies = [

--- a/easybuild/easyconfigs/p/Pango/Pango-1.40.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/Pango/Pango-1.40.1-foss-2016a.eb
@@ -24,6 +24,11 @@ dependencies = [
 
 builddependencies = [
     ('pkg-config', '0.29.1'),
+    ('libpthread-stubs', '0.3'),
+    ('xproto', '7.0.28'),
+    ('renderproto', '0.11'),
+    ('kbproto', '1.0.7'),
+    ('xextproto', '7.3.0'),
 ]
 
 configopts = "--disable-silent-rules --enable-introspection=yes --enable-static --enable-shared "

--- a/easybuild/easyconfigs/p/Pango/Pango-1.40.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Pango/Pango-1.40.1-intel-2016a.eb
@@ -24,6 +24,11 @@ dependencies = [
 
 builddependencies = [
     ('pkg-config', '0.29.1'),
+    ('libpthread-stubs', '0.3'),
+    ('xproto', '7.0.28'),
+    ('renderproto', '0.11'),
+    ('kbproto', '1.0.7'),
+    ('xextproto', '7.3.0'),
 ]
 
 configopts = "--disable-silent-rules --enable-introspection=yes --enable-static --enable-shared "

--- a/easybuild/easyconfigs/p/Pango/Pango-1.40.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Pango/Pango-1.40.1-intel-2016a.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 
 source_urls = [FTPGNOME_SOURCE]
 sources = [SOURCELOWER_TAR_XZ]
+checksums = ['e27af54172c72b3ac6be53c9a4c67053e16c905e02addcf3a603ceb2005c1a40']
 
 glibver = '2.48.0'
 dependencies = [


### PR DESCRIPTION
These easyconfigs used to build fine on the systems at HPC-UGent I'm testing on, but now don't anymore most likely because some system packages got removed.

Introducing these header-only dependencies as build dependencies fixes the problem.