### PR TITLE
{numlib} [iimpi iompi] Set up PKG_CONFIG_PATH for MKL library

### DIFF
--- a/easybuild/easyconfigs/i/imkl/imkl-2018.1.163-iimpi-2018a.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2018.1.163-iimpi-2018a.eb
@@ -36,4 +36,8 @@ modextravars = {
     'MKL_EXAMPLES': '%(installdir)s/mkl/examples/',
 }
 
+modextrapaths = {
+    'PKG_CONFIG_PATH': '%(installdir)s/compilers_and_libraries_2018.1.163/linux/mkl/bin/pkgconfig',
+}
+
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/i/imkl/imkl-2018.1.163-iompi-2018a.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2018.1.163-iompi-2018a.eb
@@ -35,4 +35,8 @@ modextravars = {
     'MKL_EXAMPLES': '%(installdir)s/mkl/examples/',
 }
 
+modextrapaths = {
+    'PKG_CONFIG_PATH': '%(installdir)s/compilers_and_libraries_2018.1.163/linux/mkl/bin/pkgconfig',
+}
+
 moduleclass = 'numlib'


### PR DESCRIPTION
Seems like a useful feature to me which can be ignored by anyone not interested in the Intel shipped `pkg-config` files.