### PR TITLE
Fix "source_urls" for mawk.

### DIFF
--- a/easybuild/easyconfigs/m/Mawk/Mawk-1.3.4-goolf-1.4.10-20150503.eb
+++ b/easybuild/easyconfigs/m/Mawk/Mawk-1.3.4-goolf-1.4.10-20150503.eb
@@ -9,13 +9,14 @@ name = 'Mawk'
 version = '1.3.4'
 versionsuffix = '-20150503'
 
-homepage = 'http://invisible-island.net/mawk/'
+homepage = 'https://invisible-island.net/mawk/'
 description = """mawk is an interpreter for the AWK Programming Language."""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-source_urls = ['ftp://invisible-island.net/mawk/']
+source_urls = ['ftp://ftp.invisible-island.net/pub/mawk']
 sources = ['%(namelower)s-%(version)s%(versionsuffix)s.tgz']
+checksums = ['461673c7c4572e1e67e69e7bf7582e02d3c175b814485f2aa52c2c28099b3c6f']
 
 parallel = 1
 

--- a/easybuild/easyconfigs/m/mawk/mawk-1.3.4-20141206-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/m/mawk/mawk-1.3.4-20141206-GCC-4.9.2.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'mawk'
 version = '1.3.4-20141206'
 
-homepage = 'http://invisible-island.net/mawk/mawk.html'
+homepage = 'https://invisible-island.net/mawk/mawk.html'
 description = """mawk is an interpreter for the AWK Programming Language."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.2'}
 
 sources = [SOURCELOWER_TGZ]
-source_urls = ['ftp://invisible-island.net/mawk']
+source_urls = ['ftp://ftp.invisible-island.net/pub/mawk']
+checksums = ['efa092ec3ea5dfd54571e8ba3b0327073f1fa51b8efa0953c2cadd87a87389c8']
 
 sanity_check_paths = {
     'files': ['bin/mawk'],

--- a/easybuild/easyconfigs/m/mawk/mawk-1.3.4-20171017-foss-2018a.eb
+++ b/easybuild/easyconfigs/m/mawk/mawk-1.3.4-20171017-foss-2018a.eb
@@ -1,0 +1,20 @@
+easyblock = 'ConfigureMake'
+
+name = 'mawk'
+version = '1.3.4-20171017'
+
+homepage = 'https://invisible-island.net/mawk/'
+description = """mawk is an interpreter for the AWK Programming Language."""
+
+toolchain = {'name': 'foss', 'version': '2018a'}
+
+source_urls = ['ftp://ftp.invisible-island.net/pub/mawk']
+sources = ['%(namelower)s-%(version)s.tgz']
+checksums = ['db17115d1ed18ed1607c8b93291db9ccd4fe5e0f30d2928c3c5d127b23ec9e5b']
+
+sanity_check_paths = {
+    'files': ['bin/mawk'],
+    'dirs': []
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/mawk/mawk-1.3.4-20171017-foss-2018b.eb
+++ b/easybuild/easyconfigs/m/mawk/mawk-1.3.4-20171017-foss-2018b.eb
@@ -1,0 +1,20 @@
+easyblock = 'ConfigureMake'
+
+name = 'mawk'
+version = '1.3.4-20171017'
+
+homepage = 'https://invisible-island.net/mawk/'
+description = """mawk is an interpreter for the AWK Programming Language."""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+source_urls = ['ftp://ftp.invisible-island.net/pub/mawk']
+sources = ['%(namelower)s-%(version)s.tgz']
+checksums = ['db17115d1ed18ed1607c8b93291db9ccd4fe5e0f30d2928c3c5d127b23ec9e5b']
+
+sanity_check_paths = {
+    'files': ['bin/mawk'],
+    'dirs': []
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/mawk/mawk-1.3.4-20171017-foss-2019a.eb
+++ b/easybuild/easyconfigs/m/mawk/mawk-1.3.4-20171017-foss-2019a.eb
@@ -1,0 +1,20 @@
+easyblock = 'ConfigureMake'
+
+name = 'mawk'
+version = '1.3.4-20171017'
+
+homepage = 'https://invisible-island.net/mawk/'
+description = """mawk is an interpreter for the AWK Programming Language."""
+
+toolchain = {'name': 'foss', 'version': '2019a'}
+
+source_urls = ['ftp://ftp.invisible-island.net/pub/mawk']
+sources = ['%(namelower)s-%(version)s.tgz']
+checksums = ['db17115d1ed18ed1607c8b93291db9ccd4fe5e0f30d2928c3c5d127b23ec9e5b']
+
+sanity_check_paths = {
+    'files': ['bin/mawk'],
+    'dirs': []
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/mawk/mawk-1.3.4-20171017-intel-2018a.eb
+++ b/easybuild/easyconfigs/m/mawk/mawk-1.3.4-20171017-intel-2018a.eb
@@ -1,0 +1,20 @@
+easyblock = 'ConfigureMake'
+
+name = 'mawk'
+version = '1.3.4-20171017'
+
+homepage = 'https://invisible-island.net/mawk/'
+description = """mawk is an interpreter for the AWK Programming Language."""
+
+toolchain = {'name': 'intel', 'version': '2018a'}
+
+source_urls = ['ftp://ftp.invisible-island.net/pub/mawk']
+sources = ['%(namelower)s-%(version)s.tgz']
+checksums = ['db17115d1ed18ed1607c8b93291db9ccd4fe5e0f30d2928c3c5d127b23ec9e5b']
+
+sanity_check_paths = {
+    'files': ['bin/mawk'],
+    'dirs': []
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/mawk/mawk-1.3.4-20171017-intel-2018b.eb
+++ b/easybuild/easyconfigs/m/mawk/mawk-1.3.4-20171017-intel-2018b.eb
@@ -1,0 +1,20 @@
+easyblock = 'ConfigureMake'
+
+name = 'mawk'
+version = '1.3.4-20171017'
+
+homepage = 'https://invisible-island.net/mawk/'
+description = """mawk is an interpreter for the AWK Programming Language."""
+
+toolchain = {'name': 'intel', 'version': '2018b'}
+
+source_urls = ['ftp://ftp.invisible-island.net/pub/mawk']
+sources = ['%(namelower)s-%(version)s.tgz']
+checksums = ['db17115d1ed18ed1607c8b93291db9ccd4fe5e0f30d2928c3c5d127b23ec9e5b']
+
+sanity_check_paths = {
+    'files': ['bin/mawk'],
+    'dirs': []
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/mawk/mawk-1.3.4-20171017-intel-2019a.eb
+++ b/easybuild/easyconfigs/m/mawk/mawk-1.3.4-20171017-intel-2019a.eb
@@ -1,0 +1,20 @@
+easyblock = 'ConfigureMake'
+
+name = 'mawk'
+version = '1.3.4-20171017'
+
+homepage = 'https://invisible-island.net/mawk/'
+description = """mawk is an interpreter for the AWK Programming Language."""
+
+toolchain = {'name': 'intel', 'version': '2019a'}
+
+source_urls = ['ftp://ftp.invisible-island.net/pub/mawk']
+sources = ['%(namelower)s-%(version)s.tgz']
+checksums = ['db17115d1ed18ed1607c8b93291db9ccd4fe5e0f30d2928c3c5d127b23ec9e5b']
+
+sanity_check_paths = {
+    'files': ['bin/mawk'],
+    'dirs': []
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
The "source_urls" for mawk changed from:
    "ftp://ftp.invisible-island.net/mawk/"
To:
    "ftp://ftp.invisible-island.net/mawk/"

but "ftp://ftp.invisible-island.net/mawk/" is a symlink,
so easybuild is unable to retreive the source archive.

cURL has problems with it too:

    $ curl -v ftp://ftp.invisible-island.net/mawk/
    * About to connect() to ftp.invisible-island.net port 21 (#0)
    *   Trying 216.194.196.78...
    * Connected to ftp.invisible-island.net (216.194.196.78) port 21 (#0)
    < 220 ProFTPD Server (ftp.invisible-island.net) [216.194.196.78]
    > USER anonymous
    < 331 Anonymous login ok, send your complete email address as your password
    > PASS ftp@example.com
    < 230 Anonymous access granted, restrictions apply
    > PWD
    < 257 "/" is the current directory
    * Entry path is '/'
    > CWD mawk
    * ftp_perform ends with SECONDARY: 0
    < 550 mawk: No such file or directory
    * Server denied you to change to the given directory
    * Connection #0 to host ftp.invisible-island.net left intact
    curl: (9) Server denied you to change to the given directory

Giving the real path without symlinks works:
    "ftp://ftp.invisible-island.net/pub/mawk/"

Note: There are two (m|M)awk easyconfig.