### PR TITLE
replace ncurses-devel OS dependency in CMake easyconfigs using dummy toolchain with proper ncurses dependency

### DIFF
--- a/easybuild/easyconfigs/c/CMake/CMake-3.12.1.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.12.1.eb
@@ -25,7 +25,7 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 configopts = "-- -DCMAKE_USE_OPENSSL=1 "
 configopts += "-DCURSES_CURSES_LIBRARY=$EBROOTNCURSES/lib/libcurses.a "
 configopts += "-DCURSES_FORM_LIBRARY=$EBROOTNCURSES/lib/libform.a "
-configopts += "-DCURSES_NCURSES_LIBRARY=$EBROOTNCURSES/lib/libncurses.a -DCURSES_INCLUDE_PATH=$EBROOTNCURSES/include"
+configopts += "-DCURSES_NCURSES_LIBRARY=$EBROOTNCURSES/lib/libncurses.a -DCURSES_INCLUDE_PATH=$EBROOTNCURSES/include "
 
 sanity_check_paths = {
     'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],

--- a/easybuild/easyconfigs/c/CMake/CMake-3.12.1.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.12.1.eb
@@ -11,20 +11,21 @@ description = """
 """
 
 # note: requires C++ compiler that supports C++11, which is not the case in older OSs like CentOS 6...
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['c53d5c2ce81d7a957ee83e3e635c8cda5dfe20c9d501a4828ee28e1615e57ab2']
 
-# Use OS dependencies in order to ensure that CMake can build software that
-# depends on them
-osdependencies = [
-    ('openssl-devel', 'libssl-dev', 'libopenssl-devel'),
-    ('ncurses-devel', 'libncurses5-dev'),
-]
+builddependencies = [('ncurses', '6.1')]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+# Use OS dependencies in order to ensure that CMake can build software that depends on them
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "-- -DCMAKE_USE_OPENSSL=1 "
+configopts += "-DCURSES_CURSES_LIBRARY=$EBROOTNCURSES/lib/libcurses.a "
+configopts += "-DCURSES_FORM_LIBRARY=$EBROOTNCURSES/lib/libform.a "
+configopts += "-DCURSES_NCURSES_LIBRARY=$EBROOTNCURSES/lib/libncurses.a -DCURSES_INCLUDE_PATH=$EBROOTNCURSES/include"
 
 sanity_check_paths = {
     'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],

--- a/easybuild/easyconfigs/c/CMake/CMake-3.6.1.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.6.1.eb
@@ -22,7 +22,7 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 configopts = "-- -DCMAKE_USE_OPENSSL=1 "
 configopts += "-DCURSES_CURSES_LIBRARY=$EBROOTNCURSES/lib/libcurses.a "
 configopts += "-DCURSES_FORM_LIBRARY=$EBROOTNCURSES/lib/libform.a "
-configopts += "-DCURSES_NCURSES_LIBRARY=$EBROOTNCURSES/lib/libncurses.a -DCURSES_INCLUDE_PATH=$EBROOTNCURSES/include"
+configopts += "-DCURSES_NCURSES_LIBRARY=$EBROOTNCURSES/lib/libncurses.a -DCURSES_INCLUDE_PATH=$EBROOTNCURSES/include "
 
 sanity_check_paths = {
     'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],

--- a/easybuild/easyconfigs/c/CMake/CMake-3.6.1.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.6.1.eb
@@ -7,17 +7,22 @@ homepage = 'http://www.cmake.org'
 description = """CMake, the cross-platform, open-source build system.
  CMake is a family of tools designed to build, test and package software."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['28ee98ec40427d41a45673847db7a905b59ce9243bb866eaf59dce0f58aaef11']
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+builddependencies = [('ncurses', '5.9')]
 
 # Use OS dependencies in order to ensure that CMake can build software that
 # depends on them
-osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel'), ('ncurses-devel', 'libncurses5-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "-- -DCMAKE_USE_OPENSSL=1 "
+configopts += "-DCURSES_CURSES_LIBRARY=$EBROOTNCURSES/lib/libcurses.a "
+configopts += "-DCURSES_FORM_LIBRARY=$EBROOTNCURSES/lib/libform.a "
+configopts += "-DCURSES_NCURSES_LIBRARY=$EBROOTNCURSES/lib/libncurses.a -DCURSES_INCLUDE_PATH=$EBROOTNCURSES/include"
 
 sanity_check_paths = {
     'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],

--- a/easybuild/easyconfigs/c/CMake/CMake-3.9.1.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.9.1.eb
@@ -22,7 +22,7 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 configopts = "-- -DCMAKE_USE_OPENSSL=1 "
 configopts += "-DCURSES_CURSES_LIBRARY=$EBROOTNCURSES/lib/libcurses.a "
 configopts += "-DCURSES_FORM_LIBRARY=$EBROOTNCURSES/lib/libform.a "
-configopts += "-DCURSES_NCURSES_LIBRARY=$EBROOTNCURSES/lib/libncurses.a -DCURSES_INCLUDE_PATH=$EBROOTNCURSES/include"
+configopts += "-DCURSES_NCURSES_LIBRARY=$EBROOTNCURSES/lib/libncurses.a -DCURSES_INCLUDE_PATH=$EBROOTNCURSES/include "
 
 sanity_check_paths = {
     'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],

--- a/easybuild/easyconfigs/c/CMake/CMake-3.9.1.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.9.1.eb
@@ -7,17 +7,22 @@ homepage = 'http://www.cmake.org'
 description = """CMake, the cross-platform, open-source build system.
  CMake is a family of tools designed to build, test and package software."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['d768ee83d217f91bb597b3ca2ac663da7a8603c97e1f1a5184bc01e0ad2b12bb']
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+builddependencies = [('ncurses', '5.9')]
 
 # Use OS dependencies in order to ensure that CMake can build software that
 # depends on them
-osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel'), ('ncurses-devel', 'libncurses5-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "-- -DCMAKE_USE_OPENSSL=1 "
+configopts += "-DCURSES_CURSES_LIBRARY=$EBROOTNCURSES/lib/libcurses.a "
+configopts += "-DCURSES_FORM_LIBRARY=$EBROOTNCURSES/lib/libform.a "
+configopts += "-DCURSES_NCURSES_LIBRARY=$EBROOTNCURSES/lib/libncurses.a -DCURSES_INCLUDE_PATH=$EBROOTNCURSES/include"
 
 sanity_check_paths = {
     'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],

--- a/easybuild/easyconfigs/c/CMake/CMake-3.9.6.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.9.6.eb
@@ -21,7 +21,7 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 configopts = "-- -DCMAKE_USE_OPENSSL=1 "
 configopts += "-DCURSES_CURSES_LIBRARY=$EBROOTNCURSES/lib/libcurses.a "
 configopts += "-DCURSES_FORM_LIBRARY=$EBROOTNCURSES/lib/libform.a "
-configopts += "-DCURSES_NCURSES_LIBRARY=$EBROOTNCURSES/lib/libncurses.a -DCURSES_INCLUDE_PATH=$EBROOTNCURSES/include"
+configopts += "-DCURSES_NCURSES_LIBRARY=$EBROOTNCURSES/lib/libncurses.a -DCURSES_INCLUDE_PATH=$EBROOTNCURSES/include "
 
 sanity_check_paths = {
     'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],

--- a/easybuild/easyconfigs/c/CMake/CMake-3.9.6.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.9.6.eb
@@ -7,17 +7,21 @@ homepage = 'http://www.cmake.org'
 description = """CMake, the cross-platform, open-source build system.
  CMake is a family of tools designed to build, test and package software."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['7410851a783a41b521214ad987bb534a7e4a65e059651a2514e6ebfc8f46b218']
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+builddependencies = [('ncurses', '5.9')]
 
-# Use OS dependencies in order to ensure that CMake can build software that
-# depends on them
-osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel'), ('ncurses-devel', 'libncurses5-dev')]
+# Use OS dependencies in order to ensure that CMake can build software that depends on them
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "-- -DCMAKE_USE_OPENSSL=1 "
+configopts += "-DCURSES_CURSES_LIBRARY=$EBROOTNCURSES/lib/libcurses.a "
+configopts += "-DCURSES_FORM_LIBRARY=$EBROOTNCURSES/lib/libform.a "
+configopts += "-DCURSES_NCURSES_LIBRARY=$EBROOTNCURSES/lib/libncurses.a -DCURSES_INCLUDE_PATH=$EBROOTNCURSES/include"
 
 sanity_check_paths = {
     'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9.eb
@@ -13,8 +13,11 @@ toolchainopts = {'optarch': True, 'pic': True}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
-
 patches = ['ncurses-%(version)s_configure_darwin.patch']
+checksums = [
+    '9046298fb440324c9d4135ecea7879ffed8546dd1b58e59430ea07a4633f563b',  # ncurses-5.9.tar.gz
+    '8c471fc2b1961a6e6e5981b7f7b3512e7fe58fcb04461aa4520157d4c1159998',  # ncurses-5.9_configure_darwin.patch
+]
 
 configopts = [
     # default build

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9.eb
@@ -19,6 +19,9 @@ checksums = [
     '8c471fc2b1961a6e6e5981b7f7b3512e7fe58fcb04461aa4520157d4c1159998',  # ncurses-5.9_configure_darwin.patch
 ]
 
+# need to use -P preprocessor option for recent GCC versions (cfr. https://gcc.gnu.org/gcc-5/porting_to.html)
+preconfigopts = "export CPPFLAGS='-P' && "
+
 configopts = [
     # default build
     '--with-shared --enable-overwrite',

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.1.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.1.eb
@@ -1,0 +1,45 @@
+easyblock = 'ConfigureMake'
+
+name = 'ncurses'
+version = '6.1'
+
+homepage = 'http://www.gnu.org/software/ncurses/'
+description = """The Ncurses (new curses) library is a free software emulation of curses in System V Release 4.0,
+ and more. It uses Terminfo format, supports pads and color and multiple highlights and forms characters and
+ function-key mapping, and has all the other SYSV-curses enhancements over BSD Curses."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17']
+
+common_configopts = "--with-shared --enable-overwrite --without-ada "
+configopts = [
+    # default build
+    common_configopts,
+    # the UTF-8 enabled version (ncursesw)
+    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+]
+
+# need to take care of $CFLAGS ourselves with dummy toolchain
+# we need to add -fPIC, but should also include -O* option to avoid compiling with -O0 (default for GCC)
+buildopts = 'CFLAGS="-O2 -fPIC"'
+
+# Symlink libtinfo to libncurses (since it can handle the API) so it doesn't get picked up from the OS
+postinstallcmds = [
+    "ln -s %(installdir)s/lib/libncurses.so %(installdir)s/lib/libtinfo.so",
+    "ln -s %(installdir)s/lib/libncurses.a %(installdir)s/lib/libtinfo.a"
+]
+
+libs = ["form", "menu", "ncurses", "panel"]
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
+                                     "reset", "tabs", "tic", "toe", "tput", "tset"]] +
+             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/libncurses++%s.a' % x for x in ['', 'w']],
+    'dirs': ['include', 'include/ncursesw'],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
These `CMake` easyconfigs using `dummy` toolchain are used as a build dependency for `Eigen` (which uses `cmake` for installation, but it's just a bunch of header files, so nothing gets compiled which means using the `dummy` toolchain is OK).

Requires `ncurses-devel` is stupid/annoying though, we can work around that by including `ncurses` a a *build* dependency and statically linking to it.

It's important that `ncurses` is a *build* dep, otherwise we may run into a version conflict on `ncurses` when these `CMake` easyconfigs are used to build something that has a runtime dependency on (another version of) `ncurses`...