### PR TITLE
Add required patch to OpenMPI-3.1.4

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.4-GCC-8.3.0-2.32.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-3.1.4-GCC-8.3.0-2.32.eb
@@ -10,7 +10,12 @@ toolchain = {'name': 'GCC', 'version': '8.3.0-2.32'}
 
 source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['a7c34ad052ea8201ed9e7389994069fe6996403beabdd2d711caf0532808156c']
+patches = ['%(name)s-3.1.3-add_ompi_datatype_attribute_to_release_ucp_datatype.patch']
+checksums = [
+    'a7c34ad052ea8201ed9e7389994069fe6996403beabdd2d711caf0532808156c',  # openmpi-3.1.4.tar.gz
+    # OpenMPI-3.1.3-add_ompi_datatype_attribute_to_release_ucp_datatype.patch
+    '46fa94eb417954bdb297291bad4f4d32018af4911bebf3e59af6276eba6a50a9',
+]
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]


### PR DESCRIPTION
The added patch is still necessary. Apparently its content will be available only from `4.x`.
`OpenMPI-3.1_fix-ib-query.patch` is no longer needed since it is already added to the sources.
