### PR TITLE
{lang}[intel/2019a] R v3.6.0

### DIFF
--- a/easybuild/easyconfigs/r/R/Cairo-1.5-10.patch
+++ b/easybuild/easyconfigs/r/R/Cairo-1.5-10.patch
@@ -1,0 +1,24 @@
+# pkg-config --libs cairo-pdf 
+# and
+# pkg-config --libs cairo-ps
+# should return zlib library location, otherwise configure would use system zlib for cairo compilation tests
+# (but not for the builds)
+# in the cairo-{ps,pdf} 
+# Requires: cairo
+# sould be 
+# Reuires: cairo zlib
+# So It might be a cairo/pkg-config issue
+# March 16th 2017 by B. Hajgato (Free Univeristy Brussels - VUB)
+# July 16 2019 by Davide Vanzo (Vanderbilt University)
+diff -ru Cairo.orig/configure Cairo/configure
+--- Cairo.orig/configure	2019-03-27 16:32:25.000000000 -0500
++++ Cairo/configure	2019-07-16 15:21:33.258381118 -0500
+@@ -3497,7 +3497,7 @@
+ 	 { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${modlist}" >&5
+ $as_echo "${modlist}" >&6; }
+ 	 CAIRO_CFLAGS=`"${PKGCONF}" --cflags ${modlist}`
+-	 CAIRO_LIBS=`"${PKGCONF}" --libs ${modlist}`
++         CAIRO_LIBS="-L$EBROOTZLIB/lib `"${PKGCONF}" --libs ${modlist}`"
+       else
+ 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ $as_echo "no" >&6; }

