### PR TITLE
restore checksums check for R-* easyconfigs 

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -342,7 +342,7 @@ class EasyConfigTest(TestCase):
 
         # list of software for which checksums can not be required,
         # e.g. because 'source' files need to be constructed manually
-        whitelist = ['Kent_tools-*', 'MATLAB-*', 'R-*']
+        whitelist = ['Kent_tools-*', 'MATLAB-*']
 
         # the check_sha256_checksums function (again) creates an EasyBlock instance
         # for easyconfigs using the Bundle easyblock, this is a problem because the 'sources' easyconfig parameter


### PR DESCRIPTION
follow-up of checksums check for `R-*` that was temporarily disabled in #7791