### PR TITLE
use CMake rather than configure script for libxc 4.3.4

### DIFF
--- a/easybuild/easyconfigs/l/libxc/libxc-4.3.4-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.3.4-GCC-8.2.0-2.31.1.eb
@@ -1,4 +1,4 @@
-easyblock = 'ConfigureMake'
+easyblock = 'CMakeMake'
 
 name = 'libxc'
 version = '4.3.4'
@@ -11,15 +11,33 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
 sources = [SOURCE_TAR_GZ]
-checksums = ['a8ee37ddc5079339854bd313272856c9d41a27802472ee9ae44b58ee9a298337']
+patches = ['libxc-%(version)s_lm-fix.patch']
+checksums = [
+    'a8ee37ddc5079339854bd313272856c9d41a27802472ee9ae44b58ee9a298337',  # libxc-4.3.4.tar.gz
+    'f2cae17533d3527e11cfec958a7f253872f7c5fcd104c3cffc02382be0ccfb9c',  # libxc-4.3.4_lm-fix.patch
+]
 
-configopts = '--enable-static --enable-shared --enable-fortran'
+builddependencies = [
+    ('CMake', '3.13.3'),
+    ('Perl', '5.28.1'),
+]
 
-runtest = 'check'
+separate_build_dir = True
+
+common_configopts = "-DENABLE_FORTRAN=ON -DENABLE_FORTRAN03=ON -DENABLE_XHOST=OFF"
+
+# perform iterative build to get both static and shared libraries
+configopts = [
+    common_configopts + ' -DBUILD_SHARED_LIBS=OFF',
+    common_configopts + ' -DBUILD_SHARED_LIBS=ON',
+]
+
+runtest = 'test'
 
 sanity_check_paths = {
-    'files': ['lib/libxc%s.%s' % (x, y) for x in ['', 'f90'] for y in ['a', SHLIB_EXT]],
-    'dirs': ['include'],
+    'files': ['bin/xc-info', 'bin/xc-threshold'] +
+             ['lib/libxc%s.%s' % (x, y) for x in ['', 'f03', 'f90'] for y in ['a', SHLIB_EXT]],
+    'dirs': ['include', 'lib/pkgconfig', 'share/cmake/Libxc'],
 }
 
 parallel = 1

--- a/easybuild/easyconfigs/l/libxc/libxc-4.3.4-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.3.4-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
@@ -1,4 +1,4 @@
-easyblock = 'ConfigureMake'
+easyblock = 'CMakeMake'
 
 name = 'libxc'
 version = '4.3.4'
@@ -11,17 +11,39 @@ toolchain = {'name': 'iccifort', 'version': '2019.1.144-GCC-8.2.0-2.31.1'}
 
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
 sources = [SOURCE_TAR_GZ]
-checksums = ['a8ee37ddc5079339854bd313272856c9d41a27802472ee9ae44b58ee9a298337']
+patches = ['libxc-%(version)s_rename-F03.patch']
+checksums = [
+    'a8ee37ddc5079339854bd313272856c9d41a27802472ee9ae44b58ee9a298337',  # libxc-4.3.4.tar.gz
+    'e494be3ca2026998f2dd7c6b03a4e662f204fd3d963271e588f9f0d5739e76b5',  # libxc-4.3.4_rename-F03.patch
+]
 
-configopts = '--enable-static --enable-shared --enable-fortran'
+builddependencies = [
+    ('CMake', '3.13.3'),
+    ('Perl', '5.28.1'),
+]
 
-runtest = 'check'
+separate_build_dir = True
 
