### PR TITLE
remove unused checksum for ballgown extension in Bioconductor 3.7 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.7-foss-2018b-R-3.5.1.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.7-foss-2018b-R-3.5.1.eb
@@ -427,7 +427,6 @@ exts_list = [
         'checksums': ['5a142ac9faa2ffbf1030b4e5db7963d8038214abd7e1296dee325c09fec27228'],
     }),
     ('ballgown', '2.12.0', {
-        'checksum': ['3e9d90b9f345d122824260c588d1d36a602a525a9daa1826190193d8c24ba483'],
         'checksums': ['782a9760d27bb529238b1ecd3fa2f2c0f364ba8f861d7fad54bd127e2935a6d2'],
     }),
     ('DropletUtils', '1.0.3', {

--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.7-iomkl-2018a-R-3.5.0.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.7-iomkl-2018a-R-3.5.0.eb
@@ -434,7 +434,6 @@ exts_list = [
         'checksums': ['5a142ac9faa2ffbf1030b4e5db7963d8038214abd7e1296dee325c09fec27228'],
     }),
     ('ballgown', '2.12.0', {
-        'checksum': ['3e9d90b9f345d122824260c588d1d36a602a525a9daa1826190193d8c24ba483'],
         'checksums': ['782a9760d27bb529238b1ecd3fa2f2c0f364ba8f861d7fad54bd127e2935a6d2'],
     }),
 ]


### PR DESCRIPTION
The `'checksum'` entry serves no purpose and is just being ignored, the actual correct checksum is specified via `'checksums'`...