### PR TITLE
add PyTorch to whitelist for not having 'use_pip' enabled

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -372,8 +372,8 @@ class EasyConfigTest(TestCase):
     def check_python_packages(self, changed_ecs):
         """Several checks for easyconfigs that install (bundles of) Python packages."""
 
-        # MATLAB-Engine does not support installation with 'pip'
-        whitelist_pip = ['MATLAB-Engine-*']
+        # MATLAB-Engine, PyTorch do not support installation with 'pip'
+        whitelist_pip = ['MATLAB-Engine-*', 'PyTorch-*']
 
         failing_checks = []
 


### PR DESCRIPTION
relevant for #7603 and various other current (& future) `PyTorch` PRs since we've put #7754 in place...