### PR TITLE
use %(pyshortver)s template in (old) SIP easyconfigs

### DIFF
--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.4-goolf-1.5.14-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.4-goolf-1.5.14-Python-2.7.9.eb
@@ -5,6 +5,7 @@ easyblock = 'ConfigureMakePythonPackage'
 
 name = 'SIP'
 version = '4.16.4'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://www.riverbankcomputing.com/software/sip/'
 description = """SIP is a tool that makes it very easy to create Python bindings for C and C++ libraries."""
@@ -14,19 +15,14 @@ toolchain = {'name': 'goolf', 'version': '1.5.14'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://sourceforge.net/projects/pyqt/files/sip/sip-%(version)s']
 
-python = 'Python'
-pyver = '2.7.9'
-versionsuffix = '-%s-%s' % (python, pyver)
+dependencies = [('Python', '2.7.9')]
 
-dependencies = [(python, pyver)]
-
-pyshortver = '.'.join(pyver.split('.')[:2])
 configopts = "configure.py --bindir %(installdir)s/bin --incdir %(installdir)s/include "
-configopts += "--destdir %%(installdir)s/lib/python%s/site-packages" % pyshortver
+configopts += "--destdir %(installdir)s/lib/python%(pyshortver)s/site-packages"
 
 sanity_check_paths = {
     'files': ['bin/sip', 'include/sip.h'] +
-             ['lib/python%s/site-packages/%s' % (pyshortver, x)
+             ['lib/python%%(pyshortver)s/site-packages/%s' % x
               for x in ['sip.%s' % SHLIB_EXT, 'sipconfig.py', 'sipdistutils.py']],
     'dirs': [],
 }

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.4-goolf-1.5.14-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.4-goolf-1.5.14-Python-2.7.9.eb
@@ -12,8 +12,9 @@ description = """SIP is a tool that makes it very easy to create Python bindings
 
 toolchain = {'name': 'goolf', 'version': '1.5.14'}
 
-sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://sourceforge.net/projects/pyqt/files/sip/sip-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['ceda443fc5e129e67a067e2cd7b73ff037f8b10b50e407baa2b1d9f2199d57f5']
 
 dependencies = [('Python', '2.7.9')]
 

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.4-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.4-intel-2015a-Python-2.7.9.eb
@@ -12,8 +12,9 @@ description = """SIP is a tool that makes it very easy to create Python bindings
 
 toolchain = {'name': 'intel', 'version': '2015a'}
 
-sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://sourceforge.net/projects/pyqt/files/sip/sip-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['ceda443fc5e129e67a067e2cd7b73ff037f8b10b50e407baa2b1d9f2199d57f5']
 
 dependencies = [('Python', '2.7.9')]
 

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.4-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.4-intel-2015a-Python-2.7.9.eb
@@ -5,6 +5,7 @@ easyblock = 'ConfigureMakePythonPackage'
 
 name = 'SIP'
 version = '4.16.4'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://www.riverbankcomputing.com/software/sip/'
 description = """SIP is a tool that makes it very easy to create Python bindings for C and C++ libraries."""
@@ -14,19 +15,14 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://sourceforge.net/projects/pyqt/files/sip/sip-%(version)s']
 
-python = 'Python'
-pyver = '2.7.9'
-versionsuffix = '-%s-%s' % (python, pyver)
+dependencies = [('Python', '2.7.9')]
 
-dependencies = [(python, pyver)]
-
-pyshortver = '.'.join(pyver.split('.')[:2])
 configopts = "configure.py --bindir %(installdir)s/bin --incdir %(installdir)s/include "
-configopts += "--destdir %%(installdir)s/lib/python%s/site-packages" % pyshortver
+configopts += "--destdir %(installdir)s/lib/python%(pyshortver)s/site-packages"
 
 sanity_check_paths = {
     'files': ['bin/sip', 'include/sip.h'] +
-             ['lib/python%s/site-packages/%s' % (pyshortver, x)
+             ['lib/python%%(pyshortver)s/site-packages/%s' % x
               for x in ['sip.%s' % SHLIB_EXT, 'sipconfig.py', 'sipdistutils.py']],
     'dirs': [],
 }

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.8-foss-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.8-foss-2015a-Python-2.7.9.eb
@@ -5,6 +5,7 @@ easyblock = 'ConfigureMakePythonPackage'
 
 name = 'SIP'
 version = '4.16.8'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://www.riverbankcomputing.com/software/sip/'
 description = """SIP is a tool that makes it very easy to create Python bindings for C and C++ libraries."""
@@ -14,19 +15,14 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://sourceforge.net/projects/pyqt/files/sip/sip-%(version)s']
 
-python = 'Python'
-pyver = '2.7.9'
-versionsuffix = '-%s-%s' % (python, pyver)
+dependencies = [('Python', '2.7.9')]
 
-dependencies = [(python, pyver)]
-
-pyshortver = '.'.join(pyver.split('.')[:2])
 configopts = "configure.py --bindir %(installdir)s/bin --incdir %(installdir)s/include "
-configopts += "--destdir %%(installdir)s/lib/python%s/site-packages" % pyshortver
+configopts += "--destdir %(installdir)s/lib/python%(pyshortver)s/site-packages"
 
 sanity_check_paths = {
     'files': ['bin/sip', 'include/sip.h'] +
-             ['lib/python%s/site-packages/%s' % (pyshortver, x)
+             ['lib/python%%(pyshortver)s/site-packages/%s' % x
               for x in ['sip.%s' % SHLIB_EXT, 'sipconfig.py', 'sipdistutils.py']],
     'dirs': [],
 }

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.8-foss-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.8-foss-2015a-Python-2.7.9.eb
@@ -12,8 +12,9 @@ description = """SIP is a tool that makes it very easy to create Python bindings
 
 toolchain = {'name': 'foss', 'version': '2015a'}
 
-sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://sourceforge.net/projects/pyqt/files/sip/sip-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['d3141b65e48a30c9ce36612f8bcd1730ebf02d044757e4d6c5234927e2063e18']
 
 dependencies = [('Python', '2.7.9')]
 

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.8-intel-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.8-intel-2014b-Python-2.7.8.eb
@@ -12,8 +12,9 @@ description = """SIP is a tool that makes it very easy to create Python bindings
 
 toolchain = {'name': 'intel', 'version': '2014b'}
 
-sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://sourceforge.net/projects/pyqt/files/sip/sip-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['d3141b65e48a30c9ce36612f8bcd1730ebf02d044757e4d6c5234927e2063e18']
 
 dependencies = [('Python', '2.7.8')]
 

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.8-intel-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.8-intel-2014b-Python-2.7.8.eb
@@ -5,6 +5,7 @@ easyblock = 'ConfigureMakePythonPackage'
 
 name = 'SIP'
 version = '4.16.8'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://www.riverbankcomputing.com/software/sip/'
 description = """SIP is a tool that makes it very easy to create Python bindings for C and C++ libraries."""
@@ -14,19 +15,14 @@ toolchain = {'name': 'intel', 'version': '2014b'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://sourceforge.net/projects/pyqt/files/sip/sip-%(version)s']
 
-python = 'Python'
-pyver = '2.7.8'
-versionsuffix = '-%s-%s' % (python, pyver)
+dependencies = [('Python', '2.7.8')]
 
-dependencies = [(python, pyver)]
-
-pyshortver = '.'.join(pyver.split('.')[:2])
 configopts = "configure.py --bindir %(installdir)s/bin --incdir %(installdir)s/include "
-configopts += "--destdir %%(installdir)s/lib/python%s/site-packages" % pyshortver
+configopts += "--destdir %(installdir)s/lib/python%(pyshortver)s/site-packages"
 
 sanity_check_paths = {
     'files': ['bin/sip', 'include/sip.h'] +
-             ['lib/python%s/site-packages/%s' % (pyshortver, x)
+             ['lib/python%%(pyshortver)s/site-packages/%s' % x
               for x in ['sip.%s' % SHLIB_EXT, 'sipconfig.py', 'sipdistutils.py']],
     'dirs': [],
 }

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.8-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.8-intel-2015a-Python-2.7.9.eb
@@ -12,8 +12,9 @@ description = """SIP is a tool that makes it very easy to create Python bindings
 
 toolchain = {'name': 'intel', 'version': '2015a'}
 
-sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://sourceforge.net/projects/pyqt/files/sip/sip-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['d3141b65e48a30c9ce36612f8bcd1730ebf02d044757e4d6c5234927e2063e18']
 
 dependencies = [('Python', '2.7.9')]
 

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.8-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.8-intel-2015a-Python-2.7.9.eb
@@ -5,6 +5,7 @@ easyblock = 'ConfigureMakePythonPackage'
 
 name = 'SIP'
 version = '4.16.8'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://www.riverbankcomputing.com/software/sip/'
 description = """SIP is a tool that makes it very easy to create Python bindings for C and C++ libraries."""
@@ -14,19 +15,14 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://sourceforge.net/projects/pyqt/files/sip/sip-%(version)s']
 
-python = 'Python'
-pyver = '2.7.9'
-versionsuffix = '-%s-%s' % (python, pyver)
+dependencies = [('Python', '2.7.9')]
 
-dependencies = [(python, pyver)]
-
-pyshortver = '.'.join(pyver.split('.')[:2])
 configopts = "configure.py --bindir %(installdir)s/bin --incdir %(installdir)s/include "
-configopts += "--destdir %%(installdir)s/lib/python%s/site-packages" % pyshortver
+configopts += "--destdir %(installdir)s/lib/python%(pyshortver)s/site-packages"
 
 sanity_check_paths = {
     'files': ['bin/sip', 'include/sip.h'] +
-             ['lib/python%s/site-packages/%s' % (pyshortver, x)
+             ['lib/python%%(pyshortver)s/site-packages/%s' % x
               for x in ['sip.%s' % SHLIB_EXT, 'sipconfig.py', 'sipdistutils.py']],
     'dirs': [],
 }


### PR DESCRIPTION
For some reason unclear to me, parsing of these old `SIP` easyconfigs fails when using `eb` on top of Python 3.6, with:

```
easybuild.tools.build_log.EasyBuildError: "Failed to process easyconfig /home/travis/build/easybuilders/easybuild-easyconfigs/easybuild/easyconfigs/s/SIP/SIP-4.16.4-goolf-1.5.14-Python-2.7.9.eb: Parsing easyconfig file failed: name 'pyshortver' is not defined (line 27)"
```

I'm not sure why this happens, it seems to be some kind of scoping problem?

In any case, switching to using the `%(pyshortver)s template rather than relying on a self-constructed `pyshortver` local variable should fix the problem...