### PR TITLE
fix checking of binutils build dep in easyconfig tests

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -560,7 +560,7 @@ def template_easyconfig_test(self, spec):
         requires_binutils &= bool(ec['sources'] or ec['exts_list'] or ec.get('components'))
 
         if requires_binutils:
-            dep_names = [d['name'] for d in ec['builddependencies']]
+            dep_names = [d['name'] for d in ec.builddependencies()]
             self.assertTrue('binutils' in dep_names, "binutils is a build dep in %s: %s" % (spec, dep_names))
 
     # make sure all patch files are available


### PR DESCRIPTION
When `multi_deps` is involved, we must use the `.builddependencies()` method rather than accessing the `builddependencies` easyconfig parameter directly, to avoid hitting a list of lists of build dependencies, cfr. https://github.com/easybuilders/easybuild-framework/blob/develop/easybuild/framework/easyconfig/easyconfig.py#L888

This will fix the failing test in #7929 (cc @Micket)