### PR TITLE
GDB: Suppress installation of libbfd and libopcode

### DIFF
--- a/easybuild/easyconfigs/g/GDB/GDB-8.0.1-foss-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/g/GDB/GDB-8.0.1-foss-2017b-Python-2.7.14.eb
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 configopts = '--with-system-zlib --with-python=$EBROOTPYTHON/bin/python --with-expat=$EBROOTEXPAT '
-configopts += '--with-system-readline --enable-tui --enable-plugins'
+configopts += '--with-system-readline --enable-tui --enable-plugins --disable-install-libbfd '
 
 parallel = 1
 

--- a/easybuild/easyconfigs/g/GDB/GDB-8.0.1-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/g/GDB/GDB-8.0.1-foss-2017b-Python-3.6.3.eb
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 configopts = '--with-system-zlib --with-python=$EBROOTPYTHON/bin/python --with-expat=$EBROOTEXPAT '
-configopts += '--with-system-readline --enable-tui --enable-plugins'
+configopts += '--with-system-readline --enable-tui --enable-plugins --disable-install-libbfd '
 
 parallel = 1
 

--- a/easybuild/easyconfigs/g/GDB/GDB-8.1-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/g/GDB/GDB-8.1-foss-2018a-Python-2.7.14.eb
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 configopts = '--with-system-zlib --with-python=$EBROOTPYTHON/bin/python --with-expat=$EBROOTEXPAT '
-configopts += '--with-system-readline --enable-tui --enable-plugins'
+configopts += '--with-system-readline --enable-tui --enable-plugins --disable-install-libbfd '
 
 parallel = 1
 

--- a/easybuild/easyconfigs/g/GDB/GDB-8.1.1-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/g/GDB/GDB-8.1.1-intel-2018a-Python-2.7.14.eb
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 configopts = '--with-system-zlib --with-python=$EBROOTPYTHON/bin/python --with-expat=$EBROOTEXPAT '
-configopts += '--with-system-readline --enable-tui --enable-plugins'
+configopts += '--with-system-readline --enable-tui --enable-plugins --disable-install-libbfd '
 
 parallel = 1
 

--- a/easybuild/easyconfigs/g/GDB/GDB-8.3-GCCcore-8.2.0-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/g/GDB/GDB-8.3-GCCcore-8.2.0-Python-3.7.2.eb
@@ -27,7 +27,7 @@ dependencies = [
 ]
 
 configopts = '--with-system-zlib --with-python=$EBROOTPYTHON/bin/python --with-expat=$EBROOTEXPAT '
-configopts += '--with-system-readline --enable-tui --enable-plugins'
+configopts += '--with-system-readline --enable-tui --enable-plugins --disable-install-libbfd '
 
 parallel = 1
 


### PR DESCRIPTION
These libraries (and corresponding headers) shadow the libraries installed by `binutils`, which may cause subtle issues when building codes that use `libbfd` and/or `libopcode` (the GDB versions are static only and not compiled with `-fPIC`).  Older versions of GDB are also most likely affected, but I'm not sure it's worth the effort to fix them as well.