### PR TITLE
Use uniform configopts for Guile 1.8.8

### DIFF
--- a/easybuild/easyconfigs/g/Guile/Guile-1.8.8-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/g/Guile/Guile-1.8.8-GCCcore-6.4.0.eb
@@ -24,7 +24,7 @@ dependencies = [
     ('GMP', '6.1.2'),
 ]
 
-configopts = 'CFLAGS="$CFLAGS -Wno-unused-but-set-variable -Wno-misleading-indentation -Wno-error=maybe-uninitialized"'
+configopts = " --enable-error-on-warning=no"
 
 sanity_check_paths = {
     'files': ['bin/guile', 'bin/guile-config', 'bin/guile-snarf', 'bin/guile-tools',

--- a/easybuild/easyconfigs/g/Guile/Guile-1.8.8-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/g/Guile/Guile-1.8.8-GCCcore-7.3.0.eb
@@ -24,8 +24,7 @@ dependencies = [
     ('GMP', '6.1.2'),
 ]
 
-configopts = 'CFLAGS="$CFLAGS -Wno-unused-but-set-variable -Wno-misleading-indentation '
-configopts += '-Wno-error=maybe-uninitialized -Wno-error=deprecated-declarations"'
+configopts = " --enable-error-on-warning=no"
 
 sanity_check_paths = {
     'files': ['bin/guile', 'bin/guile-config', 'bin/guile-snarf', 'bin/guile-tools',


### PR DESCRIPTION
Replaces #7446. Corrects for uniform `configopts` to all `Guile-1.8.8` easyconfig files.