### PR TITLE
add patch for OpenMPI 3.1.x to fix ib-query 'Invalid argument' error

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.0-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.0-GCC-7.3.0-2.30.eb
@@ -10,7 +10,11 @@ toolchain = {'name': 'GCC', 'version': '7.3.0-2.30'}
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['a72d5a3f64c7afa33fb6c795e1168de7f92b35fd1f97ef606cfcf7405273aedc']
+patches = ['OpenMPI-3.1_fix-ib-query.patch']
+checksums = [
+    'a72d5a3f64c7afa33fb6c795e1168de7f92b35fd1f97ef606cfcf7405273aedc',  # openmpi-3.1.0.tar.gz
+    '8031ff093788a750f30ec7b4b06573af008009e62ddfd558ecfe97cbe404d9d2',  # OpenMPI-3.1_fix-ib-query.patch
+]
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.1-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.1-GCC-7.3.0-2.30.eb
@@ -10,7 +10,11 @@ toolchain = {'name': 'GCC', 'version': '7.3.0-2.30'}
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['846bb7ed2aa0c96fc0594423e7b21904ee4f160dcfd62b8a0d1274256fbf25ce']
+patches = ['OpenMPI-3.1_fix-ib-query.patch']
+checksums = [
+    '846bb7ed2aa0c96fc0594423e7b21904ee4f160dcfd62b8a0d1274256fbf25ce',  # openmpi-3.1.1.tar.gz
+    '8031ff093788a750f30ec7b4b06573af008009e62ddfd558ecfe97cbe404d9d2',  # OpenMPI-3.1_fix-ib-query.patch
+]
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.1-gcccuda-2018b.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.1-gcccuda-2018b.eb
@@ -10,7 +10,11 @@ toolchain = {'name': 'gcccuda', 'version': '2018b'}
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['846bb7ed2aa0c96fc0594423e7b21904ee4f160dcfd62b8a0d1274256fbf25ce']
+patches = ['OpenMPI-3.1_fix-ib-query.patch']
+checksums = [
+    '846bb7ed2aa0c96fc0594423e7b21904ee4f160dcfd62b8a0d1274256fbf25ce',  # openmpi-3.1.1.tar.gz
+    '8031ff093788a750f30ec7b4b06573af008009e62ddfd558ecfe97cbe404d9d2',  # OpenMPI-3.1_fix-ib-query.patch
+]
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.1-iccifort-2018.3.222-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.1-iccifort-2018.3.222-GCC-7.3.0-2.30.eb
@@ -10,7 +10,11 @@ toolchain = {'name': 'iccifort', 'version': '2018.3.222-GCC-7.3.0-2.30'}
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['846bb7ed2aa0c96fc0594423e7b21904ee4f160dcfd62b8a0d1274256fbf25ce']
+patches = ['OpenMPI-3.1_fix-ib-query.patch']
+checksums = [
+    '846bb7ed2aa0c96fc0594423e7b21904ee4f160dcfd62b8a0d1274256fbf25ce',  # openmpi-3.1.1.tar.gz
+    '8031ff093788a750f30ec7b4b06573af008009e62ddfd558ecfe97cbe404d9d2',  # OpenMPI-3.1_fix-ib-query.patch
+]
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.2-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.2-GCC-8.2.0-2.31.1.eb
@@ -10,7 +10,11 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['363c8a1258d12df28657e9b13bfe41e30fc129a4cfb89fcf53ff68bbe1bd65b3']
+patches = ['OpenMPI-3.1_fix-ib-query.patch']
+checksums = [
+    '363c8a1258d12df28657e9b13bfe41e30fc129a4cfb89fcf53ff68bbe1bd65b3',  # openmpi-3.1.2.tar.gz
+    '8031ff093788a750f30ec7b4b06573af008009e62ddfd558ecfe97cbe404d9d2',  # OpenMPI-3.1_fix-ib-query.patch
+]
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-GCC-8.2.0-2.31.1.eb
@@ -10,13 +10,15 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-
-patches = ['%(name)s-%(version)s-add_ompi_datatype_attribute_to_release_ucp_datatype.patch']
-
+patches = [
+    '%(name)s-%(version)s-add_ompi_datatype_attribute_to_release_ucp_datatype.patch',
+    'OpenMPI-3.1_fix-ib-query.patch',
+]
 checksums = [
     '0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d',  # openmpi-3.1.3.tar.gz
     # OpenMPI-3.1.3-add_ompi_datatype_attribute_to_release_ucp_datatype.patch
     '46fa94eb417954bdb297291bad4f4d32018af4911bebf3e59af6276eba6a50a9',
+    '8031ff093788a750f30ec7b4b06573af008009e62ddfd558ecfe97cbe404d9d2',  # OpenMPI-3.1_fix-ib-query.patch
 ]
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
@@ -10,13 +10,15 @@ toolchain = {'name': 'iccifort', 'version': '2019.1.144-GCC-8.2.0-2.31.1'}
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-
-patches = ['%(name)s-%(version)s-add_ompi_datatype_attribute_to_release_ucp_datatype.patch']
-
+patches = [
+    '%(name)s-%(version)s-add_ompi_datatype_attribute_to_release_ucp_datatype.patch',
+    'OpenMPI-3.1_fix-ib-query.patch',
+]
 checksums = [
     '0254627d8a9b12a8f50213ed01e7a94dd7e91b340abf5c53bcf0b89afe6fb77d',  # openmpi-3.1.3.tar.gz
     # OpenMPI-3.1.3-add_ompi_datatype_attribute_to_release_ucp_datatype.patch
     '46fa94eb417954bdb297291bad4f4d32018af4911bebf3e59af6276eba6a50a9',
+    '8031ff093788a750f30ec7b4b06573af008009e62ddfd558ecfe97cbe404d9d2',  # OpenMPI-3.1_fix-ib-query.patch
 ]
 
 # needed for --with-verbs

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1_fix-ib-query.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1_fix-ib-query.patch
@@ -1,0 +1,36 @@
+fix for "error obtaining device attributes for mlx4_0 errno says Invalid argument"
+
+see also:
+* https://github.com/open-mpi/ompi/issues/5810
+* https://github.com/open-mpi/ompi/pull/6038
+
+From d70f27f9b209a00b89814fd11f7895eb82bec773 Mon Sep 17 00:00:00 2001
+From: Howard Pritchard <howardp@lanl.gov>
+Date: Wed, 31 Oct 2018 14:50:15 -0600
+Subject: [PATCH] btl/openib: fix a problem with ib query
+
+Under certain circumstances, ibv_exp_query_device was
+returning an error due to uninitialized fields in the
+extended attributes struct.
+
+Fixes: #5810
+Fixes: #5914
+
+Signed-off-by: Howard Pritchard <howardp@lanl.gov>
+(cherry picked from commit 8126779a354b3e0c720d3e1790f7b936dd5b93b2)
+---
+ opal/mca/btl/openib/btl_openib_component.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/opal/mca/btl/openib/btl_openib_component.c b/opal/mca/btl/openib/btl_openib_component.c
+index 44792a13ab8..8b86cbb587f 100644
+--- a/opal/mca/btl/openib/btl_openib_component.c
++++ b/opal/mca/btl/openib/btl_openib_component.c
+@@ -1642,6 +1642,7 @@ static int init_one_device(opal_list_t *btl_list, struct ibv_device* ib_dev)
+         goto error;
+     }
+ #if HAVE_DECL_IBV_EXP_QUERY_DEVICE
++    memset(&device->ib_exp_dev_attr, 0, sizeof(device->ib_exp_dev_attr));
+     device->ib_exp_dev_attr.comp_mask = IBV_EXP_DEVICE_ATTR_RESERVED - 1;
+     if(ibv_exp_query_device(device->ib_dev_context, &device->ib_exp_dev_attr)){
+         BTL_ERROR(("error obtaining device attributes for %s errno says %s",


### PR DESCRIPTION
I ran into this error during the sanity check for TensorFlow 1.13.1 (cfr. #7785)