### PR TITLE
added LINKS easyconfig

### DIFF
--- a/easybuild/easyconfigs/l/LINKS/LINKS-1.8.6-goolf-1.7.20-Perl-5.22.2.eb
+++ b/easybuild/easyconfigs/l/LINKS/LINKS-1.8.6-goolf-1.7.20-Perl-5.22.2.eb
@@ -1,0 +1,41 @@
+# This file is an EasyBuild reciPY as per https://easybuilders.github.io/easybuild/
+# Author: Pablo Escobar Lopez
+# sciCORE - University of Basel
+# SIB Swiss Institute of Bioinformatics 
+
+easyblock = 'Tarball'
+
+name = 'LINKS'
+version = '1.8.6'
+versionsuffix = '-Perl-%(perlver)s'
+
+homepage = 'http://www.bcgsc.ca/platform/bioinfo/software/links'
+description = "Long Interval Nucleotide K-mer Scaffolder"
+
+toolchain = {'name': 'goolf', 'version': '1.7.20'}
+
+source_urls = ['http://www.bcgsc.ca/platform/bioinfo/software/links/releases/%(version)s/']
+sources = ['links_v%s.tar.gz' % version.replace('.', '-')]
+checksums = ['d113efa48d29d825eb47abd4ee5124b9b51d7062714a83fc49104552547d5584']
+
+dependencies = [
+    ('Perl', '5.22.2'),
+]
+
+postinstallcmds = [
+    'rm %(installdir)s/lib/bloomfilter/swig/BloomFilter.so',
+    'cd %(installdir)s/lib/bloomfilter/swig/ && ${CXX} -c BloomFilter_wrap.cxx -I$EBROOTPERL/lib/perl5/%(perlver)s/x86_64-linux-thread-multi/CORE/ -fPIC -Dbool=char -O3',
+    'cd %(installdir)s/lib/bloomfilter/swig/ && ${CXX} -Wall -shared BloomFilter_wrap.o -o BloomFilter.so -O3',
+]
+
+modextrapaths = {
+    'PATH': '',
+    'PERL5LIB': 'lib',
+}
+
+sanity_check_paths = {
+    'files': ['LINKS', 'lib/bloomfilter/swig/BloomFilter.so'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
I know this is using a deprectaed toolchain and not respecting all the style conventions (too long line) and it won't be merge but I wanted to send the PR to keep it as reference because it's not a trivial easyconfig

I will try to update to a more recent toolchain once I manage to upgrade my cluster to `foss/2018b`