### PR TITLE
use https:// in homepage & source_urls for recent OpenMPI 2.x, 3.x & 4.x easyconfigs

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.0-GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.0-GCC-5.2.0.eb
@@ -3,14 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.0.0'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '5.2.0'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['6603d39a68d14bc7c44bba3e439289a86ddabd5ab1e8b570916d68a140484c00']
 
 dependencies = [('hwloc', '1.11.3')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
@@ -3,14 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.0.1'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '6.2.0-2.27'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['5c576eafb2ff10c338c67549ba1cf299a704bd052f648f4b7854115e4d07fabd']
 
 dependencies = [('hwloc', '1.11.4')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-gcccuda-2016.10.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-gcccuda-2016.10.eb
@@ -3,14 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.0.1'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'gcccuda', 'version': '2016.10'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['5c576eafb2ff10c338c67549ba1cf299a704bd052f648f4b7854115e4d07fabd']
 
 dependencies = [('hwloc', '1.11.4')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-iccifort-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-iccifort-2017.1.132-GCC-5.4.0-2.26.eb
@@ -3,14 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.0.1'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2017.1.132-GCC-5.4.0-2.26'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['5c576eafb2ff10c338c67549ba1cf299a704bd052f648f4b7854115e4d07fabd']
 
 dependencies = [('hwloc', '1.11.4')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27-opa.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27-opa.eb
@@ -4,15 +4,14 @@ name = 'OpenMPI'
 version = '2.0.2'
 versionsuffix = '-opa'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '6.3.0-2.27'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-
-checksums = ['886698becc5bea8c151c0af2074b8392']
+checksums = ['32914cc64780d3980066f3be3920b028cd381c94d1262a55415fc1d002bae0a5']
 
 dependencies = [('hwloc', '1.11.5')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27.eb
@@ -3,15 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.0.2'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '6.3.0-2.27'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-
-checksums = ['886698becc5bea8c151c0af2074b8392']
+checksums = ['32914cc64780d3980066f3be3920b028cd381c94d1262a55415fc1d002bae0a5']
 
 dependencies = [('hwloc', '1.11.5')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-gcccuda-2017.01.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-gcccuda-2017.01.eb
@@ -3,15 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.0.2'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'gcccuda', 'version': '2017.01'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-
-checksums = ['886698becc5bea8c151c0af2074b8392']
+checksums = ['32914cc64780d3980066f3be3920b028cd381c94d1262a55415fc1d002bae0a5']
 
 dependencies = [('hwloc', '1.11.5')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-iccifort-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-iccifort-2017.1.132-GCC-6.3.0-2.27.eb
@@ -3,14 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.0.2'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2017.1.132-GCC-6.3.0-2.27'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['886698becc5bea8c151c0af2074b8392']
+checksums = ['32914cc64780d3980066f3be3920b028cd381c94d1262a55415fc1d002bae0a5']
 
 dependencies = [('hwloc', '1.11.5')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.0-GCC-6.3.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.0-GCC-6.3.0-2.28.eb
@@ -3,15 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.1.0'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '6.3.0-2.28'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-
-checksums = ['c058052b53d209c7521079e3d2da613b']
+checksums = ['265a9c64a468cce464edd069ed8612e1865c5f112f84f4a7a855fb2a0d15e74b']
 
 dependencies = [('hwloc', '1.11.6')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-GCC-6.4.0-2.28.eb
@@ -3,12 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.1.1'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '6.4.0-2.28'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['afe4bef3c4378bc76eea96c623d5aa4c1c98b9e057d281c646e68869292a77dc']
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-gcccuda-2017.02.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-gcccuda-2017.02.eb
@@ -3,12 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.1.1'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'gcccuda', 'version': '2017.02'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['afe4bef3c4378bc76eea96c623d5aa4c1c98b9e057d281c646e68869292a77dc']
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-gcccuda-2017b.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-gcccuda-2017b.eb
@@ -3,12 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.1.1'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'gcccuda', 'version': '2017b'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['afe4bef3c4378bc76eea96c623d5aa4c1c98b9e057d281c646e68869292a77dc']
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-iccifort-2017.4.196-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.1-iccifort-2017.4.196-GCC-6.4.0-2.28.eb
@@ -3,14 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.1.1'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2017.4.196-GCC-6.4.0-2.28'}
 
-sources = [SOURCELOWER_TAR_GZ]
-
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['afe4bef3c4378bc76eea96c623d5aa4c1c98b9e057d281c646e68869292a77dc']
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-GCC-6.4.0-2.28.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.1.2'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '6.4.0-2.28'}

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-gcccuda-2018a.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-gcccuda-2018a.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.1.2'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'gcccuda', 'version': '2018a'}

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-iccifort-2018.1.163-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.2-iccifort-2018.1.163-GCC-6.4.0-2.28.eb
@@ -3,12 +3,10 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.1.2'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2018.1.163-GCC-6.4.0-2.28'}
-
-sources = [SOURCELOWER_TAR_GZ]
 
 source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.3-iccifort-2018.2.199-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.1.3-iccifort-2018.2.199-GCC-6.4.0-2.28.eb
@@ -3,12 +3,10 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '2.1.3'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2018.2.199-GCC-6.4.0-2.28'}
-
-sources = [SOURCELOWER_TAR_GZ]
 
 source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.0.0-GCC-7.2.0-2.29.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.0.0-GCC-7.2.0-2.29.eb
@@ -3,12 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '3.0.0'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-3 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '7.2.0-2.29'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 patches = ['%(name)s-%(version)s-add_ompi_datatype_attribute_to_release_ucp_datatype.patch']
 checksums = [

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.0-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.0-GCC-7.3.0-2.30.eb
@@ -3,12 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '3.1.0'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-3 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '7.3.0-2.30'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 patches = [
     'OpenMPI-3.1_fix-ib-query.patch',

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.1-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.1-GCC-7.3.0-2.30.eb
@@ -3,12 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '3.1.1'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-3 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '7.3.0-2.30'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 patches = [
     'OpenMPI-3.1_fix-ib-query.patch',

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.1-gcccuda-2018b.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.1-gcccuda-2018b.eb
@@ -3,12 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '3.1.1'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-3 implementation."""
 
 toolchain = {'name': 'gcccuda', 'version': '2018b'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 patches = [
     'OpenMPI-3.1_fix-ib-query.patch',

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.1-iccifort-2018.3.222-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.1-iccifort-2018.3.222-GCC-7.3.0-2.30.eb
@@ -3,12 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '3.1.1'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-3 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2018.3.222-GCC-7.3.0-2.30'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 patches = [
     'OpenMPI-3.1_fix-ib-query.patch',

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.2-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.2-GCC-8.2.0-2.31.1.eb
@@ -3,12 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '3.1.2'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-3 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 patches = [
     'OpenMPI-3.1_fix-ib-query.patch',

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-GCC-8.2.0-2.31.1.eb
@@ -3,12 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '3.1.3'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-3 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 patches = [
     '%(name)s-%(version)s-add_ompi_datatype_attribute_to_release_ucp_datatype.patch',

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.3-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
@@ -3,12 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '3.1.3'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-3 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2019.1.144-GCC-8.2.0-2.31.1'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 patches = [
     '%(name)s-%(version)s-add_ompi_datatype_attribute_to_release_ucp_datatype.patch',

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.0-GCC-8.2.0-2.31.1-hpcx.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.0-GCC-8.2.0-2.31.1-hpcx.eb
@@ -4,12 +4,12 @@ name = 'OpenMPI'
 version = '4.0.0'
 versionsuffix = '-hpcx'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """Mellanox flavored Open MPI Project is an open source MPI-3 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['36f10daa3f1b1d37530f686bf7f70966b2a13c0bc6e2e05aebc7e85e3d21b10d']
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.0-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.0-GCC-8.2.0-2.31.1.eb
@@ -3,12 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '4.0.0'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-3 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['36f10daa3f1b1d37530f686bf7f70966b2a13c0bc6e2e05aebc7e85e3d21b10d']
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.1-GCC-8.3.0-2.32.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.1-GCC-8.3.0-2.32.eb
@@ -3,12 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '4.0.1'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-3 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '8.3.0-2.32'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['e55e213fe09a214ab9f2c722acfd8bf7b39bbc1800e4b7a464d38df15e707f59']
 


### PR DESCRIPTION
fixes `OpenMPI` part of #7943 (except for OpenMPI 1.x easyconfigs)

cc @patbel-pwr