### PR TITLE
Make additional configopts work after uncommenting

### DIFF
--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.11.1-foss-2019a.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.11.1-foss-2019a.eb
@@ -31,10 +31,10 @@ dependencies = [
     ('Hypre', '2.15.1'),
 ]
 
-configopts = '--LIBS="$LIBS -lrt"'
+configopts = '--LIBS="$LIBS -lrt" '
 
 # only required when building PETSc in a SLURM job environment
-# configopts = '--with-batch=1 --known-mpi-shared-libraries=1 --known-64-bit-blas-indices=0 '
+# configopts += '--with-batch=1 --known-mpi-shared-libraries=1 --known-64-bit-blas-indices=0 '
 # prebuildopts = "srun ./conftest-arch-linux2-c-opt && ./reconfigure-arch-linux2-c-opt.py && "
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.11.1-intel-2019a.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.11.1-intel-2019a.eb
@@ -31,10 +31,10 @@ dependencies = [
     ('Hypre', '2.15.1'),
 ]
 
-configopts = '--LIBS="$LIBS -lrt"'
+configopts = '--LIBS="$LIBS -lrt" '
 
 # only required when building PETSc in a SLURM job environment
-# configopts = '--with-batch=1 --known-mpi-shared-libraries=1 --known-64-bit-blas-indices=0 '
+# configopts += '--with-batch=1 --known-mpi-shared-libraries=1 --known-64-bit-blas-indices=0 '
 # prebuildopts = "srun ./conftest-arch-linux2-c-opt && ./reconfigure-arch-linux2-c-opt.py && "
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.9.3-foss-2018a.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.9.3-foss-2018a.eb
@@ -33,10 +33,10 @@ dependencies = [
 
 builddependencies = [('CMake', '3.10.2')]
 
-configopts = '--LIBS="$LIBS -lrt"'
+configopts = '--LIBS="$LIBS -lrt" '
 
 # only required when building PETSc in a SLURM job environment
-# configopts = '--with-batch=1 --known-mpi-shared-libraries=1 --known-64-bit-blas-indices=0 '
+# configopts += '--with-batch=1 --known-mpi-shared-libraries=1 --known-64-bit-blas-indices=0 '
 # prebuildopts = "srun ./conftest-arch-linux2-c-opt && ./reconfigure-arch-linux2-c-opt.py && "
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.9.3-intel-2018a.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.9.3-intel-2018a.eb
@@ -33,10 +33,10 @@ dependencies = [
 
 builddependencies = [('CMake', '3.10.2')]
 
-configopts = '--LIBS="$LIBS -lrt"'
+configopts = '--LIBS="$LIBS -lrt" '
 
 # only required when building PETSc in a SLURM job environment
-# configopts = '--with-batch=1 --known-mpi-shared-libraries=1 --known-64-bit-blas-indices=0 '
+# configopts += '--with-batch=1 --known-mpi-shared-libraries=1 --known-64-bit-blas-indices=0 '
 # prebuildopts = "srun ./conftest-arch-linux2-c-opt && ./reconfigure-arch-linux2-c-opt.py && "
 
 moduleclass = 'numlib'


### PR DESCRIPTION
After removing comments to enable SLURM batch support the build stops working due to malformed configure options.