### PR TITLE
fix checksum for nlme in R 3.5.* easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
@@ -429,7 +429,7 @@ exts_list = [
         'checksums': ['2723523e8581cc0e2215435ac773033577a16087a3f41d111757dd96b8c5559d'],
     }),
     ('nlme', '3.1-137', {
-        'checksums': ['01049bb9c53826ff4ec5ba7117d766b17a0108c85f80871a5adb0c0b58ef7e87'],
+        'checksums': ['ac82a5d15233dfca2a1aaf9f3ceee018adfe2983344750023dd433ed49b07ba8'],
     }),
     ('minqa', '1.2.4', {
         'checksums': ['cfa193a4a9c55cb08f3faf4ab09c11b70412523767f19894e4eafc6e94cccd0c'],

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b-Python-2.7.15.eb
@@ -397,7 +397,7 @@ exts_list = [
         'checksums': ['41366f777d8adb83d0bdbac1392a1ab118b36217ca648d3bb9db763aa7ff4686'],
     }),
     ('nlme', '3.1-137', {
-        'checksums': ['01049bb9c53826ff4ec5ba7117d766b17a0108c85f80871a5adb0c0b58ef7e87'],
+        'checksums': ['ac82a5d15233dfca2a1aaf9f3ceee018adfe2983344750023dd433ed49b07ba8'],
     }),
     ('mgcv', '1.8-24', {
         'checksums': ['a9f8e9823f6d6a4a568d151f2fa619bb2811df73c013e9a105720d9b32b4740c'],

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
@@ -395,7 +395,7 @@ exts_list = [
         'checksums': ['41366f777d8adb83d0bdbac1392a1ab118b36217ca648d3bb9db763aa7ff4686'],
     }),
     ('nlme', '3.1-137', {
-        'checksums': ['01049bb9c53826ff4ec5ba7117d766b17a0108c85f80871a5adb0c0b58ef7e87'],
+        'checksums': ['ac82a5d15233dfca2a1aaf9f3ceee018adfe2983344750023dd433ed49b07ba8'],
     }),
     ('mgcv', '1.8-24', {
         'checksums': ['a9f8e9823f6d6a4a568d151f2fa619bb2811df73c013e9a105720d9b32b4740c'],


### PR DESCRIPTION
source tarball for https://cran.r-project.org/src/contrib/Archive/nlme/ was replaced in-place, but no real code changes:

```
$ diff -ru nlme.bk nlme
diff -ru nlme.bk/DESCRIPTION nlme/DESCRIPTION
--- nlme.bk/DESCRIPTION	2018-04-07 14:20:47.000000000 +0200
+++ nlme/DESCRIPTION	2018-04-07 14:20:28.000000000 +0200
@@ -33,4 +33,4 @@
   R-core [aut, cre]
 Maintainer: R-core <R-core@R-project.org>
 Repository: CRAN
-Date/Publication: 2018-04-07 12:20:47 UTC
+Date/Publication: 2018-04-07 12:20:28 UTC
diff -ru nlme.bk/MD5 nlme/MD5
--- nlme.bk/MD5	2018-04-07 14:20:47.000000000 +0200
+++ nlme/MD5	2018-04-07 14:20:28.000000000 +0200
@@ -1,5 +1,5 @@
 7d7f0fc1c5268d14ec1ff68056134762 *ChangeLog
-0a665589610bdc521aab8358ba2a96f9 *DESCRIPTION
+e5cbc2946848be223376e91ba52f513c *DESCRIPTION
 c843826752e9f806f255d79801354abb *INDEX
 967bf0c65e5a3f8c94efb6186482ade1 *LICENCE
 8b4f82f521f64516f147a4ba247837ee *NAMESPACE
```