### PR TITLE
fix source URLs for libcerf 1.7

### DIFF
--- a/easybuild/easyconfigs/l/libcerf/libcerf-1.7-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/l/libcerf/libcerf-1.7-GCCcore-7.3.0.eb
@@ -14,12 +14,9 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = [
-    'http://apps.jcns.fz-juelich.de/src/libcerf/',
-    'http://apps.jcns.fz-juelich.de/src/libcerf/old',
-]
-sources = [SOURCE_TGZ]
-checksums = ['01ddaacaab1e3b120d7480ce518bef02cb658f9728184375f0670a6eb6753da0']
+source_urls = ['https://jugit.fz-juelich.de/mlz/libcerf/-/archive/v%(version)s/']
+sources = ['libcerf-v%(version)s.tar.gz']
+checksums = ['9c5bdd138860eefea72518fef4ab43fde491dccea3cfc450a7a612af7cf55d29']
 
 builddependencies = [
     ('binutils', '2.30'),


### PR DESCRIPTION
checksum is also different because source tarball at new location is not exactly the same:

```
$ diff -ru libcerf-1.7 libcerf-v1.7
Only in libcerf-v1.7: .gitignore
Only in libcerf-1.7/man: pod2htmd.tmp
Only in libcerf-1.7/man: podstyle.css
```