### PR TITLE
add singledispatch extension to Python 2.7.15 easyconfig using GCCcore/8.2.0

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-8.2.0.eb
@@ -320,6 +320,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/f/future'],
         'checksums': ['67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8'],
     }),
+    ('singledispatch', '3.4.0.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/singledispatch/'],
+        'checksums': ['5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c'],
+    }),
 ]
 
 moduleclass = 'lang'


### PR DESCRIPTION
https://pypi.org/project/singledispatch is a backport of stuff in Python 3.4 to Python 2.x (and older Python 3.x versions)

It is required for installing `numba` with Python 2.x, but it shouldn't be installed when using Python >= 3.4.

This complicates installing `numba` for both Python 2.7.15 and 3.7.2 via `multi_deps`, especially since the "native" equivalent in `singledispatch` is provided via `functools.singledispatch` (so you can't just check with `import singledispatch` whether it's available already and the installation of it can be skipped)