### PR TITLE
also install ANTs scripts (and set $ANTSPATH as required by those scripts)

### DIFF
--- a/easybuild/easyconfigs/a/ANTs/ANTs-2.3.1-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/a/ANTs/ANTs-2.3.1-foss-2018b-Python-3.6.6.eb
@@ -34,12 +34,17 @@ configopts += '-DUSE_VTK=ON -DUSE_SYSTEM_VTK=ON '
 configopts += '-DSuperBuild_ANTS_USE_GIT_PROTOCOL=OFF'
 
 skipsteps = ['install']
+
 # need to ensure user has write permissions on all files, to avoid permission denied problems when copying
 buildopts = ' && mkdir -p %(installdir)s && chmod -R u+w . && cp -a * %(installdir)s/'
 
+postinstallcmds = ["cp -a %(builddir)s/ANTs-%(version)s/Scripts/* %(installdir)s/bin/"]
+
 sanity_check_paths = {
-    'files': ['bin/ANTS'],
+    'files': ['bin/ANTS', 'bin/antsBrainExtraction.sh'],
     'dirs': ['lib'],
 }
+
+modextravars = {'ANTSPATH': '%(installdir)s/bin'}
 
 moduleclass = 'data'


### PR DESCRIPTION
Fix for an issue I ran into when playing around with `FMRIprep` (which depends on `ANTs`), the `antsBrainExtraction.sh` was reported missing...

Even though there's a dedicated `COPY_SCRIPT_FILES_TO_BIN_DIR` option for `cmake` (which doesn't seem to do anything), just copying seems to be the correct way, see also documentation at https://github.com/ANTsX/ANTs/wiki/Compiling-ANTs-on-Linux-and-Mac-OS#copy-scripts .