### PR TITLE
temporarily only test with Python 2.6 + Lmod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ matrix:
   fast_finish: true
   include:
     - python: 2.6
-      env: LMOD_VERSION=6.6.3 EASYBUILD_MODULE_SYNTAX=Tcl
+    #  env: LMOD_VERSION=6.6.3 EASYBUILD_MODULE_SYNTAX=Tcl
     # also test default configuration with Python 2.7
-    - python: 2.7
+    #- python: 2.7
       env: LMOD_VERSION=6.6.3
 addons:
   apt:


### PR DESCRIPTION
I would like to temporarily run the easyconfigs test suite with only Python 2.6 + Lmod, to avoid that Travis becomes a bottleneck during the merge sprint we have planned Wed May 8th 2019.

@migueldiascosta Please merge this when you start your day, since you'll be the first... ;)