### PR TITLE
{math}[dummy/dummy] Mathematica v12.0.0

### DIFF
--- a/easybuild/easyconfigs/m/Mathematica/Mathematica-12.0.0.eb
+++ b/easybuild/easyconfigs/m/Mathematica/Mathematica-12.0.0.eb
@@ -1,0 +1,17 @@
+name = 'Mathematica'
+version = '12.0.0'
+
+homepage = 'http://www.wolfram.com/mathematica'
+description = """Mathematica is a computational software program used in many scientific, engineering, mathematical
+and computing fields."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = ['Mathematica_%(version)s_LINUX.sh']
+checksums = ['b9fb71e1afcc1d72c200196ffa434512d208fa2920e207878433f504e58ae9d7']
+
+license_server = 'license.example.com'
+
+sanity_check_commands = [('mathematica', '--version')]
+
+moduleclass = 'math'


### PR DESCRIPTION
new Mathematica is out since m04 so it's time to give it to $users.
based entirely on previous easyconfig, just url and sha256sum updated.

[some wording from vendor](https://blog.stephenwolfram.com/2019/04/version-12-launches-today-big-jump-for-wolfram-language-and-mathematica/)

(created using `eb --new-pr`)