### PR TITLE
Rename SALMON to SALMON-TDDFT

### DIFF
--- a/easybuild/easyconfigs/s/SALMON-TDDFT/SALMON-TDDFT-1.2.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/s/SALMON-TDDFT/SALMON-TDDFT-1.2.1-foss-2018b.eb
@@ -15,7 +15,10 @@ source_urls = ['https://github.com/SALMON-TDDFT/SALMON/archive/']
 sources = ['v.%(version)s.tar.gz']
 checksums = ['a5045149e49abe9dd9edefe00cd1508a1323081bc3d034632176b728effdbaeb']
 
-builddependencies = [('CMake', '3.12.1')]
+builddependencies = [
+    ('CMake', '3.12.1'),
+    ('Python', '2.7.15'),
+]
 
 dependencies = [('libxc', '4.2.3')]
 

--- a/easybuild/easyconfigs/s/SALMON-TDDFT/SALMON-TDDFT-1.2.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/s/SALMON-TDDFT/SALMON-TDDFT-1.2.1-foss-2018b.eb
@@ -1,6 +1,6 @@
 easyblock = 'CMakeMake'
 
-name = 'SALMON'
+name = 'SALMON-TDDFT'
 version = '1.2.1'
 
 homepage = 'https://salmon-tddft.jp'

--- a/easybuild/easyconfigs/s/SALMON-TDDFT/SALMON-TDDFT-1.2.1-intel-2018b.eb
+++ b/easybuild/easyconfigs/s/SALMON-TDDFT/SALMON-TDDFT-1.2.1-intel-2018b.eb
@@ -15,7 +15,10 @@ source_urls = ['https://github.com/SALMON-TDDFT/SALMON/archive/']
 sources = ['v.%(version)s.tar.gz']
 checksums = ['a5045149e49abe9dd9edefe00cd1508a1323081bc3d034632176b728effdbaeb']
 
-builddependencies = [('CMake', '3.12.1')]
+builddependencies = [
+    ('CMake', '3.12.1'),
+    ('Python', '2.7.15'),
+]
 
 dependencies = [('libxc', '4.2.3')]
 

--- a/easybuild/easyconfigs/s/SALMON-TDDFT/SALMON-TDDFT-1.2.1-intel-2018b.eb
+++ b/easybuild/easyconfigs/s/SALMON-TDDFT/SALMON-TDDFT-1.2.1-intel-2018b.eb
@@ -1,6 +1,6 @@
 easyblock = 'CMakeMake'
 
-name = 'SALMON'
+name = 'SALMON-TDDFT'
 version = '1.2.1'
 
 homepage = 'https://salmon-tddft.jp'


### PR DESCRIPTION
`SALMON` must be renamed in order to avoid conflicts with the already existing `Salmon` easyconfigs.