### PR TITLE
ROOT doesn't build if its CFITSIO dependency is build with cURL support

### DIFF
--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-foss-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-foss-2017b-Python-2.7.14.eb
@@ -2,7 +2,7 @@ name = 'ROOT'
 version = '6.10.08'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://root.cern.ch/drupal/'
+homepage = 'https://root.cern.ch/drupal/'
 description = """The ROOT system provides a set of OO frameworks with all the functionality
     needed to handle and analyze large amounts of data in a very efficient way."""
 

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-foss-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-foss-2017b-Python-2.7.14.eb
@@ -43,6 +43,6 @@ configopts += '-Droofit=ON '
 # Standard ROOT build doesn't account for the fact that CFITSIO could be linked against cURL.
 # Official bug: https://sft.its.cern.ch/jira/browse/ROOT-9755
 # If CFITSIO is linked against cURL, this results in undefined reference errors during builds unless setting:
-configopts += '-DCMAKE_CXX_FLAGS="-Wl,--as-needed -lcurl" '
+configopts += '-DCMAKE_CXX_FLAGS="$CXXFLAGS -Wl,--as-needed -lcurl" '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-foss-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-foss-2017b-Python-2.7.14.eb
@@ -11,7 +11,10 @@ toolchainopts = {'pic': True}
 
 source_urls = ['https://root.cern.ch/download/']
 sources = ['%(namelower)s_v%(version)s.source.tar.gz']
