### PR TITLE
fix 'Permission denied' error when running 'cp -a' for ANTs 2.3.1 insallation by first removing the .git subdirectories causing them

### DIFF
--- a/easybuild/easyconfigs/a/ANTs/ANTs-2.3.1-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/a/ANTs/ANTs-2.3.1-foss-2018b-Python-3.6.6.eb
@@ -35,8 +35,8 @@ configopts += '-DSuperBuild_ANTS_USE_GIT_PROTOCOL=OFF'
 
 skipsteps = ['install']
 
-# need to ensure user has write permissions on all files, to avoid permission denied problems when copying
-buildopts = ' && mkdir -p %(installdir)s && chmod -R u+w . && cp -a * %(installdir)s/'
+# need to remove (useless) .git subdirectories to avoid permission denied problems when copying
+buildopts = ' && mkdir -p %(installdir)s && (find . -name .git | xargs rm -rfv) && cp -a * %(installdir)s/'
 
 postinstallcmds = ["cp -a %(builddir)s/ANTs-%(version)s/Scripts/* %(installdir)s/bin/"]
 


### PR DESCRIPTION
The `Permission denied` errors that also popped in #6998 have surfaced again, so I've figured out a way to fix them properly: removing the (useless) `.git` subdirectories that trigger them (exact reason is still unclear though).