### PR TITLE
add missing ptyprocess extension in FlexiDot easyconfig

### DIFF
--- a/easybuild/easyconfigs/f/FlexiDot/FlexiDot-1.06-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/f/FlexiDot/FlexiDot-1.06-foss-2018b-Python-2.7.15.eb
@@ -56,12 +56,16 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/c/colour/'],
         'checksums': ['af20120fefd2afede8b001fbef2ea9da70ad7d49fafdb6489025dae8745c3aee'],
     }),
+    ('ptyprocess', '0.6.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/ptyprocess/'],
+        'checksums': ['923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0'],
+    }),
 ]
 
 postinstallcmds = [
     'mv %(installdir)s/code/flexidot_v%(version)s.py %(installdir)s/bin/flexidot.py',
     'chmod +x %(installdir)s/bin/flexidot.py',
-    "sed -i -e 's/\x0D$//' -e '1 s|^.*$|#!/usr/bin/env python|' %(installdir)s/bin/flexidot.py",
+    "sed -i -e '1 s|^.*$|#!/usr/bin/env python|' %(installdir)s/bin/flexidot.py",
 ]
 
 modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}


### PR DESCRIPTION
& avoid use of funky character in 'sed' command which breaks parsing of the easyconfig file

follow-up for #8228