### PR TITLE
trim down test configuration: only test with Lmod 6.x with Tcl/Lua on Python 2.6/2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,7 @@ language: python
 python: 2.6
 env:
   matrix:
-    - ENV_MOD_VERSION=3.2.10 EASYBUILD_MODULES_TOOL=EnvironmentModulesC EASYBUILD_MODULE_SYNTAX=Tcl
-    - LMOD_VERSION=6.6.3
     - LMOD_VERSION=6.6.3 EASYBUILD_MODULE_SYNTAX=Tcl
-    - LMOD_VERSION=7.7.16
-    - LMOD_VERSION=7.7.16 EASYBUILD_MODULE_SYNTAX=Tcl
-    - ENV_MOD_VERSION=4.0.0 EASYBUILD_MODULES_TOOL=EnvironmentModules EASYBUILD_MODULE_SYNTAX=Tcl
 matrix:
   # mark build as finished as soon as job has failed
   fast_finish: true


### PR DESCRIPTION
We're frequently building up a backlog on Travis w.r.t. easyconfig tests, and it's becoming quite annoying...

I can't recall seeing just one of the tests fail, so I think it's safe to trim down the test configuration to just the following two (rather than the 7 current configurations we have)

* Python 2.6 w/ Lmod 6.6.3 & Tcl syntax
* Python 2.7 w/ Lmod 6.6.3 & Lua syntax

I don't see the value of testing with other module tools, since none of the tests we use actually involve the modules tool at all...
Besides, we already extensively test the different flavors of modules tool we support in the framework tests.

The easyconfigs tests are mostly about parsing the easyconfigs, and checking for patches, checksums, missing dependencies, conflicts, dependency variants, etc.

Since this is potentially controversial, I'd like to have 3 maintainers approve this PR before getting it merged...