### PR TITLE
{math}[intel/2018b] numexpr v2.6.5 w/ Python 2.7.15

### DIFF
--- a/easybuild/easyconfigs/n/numexpr/numexpr-2.6.5-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/n/numexpr/numexpr-2.6.5-intel-2018b-Python-2.7.15.eb
@@ -20,6 +20,9 @@ dependencies = [
     ('Python', '2.7.15'),
 ]
 
+use_pip = True
+download_dep_fail = True
+
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/n/numexpr/numexpr-2.6.5-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/n/numexpr/numexpr-2.6.5-intel-2018b-Python-2.7.15.eb
@@ -1,0 +1,28 @@
+easyblock = 'PythonPackage'
+
+name = 'numexpr'
+version = '2.6.5'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://code.google.com/p/numexpr/'
+description = """The numexpr package evaluates multiple-operator array expressions many times faster than NumPy can.
+ It accepts the expression as a string, analyzes it, rewrites it more efficiently, and compiles it on the fly into
+ code for its internal virtual machine (VM). Due to its integrated just-in-time (JIT) compiler, it does not require a
+ compiler at runtime."""
+
+toolchain = {'name': 'intel', 'version': '2018b'}
+
+source_urls = ['https://github.com/pydata/numexpr/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['fe78a78e002806e87e012b6105f3b3d52d47fc7a72bafb56341fcec7ce02cfd7']
+
+dependencies = [
+    ('Python', '2.7.15'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/n/numexpr/numexpr-2.6.5-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/n/numexpr/numexpr-2.6.5-intel-2018b-Python-2.7.15.eb
@@ -4,7 +4,7 @@ name = 'numexpr'
 version = '2.6.5'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://code.google.com/p/numexpr/'
+homepage = 'https://numexpr.readthedocs.io'
 description = """The numexpr package evaluates multiple-operator array expressions many times faster than NumPy can.
  It accepts the expression as a string, analyzes it, rewrites it more efficiently, and compiles it on the fly into
  code for its internal virtual machine (VM). Due to its integrated just-in-time (JIT) compiler, it does not require a


### PR DESCRIPTION
just a port of foss2018b version into intel2018b..

(created using `eb --new-pr`)
