### PR TITLE
don't use local variable 'pylibdir' in list comprehension in PyQt easyconfig, since that doesn't work in Python 3

### DIFF
--- a/easybuild/easyconfigs/p/PyQt/PyQt-4.12.3-fosscuda-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/p/PyQt/PyQt-4.12.3-fosscuda-2018b-Python-2.7.15.eb
@@ -16,10 +16,8 @@ dependencies = [
 
 default_easyblock = 'ConfigureMakePythonPackage'
 
-pylibdir = 'lib/python%(pyshortver)s/site-packages'
-
 common_cfgopts = '--bindir=%(installdir)s/bin '
-common_cfgopts += '--destdir=%%(installdir)s/%s ' % pylibdir
+common_cfgopts += '--destdir=%(installdir)s/lib/python%(pyshortver)s/site-packages '
 common_cfgopts += '--sipdir=%(installdir)s/share/sip '
 
 sipcfgopts = 'configure.py ' + common_cfgopts
@@ -51,13 +49,14 @@ components = [
 ]
 
 modextrapaths = {
-    'PYTHONPATH': pylibdir,
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
     'QT_PLUGIN_PATH': 'plugins'
 }
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['pyuic4', 'pyrcc4', 'pylupdate4']] +
-             [pylibdir + '/%%(name)s%%(version_major)s/%s.%s' % (x, SHLIB_EXT) for x in ['sip', 'QtCore', 'Qt']],
+             ['lib/python%%(pyshortver)s/site-packages/%%(name)s%%(version_major)s/%s.%s' % (x, SHLIB_EXT)
+              for x in ['sip', 'QtCore', 'Qt']],
     'dirs': ['include', 'plugins', 'share/sip'],
 }
 


### PR DESCRIPTION
Parsing `PyQt-4.12.3-fosscuda-2018b-Python-2.7.15.eb` on top of Python 3 (using the `4.x` branches) fails with:

```
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/easybuild_framework-3.9.0.dev0-py3.6.egg/easybuild/framework/easyconfig/format/pyheaderconfigobj.py", line 187, in parse_pyheader
    exec(pyheader, global_vars, local_vars)
  File "<string>", line 60, in <module>
  File "<string>", line 60, in <listcomp>
NameError: name 'pylibdir' is not defined
```

This issue is similar to the one we danced around with #7797.

The underlying issue is probably that list comprehensions have their own scope in Python 3, see also https://portingguide.readthedocs.io/en/latest/comprehensions.html .

Another way to fix this is to declare `pylibdir` as `global` in the easyconfig, but I'd like to avoid that...