### PR TITLE
move BLAST+ 2.9.0 from foss/2019a to gompi/2019a subtoolchain

### DIFF
--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.9.0-gompi-2019a.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.9.0-gompi-2019a.eb
@@ -20,12 +20,12 @@ description = """Basic Local Alignment Search Tool, or BLAST, is an algorithm
  for comparing primary biological sequence information, such as the amino-acid
  sequences of different proteins or the nucleotides of DNA sequences."""
 
-toolchain = {'name': 'foss', 'version': '2019a'}
+toolchain = {'name': 'gompi', 'version': '2019a'}
 toolchainopts = {'usempi': True}
 
 source_urls = ['http://ftp.ncbi.nlm.nih.gov/blast/executables/%(namelower)s/%(version)s/']
 sources = ['ncbi-blast-%(version)s+-src.tar.gz']
-patches = ['BLAST+-2.9.0_fix_boost.patch']
+patches = ['BLAST+-%(version)s_fix_boost.patch']
 checksums = [
     'a390cc2d7a09422759fc178db84de9def822cbe485916bbb2ec0d215dacdc257',  # ncbi-blast-2.9.0+-src.tar.gz
     '44dc4a931896953d78c13097433ea6fc8d7990bd759c4e4e5bbb9b2574fb4154',  # BLAST+-2.9.0_fix_boost.patch


### PR DESCRIPTION
follow-up for #8375