### PR TITLE
add yaml aka PyYAML into new GCCcore Pythons {proposal}

### DIFF
--- a/easybuild/easyconfigs/l/libyaml/libyaml-0.2.1-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/l/libyaml/libyaml-0.2.1-GCCcore-8.2.0.eb
@@ -1,0 +1,32 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Nils Christian <nils.christian@uni.lu>
+# License::   MIT/GPL
+# $Id$
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'libyaml'
+version = '0.2.1'
+
+homepage = 'http://pyyaml.org/wiki/LibYAML'
+
+description = """LibYAML is a YAML parser and emitter written in C."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
+
+source_urls = ['http://pyyaml.org/download/libyaml/']
+sources = ['yaml-%(version)s.tar.gz']
+checksums = ['78281145641a080fb32d6e7a87b9c0664d611dcb4d542e90baf731f51cbb59cd']
+
+builddependencies = [('binutils', '2.31.1')]
+
+sanity_check_paths = {
+    'files': ["include/yaml.h", "lib/libyaml.a", "lib/libyaml.%s" % SHLIB_EXT],
+    'dirs': ["lib/pkgconfig"]
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-8.2.0.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('libreadline', '8.0'),
     ('ncurses', '6.1'),
     ('SQLite', '3.27.2'),
+    ('libyaml', '0.2.1'),  # required for PyYAML
     ('GMP', '6.1.2'),  # required for pycrypto
     ('libffi', '3.2.1'),  # required for cryptography
     # OS dependency should be preferred if the os version is more recent then this version,
@@ -319,6 +320,11 @@ exts_list = [
     ('future', '0.17.1', {
         'source_urls': ['https://pypi.python.org/packages/source/f/future'],
         'checksums': ['67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8'],
+    }),
+    ('PyYAML', '5.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyyaml'],
+        'checksums': ['436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95'],
+        'modulename': 'yaml',
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Python/Python-3.7.2-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.7.2-GCCcore-8.2.0.eb
@@ -21,6 +21,7 @@ dependencies = [
     ('ncurses', '6.1'),
     ('SQLite', '3.27.2'),
     ('XZ', '5.2.4'),
+    ('libyaml', '0.2.1'),  # required for PyYAML
     ('GMP', '6.1.2'),  # required for pycrypto
     ('libffi', '3.2.1'),  # required for cryptography
     # OS dependency should be preferred if the os version is more recent then this version,
@@ -314,6 +315,11 @@ exts_list = [
     ('future', '0.17.1', {
         'source_urls': ['https://pypi.python.org/packages/source/f/future'],
         'checksums': ['67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8'],
+    }),
+    ('PyYAML', '5.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyyaml'],
+        'checksums': ['436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95'],
+        'modulename': 'yaml',
     }),
 ]
 


### PR DESCRIPTION
Isn't main Python easyconfig better place for this great lib <sup>:tm:</sup> than standalone easyconfig? (https://github.com/easybuilders/easybuild-easyconfigs/tree/master/easybuild/easyconfigs/p/PyYAML)

(created using `eb --new-pr`)

why yes:

* "YAML may be the most human friendly format for structured data invented so far." <sup>[wiki.python.org/moin](https://wiki.python.org/moin/YAML)</sup>
* it's in Intel Distribution for Python too <sup>[software.intel.com](https://software.intel.com/en-us/articles/complete-list-of-packages-for-the-intel-distribution-for-python)</sup>