### PR TITLE
fix checksum for boot 1.3-22 extension in R 3.6.0 easyconfig

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
@@ -524,7 +524,7 @@ exts_list = [
         'checksums': ['1f86e33ecde6c3b0d2098c47591a9cd0fa41fb973ebf5145859677492730df97'],
     }),
     ('boot', '1.3-22', {
-        'checksums': ['cf1f0cb1e0a7a36dcb6ae038f5d0211a0e7a009c149bc9d21acb9c58c38b4dfc'],
+        'checksums': ['f8bf34b87a3e30113b7ba26935f4165fd68266b89d5e84a39b1c6ab7872fb9cc'],
     }),
     ('lme4', '1.1-21', {
         'checksums': ['7f5554b69ff8ce9bac21e8842131ea940fb7a7dfa2de03684f236d3e3114b20c'],


### PR DESCRIPTION
It looks like the `boot_1.3-22.tar.gz` source tarball at https://cran.r-project.org/src/contrib/Archive/boot/, was replaced with an older version (again, cfr. #8054).

Functionally, nothing has changed though, it's only the publication date in the description that was reverted:

```
$ diff -ru boot.old boot
diff -ru boot.old/DESCRIPTION boot/DESCRIPTION
--- boot.old/DESCRIPTION        2019-04-26 15:19:17.000000000 +0200
+++ boot/DESCRIPTION    2019-04-02 22:04:12.000000000 +0200
@@ -24,4 +24,4 @@
 Author: Angelo Canty [aut],
   Brian Ripley [aut, trl, cre] (author of parallel support)
 Repository: CRAN
-Date/Publication: 2019-04-26 13:19:17 UTC
+Date/Publication: 2019-04-02 20:04:12 UTC
diff -ru boot.old/MD5 boot/MD5
--- boot.old/MD5        2019-04-26 15:19:17.000000000 +0200
+++ boot/MD5    2019-04-02 22:04:12.000000000 +0200
@@ -1,5 +1,5 @@
 1b5ac46717dca02c841ea6e1325238a6 *ChangeLog
-8798d7ca7be4ee6a3b5e139514ee4c92 *DESCRIPTION
+e2ee2f63aa46e25c25bdcbe969e86c65 *DESCRIPTION
 e6929f73b03924d15f3af4a4c8549a45 *INDEX
 52cc784fd6ef9af32d9586726a53bb89 *NAMESPACE
 319ea125989deab41f19cb6c3071aecb *R/bootfuns.q
```