### PR TITLE
+download URL for intel2018a components

### DIFF
--- a/easybuild/easyconfigs/i/icc/icc-2018.1.163-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2018.1.163-GCC-6.4.0-2.28.eb
@@ -8,8 +8,8 @@ description = "Intel C and C++ compilers"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
+source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12382/']
 sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_composer_edition_for_cpp.tgz']
-
 checksums = ['ddbfdf88eed095817650ec0a226ef3b9c07c41c855d258e80eaade5173fedb6e']
 
 gccver = '6.4.0'

--- a/easybuild/easyconfigs/i/ifort/ifort-2018.1.163-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2018.1.163-GCC-6.4.0-2.28.eb
@@ -8,6 +8,7 @@ description = "Intel Fortran compiler"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
+source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12383/']
 sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_composer_edition_for_fortran.tgz']
 patches = ['ifort_%(version)s_no_mpi_mic_dependency.patch']
 checksums = [

--- a/easybuild/easyconfigs/i/imkl/imkl-2018.1.163-iimpi-2018a.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2018.1.163-iimpi-2018a.eb
@@ -11,6 +11,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
 
 toolchain = {'name': 'iimpi', 'version': '2018a'}
 
+source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12384/']
 sources = ['l_mkl_%(version)s.tgz']
 checksums = ['f6dc263fc6f3c350979740a13de1b1e8745d9ba0d0f067ece503483b9189c2ca']
 

--- a/easybuild/easyconfigs/i/impi/impi-2018.1.163-iccifort-2018.1.163-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2018.1.163-iccifort-2018.1.163-GCC-6.4.0-2.28.eb
@@ -8,8 +8,8 @@ description = "Intel MPI Library, compatible with MPICH ABI"
 
 toolchain = {'name': 'iccifort', 'version': '2018.1.163-GCC-6.4.0-2.28'}
 
+source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12405/']
 sources = ['l_mpi_%(version)s.tgz']
-
 checksums = ['130b11571c3f71af00a722fa8641db5a1552ac343d770a8304216d8f5d00e75c']
 
 dontcreateinstalldir = 'True'


### PR DESCRIPTION
`intel2018a` is not so old and as I need it for #7425 anyway, let's do it in _correct_ way..

(created using `eb --new-pr`)