--- a/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
@@ -1186,7 +1186,8 @@ exts_list = [
         'patches': ['locfit-1.5-9.1_Fix_logical_operators_icc.patch'],
         'checksums': [
             'f524148fdb29aac3a178618f88718d3d4ac91283014091aa11a01f1c70cd4e51',  # locfit_1.5-9.1.tar.gz
-            'e12c995539c039a8f2a1fb1a4d2b34c488f942b0fd4e31a2b9d5bd1543bce0fc',  # locfit-1.5-9.1_Fix_logical_operators_icc.patch
+            # locfit-1.5-9.1_Fix_logical_operators_icc.patch
+            'e12c995539c039a8f2a1fb1a4d2b34c488f942b0fd4e31a2b9d5bd1543bce0fc',
         ],
     }),
     ('GGally', '1.4.0', {

--- a/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
@@ -408,7 +408,8 @@ exts_list = [
         'checksums': ['41366f777d8adb83d0bdbac1392a1ab118b36217ca648d3bb9db763aa7ff4686'],
     }),
     ('nlme', '3.1-140', {
-        'checksums': ['1da12f04052549b7673da2ba7af9a20184b186b749b521801a097447862c3d4d'],
+        'checksums': [('1da12f04052549b7673da2ba7af9a20184b186b749b521801a097447862c3d4d',
+                       'b15046fb0b3e3c689a3b565461b7bd6e74b46f0c7cce7444b43f1bc5400dc409')],
     }),
     ('mgcv', '1.8-28', {
         'checksums': ['b55ea8227cd5c263c266c3885fa3299aa6bd23b54186517f9299bf38a7bdd3ea'],
@@ -513,7 +514,8 @@ exts_list = [
         'checksums': ['ff78d5f935278935f1814a69e5a913d93d6dd2ac1b5681ba86b30c6773ef64ac'],
     }),
     ('foreign', '0.8-71', {
-        'checksums': ['3bd2392fbcd9dd4f385ac1418a5e454b9769e6414a21fbb5ae1e7ce6072760d7'],
+        'checksums': [('3bd2392fbcd9dd4f385ac1418a5e454b9769e6414a21fbb5ae1e7ce6072760d7',
+                       '2f6d387f25bf4796ff00b6c678acacfca13292fb3ec2c0409161940bf0d8bef1')],
     }),
     ('psych', '1.8.12', {
         'checksums': ['6e175e049bc1ee5b79a9e51ccafb22b962b4e6c839ce5c9cfa1ad83967037743'],
@@ -528,7 +530,8 @@ exts_list = [
         'checksums': ['1f86e33ecde6c3b0d2098c47591a9cd0fa41fb973ebf5145859677492730df97'],
     }),
     ('boot', '1.3-22', {
-        'checksums': ['cf1f0cb1e0a7a36dcb6ae038f5d0211a0e7a009c149bc9d21acb9c58c38b4dfc'],
+        'checksums': [('cf1f0cb1e0a7a36dcb6ae038f5d0211a0e7a009c149bc9d21acb9c58c38b4dfc',
+                       'f8bf34b87a3e30113b7ba26935f4165fd68266b89d5e84a39b1c6ab7872fb9cc')],
     }),
     ('lme4', '1.1-21', {
         'checksums': ['7f5554b69ff8ce9bac21e8842131ea940fb7a7dfa2de03684f236d3e3114b20c'],
@@ -2190,6 +2193,16 @@ exts_list = [
     ('MIIVsem', '0.5.4', {
         'checksums': ['de918d6b1820c59a7d4324342ad15444c2370ce1d843397a136c307397ed64b9'],
     }),
+    ('medflex', '0.6-6', {
+        'checksums': ['b9d04fb5281d0ea0555ec4f327a0ee951a7f312a3af944578dc175183dc49211'],
+    }),
+    ('Rserve', '1.7-3.1', {
+        'checksums': ['3ba1e919706e16a8632def5f45d666b6e44eafa6c14b57064d6ddf3415038f99'],
+    }),
+    ('spls', '2.2-3', {
+        'checksums': ['bbd693da80487eef2939c37aba199f6d811ec289828c763d9416a05fa202ab2e'],
+    }),
+    
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
@@ -2202,7 +2202,6 @@ exts_list = [
     ('spls', '2.2-3', {
         'checksums': ['bbd693da80487eef2939c37aba199f6d811ec289828c763d9416a05fa202ab2e'],
     }),
-    
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
@@ -1,0 +1,2190 @@
+name = 'R'
+version = '3.6.0'
+
+homepage = 'http://www.r-project.org/'
+description = """R is a free software environment for statistical computing
+ and graphics."""
+
+toolchain = {'name': 'intel', 'version': '2019a'}
+
+source_urls = ['https://cloud.r-project.org/src/base/R-%(version_major)s']
+sources = [SOURCE_TAR_GZ]
+checksums = ['36fcac3e452666158e62459c6fc810adc247c7109ed71c5b6c3ad5fc2bf57509']
+
+builddependencies = [
+    ('pkg-config', '0.29.2'),
+]
+dependencies = [
+    ('X11', '20190311'),
+    ('Mesa', '19.0.1'),
+    ('libGLU', '9.0.0'),
+    ('cairo', '1.16.0'),
+    ('libreadline', '8.0'),
+    ('ncurses', '6.1'),
+    ('bzip2', '1.0.6'),
+    ('XZ', '5.2.4'),
+    ('zlib', '1.2.11'),
+    ('SQLite', '3.27.2'),
+    ('PCRE', '8.43'),
+    ('libpng', '1.6.36'),  # for plotting in R
+    ('libjpeg-turbo', '2.0.2'),  # for plottting in R
+    ('LibTIFF', '4.0.10'),
+    ('Java', '11', '', True),
+    ('Tk', '8.6.9'),  # for tcltk
+    ('cURL', '7.63.0'),  # for RCurl
+    ('libxml2', '2.9.8'),  # for XML
+    ('GMP', '6.1.2'),  # for igraph
+    ('NLopt', '2.6.1'),  # for nloptr
+    ('FFTW', '3.3.8'),  # for fftw
+    ('libsndfile', '1.0.28'),  # for seewave
+    ('ICU', '64.2'),  # for rJava & gdsfmt
+    ('HDF5', '1.10.5'),  # for hdf5r
+    ('UDUNITS', '2.2.26'),  # for units
+    ('GSL', '2.5'),  # for RcppGSL
+    ('ImageMagick', '7.0.8-46'),  # for animation
+    # OS dependency should be preferred if the os version is more recent then
+    # this version, it's nice to have an up to date openssl for security
+    # reasons
+    # ('OpenSSL', '1.0.2h'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and
+# we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
+
+exts_default_options = {
+    'source_urls': [
+        'http://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'http://cran.r-project.org/src/contrib/',  # current version of packages
+        'http://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+
+# !! order of packages is important !!
+# packages updated on June 7, 2019
+exts_list = [
+    'base',
+    'datasets',
+    'graphics',
+    'grDevices',
+    'grid',
+    'methods',
+    'splines',
+    'stats',
+    'stats4',
+    'tools',
+    'utils',
+    ('Rmpi', '0.6-9', {
+        'patches': ['Rmpi-0.6-5_impi5.patch'],
+        'checksums': [
+            'b2e1eac3e56f6b26c7ce744b29d8994ab6507ac88df64ebbb5af439414651ee6',  # Rmpi_0.6-9.tar.gz
+            'f753f0b6434295be70fe29d36edb2047c091e465b7ff0cab56b93d55883c8dd3',  # Rmpi-0.6-5_impi5.patch
+        ],
+    }),
+    ('abind', '1.4-5', {
+        'checksums': ['3a3ace5afbcb86e56889efcebf3bf5c3bb042a282ba7cc4412d450bb246a3f2c'],
+    }),
+    ('magic', '1.5-9', {
+        'checksums': ['fa1d5ef2d39e880f262d31b77006a2a7e76ea38e306aae4356e682b90d6cd56a'],
+    }),
+    ('Rcpp', '1.0.1', {
+        'checksums': ['e76de03e5db5edc760ba7372b688d3a2f34854ad2b7dcb53b31556a46dafb904'],
+    }),
+    ('RcppProgress', '0.4.1', {
+        'checksums': ['11764105922f763d4c75c502599ec7dcc2fd629a029964caf53f98b41d0c607a'],
+    }),
+    ('lpSolve', '5.6.13.1', {
+        'checksums': ['6ad8dc430f72a4698fc4a615bb5ecb73690b3c4520e84d9094af51a528f720b8'],
+    }),
+    ('geometry', '0.4.1', {
+        'checksums': ['b5fe067e37d7a8df0628295258a49ddee139261ea7b486c0eb5eae8db8da716c'],
+    }),
+    ('bit', '1.1-14', {
+        'checksums': ['5cbaace1fb643a665a6ca69b90f7a6d624270de82420ca7a44f306753fcef254'],
+    }),
+    ('filehash', '2.4-2', {
+        'checksums': ['b6d056f75d45e315943a4618f5f62802612cd8931ba3f9f474b595140a3cfb93'],
+    }),
+    ('ff', '2.2-14', {
+        'checksums': ['1c6307847275b1b8ad9e2ffdce3f4df3c9d955dc2e8a45e3fd7bfd2b0926e2f0'],
+    }),
+    ('bnlearn', '4.4.1', {
+        'checksums': ['73689fdab937cb5ed5c8ae22607cb3038a161c91030d7e1a1a05145348aa64d9'],
+    }),
+    ('bootstrap', '2017.2', {
+        'checksums': ['44f118c90ee226730175c467a16ac8d5b3169d610424e613da4f73348fd79522'],
+    }),
+    ('combinat', '0.0-8', {
+        'checksums': ['1513cf6b6ed74865bfdd9f8ca58feae12b62f38965d1a32c6130bef810ca30c1'],
+    }),
+    ('deal', '1.2-39', {
+        'checksums': ['a349db8f1c86cbd8315c068da49314ce9eb585dbb50d2e5ff09300506bd8806b'],
+    }),
+    ('fdrtool', '1.2.15', {
+        'checksums': ['65f964aa768d0703ceb7a199adc5e79ca79a6d29d7bc053a262eb533697686c0'],
+    }),
+    ('formatR', '1.6', {
+        'checksums': ['f5c98f0c3506ca51599671a2cdbc17738d0f326e8e3bb18b7a38e9f172122229'],
+    }),
+    ('gtools', '3.8.1', {
+        'checksums': ['051484459bd8ad1b03425b8843d24f6828fea18f7357cfa1c192198cc3f4ba38'],
+    }),
+    ('gdata', '2.18.0', {
+        'checksums': ['4b287f59f5bbf5fcbf18db16477852faac4a605b10c5284c46b93fa6e9918d7f'],
+    }),
+    ('GSA', '1.03.1', {
+        'checksums': ['e192d4383f53680dbd556223ea5f8cad6bae62a80a337ba5fd8d05a8aee6a917'],
+    }),
+    ('highr', '0.8', {
+        'checksums': ['4bd01fba995f68c947a99bdf9aca15327a5320151e10bd0326fad50a6d8bc657'],
+    }),
+    ('infotheo', '1.2.0', {
+        'checksums': ['9b47ebc3db5708c88dc014b4ffec6734053a9c255a9241fcede30fec3e63aaa3'],
+    }),
+    ('lars', '1.2', {
+        'checksums': ['64745b568f20b2cfdae3dad02fba92ebf78ffee466a71aaaafd4f48c3921922e'],
+    }),
+    ('lazy', '1.2-16', {
+        'checksums': ['c796c8b987ed1bd9dfddd593e17312ed681fc4fa3a1ecfe51da2def0ac1e50df'],
+    }),
+    ('kernlab', '0.9-27', {
+        'checksums': ['f6add50ed4097f04d09411491625f8d46eafc4f003b1c1cff78a6fff8cc31dd4'],
+    }),
+    ('mime', '0.6', {
+        'checksums': ['4775b605ab0117406bee7953c8af59eea8b35e67d1bd63f4007686a7097fc401'],
+    }),
+    ('markdown', '0.9', {
+        'checksums': ['3068c6a41ca7a76cbedeb93b7371798f4d8437eea69a23c0ed5204c716d1bf23'],
+    }),
+    ('mlbench', '2.1-1', {
+        'checksums': ['748141d56531a39dc4d37cf0a5165a40b653a04c507e916854053ed77119e0e6'],
+    }),
+    ('NLP', '0.2-0', {
+        'checksums': ['fc64c80124c4e53b20f92b60c68e2fd33ee189653d0ceea410c32dd66d9e7075'],
+    }),
+    ('mclust', '5.4.3', {
+        'checksums': ['e69e80786ee71e856fe0b7f7741b0a49503d8433ee92d8f3417ec49f20f3a5a3'],
+    }),
+    ('RANN', '2.6.1', {
+        'checksums': ['b299c3dfb7be17aa41e66eff5674fddd2992fb6dd3b10bc59ffbf0c401697182'],
+    }),
+    ('rmeta', '3.0', {
+        'checksums': ['b9f9d405935cffcd7a5697ff13b033f9725de45f4dc7b059fd68a7536eb76b6e'],
+    }),
+    ('segmented', '0.5-4.0', {
+        'checksums': ['7ff63a19915cbd1e190d3a4875892b4c7bd97890b0dc2909126348a19aec4071'],
+    }),
+    ('som', '0.3-5.1', {
+        'checksums': ['a6f4c0e5b36656b7a8ea144b057e3d7642a8b71972da387a7133f3dd65507fb9'],
+    }),
+    ('SuppDists', '1.1-9.4', {
+        'checksums': ['fcb571150af66b95dcf0627298c54f7813671d60521a00ed157f63fc2247ddb9'],
+    }),
+    ('stabledist', '0.7-1', {
+        'checksums': ['06c5704d3a3c179fa389675c537c39a006867bc6e4f23dd7e406476ed2c88a69'],
+    }),
+    ('survivalROC', '1.0.3', {
+        'checksums': ['1449e7038e048e6ad4d3f7767983c0873c9c7a7637ffa03a4cc7f0e25c31cd72'],
+    }),
+    ('pspline', '1.0-18', {
+        'checksums': ['f71cf293bd5462e510ac5ad16c4a96eda18891a0bfa6447dd881c65845e19ac7'],
+    }),
+    ('timeDate', '3043.102', {
+        'checksums': ['377cba03cddab8c6992e31d0683c1db3a73afa9834eee3e95b3b0723f02d7473'],
+    }),
+    ('longmemo', '1.1-1', {
+        'checksums': ['0dd88e84a8376141d117bba39fe44f7d3c29d46fc103557fe98357f06e17d657'],
+    }),
+    ('ADGofTest', '0.3', {
+        'checksums': ['9cd9313954f6ecd82480d373f6c5371ca84ab33e3f5c39d972d35cfcf1096846'],
+    }),
+    ('MASS', '7.3-51.4', {
+        'checksums': ['9911d546a8d29dc906b46cb53ef8aad76d23566f4fc3b52778a1201f8a9b2c74'],
+    }),
+    ('ade4', '1.7-13', {
+        'checksums': ['f5d0a7356ae63f82d3adb481a39007e7b0d70211b8724aa686af0c89c994e99b'],
+    }),
+    ('AlgDesign', '1.1-7.3', {
+        'checksums': ['df0d56111401474b7f06eaf9ce7145a1cb73b3c5ec4817bad06f56db48af872e'],
+    }),
+    ('base64enc', '0.1-3', {
+        'checksums': ['6d856d8a364bcdc499a0bf38bfd283b7c743d08f0b288174fba7dbf0a04b688d'],
+    }),
+    ('BH', '1.69.0-1', {
+        'checksums': ['a0fd4364b7e368f09c56dec030823f52c16da0787580af7e4615eddeb99baca2'],
+    }),
+    ('brew', '1.0-6', {
+        'checksums': ['d70d1a9a01cf4a923b4f11e4374ffd887ad3ff964f35c6f9dc0f29c8d657f0ed'],
+    }),
+    ('Brobdingnag', '1.2-6', {
+        'checksums': ['19eccaed830ce9d93b70642f6f126ac66722a98bbd48586899cc613dd9966ad4'],
+    }),
+    ('corpcor', '1.6.9', {
+        'checksums': ['2e4fabd1d3936fecea67fa365233590147ca50bb45cf80efb53a10345a8a23c2'],
+    }),
+    ('longitudinal', '1.1.12', {
+        'checksums': ['d4f894c38373ba105b1bdc89e3e7c1b215838e2fb6b4470b9f23768b84e603b5'],
+    }),
+    ('backports', '1.1.4', {
+        'checksums': ['ee4b5efef22fa7ef27d7983ffcd31db52f81e1fbb7189c6e89ee09b69349ff03'],
+    }),
+    ('checkmate', '1.9.3', {
+        'checksums': ['e4c21ad9913c8245f7b76405bdedca19f48b6cfb658230c3ff828dc3ebe68c95'],
+    }),
+    ('cubature', '2.0.3', {
+        'checksums': ['79bf03ebdb64b0de1ef19d24051b9d922df9310254bee459bb47764522407a73'],
+    }),
+    ('DEoptimR', '1.0-8', {
+        'checksums': ['846911c1b2561a9fae73a8c60a21a5680963ebb0050af3c1f1147ae9a121e5ef'],
+    }),
+    ('digest', '0.6.19', {
+        'checksums': ['28d159bd589ecbd01b8da0826eaed417f5c1bf5a11b79e76bf67ce8d935cccf4'],
+    }),
+    ('fastmatch', '1.1-0', {
+        'checksums': ['20b51aa4838dbe829e11e951444a9c77257dcaf85130807508f6d7e76797007d'],
+    }),
+    ('ffbase', '0.12.7', {
+        'checksums': ['dc16a4faf8abb778c353a5ddaf1a10a2b10b7ae867dd6d0b1be400379ce87d12'],
+    }),
+    ('iterators', '1.0.10', {
+        'checksums': ['a9e1b2302828d4527766ce12fa9ae06faf8d51e819a43f8efef632b6ddf471e8'],
+    }),
+    ('maps', '3.3.0', {
+        'checksums': ['199afe19a4edcef966ae79ef802f5dcc15a022f9c357fcb8cae8925fe8bd2216'],
+    }),
+    ('nnls', '1.4', {
+        'checksums': ['0e5d77abae12bc50639d34354f96a8e079408c9d7138a360743b73bd7bce6c1f'],
+    }),
+    ('sendmailR', '1.2-1', {
+        'checksums': ['04feb08c6c763d9c58b2db24b1222febe01e28974eac4fe87670be6fb9bff17c'],
+    }),
+    ('dotCall64', '1.0-0', {
+        'checksums': ['69318dc6b8aecc54d4f789c8105e672198363b395f1a764ebaeb54c0473d17ad'],
+    }),
+    ('spam', '2.2-2', {
+        'checksums': ['711fdbfdac1e51dc7f684b139740f1d8c8aa6c6c0ae6bfaa8f7a7727ad7b8d08'],
+    }),
+    ('subplex', '1.5-4', {
+        'checksums': ['ff94cf6b1560f78c31712c05bc2bc1b703339e09c7fc777ee94abf15fa7a8b81'],
+    }),
+    ('stringi', '1.4.3', {
+        'checksums': ['13cecb396b700f81af38746e97b550a1d9fda377ca70c78f6cdfc770d33379ed'],
+    }),
+    ('magrittr', '1.5', {
+        'checksums': ['05c45943ada9443134caa0ab24db4a962b629f00b755ccf039a2a2a7b2c92ae8'],
+    }),
+    ('glue', '1.3.1', {
+        'checksums': ['4fc1f2899d71a634e1f0adb7942772feb5ac73223891abe30ea9bd91d3633ea8'],
+    }),
+    ('stringr', '1.4.0', {
+        'checksums': ['87604d2d3a9ad8fd68444ce0865b59e2ffbdb548a38d6634796bbd83eeb931dd'],
+    }),
+    ('evaluate', '0.14', {
+        'checksums': ['a8c88bdbe4e60046d95ddf7e181ee15a6f41cdf92127c9678f6f3d328a3c5e28'],
+    }),
+    ('logspline', '2.1.12', {
+        'checksums': ['53d2d3b151e8d99e651c4acbea13be51370be9310ac9160988e030c8c21698f8'],
+    }),
+    ('ncbit', '2013.03.29', {
+        'checksums': ['4480271f14953615c8ddc2e0666866bb1d0964398ba0fab6cc29046436820738'],
+    }),
+    ('permute', '0.9-5', {
+        'checksums': ['d2885384a07497e8df273689d6713fc7c57a7c161f6935f3572015e16ab94865'],
+    }),
+    ('plotrix', '3.7-5', {
+        'checksums': ['b22f3f9d93961d23ad46e41597d1e45d2665ced04dcad8c40f6806a67cded14c'],
+    }),
+    ('randomForest', '4.6-14', {
+        'checksums': ['f4b88920419eb0a89d0bc5744af0416d92d112988702dc726882394128a8754d'],
+    }),
+    ('scatterplot3d', '0.3-41', {
+        'checksums': ['4c8326b70a3b2d37126ca806771d71e5e9fe1201cfbe5b0d5a0a83c3d2c75d94'],
+    }),
+    ('SparseM', '1.77', {
+        'checksums': ['a9329fef14ae4fc646df1f4f6e57efb0211811599d015f7bc04c04285495d45c'],
+    }),
+    ('tripack', '1.3-8', {
+        'checksums': ['6bb340292a9629a41a0e0664335ddd97be3ad46bca225034db5dfb6efe01c75d'],
+    }),
+    ('irace', '3.3', {
+        'checksums': ['4442d968d2201194555eef69f7fbd986a3c553dd6f2f63a26415168c280b0d10'],
+    }),
+    ('rJava', '0.9-11', {
+        'checksums': ['c28ae131456a98f4d3498aa8f6eac9d4df48727008dacff1aa561fc883972c69'],
+    }),
+    ('lattice', '0.20-38', {
+        'checksums': ['fdeb5e3e50dbbd9d3c5e2fa3eef865132b3eef30fbe53a10c24c7b7dfe5c0a2d'],
+    }),
+    ('RColorBrewer', '1.1-2', {
+        'checksums': ['f3e9781e84e114b7a88eb099825936cc5ae7276bbba5af94d35adb1b3ea2ccdd'],
+    }),
+    ('latticeExtra', '0.6-28', {
+        'checksums': ['780695323dfadac108fb27000011c734e2927b1e0f069f247d65d27994c67ec2'],
+    }),
+    ('Matrix', '1.2-17', {
+        'checksums': ['db43e6f0196fd5dfd05a7e88cac193877352c60d771d4ec8772763e645723fcc'],
+    }),
+    ('png', '0.1-7', {
+        'checksums': ['e269ff968f04384fc9421d17cfc7c10cf7756b11c2d6d126e9776f5aca65553c'],
+    }),
+    ('RcppArmadillo', '0.9.400.3.0', {
+        'checksums': ['56936d501fe8e6f8796ae1a6badb9294d7dad98a0b557c3b3ce6bd4ecaad13b0'],
+    }),
+    ('plyr', '1.8.4', {
+        'checksums': ['60b522d75961007658c9806f8394db27989f1154727cb0bb970062c96ec9eac5'],
+    }),
+    ('gtable', '0.3.0', {
+        'checksums': ['fd386cc4610b1cc7627dac34dba8367f7efe114b968503027fb2e1265c67d6d3'],
+    }),
+    ('reshape2', '1.4.3', {
+        'checksums': ['8aff94c935e75032344b52407593392ddd4e16a88bb206984340c816d42c710e'],
+    }),
+    ('dichromat', '2.0-0', {
+        'checksums': ['31151eaf36f70bdc1172da5ff5088ee51cc0a3db4ead59c7c38c25316d580dd1'],
+    }),
+    ('colorspace', '1.4-1', {
+        'checksums': ['693d713a050f8bfecdb7322739f04b40d99b55aed168803686e43401d5f0d673'],
+    }),
+    ('munsell', '0.5.0', {
+        'checksums': ['d0f3a9fb30e2b5d411fa61db56d4be5733a2621c0edf017d090bdfa5e377e199'],
+    }),
+    ('labeling', '0.3', {
+        'checksums': ['0d8069eb48e91f6f6d6a9148f4e2dc5026cabead15dd15fc343eff9cf33f538f'],
+    }),
+    ('R6', '2.4.0', {
+        'checksums': ['70be110174fbf5f5304049b186a6f9c05b77bfaec6d8caf980fcef5da6e0abce'],
+    }),
+    ('viridisLite', '0.3.0', {
+        'checksums': ['780ea12e7c4024d5ba9029f3a107321c74b8d6d9165262f6e64b79e00aa0c2af'],
+    }),
+    ('scales', '1.0.0', {
+        'checksums': ['0c1f4a14edd336a404da34a3cc71a6a9d0ca2040ba19360c41a79f36e06ca30c'],
+    }),
+    ('rlang', '0.3.4', {
+        'checksums': ['4e467f7b0dcbde91b60c292137d2c69cecaa713a6e4c9b7157ef6fd5453b7ade'],
+    }),
+    ('assertthat', '0.2.1', {
+        'checksums': ['85cf7fcc4753a8c86da9a6f454e46c2a58ffc70c4f47cac4d3e3bcefda2a9e9f'],
+    }),
+    ('crayon', '1.3.4', {
+        'checksums': ['fc6e9bf990e9532c4fcf1a3d2ce22d8cf12d25a95e4779adfa17713ed836fa68'],
+    }),
+    ('cli', '1.1.0', {
+        'checksums': ['4fc00fcdf4fdbdf9b5792faee8c7cf1ed5c4f45b1221d961332cda82dbe60d0a'],
+    }),
+    ('utf8', '1.1.4', {
+        'checksums': ['f6da9cadfc683057d45f54b43312a359cf96ec2731c0dda18a8eae31d1e31e54'],
+    }),
+    ('fansi', '0.4.0', {
+        'checksums': ['e104e9d01c7ff8a847f6b332ef544c0ef912859f9c6a514fe2e6f3b34fcfc209'],
+    }),
+    ('zeallot', '0.1.0', {
+        'checksums': ['439f1213c97c8ddef9a1e1499bdf81c2940859f78b76bc86ba476cebd88ba1e9'],
+    }),
+    ('vctrs', '0.1.0', {
+        'checksums': ['cc28febd74b4c7800076ac4d2c628755125981bdd3ebf295bb3952753fca818f'],
+    }),
+    ('pillar', '1.4.1', {
+        'checksums': ['f571ca7a3ef0927747510b972da31a26da24b9da68990fe1bbc9d4ae58028c55'],
+    }),
+    ('pkgconfig', '2.0.2', {
+        'checksums': ['25997754d1adbe7a251e3bf9879bb52dced27dd8b84767d558f0f644ca8d69ca'],
+    }),
+    ('tibble', '2.1.3', {
+        'checksums': ['9a8cea9e6b5d24a7e9bf5f67ab38c40b2b6489eddb0d0edb8a48a21ba3574e1a'],
+    }),
+    ('lazyeval', '0.2.2', {
+        'checksums': ['d6904112a21056222cfcd5eb8175a78aa063afe648a562d9c42c6b960a8820d4'],
+    }),
+    ('withr', '2.1.2', {
+        'checksums': ['41366f777d8adb83d0bdbac1392a1ab118b36217ca648d3bb9db763aa7ff4686'],
+    }),
+    ('nlme', '3.1-140', {
+        'checksums': ['1da12f04052549b7673da2ba7af9a20184b186b749b521801a097447862c3d4d'],
+    }),
+    ('mgcv', '1.8-28', {
+        'checksums': ['b55ea8227cd5c263c266c3885fa3299aa6bd23b54186517f9299bf38a7bdd3ea'],
+    }),
+    ('ggplot2', '3.1.1', {
+        'checksums': ['bfde297f3b4732e7f560078f4ce131812a70877e6b5b1d41a772c394939e0c79'],
+    }),
+    ('pROC', '1.15.0', {
+        'checksums': ['44d471968322ef547e3ee175576f8174969a727eaf3082ed17d2ba0e1b9fbdb7'],
+    }),
+    ('quadprog', '1.5-7', {
+        'checksums': ['1af41e57df6f2d08ee8b72a1a5ada137beadb36c7ec9ab9bdb7c05226e8ae76d'],
+    }),
+    ('BB', '2014.10-1', {
+        'checksums': ['a09f67e3a6ef36db660e4dc92832dfad4a7591ae9fadc2a265c8770ffb1e2fd2'],
+    }),
+    ('BBmisc', '1.11', {
+        'checksums': ['1ea48c281825349d8642a661bb447e23bfd651db3599bf72593bfebe17b101d2'],
+    }),
+    ('fail', '1.3', {
+        'checksums': ['ede8aa2a9f2371aff5874cd030ac625adb35c33954835b54ab4abf7aeb34d56d'],
+    }),
+    ('rlecuyer', '0.3-4', {
+        'checksums': ['c7378f1134e99abc9dfbde7906da430b34333e11aa98a03f87b638637f63b534'],
+    }),
+    ('snow', '0.4-3', {
+        'checksums': ['8512537daf334ea2b8074dbb80cf5e959a403a78d68bc1e97664e8a4f64576d8'],
+    }),
+    ('tree', '1.0-40', {
+        'checksums': ['ffab16382d7ed5b76529801ab26b4970363b2072231c6a87330326298ce626e7'],
+    }),
+    ('pls', '2.7-1', {
+        'checksums': ['f8fd817fc2aa046970c49a9a481489a3a2aef8b6f09293fb1f0218f00bfd834b'],
+    }),
+    ('class', '7.3-15', {
+        'checksums': ['f6bf33d610c726d58622b6cea78a808c7d6a317d02409d27c17741dfd1c730f4'],
+    }),
+    ('e1071', '1.7-2', {
+        'checksums': ['721c299ce83047312acfa3e0c4b3d4c223d84a4c53400c73465cca2c92913752'],
+    }),
+    ('nnet', '7.3-12', {
+        'checksums': ['2723523e8581cc0e2215435ac773033577a16087a3f41d111757dd96b8c5559d'],
+    }),
+    ('minqa', '1.2.4', {
+        'checksums': ['cfa193a4a9c55cb08f3faf4ab09c11b70412523767f19894e4eafc6e94cccd0c'],
+    }),
+    ('RcppEigen', '0.3.3.5.0', {
+        'checksums': ['e5c6af17770c5f57b7cf2fba04ad1a519901b446e8138bfff221952458207f05'],
+    }),
+    ('MatrixModels', '0.4-1', {
+        'checksums': ['fe878e401e697992a480cd146421c3a10fa331f6b37a51bac83b5c1119dcce33'],
+    }),
+    ('quantreg', '5.40', {
+        'checksums': ['86e310a235009ab85635dfb8803c175f80a35892e237db2525c4ef37a98936eb'],
+    }),
+    ('robustbase', '0.93-5', {
+        'checksums': ['bde564dbd52f04ab32f9f2f9dd09b9578f3ccd2541cf5f8ff430da42a55e7f56'],
+    }),
+    ('sp', '1.3-1', {
+        'checksums': ['57988b53ba8acc35f3912d62feba4b929a0f757c6b54080c623c5d805e0cb59f'],
+    }),
+    ('zoo', '1.8-5', {
+        'checksums': ['8773969973d28d7d1a48f74b73be1dbd97acb3b22a4668a102e8bb585a7de826'],
+    }),
+    ('lmtest', '0.9-37', {
+        'checksums': ['ddc929f94bf055974832fa4a20fdd0c1eb3a84ee11f716c287936f2141d5ca0a'],
+    }),
+    ('vcd', '1.4-4', {
+        'checksums': ['a561adf120b5ce41b66e0c0c321542fcddc772eb12b3d7020d86e9cd014ce9d2'],
+    }),
+    ('snowfall', '1.84-6.1', {
+        'checksums': ['5c446df3a931e522a8b138cf1fb7ca5815cc82fcf486dbac964dcbc0690e248d'],
+    }),
+    ('rpart', '4.1-15', {
+        'checksums': ['2b8ebe0e9e11592debff893f93f5a44a6765abd0bd956b0eb1f70e9394cfae5c'],
+    }),
+    ('survival', '2.44-1.1', {
+        'checksums': ['55b151e15fcd24ccb3acf60331c9a7ad82bc10f3841ab3be9bc2a37e9ee751b9'],
+    }),
+    ('bindr', '0.1.1', {
+        'checksums': ['7c785ca77ceb3ab9282148bcecf64d1857d35f5b800531d49483622fe67505d0'],
+    }),
+    ('plogr', '0.2.0', {
+        'checksums': ['0e63ba2e1f624005fe25c67cdd403636a912e063d682eca07f2f1d65e9870d29'],
+    }),
+    ('bindrcpp', '0.2.2', {
+        'checksums': ['48130709eba9d133679a0e959e49a7b14acbce4f47c1e15c4ab46bd9e48ae467'],
+    }),
+    ('purrr', '0.3.2', {
+        'checksums': ['27c74dd9e4f6f14bf442473df22bcafc068822f7f138f0870326532f143a9a31'],
+    }),
+    ('tidyselect', '0.2.5', {
+        'checksums': ['5ce2e86230fa35cfc09aa71dcdd6e05e1554a5739c863ca354d241bfccb86c74'],
+    }),
+    ('dplyr', '0.8.1', {
+        'checksums': ['5f3ef7f0378d89799d466be254e25857a2747d70d5d97450618ac9303f1481db'],
+    }),
+    ('tidyr', '0.8.3', {
+        'checksums': ['a18f54ec35124110058ab23f7e0a3c037a8d50f0405520cf5cc5443ec022cc37'],
+    }),
+    ('mnormt', '1.5-5', {
+        'checksums': ['ff78d5f935278935f1814a69e5a913d93d6dd2ac1b5681ba86b30c6773ef64ac'],
+    }),
+    ('foreign', '0.8-71', {
+        'checksums': ['3bd2392fbcd9dd4f385ac1418a5e454b9769e6414a21fbb5ae1e7ce6072760d7'],
+    }),
+    ('psych', '1.8.12', {
+        'checksums': ['6e175e049bc1ee5b79a9e51ccafb22b962b4e6c839ce5c9cfa1ad83967037743'],
+    }),
+    ('generics', '0.0.2', {
+        'checksums': ['71b3d1b719ce89e71dd396ac8bc6aa5f1cd99bbbf03faff61dfbbee32fec6176'],
+    }),
+    ('broom', '0.5.2', {
+        'checksums': ['16af7b446b24bc14461efbda9bea1521cf738c778c5e48fcc7bad45660a4ac62'],
+    }),
+    ('nloptr', '1.2.1', {
+        'checksums': ['1f86e33ecde6c3b0d2098c47591a9cd0fa41fb973ebf5145859677492730df97'],
+    }),
+    ('boot', '1.3-22', {
+        'checksums': ['cf1f0cb1e0a7a36dcb6ae038f5d0211a0e7a009c149bc9d21acb9c58c38b4dfc'],
+    }),
+    ('lme4', '1.1-21', {
+        'checksums': ['7f5554b69ff8ce9bac21e8842131ea940fb7a7dfa2de03684f236d3e3114b20c'],
+    }),
+    ('ucminf', '1.1-4', {
+        'checksums': ['a2eb382f9b24e949d982e311578518710f8242070b3aa3314a331c1e1e7f6f07'],
+    }),
+    ('numDeriv', '2016.8-1.1', {
+        'checksums': ['d8c4d19ff9aeb31b0c628bd4a16378e51c1c9a3813b525469a31fe89af00b345'],
+    }),
+    ('ordinal', '2019.4-25', {
+        'checksums': ['2812ad7a123cae5dbe053d1fe5f2d9935afc799314077eac185c844e3c9d79df'],
+    }),
+    ('jomo', '2.6-8', {
+        'checksums': ['cb6fd4693ac912c5c812acb639f58edee98e205679f58ebc2a440d865973ff24'],
+    }),
+    ('hms', '0.4.2', {
+        'checksums': ['a57820b3e3221e973cba9500b4ad7953730110ee398693d150af833f26d5d0bc'],
+    }),
+    ('clipr', '0.6.0', {
+        'checksums': ['55f4adaef46781c1c1e584a8840f2775efd026b138760d923833c95a678d334d'],
+    }),
+    ('readr', '1.3.1', {
+        'checksums': ['33f94de39bb7f2a342fbb2bd4e5afcfec08798eac39672ee18042ac0b349e4f3'],
+    }),
+    ('ellipsis', '0.1.0', {
+        'checksums': ['e6f1f30390182b36664b097b5fbf6e95897a766b1ddfa774d3b507f42e26895f'],
+    }),
+    ('forcats', '0.4.0', {
+        'checksums': ['7c83cb576aa6fe1379d7506dcc332f7560068b2025f9e3ab5cd0a5f28780d2b2'],
+    }),
+    ('haven', '2.1.0', {
+        'checksums': ['c0a1cf1b039549fb3ad833f9644ed3f142790236ad755d2ee7bd3d8109e3ae74'],
+    }),
+    ('pan', '1.6', {
+        'checksums': ['adc0df816ae38bc188bce0aef3aeb71d19c0fc26e063107eeee71a81a49463b6'],
+    }),
+    ('mitml', '0.3-7', {
+        'checksums': ['c6f796d0059f1b093b599a89d955982fa257de9c45763ecc2cbbce10fdec1e7b'],
+    }),
+    ('mice', '3.5.0', {
+        'checksums': ['4fccecdf9e8d8f9f63558597bfbbf054a873b2d0b0820ceefa7b6911066b9e45'],
+    }),
+    ('urca', '1.3-0', {
+        'checksums': ['621cc82398e25b58b4a16edf000ed0a1484d9a0bc458f734e97b6f371cc76aaa'],
+    }),
+    ('fracdiff', '1.4-2', {
+        'checksums': ['983781cedc2b4e3ba9fa020213957d5133ae9cd6710bc61d6225728e2f6e850e'],
+    }),
+    ('logistf', '1.23', {
+        'checksums': ['5adb22a40569883395dc048c877f849dd08d07582a991f1b160f0338f0b13838'],
+    }),
+    ('akima', '0.6-2', {
+        'checksums': ['61da3e556553eea6d1f8db7c92218254441da31e365bdef82dfe5da188cc97ce'],
+    }),
+    ('bitops', '1.0-6', {
+        'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
+    }),
+    ('mixtools', '1.1.0', {
+        'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],
+    }),
+    ('cluster', '2.0.9', {
+        'checksums': ['8ee6f02435c8befbdc9effc09478817e67113e9daa5f59cecd40fe45f46ee5ad'],
+    }),
+    ('gclus', '1.3.2', {
+        'checksums': ['9cc61cdff206c11213e73afca3d570a7234250cf6044a9202c2589932278e0b3'],
+    }),
+    ('coda', '0.19-2', {
+        'checksums': ['678a7e6a87a2723089daeb780ea37ac3d4319b37eabe26928ea3fa9c9b1eda0d'],
+    }),
+    ('codetools', '0.2-16', {
+        'checksums': ['f67a66175cb5d8882457d1e9b91ea2f16813d554fa74f80c1fd6e17cf1877501'],
+    }),
+    ('foreach', '1.4.4', {
+        'checksums': ['c0a71090d5b70b9a95a6936091dabae9c26e1fc6b9609bfe5fb6346033905e48'],
+    }),
+    ('doMC', '1.3.5', {
+        'checksums': ['792254596babd8cc074bb3c83c18672dd07a0c3246b4ebab08d8ebedf6f4d9ed'],
+    }),
+    ('DBI', '1.0.0', {
+        'checksums': ['ff16f118eb3f759183441835e932b87358dd80ab9800ce576a8f3df1b6f01cf5'],
+    }),
+    ('gam', '1.16', {
+        'checksums': ['020532e49e59b8691dbbdd44fdaee6c0cf7334708b3080c24706140edf238f2e'],
+    }),
+    ('gamlss.data', '5.1-4', {
+        'checksums': ['0d3777d8c3cd76cef273aa6bde40a91688719be401195ed9bfd1e85bd7d5eeb5'],
+    }),
+    ('gamlss.dist', '5.1-4', {
+        'checksums': ['343c6ca0fd8a1c1dfdf9ffc65c95d4dae0c6c80b3e60fccba003e5171f3d287e'],
+    }),
+    ('gamlss', '5.1-4', {
+        'checksums': ['e2fc36fe6ca3a69d69cdafd9533a4ff35090fdfb01df126f6a49156f4aa3376c'],
+    }),
+    ('gamlss.tr', '5.1-0', {
+        'checksums': ['f9e1c4935d8876bfc80dddc0a9bc2c82b4deeda9482df208297a84a638a4a9df'],
+    }),
+    ('hwriter', '1.3.2', {
+        'checksums': ['6b3531d2e7a239be9d6e3a1aa3256b2745eb68aa0bdffd2076d36552d0d7322b'],
+    }),
+    ('KernSmooth', '2.23-15', {
+        'checksums': ['8b72d23ed121a54af188b2cda4441e3ce2646359309885f6455b82c0275210f6'],
+    }),
+    ('xts', '0.11-2', {
+        'checksums': ['12772f6a66aab5b84b0665c470f11a3d8d8a992955c027261cfe8e6077ee13b8'],
+    }),
+    ('curl', '3.3', {
+        'checksums': ['0cb0b9a9280edc42ebed94708541ec86b4f48779e722171e45227eab8a88a5bd'],
+    }),
+    ('TTR', '0.23-4', {
+        'checksums': ['eb17604da986213b3b924f0af65c3d089502a658a253ee34f6b8f6caccf6bfa2'],
+    }),
+    ('quantmod', '0.4-14', {
+        'checksums': ['d95b1acf73328d675bbad18a93fa3c40faf58959e0401458ad21cf6b9f9254b3'],
+    }),
+    ('mvtnorm', '1.0-10', {
+        'checksums': ['31df19cd8b4cab9d9a70dba00442b7684e625d4ca143a2c023c2c5872b07ad12'],
+    }),
+    ('pcaPP', '1.9-73', {
+        'checksums': ['ca4566b0babfbe83ef9418283b08a12b3420dc362f93c6562f265df7926b53fc'],
+    }),
+    ('SQUAREM', '2017.10-1', {
+        'checksums': ['9b89905b436f1cf3faa9e3dabc585a76299e729e85ca659bfddb4b7cba11b283'],
+    }),
+    ('lava', '1.6.5', {
+        'checksums': ['0e7439592d9ca5a07f6a6cfad44866b9ead841a14b8cc420f9967a415ec3348f'],
+    }),
+    ('prodlim', '2018.04.18', {
+        'checksums': ['4b22b54fdf712439309be0ff74f63cde9080464667b00e19823372ac0fc254ab'],
+    }),
+    ('pscl', '1.5.2', {
+        'checksums': ['2c9fe648485c6b54c6f95a54b6e00ffe3cf06fa8c5c68f1d669664a7b91a0ede'],
+    }),
+    ('memoise', '1.1.0', {
+        'checksums': ['b276f9452a26aeb79e12dd7227fcc8712832781a42f92d70e86040da0573980c'],
+    }),
+    ('bit64', '0.9-7', {
+        'checksums': ['7b9aaa7f971198728c3629f9ba1a1b24d53db5c7e459498b0fdf86bbd3dff61f'],
+    }),
+    ('prettyunits', '1.0.2', {
+        'checksums': ['35a4980586c20650538ae1e4fed4d80fdde3f212b98546fc3c7d9469a1207f5c'],
+    }),
+    ('blob', '1.1.1', {
+        'checksums': ['accbf9c9746c983e4108c8709995e54e61611ea7e2c51d4b6a0d813261484f53'],
+    }),
+    ('RSQLite', '2.1.1', {
+        'checksums': ['dfdc7de4f453efeed8361b7bec271a9ed7f0c00110e93c24f486e93206993cbe'],
+    }),
+    ('data.table', '1.12.2', {
+        'checksums': ['db55c18f0d703a8bc1c806dd1f7551bb405cb867717f52ef9dd64405394d22f5'],
+    }),
+    ('BatchJobs', '1.8', {
+        'checksums': ['35cc2dae31994b1df982d11939509ce965e12578418c4fbb8cd7a422afd6e4ff'],
+    }),
+    ('sandwich', '2.5-1', {
+        'checksums': ['dbef6f4d12b83e166f9a2508b7c732b04493641685d6758d29f3609e564166d6'],
+    }),
+    ('sfsmisc', '1.1-4', {
+        'checksums': ['44b6a9c859922e86b7182e54eb781d3264f3819f310343518ebc66f54f305c7d'],
+    }),
+    ('spatial', '7.3-11', {
+        'checksums': ['624448d2ac22e1798097d09fc5dc4605908a33f490b8ec971fc6ea318a445c11'],
+    }),
+    ('VGAM', '1.1-1', {
+        'checksums': ['de192bd65a7e8818728008de8e60e6dd3b61a13616c887a43e0ccc8147c7da52'],
+    }),
+    ('waveslim', '1.7.5.1', {
+        'checksums': ['b323018c92674b1b49fe01ec7e3900641a1c9ce0bd1e7497cfe8f64e96057e56'],
+    }),
+    ('xtable', '1.8-4', {
+        'checksums': ['5abec0e8c27865ef0880f1d19c9f9ca7cc0fd24eadaa72bcd270c3fb4075fd1c'],
+    }),
+    ('profileModel', '0.6.0', {
+        'checksums': ['a829ceec29c817d6d15947b818e28f9cf5a188a231b9b5d0a75018388887087b'],
+    }),
+    ('brglm', '0.6.2', {
+        'checksums': ['c2af432a43ccf37e9de50317f770b9703a4c80b4ef79ec40aa8e7ec3987e3631'],
+    }),
+    ('deSolve', '1.21', {
+        'checksums': ['45c372d458fe4c7c11943d4c409517849b1be6782dc05bd9a74b066e67250c63'],
+    }),
+    ('tseriesChaos', '0.1-13.1', {
+        'checksums': ['23cb5fea56409a305e02a523ff8b7642ec383942d415c9cffdc92208dacfd961'],
+    }),
+    ('tseries', '0.10-47', {
+        'patches': ['tseries-0.10-47_ifort_explicit_free_form.patch'],
+        'checksums': [
+            '202377df56806fe611c2e12c4d9732c71b71220726e2defa7e568d2b5b62fb7b',  # tseries_0.10-47.tar.gz
+            # tseries-0.10-47_ifort_explicit_free_form.patch
+            'b5a5b342e3b647ea2d7db145cb81eedcb82ea09c993a19a17b0148691ab0813c',
+        ],
+    }),
+    ('fastICA', '1.2-1', {
+        'checksums': ['6f2997dd766a544be3a3de2780df48ca67242ac7790a4a2882c417bfaa171f81'],
+    }),
+    ('R.methodsS3', '1.7.1', {
+        'checksums': ['44b840399266cd27f8f9157777b4d9d85ab7bd31bfdc143b3fc45079a2d8e687'],
+    }),
+    ('R.oo', '1.22.0', {
+        'checksums': ['c0862e4608fb2b8f91ec4494d46c2f3ba7bc44999f9aa3d7b9625d3792e7dd4c'],
+    }),
+    ('cgdsr', '1.2.10', {
+        'checksums': ['43bc02fb33c371464f9407d5e5e6419527e9360e3e394343862cca0aebe1d0f7'],
+    }),
+    ('R.utils', '2.8.0', {
+        'checksums': ['cfc54dd2a7fd7f8d840f2d58615fdba1cccc3ecde325385180ff3e191acd4ac9'],
+    }),
+    ('R.matlab', '3.6.2', {
+        'checksums': ['1ba338f470a24b7f6ef68cadbd04eb468ead4a689f263d2642408ad591b786bb'],
+    }),
+    ('gridExtra', '2.3', {
+        'checksums': ['81b60ce6f237ec308555471ae0119158b115463df696d2eca9b177ded8988e3b'],
+    }),
+    ('gbm', '2.1.5', {
+        'checksums': ['06fbde10639dfa886554379b40a7402d1f1236a9152eca517e97738895a4466f'],
+    }),
+    ('Formula', '1.2-3', {
+        'checksums': ['1411349b20bd09611a9fd0ee6d15f780c758ad2b0e490e908facb49433823872'],
+    }),
+    ('acepack', '1.4.1', {
+        'checksums': ['82750507926f02a696f6cc03693e8d4a5ee7e92500c8c15a16a9c12addcd28b9'],
+    }),
+    ('proto', '1.0.0', {
+        'checksums': ['9294d9a3b2b680bb6fac17000bfc97453d77c87ef68cfd609b4c4eb6d11d04d1'],
+    }),
+    ('chron', '2.3-53', {
+        'checksums': ['521814b46ba958eae28e29d8766aebd285da5e6fa16c5806603df3ae39f77309'],
+    }),
+    ('viridis', '0.5.1', {
+        'checksums': ['ddf267515838c6eb092938133035cee62ab6a78760413bfc28b8256165701918'],
+    }),
+    ('yaml', '2.2.0', {
+        'checksums': ['55bcac87eca360ab5904914fcff473a6981a1f5e6d2215d2634344d0ac30c546'],
+    }),
+    ('jsonlite', '1.6', {
+        'checksums': ['88c5b425229966b7409145a6cabc72db9ed04f8c37ee95901af0146bb285db53'],
+    }),
+    ('htmltools', '0.3.6', {
+        'checksums': ['44affb82f9c2fd76c9e2b58f9229adb003217932b68c3fdbf1327c8d74c868a2'],
+    }),
+    ('htmlwidgets', '1.3', {
+        'checksums': ['f1e4ffabc29e6cfe857f627da095be3cfcbe0e1f02ae75e572f10b4a026c5a12'],
+    }),
+    ('xfun', '0.7', {
+        'checksums': ['c9efcaf8910ad66a9594c4f7eba2d0b9051ad61c2ec01214675cef09a5f794be'],
+    }),
+    ('knitr', '1.23', {
+        'checksums': ['063bfb3300fc9f3e7d223c346e19b93beced0e6784470b9bef2524868a206a99'],
+    }),
+    ('rstudioapi', '0.10', {
+        'checksums': ['80c5aa3063bcab649904cb92f0b164edffa2f6b0e6a8f7ea28ae317b80e1ab96'],
+    }),
+    ('htmlTable', '1.13.1', {
+        'checksums': ['689f32b65da6a57ad500e8d9ef3309d346401dca277c6b264a46c8d7c75884d0'],
+    }),
+    ('Hmisc', '4.2-0', {
+        'checksums': ['9e9614673288dd00295f250fa0bf96fc9e9fed692c69bf97691081c1a01411d9'],
+    }),
+    ('fastcluster', '1.1.25', {
+        'checksums': ['f3661def975802f3dd3cec5b2a1379f3707eacff945cf448e33aec0da1ed4205'],
+    }),
+    ('registry', '0.5-1', {
+        'checksums': ['dfea36edb0a703ec57e111016789b47a1ba21d9c8ff30672555c81327a3372cc'],
+    }),
+    ('bibtex', '0.4.2', {
+        'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
+    }),
+    ('pkgmaker', '0.27', {
+        'checksums': ['17a289d8f596ba5637b07077b3bff22411a2c2263c0b7de59fe848666555ec6a'],
+    }),
+    ('rngtools', '1.3.1.1', {
+        'checksums': ['99e1a8fde6b81128d0946746c1ef84ec5b6c2973ad843a080098baf73aa3364c'],
+    }),
+    ('doParallel', '1.0.14', {
+        'checksums': ['cbbb7f37606d608a9603915ee65587f8ed4bb4a8405ecfaa7f33b8c423d11207'],
+    }),
+    ('gridBase', '0.4-7', {
+        'checksums': ['be8718d24cd10f6e323dce91b15fc40ed88bccaa26acf3192d5e38fe33e15f26'],
+    }),
+    ('NMF', '0.21.0', {
+        'checksums': ['3b30c81c66066fab4a63c5611a0313418b840d8b63414db31ef0e932872d02e3'],
+    }),
+    ('irlba', '2.3.3', {
+        'checksums': ['6ee233697bcd579813bd0af5e1f4e6dd1eea971e8919c748408130d970fef5c0'],
+    }),
+    ('igraph', '1.2.4.1', {
+        'checksums': ['891acc763b5a4a4a245358a95dee69280f4013c342f14dd6a438e7bb2bf2e480'],
+    }),
+    ('GeneNet', '1.2.13', {
+        'checksums': ['3798caac3bef7dc87f97b3628eb29eb12365d571ce0837b5b6285b0be655a270'],
+    }),
+    ('ape', '5.3', {
+        'checksums': ['08b0df134c523feb00a86896d1aa2a43f0f0dab20a53bc6b5d6268d867988b23'],
+    }),
+    ('RJSONIO', '1.3-1.2', {
+        'checksums': ['550e18f7c04186376d67747b8258f529d205bfc929da9194fe45ec384e092d7e'],
+    }),
+    ('caTools', '1.17.1.2', {
+        'checksums': ['69cc542fab5677462b1a768709d0c4a0a0790f5db53e1fe9ae7123787c18726b'],
+    }),
+    ('gplots', '3.0.1.1', {
+        'checksums': ['7db103f903a25d174cddcdfc7b946039b61e236c95084b90ad17f1a41da3770c'],
+    }),
+    ('ROCR', '1.0-7', {
+        'checksums': ['e7ef710f847e441a48b20fdc781dbc1377f5a060a5ee635234053f7a2a435ec9'],
+    }),
+    ('later', '0.8.0', {
+        'checksums': ['6b2a28b43c619b2c7890840c62145cd3a34a7ed65b31207fdedde52efb00e521'],
+    }),
+    ('promises', '1.0.1', {
+        'checksums': ['c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558'],
+    }),
+    ('httpuv', '1.5.1', {
+        'checksums': ['b5bb6b3b2f1a6d792568a70f3f357d6b3a35a5e26dd0c668c61a31f2ae8f5710'],
+    }),
+    ('rjson', '0.2.20', {
+        'checksums': ['3a287c1e5ee7c333ed8385913c0a307daf99335fbdf803e9dcca6e3d5adb3f6c'],
+    }),
+    ('sourcetools', '0.1.7', {
+        'checksums': ['47984406efb3b3face133979ccbae9fefb7360b9a6ca1a1c11473681418ed2ca'],
+    }),
+    ('shiny', '1.3.2', {
+        'checksums': ['28b851ae6c196ca845f6e815c1379247595ac123a4faa10a16533d1a9ce0c24f'],
+    }),
+    ('seqinr', '3.4-5', {
+        'checksums': ['162a347495fd52cbb62e8187a4692e7c50b9fa62123c5ef98f2744c98a05fb9f'],
+    }),
+    ('LearnBayes', '2.15.1', {
+        'checksums': ['9b110858456523ca0b2a63f22013c4e1fbda6674b9d84dc1f4de8bffc5260532'],
+    }),
+    ('deldir', '0.1-16', {
+        'checksums': ['5858e145d38f6e05f89771f97e4575a33c0ec6b5a3eaae4addbe4d0a819c8914'],
+    }),
+    ('gmodels', '2.18.1', {
+        'checksums': ['626140a34eb8c53dd0a06511a76c71bc61c48777fa76fcc5e6934c9c276a1369'],
+    }),
+    ('expm', '0.999-4', {
+        'checksums': ['58d06427a08c9442462b00a5531e2575800be13ed450c5a1546261251e536096'],
+    }),
+    ('spData', '0.3.0', {
+        'checksums': ['de24ea659541a6c795cd26a1f6a213e15061af9c97a24cba1c24ce30c6c24c98'],
+    }),
+    ('units', '0.6-3', {
+        'checksums': ['03de88d9dcfe80d22dd3813413f33657c576aed24a8091dbfc7f68602020a64f'],
+    }),
+    ('classInt', '0.3-3', {
+        'checksums': ['a93e685ef9c40d5977bb91d7116505a25303b229897a20544722a94ea1365f30'],
+    }),
+    ('vegan', '2.5-5', {
+        'checksums': ['876b5266f29f3034fed881020d16f476e62d145a00cb450a1a213e019e056971'],
+    }),
+    ('progress', '1.2.2', {
+        'checksums': ['b4a4d8ed55db99394b036a29a0fb20b5dd2a91c211a1d651c52a1023cc58ff35'],
+    }),
+    ('rncl', '0.8.3', {
+        'checksums': ['daaef6874438233c73a62b59a9ee10261e1e10d7ef18b7178d2d8b517fd4880d'],
+    }),
+    ('XML', '3.98-1.19', {
+        'checksums': ['81b1c4a2df24c5747fa8b8ec2d76b4e9c3649b56ca94f6c93fbd106c8a72beab'],
+    }),
+    ('praise', '1.0.0', {
+        'checksums': ['5c035e74fd05dfa59b03afe0d5f4c53fbf34144e175e90c53d09c6baedf5debd'],
+    }),
+    ('testthat', '2.1.1', {
+        'checksums': ['776ebc8ba07ba41ac4f402e4cf1a525a66e9a50763931515b8fe9c4c21c84f0e'],
+    }),
+    ('rprojroot', '1.3-2', {
+        'checksums': ['df5665834941d8b0e377a8810a04f98552201678300f168de5f58a587b73238b'],
+    }),
+    ('tinytex', '0.13', {
+        'checksums': ['6bff663c03d45a5c1a0e20d50916f493204ab89090702841f4368bb9b28777ad'],
+    }),
+    ('rmarkdown', '1.13', {
+        'checksums': ['96fb6b08d27bbb8054145e0a55721f905341941d4f6691480a2a234e2d5a63ef'],
+    }),
+    ('sys', '3.2', {
+        'checksums': ['2819498461fe2ce83d319d1a47844e86bcea6d01d10861818dba289e7099bbcc'],
+    }),
+    ('askpass', '1.1', {
+        'checksums': ['db40827d1bdbb90c0aa2846a2961d3bf9d76ad1b392302f9dd84cc2fd18c001f'],
+    }),
+    ('openssl', '1.4', {
+        'checksums': ['64a04441d438631559ef31b6d838b1566c2c71a3b2fe1fac90c55a9e16ef0456'],
+    }),
+    ('httr', '1.4.0', {
+        'checksums': ['d633f1425da514f65f3b8c034ae0a8b6911995009840c6bb9657ceedb99ddb48'],
+    }),
+    ('reshape', '0.8.8', {
+        'checksums': ['4d5597fde8511e8fe4e4d1fd7adfc7ab37ff41ac68c76a746f7487d7b106d168'],
+    }),
+    ('xml2', '1.2.0', {
+        'checksums': ['0a7a916fe9c5da9ac45aeb4c6b6b25d33c07652d422b9f2bb570f2e8f4ac9494'],
+    }),
+    ('triebeard', '0.3.0', {
+        'checksums': ['bf1dd6209cea1aab24e21a85375ca473ad11c2eff400d65c6202c0fb4ef91ec3'],
+    }),
+    ('urltools', '1.7.3', {
+        'checksums': ['6020355c1b16a9e3956674e5dea9ac5c035c8eb3eb6bbdd841a2b5528cafa313'],
+    }),
+    ('httpcode', '0.2.0', {
+        'checksums': ['fbc1853db742a2cc1df11285cf27ce2ea43bc0ba5f7d393ee96c7e0ee328681a'],
+    }),
+    ('crul', '0.7.4', {
+        'checksums': ['c963dd666ae3fc89b661ce19fce2fa19a16fc3825e1502105cae98ceb92c6014'],
+    }),
+    ('bold', '0.8.6', {
+        'checksums': ['c697a2af76c0466c0814f328c38de203322b06cec332b437631e046e9f51015e'],
+    }),
+    ('rredlist', '0.5.0', {
+        'checksums': ['404db668f94aea7fe8c4da75085ea82b0bc9994f023ef4a52f4d75cf198db889'],
+    }),
+    ('rentrez', '1.2.2', {
+        'checksums': ['e5cb4265fd06d2ed0e11da3667ba79f7f2c8816005ba72cf5f53b8cf02dc193e'],
+    }),
+    ('rotl', '3.0.7', {
+        'checksums': ['c94d8f1a732878f1d5c724a534dc170962a523eb4b213c27497162d748deda95'],
+    }),
+    ('solrium', '1.0.2', {
+        'checksums': ['0daecc6ea4a8689bd032dd447171e7dda146dc3df903cb0617424cee84f53e04'],
+    }),
+    ('ritis', '0.7.6', {
+        'checksums': ['4659dec79ca78e8cd848419387ef4c5d165d34e845f57bcc24ee3f551b2138a8'],
+    }),
+    ('worrms', '0.3.2', {
+        'checksums': ['ece1375e987c84f72e0f3ef23971821e265c6c253d117ecfc94d3df9c653bfcf'],
+    }),
+    ('natserv', '0.3.0', {
+        'checksums': ['3c207d45bbba75dfd16f40d6eaaac122e40b3d3ca05b3b98aa8ed3c092638e5e'],
+    }),
+    ('WikipediR', '1.5.0', {
+        'checksums': ['f8d0e6f04fb65f7ad9c1c068852a6a8b699ffe8d39edf1f3fa07d32d087e8ff0'],
+    }),
+    ('WikidataR', '1.4.0', {
+        'checksums': ['64b1d53d7023249b73a77a7146adc3a8957b7bf3d808ebd6734795e9f58f4b2a'],
+    }),
+    ('wikitaxa', '0.3.0', {
+        'checksums': ['10dbabac6c56c1d0f33a66ff9b4f48b0bcb470711808a86863b48dc1140ec86c'],
+    }),
+    ('phangorn', '2.5.3', {
+        'checksums': ['a306585a0aabe7360a2adaf9116ae2993fb5ceff641b198f2e01e4329d3768af'],
+    }),
+    ('taxize', '0.9.7', {
+        'checksums': ['3af230121cb97f82465561b442290a8d19cbca2a2c3b9cc656e3be66464659d7'],
+    }),
+    ('uuid', '0.1-2', {
+        'checksums': ['dd71704dc336b0857981b92a75ed9877d4ca47780b1682def28839304cd3b1be'],
+    }),
+    ('RNeXML', '2.3.0', {
+        'checksums': ['8a52e141f2f47f4cfcb617c1a2866fdff26db4b56d47c914c9f12917c39edb73'],
+    }),
+    ('phylobase', '0.8.6', {
+        'checksums': ['e7117b210ef406115e5523b794d8c2c5779640cee8c06e73751dc14c69322fd9'],
+    }),
+    ('magick', '2.0', {
+        'checksums': ['559cd274b0148e89f66ccbf111a4123f600e67fa7258293a220ed6224631c4a3'],
+    }),
+    ('animation', '2.6', {
+        'checksums': ['90293638920ac436e7e4de76ebfd92e1643ccdb0259b62128f16dd0b13245b0a'],
+    }),
+    ('bigmemory.sri', '0.1.3', {
+        'checksums': ['55403252d8bae9627476d1f553236ea5dc7aa6e54da6980526a6cdc66924e155'],
+    }),
+    ('bigmemory', '4.5.33', {
+        'patches': ['bigmemory-4.5.19_icpc-wd308.patch'],
+        'checksums': [
+            '7237d9785d8ce3eab4e36ad3ce2c95cbae926326031661b4f237b7517f4b9479',  # bigmemory_4.5.33.tar.gz
+            'cf673010f63baff60bf5fe4521a3740aa6891bcfb64c1979a8f1e1aa21532549',  # bigmemory-4.5.19_icpc-wd308.patch
+        ],
+    }),
+    ('calibrate', '1.7.2', {
+        'checksums': ['78066a564f57f2110f1752d681d6b97915cf73135134330587fff8b46c581604'],
+    }),
+    ('clusterGeneration', '1.3.4', {
+        'checksums': ['7c591ad95a8a9d7fb0e4d5d80dfd78f7d6a63cf7d11eb53dd3c98fdfb5b868aa'],
+    }),
+    ('raster', '2.9-5', {
+        'checksums': ['d38386bb5f5f8397bfeb118804012c15a1088d02bc021a64ebea7f7275f55952'],
+    }),
+    ('dismo', '1.1-4', {
+        'checksums': ['f2110f716cd9e4cca5fd2b22130c6954658aaf61361d2fe688ba22bbfdfa97c8'],
+    }),
+    ('extrafontdb', '1.0', {
+        'checksums': ['faa1bafee5d4fbc24d03ed237f29f1179964ebac6e3a46ac25b0eceda020b684'],
+    }),
+    ('Rttf2pt1', '1.3.7', {
+        'checksums': ['4a4e50578b5c1dbfb90c289ee388c102de1f9c84f8b8ddb8d2294b58474e0e8a'],
+    }),
+    ('extrafont', '0.17', {
+        'checksums': ['2f6d7d79a890424b56ddbdced361f8b9ddede5edd33e090b816b88a99315332d'],
+    }),
+    ('fields', '9.8-3', {
+        'checksums': ['010676e009d48ff605d9881bcedb903b95bc4a271da47eb629d5cbcf1a323de1'],
+    }),
+    ('shapefiles', '0.7', {
+        'checksums': ['eeb18ea4165119519a978d4a2ba1ecbb47649deb96a7f617f5b3100d63b3f021'],
+    }),
+    ('fossil', '0.3.7', {
+        'checksums': ['3feba6ceecaa6f2f68fdc1ceb0019395ccfadb0cf033e1709dddb690c7f210a1'],
+    }),
+    ('geiger', '2.0.6.2', {
+        'checksums': ['9153047b608d652821251206d1450bb3f517c8884379f498a695315574ae001d'],
+    }),
+    ('glmnet', '2.0-18', {
+        'checksums': ['e8dce9d7b8105f9cc18ba981d420de64a53b09abee219660d3612915d554256b'],
+    }),
+    ('crosstalk', '1.0.0', {
+        'checksums': ['b31eada24cac26f24c9763d9a8cbe0adfd87b264cf57f8725027fe0c7742ca51'],
+    }),
+    ('miniUI', '0.1.1.1', {
+        'checksums': ['452b41133289f630d8026507263744e385908ca025e9a7976925c1539816b0c0'],
+    }),
+    ('ps', '1.3.0', {
+        'checksums': ['289193d0ccd2db0b6fe8702e8c5711e935219b17f90f01a6e9684982413e98d1'],
+    }),
+    ('processx', '3.3.1', {
+        'checksums': ['6123dbdf9f3bb6e5e8678980fb4587dcefb56d2190adf2ef494d7cd199720bae'],
+    }),
+    ('callr', '3.2.0', {
+        'checksums': ['4bb47b1018e8eb5c683a86c05d0d9b8b25848db1f1b30e92cfebedc0ce14b0e8'],
+    }),
+    ('webshot', '0.5.1', {
+        'checksums': ['b9750d206c6fa0f1f16cc212b0a34f4f4bfa916962d2c877f0ee9a33620f4b23'],
+    }),
+    ('manipulateWidget', '0.10.0', {
+        'checksums': ['3d61a3d0cedf5c8a850a3e62ed6af38c600dc3f25b44c4ff07a5093bf9ca4ffd'],
+    }),
+    ('rgl', '0.100.19', {
+        'checksums': ['50630702554e422e0603f27d499aad3b6f822de5a73da7fdf70404ac50df7025'],
+    }),
+    ('labdsv', '1.8-0', {
+        'checksums': ['dfaeb03a6e1bab6cfd384c00671235b22f2b4254cac1129b24a348cb353b6e65'],
+    }),
+    ('stabs', '0.6-3', {
+        'checksums': ['e961ae21d45babc1162b6eeda874c4e3677fc286fd06f5427f071ad7a5064a9f'],
+    }),
+    ('modeltools', '0.2-22', {
+        'checksums': ['256a088fc80b0d9182f984f9bd3d6207fb7c1e743f72e2ecb480e6c1d4ac34e9'],
+    }),
+    ('strucchange', '1.5-1', {
+        'checksums': ['740e2e20477b9fceeef767ae1002adc5ec397cb0f7daba5289a2c23b0dddaf31'],
+    }),
+    ('TH.data', '1.0-10', {
+        'checksums': ['618a1c67a30536d54b1e48ba3af46a6edcd6c2abef17935b5d4ba526a43aff55'],
+    }),
+    ('multcomp', '1.4-10', {
+        'checksums': ['29bcc635c0262e304551b139cd9ee655ab25a908d9693e1cacabfc2a936df5cf'],
+    }),
+    ('libcoin', '1.0-4', {
+        'checksums': ['91dcbaa0ab8c2109aa54c3eda29ad0acd67c870efcda208e27acce9d641c09c5'],
+    }),
+    ('matrixStats', '0.54.0', {
+        'patches': ['matrixStats-0.53.1_O1.patch'],
+        'checksums': [
+            '8f0db4e181300a208b9aedbebfdf522a2626e6675d2662656efb8ba71b05a06f',  # matrixStats_0.54.0.tar.gz
+            '96ef21a1d5ee4ccd1f4a6b74ef5aa2699a52c38b34613d8ff9f3c4af952aa8fd',  # matrixStats-0.53.1_O1.patch
+        ],
+    }),
+    ('coin', '1.3-0', {
+        'checksums': ['adcebb37e0a7dfddbf8ec1e09c12a809bd76d90b5b8ff2b1048a75252ba11ef8'],
+    }),
+    ('party', '1.3-3', {
+        'checksums': ['9f72eea02d43a4cee105790ae7185b0478deb6011ab049cc9d31a0df3abf7ce9'],
+    }),
+    ('inum', '1.0-1', {
+        'checksums': ['3c2f94c13c03607e05817e4859595592068b55e810fed94e29bc181ad248a099'],
+    }),
+    ('partykit', '1.2-4', {
+        'checksums': ['d6aff810154d7b11ee75adf6744b774f7963f67b89ffe5c87f113a04417e75ba'],
+    }),
+    ('mboost', '2.9-1', {
+        'checksums': ['67ed26093fc2c1e57d7fac842a51a0de0162e448d4dab09c0054baee801f2a0a'],
+    }),
+    ('msm', '1.6.7', {
+        'checksums': ['7503c0f61916033ed0efad54727368bce629ff2d370f302b71bc1cb924d2e23a'],
+    }),
+    ('nor1mix', '1.2-3', {
+        'checksums': ['435e6519e832ef5229c51ccb2619640e6b50dfc7470f70f0c938d18a114273af'],
+    }),
+    ('np', '0.60-9', {
+        'checksums': ['fe31a8985f0b1a576a7775022b7131093b1c9a8337734136d5fcad85fa6592fc'],
+    }),
+    ('polynom', '1.4-0', {
+        'checksums': ['c5b788b26f7118a18d5d8e7ba93a0abf3efa6603fa48603c70ed63c038d3d4dd'],
+    }),
+    ('polspline', '1.1.14', {
+        'checksums': ['40ed803ea25975b6fcd96292009897db22a2f346dc271396d1ce8f10b92d9a3c'],
+    }),
+    ('rms', '5.1-3.1', {
+        'checksums': ['0946d9547a4e3ff020a61ab3fce38f88aa9545729683e2bfefeb960edec82b37'],
+    }),
+    ('RWekajars', '3.9.3-1', {
+        'checksums': ['dcbd2974751a2b27953b59359497472948c67e9d518edba44ec13a9cd8dd5e9b'],
+    }),
+    ('RWeka', '0.4-40', {
+        'checksums': ['ef9b6eeb4ff60c89ef4490b9269eaeaddb701180e193514257be8000f2cab0a7'],
+    }),
+    ('slam', '0.1-45', {
+        'checksums': ['84ab3919c7dbac41d97d076787feacfd6861f669aa2842879dffb46ed4467277'],
+    }),
+    ('tm', '0.7-6', {
+        'checksums': ['3995ef712ce4454d2cbaef4c1e9b2f8379c96c7edaa3de5b1eb8df25e720fb6a'],
+    }),
+    ('TraMineR', '2.0-11.1', {
+        'checksums': ['51d88fc4daa49d7b655d1876e07cd7c29a850950268341d39f5680a1c841e5a3'],
+    }),
+    ('chemometrics', '1.4.2', {
+        'checksums': ['b705832fa167dc24b52b642f571ed1efd24c5f53ba60d02c7797986481b6186a'],
+    }),
+    ('FNN', '1.1.3', {
+        'checksums': ['de763a25c9cfbd19d144586b9ed158135ec49cf7b812938954be54eb2dc59432'],
+    }),
+    ('ipred', '0.9-9', {
+        'checksums': ['0da87a70730d5a60b97e46b2421088765e7d6a7cc2695757eba0f9d31d86416f'],
+    }),
+    ('statmod', '1.4.32', {
+        'checksums': ['2f67a1cfa66126e6345f8a40564a3077d08f1748f17cb8c8fb05c94ed0f57e20'],
+    }),
+    ('miscTools', '0.6-22', {
+        'checksums': ['d00bb2602d1d31e9e1e13c8868cfe69d432bbe15afa8d4bbb83b3c9e0b9dcfea'],
+    }),
+    ('maxLik', '1.3-6', {
+        'checksums': ['95e92124776d70c5aaf5af99f184b0fac0ec726a98537d32518a8d7acf43924a'],
+    }),
+    ('gbRd', '0.4-11', {
+        'checksums': ['0251f6dd6ca987a74acc4765838b858f1edb08b71dbad9e563669b58783ea91b'],
+    }),
+    ('Rdpack', '0.11-0', {
+        'checksums': ['8fb449c80fbe931cdce51f728fb03a1978009ccce66fd6b9edacdc6ff4118d85'],
+    }),
+    ('mlogit', '0.4-2', {
+        'checksums': ['0eaf4f6198b9ad5b60d30daac28bbc5a264ad32e91c30977ed1695ead2ab0ac6'],
+    }),
+    ('getopt', '1.20.3', {
+        'checksums': ['531f5fdfdcd6b96a73df2b39928418de342160ac1b0043861e9ea844f9fbf57f'],
+    }),
+    ('gsalib', '2.1', {
+        'checksums': ['e1b23b986c18b89a94c58d9db45e552d1bce484300461803740dacdf7c937fcc'],
+    }),
+    ('optparse', '1.6.2', {
+        'checksums': ['b5a5a49ae05005f20359868329b73daac83d50f5e088981dcf5c41399534377f'],
+    }),
+    ('labelled', '2.2.1', {
+        'checksums': ['51851d8a50acadb144e0d2300f65d0962d617aa963b2a3051fb56495bdd237d7'],
+    }),
+    ('questionr', '0.7.0', {
+        'checksums': ['c4566880a1ca8f01faad396e20d907d913f4a252acaf83a0cb508a3738874cb3'],
+    }),
+    ('klaR', '0.6-14', {
+        'checksums': ['51e9d9149ba77874ccecc816a2a75619e2f9615c091f6e8969da20615c2b29bd'],
+    }),
+    ('neuRosim', '0.2-12', {
+        'checksums': ['f4f718c7bea2f4b61a914023015f4c71312f8a180124dcbc2327b71b7be256c3'],
+    }),
+    #    ('locfit', '1.5-9.1', {
+    #        'checksums': ['f524148fdb29aac3a178618f88718d3d4ac91283014091aa11a01f1c70cd4e51'],
+    #    }),
+    ('GGally', '1.4.0', {
+        'checksums': ['9a47cdf004c41f5e4024327b94227707f4dad3a0ac5556d8f1fba9bf0a6355fe'],
+    }),
+    ('beanplot', '1.2', {
+        'checksums': ['49da299139a47171c5b4ccdea79ffbbc152894e05d552e676f135147c0c9b372'],
+    }),
+    ('clValid', '0.6-6', {
+        'checksums': ['c13ef1b6258e34ba53615b78f39dbe4d8ba47b976b3c24a3eedaecf5ffba19ed'],
+    }),
+    ('DiscriMiner', '0.1-29', {
+        'checksums': ['5aab7671086ef9940e030324651976456f0e84dab35edb7048693ade885228c6'],
+    }),
+    ('ellipse', '0.4.1', {
+        'checksums': ['1a9a9c52195b26c2b4d51ad159ab98aff7aa8ca25fdc6b2198818d1a0adb023d'],
+    }),
+    ('leaps', '3.0', {
+        'checksums': ['55a879cdad5a4c9bc3b5697dd4d364b3a094a49d8facb6692f5ce6af82adf285'],
+    }),
+    ('pbkrtest', '0.4-7', {
+        'checksums': ['5cbb03ad2b2468720a5a610a0ebda48ac08119a34fca77810a85f554225c23ea'],
+    }),
+    ('carData', '3.0-2', {
+        'checksums': ['3b5c4eff1cc1e456a5331084774503eaa06cf61fb7acf6b9e8a6bfabd5735494'],
+    }),
+    ('maptools', '0.9-5', {
+        'checksums': ['5d9511f09fb49d57a51f28495b02239800596a4fcfad7b03ee1074d793657bdd'],
+    }),
+    ('zip', '2.0.2', {
+        'checksums': ['3da26f3a807f257c310cebdc7856390e399a2ad6d1921ecb6d1ac40eebd16ff7'],
+    }),
+    ('openxlsx', '4.1.0.1', {
+        'checksums': ['8b7011debe14714de035ef42797c8caa923162d5dc3cc3c2a299fc10eff3d4d1'],
+    }),
+    ('rematch', '1.0.1', {
+        'checksums': ['a409dec978cd02914cdddfedc974d9b45bd2975a124d8870d52cfd7d37d47578'],
+    }),
+    ('cellranger', '1.1.0', {
+        'checksums': ['5d38f288c752bbb9cea6ff830b8388bdd65a8571fd82d8d96064586bd588cf99'],
+    }),
+    ('readxl', '1.3.1', {
+        'checksums': ['24b441713e2f46a3e7c6813230ad6ea4d4ddf7e0816ad76614f33094fbaaaa96'],
+    }),
+    ('rio', '0.5.16', {
+        'checksums': ['d3eb8d5a11e0a3d26169bb9d08f834a51a6516a349854250629072d59c29d465'],
+    }),
+    ('car', '3.0-3', {
+        'checksums': ['fa807cb12f6e7fb38ec534cac4eef54747945c2119a7d51155a2492ad778c36f'],
+    }),
+    ('flashClust', '1.01-2', {
+        'checksums': ['48a7849bb86530465ff3fbfac1c273f0df4b846e67d5eee87187d250c8bf9450'],
+    }),
+    ('FactoMineR', '1.41', {
+        'checksums': ['a9889d69e298b8a01e8d0a5a54260730e742c95681e367d759829aad9a8740c0'],
+    }),
+    ('flexclust', '1.4-0', {
+        'checksums': ['82fe445075a795c724644864c7ee803c5dd332a89ea9e6ccf7cd1ae2d1ecfc74'],
+    }),
+    ('flexmix', '2.3-15', {
+        'checksums': ['ba444c0bfe33ab87d440ab590c06b03605710acd75811c1622253171bb123f43'],
+    }),
+    ('prabclus', '2.3-1', {
+        'checksums': ['ef3294767d43bc3f72478fdaf0d1f13c8de18881bf9040c9f1add68af808b3c0'],
+    }),
+    ('diptest', '0.75-7', {
+        'checksums': ['462900100ca598ef21dbe566bf1ab2ce7c49cdeab6b7a600a50489b05f61b61b'],
+    }),
+    ('trimcluster', '0.1-2.1', {
+        'checksums': ['b64a872a6c2ad677dfeecc776c9fe5aff3e8bab6bc6a8c86957b5683fd5d2300'],
+    }),
+    ('fpc', '2.2-1', {
+        'checksums': ['05f9761bcab1899dd23c7d4292d6ba5f3c777f1ab4bccaf3f0fac5e592e56aa0'],
+    }),
+    ('BiasedUrn', '1.07', {
+        'checksums': ['2377c2e59d68e758a566452d7e07e88663ae61a182b9ee455d8b4269dda3228e'],
+    }),
+    ('TeachingDemos', '2.10', {
+        'checksums': ['2ef4c2e36ba13e32f66000e84281a3616584c86b255bca8643ff3fe4f78ed704'],
+    }),
+    ('kohonen', '3.0.8', {
+        'patches': ['kohonen-3.0.8_intel-wd308.patch'],
+        'checksums': [
+            '38d887a154e8c98fd4749a4219c346c9bec2ec8cf37ad80d473ed38683c26efd',  # kohonen_3.0.8.tar.gz
+            '816d22f6aec48691e3383c66274df9c83fcabcf68250d627a3e0cfd694dbe78e',  # kohonen-3.0.8_intel-wd308.patch
+        ],
+    }),
+    ('base64', '2.0', {
+        'checksums': ['8e259c2b12446197d1152b83a81bab84ccb5a5b77021a9b5645dd4c63c804bd1'],
+    }),
+    ('doRNG', '1.7.1', {
+        'checksums': ['27533d54464889d1c21301594137fc0f536574e3a413d61d7df9463ab12a67e9'],
+    }),
+    ('nleqslv', '3.3.2', {
+        'checksums': ['f54956cf67f9970bb3c6803684c84a27ac78165055745e444efc45cfecb63fed'],
+    }),
+    ('Deriv', '3.8.5', {
+        'checksums': ['40d43da3a8e93068874415995fdeba9ca2ef109b55211b228b43d1fa85e62520'],
+    }),
+    ('RGCCA', '2.1.2', {
+        'checksums': ['20f341fca8f616c556699790814debdf2ac7aa4dd9ace2071100c66af1549d7d'],
+    }),
+    ('pheatmap', '1.0.12', {
+        'checksums': ['579d96ee0417203b85417780eca921969cda3acc210c859bf9dfeff11539b0c1'],
+    }),
+    ('pvclust', '2.0-0', {
+        'checksums': ['1a4615214992307fd7c786cf4607a3ae2af5c0d4067f5053e1c195798a70d741'],
+    }),
+    ('RCircos', '1.2.1', {
+        'checksums': ['3b9489ab05ea83ead99ca6e4a1e6830467a2064779834aff1317b42bd41bb8fd'],
+    }),
+    ('lambda.r', '1.2.3', {
+        'checksums': ['0cd8e37ba1a0960888016a85d492da51a57df54bd65ff920b08c79a3bfbe8631'],
+    }),
+    ('futile.options', '1.0.1', {
+        'checksums': ['7a9cc974e09598077b242a1069f7fbf4fa7f85ffe25067f6c4c32314ef532570'],
+    }),
+    ('futile.logger', '1.4.3', {
+        'checksums': ['5e8b32d65f77a86d17d90fd8690fc085aa0612df8018e4d6d6c1a60fa65776e4'],
+    }),
+    ('VennDiagram', '1.6.20', {
+        'checksums': ['e51cb3fff23c6ec8191966490bf875a7415f8725d4054bae881a25febb9281c5'],
+    }),
+    ('xlsxjars', '0.6.1', {
+        'checksums': ['37c1517f95f8bca6e3514429394d2457b9e62383305eba288416fb53ab2e6ae6'],
+    }),
+    ('xlsx', '0.6.1', {
+        'checksums': ['a580bd16b5477c1c185bf681c12c1ffff4088089f97b6a37997913d93ec5a8b4'],
+    }),
+    ('uroot', '2.0-9.1', {
+        'patches': ['uroot-2.0-9.1_CUDA.patch'],
+        'checksums': [
+            'f7b6f59b6118e2b35bdb3a5a5df721bd0f02d0706d4df67a086b8ba5610b919b',  # uroot_2.0-9.1.tar.gz
+            '5de954038020d1d0c42eb0cb6b51950228ccc900c401dff6fbae43e4bc8fb936',  # uroot-2.0-9.1_CUDA.patch
+        ],
+    }),
+    ('forecast', '8.7', {
+        'patches': ['forecast-6.1_icpc-wd308.patch'],
+        'checksums': [
+            '0d3aec2d10e05cb7961695f0639d3c4b848dbfd4f551c7bc699b9f95e06e3a39',  # forecast_8.7.tar.gz
+            '5100dce59858960fc2ade7c599ecda13f3473984fb2bd90f8fa6598653e7ddc2',  # forecast-6.1_icpc-wd308.patch
+        ],
+    }),
+    ('fma', '2.3', {
+        'checksums': ['f516eff79e14d4ffefcdc2db06d97ae57f998e37e871264457078f671384fafc'],
+    }),
+    ('expsmooth', '2.3', {
+        'checksums': ['ac7da36347f983d6ec71715daefd2797fe2fc505c019f4965cff9f77ce79982a'],
+    }),
+    ('fpp', '0.5', {
+        'checksums': ['9c87dd8591b8a87327cae7a03fd362a5492495a96609e5845ccbeefb96e916cb'],
+    }),
+    ('tensor', '1.5', {
+        'checksums': ['e1dec23e3913a82e2c79e76313911db9050fb82711a0da227f94fc6df2d3aea6'],
+    }),
+    ('polyclip', '1.10-0', {
+        'checksums': ['74dabc0dfe5a527114f0bb8f3d22f5d1ae694e6ea9345912909bae885525d34b'],
+    }),
+    ('goftest', '1.1-1', {
+        'checksums': ['db6cb1ff6e18520b172e93fca5d7d953bd2d06f4af73bf90aa0a09df8cad71a0'],
+    }),
+    ('spatstat.utils', '1.13-0', {
+        'checksums': ['81a26d2e1542b8de241512b4c0d267d039847415415c2d9c2e7fd7eac48a3272'],
+    }),
+    ('spatstat.data', '1.4-0', {
+        'checksums': ['121e5bb92beb7ccac920f921e760f429fd71bcfe11cb9b07a7e7326c7a72ec8c'],
+    }),
+    ('spatstat', '1.59-0', {
+        'checksums': ['a78485f3693f606a473c74f0e395458b67766202499d60a02135b9a33cf9470d'],
+    }),
+    ('pracma', '2.2.5', {
+        'checksums': ['2fe83e3a556f5aab3ba4c9867630283c78c9a13912c04991daf55712811e4d47'],
+    }),
+    ('RCurl', '1.95-4.12', {
+        'checksums': ['393779efafdf40823dac942a1e028905d65c34f3d41cfd21bcd225e411385ff4'],
+    }),
+    ('bio3d', '2.3-4', {
+        'checksums': ['f9b39ab242cbedafcd98c1732cb1f5c0dd9ef66e28be39695e3420dd93e2bafe'],
+    }),
+    ('AUC', '0.3.0', {
+        'checksums': ['e705f2c63d336249d19187f3401120d738d42d323fce905f3e157c2c56643766'],
+    }),
+    ('interpretR', '0.2.4', {
+        'checksums': ['4c08a6dffd6fd5764f27812f3a085c53e6a21d59ae82d903c9c0da93fd1dd059'],
+    }),
+    ('cvAUC', '1.1.0', {
+        'checksums': ['c4d8ed53b93869650aa2f666cf6d1076980cbfea7fa41f0b8227595be849738d'],
+    }),
+    ('SuperLearner', '2.0-24', {
+        'checksums': ['adf658a2c885b125c570fb9b4fa9b84a6610cfa821f24c5a660d0d2327c4ef43'],
+    }),
+    ('mediation', '4.4.7', {
+        'checksums': ['b40cc1a859566566371a7641ff6fedea60c496093e6c02887b706b1c22b5a459'],
+    }),
+    ('ModelMetrics', '1.2.2', {
+        'checksums': ['66d6fc75658287fdbae4d437b51d26781e138b8baa558345fb9e5a2df86a0d95'],
+    }),
+    ('CVST', '0.2-2', {
+        'checksums': ['854b8c983427ecf9f2f7798c4fd1c1d06762b5b0bcb1045502baadece6f78316'],
+    }),
+    ('DRR', '0.0.3', {
+        'checksums': ['7493389c1fb9ddc4d4261e15bf2d4198603227275688b1d3e3994d47e976a1f9'],
+    }),
+    ('dimRed', '0.2.3', {
+        'checksums': ['e6e56e3f6999ebdc326e64ead5269f3aaf61dd587beefafb7536ac3890370d84'],
+    }),
+    ('lubridate', '1.7.4', {
+        'checksums': ['510ca87bd91631c395655ee5029b291e948b33df09e56f6be5839f43e3104891'],
+    }),
+    ('ddalpha', '1.3.9', {
+        'checksums': ['62d95309c643c3da2708de8881a065fdf12e8086e3650062828377433703faef'],
+    }),
+    ('gower', '0.2.1', {
+        'checksums': ['af3fbe91cf818c0841b2c0ec4ddf282c182a588031228c8d88f7291b2cdff100'],
+    }),
+    ('RcppRoll', '0.3.0', {
+        'checksums': ['cbff2096443a8a38a6f1dabf8c90b9e14a43d2196b412b5bfe5390393f743f6b'],
+    }),
+    ('recipes', '0.1.5', {
+        'checksums': ['af8e87f8464745ad672d2f88b7637fc23998d6b2b3b11f1346de7b0537d9df14'],
+    }),
+    ('caret', '6.0-84', {
+        'checksums': ['a1831c086a9c71b469f7405649ba04517683cdf229e119c005189cf57244090d'],
+    }),
+    ('adabag', '4.2', {
+        'checksums': ['47019eb8cefc8372996fbb2642f64d4a91d7cedc192690a8d8be6e7e03cd3c81'],
+    }),
+    ('parallelMap', '1.4', {
+        'checksums': ['fb6f15e325f729f1c5218768b17c20909ee857069c6cc5d8df50e1dafe26ed5b'],
+    }),
+    ('ParamHelpers', '1.12', {
+        'checksums': ['b54db9e6608ba530345c380c757a60cb2b78ab08992a890b1a41914ce7abcc14'],
+    }),
+    ('ggvis', '0.4.4', {
+        'checksums': ['1332ea122b768688c8a407a483be80febc4576de0ec8929077738421b27cafaf'],
+    }),
+    ('mlr', '2.14.0', {
+        'checksums': ['1f72184400678386c7c44297c4c92a448b50148de700df5ba0438d4e486e944a'],
+    }),
+    ('unbalanced', '2.0', {
+        'checksums': ['9be32b1ce9d972f1abfff2fbe18f5bb5ba9c3f4fb1282063dc410b82ad4d1ea2'],
+    }),
+    ('RSNNS', '0.4-11', {
+        'checksums': ['87943126e98ae47f366e3025d0f3dc2f5eb0aa2924508fd9ee9a0685d7cb477c'],
+    }),
+    ('abc.data', '1.0', {
+        'checksums': ['b242f43c3d05de2e8962d25181c6b1bb6ca1852d4838868ae6241ca890b161af'],
+    }),
+    #    ('abc', '2.1', {
+    #        'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
+    #    }),
+    ('lhs', '1.0.1', {
+        'checksums': ['a4d5ac0c6f585f2880364c867fa94e6554698beb65d3678ba5938dd84fc6ea53'],
+    }),
+    ('tensorA', '0.36.1', {
+        'checksums': ['c7ffe12b99867675b5e9c9f31798f9521f14305c9d9f9485b171bcbd8697d09c'],
+    }),
+    #    ('EasyABC', '1.5', {
+    #        'checksums': ['1dd7b1383a7c891cafb34d9cec65d92f1511a336cff1b219e63c0aa791371b9f'],
+    #    }),
+    ('shape', '1.4.4', {
+        'checksums': ['f4cb1b7d7c84cf08d2fa97f712ea7eb53ed5fa16e5c7293b820bceabea984d41'],
+    }),
+    ('whisker', '0.3-2', {
+        'checksums': ['484836510fcf123a66ddd13cdc8f32eb98e814cad82ed30c0294f55742b08c7c'],
+    }),
+    ('commonmark', '1.7', {
+        'checksums': ['d14a767a3ea9778d6165f44f980dd257423ca6043926e3cd8f664f7171f89108'],
+    }),
+    ('desc', '1.2.0', {
+        'checksums': ['e66fb5d4fc7974bc558abcdc107a1f258c9177a29dcfcf9164bc6b33dd08dae8'],
+    }),
+    ('pkgbuild', '1.0.3', {
+        'checksums': ['c93aceb499886e42bcd61eb7fb59e47a76c9ba5ab5349a426736d46c8ce21f4d'],
+    }),
+    ('pkgload', '1.0.2', {
+        'checksums': ['3186564e690fb05eabe76e1ac0bfd4312562c3ac8794b29f8850399515dcf27c'],
+    }),
+    ('roxygen2', '6.1.1', {
+        'checksums': ['ed46b7e062e0dfd8de671c7a5f6d120fb2b720982e918dbeb01e6985694c0273'],
+    }),
+    ('git2r', '0.25.2', {
+        'checksums': ['e002c44551f021a7a1fabce9cbd6ac6f16f6dee4d2c60f4b8c280b9fcddf7796'],
+    }),
+    ('rversions', '2.0.0', {
+        'checksums': ['b50c321d9e973284ae6b1d0c89bd46a40f5174de51fb28e3c77cd12ef34f6f56'],
+    }),
+    ('xopen', '1.0.0', {
+        'checksums': ['e207603844d69c226142be95281ba2f4a056b9d8cbfae7791ba60535637b3bef'],
+    }),
+    ('sessioninfo', '1.1.1', {
+        'checksums': ['166b04678448a7decd50f24afabe5e2ad613e3c55b180ef6e8dd7a870a1dae48'],
+    }),
+    ('rcmdcheck', '1.3.3', {
+        'checksums': ['1ab679eb1976d74cd3be5bcad0af7fcc673dbdfd4406bbce32591c8fddfb93b4'],
+    }),
+    ('remotes', '2.0.4', {
+        'checksums': ['379866c034b95ffb0ce3c77569ec36491d4484c21d5b5af61728b31ae52476c9'],
+    }),
+    ('fs', '1.3.1', {
+        'checksums': ['d6934dca8f835d8173e3fb9fd4d5e2740c8c04348dd2bcc57df1b711facb46bc'],
+    }),
+    ('clisymbols', '1.2.0', {
+        'checksums': ['0649f2ce39541820daee3ed408d765eddf83db5db639b493561f4e5fbf88efe0'],
+    }),
+    ('ini', '0.3.1', {
+        'checksums': ['7b191a54019c8c52d6c2211c14878c95564154ec4865f57007953742868cd813'],
+    }),
+    ('gh', '1.0.1', {
+        'checksums': ['f3c02b16637ae390c3599265852d94b3de3ef585818b260d00e7812595b391d2'],
+    }),
+    ('usethis', '1.5.0', {
+        'checksums': ['4fe91458ebc664193e1593d4623370578114bb356f9cd22956fa1a71869ac65e'],
+    }),
+    ('devtools', '2.0.2', {
+        'checksums': ['99a2fa957068254b8ecdb3fc2d50e2950230910ea31c314fc0e7d934e4bd1709'],
+    }),
+    ('Rook', '1.1-1', {
+        'checksums': ['00f4ecfa4c5c57018acbb749080c07154549a6ecaa8d4130dd9de79427504903'],
+    }),
+    ('Cairo', '1.5-10', {
+        'patches': ['Cairo-1.5-10.patch'],
+        'checksums': [
+            '7837f0c384cd49bb3342cb39a916d7a80b02fffbf123913a58014e597f69b5d5',  # Cairo_1.5-10.tar.gz
+            'da36002db4d70583ef3c772ae56b507f19970d16fd35c412ce52b19ffb6466d8',  # Cairo-1.5-10.patch
+        ],
+    }),
+    ('RMTstat', '0.3', {
+        'checksums': ['81eb4c5434d04cb66c749a434c33ceb1c07d92ba79765d4e9233c13a092ec2da'],
+    }),
+    ('Lmoments', '1.3-1', {
+        'checksums': ['7c9d489a08f93fa5877e2f233ab9732e0d1b2761596b3f6ac91f2295e41a865d'],
+    }),
+    ('distillery', '1.0-6', {
+        'checksums': ['4910e2952f767c1062d7cbe648c90a97009e2b3da316c6b33f6d022cd38b23d6'],
+    }),
+    ('extRemes', '2.0-10', {
+        'checksums': ['2c96ae999b0a64f38e5f39e6e913009f18aa1e7f6cd4054b32a6097c9f38d221'],
+    }),
+    ('pixmap', '0.4-11', {
+        'checksums': ['6fa010749a59cdf56aad9f81271473b7d55697036203f2cd5d81372bcded7412'],
+    }),
+    ('tkrplot', '0.0-24', {
+        'checksums': ['2873630a37d7ae1e09a5803d9a89ca0494edd83526c7b1860d9246543722f311'],
+    }),
+    ('misc3d', '0.8-4', {
+        'checksums': ['75de3d2237f67f9e58a36e80a6bbf7e796d43eb46789f2dd1311270007bf5f62'],
+    }),
+    ('multicool', '0.1-10', {
+        'patches': ['multicool-0.1-10_icpc-wd308.patch'],
+        'checksums': [
+            '5bb0cb0d9eb64420c862877247a79bb0afadacfe23262ec8c3fa26e5e34d6ff9',  # multicool_0.1-10.tar.gz
+            '2afcb15d37d0e4adc43530e448325cb97bc46ebf4d1da9fe6c07cf0070fe0a0c',  # multicool-0.1-10_icpc-wd308.patch
+        ],
+    }),
+    ('plot3D', '1.1.1', {
+        'checksums': ['f6fe4a001387132626fc553ed1d5720d448b8064eb5a6917458a798e1d381632'],
+    }),
+    ('plot3Drgl', '1.0.1', {
+        'checksums': ['466d428d25c066c9c96d892f24da930513d42b1bdf76d3b53628c3ba13c3e48a'],
+    }),
+    ('OceanView', '1.0.4', {
+        'checksums': ['e67f6f376737e1e5cf22fdfe2769a8f674e90c886b0e43942e97d9a3e6924f1c'],
+    }),
+    ('ks', '1.11.5', {
+        'checksums': ['4f65565376391b8a6dcce76168ef628fd4859dba8496910cbdd54e4f88e8d51b'],
+    }),
+    ('logcondens', '2.1.5', {
+        'checksums': ['72e61abc1f3eb28830266fbe5b0da0999eb5520586000a3024e7c26be93c02eb'],
+    }),
+    ('Iso', '0.0-18', {
+        'checksums': ['2d7e8c4452653364ee086d95cea620c50378e30acfcff129b7261e1756a99504'],
+    }),
+    ('penalized', '0.9-51', {
+        'checksums': ['eaa80dca99981fb9eb576261f30046cfe492d014cc2bf286c447b03a92e299fd'],
+    }),
+    ('clusterRepro', '0.9', {
+        'checksums': ['940d84529ff429b315cf4ad25700f93e1156ccacee7b6c38e4bdfbe2d4c6f868'],
+    }),
+    ('randomForestSRC', '2.9.0', {
+        'checksums': ['9ce9ad6c51c0f8284efbac733063e31dbf162eec0ffda7a883e328c1ce9fbdcd'],
+    }),
+    ('sm', '2.2-5.6', {
+        'checksums': ['b890cd7ebe8ed711ab4a3792c204c4ecbe9e6ca1fd5bbc3925eba5833a839c30'],
+    }),
+    ('pbivnorm', '0.6.0', {
+        'checksums': ['07c37d507cb8f8d2d9ae51a9a6d44dfbebd8a53e93c242c4378eaddfb1cc5f16'],
+    }),
+    ('lavaan', '0.6-3', {
+        'checksums': ['bffb89d7fb70f6bde5c984009803b3ab9b9802cc2608d2acb1f887b0a7298843'],
+    }),
+    ('matrixcalc', '1.0-3', {
+        'checksums': ['17e6caeeecd596b850a6caaa257984398de9ec5d2b41ce83c428f112614b9cb0'],
+    }),
+    ('arm', '1.10-1', {
+        'checksums': ['6f1158c9295e65bd649139224497d3356189b931ff143f9b374daae72548776f'],
+    }),
+    ('mi', '1.0', {
+        'checksums': ['34f44353101e8c3cb6bf59c5f4ff5b2391d884dcbb9d23066a11ee756b9987c0'],
+    }),
+    ('visNetwork', '2.0.6', {
+        'checksums': ['ec2478e6a2af446569ef2d5210a2bc6b2600bcb7fd9908cef8f8c80b01e9c8aa'],
+    }),
+    ('rgexf', '0.15.3', {
+        'checksums': ['2e8a7978d1fb977318e6310ba65b70a9c8890185c819a7951ac23425c6dc8147'],
+    }),
+    ('influenceR', '0.1.0', {
+        'checksums': ['4fc9324179bd8896875fc0e879a8a96b9ef2a6cf42a296c3b7b4d9098519e98a'],
+    }),
+    ('downloader', '0.4', {
+        'checksums': ['1890e75b028775154023f2135cafb3e3eed0fe908138ab4f7eff1fc1b47dafab'],
+    }),
+    ('DiagrammeR', '1.0.1', {
+        'checksums': ['ccee8acf608fc909e73c6de4374cef5a570cb62e5f454ac55dda736f22f3f013'],
+    }),
+    ('sem', '3.1-9', {
+        'checksums': ['4a33780202506543da85877cd2813250114420d6ec5e75457bc67477cd332cb9'],
+    }),
+    ('jpeg', '0.1-8', {
+        'checksums': ['d032befeb3a414cefdbf70ba29a6c01541c54387cc0a1a98a4022d86cbe60a16'],
+    }),
+    ('network', '1.15', {
+        'checksums': ['5cbe5c0369e5f8363e33a86f14fd33ce8727166106381627ecd13b7452e14cb3'],
+    }),
+    ('statnet.common', '4.3.0', {
+        'checksums': ['834a3359eac967df0420eee416ae4983e3b502a3de56bb24f494a7ca4104e959'],
+    }),
+    ('sna', '2.4', {
+        'checksums': ['2292b3190e8d879e494527ae9d9d1174c31cb4183749ecb455aedd8d534048cf'],
+    }),
+    ('glasso', '1.10', {
+        'checksums': ['e6fa74139a2b5f475f134cc0d6b4000ed870beb5865294e9f1d68b4d42bf505b'],
+    }),
+    ('huge', '1.3.2', {
+        'checksums': ['0d4b683c50fb99ee0ef7c3551ac7cca4e828eacd10372853a3037b19e27e23c9'],
+    }),
+    ('d3Network', '0.5.2.1', {
+        'checksums': ['5c798dc0c87c6d574abb7c1f1903346e6b0fec8adfd1df7aef5e4f9e7e3a09be'],
+    }),
+    ('ggm', '2.3', {
+        'checksums': ['832ffe81ff87c6f1a6644e689ebbfb172924b4c4584ac8108d1244d153219ed8'],
+    }),
+    ('BDgraph', '2.59', {
+        'checksums': ['f7cc6c1e7feecb14da20e971a1b4631ddd0ee94ed0b2a71b5419a980a0a31b05'],
+    }),
+    ('pbapply', '1.4-0', {
+        'checksums': ['f3741b625e0687f6ef80ffabd767c912cdd0def033d16c992abe9b116d52c72e'],
+    }),
+    ('qgraph', '1.6.2', {
+        'checksums': ['26b5bb167d9aea4289b31e8f5543fcde1123005ba846fee21d6ca5960cae530e'],
+    }),
+    ('HWxtest', '1.1.9', {
+        'checksums': ['a37309bed4a99212ca104561239d834088217e6c5e5e136ff022544c706f25e6'],
+    }),
+    ('diveRsity', '1.9.90', {
+        'checksums': ['b8f49cdbfbd82805206ad293fcb2dad65b962fb5523059a3e3aecaedf5c0ee86'],
+    }),
+    ('doSNOW', '1.0.16', {
+        'checksums': ['161434ecd55f04d6b070da784b222a7686c914b73de558eef6048a229022398e'],
+    }),
+    ('geepack', '1.2-1', {
+        'checksums': ['7effe67381129a48154c445704490ea3b5f2e1adedb66cb65f61369dd1f8d38d'],
+    }),
+    ('biom', '0.3.12', {
+        'checksums': ['4ad17f7811c7346dc4923bd6596a007c177eebb1944a9f46e5674afcc5fdd5a1'],
+    }),
+    ('pim', '2.0.1', {
+        'checksums': ['174568a01f68b9601a4ea89ca5857bf4888242f00e4212bfb7a422d6292300d5'],
+    }),
+    ('minpack.lm', '1.2-1', {
+        'checksums': ['14cb7dba3ef2b46da0479b46d46c76198e129a31f6157cd8b37f178adb15d5a3'],
+    }),
+    ('rootSolve', '1.7', {
+        'checksums': ['08b3bb63f04fc0b065cb615b6ca1ef95eb6df7a813eb9eb625bc15c6de332c22'],
+    }),
+    ('diagram', '1.6.4', {
+        'checksums': ['7c2bc5d5d634c3b8ca7fea79fb463e412962d88f47a77a74c811cc62f375ce38'],
+    }),
+    ('FME', '1.3.5', {
+        'checksums': ['3619d88df2a41ca8819b93bb7dff3b8233f76ff8ab0ca67c664f530f835935e4'],
+    }),
+    ('bmp', '0.3', {
+        'checksums': ['bdf790249b932e80bc3a188a288fef079d218856cf64ffb88428d915423ea649'],
+    }),
+    ('tiff', '0.1-5', {
+        'checksums': ['9514e6a9926fcddc29ce1dd12b1072ad8265900373f738de687ef4a1f9124e2b'],
+    }),
+    ('readbitmap', '0.1.5', {
+        'checksums': ['737d7d585eb33de2c200da64d16781e3c9522400fe2af352e1460c6a402a0291'],
+    }),
+    ('imager', '0.41.2', {
+        'patches': ['imager-0.41.2_icpc-wd308.patch'],
+        'checksums': [
+            '9be8bc8b3190d469fcb2883045a404d3b496a0380f887ee3caea11f0a07cd8a5',  # imager_0.41.2.tar.gz
+            'ad90b664505ccb630cc6c517da787e81d6a1e042a74fe5be413da47dbd29a817',  # imager-0.41.2_icpc-wd308.patch
+        ],
+    }),
+    ('signal', '0.7-6', {
+        'checksums': ['6b60277b07cf0167f8272059b128cc82f27a9bab1fd33d74c2a9e1f2abca5def'],
+    }),
+    ('tuneR', '1.3.3', {
+        'checksums': ['bdc3c2017b162d2ba0a249e80361a4f47202e763c21aecfc57380a482a3a692b'],
+    }),
+    ('pastecs', '1.3.21', {
+        'checksums': ['8c1ef2affe88627f0b23295aa5edb758b8fd6089ef09f60f37c46445128b8d7c'],
+    }),
+    ('audio', '0.1-6', {
+        'checksums': ['3f261413ba2d3e9ae58c44abffe5188cc7c21a78a0c93448c7d384d3913d73b8'],
+    }),
+    ('fftw', '1.0-5', {
+        'checksums': ['afc94fe8e5bed9195c191606239cd37f1b88e24e7422e9c5249cca0781b3f20c'],
+    }),
+    ('seewave', '2.1.3', {
+        'checksums': ['f1796cf39d5372bfa96a1319109ddb80919509b859560c1b747474e01ebe2556'],
+    }),
+    ('gsw', '1.0-5', {
+        'checksums': ['eb468918ee91e429b47fbcac43269eca627b7f64b61520de5bbe8fa223e96453'],
+    }),
+    ('oce', '1.0-1', {
+        'checksums': ['f718288f83ff0dd6a296f446ac190378d9d828c6ab49d077bfd1ed7f6e4fc472'],
+    }),
+    ('ineq', '0.2-13', {
+        'checksums': ['e0876403f59a3dfc2ea7ffc0d965416e1ecfdecf154e5856e5f54800b3efda25'],
+    }),
+    ('soundecology', '1.3.3', {
+        'checksums': ['276164d5eb92c78726c647be16232d2443acbf7061371ddde2672b4fdb7a069a'],
+    }),
+    ('memuse', '4.0-0', {
+        'checksums': ['fbf8716a1388692ee439f69ac99643fa427eb100027d8911ff0fbfdcb5b6c3bc'],
+    }),
+    ('pinfsc50', '1.1.0', {
+        'checksums': ['b6b9b6365a3f408533264d7ec820494f57eccaf362553e8478a46a8e5b474aba'],
+    }),
+    ('vcfR', '1.8.0', {
+        'checksums': ['5ffcf9980c1936b9be41b92d5887c56a7ec6e3cf197e5ef7c78aefa8aba20499'],
+    }),
+    ('glmmML', '1.1.0', {
+        'checksums': ['34f088a73ccf6092908502a5bdaaf8209e9134d38abbbd7c4dd559832e653188'],
+    }),
+    ('Rtsne', '0.15', {
+        'patches': ['Rtsne-0.15_icpc-wd308.patch'],
+        'checksums': [
+            '56376e4f0a382fad3d3d40e2cb0562224be5265b827622bcd235e8fc63df276c',  # Rtsne_0.15.tar.gz
+            '150eedeb0ce59d1f9fe9f24a63be19961a32df5b2ec734c43deceb377940070d',  # Rtsne-0.15_icpc-wd308.patch
+        ],
+    }),
+    ('cowplot', '0.9.4', {
+        'checksums': ['fb57091f4d089797bafa4aeb71371390761bcc40de180c26f6adf94d15a76a7b'],
+    }),
+    ('tsne', '0.1-3', {
+        'checksums': ['66fdf5d73e69594af529a9c4f261d972872b9b7bffd19f85c1adcd66afd80c69'],
+    }),
+    ('sn', '1.5-4', {
+        'checksums': ['46677ebc109263a68f62b5cf53ec59916cda490e5bc5bbb08276757a677f8674'],
+    }),
+    ('tclust', '1.4-1', {
+        'checksums': ['4b0be612c8ecd7b4eb19a44ab6ac8f5d40515600ae1144c55989b6b41335ad9e'],
+    }),
+    ('ranger', '0.11.2', {
+        'checksums': ['13ac8a9433fdd92f62f66de44abc52477dcbb436b2045c1947951a266bffbeeb'],
+    }),
+    ('hexbin', '1.27.3', {
+        'checksums': ['7ea422a76542c2fc2840df601af1b7803aa96df4fee6d51dec456ac36940c191'],
+    }),
+    ('pryr', '0.1.4', {
+        'checksums': ['d39834316504c49ecd4936cbbcaf3ee3dae6ded287af42475bf38c9e682f721b'],
+    }),
+    ('moments', '0.14', {
+        'checksums': ['2a3b81e60dafdd092d2bdd3513d7038855ca7d113dc71df1229f7518382a3e39'],
+    }),
+    ('laeken', '0.5.0', {
+        'checksums': ['ea529f9e45a3825e1f13f8dbd8e7c5f5a42933525ca529230c893eb08e1f39bd'],
+    }),
+    ('VIM', '4.8.0', {
+        'checksums': ['3c6b4fdc10c0375e3fdc56b34a8c05661155bd3166a8b3f36b0addf73d51a423'],
+    }),
+    ('proxy', '0.4-23', {
+        'checksums': ['9dd4eb0978f40e4fcb55c8a8a26266d32eff9c63ac9dfe70cf1f664ca9c3669d'],
+    }),
+    ('smoother', '1.1', {
+        'checksums': ['91b55b82f805cfa1deedacc0a4e844a2132aa59df593f3b05676954cf70a195b'],
+    }),
+    ('dynamicTreeCut', '1.63-1', {
+        'checksums': ['831307f64eddd68dcf01bbe2963be99e5cde65a636a13ce9de229777285e4db9'],
+    }),
+    ('DT', '0.6', {
+        'checksums': ['2ed68e9d161559171fa74b6105eee87b98acf755eae072b38ada60a83d427916'],
+    }),
+    ('beeswarm', '0.2.3', {
+        'checksums': ['0115425e210dced05da8e162c8455526a47314f72e441ad2a33dcab3f94ac843'],
+    }),
+    ('vipor', '0.4.5', {
+        'checksums': ['7d19251ac37639d6a0fed2d30f1af4e578785677df5e53dcdb2a22771a604f84'],
+    }),
+    ('ggbeeswarm', '0.6.0', {
+        'checksums': ['bbac8552f67ff1945180fbcda83f7f1c47908f27ba4e84921a39c45d6e123333'],
+    }),
+    ('shinydashboard', '0.7.1', {
+        'checksums': ['51a49945c6b8a684111a2ba4b2a5964e3a50610286ce0378e37ae02316620a4e'],
+    }),
+    ('rrcov', '1.4-7', {
+        'checksums': ['cbd08ccce8b583a2f88946a3267c8fc494ee2b44ba749b9296a6e3d818f6f293'],
+    }),
+    ('WriteXLS', '4.1.0', {
+        'checksums': ['455849d9d369593c2cb313b21dbd479342ce3b09fc4e0aaf9c9d3e65811fecc1'],
+    }),
+    ('bst', '0.3-17', {
+        'checksums': ['1ed161d33a7304abfa2fb23daeda2f870ad8483b7fa9b91e6fc8ced21fd8f074'],
+    }),
+    ('mpath', '0.3-15', {
+        'checksums': ['0172c32577a09e921548f2caefcdce29f54ef217bb2659fe5171b80da5c5fed4'],
+    }),
+    ('timereg', '1.9.3', {
+        'checksums': ['8c5bbfa63d83e4e1deb3b4aba7bf4865c6da540539d94b2da6e37bf7214e92c2'],
+    }),
+    ('peperr', '1.1-7.1', {
+        'checksums': ['5d4eff0f0b61c0b3e479c2ac2978c8e32373b9630565bf58fee48ead6166698a'],
+    }),
+    ('heatmap3', '1.1.6', {
+        'checksums': ['5d5a3d574e9e3699490c93a523ce242006257e5be110935d58c74c135a4e4a8d'],
+    }),
+    ('GlobalOptions', '0.1.0', {
+        'checksums': ['567a0a51f6b7b14127302f00e6e4944befd4964c069f96a9e61256e8c3c79ef2'],
+    }),
+    ('circlize', '0.4.6', {
+        'checksums': ['cec88cfc5e512a111cc37177552c25698ccc0e9bbecb0d6e60657e7b115a56fa'],
+    }),
+    ('GetoptLong', '0.1.7', {
+        'checksums': ['b9a98881db407eae9b711c4fa9170168fd5f3be1f8485cd8f28d0a60ace083ba'],
+    }),
+    ('dendextend', '1.12.0', {
+        'checksums': ['b487fed8c1878a23b9e28394ee11f16a1831b76c90793eb486e6963c7162fa55'],
+    }),
+    ('RInside', '0.2.15', {
+        'checksums': ['1e1d87a3584961f3aa4ca6acd4d2f3cda26abdab027ff5be2fd5cd76a98af02b'],
+    }),
+    ('limSolve', '1.5.5.3', {
+        'checksums': ['2f27c03411e0d771ad50d5412125bf4fa0ba461051610edc77e20d28488e86d2'],
+    }),
+    ('dbplyr', '1.4.1', {
+        'checksums': ['cfe829f56acdc785c5af21bf3927cf08327504d78c4ae1477c405c81b131da95'],
+    }),
+    ('modelr', '0.1.4', {
+        'checksums': ['b4da77c1244bbda512ce323751c8338741eeaa195283f172a0feec2917bcfdd9'],
+    }),
+    ('debugme', '1.1.0', {
+        'checksums': ['4dae0e2450d6689a6eab560e36f8a7c63853abbab64994028220b8fd4b793ab1'],
+    }),
+    ('reprex', '0.3.0', {
+        'checksums': ['203c2ae6343f6ff887e7a5a3f5d20bae465f6e8d9745c982479f5385f4effb6c'],
+    }),
+    ('selectr', '0.4-1', {
+        'checksums': ['8bd42f167629344e485e586f9b05fed342746132489079084d82133d7b3ee2ca'],
+    }),
+    ('rvest', '0.3.4', {
+        'checksums': ['413e171b9e89b7dc4e8b41165027cf19eb97cd73e149c252237bbdf0d0a4254a'],
+    }),
+    ('tidyverse', '1.2.1', {
+        'checksums': ['ad67a27bb4e89417a15338fe1a40251a7b5dedba60e9b72637963d3de574c37b'],
+    }),
+    ('R.cache', '0.13.0', {
+        'checksums': ['d3d4a99a676734ea53e96747d87857fa69615e59858804e92f8ad9ddcf62c5c1'],
+    }),
+    ('R.rsp', '0.43.1', {
+        'checksums': ['d979113b4a0c6088600b9107f941311b966adddd7b7ab105fd4412d625ba0144'],
+    }),
+    ('listenv', '0.7.0', {
+        'checksums': ['6126020b111870baea08b36afa82777cd578e88c17db5435cd137f11b3964555'],
+    }),
+    ('globals', '0.12.4', {
+        'checksums': ['7985356ad75afa1f795f8267a20dee847020c0207252dc075c614cef55d8fe6b'],
+    }),
+    ('future', '1.13.0', {
+        'checksums': ['5fda4f39b396fe25704304282744fc25b574e358ac97e34aeb8abc6d94781641'],
+    }),
+    ('gdistance', '1.2-2', {
+        'checksums': ['c8c923f02ae4e9ef8376d1b195e0246b6941356c8c790c0a5673c5009eee1753'],
+    }),
+    ('vioplot', '0.3.0', {
+        'checksums': ['76aa941bfb58f1dbc6b653da5415ca8c1d9ab5b74ea15070c9db667c30aeb5b5'],
+    }),
+    ('emulator', '1.2-20', {
+        'checksums': ['7cabf2cf74d879ad9dbaed8fdee54a5c94a8658a0645c021d160b2ef712ce287'],
+    }),
+    ('gmm', '1.6-2', {
+        'checksums': ['b12f888276c2d480f17ae2711e4915bb253574e3fc36531349f1c2f2c8ad715d'],
+    }),
+    ('tmvtnorm', '1.4-10', {
+        'checksums': ['1a9f35e9b4899672e9c0b263affdc322ecb52ec198b2bb015af9d022faad73f0'],
+    }),
+    ('IDPmisc', '1.1.19', {
+        'checksums': ['0d5e35252c7ec2654a3d64949bdc0977cc8479f8ada97bccd0d90d70aadb0c8f'],
+    }),
+    ('gap', '1.2.1', {
+        'checksums': ['5a20adcc7e503b9a2123048510d56ce3ec9f00d5855629b4cbf0d7c7ad8c6fb5'],
+    }),
+    ('qrnn', '2.0.3', {
+        'checksums': ['4f10a22d1e064f75dd17f7bceea0c34aeeda3f803c2cb61a328152728c7c8151'],
+    }),
+    ('TMB', '1.7.15', {
+        'checksums': ['facbc7cc44f993e0d827a6eb84928f8e35b0b3f263582d885a307e150b434de4'],
+    }),
+    ('glmmTMB', '0.2.3', {
+        'checksums': ['6b6f62addaa54b32b975bc984110e245330749ebf69bed4a297f9da1b89fb00c'],
+    }),
+    ('spaMM', '2.7.1', {
+        'checksums': ['a7c9b5413049614c7a0041f321c6938aa9ba7dc29d7439e14a6d21ec2004cae6'],
+    }),
+    ('DHARMa', '0.2.4', {
+        'checksums': ['98ae8c47a3cccf15eb240789b7e77e53b29815ea3fc6c5e29e42cc720b707f3a'],
+    }),
+    ('bridgesampling', '0.6-0', {
+        'checksums': ['172da757014ea804c6c55761dde29a53c82e13cf6769b124da00ca07b1a64694'],
+    }),
+    ('BayesianTools', '0.1.6', {
+        'checksums': ['e5da5df8626085c3338461b23b1b96abaf25d95aadf29206094b5f52377ce784'],
+    }),
+    ('gomms', '1.0', {
+        'checksums': ['52828c6fe9b78d66bde5474e45ff153efdb153f2bd9f0e52a20a668e842f2dc5'],
+    }),
+    ('feather', '0.3.3', {
+        'checksums': ['4abbb69da7a937825d362008355ab8f233779a3110217d0c01064bff7ca54853'],
+    }),
+    ('dummies', '1.5.6', {
+        'checksums': ['7551bc2df0830b98c53582cac32145d5ce21f5a61d97e2bb69fd848e3323c805'],
+    }),
+    ('SimSeq', '1.4.0', {
+        'checksums': ['5ab9d4fe2cb1b7634432ff125a9e04d2f574fed06246a93859f8004e10790f19'],
+    }),
+    ('uniqueAtomMat', '0.1-3-2', {
+        'checksums': ['f7024e73274e1e76a870ce5e26bd58f76e8f6df0aa9775c631b861d83f4f53d7'],
+    }),
+    ('PoissonSeq', '1.1.2', {
+        'checksums': ['6f3dc30ad22e33e4fcfa37b3427c093d591c02f1b89a014d85e63203f6031dc2'],
+    }),
+    ('aod', '1.3.1', {
+        'checksums': ['052d8802500fcfdb3b37a8e3e6f3fbd5c3a54e48c3f68122402d2ea3a15403bc'],
+    }),
+    ('cghFLasso', '0.2-1', {
+        'checksums': ['6e697959b35a3ceb2baa1542ef81f0335006a5a9c937f0173c6483979cb4302c'],
+    }),
+    ('svd', '0.4.3', {
+        'checksums': ['c467f6ad914efc75de7e6eb8c2af12cce5ee32bc1e8e43ca36cf3a3315fe9b72'],
+    }),
+    ('Rssa', '1.0', {
+        'checksums': ['9cc20a7101d8dff4c6cfb789f9bdc14e2b3bb128d7613a67b0f9633cf006902a'],
+    }),
+    ('JBTools', '0.7.2.9', {
+        'checksums': ['b33cfa17339df7113176ad1832cbb0533acf5d25c36b95e888f561d586c5d62f'],
+    }),
+    ('RUnit', '0.4.32', {
+        'checksums': ['23a393059989000734898685d0d5509ece219879713eb09083f7707f167f81f1'],
+    }),
+    ('DistributionUtils', '0.6-0', {
+        'checksums': ['7443d6cd154760d55b6954142908eae30385672c4f3f838dd49876ec2f297823'],
+    }),
+    ('gapfill', '0.9.6', {
+        'checksums': ['850d0be9d05e3f3620f0f5143496321f1004ed966299bffd6a67a9abd8d9040d'],
+    }),
+    ('gee', '4.13-19', {
+        'checksums': ['ebd3eb754b338dc8d89a35fff149af57c1be3aa2eb6162912c7cc52a8572c292'],
+    }),
+    ('Matching', '4.9-6', {
+        'checksums': ['8e0dced7d1242e52de68a6e3010484bb29eb0633733549c82a06e9c6508b66dc'],
+    }),
+    ('MatchIt', '3.0.2', {
+        'checksums': ['782b159a2b5172e758e3993177930d604140ae668fd8a7c98c30792df80de9de'],
+    }),
+    ('RItools', '0.1-16.1', {
+        'checksums': ['559b8545c9ca8b405f316175bec924547c0a67d6511372d8676588cc5dda76e8'],
+    }),
+    ('optmatch', '0.9-10', {
+        'patches': ['optmatch-0.9-10_icpc-wd308.patch'],
+        'checksums': [
+            'e1fcc23ab969a4018ef33ca22a210c14f8ca81840bee8e5e2e1c3179729adbca',  # optmatch_0.9-10.tar.gz
+            '1f0f2a6665267e7c5693f858afddc80a9912301e82c62a5b58c5694d28f3f7ec',  # optmatch-0.9-10_icpc-wd308.patch
+        ],
+    }),
+    ('SKAT', '1.3.2.1', {
+        'checksums': ['7442408ccd1b9d2abb3f3dbd27e1b46e50b87042195bc46ce25fe0d887f98e7a'],
+    }),
+    ('GillespieSSA', '0.5-4', {
+        'checksums': ['d88c09e598cabfa3bcb28c12e0809439b8ea9a439292f4c8d9d9a7bad133412f'],
+    }),
+    ('startupmsg', '0.9.6', {
+        'checksums': ['1d60ff13bb260630f797bde66a377a5d4cd65d78ae81a3936dc4374572ec786e'],
+    }),
+    ('distr', '2.8.0', {
+        'checksums': ['bb7df05d6b946bcdbbec2e3397c7c7e349b537cabfcbb13a34bcf6312a71ceb7'],
+    }),
+    ('distrEx', '2.8.0', {
+        'checksums': ['b064cde7d63ce93ec9969c8c4463c1e327758b6f8ea7765217d77f9ba9d590bf'],
+    }),
+    ('KODAMA', '1.5', {
+        'checksums': ['8ecf53732c1be2bd1e111b3c6de65b66caf28360306e683fe945dc76d4c267dd'],
+    }),
+    ('locfdr', '1.1-8', {
+        'checksums': ['42d6e12593ae6d541e6813a140b92591dabeb1df94432a515507fc2eee9a54b9'],
+    }),
+    ('ica', '1.0-2', {
+        'checksums': ['e721596fc6175d3270a60d5e0b5b98be103a8fd0dd93ef16680af21fe0b54179'],
+    }),
+    ('dtw', '1.20-1', {
+        'checksums': ['43ca1a47a7c81a2b5d5054da1be8b8af79a85d6f9ce7b4512e9ed91f790f60f0'],
+    }),
+    ('SDMTools', '1.1-221.1', {
+        'checksums': ['3825856263bdb648ca018b27dc6ab8ceaef24691215c197f8d5cd17718b54fbb'],
+    }),
+    ('ggridges', '0.5.1', {
+        'checksums': ['01f87cdcdf2052ed9c078d9352465cdeda920a41e2ca55bc154c1574fc651c36'],
+    }),
+    ('metap', '1.1', {
+        'checksums': ['20120428672d39dc15829c7e66850fc4350a34df290d48cef0b1cc78d13f7b82'],
+    }),
+    ('lsei', '1.2-0', {
+        'checksums': ['4781ebd9ef93880260d5d5f23066580ac06061e95c1048fb25e4e838963380f6'],
+    }),
+    ('npsurv', '0.4-0', {
+        'checksums': ['404cf7135dc40a04e9b81224a543307057a8278e11109ba1fcaa28e87c6204f3'],
+    }),
+    ('fitdistrplus', '1.0-14', {
+        'checksums': ['85082590f62aa08d99048ea3414c5cc1e5b780d97b3779d2397c6cb435470083'],
+    }),
+    ('reticulate', '1.12', {
+        'checksums': ['6b82edf9fc7d1f98d5632bc94476bd10b39134a7bb267120b5e979a4590e195f'],
+    }),
+    ('hdf5r', '1.2.0', {
+        'installopts': '--configure-args="--with-hdf5=$EBROOTHDF5/bin/h5pcc"',
+        'preinstallopts': "unset LIBS && ",
+        'checksums': ['58813e334fd3f9040038345a7186e5cb02090898883ac192477a76a5b8b4fe81'],
+    }),
+    ('DTRreg', '1.3', {
+        'checksums': ['835df542d0ec55368834bc4173dc4aa90f1c0ff146ab243d6e377bba309b8484'],
+    }),
+    ('pulsar', '0.3.5', {
+        'checksums': ['a1cab4a9ab39c57b0a8d8fbd1a799714ac95d4de43b628027b297cd525932658'],
+    }),
+    ('bayesm', '3.1-1', {
+        'checksums': ['4854517dec30ab7c994de862aae1998c2d0c5e71265fd9eb7ed36891d4676078'],
+    }),
+    ('energy', '1.7-5', {
+        'checksums': ['24c2cf080939f8f56cd9cda06d2dfc30d0389cd3ec7250af4f9a09a4c06b6996'],
+    }),
+    ('compositions', '1.40-2', {
+        'checksums': ['110d71ae000561987cb73fc76cd953bd69d37562cb401ed3c36dca137d01b78a'],
+    }),
+    ('farver', '1.1.0', {
+        'checksums': ['2086f309135f37705280fe2df851ad91dc886ad8f2a6eb1f3983aa20427f94b6'],
+    }),
+    ('tweenr', '1.0.1', {
+        'checksums': ['efd68162cd6d5a4f6d833dbf785a2bbce1cb7b9f90ba3fb060931a4bd705096b'],
+    }),
+    ('ggforce', '0.2.2', {
+        'checksums': ['e27540a42ca2424b270c681f52c9af695756b15cc3ddf4ef519d31067feadd6a'],
+    }),
+    ('ggrepel', '0.8.1', {
+        'checksums': ['d5d03a77ab6d8c831934bc46e840cc4e3df487272ab591fa72767ad42bcb7283'],
+    }),
+    ('ggraph', '1.0.2', {
+        'checksums': ['4c24739ecabfc65c290a11980491a20bdaac675392a98dc30ccde76ac4b8f53a'],
+    }),
+    ('tidygraph', '1.1.2', {
+        'checksums': ['5642001d4cccb122d66481b7c61a06c724c02007cbd356ee61cb29726a56fafe'],
+    }),
+    ('clustree', '0.4.0', {
+        'checksums': ['6b4284c11e98e8dd1a3f478c880d3f899e8e7437f05cd6731d555ca6f4f19351'],
+    }),
+    ('plotly', '4.9.0', {
+        'checksums': ['f761148338231f210fd7fe2f8325ffe9cfdaaaeddd7b933b65c44ebb4f85e2cf'],
+    }),
+    ('tweedie', '2.3.2', {
+        'checksums': ['9a6226e64e3d56eb7eb2a408f8b825c2ad6ee0ea203a9220e85e7789514adb81'],
+    }),
+    ('RcppGSL', '0.3.6', {
+        'checksums': ['35e8a8e3c0837df58b7f710d7b4c38a9b63d2522cb3e35ca6a499c30f055ed9a'],
+    }),
+    ('mvabund', '4.0.1', {
+        'checksums': ['1399fa0a5f7a3673d788abe36b520f476c05246e21f71e3f60cee7a85f194951'],
+    }),
+    ('fishMod', '0.29', {
+        'checksums': ['5989e49ca6d6b2c5d514655e61f75b019528a8c975f0d6056143f17dc4277a5d'],
+    }),
+    ('gllvm', '1.1.3', {
+        'checksums': ['7cf0bd8329f3692404b245dfbf088c7dbdbb9f51df26707b082a09b696317f1a'],
+    }),
+    ('grpreg', '3.2-1', {
+        'checksums': ['6be37719a74d59582107273385d70963b4ccc6c394948c7617e65246d713cb88'],
+    }),
+    ('trust', '0.1-7', {
+        'checksums': ['e3d15aa84a71becd2824253d4a8156bdf1ab9ac3b72ced0cd53f3bb370ac6f04'],
+    }),
+    ('ergm', '3.10.1', {
+        'checksums': ['a2ac249ff07ba55b3359242f20389a892543b4fff5956d74143d2d41fa6d4beb'],
+    }),
+    ('networkDynamic', '0.10.0', {
+        'checksums': ['eb31d72c73a06a145d231ad3489d450d63b9fecc069aeb19331d7417241df3b5'],
+    }),
+    ('tergm', version, {
+        'checksums': ['4204095e2b0c4859c32005953e8dcb621cf14e5a84b92eda79785ed86defe7cc'],
+    }),
+    ('ergm.count', '3.4.0', {
+        'checksums': ['7c24c79d0901c18991cce907306a1531cca676ae277c6b0a0e4962ad27c36baf'],
+    }),
+    ('tsna', '0.3.0', {
+        'checksums': ['29f599d3e774289614608b0fa49e05a09e76e6b15dd1d46988785eaacf2e1a35'],
+    }),
+    ('statnet', '2018.10', {
+        'checksums': ['387ae8294b6d41d747a62d726a21e10a70ad2a9e612c311658e97f6ce54214ec'],
+    }),
+    ('aggregation', '1.0.1', {
+        'checksums': ['86f88a02479ddc8506bafb154117ebc3b1a4a44fa308e0193c8c315109302f49'],
+    }),
+    ('ComICS', '1.0.4', {
+        'checksums': ['0af7901215876f95f309d7da6e633c38e4d7faf04112dd6fd343bc15fc593a2f'],
+    }),
+    ('dtangle', '0.3.1', {
+        'checksums': ['86c8c16411e4e20396fc0287a72dfe45499be4c81d28c972cda0a0fe12d16d4f'],
+    }),
+    ('mcmc', '0.9-6', {
+        'checksums': ['443a189fff907830627029dd55d925db9a70562d8bda7bfae97414ab955186b9'],
+    }),
+    ('MCMCpack', '1.4-4', {
+        'patches': ['MCMCpack-1.4-4_intel_wd308.patch'],
+        'checksums': [
+            '97e193d628f7161e59288ed594a313af3a520bf30d5a95f1ede0cb2a567cf9f7',  # MCMCpack_1.4-4.tar.gz
+            '8820c9153c4717614ed5f3fce9b8507fca1194d4296ea3426e0a3ca7b92bb74a',  # MCMCpack-1.4-4_intel_wd308.patch
+        ],
+
+    }),
+    ('shinythemes', '1.1.2', {
+        'checksums': ['2e13d4d5317fc61082e8f3128b15e0b10ed9736ce81e152dd7ae7f6109f9b18a'],
+    }),
+    ('csSAM', '1.2.4', {
+        'checksums': ['3d6442ad8c41fa84633cbbc275cd67e88490a160927a5c55d29da55a36e148d7'],
+    }),
+    ('bridgedist', '0.1.0', {
+        'checksums': ['dc7c1c8874d6cfa34d550d9af194389e13471dfbc55049a1ab66db112fbf1343'],
+    }),
+    ('asnipe', '1.1.11', {
+        'checksums': ['982b9f34dbcf98136a8406b9ce4717faf155c7d5d923dcdf0dca6a9d53e27219'],
+    }),
+    ('liquidSVM', '1.2.2.1', {
+        'patches': ['liquidSVM-1.2.2_intel.patch'],
+        'checksums': [
+            '95e5620fa1561b8410398ea56480c540555615b2c94bb0356106f4638e7cfce8',  # liquidSVM_1.2.2.1.tar.gz
+            'a670a6de7c8a7755a9f6f0cc658772f40aebe342512be4a20dea6c56595ff44e',  # liquidSVM-1.2.2_intel.patch
+        ],
+    }),
+    ('oddsratio', '1.0.3', {
+        'checksums': ['b33861d8beae189c66e6b94d59cc698bf08aeafb47262b5f7a1d2e88a2b2b8cd'],
+    }),
+    ('mltools', '0.3.5', {
+        'checksums': ['7093ffceccdf5d4c3f045d8c8143deaa8ab79935cc6d5463973ffc7d3812bb10'],
+    }),
+    ('h2o', '3.22.1.1', {
+        'checksums': ['e4c9d50d2a6a42ffecb15aa1561495599b206a7edd77db95501c7d09253fc412'],
+    }),
+    ('mlegp', '3.1.7', {
+        'checksums': ['d4845eaf9260f8b8112726dd7ceb5c2f5ce75125fa313191db9de121f2ee15e0'],
+    }),
+    ('itertools', '0.1-3', {
+        'checksums': ['b69b0781318e175532ad2d4f2840553bade9637e04de215b581704b5635c45d3'],
+    }),
+    ('missForest', '1.4', {
+        'checksums': ['f785804b03bdf424e1c76095989a803afb3b47d6bebca9a6832074b6326c0278'],
+    }),
+    ('bartMachineJARs', '1.1', {
+        'checksums': ['f2c31cb94d7485174a2519771127a102e35b9fe7f665e27beda3e76a56feeef2'],
+    }),
+    ('bartMachine', '1.2.4.2', {
+        'checksums': ['28a5f7363325021bd93f9bd060cc48f20c689dae2f2f6f7100faae66d7651f80'],
+    }),
+    ('lqa', '1.0-3', {
+        'checksums': ['3889675dc4c8cbafeefe118f4f20c3bd3789d4875bb725933571f9991a133990'],
+    }),
+    ('PresenceAbsence', '1.1.9', {
+        'checksums': ['1a30b0a4317ea227d674ac873ab94f87f8326490304e5b08ad58953cdf23169f'],
+    }),
+    ('GUTS', '1.1.0', {
+        'checksums': ['af326f918bd46f3f653be1907e01551025fd961077ca719c861ab0f29d14d516'],
+    }),
+    ('GenSA', '1.1.7', {
+        'checksums': ['9d99d3d0a4b7770c3c3a6de44206811272d78ab94481713a8c369f7d6ae7b80f'],
+    }),
+    ('rematch2', '2.0.1', {
+        'checksums': ['0612bb904334bd022ba6d1e69925b1e85f8e86b15ec65476777828776e89609a'],
+    }),
+    ('parsedate', '1.2.0', {
+        'checksums': ['39ab3c507cb3efcd677c6cf453f46d6b1948662bd70c7765845e755ea1e1633d'],
+    }),
+    ('circular', '0.4-93', {
+        'checksums': ['76cee2393757390ad91d3db3e5aeb2c2d34c0a46822b7941498571a473417142'],
+    }),
+    ('cobs', '1.3-3', {
+        'checksums': ['6b1e760cf8dec6b6e63f042cdc3e5e633de5f982e8bc743a891932f6d9f91bdf'],
+    }),
+    ('resample', '0.4', {
+        'checksums': ['f0d5f735e1b812612720845d79167a19f713a438fd10a6a3206e667045fd93e5'],
+    }),
+    ('MIIVsem', '0.5.4', {
+        'checksums': ['de918d6b1820c59a7d4324342ad15444c2370ce1d843397a136c307397ed64b9'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
@@ -1182,9 +1182,13 @@ exts_list = [
     ('neuRosim', '0.2-12', {
         'checksums': ['f4f718c7bea2f4b61a914023015f4c71312f8a180124dcbc2327b71b7be256c3'],
     }),
-    #    ('locfit', '1.5-9.1', {
-    #        'checksums': ['f524148fdb29aac3a178618f88718d3d4ac91283014091aa11a01f1c70cd4e51'],
-    #    }),
+    ('locfit', '1.5-9.1', {
+        'patches': ['locfit-1.5-9.1_Fix_logical_operators_icc.patch'],
+        'checksums': [
+            'f524148fdb29aac3a178618f88718d3d4ac91283014091aa11a01f1c70cd4e51',  # locfit_1.5-9.1.tar.gz
+            'e12c995539c039a8f2a1fb1a4d2b34c488f942b0fd4e31a2b9d5bd1543bce0fc',  # locfit-1.5-9.1_Fix_logical_operators_icc.patch
+        ],
+    }),
     ('GGally', '1.4.0', {
         'checksums': ['9a47cdf004c41f5e4024327b94227707f4dad3a0ac5556d8f1fba9bf0a6355fe'],
     }),
@@ -1431,18 +1435,18 @@ exts_list = [
     ('abc.data', '1.0', {
         'checksums': ['b242f43c3d05de2e8962d25181c6b1bb6ca1852d4838868ae6241ca890b161af'],
     }),
-    #    ('abc', '2.1', {
-    #        'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
-    #    }),
+    ('abc', '2.1', {
+        'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
+    }),
     ('lhs', '1.0.1', {
         'checksums': ['a4d5ac0c6f585f2880364c867fa94e6554698beb65d3678ba5938dd84fc6ea53'],
     }),
     ('tensorA', '0.36.1', {
         'checksums': ['c7ffe12b99867675b5e9c9f31798f9521f14305c9d9f9485b171bcbd8697d09c'],
     }),
-    #    ('EasyABC', '1.5', {
-    #        'checksums': ['1dd7b1383a7c891cafb34d9cec65d92f1511a336cff1b219e63c0aa791371b9f'],
-    #    }),
+    ('EasyABC', '1.5', {
+        'checksums': ['1dd7b1383a7c891cafb34d9cec65d92f1511a336cff1b219e63c0aa791371b9f'],
+    }),
     ('shape', '1.4.4', {
         'checksums': ['f4cb1b7d7c84cf08d2fa97f712ea7eb53ed5fa16e5c7293b820bceabea984d41'],
     }),

--- a/easybuild/easyconfigs/r/R/Rtsne-0.15_icpc-wd308.patch
+++ b/easybuild/easyconfigs/r/R/Rtsne-0.15_icpc-wd308.patch
@@ -1,0 +1,27 @@
+add -wd308 compiler option to avoid compiler warning #308 being treated as an error
+author: Kenneth Hoste (HPC-UGent)
+author: Davide Vanzo (Vanderbilt University)
+diff -ru Rtsne.orig/MD5 Rtsne/MD5
+--- Rtsne.orig/MD5	2019-07-18 14:00:05.970636224 -0500
++++ Rtsne/MD5	2019-07-18 14:01:23.186638361 -0500
+@@ -10,7 +10,7 @@
+ 42ae2f3c4872e03c5e401d949a86cad9 *inst/CITATION
+ 1064b7fbe0f6a9fc5c85ce0cdd70c7a3 *man/Rtsne.Rd
+ 534b6db9f30e8d2ccc33ce366180e0e8 *man/normalize_input.Rd
+-fccdbee9a90c6ec50412daaf3f641201 *src/Makevars
++7e7119a26218849f23621f9251d90b89 *src/Makevars
+ cd626b9e988ce6dd307bf23e23e5f26c *src/Makevars.win
+ fadd501c152c2941c91ad84ccaf2ea63 *src/RcppExports.cpp
+ d5cd293f39fb84f7d1d8ef9f30196182 *src/Rtsne.cpp
+diff -ru Rtsne.orig/src/Makevars Rtsne/src/Makevars
+--- Rtsne.orig/src/Makevars	2019-07-18 14:00:05.966636224 -0500
++++ Rtsne/src/Makevars	2019-07-18 14:00:51.254637477 -0500
+@@ -1,7 +1,7 @@
+ ## Use the R_HOME indirection to support installations of multiple R version
+ ## PKG_LIBS = `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"` $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
+ PKG_LIBS =  $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)  $(SHLIB_OPENMP_CXXFLAGS)
+-PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
++PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS) -wd308
+ 
+ ## As an alternative, one can also add this code in a file 'configure'
+ ##

--- a/easybuild/easyconfigs/r/R/imager-0.41.2_icpc-wd308.patch
+++ b/easybuild/easyconfigs/r/R/imager-0.41.2_icpc-wd308.patch
@@ -1,0 +1,12 @@
+add -wd308 compiler option to avoid compiler warning #308 being treated as an error
+author: Kenneth Hoste (HPC-UGent)
+author: Davide Vanzo (Vanderbilt University)
+diff -ru imager.orig/src/Makevars.in imager/src/Makevars.in
+--- imager.orig/src/Makevars.in	2019-07-17 15:44:10.138634597 -0500
++++ imager/src/Makevars.in	2019-07-17 15:44:35.426635297 -0500
+@@ -1,4 +1,4 @@
+ PKG_CPPFLAGS = @CPPFLAGS@ @HAVE_FFTW@ @FFTW_CFLAGS@ @TIFF_CFLAGS@ -I../inst/include -DCIMG_COMPILING -Dcimg_use_rng -Dcimg_use_r -Dcimg_use_fftw3_singlethread -Dcimg_verbosity=1 -Dcimg_date='""' -Dcimg_time='""'
+-PKG_CXXFLAGS = $(OPENMP_CXXFLAGS) 
++PKG_CXXFLAGS = $(OPENMP_CXXFLAGS) -wd308
+ PKG_LIBS =  $(OPENMP_CXXFLAGS) @LIBS@  @HAVE_FFTW@ @FFTW_LIBS@ @TIFF_LIBS@ $(RCPP_LDFLAGS)
+ 

--- a/easybuild/easyconfigs/r/R/kohonen-3.0.8_intel-wd308.patch
+++ b/easybuild/easyconfigs/r/R/kohonen-3.0.8_intel-wd308.patch
@@ -1,0 +1,13 @@
+add -wd308 compiler option to avoid compiler warning #308 being treated as an error
+Author: Samuel Moors, Vrije Universiteit Brussel (VUB)
+Author: Davide Vanzo, Vanderbilt University
+diff -ru kohonen.orig/src/Makevars kohonen/src/Makevars
+--- kohonen.orig/src/Makevars	2019-07-17 13:32:51.214416582 -0500
++++ kohonen/src/Makevars	2019-07-17 13:34:46.310419767 -0500
+@@ -1,2 +1,5 @@
+-PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
+ PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS)
++# Disable Intel C++ compiler (icpc) warning/error #308, to avoid
++# 'member "std::complex<double>::_M_value" is inaccessible'
++PKG_CFLAGS = -wd308
++PKG_CXXFLAGS = -wd308 $(SHLIB_OPENMP_CXXFLAGS)

--- a/easybuild/easyconfigs/r/R/locfit-1.5-9.1_Fix_logical_operators_icc.patch
+++ b/easybuild/easyconfigs/r/R/locfit-1.5-9.1_Fix_logical_operators_icc.patch
@@ -1,0 +1,43 @@
+The Intel compiler throws an internal error 04010026_1450 where bitwise
+AND and OR operator are used. Converting them to logical operator seems
+more correct.
+Author: Davide Vanzo (Vanderbilt University)
+diff -ru locfit.orig/src/lf_adap.c locfit/src/lf_adap.c
+--- locfit.orig/src/lf_adap.c	2019-07-22 08:20:24.778193326 -0500
++++ locfit/src/lf_adap.c	2019-07-22 08:44:12.342245385 -0500
+@@ -118,7 +118,7 @@
+   h1 = des->h = h0;
+   done = 0; nu1 = 0.0;
+   inc = 0; ncp = 0.0;
+-  while ((!done) & (nu1<(n-p)*0.95))
++  while ((!done) && (nu1<(n-p)*0.95))
+   { fixh(sp) = (1+0.3/d)*des->h;
+     nbhd(lfd,des,0,1,sp);
+     if (locfit(lfd,des,sp,1,0,0) > 0) WARN(("aband2: failed fit"));
+@@ -129,7 +129,7 @@
+         tlo = des->cf[0]-pen(sp)*t[5];
+         tup = des->cf[0]+pen(sp)*t[5];
+ /* printf("h %8.5f  tlo %8.5f  tup %8.5f\n",des->h,tlo,tup); */
+-        done = ((tlo>cup) | (tup<clo));
++        done = ((tlo>cup) || (tup<clo));
+         if (!done)
+         { clo = MAX(clo,tlo);
+           cup = MIN(cup,tup);
+@@ -142,7 +142,7 @@
+         if (cp<mcp) { mcp = cp; h1 = des->h; }
+         if (cp>=ncp) inc++; else inc = 0;
+         ncp = cp;
+-        done = (inc>=10) | ((inc>=3) & ((t[0]-t[2])>=10) & (cp>1.5*mcp));
++        done = (inc>=10) || ((inc>=3) && ((t[0]-t[2])>=10) && (cp>1.5*mcp));
+         break;
+       case AMDI:
+         cp = mmse(lfd,sp,dv,des);
+@@ -185,7 +185,7 @@
+     { case AKAT:
+         tlo = des->cf[0]-pen(sp)*t[5];
+         tup = des->cf[0]+pen(sp)*t[5];
+-        if ((tlo>cup) | (tup<clo)) /* done */
++        if ((tlo>cup) || (tup<clo)) /* done */
+           i = 2;
+         else
+         { h1 = des->h;

--- a/easybuild/easyconfigs/r/R/tseries-0.10-47_ifort_explicit_free_form.patch
+++ b/easybuild/easyconfigs/r/R/tseries-0.10-47_ifort_explicit_free_form.patch
@@ -1,0 +1,11 @@
+Since the ifort compiler only recognizes .f90 extensions as free format code,
+this .f95 file requires explicit free-form compiler directive
+Author: Davide Vanzo (Vanderbilt University)
+diff -ru tseries.orig/src/cfuncs.f95 tseries/src/cfuncs.f95
+--- tseries.orig/src/cfuncs.f95	2019-07-16 15:39:24.086410749 -0500
++++ tseries/src/cfuncs.f95	2019-07-16 15:39:38.222411140 -0500
+@@ -1,3 +1,4 @@
++!DIR$ FREEFORM
+ module cfuncs
+   interface
+      subroutine cnlprt(msg, plen) bind(C, name = 'cnlprt_C')

--- a/easybuild/easyconfigs/r/R/uroot-2.0-9.1_CUDA.patch
+++ b/easybuild/easyconfigs/r/R/uroot-2.0-9.1_CUDA.patch
@@ -1,0 +1,15 @@
+Do not search and initialize CUDA_HOME if it is not already defined in the environment
+Author: Samuel Moors, Vrije Universiteit Brussel (VUB)
+Author: Davide Vanzo (Vanderbilt University)
+diff -ru uroot.orig/configure uroot/configure
+--- uroot.orig/configure	2019-07-16 15:12:23.478365905 -0500
++++ uroot/configure	2019-07-16 15:12:41.898366415 -0500
+@@ -1775,7 +1775,7 @@
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking CUDA_HOME environment variable" >&5
+ $as_echo_n "checking CUDA_HOME environment variable... " >&6; }
+ if test -z "${CUDA_HOME}"; then
+-  CUDA_HOME=`find /usr/local/ -maxdepth 1 -type d -name "cuda*" | sort -V | tail -1`
++#  CUDA_HOME=`find /usr/local/ -maxdepth 1 -type d -name "cuda*" | sort -V | tail -1`
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: not set" >&5
+ $as_echo "not set" >&6; }
+   #highest version found ${CUDA_HOME}


### PR DESCRIPTION
Still a WIP since the build of the `locfit` library causes an internal error for `icc`:
```
icc -I"/opt/easybuild/software/MPI/intel/2019.1.144-GCC-8.2.0-2.31.1/impi/2018.4.274/R/3.6.0/lib/R/include" -DNDEBUG   -I/opt/easybuild/software/MPI/intel/2019.1.144-GCC-8.2.0-2.31.1/impi/2018.4.274/imkl/2019.1.144/mkl/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/X11/20190311/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/Mesa/19.0.1/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/libGLU/9.0.0/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/cairo/1.16.0/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/libreadline/8.0/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/ncurses/6.1/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/bzip2/1.0.6/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/XZ/5.2.4/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/zlib/1.2.11/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/SQLite/3.27.2/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/PCRE/8.43/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/libpng/1.6.36/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/libjpeg-turbo/2.0.2/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/LibTIFF/4.0.10/include -I/opt/easybuild/software/Core/Java/11.0.2/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/Tk/8.6.9/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/cURL/7.63.0/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/libxml2/2.9.8/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/GMP/6.1.2/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/NLopt/2.6.1/include -I/opt/easybuild/software/MPI/intel/2019.1.144-GCC-8.2.0-2.31.1/impi/2018.4.274/FFTW/3.3.8/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/libsndfile/1.0.28/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/ICU/64.2/include -I/opt/easybuild/software/MPI/intel/2019.1.144-GCC-8.2.0-2.31.1/impi/2018.4.274/HDF5/1.10.5/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/UDUNITS/2.2.26/include -I/opt/easybuild/software/Compiler/intel/2019.1.144-GCC-8.2.0-2.31.1/GSL/2.5/include -I/opt/easybuild/software/Compiler/GCCcore/8.2.0/ImageMagick/7.0.8-46/include  -fpic  -O2 -xHost -ftz -fp-speculation=safe -fp-model source  -c lf_adap.c -o lf_adap.o
lf_adap.c(132) (col. 34): internal error: 04010026_1450

compilation aborted for lf_adap.c (code 4)
/opt/easybuild/software/MPI/intel/2019.1.144-GCC-8.2.0-2.31.1/impi/2018.4.274/R/3.6.0/lib/R/etc/Makeconf:167: recipe for target 'lf_adap.o' failed
make: *** [lf_adap.o] Error 4
ERROR: compilation failed for package ‘locfit’
```
For this reason `locfit`, `abc` and `EasyABC` are currently commented out in the easyconfig file.