### PR TITLE
{lib}[GCCcore/8.2.0] LibUUID v1.0.3

### DIFF
--- a/easybuild/easyconfigs/l/LibUUID/LibUUID-1.0.3-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/l/LibUUID/LibUUID-1.0.3-GCCcore-8.2.0.eb
@@ -1,0 +1,40 @@
+easyblock = 'ConfigureMake'
+
+name = 'LibUUID'
+version = '1.0.3'
+
+homepage = 'http://sourceforge.net/projects/libuuid/'
+
+description = """Portable uuid C library"""
+
+toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
+
+source_urls = [
+    SOURCEFORGE_SOURCE,
+    'https://raw.githubusercontent.com/karelzak/util-linux/stable/v2.32/libuuid/src',
+]
+sources = [
+    SOURCELOWER_TAR_GZ,
+    {'filename': 'libuuid.sym', 'extract_cmd': 'cp %s %(builddir)s'},
+]
+checksums = [
+    '46af3275291091009ad7f1b899de3d0cea0252737550e7919d17237997db5644',  # libuuid-1.0.3.tar.gz
+    '5932866797560bf5822c3340b64dff514afb6cef23a824f96991f8e9e9d29028',  # libuuid.sym
+]
+
+builddependencies = [
+    ('binutils', '2.31.1'),
+]
+
+preconfigopts = 'LDFLAGS="$LDFLAGS -Wl,--version-script=%(builddir)s/libuuid.sym"'
+
+sanity_check_paths = {
+    'files': [
+        'include/uuid/uuid.h',
+        'lib/libuuid.a',
+        'lib/libuuid.%s' % SHLIB_EXT
+    ],
+    'dirs': [],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
just shifting GCCcore toolchain version to 8.2.0

(created using `eb --new-pr`)