### PR TITLE
fix problems in MetaBAT easyconfig

### DIFF
--- a/easybuild/easyconfigs/m/MetaBAT/MetaBAT-2.12.1-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/MetaBAT/MetaBAT-2.12.1-foss-2018b-Python-2.7.15.eb
@@ -26,7 +26,7 @@ dependencies = [
     ('SAMtools', '1.9'),
 ]
 
-prebuildopts = "ln -s $EBROOTSAMTOOLS samtools && "
+prebuildopts = "cp -a $EBROOTSAMTOOLS samtools && "
 
 sanity_check_paths = {
     'files': ['bin/aggregateBinDepths.pl', 'bin/aggregateContigOverlapsByBin.pl', 'bin/metabat', 'bin/metabat2'],

--- a/easybuild/easyconfigs/m/MetaBAT/MetaBAT-2.12.1-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/MetaBAT/MetaBAT-2.12.1-foss-2018b-Python-2.7.15.eb
@@ -14,7 +14,7 @@ sources = ['v%(version)s.tar.gz']
 patches = ['MetaBAT-%(version)s_fix-prepend-PATH.patch']
 checksums = [
     'e3aca0656f56f815135521360dc56667ec26af25143c3a31d645fef1a96abbc2',  # v2.12.1.tar.gz
-    '5735d2661f1b890688029ccccf24d278c71ece9d6c603ced442327010de1287b',  # MetaBAT-2.12.1_fix-prepend-PATH.patch
+    '2e5f84ad7090e7853c506278adf2d09a8af57b90d7003c5c01a62fa58c9f4931',  # MetaBAT-2.12.1_fix-prepend-PATH.patch
 ]
 
 builddependencies = [('SCons', '3.0.4', versionsuffix)]
@@ -24,6 +24,8 @@ dependencies = [
     ('Boost', '1.67.0'),
     ('zlib', '1.2.11'),
     ('SAMtools', '1.9'),
+    ('XZ', '5.2.4'),
+    ('bzip2', '1.0.6'),
 ]
 
 prebuildopts = "cp -a $EBROOTSAMTOOLS samtools && "

--- a/easybuild/easyconfigs/m/MetaBAT/MetaBAT-2.12.1_fix-prepend-PATH.patch
+++ b/easybuild/easyconfigs/m/MetaBAT/MetaBAT-2.12.1_fix-prepend-PATH.patch
@@ -1,8 +1,9 @@
-prepend to $PATH rather than append, to avoid picking up system compiler (g++)
+prepend to $PATH rather than append, to avoid picking up system compiler (g++);
+add missing -llzma -lbz2 link options, required when linking to libhts.a
 author: Kenneth Hoste (HPC-UGent)
 see also https://bitbucket.org/berkeleylab/metabat/issues/52
 --- berkeleylab-metabat-37db58fe3fda/SConstruct.orig	2017-09-01 07:28:02.000000000 +0200
-+++ berkeleylab-metabat-37db58fe3fda/SConstruct	2019-02-26 16:13:03.150132631 +0100
++++ berkeleylab-metabat-37db58fe3fda/SConstruct	2019-03-21 12:24:35.516202521 +0100
 @@ -7,7 +7,7 @@
  def ENV_update(tgt_ENV, src_ENV):
      for K in src_ENV.keys():
@@ -12,3 +13,21 @@ see also https://bitbucket.org/berkeleylab/metabat/issues/52
          else:
              tgt_ENV[K]=src_ENV[K]
  
+@@ -184,7 +184,7 @@
+                 sources,
+                 CCFLAGS=ccflags,
+                 CPPPATH=[hts_inc, boost_inc],
+-                LIBS=['pthread', 'z'],
++                LIBS=['pthread', 'z', 'lzma', 'bz2'],
+                 LINKFLAGS=linkflags
+                 )
+ 
+@@ -204,7 +204,7 @@
+                 CPPPATH=[hts_inc, boost_inc],
+                 LINKPATH=[hts_lib, boost_lib],
+                 LINKFLAGS=linkflags,
+-                LIBS=['z']
++                LIBS=['z', 'lzma', 'bz2']
+                 )
+ 
+ test_sum = env.Alias('test_sum', [jgi_summarize_bam_contig_depths],  ' '.join([jgi_summarize_bam_contig_depths[0].abspath, '--outputDepth', test_depth, test_bam]) )


### PR DESCRIPTION
It turns out that symlinking leaves the door open to let `MetaBAT` add stuff in the `SAMtools` installation, cfr. discussion in https://github.com/easybuilders/easybuild-easyconfigs/pull/7746#issuecomment-473893319

One other thing I noticed is that during the installation an old version of `SAMtools` is being downloaded, rather than using the one included as a dependency...