### PR TITLE
set $XDG_CACHE_HOME to $TMPDIR before 'pip install' in Arrow 0.12.0 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/a/Arrow/Arrow-0.12.0-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/a/Arrow/Arrow-0.12.0-intel-2018b-Python-2.7.15.eb
@@ -55,7 +55,7 @@ exts_list = [
 install_pyarrow_cmds = "export PKG_CONFIG_PATH=%(installdir)s/lib/pkgconfig:$PKG_CONFIG_PATH && "
 install_pyarrow_cmds += "export PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH && "
 install_pyarrow_cmds += " cd %(builddir)s/*arrow-%(version)s/python && "
-install_pyarrow_cmds += " pip install --prefix %(installdir)s ."
+install_pyarrow_cmds += " export XDG_CACHE_HOME=$TMPDIR && pip install --prefix %(installdir)s ."
 postinstallcmds = [install_pyarrow_cmds]
 
 modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}

--- a/easybuild/easyconfigs/a/Arrow/Arrow-0.12.0-intel-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/a/Arrow/Arrow-0.12.0-intel-2018b-Python-3.6.6.eb
@@ -40,7 +40,7 @@ configopts = "-DCMAKE_BUILD_TYPE=Release -DARROW_PYTHON=on -DCMAKE_INSTALL_LIBDI
 install_pyarrow_cmds = "export PKG_CONFIG_PATH=%(installdir)s/lib/pkgconfig:$PKG_CONFIG_PATH && "
 install_pyarrow_cmds += "export PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH && "
 install_pyarrow_cmds += " cd %(builddir)s/*arrow-%(version)s/python && "
-install_pyarrow_cmds += " pip install --prefix %(installdir)s ."
+install_pyarrow_cmds += " export XDG_CACHE_HOME=$TMPDIR && pip install --prefix %(installdir)s ."
 postinstallcmds = [install_pyarrow_cmds]
 
 modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}


### PR DESCRIPTION
That way, `pip install` does not abuse `$HOME/.cache/pip`...