### PR TITLE
Pysam - Add XZ dependency for versions > 0.12

### DIFF
--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.12.0.1-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.12.0.1-intel-2017a-Python-2.7.13.eb
@@ -29,6 +29,9 @@ dependencies = [
     ('XZ', '5.2.3'),
 ]
 
+use_pip = True
+download_dep_fail = True
+
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.12.0.1-intel-2017a-Python-2.7.13.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.12.0.1-intel-2017a-Python-2.7.13.eb
@@ -26,6 +26,7 @@ dependencies = [
     ('Python', '2.7.13'),
     ('ncurses', '6.0'),
     ('cURL', '7.54.0'),
+    ('XZ', '5.2.3'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.12.0.1-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.12.0.1-intel-2017b-Python-2.7.14.eb
@@ -29,6 +29,9 @@ dependencies = [
     ('XZ', '5.2.3'),
 ]
 
+use_pip = True
+download_dep_fail = True
+
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.12.0.1-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.12.0.1-intel-2017b-Python-2.7.14.eb
@@ -26,6 +26,7 @@ dependencies = [
     ('Python', '2.7.14'),
     ('ncurses', '6.0'),
     ('cURL', '7.56.0'),
+    ('XZ', '5.2.3'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.12.0.1-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.12.0.1-intel-2017b-Python-3.6.3.eb
@@ -29,6 +29,9 @@ dependencies = [
     ('XZ', '5.2.3'),
 ]
 
+use_pip = True
+download_dep_fail = True
+
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.12.0.1-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.12.0.1-intel-2017b-Python-3.6.3.eb
@@ -26,6 +26,7 @@ dependencies = [
     ('Python', '3.6.3'),
     ('ncurses', '6.0'),
     ('cURL', '7.56.0'),
+    ('XZ', '5.2.3'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.13-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.13-intel-2017b-Python-2.7.14.eb
@@ -28,6 +28,9 @@ dependencies = [
     ('XZ', '5.2.3'),
 ]
 
+use_pip = True
+download_dep_fail = True
+
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.13-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.13-intel-2017b-Python-2.7.14.eb
@@ -25,6 +25,7 @@ dependencies = [
     ('Python', '2.7.14'),
     ('ncurses', '6.0'),
     ('cURL', '7.56.1'),
+    ('XZ', '5.2.3'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.13.0-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.13.0-intel-2017b-Python-3.6.3.eb
@@ -26,6 +26,7 @@ dependencies = [
     ('Python', '3.6.3'),
     ('ncurses', '6.0'),
     ('cURL', '7.56.0'),
+    ('XZ', '5.2.3'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.13.0-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.13.0-intel-2017b-Python-3.6.3.eb
@@ -29,6 +29,10 @@ dependencies = [
     ('XZ', '5.2.3'),
 ]
 
+
+use_pip = True
+download_dep_fail = True
+
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.14-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.14-intel-2017b-Python-2.7.14.eb
@@ -29,6 +29,9 @@ dependencies = [
     ('XZ', '5.2.3'),
 ]
 
+use_pip = True
+download_dep_fail = True
+
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.14-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.14-intel-2017b-Python-2.7.14.eb
@@ -26,6 +26,7 @@ dependencies = [
     ('Python', '2.7.14'),
     ('ncurses', '6.0'),
     ('cURL', '7.56.1'),
+    ('XZ', '5.2.3'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.14-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.14-intel-2018a-Python-3.6.4.eb
@@ -29,6 +29,9 @@ dependencies = [
     ('XZ', '5.2.3'),
 ]
 
+use_pip = True
+download_dep_fail = True
+
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.14-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.14-intel-2018a-Python-3.6.4.eb
@@ -26,6 +26,7 @@ dependencies = [
     ('Python', '3.6.4'),
     ('ncurses', '6.0'),
     ('cURL', '7.58.0'),
+    ('XZ', '5.2.3'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.14.1-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.14.1-foss-2018a-Python-3.6.4.eb
@@ -31,6 +31,9 @@ dependencies = [
     ('XZ', '5.2.3'),
 ]
 
+use_pip = True
+download_dep_fail = True
+
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.14.1-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.14.1-foss-2018a-Python-3.6.4.eb
@@ -28,6 +28,7 @@ dependencies = [
     ('Python', '3.6.4'),
     ('ncurses', '6.0'),
     ('cURL', '7.58.0'),
+    ('XZ', '5.2.3'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.14.1-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.14.1-intel-2018a-Python-2.7.14.eb
@@ -31,6 +31,9 @@ dependencies = [
     ('XZ', '5.2.3'),
 ]
 
+use_pip = True
+download_dep_fail = True
+
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.14.1-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.14.1-intel-2018a-Python-2.7.14.eb
@@ -28,6 +28,7 @@ dependencies = [
     ('Python', '2.7.14'),
     ('ncurses', '6.0'),
     ('cURL', '7.58.0'),
+    ('XZ', '5.2.3'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.14.1-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.14.1-intel-2018a-Python-3.6.4.eb
@@ -31,6 +31,9 @@ dependencies = [
     ('XZ', '5.2.3'),
 ]
 
+use_pip = True
+download_dep_fail = True
+
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.14.1-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.14.1-intel-2018a-Python-3.6.4.eb
@@ -28,6 +28,7 @@ dependencies = [
     ('Python', '3.6.4'),
     ('ncurses', '6.0'),
     ('cURL', '7.58.0'),
+    ('XZ', '5.2.3'),
 ]
 
 sanity_check_paths = {


### PR DESCRIPTION
From version 0.12 `XZ` is required as dependency. Otherwise the following error may appear:
```
htslib/hts_os.c(30): catastrophic error: cannot open source file "os/rand.c"
  #include "os/rand.c"
```