### PR TITLE
extra patch for TensorFlow 1.12.0 to remove -B/usr/bin from linker_bin_path_flag in cuda_configure.bzl

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.12.0-fosscuda-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.12.0-fosscuda-2018b-Python-2.7.15.eb
@@ -91,7 +91,8 @@ exts_list = [
             'TensorFlow-1.11.0_swig-env.patch',
             'TensorFlow-1.11.0_remove-msse-hardcoding.patch',
             'TensorFlow-1.12.0_lrt-flag.patch',
-            'TensorFlow-1.12.0_dont_expand_cuda_cudnn_path.patch'
+            'TensorFlow-1.12.0_dont_expand_cuda_cudnn_path.patch',
+            'TensorFlow-1.12.0_remove_usrbin_from_linker_bin_path_flag.patch'
         ],
         'checksums': [
             '3c87b81e37d4ed7f3da6200474fa5e656ffd20d8811068572f43610cae97ca92',  # v1.12.0.tar.gz
@@ -101,6 +102,8 @@ exts_list = [
             '164d048c69671f870e306760ee7609564fe02bb6378a06414752f3d6da80a631',  # TensorFlow-1.12.0_lrt-flag.patch
             # TensorFlow-1.12.0_dont_expand_cuda_cudnn_path.patch
             '843acddc197639273cb26e676685a12a1107a3bccca516be1af873df6352bb00',
+            # TensorFlow-1.12.0_remove_usrbin_from_linker_bin_path_flag.patch
+            '082ef23b49ce50d2bd225bd462ebfed536bcc50eaa7264fca60521f5432d4b94'
         ],
     }),
 ]

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.12.0-fosscuda-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.12.0-fosscuda-2018b-Python-3.6.6.eb
@@ -90,7 +90,8 @@ exts_list = [
             'TensorFlow-1.11.0_swig-env.patch',
             'TensorFlow-1.11.0_remove-msse-hardcoding.patch',
             'TensorFlow-1.12.0_lrt-flag.patch',
-            'TensorFlow-1.12.0_dont_expand_cuda_cudnn_path.patch'
+            'TensorFlow-1.12.0_dont_expand_cuda_cudnn_path.patch',
+            'TensorFlow-1.12.0_remove_usrbin_from_linker_bin_path_flag.patch'
         ],
         'checksums': [
             '3c87b81e37d4ed7f3da6200474fa5e656ffd20d8811068572f43610cae97ca92',  # v1.12.0.tar.gz
@@ -100,6 +101,8 @@ exts_list = [
             '164d048c69671f870e306760ee7609564fe02bb6378a06414752f3d6da80a631',  # TensorFlow-1.12.0_lrt-flag.patch
             # TensorFlow-1.12.0_dont_expand_cuda_cudnn_path.patch
             '843acddc197639273cb26e676685a12a1107a3bccca516be1af873df6352bb00',
+            # TensorFlow-1.12.0_remove_usrbin_from_linker_bin_path_flag.patch
+            'd57a2b90cd36ab9a013c946eb2a1d3aaef904cb657ca85e0f8c91c326e659bd6'
         ],
     }),
 ]

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.12.0-fosscuda-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.12.0-fosscuda-2018b-Python-3.6.6.eb
@@ -102,7 +102,7 @@ exts_list = [
             # TensorFlow-1.12.0_dont_expand_cuda_cudnn_path.patch
             '843acddc197639273cb26e676685a12a1107a3bccca516be1af873df6352bb00',
             # TensorFlow-1.12.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'd57a2b90cd36ab9a013c946eb2a1d3aaef904cb657ca85e0f8c91c326e659bd6'
+            '082ef23b49ce50d2bd225bd462ebfed536bcc50eaa7264fca60521f5432d4b94'
         ],
     }),
 ]

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.12.0_remove_usrbin_from_linker_bin_path_flag.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.12.0_remove_usrbin_from_linker_bin_path_flag.patch
@@ -1,0 +1,16 @@
+# Remove -B/usr/bin from linker_bin_path_flag, as it causes a possibly
+# incompatible linker from the system to be used.
+#
+# Fokke Dijkstra, 20190228
+diff -ru tensorflow-1.12.0.orig/third_party/gpus/cuda_configure.bzl tensorflow-1.12.0/third_party/gpus/cuda_configure.bzl
+--- tensorflow-1.12.0.orig/third_party/gpus/cuda_configure.bzl	2018-11-02 02:35:10.000000000 +0100
++++ tensorflow-1.12.0/third_party/gpus/cuda_configure.bzl	2019-02-28 14:25:50.227358135 +0100
+@@ -1316,7 +1316,7 @@
+     if should_download_clang:
+       cuda_defines["%{linker_bin_path_flag}"] = ""
+     else:
+-      cuda_defines["%{linker_bin_path_flag}"] = 'flag: "-B/usr/bin"'
++      cuda_defines["%{linker_bin_path_flag}"] = ""
+ 
+     if is_cuda_clang:
+         cuda_defines["%{host_compiler_path}"] = str(cc)


### PR DESCRIPTION
Added extra patch to remove -B/usr/bin from linker_bin_path_flag in 
tensorflow-1.12.0/third_party/gpus/cuda_configure.bzl
This prevents the wrong linker from being used.