### PR TITLE
also run easyconfigs tests using Python 3.5 and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,13 @@ matrix:
     # also test default configuration with Python 2.7
     - python: 2.7
       env: LMOD_VERSION=6.6.3
-    # also test with Python 3.6
+    # also test with Python 3.5/3.6/3.7
     - python: 3.6
+      env: LMOD_VERSION=7.8.5
+    - python: 3.5
+      env: LMOD_VERSION=7.8.5
+    - python: 3.7
+      dist: xenial
       env: LMOD_VERSION=7.8.5
 addons:
   apt:


### PR DESCRIPTION
May trim this down again to only Python 3.5 (or 3.6?) later, but want to make sure now everything passes with the Python 3.x versions we plan to support with EasyBuild 4.x...