### PR TITLE
Old style exceptions are syntax errors in Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ try:
     log.info("Installing with setuptools.setup...")
     install_package = 'setuptools'
 
-except ImportError, err:
+except ImportError as err:
     log.info("Failed to import setuptools.setup (%s), so falling back to distutils.setup" % err)
     from distutils.core import setup
     install_package = 'distutils'


### PR DESCRIPTION
Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.