### PR TITLE
use correct buildopts + add missing zlib dependency in StringTie 1.3.5 easyconfig

### DIFF
--- a/easybuild/easyconfigs/s/StringTie/StringTie-1.3.5-foss-2018b.eb
+++ b/easybuild/easyconfigs/s/StringTie/StringTie-1.3.5-foss-2018b.eb
@@ -15,6 +15,12 @@ sources = [SOURCELOWER_TAR_GZ]
 
 checksums = ['f16ec07d4869b7656bc1a9b6eb662fd9404c122d18431c845e93d810840c5db9']
 
+dependencies = [
+    ('zlib', '1.2.11'),
+]
+
+buildopts = "release"
+
 files_to_copy = [(['%(namelower)s'], 'bin'), 'README', 'LICENSE']
 
 sanity_check_paths = {


### PR DESCRIPTION
cfr. https://github.com/easybuilders/easybuild-easyconfigs/pull/7736/files#r260261055