### PR TITLE
add mlegp extension + fix checksum for boot extension in R 3.5.1 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b-Python-2.7.15.eb
@@ -559,7 +559,7 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': ['f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06'],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],
@@ -2077,6 +2077,9 @@ exts_list = [
     }),
     ('h2o', '3.22.1.1', {
         'checksums': ['e4c9d50d2a6a42ffecb15aa1561495599b206a7edd77db95501c7d09253fc412'],
+    }),
+    ('mlegp', '3.1.7', {
+        'checksums': ['d4845eaf9260f8b8112726dd7ceb5c2f5ce75125fa313191db9de121f2ee15e0'],
     }),
 ]
 

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
@@ -557,7 +557,7 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': ['f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06'],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],
@@ -2075,6 +2075,9 @@ exts_list = [
     }),
     ('h2o', '3.22.1.1', {
         'checksums': ['e4c9d50d2a6a42ffecb15aa1561495599b206a7edd77db95501c7d09253fc412'],
+    }),
+    ('mlegp', '3.1.7', {
+        'checksums': ['d4845eaf9260f8b8112726dd7ceb5c2f5ce75125fa313191db9de121f2ee15e0'],
     }),
 ]
 


### PR DESCRIPTION
Apparently the source tarball for `boot` 1.3-20 was updated in-place recently... 😡 