### PR TITLE
{math}[foss/2018b,intel/2018b] ncdf4 v1.16.1

### DIFF
--- a/easybuild/easyconfigs/n/ncdf4/ncdf4-1.16.1-foss-2018b-R-3.5.1.eb
+++ b/easybuild/easyconfigs/n/ncdf4/ncdf4-1.16.1-foss-2018b-R-3.5.1.eb
@@ -1,0 +1,29 @@
+easyblock = 'RPackage'
+
+name = 'ncdf4'
+version = '1.16.1'
+versionsuffix = '-R-%(rver)s'
+
+homepage = 'http://cran.r-project.org/web/packages/%(name)s'
+description = "ncdf4: Interface to Unidata netCDF (version 4 or earlier) format data files"
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+source_urls = [
+    'http://cran.r-project.org/src/contrib/',
+    'http://cran.r-project.org/src/contrib/Archive/$(name)s/',
+]
+sources = ['%(name)s_%(version)s.tar.gz']
+checksums = ['0dde2d6d1e8474f4abd15a61af8a2f7de564f13da00f1a01d7a479ab88587a20']
+
+dependencies = [
+    ('R', '3.5.1'),
+    ('netCDF', '4.6.1'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['ncdf4'],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/n/ncdf4/ncdf4-1.16.1-intel-2018b-R-3.5.1.eb
+++ b/easybuild/easyconfigs/n/ncdf4/ncdf4-1.16.1-intel-2018b-R-3.5.1.eb
@@ -1,0 +1,29 @@
+easyblock = 'RPackage'
+
+name = 'ncdf4'
+version = '1.16.1'
+versionsuffix = '-R-%(rver)s'
+
+homepage = 'http://cran.r-project.org/web/packages/%(name)s'
+description = "ncdf4: Interface to Unidata netCDF (version 4 or earlier) format data files"
+
+toolchain = {'name': 'intel', 'version': '2018b'}
+
+source_urls = [
+    'http://cran.r-project.org/src/contrib/',
+    'http://cran.r-project.org/src/contrib/Archive/$(name)s/',
+]
+sources = ['%(name)s_%(version)s.tar.gz']
+checksums = ['0dde2d6d1e8474f4abd15a61af8a2f7de564f13da00f1a01d7a479ab88587a20']
+
+dependencies = [
+    ('R', '3.5.1'),
+    ('netCDF', '4.6.1'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['ncdf4'],
+}
+
+moduleclass = 'math'


### PR DESCRIPTION
Minor update of the R package `ncdf4` to version 1.16.1. One easyconfig for `foss/2018b` and another for `intel/2018b`. 