### PR TITLE
{math} [intel/2018a, GCC/6.4.0-2.28] Create libcerf v1.5 {REVIEW}

### DIFF
--- a/easybuild/easyconfigs/l/libcerf/libcerf-1.5-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/l/libcerf/libcerf-1.5-GCC-6.4.0-2.28.eb
@@ -1,0 +1,38 @@
+easyblock = 'ConfigureMake'
+
+name = 'libcerf'
+version = '1.5'
+
+homepage = 'http://apps.jcns.fz-juelich.de/doku/sc/libcerf'
+
+description = """
+ libcerf is a self-contained numeric library that provides an efficient and
+ accurate implementation of complex error functions, along with Dawson,
+ Faddeeva, and Voigt functions.
+"""
+
+toolchain = {'name': 'GCC', 'version': '6.4.0-2.28'}
+toolchainopts = {'pic': True}
+
+source_urls = [
+    'http://apps.jcns.fz-juelich.de/src/libcerf/',
+    'http://apps.jcns.fz-juelich.de/src/libcerf/old',
+]
+sources = [SOURCE_TGZ]
+checksums = ['e36dc147e7fff81143074a21550c259b5aac1b99fc314fc0ae33294231ca5c86']
+
+builddependencies = [
+    ('Autotools', '20170619'),
+    ('binutils', '2.28'),
+    ('libtool', '2.4.6'),
+]
+
+buildopts = '&& $FC -c fortran/ccerflib_f95_interface/use_libcerf_mod.f90'
+postinstallcmds = ['cp use_libcerf.mod %(installdir)s/include']
+
+sanity_check_paths = {
+    'files': ['include/use_libcerf.mod', 'lib/libcerf.%s' % SHLIB_EXT],
+    'dirs': []
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/l/libcerf/libcerf-1.5-intel-2018a.eb
+++ b/easybuild/easyconfigs/l/libcerf/libcerf-1.5-intel-2018a.eb
@@ -1,0 +1,38 @@
+easyblock = 'ConfigureMake'
+
+name = 'libcerf'
+version = '1.5'
+
+homepage = 'http://apps.jcns.fz-juelich.de/doku/sc/libcerf'
+
+description = """
+ libcerf is a self-contained numeric library that provides an efficient and
+ accurate implementation of complex error functions, along with Dawson,
+ Faddeeva, and Voigt functions.
+"""
+
+toolchain = {'name': 'intel', 'version': '2018a'}
+toolchainopts = {'pic': True}
+
+source_urls = [
+    'http://apps.jcns.fz-juelich.de/src/libcerf/',
+    'http://apps.jcns.fz-juelich.de/src/libcerf/old',
+]
+sources = [SOURCE_TGZ]
+checksums = ['e36dc147e7fff81143074a21550c259b5aac1b99fc314fc0ae33294231ca5c86']
+
+builddependencies = [
+    ('Autotools', '20170619'),
+    ('binutils', '2.28'),
+    ('libtool', '2.4.6'),
+]
+
+buildopts = '&& $FC -c fortran/ccerflib_f95_interface/use_libcerf_mod.f90'
+postinstallcmds = ['cp use_libcerf.mod %(installdir)s/include']
+
+sanity_check_paths = {
+    'files': ['include/use_libcerf.mod', 'lib/libcerf.%s' % SHLIB_EXT],
+    'dirs': []
+}
+
+moduleclass = 'math'


### PR DESCRIPTION
Compared to existing modules, these two also provide the Fortran interface.