### PR TITLE
fix parsing IntelPython and NBO 7.0 easyconfigs when running EasyBuild on top of Python 3

### DIFF
--- a/easybuild/easyconfigs/i/IntelPython/IntelPython-2.7.15-2019.2.066.eb
+++ b/easybuild/easyconfigs/i/IntelPython/IntelPython-2.7.15-2019.2.066.eb
@@ -4,7 +4,6 @@ easyblock = 'Binary'
 
 name = 'IntelPython'
 version = '2.7.15'
-pysver = version[0]
 relver = '2019.2.066'
 versionsuffix = '-%s' % relver
 
@@ -16,7 +15,7 @@ description = """
 """
 
 source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15115/']
-sources = ['l_pythoni%s_p_%s.tar.gz' % (pysver, relver)]
+sources = ['l_pythoni%%(version_major)s_p_%s.tar.gz' % relver]
 checksums = ['dd0b73db5d0d79c3cdf779d10092eae32780d720b74ed8fde2a2c46e23143de1']
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
@@ -28,14 +27,14 @@ extract_sources = True
 install_cmd = "./setup_intel_python.sh"
 
 sanity_check_paths = {
-    'dirs': ['intelpython%s/%s' % (pysver, x) for x in ['bin', 'etc', 'include', 'lib']],
-    'files': ['intelpython%s/bin/ipython' % pysver],
+    'dirs': ['intelpython%%(version_major)s/%s' % x for x in ['bin', 'etc', 'include', 'lib']],
+    'files': ['intelpython%(version_major)s/bin/ipython'],
 }
 
 modextrapaths = {
-    'CONDA_PREFIX': 'intelpython%s' % pysver,
-    'PATH': 'intelpython%s/bin' % pysver,
-    'LD_LIBRARY_PATH': 'intelpython%s/lib' % pysver,
+    'CONDA_PREFIX': 'intelpython%(version_major)s',
+    'PATH': 'intelpython%(version_major)s/bin',
+    'LD_LIBRARY_PATH': 'intelpython%(version_major)s/lib',
 }
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/i/IntelPython/IntelPython-3.6.8-2019.2.066.eb
+++ b/easybuild/easyconfigs/i/IntelPython/IntelPython-3.6.8-2019.2.066.eb
@@ -4,7 +4,6 @@ easyblock = 'Binary'
 
 name = 'IntelPython'
 version = '3.6.8'
-pysver = version[0]
 relver = '2019.2.066'
 versionsuffix = '-%s' % relver
 
@@ -16,7 +15,7 @@ description = """
 """
 
 source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15115/']
-sources = ['l_pythoni%s_p_%s.tar.gz' % (pysver, relver)]
+sources = ['l_pythoni%%(version_major)s_p_%s.tar.gz' % relver]
 checksums = ['804883fc1413ee72b0ae421a8ac82ab158fc01c8b4631a44a9d2ef1a19324751']
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
@@ -28,14 +27,14 @@ extract_sources = True
 install_cmd = "./setup_intel_python.sh"
 
 sanity_check_paths = {
-    'dirs': ['intelpython%s/%s' % (pysver, x) for x in ['bin', 'etc', 'include', 'lib']],
-    'files': ['intelpython%s/bin/ipython' % pysver],
+    'dirs': ['intelpython%%(version_major)s/%s' % x for x in ['bin', 'etc', 'include', 'lib']],
+    'files': ['intelpython%(version_major)s/bin/ipython'],
 }
 
 modextrapaths = {
-    'CONDA_PREFIX': 'intelpython%s' % pysver,
-    'PATH': 'intelpython%s/bin' % pysver,
-    'LD_LIBRARY_PATH': 'intelpython%s/lib' % pysver,
+    'CONDA_PREFIX': 'intelpython%(version_major)s',
+    'PATH': 'intelpython%(version_major)s/bin',
+    'LD_LIBRARY_PATH': 'intelpython%(version_major)s/lib',
 }
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/n/NBO/NBO-7.0-intel-2017b.eb
+++ b/easybuild/easyconfigs/n/NBO/NBO-7.0-intel-2017b.eb
@@ -37,7 +37,7 @@ postinstallcmds = [
 ]
 
 sanity_check_paths = {
-    'files': ['bin/%s.%s.exe' % (x, intlength) for x in ('gennbo', 'g09nbo', 'g16nbo', 'nbo7')],
+    'files': ['bin/%s.i8.exe' % x for x in ('gennbo', 'g09nbo', 'g16nbo', 'nbo7')],
     'dirs': [],
 }
 


### PR DESCRIPTION
Local variables can't be used in list comprehensions in Python 3.x

Fixes problems like:

```
ERROR: test__parse_easyconfig_IntelPython-2.7.15-2019.2.066.eb (test.easyconfigs.easyconfigs.EasyConfigTest)
Test for parsing of easyconfig IntelPython-2.7.15-2019.2.066.eb
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/easybuild_framework-4.0.0.dev0-py3.6.egg/easybuild/framework/easyconfig/format/pyheaderconfigobj.py", line 187, in parse_pyheader
    exec(pyheader, global_vars, local_vars)
  File "<string>", line 29, in <module>
  File "<string>", line 29, in <listcomp>
NameError: name 'pysver' is not defined
```

and

```
ERROR: test__parse_easyconfig_NBO-7.0-intel-2017b.eb (test.easyconfigs.easyconfigs.EasyConfigTest)
Test for parsing of easyconfig NBO-7.0-intel-2017b.eb
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/easybuild_framework-4.0.0.dev0-py3.6.egg/easybuild/framework/easyconfig/format/pyheaderconfigobj.py", line 187, in parse_pyheader
    exec(pyheader, global_vars, local_vars)
  File "<string>", line 38, in <module>
  File "<string>", line 38, in <listcomp>
NameError: name 'intlength' is not defined
```

This is clearly going to be a pain in the butt when running EasyBuild on top of Python 3.x...
Maybe we can fix this in the EasyBuild framework somehow, but I'm not sure.