### PR TITLE
remove outdated 'typing' Python package from Python 3.7.2 easyconfig

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.7.2-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.7.2-GCCcore-8.2.0.eb
@@ -299,10 +299,6 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/a/alabaster/'],
         'checksums': ['a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02'],
     }),
-    ('typing', '3.6.6', {
-        'source_urls': ['https://pypi.python.org/packages/source/t/typing/'],
-        'checksums': ['4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d'],
-    }),
     ('Sphinx', '1.8.5', {
         'source_urls': ['https://pypi.python.org/packages/source/S/Sphinx/'],
         'checksums': ['c7658aab75c920288a8cf6f09f244c6cfdae30d82d803ac1634d9f223a80ca08'],


### PR DESCRIPTION
The `typing` Python package should not be included as an extension to Python 3.7.x, since it's a backport of the standard library `typing` module to Python versions older than 3.5...

Having it around causes problems like `AttributeError: type object 'Callable' has no attribute '_abc_registry'` (cfr. https://github.com/GNS3/gns3-server/issues/1414)