### PR TITLE
fix undefined reference error in CP2K due to libxc 4.3.4 built with CMake

### DIFF
--- a/easybuild/easyconfigs/l/libxc/libxc-4.3.4-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.3.4-GCC-8.2.0-2.31.1.eb
@@ -11,10 +11,14 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
 sources = [SOURCE_TAR_GZ]
-patches = ['libxc-%(version)s_lm-fix.patch']
+patches = [
+    'libxc-%(version)s_lm-fix.patch',
+    'libxc-%(version)s_fix-CMakeLists.patch',
+]
 checksums = [
     'a8ee37ddc5079339854bd313272856c9d41a27802472ee9ae44b58ee9a298337',  # libxc-4.3.4.tar.gz
     'f2cae17533d3527e11cfec958a7f253872f7c5fcd104c3cffc02382be0ccfb9c',  # libxc-4.3.4_lm-fix.patch
+    '5a5e7d69729326e0d44e60b554ba6d8650a28958ec54b27a98757dc78a040946',  # libxc-4.3.4_fix-CMakeLists.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/l/libxc/libxc-4.3.4_fix-CMakeLists.patch
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.3.4_fix-CMakeLists.patch
@@ -1,0 +1,13 @@
+add missing func_reference.c to raw_sources_list in CMakeLists.txt
+fixes "error: undefined reference to 'xc_func_reference_get_ref'"
+cfr. https://gitlab.com/libxc/libxc/issues/91 + https://gitlab.com/libxc/libxc/merge_requests/165
+--- libxc-4.3.4/CMakeLists.txt.orig	2019-06-07 11:47:56.377984881 +0200
++++ libxc-4.3.4/CMakeLists.txt	2019-06-07 11:48:17.508415975 +0200
+@@ -77,6 +77,7 @@
+ bessel.c
+ expint_e1.c
+ func_info.c
++func_reference.c
+ functionals.c
+ gga.c
+ gga_c_am05.c


### PR DESCRIPTION
installation of `CP2K-6.1-foss-2019a.eb` got broken due to changes in #8361