### PR TITLE
download correct Net-core tarball and add new easyconfig for Net-core 2.2.5

### DIFF
--- a/easybuild/easyconfigs/n/Net-core/Net-core-2.2.5.eb
+++ b/easybuild/easyconfigs/n/Net-core/Net-core-2.2.5.eb
@@ -6,7 +6,7 @@
 easyblock = 'Tarball'
 
 name = 'Net-core'
-version = '2.1.8'
+version = '2.2.5'
 
 homepage = 'https://dotnet.microsoft.com/'
 description = """.NET Core is a free and open-source managed computer software framework for the Windows,
@@ -16,11 +16,11 @@ toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = [
     'https://download.visualstudio.microsoft.com/download/pr/' +
-    'eae50d35-ec30-4416-829a-36e8b5158f22/52d8370bea6e696cee4280bec0eda4bc/'
+    '21968111-f65e-48c7-9c35-8b40de4af06c/66b7a2c7b92b54bd3311f4509cc9b9ed/'
     # url splitted in two lines to make travis happy (line too long)
 ]
 sources = ['dotnet-runtime-%(version)s-linux-x64.tar.gz']
-checksums = ['990110e1c166fa3a90d57ebf13dd3c1ab0a4b47f8c3e1b5b06e9a8dde1a05840']
+checksums = ['a49ebecf9b1a4cadd47e4db65ae63425b94be75628314107def3abf52d5d0221']
 
 sanity_check_paths = {
     'files': ['dotnet'],


### PR DESCRIPTION
I realized that the tarball to download is named `dotnet-runtime` and not `aspnetcore-runtime` 

I have also added another easyconfig with the latest version