### PR TITLE
fix Travis config to test with both Python 2.6 & 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: python
-python: 2.6
-env:
-  matrix:
-    - LMOD_VERSION=6.6.3 EASYBUILD_MODULE_SYNTAX=Tcl
 matrix:
   # mark build as finished as soon as job has failed
   fast_finish: true
   include:
+    - python: 2.6
+      env: LMOD_VERSION=6.6.3 EASYBUILD_MODULE_SYNTAX=Tcl
     # also test default configuration with Python 2.7
     - python: 2.7
       env: LMOD_VERSION=6.6.3


### PR DESCRIPTION
Turns out only *one* configuration is being tested after #7795 got merged, which was certainly not the intention...