### PR TITLE
add patch for M4 1.4.17 to fix installation on top of glibc 2.28

### DIFF
--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.06.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.06.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'CrayGNU', 'version': '2015.06'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.11.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'CrayGNU', 'version': '2015.11'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.2.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCC', 'version': '4.8.2'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.4.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCC', 'version': '4.8.4'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2-binutils-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2-binutils-2.25.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCC', 'version': '4.9.2-binutils-2.25'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCC', 'version': '4.9.2'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-2.25.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCC', 'version': '4.9.3-2.25'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-binutils-2.25.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCC', 'version': '4.9.3-binutils-2.25'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCC', 'version': '4.9.3'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.1.0-binutils-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.1.0-binutils-2.25.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCC', 'version': '5.1.0-binutils-2.25'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.2.0.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCC', 'version': '5.2.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.4.0-2.26.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.2.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCCcore', 'version': '4.9.2'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.3.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.4.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.4.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCCcore', 'version': '4.9.4'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.3.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.3.0.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCCcore', 'version': '5.3.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.26', '', True)]

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.4.0.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCCcore', 'version': '5.4.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.26', '', True)]

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.1.0.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCCcore', 'version': '6.1.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # use same binutils version that was used when building GCCcore
 builddependencies = [('binutils', '2.27', '', True)]

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.2.0.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCCcore', 'version': '6.2.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.27', '', True)]

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.2-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.2-2.25.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GNU', 'version': '4.9.2-2.25'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.3-2.25.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GNU', 'version': '4.9.3-2.25'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-5.1.0-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-5.1.0-2.25.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GNU', 'version': '5.1.0-2.25'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016.04.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016.04.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'foss', 'version': '2016.04'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016a.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016a.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016b.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-gimkl-2.11.5.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'gimkl', 'version': '2.11.5'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016.02-GCC-4.9.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016a.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016a.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016b.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-iomkl-2016.07.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-iomkl-2016.07.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'iomkl', 'version': '2016.07'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'iomkl', 'version': '2016.09-GCC-4.9.3-2.25'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
 

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17.eb
@@ -16,7 +16,11 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17_glibc_2.28.patch
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17_glibc_2.28.patch
@@ -1,0 +1,54 @@
+fix problems occuring from changes in glibc 2.28
+https://github.com/coreutils/gnulib/commit/4af4a4a71827c0bc5e0ec67af23edef4f15cee8e
+
+diff -ru m4-1.4.17.orig/lib/freadahead.c m4-1.4.17/lib/freadahead.c
+--- m4-1.4.17.orig/lib/freadahead.c	2019-06-19 15:21:26.897812071 -0400
++++ m4-1.4.17/lib/freadahead.c	2019-06-19 15:25:40.075547063 -0400
+@@ -25,7 +25,7 @@
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)
+diff -ru m4-1.4.17.orig/lib/fseeko.c m4-1.4.17/lib/fseeko.c
+--- m4-1.4.17.orig/lib/fseeko.c	2019-06-19 15:21:26.897812071 -0400
++++ m4-1.4.17/lib/fseeko.c	2019-06-19 15:27:19.368232257 -0400
+@@ -47,7 +47,7 @@
+ #endif
+ 
+   /* These tests are based on fpurge.c.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_read_end == fp->_IO_read_ptr
+       && fp->_IO_write_ptr == fp->_IO_write_base
+       && fp->_IO_save_base == NULL)
+@@ -121,7 +121,7 @@
+           return -1;
+         }
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+       fp->_flags &= ~_IO_EOF_SEEN;
+       fp->_offset = pos;
+ #elif defined __sferror || defined __DragonFly__ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin */
+diff -ru m4-1.4.17.orig/lib/stdio-impl.h m4-1.4.17/lib/stdio-impl.h
+--- m4-1.4.17.orig/lib/stdio-impl.h	2019-06-19 15:21:26.909812152 -0400
++++ m4-1.4.17/lib/stdio-impl.h	2019-06-19 15:29:10.789003521 -0400
+@@ -21,6 +21,14 @@
+ 
+ /* BSD stdio derived implementations.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
++
+ #if defined __NetBSD__                         /* NetBSD */
+ /* Get __NetBSD_Version__.  */
+ # include <sys/param.h>


### PR DESCRIPTION
cfr. #8501 and #8633

applies fix that was already applied for M4 1.4.18 in #7384 to version 1.14.17

M4 1.4.17 easyconfigs that have been archived in #8557, #8564, #8585 were left untouched