### PR TITLE
{vis}[GCCcore/8.2.0] GTK+ v3.24.8, Gdk-Pixbuf v2.38.1, libepoxy v1.5.3, Pango v1.43.0, HarfBuzz v2.4.0

### DIFF
--- a/easybuild/easyconfigs/g/GTK+/GTK+-3.24.8-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/g/GTK+/GTK+-3.24.8-GCCcore-8.2.0.eb
@@ -1,0 +1,39 @@
+easyblock = 'ConfigureMake'
+
+name = 'GTK+'
+version = '3.24.8'
+
+homepage = 'https://developer.gnome.org/gtk+/stable/'
+description = """
+ The GTK+ 2 package contains libraries used for creating graphical user interfaces for applications.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['666962de9b9768fe9ca785b0e2f42c8b9db3868a12fa9b356b167238d70ac799']
+
+builddependencies = [
+    ('binutils', '2.31.1'),
+    ('GObject-Introspection', '1.60.1', '-Python-3.7.2'),
+    ('gettext', '0.19.8.1'),
+    ('pkg-config', '0.29.2'),
+    ('cairo', '1.16.0'),
+    ('Perl', '5.28.1'),
+]
+
+dependencies = [
+    ('ATK', '2.32.0'),
+    ('at-spi2-atk', '2.32.0'),
+    ('Gdk-Pixbuf', '2.38.1'),
+    ('Pango', '1.43.0'),
+    ('libepoxy', '1.5.3'),
+    ('X11', '20190311'),
+    ('FriBidi', '1.0.5'),
+]
+
+configopts = "--disable-silent-rules --disable-glibtest --enable-introspection=yes --disable-visibility "
+preconfigopts = "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/"
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GTK+/GTK+-3.24.8-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/g/GTK+/GTK+-3.24.8-GCCcore-8.2.0.eb
@@ -34,6 +34,5 @@ dependencies = [
 ]
 
 configopts = "--disable-silent-rules --disable-glibtest --enable-introspection=yes --disable-visibility "
-preconfigopts = "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/"
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.38.1-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.38.1-GCCcore-8.2.0.eb
@@ -1,0 +1,49 @@
+easyblock = 'MesonNinja'
+
+name = 'Gdk-Pixbuf'
+version = '2.38.1'
+
+homepage = 'https://developer.gnome.org/gdk-pixbuf/stable/'
+description = """
+ The Gdk Pixbuf is a toolkit for image loading and pixel buffer manipulation.
+ It is used by GTK+ 2 and GTK+ 3 to load and manipulate images. In the past it
+ was distributed as part of GTK+ 2 but it was split off into a separate package
+ in preparation for the change to GTK+ 3.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+patches = ['Gdk-Pixbuf-%(version)s-post-install-bin.patch']
+checksums = [
+    'f19ff836ba991031610dcc53774e8ca436160f7d981867c8c3a37acfe493ab3a',  # gdk-pixbuf-2.38.1.tar.xz
+    'a7560a9582944a82c5b8a41db9831029f7867616ed2dd0af84edf299c6c7aaa0',  # Gdk-Pixbuf-2.38.1-post-install-bin.patch
+]
+
+builddependencies = [
+    ('Meson', '0.50.0', '-Python-3.7.2'),
+    ('Ninja', '1.9.0'),
+    ('binutils', '2.31.1'),
+    ('GObject-Introspection', '1.60.1', '-Python-3.7.2'),
+]
+dependencies = [
+    ('GLib', '2.60.1'),
+    ('libjpeg-turbo', '2.0.2'),
+    ('libpng', '1.6.36'),
+    ('LibTIFF', '4.0.10'),
+]
+
+configopts = "--buildtype=release --default-library=both "
+configopts += "-Dgio_sniffing=false -Dgir=true "
+
+sanity_check_paths = {
+    'files': ['lib/libgdk_pixbuf-%(version_major)s.0.a', 'lib/libgdk_pixbuf-%%(version_major)s.0.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'include/gdk-pixbuf-%(version_major)s.0', 'lib/gdk-pixbuf-%(version_major)s.0', 'share'],
+}
+
+modextrapaths = {
+    'XDG_DATA_DIRS': 'share',
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.38.1-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.38.1-GCCcore-8.2.0.eb
@@ -18,7 +18,7 @@ sources = [SOURCELOWER_TAR_XZ]
 patches = ['Gdk-Pixbuf-%(version)s-post-install-bin.patch']
 checksums = [
     'f19ff836ba991031610dcc53774e8ca436160f7d981867c8c3a37acfe493ab3a',  # gdk-pixbuf-2.38.1.tar.xz
-    'a7560a9582944a82c5b8a41db9831029f7867616ed2dd0af84edf299c6c7aaa0',  # Gdk-Pixbuf-2.38.1-post-install-bin.patch
+    '4fcbc1ca390405cba34830ef6a28d0de1f68a730aa6aa2b9cba3a9d3ce145350',  # Gdk-Pixbuf-2.38.1-post-install-bin.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.38.1-post-install-bin.patch
+++ b/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.38.1-post-install-bin.patch
@@ -1,0 +1,27 @@
+--- meson.build.orig	2019-03-16 22:39:43.546535740 +0100
++++ meson.build	2019-03-16 22:41:25.341826529 +0100
+@@ -415,6 +415,7 @@
+   else
+     meson.add_install_script('build-aux/post-install.sh',
+       gdk_pixbuf_libdir,
++      gdk_pixbuf_bindir,
+       gdk_pixbuf_binary_version,
+     )
+   endif
+--- build-aux/post-install.sh.orig	2019-03-16 20:25:21.737362740 +0100
++++ build-aux/post-install.sh	2019-03-16 22:37:52.524946556 +0100
+@@ -1,11 +1,12 @@
+ #!/bin/sh
+ 
+ libdir="$1"
+-binary_version="$2"
++bindir="$2"
++binary_version="$3"
+ 
+ if [ -z "$DESTDIR" ]; then
+         mkdir -p "$libdir/gdk-pixbuf-2.0/$binary_version"
+-        gdk-pixbuf-query-loaders > "$libdir/gdk-pixbuf-2.0/$binary_version/loaders.cache"
++        "$bindir/gdk-pixbuf-query-loaders" > "$libdir/gdk-pixbuf-2.0/$binary_version/loaders.cache"
+ else
+         echo "***"
+         echo "*** Warning: loaders.cache not built"

--- a/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.38.1-post-install-bin.patch
+++ b/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.38.1-post-install-bin.patch
@@ -1,3 +1,5 @@
+# Fix postinstall bug where it assumes install prefix is in PATH
+# Mikael Öhman <micketeer@gmail.com>, 2019-04-16
 --- meson.build.orig	2019-03-16 22:39:43.546535740 +0100
 +++ meson.build	2019-03-16 22:41:25.341826529 +0100
 @@ -415,6 +415,7 @@

--- a/easybuild/easyconfigs/h/HarfBuzz/HarfBuzz-2.4.0-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/h/HarfBuzz/HarfBuzz-2.4.0-GCCcore-8.2.0.eb
@@ -1,0 +1,39 @@
+easyblock = 'ConfigureMake'
+
+name = 'HarfBuzz'
+version = '2.4.0'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/HarfBuzz'
+description = """HarfBuzz is an OpenType text shaping engine."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
+
+source_urls = ['http://www.freedesktop.org/software/harfbuzz/release/']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['b470eff9dd5b596edf078596b46a1f83c179449f051a469430afc15869db336f']
+
+builddependencies = [
+    ('binutils', '2.31.1'),
+    ('GObject-Introspection', '1.60.1', '-Python-3.7.2'),
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('GLib', '2.60.1'),
+    ('cairo', '1.16.0'),
+    ('freetype', '2.9.1'),
+]
+
+configopts = "--enable-introspection=yes --with-gobject=yes --enable-static --enable-shared --with-cairo "
+
+modextrapaths = {
+    'GI_TYPELIB_PATH': 'share',
+    'XDG_DATA_DIRS': 'share',
+}
+
+sanity_check_paths = {
+    'files': ['lib/libharfbuzz.%s' % SHLIB_EXT, 'bin/hb-view'],
+    'dirs': []
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libepoxy/libepoxy-1.5.3-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/l/libepoxy/libepoxy-1.5.3-GCCcore-8.2.0.eb
@@ -1,0 +1,34 @@
+easyblock = 'MesonNinja'
+
+name = 'libepoxy'
+version = '1.5.3'
+
+homepage = 'https://github.com/anholt/libepoxy'
+description = "Epoxy is a library for handling OpenGL function pointer management for you"
+
+toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
+
+source_urls = ['https://github.com/anholt/%(name)s/releases/download/%(version)s']
+sources = [SOURCE_TAR_XZ]
+checksums = ['002958c5528321edd53440235d3c44e71b5b1e09b9177e8daf677450b6c4433d']
+
+builddependencies = [
+    ('binutils', '2.31.1'),
+    ('Meson', '0.50.0', '-Python-3.7.2'),
+    ('Ninja', '1.9.0'),
+]
+
+dependencies = [
+    ('X11', '20190311'),
+    ('Mesa', '19.0.1'),
+]
+
+configopts = '-Degl=no --libdir %(installdir)s/lib '
+
+sanity_check_paths = {
+    'files': ['include/epoxy/%s' % x for x in ['common.h', 'gl_generated.h', 'gl.h', 'glx_generated.h', 'glx.h']] +
+             ['lib/libepoxy.%s' % SHLIB_EXT],
+    'dirs': ['lib']
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/Pango/Pango-1.43.0-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/p/Pango/Pango-1.43.0-GCCcore-8.2.0.eb
@@ -1,0 +1,39 @@
+easyblock = 'MesonNinja'
+
+name = 'Pango'
+version = '1.43.0'
+
+homepage = 'http://www.pango.org/'
+description = """Pango is a library for laying out and rendering of text, with an emphasis on internationalization.
+Pango can be used anywhere that text layout is needed, though most of the work on Pango so far has been done in the
+context of the GTK+ widget toolkit. Pango forms the core of text and font handling for GTK+-2.x."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['d2c0c253a5328a0eccb00cdd66ce2c8713fabd2c9836000b6e22a8b06ba3ddd2']
+
+builddependencies = [
+    ('binutils', '2.31.1'),
+    ('Meson', '0.50.0', '-Python-3.7.2'),
+    ('Ninja', '1.9.0'),
+    ('GObject-Introspection', '1.60.1', '-Python-3.7.2'),
+    ('pkg-config', '0.29.2'),
+    ('FriBidi', '1.0.5'),
+]
+
+dependencies = [
+    ('X11', '20190311'),
+    ('GLib', '2.60.1'),
+    ('cairo', '1.16.0'),
+    ('HarfBuzz', '2.4.0'),
+]
+
+configopts = "--buildtype=release --default-library=both "
+
+modextrapaths = {
+    'XDG_DATA_DIRS': 'share',
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
depends on ~~#8079~~ ~~#8080~~ ~~#7947~~ 