### PR TITLE
stick to intervaltree 2.1.0 as required extension for VCF-kit + fix stripping out of hardcoded versions for dependencies

### DIFF
--- a/easybuild/easyconfigs/v/VCF-kit/VCF-kit-0.1.6-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/v/VCF-kit/VCF-kit-0.1.6-intel-2018b-Python-2.7.15.eb
@@ -41,9 +41,9 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/s/sortedcontainers'],
         'checksums': ['974e9a32f56b17c1bac2aebd9dcf197f3eb9cd30553c5852a3187ad162e1a03a'],
     }),
-    ('intervaltree', '3.0.2', {
+    ('intervaltree', '2.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/i/intervaltree'],
-        'checksums': ['cb4f61c81dcb4fea6c09903f3599015a83c9bdad1f0bbd232495e6681e19e273'],
+        'checksums': ['aca5804b88f70cb49050c37b6de59090570f77a75aec1932966cf69f6a48810b'],
     }),
     ('args', '0.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/a/args'],
@@ -78,8 +78,7 @@ exts_list = [
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/V/VCF-kit'],
         'checksums': ['e44319bc057ff4f90cc3a777bb6b1794e5dc3dcf56fe2753fee199f782fed6b6'],
-        # get rid of hardcoded versions for dependencies
-        'prebuildopts': "sed -i 's/==[0-9.]*//g' requirements.txt && ",
+        'preinstallopts': "sed -i 's/==[0-9.]*//g' requirements.txt && ",
         'modulename': 'vcfkit',
     }),
 ]
@@ -88,5 +87,7 @@ sanity_check_paths = {
     'files': ['bin/vk'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
+
+sanity_check_commands = ["vk --help"]
 
 moduleclass = 'bio'


### PR DESCRIPTION
…