### PR TITLE
build OpenBLAS with -fno-tree-vectorize (asm constraint bugs for <0.3.6) + cleanup & SHA256 checksums

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.12-GCC-4.9.2-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.12-GCC-4.9.2-LAPACK-3.5.0.eb
@@ -17,23 +17,31 @@ toolchainopts = {'vectorize': False}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
 patches = [
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    'b41f71f46faab1215f6f6d17541113dc01fd4d8fee0694f3f459bc2e3c2aaaaf',  # v0.2.12.tar.gz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.12-GCC-4.9.2-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.12-GCC-4.9.2-LAPACK-3.5.0.eb
@@ -7,6 +7,9 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.2'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.12-GCC-4.9.2-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.12-GCC-4.9.2-LAPACK-3.5.0.eb
@@ -7,12 +7,12 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.2'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.12-GCC-4.9.2-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.12-GCC-4.9.2-LAPACK-3.5.0.eb
@@ -14,31 +14,20 @@ toolchain = {'name': 'GCC', 'version': '4.9.2'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
+sources = ['v%(version)s.tar.gz']
 patches = [
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     'b41f71f46faab1215f6f6d17541113dc01fd4d8fee0694f3f459bc2e3c2aaaaf',  # v0.2.12.tar.gz
-    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.8.4-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.8.4-LAPACK-3.5.0.eb
@@ -7,12 +7,12 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.4'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.8.4-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.8.4-LAPACK-3.5.0.eb
@@ -17,23 +17,31 @@ toolchainopts = {'vectorize': False}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
 patches = [
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '5f1f986a1900949058b578c61c2b65b4de324f1968ec505daeb526b9f9af14ab',  # v0.2.13.tar.gz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.8.4-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.8.4-LAPACK-3.5.0.eb
@@ -7,6 +7,9 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.4'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.8.4-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.8.4-LAPACK-3.5.0.eb
@@ -14,31 +14,20 @@ toolchain = {'name': 'GCC', 'version': '4.8.4'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
+sources = ['v%(version)s.tar.gz']
 patches = [
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '5f1f986a1900949058b578c61c2b65b4de324f1968ec505daeb526b9f9af14ab',  # v0.2.13.tar.gz
-    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.9.2-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.9.2-LAPACK-3.5.0.eb
@@ -14,31 +14,20 @@ toolchain = {'name': 'GCC', 'version': '4.9.2'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
+sources = ['v%(version)s.tar.gz']
 patches = [
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '5f1f986a1900949058b578c61c2b65b4de324f1968ec505daeb526b9f9af14ab',  # v0.2.13.tar.gz
-    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.9.2-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.9.2-LAPACK-3.5.0.eb
@@ -17,23 +17,31 @@ toolchainopts = {'vectorize': False}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
 patches = [
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '5f1f986a1900949058b578c61c2b65b4de324f1968ec505daeb526b9f9af14ab',  # v0.2.13.tar.gz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.9.2-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.9.2-LAPACK-3.5.0.eb
@@ -7,6 +7,9 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.2'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.9.2-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.9.2-LAPACK-3.5.0.eb
@@ -7,12 +7,12 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.2'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-gompi-1.5.16-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-gompi-1.5.16-LAPACK-3.5.0.eb
@@ -17,23 +17,31 @@ toolchainopts = {'vectorize': False}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
 patches = [
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '5f1f986a1900949058b578c61c2b65b4de324f1968ec505daeb526b9f9af14ab',  # v0.2.13.tar.gz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-gompi-1.5.16-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-gompi-1.5.16-LAPACK-3.5.0.eb
@@ -14,31 +14,20 @@ toolchain = {'name': 'gompi', 'version': '1.5.16'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
+sources = ['v%(version)s.tar.gz']
 patches = [
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '5f1f986a1900949058b578c61c2b65b4de324f1968ec505daeb526b9f9af14ab',  # v0.2.13.tar.gz
-    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-gompi-1.5.16-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-gompi-1.5.16-LAPACK-3.5.0.eb
@@ -7,6 +7,9 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'gompi', 'version': '1.5.16'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-gompi-1.5.16-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-gompi-1.5.16-LAPACK-3.5.0.eb
@@ -7,12 +7,12 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'gompi', 'version': '1.5.16'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.2-2.25-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.2-2.25-LAPACK-3.5.0.eb
@@ -17,23 +17,31 @@ toolchainopts = {'vectorize': False}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
 patches = [
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '2411c4f56f477b42dff54db2b7ffc0b7cf53bb9778d54982595c64cc69c40fc1',  # v0.2.14.tar.gz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.2-2.25-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.2-2.25-LAPACK-3.5.0.eb
@@ -7,6 +7,9 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GNU', 'version': '4.9.2-2.25'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.2-2.25-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.2-2.25-LAPACK-3.5.0.eb
@@ -14,31 +14,20 @@ toolchain = {'name': 'GNU', 'version': '4.9.2-2.25'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
+sources = ['v%(version)s.tar.gz']
 patches = [
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '2411c4f56f477b42dff54db2b7ffc0b7cf53bb9778d54982595c64cc69c40fc1',  # v0.2.14.tar.gz
-    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.2-2.25-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.2-2.25-LAPACK-3.5.0.eb
@@ -7,12 +7,12 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GNU', 'version': '4.9.2-2.25'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.3-2.25-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.3-2.25-LAPACK-3.5.0.eb
@@ -17,23 +17,31 @@ toolchainopts = {'vectorize': False}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
 patches = [
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '2411c4f56f477b42dff54db2b7ffc0b7cf53bb9778d54982595c64cc69c40fc1',  # v0.2.14.tar.gz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.3-2.25-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.3-2.25-LAPACK-3.5.0.eb
@@ -7,12 +7,12 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GNU', 'version': '4.9.3-2.25'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.3-2.25-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.3-2.25-LAPACK-3.5.0.eb
@@ -7,6 +7,9 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GNU', 'version': '4.9.3-2.25'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.3-2.25-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.3-2.25-LAPACK-3.5.0.eb
@@ -14,31 +14,20 @@ toolchain = {'name': 'GNU', 'version': '4.9.3-2.25'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
+sources = ['v%(version)s.tar.gz']
 patches = [
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '2411c4f56f477b42dff54db2b7ffc0b7cf53bb9778d54982595c64cc69c40fc1',  # v0.2.14.tar.gz
-    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.15-GCC-4.9.3-2.25-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.15-GCC-4.9.3-2.25-LAPACK-3.6.0.eb
@@ -7,12 +7,12 @@ lapackver = '3.6.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.3-2.25'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.15-GCC-4.9.3-2.25-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.15-GCC-4.9.3-2.25-LAPACK-3.6.0.eb
@@ -14,31 +14,20 @@ toolchain = {'name': 'GCC', 'version': '4.9.3-2.25'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
+sources = ['v%(version)s.tar.gz']
 patches = [
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '73c40ace5978282224e5e122a41c8388c5a19e65a6f2329c2b7c0b61bacc9044',  # v0.2.15.tar.gz
-    'a9a0082c918fe14e377bbd570057616768dca76cbdc713457d8199aaa233ffc3',  # lapack-3.6.0.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     'a9a0082c918fe14e377bbd570057616768dca76cbdc713457d8199aaa233ffc3',  # lapack-3.6.0.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.15-GCC-4.9.3-2.25-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.15-GCC-4.9.3-2.25-LAPACK-3.6.0.eb
@@ -17,23 +17,31 @@ toolchainopts = {'vectorize': False}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
 patches = [
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '73c40ace5978282224e5e122a41c8388c5a19e65a6f2329c2b7c0b61bacc9044',  # v0.2.15.tar.gz
+    'a9a0082c918fe14e377bbd570057616768dca76cbdc713457d8199aaa233ffc3',  # lapack-3.6.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    'a9a0082c918fe14e377bbd570057616768dca76cbdc713457d8199aaa233ffc3',  # lapack-3.6.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.15-GCC-4.9.3-2.25-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.15-GCC-4.9.3-2.25-LAPACK-3.6.0.eb
@@ -7,6 +7,9 @@ lapackver = '3.6.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.3-2.25'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-4.9.4-2.25-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-4.9.4-2.25-LAPACK-3.6.0.eb
@@ -7,6 +7,9 @@ lapackver = '3.6.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.4-2.25'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-4.9.4-2.25-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-4.9.4-2.25-LAPACK-3.6.0.eb
@@ -22,22 +22,29 @@ lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
-sources = [
-    'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
+    large_src,
+    timing_src,
+]
 patches = [
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '7d9f8d4ea4a65ab68088f3bb557f03a7ac9cb5036ef2ba30546c3a28774a4112',  # v0.2.18.tar.gz
+    'a9a0082c918fe14e377bbd570057616768dca76cbdc713457d8199aaa233ffc3',  # lapack-3.6.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-4.9.4-2.25-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-4.9.4-2.25-LAPACK-3.6.0.eb
@@ -14,10 +14,6 @@ toolchain = {'name': 'GCC', 'version': '4.9.4-2.25'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
@@ -30,19 +26,15 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
+    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
 ]
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '7d9f8d4ea4a65ab68088f3bb557f03a7ac9cb5036ef2ba30546c3a28774a4112',  # v0.2.18.tar.gz
     'a9a0082c918fe14e377bbd570057616768dca76cbdc713457d8199aaa233ffc3',  # lapack-3.6.0.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-4.9.4-2.25-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-4.9.4-2.25-LAPACK-3.6.0.eb
@@ -7,12 +7,12 @@ lapackver = '3.6.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.4-2.25'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.3.0-2.26-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.3.0-2.26-LAPACK-3.6.0.eb
@@ -22,22 +22,29 @@ lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
-sources = [
-    'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
+    large_src,
+    timing_src,
+]
 patches = [
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '7d9f8d4ea4a65ab68088f3bb557f03a7ac9cb5036ef2ba30546c3a28774a4112',  # v0.2.18.tar.gz
+    'a9a0082c918fe14e377bbd570057616768dca76cbdc713457d8199aaa233ffc3',  # lapack-3.6.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.3.0-2.26-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.3.0-2.26-LAPACK-3.6.0.eb
@@ -14,10 +14,6 @@ toolchain = {'name': 'GCC', 'version': '5.3.0-2.26'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
@@ -30,19 +26,15 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
+    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
 ]
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '7d9f8d4ea4a65ab68088f3bb557f03a7ac9cb5036ef2ba30546c3a28774a4112',  # v0.2.18.tar.gz
     'a9a0082c918fe14e377bbd570057616768dca76cbdc713457d8199aaa233ffc3',  # lapack-3.6.0.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.3.0-2.26-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.3.0-2.26-LAPACK-3.6.0.eb
@@ -7,12 +7,12 @@ lapackver = '3.6.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '5.3.0-2.26'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.3.0-2.26-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.3.0-2.26-LAPACK-3.6.0.eb
@@ -7,6 +7,9 @@ lapackver = '3.6.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '5.3.0-2.26'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.0.eb
@@ -22,22 +22,29 @@ lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
-sources = [
-    'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
+    large_src,
+    timing_src,
+]
 patches = [
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '7d9f8d4ea4a65ab68088f3bb557f03a7ac9cb5036ef2ba30546c3a28774a4112',  # v0.2.18.tar.gz
+    'a9a0082c918fe14e377bbd570057616768dca76cbdc713457d8199aaa233ffc3',  # lapack-3.6.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.0.eb
@@ -7,6 +7,9 @@ lapackver = '3.6.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.0.eb
@@ -7,12 +7,12 @@ lapackver = '3.6.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.0.eb
@@ -14,10 +14,6 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
@@ -30,19 +26,15 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
+    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
 ]
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '7d9f8d4ea4a65ab68088f3bb557f03a7ac9cb5036ef2ba30546c3a28774a4112',  # v0.2.18.tar.gz
     'a9a0082c918fe14e377bbd570057616768dca76cbdc713457d8199aaa233ffc3',  # lapack-3.6.0.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1.eb
@@ -14,10 +14,6 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
@@ -30,19 +26,15 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
+    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
 ]
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '7d9f8d4ea4a65ab68088f3bb557f03a7ac9cb5036ef2ba30546c3a28774a4112',  # v0.2.18.tar.gz
     '888a50d787a9d828074db581c80b2d22bdb91435a673b1bf6cd6eb51aa50d1de',  # lapack-3.6.1.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1.eb
@@ -7,6 +7,9 @@ lapackver = '3.6.1'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1.eb
@@ -7,12 +7,12 @@ lapackver = '3.6.1'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
@@ -22,22 +22,29 @@ lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
-sources = [
-    'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
+    large_src,
+    timing_src,
+]
 patches = [
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '7d9f8d4ea4a65ab68088f3bb557f03a7ac9cb5036ef2ba30546c3a28774a4112',  # v0.2.18.tar.gz
+    '888a50d787a9d828074db581c80b2d22bdb91435a673b1bf6cd6eb51aa50d1de',  # lapack-3.6.1.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
@@ -14,10 +14,6 @@ toolchain = {'name': 'gompi', 'version': '2016.07'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
@@ -30,19 +26,15 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
+    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
 ]
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '7d9f8d4ea4a65ab68088f3bb557f03a7ac9cb5036ef2ba30546c3a28774a4112',  # v0.2.18.tar.gz
     '888a50d787a9d828074db581c80b2d22bdb91435a673b1bf6cd6eb51aa50d1de',  # lapack-3.6.1.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
@@ -7,12 +7,12 @@ lapackver = '3.6.1'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'gompi', 'version': '2016.07'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
@@ -7,6 +7,9 @@ lapackver = '3.6.1'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'gompi', 'version': '2016.07'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-5.4.0-2.26-LAPACK-3.7.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-5.4.0-2.26-LAPACK-3.7.0.eb
@@ -7,12 +7,12 @@ lapackver = '3.7.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-5.4.0-2.26-LAPACK-3.7.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-5.4.0-2.26-LAPACK-3.7.0.eb
@@ -14,10 +14,6 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
@@ -30,20 +26,16 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
+    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
 ]
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
     'OpenBLAS-%(version)s_LAPACK-3.7.0-fixes.patch',
 ]
 checksums = [
     '9c40b5e4970f27c5f6911cb0a28aa26b6c83f17418b69f8e5a116bb983ca8557',  # v0.2.19.tar.gz
     'ed967e4307e986474ab02eb810eed1d1adc73f5e1e3bc78fb009f6fe766db3be',  # lapack-3.7.0.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     'a965fef840eb93e120cd24b945ab4def1c6194946ed02f8107e5e626018bb03d',  # OpenBLAS-0.2.19_LAPACK-3.7.0-fixes.patch

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-5.4.0-2.26-LAPACK-3.7.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-5.4.0-2.26-LAPACK-3.7.0.eb
@@ -22,23 +22,31 @@ lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
-sources = [
-    'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
+    large_src,
+    timing_src,
+]
 patches = [
     (large_src, '.'),
     (timing_src, '.'),
     'OpenBLAS-%(version)s_LAPACK-3.7.0-fixes.patch',
+]
+checksums = [
+    '9c40b5e4970f27c5f6911cb0a28aa26b6c83f17418b69f8e5a116bb983ca8557',  # v0.2.19.tar.gz
+    'ed967e4307e986474ab02eb810eed1d1adc73f5e1e3bc78fb009f6fe766db3be',  # lapack-3.7.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    'a965fef840eb93e120cd24b945ab4def1c6194946ed02f8107e5e626018bb03d',  # OpenBLAS-0.2.19_LAPACK-3.7.0-fixes.patch
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-5.4.0-2.26-LAPACK-3.7.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-5.4.0-2.26-LAPACK-3.7.0.eb
@@ -7,6 +7,9 @@ lapackver = '3.7.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-6.3.0-2.27-LAPACK-3.7.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-6.3.0-2.27-LAPACK-3.7.0.eb
@@ -7,6 +7,9 @@ lapackver = '3.7.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '6.3.0-2.27'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-6.3.0-2.27-LAPACK-3.7.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-6.3.0-2.27-LAPACK-3.7.0.eb
@@ -22,23 +22,31 @@ lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
-sources = [
-    'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
+    large_src,
+    timing_src,
+]
 patches = [
     (large_src, '.'),
     (timing_src, '.'),
     'OpenBLAS-%(version)s_LAPACK-3.7.0-fixes.patch',
+]
+checksums = [
+    '9c40b5e4970f27c5f6911cb0a28aa26b6c83f17418b69f8e5a116bb983ca8557',  # v0.2.19.tar.gz
+    'ed967e4307e986474ab02eb810eed1d1adc73f5e1e3bc78fb009f6fe766db3be',  # lapack-3.7.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    'a965fef840eb93e120cd24b945ab4def1c6194946ed02f8107e5e626018bb03d',  # OpenBLAS-0.2.19_LAPACK-3.7.0-fixes.patch
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-6.3.0-2.27-LAPACK-3.7.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-6.3.0-2.27-LAPACK-3.7.0.eb
@@ -7,12 +7,12 @@ lapackver = '3.7.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '6.3.0-2.27'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-6.3.0-2.27-LAPACK-3.7.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-6.3.0-2.27-LAPACK-3.7.0.eb
@@ -14,10 +14,6 @@ toolchain = {'name': 'GCC', 'version': '6.3.0-2.27'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
@@ -30,20 +26,16 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
+    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
 ]
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
     'OpenBLAS-%(version)s_LAPACK-3.7.0-fixes.patch',
 ]
 checksums = [
     '9c40b5e4970f27c5f6911cb0a28aa26b6c83f17418b69f8e5a116bb983ca8557',  # v0.2.19.tar.gz
     'ed967e4307e986474ab02eb810eed1d1adc73f5e1e3bc78fb009f6fe766db3be',  # lapack-3.7.0.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     'a965fef840eb93e120cd24b945ab4def1c6194946ed02f8107e5e626018bb03d',  # OpenBLAS-0.2.19_LAPACK-3.7.0-fixes.patch

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
@@ -14,10 +14,6 @@ toolchain = {'name': 'gompi', 'version': '2016.09'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
@@ -30,19 +26,15 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
+    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
 ]
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '9c40b5e4970f27c5f6911cb0a28aa26b6c83f17418b69f8e5a116bb983ca8557',  # v0.2.19.tar.gz
     '888a50d787a9d828074db581c80b2d22bdb91435a673b1bf6cd6eb51aa50d1de',  # lapack-3.6.1.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
@@ -22,22 +22,29 @@ lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
-sources = [
-    'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
+    large_src,
+    timing_src,
+]
 patches = [
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '9c40b5e4970f27c5f6911cb0a28aa26b6c83f17418b69f8e5a116bb983ca8557',  # v0.2.19.tar.gz
+    '888a50d787a9d828074db581c80b2d22bdb91435a673b1bf6cd6eb51aa50d1de',  # lapack-3.6.1.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
@@ -7,6 +7,9 @@ lapackver = '3.6.1'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'gompi', 'version': '2016.09'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
@@ -7,12 +7,12 @@ lapackver = '3.6.1'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'gompi', 'version': '2016.09'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompic-2016.10-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompic-2016.10-LAPACK-3.6.1.eb
@@ -22,22 +22,29 @@ lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
-sources = [
-    'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
+    large_src,
+    timing_src,
+]
 patches = [
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '9c40b5e4970f27c5f6911cb0a28aa26b6c83f17418b69f8e5a116bb983ca8557',  # v0.2.19.tar.gz
+    '888a50d787a9d828074db581c80b2d22bdb91435a673b1bf6cd6eb51aa50d1de',  # lapack-3.6.1.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompic-2016.10-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompic-2016.10-LAPACK-3.6.1.eb
@@ -14,10 +14,6 @@ toolchain = {'name': 'gompic', 'version': '2016.10'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
 lapack_unpack_cmd += 'mkdir lapack-netlib;'
 lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
@@ -30,19 +26,15 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': lapack_src, 'extract_cmd': lapack_unpack_cmd},
-    large_src,
-    timing_src,
+    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
 ]
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '9c40b5e4970f27c5f6911cb0a28aa26b6c83f17418b69f8e5a116bb983ca8557',  # v0.2.19.tar.gz
     '888a50d787a9d828074db581c80b2d22bdb91435a673b1bf6cd6eb51aa50d1de',  # lapack-3.6.1.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompic-2016.10-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompic-2016.10-LAPACK-3.6.1.eb
@@ -7,12 +7,12 @@ lapackver = '3.6.1'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'gompic', 'version': '2016.10'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompic-2016.10-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompic-2016.10-LAPACK-3.6.1.eb
@@ -7,6 +7,9 @@ lapackver = '3.6.1'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'gompic', 'version': '2016.10'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-5.4.0-2.26.eb
@@ -20,20 +20,19 @@ source_urls = [
     'https://github.com/xianyi/OpenBLAS/archive/',
 ]
 sources = ['v%(version)s.tar.gz']
-checksums = [
-    '5ef38b15d9c652985774869efd548b8e3e972e1e99475c673b25537ed7bcf394',  # v0.2.20.tar.gz (OpenBLAS)
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
-    # OpenBLAS-0.2.20_fix-Intel-L1-cache-size-detection.patch
-    '1d043e4838ec1f90b2b49318b780e3ab13b46133cb72a8d83eb0e3b1b056c4d6',
-    '1e6a046ab658c6e0b351de901d2812db28c2042f9f141416144c2faaf71fbb37',  # OpenBLAS-0.2.20_revert-honor-cpuset.patch
-]
-
 patches = [
     (large_src, '.'),
     (timing_src, '.'),
     'OpenBLAS-%(version)s_fix-Intel-L1-cache-size-detection.patch',
     'OpenBLAS-%(version)s_revert-honor-cpuset.patch',
+]
+checksums = [
+    '5ef38b15d9c652985774869efd548b8e3e972e1e99475c673b25537ed7bcf394',  # v0.2.20.tar.gz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    # OpenBLAS-0.2.20_fix-Intel-L1-cache-size-detection.patch
+    '1d043e4838ec1f90b2b49318b780e3ab13b46133cb72a8d83eb0e3b1b056c4d6',
+    '1e6a046ab658c6e0b351de901d2812db28c2042f9f141416144c2faaf71fbb37',  # OpenBLAS-0.2.20_revert-honor-cpuset.patch
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-5.4.0-2.26.eb
@@ -11,9 +11,6 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 source_urls = [
     # order matters, trying to download the large.tgz/timing.tgz LAPACK tarballs from GitHub causes trouble
     'http://www.netlib.org/lapack/timing/',
@@ -21,8 +18,8 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
     'OpenBLAS-%(version)s_fix-Intel-L1-cache-size-detection.patch',
     'OpenBLAS-%(version)s_revert-honor-cpuset.patch',
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-5.4.0-2.26.eb
@@ -7,6 +7,9 @@ homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
 
 toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-6.4.0-2.28.eb
@@ -20,20 +20,19 @@ source_urls = [
     'https://github.com/xianyi/OpenBLAS/archive/',
 ]
 sources = ['v%(version)s.tar.gz']
-checksums = [
-    '5ef38b15d9c652985774869efd548b8e3e972e1e99475c673b25537ed7bcf394',  # v0.2.20.tar.gz (OpenBLAS)
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
-    # OpenBLAS-0.2.20_fix-Intel-L1-cache-size-detection.patch
-    '1d043e4838ec1f90b2b49318b780e3ab13b46133cb72a8d83eb0e3b1b056c4d6',
-    '1e6a046ab658c6e0b351de901d2812db28c2042f9f141416144c2faaf71fbb37',  # OpenBLAS-0.2.20_revert-honor-cpuset.patch
-]
-
 patches = [
     (large_src, '.'),
     (timing_src, '.'),
     'OpenBLAS-%(version)s_fix-Intel-L1-cache-size-detection.patch',
     'OpenBLAS-%(version)s_revert-honor-cpuset.patch',
+]
+checksums = [
+    '5ef38b15d9c652985774869efd548b8e3e972e1e99475c673b25537ed7bcf394',  # v0.2.20.tar.gz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    # OpenBLAS-0.2.20_fix-Intel-L1-cache-size-detection.patch
+    '1d043e4838ec1f90b2b49318b780e3ab13b46133cb72a8d83eb0e3b1b056c4d6',
+    '1e6a046ab658c6e0b351de901d2812db28c2042f9f141416144c2faaf71fbb37',  # OpenBLAS-0.2.20_revert-honor-cpuset.patch
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-6.4.0-2.28.eb
@@ -7,6 +7,9 @@ homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
 
 toolchain = {'name': 'GCC', 'version': '6.4.0-2.28'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-6.4.0-2.28.eb
@@ -11,9 +11,6 @@ toolchain = {'name': 'GCC', 'version': '6.4.0-2.28'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 source_urls = [
     # order matters, trying to download the large.tgz/timing.tgz LAPACK tarballs from GitHub causes trouble
     'http://www.netlib.org/lapack/timing/',
@@ -21,8 +18,8 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
     'OpenBLAS-%(version)s_fix-Intel-L1-cache-size-detection.patch',
     'OpenBLAS-%(version)s_revert-honor-cpuset.patch',
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-7.2.0-2.29.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-7.2.0-2.29.eb
@@ -20,20 +20,19 @@ source_urls = [
     'https://github.com/xianyi/OpenBLAS/archive/',
 ]
 sources = ['v%(version)s.tar.gz']
-checksums = [
-    '5ef38b15d9c652985774869efd548b8e3e972e1e99475c673b25537ed7bcf394',  # v0.2.20.tar.gz (OpenBLAS)
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
-    # OpenBLAS-0.2.20_fix-Intel-L1-cache-size-detection.patch
-    '1d043e4838ec1f90b2b49318b780e3ab13b46133cb72a8d83eb0e3b1b056c4d6',
-    '1e6a046ab658c6e0b351de901d2812db28c2042f9f141416144c2faaf71fbb37',  # OpenBLAS-0.2.20_revert-honor-cpuset.patch
-]
-
 patches = [
     (large_src, '.'),
     (timing_src, '.'),
     'OpenBLAS-%(version)s_fix-Intel-L1-cache-size-detection.patch',
     'OpenBLAS-%(version)s_revert-honor-cpuset.patch',
+]
+checksums = [
+    '5ef38b15d9c652985774869efd548b8e3e972e1e99475c673b25537ed7bcf394',  # v0.2.20.tar.gz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    # OpenBLAS-0.2.20_fix-Intel-L1-cache-size-detection.patch
+    '1d043e4838ec1f90b2b49318b780e3ab13b46133cb72a8d83eb0e3b1b056c4d6',
+    '1e6a046ab658c6e0b351de901d2812db28c2042f9f141416144c2faaf71fbb37',  # OpenBLAS-0.2.20_revert-honor-cpuset.patch
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-7.2.0-2.29.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-7.2.0-2.29.eb
@@ -11,9 +11,6 @@ toolchain = {'name': 'GCC', 'version': '7.2.0-2.29'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 source_urls = [
     # order matters, trying to download the large.tgz/timing.tgz LAPACK tarballs from GitHub causes trouble
     'http://www.netlib.org/lapack/timing/',
@@ -21,8 +18,8 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
     'OpenBLAS-%(version)s_fix-Intel-L1-cache-size-detection.patch',
     'OpenBLAS-%(version)s_revert-honor-cpuset.patch',
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-7.2.0-2.29.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-7.2.0-2.29.eb
@@ -7,6 +7,9 @@ homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
 
 toolchain = {'name': 'GCC', 'version': '7.2.0-2.29'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-gompi-1.4.10-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-gompi-1.4.10-LAPACK-3.4.2.eb
@@ -7,6 +7,9 @@ lapackver = '3.4.2'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'gompi', 'version': '1.4.10'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-gompi-1.4.10-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-gompi-1.4.10-LAPACK-3.4.2.eb
@@ -7,12 +7,12 @@ lapackver = '3.4.2'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'gompi', 'version': '1.4.10'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-gompi-1.4.10-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-gompi-1.4.10-LAPACK-3.4.2.eb
@@ -17,24 +17,33 @@ toolchainopts = {'vectorize': False}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
 patches = [
     'OpenBLAS-%(version)s_Makefile-LAPACK-sources.patch',
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '002f267b44a2cb2d94e89ac4a785923ef6597f0a17cc3ef4b5af9e4a431da716',  # v0.2.6.tar.gz
+    '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    '6b588ec03e76243b1fb7e1693e6f45d6dceef4e11761740b339ed4df31648e32',  # OpenBLAS-0.2.6_Makefile-LAPACK-sources.patch
+    '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-gompi-1.4.10-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-gompi-1.4.10-LAPACK-3.4.2.eb
@@ -14,32 +14,21 @@ toolchain = {'name': 'gompi', 'version': '1.4.10'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
+sources = ['v%(version)s.tar.gz']
 patches = [
     'OpenBLAS-%(version)s_Makefile-LAPACK-sources.patch',
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '002f267b44a2cb2d94e89ac4a785923ef6597f0a17cc3ef4b5af9e4a431da716',  # v0.2.6.tar.gz
-    '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     '6b588ec03e76243b1fb7e1693e6f45d6dceef4e11761740b339ed4df31648e32',  # OpenBLAS-0.2.6_Makefile-LAPACK-sources.patch
     '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-ictce-5.3.0-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-ictce-5.3.0-LAPACK-3.4.2.eb
@@ -7,6 +7,9 @@ lapackver = '3.4.2'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-ictce-5.3.0-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-ictce-5.3.0-LAPACK-3.4.2.eb
@@ -7,12 +7,12 @@ lapackver = '3.4.2'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-ictce-5.3.0-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-ictce-5.3.0-LAPACK-3.4.2.eb
@@ -14,32 +14,21 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
+sources = ['v%(version)s.tar.gz']
 patches = [
     'OpenBLAS-%(version)s_Makefile-LAPACK-sources.patch',
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '002f267b44a2cb2d94e89ac4a785923ef6597f0a17cc3ef4b5af9e4a431da716',  # v0.2.6.tar.gz
-    '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     '6b588ec03e76243b1fb7e1693e6f45d6dceef4e11761740b339ed4df31648e32',  # OpenBLAS-0.2.6_Makefile-LAPACK-sources.patch
     '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-ictce-5.3.0-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.6-ictce-5.3.0-LAPACK-3.4.2.eb
@@ -17,24 +17,33 @@ toolchainopts = {'vectorize': False}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
 patches = [
     'OpenBLAS-%(version)s_Makefile-LAPACK-sources.patch',
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '002f267b44a2cb2d94e89ac4a785923ef6597f0a17cc3ef4b5af9e4a431da716',  # v0.2.6.tar.gz
+    '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    '6b588ec03e76243b1fb7e1693e6f45d6dceef4e11761740b339ed4df31648e32',  # OpenBLAS-0.2.6_Makefile-LAPACK-sources.patch
+    '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.5.14-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.5.14-LAPACK-3.5.0.eb
@@ -17,23 +17,31 @@ toolchainopts = {'vectorize': False}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
 patches = [
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '359f5cd2604ed76d97b0669b9b846a59a1d0283065d23f8847956629871fedd8',  # v0.2.8.tar.gz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.5.14-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.5.14-LAPACK-3.5.0.eb
@@ -7,12 +7,12 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'gompi', 'version': '1.5.14'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.5.14-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.5.14-LAPACK-3.5.0.eb
@@ -7,6 +7,9 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'gompi', 'version': '1.5.14'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.5.14-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.5.14-LAPACK-3.5.0.eb
@@ -14,31 +14,20 @@ toolchain = {'name': 'gompi', 'version': '1.5.14'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
+sources = ['v%(version)s.tar.gz']
 patches = [
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '359f5cd2604ed76d97b0669b9b846a59a1d0283065d23f8847956629871fedd8',  # v0.2.8.tar.gz
-    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.6.10-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.6.10-LAPACK-3.4.2.eb
@@ -14,31 +14,20 @@ toolchain = {'name': 'gompi', 'version': '1.6.10'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
+sources = ['v%(version)s.tar.gz']
 patches = [
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '359f5cd2604ed76d97b0669b9b846a59a1d0283065d23f8847956629871fedd8',  # v0.2.8.tar.gz
-    '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.6.10-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.6.10-LAPACK-3.4.2.eb
@@ -17,23 +17,31 @@ toolchainopts = {'vectorize': False}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
 patches = [
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '359f5cd2604ed76d97b0669b9b846a59a1d0283065d23f8847956629871fedd8',  # v0.2.8.tar.gz
+    '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.6.10-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.6.10-LAPACK-3.4.2.eb
@@ -7,6 +7,9 @@ lapackver = '3.4.2'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'gompi', 'version': '1.6.10'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.6.10-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.6.10-LAPACK-3.4.2.eb
@@ -7,12 +7,12 @@ lapackver = '3.4.2'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'gompi', 'version': '1.6.10'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-ictce-5.3.0-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-ictce-5.3.0-LAPACK-3.4.2.eb
@@ -7,6 +7,9 @@ lapackver = '3.4.2'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-ictce-5.3.0-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-ictce-5.3.0-LAPACK-3.4.2.eb
@@ -17,23 +17,31 @@ toolchainopts = {'vectorize': False}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
 patches = [
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    '359f5cd2604ed76d97b0669b9b846a59a1d0283065d23f8847956629871fedd8',  # v0.2.8.tar.gz
+    '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-ictce-5.3.0-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-ictce-5.3.0-LAPACK-3.4.2.eb
@@ -7,12 +7,12 @@ lapackver = '3.4.2'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-ictce-5.3.0-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-ictce-5.3.0-LAPACK-3.4.2.eb
@@ -14,31 +14,20 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
+sources = ['v%(version)s.tar.gz']
 patches = [
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '359f5cd2604ed76d97b0669b9b846a59a1d0283065d23f8847956629871fedd8',  # v0.2.8.tar.gz
-    '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     '60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0',  # lapack-3.4.2.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.9-GCC-4.8.3-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.9-GCC-4.8.3-LAPACK-3.5.0.eb
@@ -17,23 +17,31 @@ toolchainopts = {'vectorize': False}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
 patches = [
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+]
+checksums = [
+    'a9ce75fe29f8527467b159490facca0bfc62e8a40a165b51822caa46368b0dc0',  # v0.2.9.tar.gz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
+    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
+    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
 ]
 
 skipsteps = ['configure']

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.9-GCC-4.8.3-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.9-GCC-4.8.3-LAPACK-3.5.0.eb
@@ -7,6 +7,9 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.3'}

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.9-GCC-4.8.3-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.9-GCC-4.8.3-LAPACK-3.5.0.eb
@@ -7,12 +7,12 @@ lapackver = '3.5.0'
 versionsuffix = '-LAPACK-%s' % lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
-# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
-# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
-toolchainopts = {'vectorize': False}
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.3'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.9-GCC-4.8.3-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.9-GCC-4.8.3-LAPACK-3.5.0.eb
@@ -14,31 +14,20 @@ toolchain = {'name': 'GCC', 'version': '4.8.3'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
     "http://www.netlib.org/lapack/",
     "http://www.netlib.org/lapack/timing/",
     "https://github.com/xianyi/OpenBLAS/archive/",
 ]
-sources = [
-    'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
-]
+sources = ['v%(version)s.tar.gz']
 patches = [
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     'a9ce75fe29f8527467b159490facca0bfc62e8a40a165b51822caa46368b0dc0',  # v0.2.9.tar.gz
-    '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
     '9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352',  # lapack-3.5.0.tgz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.0-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.0-GCC-6.4.0-2.28.eb
@@ -7,6 +7,9 @@ homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
 
 toolchain = {'name': 'GCC', 'version': '6.4.0-2.28'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.0-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.0-GCC-6.4.0-2.28.eb
@@ -11,9 +11,6 @@ toolchain = {'name': 'GCC', 'version': '6.4.0-2.28'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 source_urls = [
     # order matters, trying to download the large.tgz/timing.tgz LAPACK tarballs from GitHub causes trouble
     'http://www.netlib.org/lapack/timing/',
@@ -21,8 +18,8 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     'cf51543709abe364d8ecfb5c09a2b533d2b725ea1a66f203509b21a8e9d8f1a1',  # v0.3.0.tar.gz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.0-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.0-GCC-7.3.0-2.30.eb
@@ -11,9 +11,6 @@ toolchain = {'name': 'GCC', 'version': '7.3.0-2.30'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 source_urls = [
     # order matters, trying to download the large.tgz/timing.tgz LAPACK tarballs from GitHub causes trouble
     'http://www.netlib.org/lapack/timing/',
@@ -21,8 +18,8 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     'cf51543709abe364d8ecfb5c09a2b533d2b725ea1a66f203509b21a8e9d8f1a1',  # v0.3.0.tar.gz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.0-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.0-GCC-7.3.0-2.30.eb
@@ -7,6 +7,9 @@ homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
 
 toolchain = {'name': 'GCC', 'version': '7.3.0-2.30'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.1-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.1-GCC-7.3.0-2.30.eb
@@ -11,9 +11,6 @@ toolchain = {'name': 'GCC', 'version': '7.3.0-2.30'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 source_urls = [
     # order matters, trying to download the large.tgz/timing.tgz LAPACK tarballs from GitHub causes trouble
     'http://www.netlib.org/lapack/timing/',
@@ -21,8 +18,8 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '1f5e956f35f3acdd3c74516e955d797a320c2e0135e31d838cbdb3ea94d0eb33',  # v0.3.1.tar.gz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.1-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.1-GCC-7.3.0-2.30.eb
@@ -7,6 +7,9 @@ homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
 
 toolchain = {'name': 'GCC', 'version': '7.3.0-2.30'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.3-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.3-GCC-8.2.0-2.31.1.eb
@@ -7,6 +7,9 @@ homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
 
 toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.3-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.3-GCC-8.2.0-2.31.1.eb
@@ -11,9 +11,6 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 source_urls = [
     # order matters, trying to download the large.tgz/timing.tgz LAPACK tarballs from GitHub causes trouble
     'http://www.netlib.org/lapack/timing/',
@@ -21,8 +18,8 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '49d88f4494ae780e3d7fa51769c00d982d7cdb73e696054ac3baa81d42f13bab',  # v0.3.3.tar.gz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.4-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.4-GCC-8.2.0-2.31.1.eb
@@ -7,6 +7,9 @@ homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
 
 toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.4-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.4-GCC-8.2.0-2.31.1.eb
@@ -11,9 +11,6 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 source_urls = [
     # order matters, trying to download the large.tgz/timing.tgz LAPACK tarballs from GitHub causes trouble
     'http://www.netlib.org/lapack/timing/',
@@ -21,8 +18,8 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '4b4b4453251e9edb5f57465bf2b3cf67b19d811d50c8588cdf2ea1f201bb834f',  # v0.3.4.tar.gz

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.5-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.5-GCC-8.2.0-2.31.1.eb
@@ -7,6 +7,9 @@ homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
 
 toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
+# need to build with -fno-tree-vectorize due to asm constraint bugs in OpenBLAS<0.3.6
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
+toolchainopts = {'vectorize': False}
 
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.5-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.5-GCC-8.2.0-2.31.1.eb
@@ -11,9 +11,6 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
-
 source_urls = [
     # order matters, trying to download the large.tgz/timing.tgz LAPACK tarballs from GitHub causes trouble
     'http://www.netlib.org/lapack/timing/',
@@ -21,8 +18,8 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    (large_src, '.'),
-    (timing_src, '.'),
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
 ]
 checksums = [
     '0950c14bd77c90a6427e26210d6dab422271bc86f9fc69126725833ecdaa0e85',  # v0.3.5.tar.gz


### PR DESCRIPTION
wrapper PR for #7790 by @bartoldeman, which deals with relative order of `toolchainopts` + adds missing checksums