### PR TITLE
use https:// in homepage & source_urls for old OpenMPI 1.x easyconfigs

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.1-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.1-GCC-4.9.3-2.25.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.10.1'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.3-2.25'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['90eda119e8dcae8d904e44f5fc38a5051a4fb94134f56dc24b9051baff8bb29e']
 
 dependencies = [('hwloc', '1.11.2')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-4.9.3-2.25.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.10.2'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.3-2.25'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['01db467676cb5d974166591d403a8ffe38dfac4becb67071f59971e86bef0f63']
 
 dependencies = [('hwloc', '1.11.2')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-5.3.0-2.26.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.10.2'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '5.3.0-2.26'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['01db467676cb5d974166591d403a8ffe38dfac4becb67071f59971e86bef0f63']
 
 dependencies = [('hwloc', '1.11.3')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-6.1.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-6.1.0-2.27.eb
@@ -3,14 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.10.2'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '6.1.0-2.27'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['01db467676cb5d974166591d403a8ffe38dfac4becb67071f59971e86bef0f63']
 
 dependencies = [('hwloc', '1.11.3')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.3-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.3-GCC-4.9.3-2.25.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.10.2'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'PGI', 'version': '16.3-GCC-4.9.3-2.25'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['01db467676cb5d974166591d403a8ffe38dfac4becb67071f59971e86bef0f63']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.4-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.4-GCC-5.3.0-2.26.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.10.2'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'PGI', 'version': '16.4-GCC-5.3.0-2.26'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['01db467676cb5d974166591d403a8ffe38dfac4becb67071f59971e86bef0f63']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-5.4.0-2.26.eb
@@ -3,12 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.10.3'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['681c2ed1c96d187a3c84f30811a2b143d26de74884a740e5d02ec265ef70ab00']
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-6.1.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-6.1.0-2.27.eb
@@ -3,14 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.10.3'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '6.1.0-2.27'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['681c2ed1c96d187a3c84f30811a2b143d26de74884a740e5d02ec265ef70ab00']
 
 dependencies = [('hwloc', '1.11.3')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-gcccuda-2016.08.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-gcccuda-2016.08.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = "1.10.3"
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'gcccuda', 'version': '2016.08'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['681c2ed1c96d187a3c84f30811a2b143d26de74884a740e5d02ec265ef70ab00']
 
 dependencies = [('hwloc', '1.11.3')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -3,14 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.10.3'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2016.3.210-GCC-5.4.0-2.26'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
+checksums = ['681c2ed1c96d187a3c84f30811a2b143d26de74884a740e5d02ec265ef70ab00']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-PGI-16.7-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-PGI-16.7-GCC-5.4.0-2.26.eb
@@ -3,15 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.10.4'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'PGI', 'version': '16.7-GCC-5.4.0-2.26'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
-checksums = ['fb2fdb6a5b65c80d7dfa4bc9a0caf665']
+checksums = ['492332cd77d8af8ce37ab9d82964dae7ddfc1c2c60c0b417973ff7a70cd89991']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -3,14 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.10.4'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2016.3.210-GCC-4.9.3-2.25'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
+checksums = ['492332cd77d8af8ce37ab9d82964dae7ddfc1c2c60c0b417973ff7a70cd89991']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3-no-OFED.eb
@@ -4,15 +4,18 @@ name = 'OpenMPI'
 version = '1.4.5'
 versionsuffix = "-no-OFED"
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.6.3'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
 patches = ['pax_disable.patch']
+checksums = [
+    'a1306bb4d44d0cf3a89680c4c6723bb665126c9d5523022f187b944b9d4ea6a5',  # openmpi-1.4.5.tar.gz
+    '7bd7c339aee9ee731d2c6a8641901886e52faf0913bfb7191d0edc449e2c0a81',  # pax_disable.patch
+]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-threads --without-openib '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-GCC-4.6.3.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.4.5'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.6.3'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['a1306bb4d44d0cf3a89680c4c6723bb665126c9d5523022f187b944b9d4ea6a5']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-threads --with-openib '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.4.5-ictce-5.5.0.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = "1.4.5"
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['a1306bb4d44d0cf3a89680c4c6723bb665126c9d5523022f187b944b9d4ea6a5']
 
 builddependencies = [
     ('Automake', '1.14'),

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.6.4.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.6.4.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.6.4'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.6.4'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['d8b507309dcbd463b76c1ae504998a8c6221292e6bf10533880ea264be604dc4']
 
 dependencies = [('hwloc', '1.6.2')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2-no-OFED.eb
@@ -4,13 +4,14 @@ name = 'OpenMPI'
 version = '1.6.4'
 versionsuffix = '-no-OFED'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = "The Open MPI Project is an open source MPI-2 implementation."
 
 toolchain = {'name': 'GCC', 'version': '4.7.2'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['d8b507309dcbd463b76c1ae504998a8c6221292e6bf10533880ea264be604dc4']
 
 dependencies = [('hwloc', '1.6.2')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.6.4'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.7.2'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['d8b507309dcbd463b76c1ae504998a8c6221292e6bf10533880ea264be604dc4']
 
 dependencies = [('hwloc', '1.6.2')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.7.2.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.6.5'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.7.2'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['ac308dc38e77c622aedea5f3fd368c800b6636d0500f2124c36a505a65806559']
 
 dependencies = [
     ('hwloc', '1.6.2'),

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.7.3-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.7.3-no-OFED.eb
@@ -4,16 +4,19 @@ name = 'OpenMPI'
 version = '1.6.5'
 versionsuffix = "-no-OFED"
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.7.3'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
 patches = [
     'OpenMPI-1.6.5-vt_cupti_events.patch',
+]
+checksums = [
+    'ac308dc38e77c622aedea5f3fd368c800b6636d0500f2124c36a505a65806559',  # openmpi-1.6.5.tar.gz
+    '7de06818f3e83e64ca004458acac679e95ba1c658f051e6a91db2b726c53f9bc',  # OpenMPI-1.6.5-vt_cupti_events.patch
 ]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --without-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.1-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.1-no-OFED.eb
@@ -4,16 +4,19 @@ name = 'OpenMPI'
 version = '1.6.5'
 versionsuffix = "-no-OFED"
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.1'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
 patches = [
     'OpenMPI-1.6.5-vt_cupti_events.patch',
+]
+checksums = [
+    'ac308dc38e77c622aedea5f3fd368c800b6636d0500f2124c36a505a65806559',  # openmpi-1.6.5.tar.gz
+    '7de06818f3e83e64ca004458acac679e95ba1c658f051e6a91db2b726c53f9bc',  # OpenMPI-1.6.5-vt_cupti_events.patch
 ]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --without-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.1.eb
@@ -3,16 +3,19 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.6.5'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.1'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
 patches = [
     'OpenMPI-1.6.5-vt_cupti_events.patch',
+]
+checksums = [
+    'ac308dc38e77c622aedea5f3fd368c800b6636d0500f2124c36a505a65806559',  # openmpi-1.6.5.tar.gz
+    '7de06818f3e83e64ca004458acac679e95ba1c658f051e6a91db2b726c53f9bc',  # OpenMPI-1.6.5-vt_cupti_events.patch
 ]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.2-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.2-no-OFED.eb
@@ -4,16 +4,19 @@ name = 'OpenMPI'
 version = '1.6.5'
 versionsuffix = '-no-OFED'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.2'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
 patches = [
     'OpenMPI-1.6.5-vt_cupti_events.patch',
+]
+checksums = [
+    'ac308dc38e77c622aedea5f3fd368c800b6636d0500f2124c36a505a65806559',  # openmpi-1.6.5.tar.gz
+    '7de06818f3e83e64ca004458acac679e95ba1c658f051e6a91db2b726c53f9bc',  # OpenMPI-1.6.5-vt_cupti_events.patch
 ]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --without-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.2.eb
@@ -3,16 +3,19 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.6.5'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.2'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
 patches = [
     'OpenMPI-1.6.5-vt_cupti_events.patch',
+]
+checksums = [
+    'ac308dc38e77c622aedea5f3fd368c800b6636d0500f2124c36a505a65806559',  # openmpi-1.6.5.tar.gz
+    '7de06818f3e83e64ca004458acac679e95ba1c658f051e6a91db2b726c53f9bc',  # OpenMPI-1.6.5-vt_cupti_events.patch
 ]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.3.eb
@@ -3,16 +3,19 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.6.5'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.3'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
 patches = [
     'OpenMPI-1.6.5-vt_cupti_events.patch',
+]
+checksums = [
+    'ac308dc38e77c622aedea5f3fd368c800b6636d0500f2124c36a505a65806559',  # openmpi-1.6.5.tar.gz
+    '7de06818f3e83e64ca004458acac679e95ba1c658f051e6a91db2b726c53f9bc',  # OpenMPI-1.6.5-vt_cupti_events.patch
 ]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.2.144.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.2.144.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.6.5'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2013_sp1.2.144'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['ac308dc38e77c622aedea5f3fd368c800b6636d0500f2124c36a505a65806559']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.4.211-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.4.211-no-OFED.eb
@@ -4,13 +4,14 @@ name = 'OpenMPI'
 version = '1.6.5'
 versionsuffix = '-no-OFED'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2013_sp1.4.211'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['ac308dc38e77c622aedea5f3fd368c800b6636d0500f2124c36a505a65806559']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --without-openib '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.4.211.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.4.211.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.6.5'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2013_sp1.4.211'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['ac308dc38e77c622aedea5f3fd368c800b6636d0500f2124c36a505a65806559']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-GCC-4.8.2.eb
@@ -3,15 +3,18 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = "1.7.3"
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.2'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
 patches = ['OpenMPI-%(version)s-vt_cupti_events.patch']
+checksums = [
+    'bcddffc1e2bee64790205c95bd7dff62af43ea1276ac37987da44ed5ad815874',  # openmpi-1.7.3.tar.gz
+    'c155b47f44497658aecc56bb40fc93de8a2e3986be638679946e6e41cf047b3f',  # OpenMPI-1.7.3-vt_cupti_events.patch
+]
 
 dependencies = [('hwloc', '1.7.2')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.1-GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.1-GCC-4.8.3.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = "1.8.1"
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.3'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['1ebeb5af9db47f1f0bb63d14265d34a7be0d99bb34a0b2a41c3e926f3d27fd50']
 
 dependencies = [('hwloc', '1.9')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-GCC-4.9.2.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = "1.8.3"
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.2'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['b7487ee77bde880308429a72f56612b840690cc3b927be4bf191677b9a2ef5a8']
 
 dependencies = [('hwloc', '1.10.0')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-iccifort-2013_sp1.4.211-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-iccifort-2013_sp1.4.211-no-OFED.eb
@@ -4,14 +4,14 @@ name = 'OpenMPI'
 version = '1.8.3'
 versionsuffix = '-no-OFED'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2013_sp1.4.211'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
+checksums = ['b7487ee77bde880308429a72f56612b840690cc3b927be4bf191677b9a2ef5a8']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --without-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-iccifort-2013_sp1.4.211.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-iccifort-2013_sp1.4.211.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.8.3'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2013_sp1.4.211'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['b7487ee77bde880308429a72f56612b840690cc3b927be4bf191677b9a2ef5a8']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.8.4.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = "1.8.4"
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.4'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['3c602955fa16d03806ec704e089e2a14fe092d7fe7d444972f4a99407f645661']
 
 dependencies = [('hwloc', '1.10.1')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.9.2.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.8.4'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.2'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['3c602955fa16d03806ec704e089e2a14fe092d7fe7d444972f4a99407f645661']
 
 dependencies = [('hwloc', '1.10.0')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.1.133-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.1.133-GCC-4.9.2.eb
@@ -3,14 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.8.4'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2015.1.133-GCC-4.9.2'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
+checksums = ['3c602955fa16d03806ec704e089e2a14fe092d7fe7d444972f4a99407f645661']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.2.164-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.2.164-GCC-4.9.2.eb
@@ -3,14 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.8.4'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2015.2.164-GCC-4.9.2'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
+checksums = ['3c602955fa16d03806ec704e089e2a14fe092d7fe7d444972f4a99407f645661']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.5-GNU-4.9.2-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.5-GNU-4.9.2-2.25.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.8.5'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GNU', 'version': '4.9.2-2.25'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['91de8828f7257b6c011a9015321c0fd027782ee04a269c74194f2e3c837e28c8']
 
 dependencies = [('hwloc', '1.10.1')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.6-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.6-GNU-4.9.3-2.25.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.8.6'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GNU', 'version': '4.9.3-2.25'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['167bdc76b44b7961871ea5973ffc545035d44f577152c4a9ab8d2be795ce27d1']
 
 dependencies = [('hwloc', '1.11.0')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.8-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.8-GNU-4.9.3-2.25.eb
@@ -3,13 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.8.8'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'GNU', 'version': '4.9.3-2.25'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+checksums = ['56764d8eea8fd1812be4e7e71314e3c60e300be9bb59eafe866348db1ac4e306']
 
 dependencies = [('hwloc', '1.11.0')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.8-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.8-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
@@ -3,14 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'OpenMPI'
 version = '1.8.8'
 
-homepage = 'http://www.open-mpi.org/'
+homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
 toolchain = {'name': 'iccifort', 'version': '2015.3.187-GNU-4.9.3-2.25'}
 
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
-
+checksums = ['56764d8eea8fd1812be4e7e71314e3c60e300be9bb59eafe866348db1ac4e306']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path


### PR DESCRIPTION
fixes OpenMPI part of #7943 (only old OpenMPI 1.x easyconfigs)

cc @patbel-pwr