-checksums = ['2cd276d2ac365403c66f08edd1be62fe932a0334f76349b24d8c737c0d6dad8a']
+
+checksums = [
+    '2cd276d2ac365403c66f08edd1be62fe932a0334f76349b24d8c737c0d6dad8a', # ROOT source
+]
 
 builddependencies = [
     ('CMake', '3.9.5'),
@@ -38,6 +41,9 @@ dependencies = [
 configopts = '-Dxrootd=OFF -Dmysql=OFF -Dkrb5=OFF -Dodbc=OFF '
 configopts += '-Doracle=OFF -Dpgsql=OFF -Dqt=OFF '
 configopts += '-Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON '
-configopts += '-Droofit=ON'
+configopts += '-Droofit=ON '
+
+# Needed if CFITSIO was build with cURL (optional dependency)
+configopts += '-DCMAKE_CXX_FLAGS="-Wl,--as-needed -lcurl" '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-foss-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-foss-2017b-Python-2.7.14.eb
@@ -13,7 +13,7 @@ source_urls = ['https://root.cern.ch/download/']
 sources = ['%(namelower)s_v%(version)s.source.tar.gz']
 
 checksums = [
-    '2cd276d2ac365403c66f08edd1be62fe932a0334f76349b24d8c737c0d6dad8a', # ROOT source
+    '2cd276d2ac365403c66f08edd1be62fe932a0334f76349b24d8c737c0d6dad8a',  # ROOT source
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-foss-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-foss-2017b-Python-2.7.14.eb
@@ -11,10 +11,7 @@ toolchainopts = {'pic': True}
 
 source_urls = ['https://root.cern.ch/download/']
 sources = ['%(namelower)s_v%(version)s.source.tar.gz']
-
-checksums = [
-    '2cd276d2ac365403c66f08edd1be62fe932a0334f76349b24d8c737c0d6dad8a',  # ROOT source
-]
+checksums = ['2cd276d2ac365403c66f08edd1be62fe932a0334f76349b24d8c737c0d6dad8a']
 
 builddependencies = [
     ('CMake', '3.9.5'),
@@ -43,7 +40,9 @@ configopts += '-Doracle=OFF -Dpgsql=OFF -Dqt=OFF '
 configopts += '-Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON '
 configopts += '-Droofit=ON '
 
-# Needed if CFITSIO was build with cURL (optional dependency)
+# Standard ROOT build doesn't account for the fact that CFITSIO could be linked against cURL.
+# Official bug: https://sft.its.cern.ch/jira/browse/ROOT-9755
+# If CFITSIO is linked against cURL, this results in undefined reference errors during builds unless setting:
 configopts += '-DCMAKE_CXX_FLAGS="-Wl,--as-needed -lcurl" '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-intel-2017b-Python-2.7.14.eb
@@ -54,6 +54,6 @@ configopts += "-Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON -Droofit=ON
 # Standard ROOT build doesn't account for the fact that CFITSIO could be linked against cURL.
 # Official bug: https://sft.its.cern.ch/jira/browse/ROOT-9755
 # If CFITSIO is linked against cURL, this results in undefined reference errors during builds unless setting:
-configopts += '-DCMAKE_CXX_FLAGS="-Wl,--as-needed -lcurl" '
+configopts += '$CXXFLAGS -DCMAKE_CXX_FLAGS="-Wl,--as-needed -lcurl" '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-intel-2017b-Python-2.7.14.eb
@@ -2,7 +2,7 @@ name = 'ROOT'
 version = '6.10.08'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://root.cern.ch/drupal/'
+homepage = 'https://root.cern.ch/drupal/'
 description = """The ROOT system provides a set of OO frameworks with all the functionality
     needed to handle and analyze large amounts of data in a very efficient way."""
 

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-intel-2017b-Python-2.7.14.eb
@@ -51,4 +51,7 @@ configopts = "-Dxrootd=OFF -Dmysql=OFF -Dkrb5=OFF -Dodbc=OFF -Doracle=OFF -Dpgsq
 # make sure some components are enabled
 configopts += "-Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON -Droofit=ON "
 
+# Needed if CFITSIO was build with cURL (optional dependency)
+configopts += '-DCMAKE_CXX_FLAGS="-Wl,--as-needed -lcurl" '
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.10.08-intel-2017b-Python-2.7.14.eb
@@ -51,7 +51,9 @@ configopts = "-Dxrootd=OFF -Dmysql=OFF -Dkrb5=OFF -Dodbc=OFF -Doracle=OFF -Dpgsq
 # make sure some components are enabled
 configopts += "-Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON -Droofit=ON "
 
-# Needed if CFITSIO was build with cURL (optional dependency)
+# Standard ROOT build doesn't account for the fact that CFITSIO could be linked against cURL.
+# Official bug: https://sft.its.cern.ch/jira/browse/ROOT-9755
+# If CFITSIO is linked against cURL, this results in undefined reference errors during builds unless setting:
 configopts += '-DCMAKE_CXX_FLAGS="-Wl,--as-needed -lcurl" '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.14.06-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.14.06-foss-2018b-Python-2.7.15.eb
@@ -48,6 +48,6 @@ configopts += "-Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON -Droofit=ON
 # Standard ROOT build doesn't account for the fact that CFITSIO could be linked against cURL.
 # Official bug: https://sft.its.cern.ch/jira/browse/ROOT-9755
 # If CFITSIO is linked against cURL, this results in undefined reference errors during builds unless setting:
-configopts += '-DCMAKE_CXX_FLAGS="-Wl,--as-needed -lcurl" '
+configopts += '-DCMAKE_CXX_FLAGS="$CXXFLAGS -Wl,--as-needed -lcurl" '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.14.06-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.14.06-foss-2018b-Python-2.7.15.eb
@@ -2,7 +2,7 @@ name = 'ROOT'
 version = '6.14.06'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://root.cern.ch/drupal/'
+homepage = 'https://root.cern.ch/drupal/'
 description = """The ROOT system provides a set of OO frameworks with all the functionality
     needed to handle and analyze large amounts of data in a very efficient way."""
 

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.14.06-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.14.06-foss-2018b-Python-2.7.15.eb
@@ -45,4 +45,9 @@ configopts = "-Dxrootd=OFF -Dmysql=OFF -Dkrb5=OFF -Dodbc=OFF -Doracle=OFF -Dpgsq
 # make sure some components are enabled
 configopts += "-Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON -Droofit=ON "
 
+# Standard ROOT build doesn't account for the fact that CFITSIO could be linked against cURL.
+# Official bug: https://sft.its.cern.ch/jira/browse/ROOT-9755
+# If CFITSIO is linked against cURL, this results in undefined reference errors during builds unless setting:
+configopts += '-DCMAKE_CXX_FLAGS="-Wl,--as-needed -lcurl" '
+
 moduleclass = 'data'


### PR DESCRIPTION
If dependency CFITSIO is build with optional cURL dependency, and extra configure option -DCMAKE_CXX_FLAGS=-Wl,--as-needed -lcurl is needed in order for ROOT to compile. The --as-needed flag ensures lcurl is only linked to those libraries that need it, so it doesn't hurt anyone - even if people use a CFITSIO that was compiled without curl