### PR TITLE
revert checksum 'fix' for boot extension in R 3.6.0 

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
@@ -524,7 +524,7 @@ exts_list = [
         'checksums': ['1f86e33ecde6c3b0d2098c47591a9cd0fa41fb973ebf5145859677492730df97'],
     }),
     ('boot', '1.3-22', {
-        'checksums': ['f8bf34b87a3e30113b7ba26935f4165fd68266b89d5e84a39b1c6ab7872fb9cc'],
+        'checksums': ['cf1f0cb1e0a7a36dcb6ae038f5d0211a0e7a009c149bc9d21acb9c58c38b4dfc'],
     }),
     ('lme4', '1.1-21', {
         'checksums': ['7f5554b69ff8ce9bac21e8842131ea940fb7a7dfa2de03684f236d3e3114b20c'],


### PR DESCRIPTION
This reverts the checksum 'fix' done in #8537, since the upstream source tarball was changed again to what it was before...

```
$ diff -ru boot.20190704 boot.20190607
diff -ru boot.20190704/DESCRIPTION boot.20190607/DESCRIPTION
--- boot.20190704/DESCRIPTION   2019-04-02 22:04:12.000000000 +0200
+++ boot.20190607/DESCRIPTION   2019-04-26 15:19:17.000000000 +0200
@@ -24,4 +24,4 @@
 Author: Angelo Canty [aut],
   Brian Ripley [aut, trl, cre] (author of parallel support)
 Repository: CRAN
-Date/Publication: 2019-04-02 20:04:12 UTC
+Date/Publication: 2019-04-26 13:19:17 UTC
diff -ru boot.20190704/MD5 boot.20190607/MD5
--- boot.20190704/MD5   2019-04-02 22:04:12.000000000 +0200
+++ boot.20190607/MD5   2019-04-26 15:19:17.000000000 +0200
@@ -1,5 +1,5 @@
 1b5ac46717dca02c841ea6e1325238a6 *ChangeLog
-e2ee2f63aa46e25c25bdcbe969e86c65 *DESCRIPTION
+8798d7ca7be4ee6a3b5e139514ee4c92 *DESCRIPTION
 e6929f73b03924d15f3af4a4c8549a45 *INDEX
 52cc784fd6ef9af32d9586726a53bb89 *NAMESPACE
 319ea125989deab41f19cb6c3071aecb *R/bootfuns.q
```