### PR TITLE
use Java/11 rather than Java/1.8 as dependency for OR-Tools

### DIFF
--- a/easybuild/easyconfigs/o/OR-Tools/OR-Tools-7.1-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/o/OR-Tools/OR-Tools-7.1-foss-2019a-Python-3.7.2.eb
@@ -30,7 +30,7 @@ gurobiver = '8.1.1'
 dependencies = [
     ('Python', '3.7.2'),
     ('zlib', '1.2.11'),
-    ('Java', '1.8', '', True),
+    ('Java', '11', '', True),
     # Gurobi is optional
     ('Gurobi', gurobiver, '', True),
 ]


### PR DESCRIPTION
Easyconfig tests are broken after the merge of #8364 (because Travis approved the PR before other easyconfigs that use `Java/11` as a dep got merged).

@wpoely86 How do we test whether `Java/11` works as expected here?