### PR TITLE
{tools}[GCCcore/6.4.0] bug fix, lftp requires ncurses as dependency

### DIFF
--- a/easybuild/easyconfigs/l/lftp/lftp-4.8.4-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/lftp/lftp-4.8.4-GCCcore-6.4.0.eb
@@ -16,6 +16,10 @@ source_urls = ['http://lftp.yar.ru/ftp/']
 sources = [SOURCE_TAR_GZ]
 checksums = ['19f3a4236558fbdb88eec01bc9d693c51b122d23487b6bedad4cc67ae6825fc2']
 
+dependencies = [
+    ('ncurses', '6.0'),
+]
+
 builddependencies = [
     ('binutils', '2.28'),
     ('libreadline', '7.0'),


### PR DESCRIPTION
The builddependency libreadline pulls in ncurses/6.0, but that is also needed at runtime.