### PR TITLE
new easyconfig for CFITSIO-3.47, updating CFITSIO-3.45 with https and sanity check

### DIFF
--- a/easybuild/easyconfigs/c/CFITSIO/CFITSIO-3.47-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/c/CFITSIO/CFITSIO-3.47-GCCcore-8.2.0.eb
@@ -1,31 +1,31 @@
 easyblock = 'ConfigureMake'
 
 name = 'CFITSIO'
-version = '3.45'
+version = '3.47'
 
 homepage = 'https://heasarc.gsfc.nasa.gov/fitsio/'
 description = """CFITSIO is a library of C and Fortran subroutines for reading and writing data files in
 FITS (Flexible Image Transport System) data format."""
 
-toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 toolchainopts = {'pic': True}
 
-srcversion = '%s0' % version.replace('.', '')
+sources = ['%%(namelower)s-%s.tar.gz' % version]
 source_urls = ['https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/']
-sources = ['%%(namelower)s%s.tar.gz' % srcversion]
+
 patches = ['CFITSIO_install_test_data.patch']
 
 checksums = [
-    'bf6012dbe668ecb22c399c4b7b2814557ee282c74a7d5dc704eb17c30d9fb92e',  # cfitsio3450.tar.gz
+    '418516f10ee1e0f1b520926eeca6b77ce639bed88804c7c545e74f26b3edf4ef',  # cfitsio-3.47.tar.gz
     'e7b99d380976e2695f524254add38298c35117d152d67be36f105c3cb57e4375',  # CFITSIO_install_test_data.patch
 ]
 
 # curl for HTTPs support
-dependencies = [('cURL', '7.60.0')]
+dependencies = [('cURL', '7.63.0')]
 
-builddependencies = [('binutils', '2.30')]
+builddependencies = [('binutils', '2.31.1')]
 
-# make would create just static libcfitsio.a.
+# make would create just static libcfitsio.a. 
 # Let's create dynamic lib and testprog too.
 buildopts = '&& make shared && make testprog'
 
@@ -33,7 +33,7 @@ sanity_check_paths = {
     'files': [
         'lib/libcfitsio.a',
         'lib/libcfitsio.so',
-        'lib/libcfitsio.so.7.%(version)s'
+        'lib/libcfitsio.so.8.%(version)s'
     ],
     'dirs': ['include'],
 }

--- a/easybuild/easyconfigs/c/CFITSIO/CFITSIO_install_test_data.patch
+++ b/easybuild/easyconfigs/c/CFITSIO/CFITSIO_install_test_data.patch
@@ -1,0 +1,26 @@
+part of CFITSIO installation is "testprog".
+Let's copy its data (testprog.tpt) into ${installdir}/share to be able use it as sanity_check_program.
+Josef Dvoracek | Institute of Physics | Czech Academy of Sciences | 2019-06-10
+
+diff -Nru cfitsio-3.47.orig/Makefile.in cfitsio-3.47/Makefile.in
+--- cfitsio-3.47.orig/Makefile.in	2019-06-10 15:58:05.551356000 +0200
++++ cfitsio-3.47/Makefile.in	2019-06-10 16:02:17.683505000 +0200
+@@ -30,7 +30,9 @@
+ CFITSIO_BIN	= ${DESTDIR}@bindir@
+ CFITSIO_LIB	= ${DESTDIR}@libdir@
+ CFITSIO_INCLUDE	= ${DESTDIR}@includedir@
+-INSTALL_DIRS	= @INSTALL_ROOT@ ${CFITSIO_INCLUDE} ${CFITSIO_LIB} ${CFITSIO_LIB}/pkgconfig
++CFITSIO_DATADIR = ${DESTDIR}@datadir@
++
++INSTALL_DIRS	= @INSTALL_ROOT@ ${CFITSIO_INCLUDE} ${CFITSIO_LIB} ${CFITSIO_LIB}/pkgconfig ${CFITSIO_DATADIR}
+ 
+ 
+ SHELL =		/bin/sh
+@@ -118,6 +120,7 @@
+ 		    fi; \
+ 		done
+ 		/bin/cp fitsio.h fitsio2.h longnam.h drvrsmem.h ${CFITSIO_INCLUDE}
++		/bin/cp testprog.tpt ${CFITSIO_DATADIR}
+ 		/bin/cp cfitsio.pc ${CFITSIO_LIB}/pkgconfig
+ 		@for task in ${FPACK_UTILS} ${UTILS}; do \
+ 		    if [ -f $$task ]; then \


### PR DESCRIPTION
let's make easyconfig for recent CFITSIO with current GCCcore toolchain.

new sanity check implemented using `testprog` from source tarball and backported into older `CFITSIO-3.45` which is still used by my $users.

(created using `eb --new-pr`)