-sanity_check_paths = {
-    'files': ['lib/libxc%s.%s' % (x, y) for x in ['', 'f90'] for y in ['a', SHLIB_EXT]],
-    'dirs': ['include'],
-}
+# rename *.F03 source file since Intel Fortran compiler doesn't like that extension
+# also requires patch file to rename file in CMakeLists.txt and src/Makefile.in
+preconfigopts = "mv ../libxc-%(version)s/src/libxc_master.F03 ../libxc-%(version)s/src/libxc_master_F03.F90 && "
+
+common_configopts = "-DENABLE_FORTRAN=ON -DENABLE_FORTRAN03=ON -DENABLE_XHOST=OFF"
+
+# perform iterative build to get both static and shared libraries
+configopts = [
+    common_configopts + ' -DBUILD_SHARED_LIBS=OFF',
+    common_configopts + ' -DBUILD_SHARED_LIBS=ON',
+]
 
 parallel = 1
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['bin/xc-info', 'bin/xc-threshold'] +
+             ['lib/libxc%s.%s' % (x, y) for x in ['', 'f03', 'f90'] for y in ['a', SHLIB_EXT]],
+    'dirs': ['include', 'lib/pkgconfig', 'share/cmake/Libxc'],
+}
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/libxc/libxc-4.3.4_lm-fix.patch
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.3.4_lm-fix.patch
@@ -1,0 +1,14 @@
+make sure that -lm is included when linking libxc executables
+cfr. https://gitlab.com/libxc/libxc/issues/93
+author: Kenneth Hoste (HPC-UGent)
+--- libxc-4.3.4/CMakeLists.txt.orig	2019-05-21 14:17:21.491272049 +0200
++++ libxc-4.3.4/CMakeLists.txt	2019-05-21 14:16:34.301597402 +0200
+@@ -38,7 +38,7 @@
+ set(PN ${PROJECT_NAME})
+ 
+ # link -lm only if necessary
+-find_package(StandardMathLibraryC)
++set(STANDARD_MATH_LIBRARY "m") #find_package(StandardMathLibraryC)
+ # check if cbrt exists and declare HAVE_CBRT if it does
+ check_c_source_compiles (
+   "#include <math.h>

--- a/easybuild/easyconfigs/l/libxc/libxc-4.3.4_rename-F03.patch
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.3.4_rename-F03.patch
@@ -1,0 +1,37 @@
+rename libxc_master.F03 to libxc_master_F03.F90, since Intel Fortran compiler doesn't like *.F03 files
+cfr. https://gitlab.com/libxc/libxc/issues/85
+requires that libxc_master.F03 is renamed to libxc_master_F03.F90 via 'preconfigopts' in easyconfig file
+author: Kenneth Hoste (HPC-UGent)
+--- libxc-4.3.4/src/Makefile.in.orig	2019-03-05 00:43:32.000000000 +0100
++++ libxc-4.3.4/src/Makefile.in	2019-05-21 17:56:25.140868203 +0200
+@@ -611,7 +611,7 @@
+ 	string_f.h references.h util.h work_lda.c \
+ 	work_gga_x.c work_gga_c.c \
+ 	work_mgga_x.c work_mgga_c.c \
+-	libxc_master.F90 libxc_master.F03
++	libxc_master.F90 libxc_master_F03.F90
+ 
+ include_HEADERS = xc.h xc_funcs_removed.h
+ nodist_include_HEADERS = xc_funcs.h
+@@ -1453,8 +1453,8 @@
+ $(LTPREF)libxc.lo   $(LTPREF)libxc.o   : $(LIBFUNCMOD)
+ 
+ $(XCLIBMODS)   : $(LTPREF)libxc.lo
+-libxcf03.f90 : libxc_master.F03 libxc_inc.f03
+-	@FCCPP@ @CPPFLAGS@ $(AM_CPPFLAGS) -I$(top_builddir)/src $(srcdir)/libxc_master.F03 > $(top_builddir)/src/libxcf03.f90
++libxcf03.f90 : libxc_master_F03.F90 libxc_inc.f03
++	@FCCPP@ @CPPFLAGS@ $(AM_CPPFLAGS) -I$(top_builddir)/src $(srcdir)/libxc_master_F03.F90 > $(top_builddir)/src/libxcf03.f90
+ 	@if [ "@F90_ACCEPTS_LINE_NUMBERS@" = "no" ]; then \
+ 		grep -v "^#" $(top_builddir)/src/libxcf03.f90 > $(top_builddir)/src/libxcf03.f91; \
+ 		mv -f $(top_builddir)/src/libxcf03.f91 $(top_builddir)/src/libxcf03.f90; \
+--- libxc-4.3.4/CMakeLists.txt.orig	2019-05-21 18:04:02.978334306 +0200
++++ libxc-4.3.4/CMakeLists.txt	2019-05-21 18:04:34.308604175 +0200
+@@ -296,7 +296,7 @@
+     gen_funcidx/libxc_funcs.f90
+ )
+ set(raw_sources_list_f03
+-    src/libxc_master.F03
++    src/libxc_master_F03.F90
+ )
+ 
+ # when headers namespaced, xc_version include in xc.h needs to be local, not


### PR DESCRIPTION
Using CMake is important to also get the CMake-related scripts in `share/cmake/libxc` installed, which are required to use `libxc` as a dependency for PSI4 (rather than letting it build its own (old & unpatched) version of `libxc`).