### PR TITLE
Remove xbitmaps dependency from motif

### DIFF
--- a/easybuild/easyconfigs/m/motif/motif-2.3.7-intel-2017a.eb
+++ b/easybuild/easyconfigs/m/motif/motif-2.3.7-intel-2017a.eb
@@ -10,22 +10,23 @@ description = """Motif refers to both a graphical user interface (GUI) specifica
 
 toolchain = {'name': 'intel', 'version': '2017a'}
 
-sources = ['%(name)s-%(version)s.tar.gz']
 source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%(name)s-%(version)s.tar.gz']
+checksums = ['8f7aadbb0f42df2093d4690735a2b9a02ea2bf69dfb15ae0a39cae28f1580d14']
 
-dependencies = [
-    ('X11', '20170314'),
-    ('libpng', '1.6.29'),
-    ('xbitmaps', '1.1.1', '', True),
-    ('freetype', '2.7.1', '-libpng-1.6.29'),
-    ('libjpeg-turbo', '1.5.1'),
-    ('bzip2', '1.0.6'),
-]
 builddependencies = [
     ('Autotools', '20150215'),
     ('flex', '2.6.4'),
     ('Bison', '3.0.4'),
     ('util-linux', '2.29.2'),
+]
+
+dependencies = [
+    ('X11', '20170314'),
+    ('libpng', '1.6.29'),
+    ('freetype', '2.7.1', '-libpng-1.6.29'),
+    ('libjpeg-turbo', '1.5.1'),
+    ('bzip2', '1.0.6'),
 ]
 
 # makefile is not parallel safe

--- a/easybuild/easyconfigs/m/motif/motif-2.3.8-foss-2018a.eb
+++ b/easybuild/easyconfigs/m/motif/motif-2.3.8-foss-2018a.eb
@@ -14,19 +14,19 @@ source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(name)s-%(version)s.tar.gz']
 checksums = ['859b723666eeac7df018209d66045c9853b50b4218cecadb794e2359619ebce7']
 
-dependencies = [
-    ('X11', '20180131'),
-    ('libpng', '1.6.34'),
-    ('xbitmaps', '1.1.1', '', True),
-    ('freetype', '2.9'),
-    ('libjpeg-turbo', '1.5.3'),
-    ('bzip2', '1.0.6'),
-]
 builddependencies = [
     ('Autotools', '20170619'),
     ('flex', '2.6.4'),
     ('Bison', '3.0.4'),
     ('util-linux', '2.31.1'),
+]
+
+dependencies = [
+    ('X11', '20180131'),
+    ('libpng', '1.6.34'),
+    ('freetype', '2.9'),
+    ('libjpeg-turbo', '1.5.3'),
+    ('bzip2', '1.0.6'),
 ]
 
 # makefile is not parallel safe

--- a/easybuild/easyconfigs/m/motif/motif-2.3.8-foss-2018b.eb
+++ b/easybuild/easyconfigs/m/motif/motif-2.3.8-foss-2018b.eb
@@ -14,19 +14,19 @@ source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(name)s-%(version)s.tar.gz']
 checksums = ['859b723666eeac7df018209d66045c9853b50b4218cecadb794e2359619ebce7']
 
-dependencies = [
-    ('X11', '20180604'),
-    ('libpng', '1.6.34'),
-    ('xbitmaps', '1.1.2', '', True),
-    ('freetype', '2.9.1'),
-    ('libjpeg-turbo', '2.0.0'),
-    ('bzip2', '1.0.6'),
-]
 builddependencies = [
     ('Autotools', '20180311'),
     ('flex', '2.6.4'),
     ('Bison', '3.0.5'),
     ('util-linux', '2.32'),
+]
+
+dependencies = [
+    ('X11', '20180604'),
+    ('libpng', '1.6.34'),
+    ('freetype', '2.9.1'),
+    ('libjpeg-turbo', '2.0.0'),
+    ('bzip2', '1.0.6'),
 ]
 
 # makefile is not parallel safe

--- a/easybuild/easyconfigs/m/motif/motif-2.3.8-intel-2017b.eb
+++ b/easybuild/easyconfigs/m/motif/motif-2.3.8-intel-2017b.eb
@@ -14,19 +14,19 @@ source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(name)s-%(version)s.tar.gz']
 checksums = ['859b723666eeac7df018209d66045c9853b50b4218cecadb794e2359619ebce7']
 
-dependencies = [
-    ('X11', '20171023'),
-    ('libpng', '1.6.32'),
-    ('xbitmaps', '1.1.1', '', True),
-    ('freetype', '2.8'),
-    ('libjpeg-turbo', '1.5.2'),
-    ('bzip2', '1.0.6'),
-]
 builddependencies = [
     ('Autotools', '20170619'),
     ('flex', '2.6.4'),
     ('Bison', '3.0.4'),
     ('util-linux', '2.31'),
+]
+
+dependencies = [
+    ('X11', '20171023'),
+    ('libpng', '1.6.32'),
+    ('freetype', '2.8'),
+    ('libjpeg-turbo', '1.5.2'),
+    ('bzip2', '1.0.6'),
 ]
 
 # makefile is not parallel safe

--- a/easybuild/easyconfigs/m/motif/motif-2.3.8-intel-2018a.eb
+++ b/easybuild/easyconfigs/m/motif/motif-2.3.8-intel-2018a.eb
@@ -14,19 +14,19 @@ source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(name)s-%(version)s.tar.gz']
 checksums = ['859b723666eeac7df018209d66045c9853b50b4218cecadb794e2359619ebce7']
 
-dependencies = [
-    ('X11', '20180131'),
-    ('libpng', '1.6.34'),
-    ('xbitmaps', '1.1.1', '', True),
-    ('freetype', '2.9'),
-    ('libjpeg-turbo', '1.5.3'),
-    ('bzip2', '1.0.6'),
-]
 builddependencies = [
     ('Autotools', '20170619'),
     ('flex', '2.6.4'),
     ('Bison', '3.0.4'),
     ('util-linux', '2.31.1'),
+]
+
+dependencies = [
+    ('X11', '20180131'),
+    ('libpng', '1.6.34'),
+    ('freetype', '2.9'),
+    ('libjpeg-turbo', '1.5.3'),
+    ('bzip2', '1.0.6'),
 ]
 
 # makefile is not parallel safe


### PR DESCRIPTION
The `xbitmaps` dependency is no longer needed since it is now included in the X11 bundle (see ~~#7494~~)