### PR TITLE
fix checksums for boot/nlme extensions in R easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.4.3-foss-2017b-X11-20171023.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.3-foss-2017b-X11-20171023.eb
@@ -462,7 +462,7 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': ['f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06'],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],

--- a/easybuild/easyconfigs/r/R/R-3.4.3-intel-2017b-X11-20171023.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.3-intel-2017b-X11-20171023.eb
@@ -470,7 +470,7 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': ['f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06'],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],

--- a/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb
@@ -489,7 +489,7 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': ['f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06'],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],

--- a/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-intel-2018a-X11-20180131.eb
@@ -489,7 +489,7 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': ['f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06'],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],

--- a/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.4.4-iomkl-2018a-X11-20180131.eb
@@ -489,7 +489,7 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': ['f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06'],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],

--- a/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
@@ -429,7 +429,7 @@ exts_list = [
         'checksums': ['2723523e8581cc0e2215435ac773033577a16087a3f41d111757dd96b8c5559d'],
     }),
     ('nlme', '3.1-137', {
-        'checksums': ['01049bb9c53826ff4ec5ba7117d766b17a0108c85f80871a5adb0c0b58ef7e87'],
+        'checksums': ['ac82a5d15233dfca2a1aaf9f3ceee018adfe2983344750023dd433ed49b07ba8'],
     }),
     ('minqa', '1.2.4', {
         'checksums': ['cfa193a4a9c55cb08f3faf4ab09c11b70412523767f19894e4eafc6e94cccd0c'],

--- a/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
@@ -552,7 +552,7 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': ['f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06'],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b-Python-2.7.15.eb
@@ -397,7 +397,7 @@ exts_list = [
         'checksums': ['41366f777d8adb83d0bdbac1392a1ab118b36217ca648d3bb9db763aa7ff4686'],
     }),
     ('nlme', '3.1-137', {
-        'checksums': ['01049bb9c53826ff4ec5ba7117d766b17a0108c85f80871a5adb0c0b58ef7e87'],
+        'checksums': ['ac82a5d15233dfca2a1aaf9f3ceee018adfe2983344750023dd433ed49b07ba8'],
     }),
     ('mgcv', '1.8-24', {
         'checksums': ['a9f8e9823f6d6a4a568d151f2fa619bb2811df73c013e9a105720d9b32b4740c'],

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
@@ -395,7 +395,7 @@ exts_list = [
         'checksums': ['41366f777d8adb83d0bdbac1392a1ab118b36217ca648d3bb9db763aa7ff4686'],
     }),
     ('nlme', '3.1-137', {
-        'checksums': ['01049bb9c53826ff4ec5ba7117d766b17a0108c85f80871a5adb0c0b58ef7e87'],
+        'checksums': ['ac82a5d15233dfca2a1aaf9f3ceee018adfe2983344750023dd433ed49b07ba8'],
     }),
     ('mgcv', '1.8-24', {
         'checksums': ['a9f8e9823f6d6a4a568d151f2fa619bb2811df73c013e9a105720d9b32b4740c'],

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -560,7 +560,7 @@ def template_easyconfig_test(self, spec):
         requires_binutils &= bool(ec['sources'] or ec['exts_list'] or ec.get('components'))
 
         if requires_binutils:
-            dep_names = [d['name'] for d in ec['builddependencies']]
+            dep_names = [d['name'] for d in ec.builddependencies()]
             self.assertTrue('binutils' in dep_names, "binutils is a build dep in %s: %s" % (spec, dep_names))
 
     # make sure all patch files are available


### PR DESCRIPTION
wrapper PR for #8052 and #8053, since both need to combined in order to submit a working test report (with `eb --fetch`) since `R-3.5.0-iomkl-2018a-X11-20180131.eb` is touched in both...