### PR TITLE
add missing configopts in GATE 8.1 easyconfig to enable Davis feature

### DIFF
--- a/easybuild/easyconfigs/g/GATE/GATE-8.1.p01-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/g/GATE/GATE-8.1.p01-foss-2018b-Python-2.7.15.eb
@@ -28,4 +28,7 @@ dependencies = [
     ('ROOT', '6.14.06', versionsuffix),
 ]
 
+# enable extra capabilities (Davis requires Geant4 10.04 or newer)
+configopts = "-DGATE_USE_OPTICAL=1 -DGATE_USE_DAVIS=1"
+
 moduleclass = 'cae'


### PR DESCRIPTION
These were added in (some of) the `GATE` 8.0 easyconfigs, and are also used in the GATE 8.2 easyconfig added in #7999, so just enabling it here too for consistency sake...