### PR TITLE
{astro}[foss/2019a] astropy v2.0.14 w/ Python 2.7.15 + 3.7.2

### DIFF
--- a/easybuild/easyconfigs/a/astropy/astropy-2.0.14-foss-2019a.eb
+++ b/easybuild/easyconfigs/a/astropy/astropy-2.0.14-foss-2019a.eb
@@ -35,7 +35,7 @@ exts_list = [
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%(pyshortver)s/site-packages/astropy'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s'],
 }
 
 moduleclass = 'astro'

--- a/easybuild/easyconfigs/a/astropy/astropy-2.0.14-foss-2019a.eb
+++ b/easybuild/easyconfigs/a/astropy/astropy-2.0.14-foss-2019a.eb
@@ -1,0 +1,41 @@
+easyblock = 'PythonBundle'
+
+name = 'astropy'
+version = '2.0.14'
+
+homepage = 'http://www.astropy.org/'
+description = """The Astropy Project is a community effort to develop 
+ a single core package for Astronomy in Python and foster interoperability 
+ between Python astronomy packages."""
+
+toolchain = {'name': 'foss', 'version': '2019a'}
+
+multi_deps = {'Python': ['3.7.2', '2.7.15']}
+
+dependencies = [
+    ('SciPy-bundle', '2019.03'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('astropy-helpers', '2.0.10', {
+        'source_urls': ['https://pypi.python.org/packages/source/A/astropy-helpers/'],
+        'checksums': ['c5ca146e2b8607087f907b5cd1c5aabb0854cca0df43043a38aea1757e5eb65c'],
+    }),
+    (name, version, {
+        'patches': ['astropy-ah_no_auto_use.patch'],
+        'source_urls': ['https://pypi.python.org/packages/source/A/astropy/'],
+        'checksums': [
+            '618807068609a4d8aeb403a07624e9984f566adc0dc0f5d6b477c3658f31aeb6',  # astropy-2.0.14.tar.gz
+            'fb339ff90fff8ed760b5ea9b8b65be3babb355f956a5588fd7e2e2656b4a7ca8',  # astropy-ah_no_auto_use.patch
+        ],
+    }),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/astropy'],
+}
+
+moduleclass = 'astro'


### PR DESCRIPTION
current version astropy for current toolchain.
Multideps used.

(created using `eb --new-pr`)
