### PR TITLE
prevent LUSCUS from installing it's configuration into $HOME/.luscus

### DIFF
--- a/easybuild/easyconfigs/l/LUSCUS/LUSCUS-0.8.6-foss-2018b.eb
+++ b/easybuild/easyconfigs/l/LUSCUS/LUSCUS-0.8.6-foss-2018b.eb
@@ -10,10 +10,14 @@ toolchain = {'name': 'foss', 'version': '2018b'}
 
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['luscus_%(version)s.tar.gz']
-patches = ['LUSCUS-%(version)s_fix-X11-link.patch']
+patches = [
+    'LUSCUS-%(version)s_fix-X11-link.patch',
+    'LUSCUS-%(version)s_config-dir.patch',
+]
 checksums = [
     'e1bf08de586b6e1c88c22b3d1d9b00a49c227fded7d6dc17023d3e9a84c573a3',  # luscus_0.8.6.tar.gz
     'b4831c00ecb2311738ed236bbbe5307522d9fca90544967186cab342065b8fc7',  # LUSCUS-0.8.6_fix-X11-link.patch
+    'f2abb45185a8b0e2bfb766ee035d8e250a3f9b1cb5261da60e3514504de7a490',  # LUSCUS-0.8.6_config-dir.patch
 ]
 
 builddependencies = [
@@ -29,7 +33,9 @@ dependencies = [
 
 sanity_check_paths = {
     'files': ['bin/luscus'],
-    'dirs': [],
+    'dirs': ['config'],
 }
+
+modextravars = {'LUSCUS_DIR': '%(installdir)s/config'}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/LUSCUS/LUSCUS-0.8.6-intel-2018a.eb
+++ b/easybuild/easyconfigs/l/LUSCUS/LUSCUS-0.8.6-intel-2018a.eb
@@ -10,10 +10,14 @@ toolchain = {'name': 'intel', 'version': '2018a'}
 
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['luscus_%(version)s.tar.gz']
-patches = ['LUSCUS-%(version)s_fix-X11-link.patch']
+patches = [
+    'LUSCUS-%(version)s_fix-X11-link.patch',
+    'LUSCUS-%(version)s_config-dir.patch',
+]
 checksums = [
     'e1bf08de586b6e1c88c22b3d1d9b00a49c227fded7d6dc17023d3e9a84c573a3',  # luscus_0.8.6.tar.gz
     'b4831c00ecb2311738ed236bbbe5307522d9fca90544967186cab342065b8fc7',  # LUSCUS-0.8.6_fix-X11-link.patch
+    'f2abb45185a8b0e2bfb766ee035d8e250a3f9b1cb5261da60e3514504de7a490',  # LUSCUS-0.8.6_config-dir.patch
 ]
 
 builddependencies = [
@@ -29,7 +33,9 @@ dependencies = [
 
 sanity_check_paths = {
     'files': ['bin/luscus'],
-    'dirs': [],
+    'dirs': ['config'],
 }
+
+modextravars = {'LUSCUS_DIR': '%(installdir)s/config'}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/LUSCUS/LUSCUS-0.8.6_config-dir.patch
+++ b/easybuild/easyconfigs/l/LUSCUS/LUSCUS-0.8.6_config-dir.patch
@@ -1,0 +1,13 @@
+change hardcoded $HOME/.luscus path to config subdir of installation ($LUSCUS_DIR should be set to point there)
+author: Kenneth Hoste (HPC-UGent)
+--- luscus_0.8.6/CMakeLists.txt.orig	2019-05-09 20:54:35.712120873 +0200
++++ luscus_0.8.6/CMakeLists.txt	2019-05-09 20:55:06.922437408 +0200
+@@ -31,7 +31,7 @@
+     set(CONFIG_DIR "/etc/luscus")
+ #    message(status " CMAKE_PREFIX_PATH NOT DEFINED!")    # DEBUG
+   else ()
+-    set(CONFIG_DIR "$ENV{HOME}/.luscus")
++    set(CONFIG_DIR "${CMAKE_INSTALL_PREFIX}/config")
+ #    message(status " CMAKE_PREFIX_PATH DEFINED!")        # DEBUG
+   endif ()
+   set(TMP_CONFIG_DIR ${CMAKE_CURRENT_BINARY_DIR}/luscusrc)


### PR DESCRIPTION
I couldn't find another way than using a patch file, the `$HOME/.luscus` is hardwired, no way to override it using an option to `cmake`...