### PR TITLE
{lib}[GCC/8.2.0-2.31.1,iccifort-2019.1.144-GCC-8.2.0-2.31.1] OpenMPI v3.1.3: Fix ucx memory leak and init

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-GCC-8.2.0-2.31.1.eb
@@ -15,7 +15,8 @@ patches = ['%(name)s-%(version)s-backported_patches.patch']
 
 checksums = [
     '0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d',  # openmpi-3.1.3.tar.gz
-    '46fa94eb417954bdb297291bad4f4d32018af4911bebf3e59af6276eba6a50a9',  # OpenMPI-3.1.3-add_ompi_datatype_attribute_to_release_ucp_datatype.patch
+    # OpenMPI-3.1.3-add_ompi_datatype_attribute_to_release_ucp_datatype.patch
+    '46fa94eb417954bdb297291bad4f4d32018af4911bebf3e59af6276eba6a50a9',
 ]
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-GCC-8.2.0-2.31.1.eb
@@ -10,7 +10,13 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d']
+
+patches = [ '%(name)s-%(version)s-backported_patches.patch']
+
+checksums = [
+    '0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d', # openmpi-3.1.3.tar.gz
+    '6268e34ae8c322e2a784ec3b92e8df34a3074463066c43382b3eaf248f0f17f6', # OpenMPI-3.1.3-backported_patches.eb
+]
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-GCC-8.2.0-2.31.1.eb
@@ -15,7 +15,7 @@ patches = ['%(name)s-%(version)s-backported_patches.patch']
 
 checksums = [
     '0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d',  # openmpi-3.1.3.tar.gz
-    '6268e34ae8c322e2a784ec3b92e8df34a3074463066c43382b3eaf248f0f17f6',  # OpenMPI-3.1.3-backported_patches.eb
+    '46fa94eb417954bdb297291bad4f4d32018af4911bebf3e59af6276eba6a50a9',  # OpenMPI-3.1.3-add_ompi_datatype_attribute_to_release_ucp_datatype.patch
 ]
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-GCC-8.2.0-2.31.1.eb
@@ -11,11 +11,11 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 
-patches = [ '%(name)s-%(version)s-backported_patches.patch']
+patches = ['%(name)s-%(version)s-backported_patches.patch']
 
 checksums = [
-    '0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d', # openmpi-3.1.3.tar.gz
-    '6268e34ae8c322e2a784ec3b92e8df34a3074463066c43382b3eaf248f0f17f6', # OpenMPI-3.1.3-backported_patches.eb
+    '0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d',  # openmpi-3.1.3.tar.gz
+    '6268e34ae8c322e2a784ec3b92e8df34a3074463066c43382b3eaf248f0f17f6',  # OpenMPI-3.1.3-backported_patches.eb
 ]
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-GCC-8.2.0-2.31.1.eb
@@ -11,7 +11,7 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 
-patches = ['%(name)s-%(version)s-backported_patches.patch']
+patches = ['%(name)s-%(version)s-add_ompi_datatype_attribute_to_release_ucp_datatype.patch']
 
 checksums = [
     '0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d',  # openmpi-3.1.3.tar.gz

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-add_ompi_datatype_attribute_to_release_ucp_datatype.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-add_ompi_datatype_attribute_to_release_ucp_datatype.patch
@@ -1,15 +1,30 @@
-diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx.c openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx.c
---- openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx.c	2018-10-29 22:31:25.000000000 +0100
-+++ openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx.c	2018-11-23 10:38:12.000000000 +0100
-@@ -14,6 +14,7 @@
+From 4763822a64c9002f24429aef95d87f6abfc45c06 Mon Sep 17 00:00:00 2001
+From: Yossi Itigin <yosefe@mellanox.com>
+Date: Tue, 9 Oct 2018 16:38:49 +0300
+Subject: [PATCH 1/2] pml_ucx: add ompi datatype attribute to release
+ ucp_datatype
+
+Signed-off-by: Yossi Itigin <yosefe@mellanox.com>
+---
+ ompi/mca/pml/ucx/pml_ucx.c          | 62 ++++++++++++++++++++++++-----
+ ompi/mca/pml/ucx/pml_ucx.h          |  5 +++
+ ompi/mca/pml/ucx/pml_ucx_datatype.c | 37 +++++++++++++++--
+ ompi/mca/pml/ucx/pml_ucx_datatype.h |  7 +++-
+ 4 files changed, 96 insertions(+), 15 deletions(-)
+
+diff --git a/ompi/mca/pml/ucx/pml_ucx.c b/ompi/mca/pml/ucx/pml_ucx.c
+index 1f37212c58f..d92ad5a58cb 100644
+--- a/ompi/mca/pml/ucx/pml_ucx.c
++++ b/ompi/mca/pml/ucx/pml_ucx.c
+@@ -16,6 +16,7 @@
  
  #include "opal/runtime/opal.h"
  #include "opal/mca/pmix/pmix.h"
 +#include "ompi/attribute/attribute.h"
  #include "ompi/message/message.h"
  #include "ompi/mca/pml/base/pml_base_bsend.h"
- #include "pml_ucx_request.h"
-@@ -187,9 +188,9 @@
+ #include "opal/mca/common/ucx/common_ucx.h"
+@@ -190,9 +191,9 @@ int mca_pml_ucx_close(void)
  int mca_pml_ucx_init(void)
  {
      ucp_worker_params_t params;
@@ -21,7 +36,7 @@ diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx.c openmpi-3.1.3/ompi/mca/p
  
      PML_UCX_VERBOSE(1, "mca_pml_ucx_init");
  
-@@ -206,30 +207,34 @@
+@@ -209,30 +210,34 @@ int mca_pml_ucx_init(void)
                                 &ompi_pml_ucx.ucp_worker);
      if (UCS_OK != status) {
          PML_UCX_ERROR("Failed to create UCP worker");
@@ -65,12 +80,10 @@ diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx.c openmpi-3.1.3/ompi/mca/p
      }
  
      /* Initialize the free lists */
-@@ -245,15 +250,34 @@
-     PML_UCX_VERBOSE(2, "created ucp context %p, worker %p",
+@@ -249,14 +254,33 @@ int mca_pml_ucx_init(void)
                      (void *)ompi_pml_ucx.ucp_context,
                      (void *)ompi_pml_ucx.ucp_worker);
--    return OMPI_SUCCESS;
-+    return rc;
+     return OMPI_SUCCESS;
 +
 +err_destroy_worker:
 +    ucp_worker_destroy(ompi_pml_ucx.ucp_worker);
@@ -101,7 +114,7 @@ diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx.c openmpi-3.1.3/ompi/mca/p
      ompi_pml_ucx.completed_send_req.req_state = OMPI_REQUEST_INVALID;
      OMPI_REQUEST_FINI(&ompi_pml_ucx.completed_send_req);
      OBJ_DESTRUCT(&ompi_pml_ucx.completed_send_req);
-@@ -452,6 +476,22 @@
+@@ -398,6 +422,22 @@ int mca_pml_ucx_del_procs(struct ompi_proc_t **procs, size_t nprocs)
  
  int mca_pml_ucx_enable(bool enable)
  {
@@ -124,9 +137,10 @@ diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx.c openmpi-3.1.3/ompi/mca/p
      PML_UCX_FREELIST_INIT(&ompi_pml_ucx.persistent_reqs,
                            mca_pml_ucx_persistent_request_t,
                            128, -1, 128);
-diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx.h openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx.h
---- openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx.h	2018-10-29 22:31:25.000000000 +0100
-+++ openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx.h	2018-11-23 10:36:28.000000000 +0100
+diff --git a/ompi/mca/pml/ucx/pml_ucx.h b/ompi/mca/pml/ucx/pml_ucx.h
+index da1b3ef0c57..484ad5ebe1c 100644
+--- a/ompi/mca/pml/ucx/pml_ucx.h
++++ b/ompi/mca/pml/ucx/pml_ucx.h
 @@ -15,6 +15,7 @@
  #include "ompi/mca/pml/pml.h"
  #include "ompi/mca/pml/base/base.h"
@@ -134,8 +148,8 @@ diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx.h openmpi-3.1.3/ompi/mca/p
 +#include "ompi/datatype/ompi_datatype_internal.h"
  #include "ompi/communicator/communicator.h"
  #include "ompi/request/request.h"
- 
-@@ -37,6 +38,10 @@
+ #include "opal/mca/common/ucx/common_ucx.h"
+@@ -42,6 +43,10 @@ struct mca_pml_ucx_module {
      ucp_context_h             ucp_context;
      ucp_worker_h              ucp_worker;
  
@@ -146,9 +160,10 @@ diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx.h openmpi-3.1.3/ompi/mca/p
      /* Requests */
      mca_pml_ucx_freelist_t    persistent_reqs;
      ompi_request_t            completed_send_req;
-diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx_datatype.c openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx_datatype.c
---- openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx_datatype.c	2018-10-29 22:31:25.000000000 +0100
-+++ openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx_datatype.c	2018-11-23 10:36:28.000000000 +0100
+diff --git a/ompi/mca/pml/ucx/pml_ucx_datatype.c b/ompi/mca/pml/ucx/pml_ucx_datatype.c
+index 98b7b190df7..74b5fbe19c3 100644
+--- a/ompi/mca/pml/ucx/pml_ucx_datatype.c
++++ b/ompi/mca/pml/ucx/pml_ucx_datatype.c
 @@ -10,6 +10,7 @@
  #include "pml_ucx_datatype.h"
  
@@ -157,7 +172,7 @@ diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx_datatype.c openmpi-3.1.3/o
  
  #include <inttypes.h>
  
-@@ -127,12 +128,25 @@
+@@ -127,12 +128,25 @@ static ucp_generic_dt_ops_t pml_ucx_generic_datatype_ops = {
      .finish       = pml_ucx_generic_datatype_finish
  };
  
@@ -183,7 +198,7 @@ diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx_datatype.c openmpi-3.1.3/o
  
      ompi_datatype_type_lb(datatype, &lb);
  
-@@ -147,16 +161,33 @@
+@@ -147,16 +161,33 @@ ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype)
      }
  
      status = ucp_dt_create_generic(&pml_ucx_generic_datatype_ops,
@@ -220,9 +235,10 @@ diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx_datatype.c openmpi-3.1.3/o
      return ucp_datatype;
  }
  
-diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx_datatype.h openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx_datatype.h
---- openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx_datatype.h	2018-10-29 22:31:25.000000000 +0100
-+++ openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx_datatype.h	2018-11-23 10:36:28.000000000 +0100
+diff --git a/ompi/mca/pml/ucx/pml_ucx_datatype.h b/ompi/mca/pml/ucx/pml_ucx_datatype.h
+index 26b1835a153..f5207cecc75 100644
+--- a/ompi/mca/pml/ucx/pml_ucx_datatype.h
++++ b/ompi/mca/pml/ucx/pml_ucx_datatype.h
 @@ -13,6 +13,8 @@
  #include "pml_ucx.h"
  
@@ -232,7 +248,7 @@ diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx_datatype.h openmpi-3.1.3/o
  struct pml_ucx_convertor {
      opal_free_list_item_t     super;
      ompi_datatype_t           *datatype;
-@@ -23,6 +25,9 @@
+@@ -23,6 +25,9 @@ struct pml_ucx_convertor {
  
  ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype);
  
@@ -242,7 +258,7 @@ diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx_datatype.h openmpi-3.1.3/o
  OBJ_CLASS_DECLARATION(mca_pml_ucx_convertor_t);
  
  
-@@ -30,7 +35,7 @@
+@@ -30,7 +35,7 @@ static inline ucp_datatype_t mca_pml_ucx_get_datatype(ompi_datatype_t *datatype)
  {
      ucp_datatype_t ucp_type = datatype->pml_data;
  
@@ -251,3 +267,27 @@ diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx_datatype.h openmpi-3.1.3/o
          return ucp_type;
      }
  
+
+From 40ac9e477165616ab98085e2d590dbbbe4874b9f Mon Sep 17 00:00:00 2001
+From: Yossi Itigin <yosefe@mellanox.com>
+Date: Wed, 10 Oct 2018 12:10:28 +0300
+Subject: [PATCH 2/2] pml_ucx: fix return code from mca_pml_ucx_init()
+
+Signed-off-by: Yossi Itigin <yosefe@mellanox.com>
+---
+ ompi/mca/pml/ucx/pml_ucx.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ompi/mca/pml/ucx/pml_ucx.c b/ompi/mca/pml/ucx/pml_ucx.c
+index d92ad5a58cb..2e10a3b768c 100644
+--- a/ompi/mca/pml/ucx/pml_ucx.c
++++ b/ompi/mca/pml/ucx/pml_ucx.c
+@@ -253,7 +253,7 @@ int mca_pml_ucx_init(void)
+     PML_UCX_VERBOSE(2, "created ucp context %p, worker %p",
+                     (void *)ompi_pml_ucx.ucp_context,
+                     (void *)ompi_pml_ucx.ucp_worker);
+-    return OMPI_SUCCESS;
++    return rc;
+ 
+ err_destroy_worker:
+     ucp_worker_destroy(ompi_pml_ucx.ucp_worker);

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-backported_patches.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-backported_patches.patch
@@ -1,0 +1,253 @@
+diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx.c openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx.c
+--- openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx.c	2018-10-29 22:31:25.000000000 +0100
++++ openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx.c	2018-11-23 10:38:12.000000000 +0100
+@@ -14,6 +14,7 @@
+ 
+ #include "opal/runtime/opal.h"
+ #include "opal/mca/pmix/pmix.h"
++#include "ompi/attribute/attribute.h"
+ #include "ompi/message/message.h"
+ #include "ompi/mca/pml/base/pml_base_bsend.h"
+ #include "pml_ucx_request.h"
+@@ -187,9 +188,9 @@
+ int mca_pml_ucx_init(void)
+ {
+     ucp_worker_params_t params;
+-    ucs_status_t status;
+     ucp_worker_attr_t attr;
+-    int rc;
++    ucs_status_t status;
++    int i, rc;
+ 
+     PML_UCX_VERBOSE(1, "mca_pml_ucx_init");
+ 
+@@ -206,30 +207,34 @@
+                                &ompi_pml_ucx.ucp_worker);
+     if (UCS_OK != status) {
+         PML_UCX_ERROR("Failed to create UCP worker");
+-        return OMPI_ERROR;
++        rc = OMPI_ERROR;
++        goto err;
+     }
+ 
+     attr.field_mask = UCP_WORKER_ATTR_FIELD_THREAD_MODE;
+     status = ucp_worker_query(ompi_pml_ucx.ucp_worker, &attr);
+     if (UCS_OK != status) {
+-        ucp_worker_destroy(ompi_pml_ucx.ucp_worker);
+-        ompi_pml_ucx.ucp_worker = NULL;
+         PML_UCX_ERROR("Failed to query UCP worker thread level");
+-        return OMPI_ERROR;
++        rc = OMPI_ERROR;
++        goto err_destroy_worker;
+     }
+ 
+-    if (ompi_mpi_thread_multiple && attr.thread_mode != UCS_THREAD_MODE_MULTI) {
++    if (ompi_mpi_thread_multiple && (attr.thread_mode != UCS_THREAD_MODE_MULTI)) {
+         /* UCX does not support multithreading, disqualify current PML for now */
+         /* TODO: we should let OMPI to fallback to THREAD_SINGLE mode */
+-        ucp_worker_destroy(ompi_pml_ucx.ucp_worker);
+-        ompi_pml_ucx.ucp_worker = NULL;
+         PML_UCX_ERROR("UCP worker does not support MPI_THREAD_MULTIPLE");
+-        return OMPI_ERROR;
++        rc = OMPI_ERR_NOT_SUPPORTED;
++        goto err_destroy_worker;
+     }
+ 
+     rc = mca_pml_ucx_send_worker_address();
+     if (rc < 0) {
+-        return rc;
++        goto err_destroy_worker;
++    }
++
++    ompi_pml_ucx.datatype_attr_keyval = MPI_KEYVAL_INVALID;
++    for (i = 0; i < OMPI_DATATYPE_MAX_PREDEFINED; ++i) {
++        ompi_pml_ucx.predefined_types[i] = PML_UCX_DATATYPE_INVALID;
+     }
+ 
+     /* Initialize the free lists */
+@@ -245,15 +250,34 @@
+     PML_UCX_VERBOSE(2, "created ucp context %p, worker %p",
+                     (void *)ompi_pml_ucx.ucp_context,
+                     (void *)ompi_pml_ucx.ucp_worker);
+-    return OMPI_SUCCESS;
++    return rc;
++
++err_destroy_worker:
++    ucp_worker_destroy(ompi_pml_ucx.ucp_worker);
++    ompi_pml_ucx.ucp_worker = NULL;
++err:
++    return OMPI_ERROR;
+ }
+ 
+ int mca_pml_ucx_cleanup(void)
+ {
++    int i;
++
+     PML_UCX_VERBOSE(1, "mca_pml_ucx_cleanup");
+ 
+     opal_progress_unregister(mca_pml_ucx_progress);
+ 
++    if (ompi_pml_ucx.datatype_attr_keyval != MPI_KEYVAL_INVALID) {
++        ompi_attr_free_keyval(TYPE_ATTR, &ompi_pml_ucx.datatype_attr_keyval, false);
++    }
++
++    for (i = 0; i < OMPI_DATATYPE_MAX_PREDEFINED; ++i) {
++        if (ompi_pml_ucx.predefined_types[i] != PML_UCX_DATATYPE_INVALID) {
++            ucp_dt_destroy(ompi_pml_ucx.predefined_types[i]);
++            ompi_pml_ucx.predefined_types[i] = PML_UCX_DATATYPE_INVALID;
++        }
++    }
++
+     ompi_pml_ucx.completed_send_req.req_state = OMPI_REQUEST_INVALID;
+     OMPI_REQUEST_FINI(&ompi_pml_ucx.completed_send_req);
+     OBJ_DESTRUCT(&ompi_pml_ucx.completed_send_req);
+@@ -452,6 +476,22 @@
+ 
+ int mca_pml_ucx_enable(bool enable)
+ {
++    ompi_attribute_fn_ptr_union_t copy_fn;
++    ompi_attribute_fn_ptr_union_t del_fn;
++    int ret;
++
++    /* Create a key for adding custom attributes to datatypes */
++    copy_fn.attr_datatype_copy_fn  =
++                    (MPI_Type_internal_copy_attr_function*)MPI_TYPE_NULL_COPY_FN;
++    del_fn.attr_datatype_delete_fn = mca_pml_ucx_datatype_attr_del_fn;
++    ret = ompi_attr_create_keyval(TYPE_ATTR, copy_fn, del_fn,
++                                  &ompi_pml_ucx.datatype_attr_keyval, NULL, 0,
++                                  NULL);
++    if (ret != OMPI_SUCCESS) {
++        PML_UCX_ERROR("Failed to create keyval for UCX datatypes: %d", ret);
++        return ret;
++    }
++
+     PML_UCX_FREELIST_INIT(&ompi_pml_ucx.persistent_reqs,
+                           mca_pml_ucx_persistent_request_t,
+                           128, -1, 128);
+diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx.h openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx.h
+--- openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx.h	2018-10-29 22:31:25.000000000 +0100
++++ openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx.h	2018-11-23 10:36:28.000000000 +0100
+@@ -15,6 +15,7 @@
+ #include "ompi/mca/pml/pml.h"
+ #include "ompi/mca/pml/base/base.h"
+ #include "ompi/datatype/ompi_datatype.h"
++#include "ompi/datatype/ompi_datatype_internal.h"
+ #include "ompi/communicator/communicator.h"
+ #include "ompi/request/request.h"
+ 
+@@ -37,6 +38,10 @@
+     ucp_context_h             ucp_context;
+     ucp_worker_h              ucp_worker;
+ 
++    /* Datatypes */
++    int                       datatype_attr_keyval;
++    ucp_datatype_t            predefined_types[OMPI_DATATYPE_MPI_MAX_PREDEFINED];
++
+     /* Requests */
+     mca_pml_ucx_freelist_t    persistent_reqs;
+     ompi_request_t            completed_send_req;
+diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx_datatype.c openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx_datatype.c
+--- openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx_datatype.c	2018-10-29 22:31:25.000000000 +0100
++++ openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx_datatype.c	2018-11-23 10:36:28.000000000 +0100
+@@ -10,6 +10,7 @@
+ #include "pml_ucx_datatype.h"
+ 
+ #include "ompi/runtime/mpiruntime.h"
++#include "ompi/attribute/attribute.h"
+ 
+ #include <inttypes.h>
+ 
+@@ -127,12 +128,25 @@
+     .finish       = pml_ucx_generic_datatype_finish
+ };
+ 
++int mca_pml_ucx_datatype_attr_del_fn(ompi_datatype_t* datatype, int keyval,
++                                     void *attr_val, void *extra)
++{
++    ucp_datatype_t ucp_datatype = (ucp_datatype_t)attr_val;
++
++    PML_UCX_ASSERT((void*)ucp_datatype == datatype->pml_data);
++
++    ucp_dt_destroy(ucp_datatype);
++    datatype->pml_data = PML_UCX_DATATYPE_INVALID;
++    return OMPI_SUCCESS;
++}
++
+ ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype)
+ {
+     ucp_datatype_t ucp_datatype;
+     ucs_status_t status;
+     ptrdiff_t lb;
+     size_t size;
++    int ret;
+ 
+     ompi_datatype_type_lb(datatype, &lb);
+ 
+@@ -147,16 +161,33 @@
+     }
+ 
+     status = ucp_dt_create_generic(&pml_ucx_generic_datatype_ops,
+-                                         datatype, &ucp_datatype);
++                                   datatype, &ucp_datatype);
+     if (status != UCS_OK) {
+         PML_UCX_ERROR("Failed to create UCX datatype for %s", datatype->name);
+         ompi_mpi_abort(&ompi_mpi_comm_world.comm, 1);
+     }
+ 
++    datatype->pml_data = ucp_datatype;
++
++    /* Add custom attribute, to clean up UCX resources when OMPI datatype is
++     * released.
++     */
++    if (ompi_datatype_is_predefined(datatype)) {
++        PML_UCX_ASSERT(datatype->id < OMPI_DATATYPE_MAX_PREDEFINED);
++        ompi_pml_ucx.predefined_types[datatype->id] = ucp_datatype;
++    } else {
++        ret = ompi_attr_set_c(TYPE_ATTR, datatype, &datatype->d_keyhash,
++                              ompi_pml_ucx.datatype_attr_keyval,
++                              (void*)ucp_datatype, false);
++        if (ret != OMPI_SUCCESS) {
++            PML_UCX_ERROR("Failed to add UCX datatype attribute for %s: %d",
++                          datatype->name, ret);
++            ompi_mpi_abort(&ompi_mpi_comm_world.comm, 1);
++        }
++    }
++
+     PML_UCX_VERBOSE(7, "created generic UCX datatype 0x%"PRIx64, ucp_datatype)
+-    // TODO put this on a list to be destroyed later
+ 
+-    datatype->pml_data = ucp_datatype;
+     return ucp_datatype;
+ }
+ 
+diff -Nur openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx_datatype.h openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx_datatype.h
+--- openmpi-3.1.3.orig/ompi/mca/pml/ucx/pml_ucx_datatype.h	2018-10-29 22:31:25.000000000 +0100
++++ openmpi-3.1.3/ompi/mca/pml/ucx/pml_ucx_datatype.h	2018-11-23 10:36:28.000000000 +0100
+@@ -13,6 +13,8 @@
+ #include "pml_ucx.h"
+ 
+ 
++#define PML_UCX_DATATYPE_INVALID   0
++
+ struct pml_ucx_convertor {
+     opal_free_list_item_t     super;
+     ompi_datatype_t           *datatype;
+@@ -23,6 +25,9 @@
+ 
+ ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype);
+ 
++int mca_pml_ucx_datatype_attr_del_fn(ompi_datatype_t* datatype, int keyval,
++                                     void *attr_val, void *extra);
++
+ OBJ_CLASS_DECLARATION(mca_pml_ucx_convertor_t);
+ 
+ 
+@@ -30,7 +35,7 @@
+ {
+     ucp_datatype_t ucp_type = datatype->pml_data;
+ 
+-    if (OPAL_LIKELY(ucp_type != 0)) {
++    if (OPAL_LIKELY(ucp_type != PML_UCX_DATATYPE_INVALID)) {
+         return ucp_type;
+     }
+ 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
@@ -15,7 +15,8 @@ patches = ['%(name)s-%(version)s-backported_patches.patch']
 
 checksums = [
     '0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d',  # openmpi-3.1.3.tar.gz
-    '46fa94eb417954bdb297291bad4f4d32018af4911bebf3e59af6276eba6a50a9',  # OpenMPI-3.1.3-add_ompi_datatype_attribute_to_release_ucp_datatype.patch
+    # OpenMPI-3.1.3-add_ompi_datatype_attribute_to_release_ucp_datatype.patch
+    '46fa94eb417954bdb297291bad4f4d32018af4911bebf3e59af6276eba6a50a9',
 ]
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
@@ -11,7 +11,7 @@ toolchain = {'name': 'iccifort', 'version': '2019.1.144-GCC-8.2.0-2.31.1'}
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 
-patches = ['%(name)s-%(version)s-backported_patches.patch']
+patches = ['%(name)s-%(version)s-add_ompi_datatype_attribute_to_release_ucp_datatype.patch']
 
 checksums = [
     '0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d',  # openmpi-3.1.3.tar.gz

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
@@ -15,7 +15,7 @@ patches = ['%(name)s-%(version)s-backported_patches.patch']
 
 checksums = [
     '0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d',  # openmpi-3.1.3.tar.gz
-    '6268e34ae8c322e2a784ec3b92e8df34a3074463066c43382b3eaf248f0f17f6',  # OpenMPI-3.1.3-backported_patches.eb
+    '46fa94eb417954bdb297291bad4f4d32018af4911bebf3e59af6276eba6a50a9',  # OpenMPI-3.1.3-add_ompi_datatype_attribute_to_release_ucp_datatype.patch
 ]
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
@@ -10,7 +10,13 @@ toolchain = {'name': 'iccifort', 'version': '2019.1.144-GCC-8.2.0-2.31.1'}
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d']
+
+patches = [ '%(name)s-%(version)s-backported_patches.patch']
+
+checksums = [
+    '0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d', # openmpi-3.1.3.tar.gz
+    '6268e34ae8c322e2a784ec3b92e8df34a3074463066c43382b3eaf248f0f17f6', # OpenMPI-3.1.3-backported_patches.eb
+]
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
@@ -11,11 +11,11 @@ toolchain = {'name': 'iccifort', 'version': '2019.1.144-GCC-8.2.0-2.31.1'}
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 
-patches = [ '%(name)s-%(version)s-backported_patches.patch']
+patches = ['%(name)s-%(version)s-backported_patches.patch']
 
 checksums = [
-    '0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d', # openmpi-3.1.3.tar.gz
-    '6268e34ae8c322e2a784ec3b92e8df34a3074463066c43382b3eaf248f0f17f6', # OpenMPI-3.1.3-backported_patches.eb
+    '0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d',  # openmpi-3.1.3.tar.gz
+    '6268e34ae8c322e2a784ec3b92e8df34a3074463066c43382b3eaf248f0f17f6',  # OpenMPI-3.1.3-backported_patches.eb
 ]
 
 # needed for --with-verbs


### PR DESCRIPTION
Includes:
From 4763822a64c9002f24429aef95d87f6abfc45c06 Mon Sep 17 00:00:00 2001
From: Yossi Itigin <yosefe@mellanox.com>
Date: Tue, 9 Oct 2018 16:38:49 +0300
Subject: [PATCH] pml_ucx: add ompi datatype attribute to release ucp_datatype

From 40ac9e477165616ab98085e2d590dbbbe4874b9f Mon Sep 17 00:00:00 2001
From: Yossi Itigin <yosefe@mellanox.com>
Date: Wed, 10 Oct 2018 12:10:28 +0300
Subject: [PATCH] pml_ucx: fix return code from mca_pml_ucx_init()



