### PR TITLE
stick to Ubuntu Trusty when testing with Python 2.6 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ matrix:
   # mark build as finished as soon as job has failed
   fast_finish: true
   include:
-    - python: 2.6
+    - dist: trusty
+      python: 2.6
       env: LMOD_VERSION=6.6.3 EASYBUILD_MODULE_SYNTAX=Tcl
     # also test default configuration with Python 2.7
     - python: 2.7


### PR DESCRIPTION
This change is necessary because Travis CI is changing the default from Ubuntu Trusty (14.04) to Ubuntu Xenial (16.04), see also https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment .

Should fix following issue that occurs when running the easyconfig test suite with Python 2.6:

```
2.6 is not installed; attempting download
Downloading archive: https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64/python-2.6.tar.bz2
0.11s$ curl -sSf -o python-2.6.tar.bz2 ${archive_url}
curl: (22) The requested URL returned error: 404 Not Found
Unable to download 2.6 archive. The archive may not exist. Please consider a different version.
```