### PR TITLE
also fix checksum for boot 1.3-20 extension in older R easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.4.3-foss-2017b-X11-20171023.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.3-foss-2017b-X11-20171023.eb
@@ -462,7 +462,7 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': ['f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06'],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],

--- a/easybuild/easyconfigs/r/R/R-3.4.3-intel-2017b-X11-20171023.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.3-intel-2017b-X11-20171023.eb
@@ -470,7 +470,7 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': ['f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06'],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],

--- a/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
@@ -489,7 +489,7 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': ['f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06'],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],

--- a/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
@@ -489,7 +489,7 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': ['f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06'],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],

--- a/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
@@ -489,7 +489,7 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': ['f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06'],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],

--- a/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
@@ -552,7 +552,7 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': ['f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06'],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],


### PR DESCRIPTION
We fixed the checksum for boot 1.3-20 in #7814, but only in the R 3.5.x easyconfigs...