### PR TITLE
add Logger::Simple, Scalar::Util::Numeric, YAML, Object::InsideOut extensions to Perl 5.28.1 easyconfig

### DIFF
--- a/easybuild/easyconfigs/p/Perl/Perl-5.28.1-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.28.1-GCCcore-8.2.0.eb
@@ -1475,6 +1475,21 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/Y/YA/YANICK/'],
         'checksums': ['c1b2970a8bb666c3de7caac4a8f4dbcc043ab819bbc337692ec7bf27adae4404'],
     }),
+    ('Logger::Simple', '2.0', {
+        'source_tmpl': 'Logger-Simple-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TS/TSTANLEY/'],
+        'checksums': ['2e63fd3508775b5902132ba1bfb03b42bee468dfaf35dfe42e1909ff6d291b2d'],
+    }),
+    ('Scalar::Util::Numeric', '0.40', {
+        'source_tmpl': 'Scalar-Util-Numeric-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/C/CH/CHOCOLATE/'],
+        'checksums': ['d7501b6d410703db5b1c1942fbfc41af8964a35525d7f766058acf5ca2cc4440'],
+    }),
+    ('YAML', '1.29', {
+        'source_tmpl': 'YAML-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TI/TINITA/'],
+        'checksums': ['9c5c57389c31fa1d863ae9235ca6d694b364c741df7856105b54aa96b7d6853e'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.28.1-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.28.1-GCCcore-8.2.0.eb
@@ -1490,6 +1490,11 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/T/TI/TINITA/'],
         'checksums': ['9c5c57389c31fa1d863ae9235ca6d694b364c741df7856105b54aa96b7d6853e'],
     }),
+    ('Object::InsideOut', '4.05', {
+        'source_tmpl': 'Object-InsideOut-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JD/JDHEDDEN/'],
+        'checksums': ['9dfd6ca2822724347e0eb6759d00709425814703ad5c66bdb6214579868bcac4'],
+    }),
 ]
 
 moduleclass = 'lang'


### PR DESCRIPTION
extra Perl modules required for `BRAKER`, cfr. https://github.com/Gaius-Augustus/BRAKER#perl-pipeline-dependencies