### PR TITLE
add missing bokeh dependency for dask 1.0.0 (+ add dask-jobqueue) + add easyconfig for dask 1.0.0 with foss/2018b

### DIFF
--- a/easybuild/easyconfigs/b/bokeh/bokeh-1.0.4-intel-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/b/bokeh/bokeh-1.0.4-intel-2018b-Python-3.6.6.eb
@@ -7,7 +7,7 @@ versionsuffix = '-Python-%(pyver)s'
 homepage = 'http://github.com/bokeh/bokeh'
 description = "Statistical and novel interactive HTML plots for Python"
 
-toolchain = {'name': 'foss', 'version': '2018b'}
+toolchain = {'name': 'intel', 'version': '2018b'}
 
 dependencies = [
     ('Python', '3.6.6'),

--- a/easybuild/easyconfigs/d/dask/dask-1.0.0-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/d/dask/dask-1.0.0-foss-2018b-Python-3.6.6.eb
@@ -8,7 +8,7 @@ homepage = 'http://github.com/dask/dask/'
 description = """Dask provides multi-core execution on larger-than-memory datasets using blocked algorithms
  and task scheduling."""
 
-toolchain = {'name': 'intel', 'version': '2018b'}
+toolchain = {'name': 'foss', 'version': '2018b'}
 
 dependencies = [
     ('Python', '3.6.6'),

--- a/easybuild/easyconfigs/d/dask/dask-1.0.0-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/d/dask/dask-1.0.0-foss-2018b-Python-3.6.6.eb
@@ -1,4 +1,4 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'dask'
 version = '1.0.0'
@@ -16,11 +16,7 @@ dependencies = [
     ('bokeh', '1.0.4', versionsuffix),
 ]
 
-exts_defaultclass = 'PythonPackage'
-exts_default_options = {
-    'download_dep_fail': True,
-    'use_pip': True,
-}
+use_pip = True
 
 exts_list = [
     ('toolz', '0.9.0', {
@@ -89,7 +85,5 @@ sanity_check_paths = {
     'files': ['bin/dask-%s' % x for x in ['mpi', 'remote', 'scheduler', 'ssh', 'submit', 'worker']],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
-
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/d/dask/dask-1.0.0-intel-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/d/dask/dask-1.0.0-intel-2018b-Python-3.6.6.eb
@@ -1,4 +1,4 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'dask'
 version = '1.0.0'
@@ -16,11 +16,7 @@ dependencies = [
     ('bokeh', '1.0.4', versionsuffix),
 ]
 
-exts_defaultclass = 'PythonPackage'
-exts_default_options = {
-    'download_dep_fail': True,
-    'use_pip': True,
-}
+use_pip = True
 
 exts_list = [
     ('toolz', '0.9.0', {
@@ -89,7 +85,5 @@ sanity_check_paths = {
     'files': ['bin/dask-%s' % x for x in ['mpi', 'remote', 'scheduler', 'ssh', 'submit', 'worker']],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
-
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'data'


### PR DESCRIPTION
Parts of dask need bokeh, so added it as a dep. Also added `dask-jobqueue` extension to dask.

And added foss version of it all as that seems to work more stable.