### PR TITLE
{chem}[foss-2018b] PCMSolver-1.2.3 w/ Python 3.6.6

### DIFF
--- a/easybuild/easyconfigs/p/PCMSolver/PCMSolver-1.2.3-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/p/PCMSolver/PCMSolver-1.2.3-foss-2018b-Python-3.6.6.eb
@@ -1,0 +1,42 @@
+easyblock = 'CMakeMake'
+
+name = 'PCMSolver'
+version = '1.2.3'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://pcmsolver.readthedocs.org'
+description = """An API for the Polarizable Continuum Model."""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+#toolchainopts = {'cstd': 'c99'}
+
+source_urls = ['https://github.com/PCMSolver/pcmsolver/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['d1ef6bdc268a2e719b36c85125c3543df7a26e1a738daf4483f4ded0c76f5b60']
+
+dependencies = [
+    ('Python', '3.6.6'),
+    ('zlib', '1.2.11'),
+    ('Boost', '1.67.0'),
+]
+
+builddependencies = [
+    ('CMake', '3.12.1'),
+    ('Eigen', '3.3.7', '', True),
+]
+
+configopts = '-DCMAKE_BUILD_TYPE=Release -DEIGEN3_ROOT=$EBROOTEIGEN'
+configopts += ' -DCMAKE_CXX_FLAGS="$CXXFLAGS $LIBLAPACK_MT"'
+
+separate_build_dir = True
+
+runtest = 'test'
+
+postinstallcmds = ["chmod +x %(installdir)s/bin/pcmsolver.py"]
+
+sanity_check_paths = {
+    'files': ['bin/pcmsolver.py', 'lib/libpcm.a', 'lib/libpcm.%s' % SHLIB_EXT],
+    'dirs': ['include']
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
This is not working yet and I need some help to fix it. When I try to install PCMSolver with this config, I get the following error:

```
== 2019-02-28 11:15:40,570 build_log.py:162 ERROR EasyBuild crashed with an error (at ?:124 in __init__): cmd " cmake -DCMAKE_INSTALL_PREFIX=/data/gent/vo/000/gvo00003/vsc40019/apps_private/victini/software/PCMSolver/1.2.3-foss-2018b-Python-3.6.6 -DCMAKE_C_COMPILER='gcc' -DCMAKE_Fortran_FLAGS='-O2 -ftree-vectorize -march=native -fno-math-errno' -DCMAKE_CXX_FLAGS='-O2 -ftree-vectorize -march=native -fno-math-errno' -DCMAKE_CXX_COMPILER='g++' -DCMAKE_Fortran_COMPILER='gfortran' -DCMAKE_C_FLAGS='-O2 -ftree-vectorize -march=native -fno-math-errno' -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Release -DEIGEN3_ROOT=$EBROOTEIGEN -DCMAKE_CXX_FLAGS="$CXXFLAGS $LIBLAPACK_MT" /vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/pcmsolver-1.2.3/" exited with exit code 1 and output:
-- The CXX compiler identification is GNU 7.3.0
-- The C compiler identification is GNU 7.3.0
-- The Fortran compiler identification is GNU 7.3.0
-- Check for working CXX compiler: /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/g++
-- Check for working CXX compiler: /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Check for working C compiler: /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/gcc
-- Check for working C compiler: /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working Fortran compiler: /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/gfortran
-- Check for working Fortran compiler: /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/gfortran  -- works
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Checking whether /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/gfortran supports Fortran 90
-- Checking whether /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/gfortran supports Fortran 90 -- yes
-- FCFLAGS is set to '-O2 -ftree-vectorize -march=native -fno-math-errno'.
-- CFLAGS is set to '-O2 -ftree-vectorize -march=native -fno-math-errno'.
-- CXXFLAGS is set to '-O2 -ftree-vectorize -march=native -fno-math-errno'.
-- Detecting Fortran/C Interface
-- Detecting Fortran/C Interface - Found GLOBAL and MODULE mangling
-- Verifying Fortran/CXX Compiler Compatibility
-- Verifying Fortran/CXX Compiler Compatibility - Failed
CMake Error at /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/share/cmake-3.9/Modules/FortranCInterface.cmake:383 (message):
  The Fortran compiler:

    /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/gfortran

  and the CXX compiler:

    /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/g++

  failed to compile a simple test project using both languages.  The output
  was:

    Change Dir: /vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX
    
    Run Build Command:"/usr/bin/gmake" "VerifyFortranC"
    /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/bin/cmake -H/vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/share/cmake-3.9/Modules/FortranCInterface/Verify -B/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX --check-build-system CMakeFiles/Makefile.cmake 0
    /usr/bin/gmake -f CMakeFiles/Makefile2 VerifyFortranC
    gmake[1]: Entering directory `/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX'
    /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/bin/cmake -H/vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/share/cmake-3.9/Modules/FortranCInterface/Verify -B/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX --check-build-system CMakeFiles/Makefile.cmake 0
    /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/bin/cmake -E cmake_progress_start /vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX/CMakeFiles 6
    /usr/bin/gmake -f CMakeFiles/Makefile2 CMakeFiles/VerifyFortranC.dir/all
    gmake[2]: Entering directory `/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX'
    /usr/bin/gmake -f CMakeFiles/VerifyFortran.dir/build.make CMakeFiles/VerifyFortran.dir/depend
    gmake[3]: Entering directory `/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX'
    cd /vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX && /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/bin/cmake -E cmake_depends "Unix Makefiles" /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/share/cmake-3.9/Modules/FortranCInterface/Verify /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/share/cmake-3.9/Modules/FortranCInterface/Verify /vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX /vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX /vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX/CMakeFiles/VerifyFortran.dir/DependInfo.cmake
    Scanning dependencies of target VerifyFortran
    gmake[3]: Leaving directory `/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX'
    /usr/bin/gmake -f CMakeFiles/VerifyFortran.dir/build.make CMakeFiles/VerifyFortran.dir/requires
    gmake[3]: Entering directory `/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX'
    gmake[3]: Nothing to be done for `CMakeFiles/VerifyFortran.dir/requires'.
    gmake[3]: Leaving directory `/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX'
    /usr/bin/gmake -f CMakeFiles/VerifyFortran.dir/build.make CMakeFiles/VerifyFortran.dir/build
    gmake[3]: Entering directory `/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX'
    [ 16%] Building Fortran object CMakeFiles/VerifyFortran.dir/VerifyFortran.f.o
    /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/gfortran -DVERIFY_CXX -I/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX  -O2 -ftree-vectorize -march=native -fno-math-errno -O3 -DNDEBUG -O3   -c /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/share/cmake-3.9/Modules/FortranCInterface/Verify/VerifyFortran.f -o CMakeFiles/VerifyFortran.dir/VerifyFortran.f.o
    [ 33%] Linking Fortran static library libVerifyFortran.a
    /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/bin/cmake -P CMakeFiles/VerifyFortran.dir/cmake_clean_target.cmake
    /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/bin/cmake -E cmake_link_script CMakeFiles/VerifyFortran.dir/link.txt --verbose=1
    /apps/gent/CO7/skylake-ib/software/binutils/2.30-GCCcore-7.3.0/bin/ar qc libVerifyFortran.a  CMakeFiles/VerifyFortran.dir/VerifyFortran.f.o
    /apps/gent/CO7/skylake-ib/software/binutils/2.30-GCCcore-7.3.0/bin/ranlib libVerifyFortran.a
    gmake[3]: Leaving directory `/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX'
    [ 33%] Built target VerifyFortran
    /usr/bin/gmake -f CMakeFiles/VerifyFortranC.dir/build.make CMakeFiles/VerifyFortranC.dir/depend
    gmake[3]: Entering directory `/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX'
    cd /vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX && /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/bin/cmake -E cmake_depends "Unix Makefiles" /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/share/cmake-3.9/Modules/FortranCInterface/Verify /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/share/cmake-3.9/Modules/FortranCInterface/Verify /vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX /vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX /vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX/CMakeFiles/VerifyFortranC.dir/DependInfo.cmake
    Scanning dependencies of target VerifyFortranC
    gmake[3]: Leaving directory `/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX'
    /usr/bin/gmake -f CMakeFiles/VerifyFortranC.dir/build.make CMakeFiles/VerifyFortranC.dir/build
    gmake[3]: Entering directory `/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX'
    [ 50%] Building C object CMakeFiles/VerifyFortranC.dir/main.c.o
    /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/gcc -DVERIFY_CXX -I/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX  -O2 -ftree-vectorize -march=native -fno-math-errno -O3 -DNDEBUG   -o CMakeFiles/VerifyFortranC.dir/main.c.o   -c /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/share/cmake-3.9/Modules/FortranCInterface/Verify/main.c
    [ 66%] Building C object CMakeFiles/VerifyFortranC.dir/VerifyC.c.o
    /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/gcc -DVERIFY_CXX -I/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX  -O2 -ftree-vectorize -march=native -fno-math-errno -O3 -DNDEBUG   -o CMakeFiles/VerifyFortranC.dir/VerifyC.c.o   -c /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/share/cmake-3.9/Modules/FortranCInterface/Verify/VerifyC.c
    [ 83%] Building CXX object CMakeFiles/VerifyFortranC.dir/VerifyCXX.cxx.o
    /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/g++  -DVERIFY_CXX -I/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX  -O2 -ftree-vectorize -march=native -fno-math-errno -O3 -DNDEBUG   -o CMakeFiles/VerifyFortranC.dir/VerifyCXX.cxx.o -c /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/share/cmake-3.9/Modules/FortranCInterface/Verify/VerifyCXX.cxx
    [100%] Linking CXX executable VerifyFortranC
    /vscmnt/gent_kyukon_apps/_kyukon_home_apps/CO7/skylake-ib/software/CMake/3.9.1/bin/cmake -E cmake_link_script CMakeFiles/VerifyFortranC.dir/link.txt --verbose=1
    /apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/bin/g++  -O2 -ftree-vectorize -march=native -fno-math-errno -O3 -DNDEBUG  -L/apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/lib64 -L/apps/gent/CO7/skylake-ib/software/GCCcore/7.3.0/lib -L/apps/gent/CO7/skylake-ib/software/OpenBLAS/0.3.1-GCC-7.3.0-2.30/lib -L/apps/gent/CO7/skylake-ib/software/ScaLAPACK/2.0.2-gompi-2018b-OpenBLAS-0.3.1/lib -L/apps/gent/CO7/skylake-ib/software/FFTW/3.3.8-gompi-2018b/lib -L/apps/gent/CO7/skylake-ib/software/Python/3.6.6-foss-2018b/lib -L/apps/gent/CO7/skylake-ib/software/zlib/1.2.11-GCCcore-7.3.0/lib -L/apps/gent/CO7/skylake-ib/software/Boost/1.67.0-foss-2018b/lib CMakeFiles/VerifyFortranC.dir/main.c.o CMakeFiles/VerifyFortranC.dir/VerifyC.c.o CMakeFiles/VerifyFortranC.dir/VerifyCXX.cxx.o  -o VerifyFortranC libVerifyFortran.a -lquadmath 
    libVerifyFortran.a(VerifyFortran.f.o):VerifyFortran.f:function verifyfortran_: error: undefined reference to '_gfortran_st_write'
    libVerifyFortran.a(VerifyFortran.f.o):VerifyFortran.f:function verifyfortran_: error: undefined reference to '_gfortran_transfer_character_write'
    libVerifyFortran.a(VerifyFortran.f.o):VerifyFortran.f:function verifyfortran_: error: undefined reference to '_gfortran_st_write_done'
    collect2: error: ld returned 1 exit status
    gmake[3]: *** [VerifyFortranC] Error 1
    gmake[3]: Leaving directory `/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX'
    gmake[2]: *** [CMakeFiles/VerifyFortranC.dir/all] Error 2
    gmake[2]: Leaving directory `/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX'
    gmake[1]: *** [CMakeFiles/VerifyFortranC.dir/rule] Error 2
    gmake[1]: Leaving directory `/vscmnt/gent_kyukon_data/_kyukon_data_gent/vo/000/gvo00003/vsc40019/apps_private/b/v/PCMSolver/1.2.3/foss-2018b-Python-3.6.6/easybuild_obj/CMakeFiles/FortranCInterface/VerifyCXX'
    gmake: *** [VerifyFortranC] Error 2
    
Call Stack (most recent call first):
  cmake/custom/compilers/Fortran_C.cmake:19 (FortranCInterface_VERIFY)
  CMakeLists.txt:61 (include)


-- Configuring incomplete, errors occurred!
```

When I try to run exactly the same `cmake` command in the build directory (after module loading the dependencies), cmake does not complain. How do I figure out which other factors affect cmake's behavior when it is called by EasyBuild?