### PR TITLE
Add printproto, libXp and xbitmaps to X11

### DIFF
--- a/easybuild/easyconfigs/x/X11/X11-20160819-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20160819-GCCcore-5.4.0.eb
@@ -15,6 +15,7 @@ source_urls = [
     'http://xkbcommon.org/download/',
     'http://cgit.freedesktop.org/xorg/util/macros/snapshot',
     XORG_DATA_SOURCE + '/xkeyboard-config',
+    XORG_DATA_SOURCE,
 ]
 
 builddependencies = [
@@ -259,6 +260,15 @@ components = [
     }),
     ('xkeyboard-config', '2.18', {  # 2016-06-02
         'checksums': ['d5c511319a3bd89dc40622a33b51ba41a2c2caad33ee2bfe502363fcc4c3817d'],
+    }),
+    ('printproto', '1.0.5', {  # 2011-01-06
+        'checksums': ['e8b6f405fd865f0ea7a3a2908dfbf06622f57f2f91359ec65d13b955e49843fc'],
+    }),
+    ('libXp', '1.0.3', {  # 2015-02-21
+        'checksums': ['f6b8cc4ef05d3eafc9ef5fc72819dd412024b4ed60197c0d5914758125817e9c'],
+    }),
+    ('xbitmaps', '1.1.1', {
+        'checksums': ['3bc89e05be4179ce4d3dbba1ae554da4591d41f7a489d9e2735a18cfd8378188'],
     }),
 ]
 

--- a/easybuild/easyconfigs/x/X11/X11-20170129-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20170129-GCCcore-6.3.0.eb
@@ -15,6 +15,7 @@ source_urls = [
     'http://xkbcommon.org/download/',
     'http://cgit.freedesktop.org/xorg/util/macros/snapshot',
     XORG_DATA_SOURCE + '/xkeyboard-config',
+    XORG_DATA_SOURCE,
 ]
 
 dependencies = [
@@ -268,6 +269,15 @@ components = [
     }),
     ('xkeyboard-config', '2.19', {  # 2016-09-29
         'checksums': ['f278c3ef6939122e727dab48e06f08916b09e5cfe1837fbfe6b0f69af96a8048'],
+    }),
+    ('printproto', '1.0.5', {  # 2011-01-06
+        'checksums': ['e8b6f405fd865f0ea7a3a2908dfbf06622f57f2f91359ec65d13b955e49843fc'],
+    }),
+    ('libXp', '1.0.3', {  # 2015-02-21
+        'checksums': ['f6b8cc4ef05d3eafc9ef5fc72819dd412024b4ed60197c0d5914758125817e9c'],
+    }),
+    ('xbitmaps', '1.1.1', {
+        'checksums': ['3bc89e05be4179ce4d3dbba1ae554da4591d41f7a489d9e2735a18cfd8378188'],
     }),
 ]
 

--- a/easybuild/easyconfigs/x/X11/X11-20170314-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20170314-GCCcore-6.3.0.eb
@@ -15,6 +15,7 @@ source_urls = [
     'http://xkbcommon.org/download/',
     'http://cgit.freedesktop.org/xorg/util/macros/snapshot',
     XORG_DATA_SOURCE + '/xkeyboard-config',
+    XORG_DATA_SOURCE,
 ]
 
 dependencies = [
@@ -269,6 +270,15 @@ components = [
     }),
     ('xkeyboard-config', '2.20', {  # 2017-02-01
         'checksums': ['327ff78eeda1529ff0f1bd1c0962b46de388d5b7e69c8ee5f47e2fddecef6b2a'],
+    }),
+    ('printproto', '1.0.5', {  # 2011-01-06
+        'checksums': ['e8b6f405fd865f0ea7a3a2908dfbf06622f57f2f91359ec65d13b955e49843fc'],
+    }),
+    ('libXp', '1.0.3', {  # 2015-02-21
+        'checksums': ['f6b8cc4ef05d3eafc9ef5fc72819dd412024b4ed60197c0d5914758125817e9c'],
+    }),
+    ('xbitmaps', '1.1.1', {
+        'checksums': ['3bc89e05be4179ce4d3dbba1ae554da4591d41f7a489d9e2735a18cfd8378188'],
     }),
 ]
 

--- a/easybuild/easyconfigs/x/X11/X11-20171023-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20171023-GCCcore-6.4.0.eb
@@ -15,6 +15,7 @@ source_urls = [
     'http://xkbcommon.org/download/',
     'http://cgit.freedesktop.org/xorg/util/macros/snapshot',
     XORG_DATA_SOURCE + '/xkeyboard-config',
+    XORG_DATA_SOURCE,
 ]
 
 dependencies = [
@@ -268,6 +269,15 @@ components = [
     }),
     ('xkeyboard-config', '2.22', {  # 2017-10-04
         'checksums': ['17b61ccd0f67ef9354453947cbbbcc87e4abe5b9abc71f7e663066db62d5a22a'],
+    }),
+    ('printproto', '1.0.5', {  # 2011-01-06
+        'checksums': ['e8b6f405fd865f0ea7a3a2908dfbf06622f57f2f91359ec65d13b955e49843fc'],
+    }),
+    ('libXp', '1.0.3', {  # 2015-02-21
+        'checksums': ['f6b8cc4ef05d3eafc9ef5fc72819dd412024b4ed60197c0d5914758125817e9c'],
+    }),
+    ('xbitmaps', '1.1.1', {
+        'checksums': ['3bc89e05be4179ce4d3dbba1ae554da4591d41f7a489d9e2735a18cfd8378188'],
     }),
 ]
 

--- a/easybuild/easyconfigs/x/X11/X11-20180131-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20180131-GCCcore-6.4.0.eb
@@ -15,6 +15,7 @@ source_urls = [
     'http://xkbcommon.org/download/',
     'http://cgit.freedesktop.org/xorg/util/macros/snapshot',
     XORG_DATA_SOURCE + '/xkeyboard-config',
+    XORG_DATA_SOURCE,
 ]
 
 dependencies = [
@@ -274,6 +275,9 @@ components = [
     }),
     ('libXp', '1.0.3', {  # 2015-02-21
         'checksums': ['f6b8cc4ef05d3eafc9ef5fc72819dd412024b4ed60197c0d5914758125817e9c'],
+    }),
+    ('xbitmaps', '1.1.1', {
+        'checksums': ['3bc89e05be4179ce4d3dbba1ae554da4591d41f7a489d9e2735a18cfd8378188'],
     }),
 ]
 

--- a/easybuild/easyconfigs/x/X11/X11-20180604-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20180604-GCCcore-7.3.0.eb
@@ -15,6 +15,7 @@ source_urls = [
     'http://xkbcommon.org/download/',
     'http://cgit.freedesktop.org/xorg/util/macros/snapshot',
     XORG_DATA_SOURCE + '/xkeyboard-config',
+    XORG_DATA_SOURCE,
 ]
 
 dependencies = [
@@ -270,6 +271,9 @@ components = [
     }),
     ('libXp', '1.0.3', {  # 2015-02-21
         'checksums': ['f6b8cc4ef05d3eafc9ef5fc72819dd412024b4ed60197c0d5914758125817e9c'],
+    }),
+    ('xbitmaps', '1.1.1', {
+        'checksums': ['3bc89e05be4179ce4d3dbba1ae554da4591d41f7a489d9e2735a18cfd8378188'],
     }),
 ]
 


### PR DESCRIPTION
Added `printproto` and `libXp` to the easyconfig files that were missing them.
Also added `xbitmaps` which is required by `motif`.
