### PR TITLE
fix names of local variables in GCCcore and GCC easyconfigs

### DIFF
--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG-multilib.eb
@@ -8,7 +8,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -23,13 +23,13 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
     'cloog-0.18.1.tar.gz',
     'isl-0.12.2.tar.bz2',
 ]
 
-patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20140630.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     '9709b49ae0e904cbb0a6a1b62853b556',     # gcc-4.9.0.tar.bz2

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG.eb
@@ -8,7 +8,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -23,13 +23,13 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
     'cloog-0.18.1.tar.gz',
     'isl-0.12.2.tar.bz2',
 ]
 
-patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20140630.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     '9709b49ae0e904cbb0a6a1b62853b556',     # gcc-4.9.0.tar.bz2

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.0.eb
@@ -7,7 +7,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -18,11 +18,11 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
 ]
 
-patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20140630.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     '9709b49ae0e904cbb0a6a1b62853b556',     # gcc-4.9.0.tar.bz2

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG-multilib.eb
@@ -8,7 +8,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -23,13 +23,13 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
     'cloog-0.18.1.tar.gz',
     'isl-0.12.2.tar.bz2',
 ]
 
-patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20140630.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     'fddf71348546af523353bd43d34919c1',     # gcc-4.9.1.tar.gz

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG.eb
@@ -8,7 +8,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -23,13 +23,13 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
     'cloog-0.18.1.tar.gz',
     'isl-0.12.2.tar.bz2',
 ]
 
-patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20140630.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     'fddf71348546af523353bd43d34919c1',     # gcc-4.9.1.tar.gz

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.1.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.1.eb
@@ -7,7 +7,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -18,11 +18,11 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
 ]
 
-patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20140630.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     'fddf71348546af523353bd43d34919c1',     # gcc-4.9.1.tar.gz

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG-multilib.eb
@@ -8,7 +8,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -23,13 +23,13 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
     'cloog-0.18.1.tar.gz',
     'isl-0.12.2.tar.bz2',
 ]
 
-patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20140630.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     '4df8ee253b7f3863ad0b86359cd39c43',     # gcc-4.9.2.tar.bz2

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG.eb
@@ -8,7 +8,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -23,13 +23,13 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
     'cloog-0.18.1.tar.gz',
     'isl-0.12.2.tar.bz2',
 ]
 
-patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20140630.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     '4df8ee253b7f3863ad0b86359cd39c43',     # gcc-4.9.2.tar.bz2

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2-binutils-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2-binutils-2.25.eb
@@ -1,8 +1,8 @@
 name = "GCC"
 version = '4.9.2'
 
-binutilsver = '2.25'
-versionsuffix = '-binutils-%s' % binutilsver
+local_binutilsver = '2.25'
+versionsuffix = '-binutils-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -10,7 +10,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -21,13 +21,13 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
 ]
 
-builddependencies = [('binutils', binutilsver)]
+builddependencies = [('binutils', local_binutilsver)]
 
-patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20140630.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     '4df8ee253b7f3863ad0b86359cd39c43',     # gcc-4.9.2.tar.bz2

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2.eb
@@ -7,7 +7,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -18,11 +18,11 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
 ]
 
-patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20140630.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     '4df8ee253b7f3863ad0b86359cd39c43',     # gcc-4.9.2.tar.bz2

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.3-2.25.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '4.9.3'
 
-binutilsver = '2.25'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.25'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.3-binutils-2.25.eb
@@ -1,8 +1,8 @@
 name = "GCC"
 version = '4.9.3'
 
-binutilsver = '2.25'
-versionsuffix = '-binutils-%s' % binutilsver
+local_binutilsver = '2.25'
+versionsuffix = '-binutils-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -10,7 +10,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -21,13 +21,13 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
 ]
 
-builddependencies = [('binutils', binutilsver)]
+builddependencies = [('binutils', local_binutilsver)]
 
-patches = [('mpfr-%s-allpatches-20141204.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20141204.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     '6f831b4d251872736e8e9cc09746f327',     # gcc-4.9.3.tar.bz2

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.3.eb
@@ -7,7 +7,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -18,11 +18,11 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
 ]
 
-patches = [('mpfr-%s-allpatches-20141204.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20141204.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     '6f831b4d251872736e8e9cc09746f327',     # gcc-4.9.3.tar.bz2

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.4-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.4-2.25.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '4.9.4'
 
-binutilsver = '2.25'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.25'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-5.1.0-binutils-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.1.0-binutils-2.25.eb
@@ -1,8 +1,8 @@
 name = "GCC"
 version = '5.1.0'
 
-binutilsver = '2.25'
-versionsuffix = '-binutils-%s' % binutilsver
+local_binutilsver = '2.25'
+versionsuffix = '-binutils-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -10,7 +10,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -25,17 +25,17 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.3.tar.gz',
     'isl-0.14.tar.bz2',
 ]
 
 builddependencies = [
     ('M4', '1.4.17'),
-    ('binutils', binutilsver),
+    ('binutils', local_binutilsver),
 ]
 
-patches = [('mpfr-%s-allpatches-20141204.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20141204.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     'd5525b1127d07d215960e6051c5da35e',     # gcc-5.1.0.tar.bz2

--- a/easybuild/easyconfigs/g/GCC/GCC-5.1.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.1.0.eb
@@ -7,7 +7,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -22,12 +22,12 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.3.tar.gz',
     'isl-0.14.tar.bz2',
 ]
 
-patches = [('mpfr-%s-allpatches-20141204.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20141204.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 builddependencies = [('M4', '1.4.17')]
 

--- a/easybuild/easyconfigs/g/GCC/GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.2.0.eb
@@ -7,7 +7,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.3'
+local_mpfr_version = '3.1.3'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -22,12 +22,12 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.3.tar.gz',
     'isl-0.14.tar.bz2',
 ]
 
-patches = [('mpfr-%s-allpatches-20150717.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20150717.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 builddependencies = [('M4', '1.4.17')]
 

--- a/easybuild/easyconfigs/g/GCC/GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.3.0-2.26.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '5.3.0'
 
-binutilsver = '2.26'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.26'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-5.3.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.3.0.eb
@@ -7,7 +7,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.3'
+local_mpfr_version = '3.1.3'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -22,12 +22,12 @@ source_urls = [
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.1.0.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.3.tar.gz',
     'isl-0.15.tar.bz2',
 ]
 
-patches = [('mpfr-%s-allpatches-20151029.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20151029.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 builddependencies = [('M4', '1.4.17')]
 

--- a/easybuild/easyconfigs/g/GCC/GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.4.0-2.26.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '5.4.0'
 
-binutilsver = '2.26'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.26'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-5.5.0-2.26.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.5.0-2.26.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '5.5.0'
 
-binutilsver = '2.26'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.26'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-6.1.0-2.27.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-6.1.0-2.27.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '6.1.0'
 
-binutilsver = '2.27'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.27'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-6.2.0-2.27.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-6.2.0-2.27.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '6.2.0'
 
-binutilsver = '2.27'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.27'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-6.3.0-2.27.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '6.3.0'
 
-binutilsver = '2.27'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.27'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-6.3.0-2.28.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-6.3.0-2.28.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '6.3.0'
 
-binutilsver = '2.28'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.28'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-6.4.0-2.28.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '6.4.0'
 
-binutilsver = '2.28'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.28'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 
@@ -20,7 +20,7 @@ dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built
     # on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-7.1.0-2.28.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-7.1.0-2.28.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '7.1.0'
 
-binutilsver = '2.28'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.28'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-7.2.0-2.29.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-7.2.0-2.29.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '7.2.0'
 
-binutilsver = '2.29'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.29'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-7.3.0-2.30.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '7.3.0'
 
-binutilsver = '2.30'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.30'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-7.4.0-2.31.1.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-7.4.0-2.31.1.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '7.4.0'
 
-binutilsver = '2.31.1'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.31.1'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-8.1.0-2.30.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-8.1.0-2.30.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '8.1.0'
 
-binutilsver = '2.30'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.30'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-8.2.0-2.31.1.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '8.2.0'
 
-binutilsver = '2.31.1'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.31.1'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-8.3.0-2.32.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-8.3.0-2.32.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '8.3.0'
 
-binutilsver = '2.32'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.32'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-9.1.0-2.32.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-9.1.0-2.32.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = '9.1.0'
 
-binutilsver = '2.32'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.32'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'https://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCC/GCC-system-2.29.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-system-2.29.eb
@@ -3,8 +3,8 @@ easyblock = 'Bundle'
 name = 'GCC'
 version = 'system'
 
-binutilsver = '2.29'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.29'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -15,7 +15,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.2.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.2.eb
@@ -9,8 +9,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
-gcc_name = 'GCC'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%s' % version,  # GCC auto-resolving HTTP mirror
@@ -19,9 +18,9 @@ source_urls = [
     'http://ftpmirror.gnu.org/gnu/mpc',  # idem for MPC
 ]
 sources = [
-    '%s-%s.tar.bz2' % (gcc_name.lower(), version),
+    'gcc-%(version)s.tar.bz2',
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
 ]
 
@@ -30,7 +29,7 @@ builddependencies = [
     ('binutils', '2.25'),
 ]
 
-patches = [('mpfr-%s-allpatches-20141204.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20141204.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     '4df8ee253b7f3863ad0b86359cd39c43',     # gcc-4.9.2.tar.bz2

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.3.eb
@@ -9,7 +9,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%s' % version,  # GCC auto-resolving HTTP mirror
@@ -20,7 +20,7 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.bz2',
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
 ]
 
@@ -29,7 +29,7 @@ builddependencies = [
     ('binutils', '2.25'),
 ]
 
-patches = [('mpfr-%s-allpatches-20141204.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20141204.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     '6f831b4d251872736e8e9cc09746f327',     # gcc-4.9.3.tar.bz2

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.4.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.4.eb
@@ -9,7 +9,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.4'
+local_mpfr_version = '3.1.4'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%s' % version,  # GCC auto-resolving HTTP mirror
@@ -20,7 +20,7 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.bz2',
     'gmp-6.1.1.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.3.tar.gz',
 ]
 
@@ -29,7 +29,7 @@ builddependencies = [
     ('binutils', '2.25'),
 ]
 
-patches = [('mpfr-%s-allpatches-20160601.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20160601.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 checksums = [
     '87c24a4090c1577ba817ec6882602491',     # gcc-4.9.4.tar.bz2

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-5.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-5.3.0.eb
@@ -9,7 +9,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.3'
+local_mpfr_version = '3.1.3'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -24,12 +24,12 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.bz2',
     'gmp-6.1.0.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.3.tar.gz',
     'isl-0.15.tar.bz2',
 ]
 
-patches = [('mpfr-%s-allpatches-20151029.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20151029.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 builddependencies = [
     ('binutils', '2.26'),

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-5.4.0.eb
@@ -9,7 +9,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.4'
+local_mpfr_version = '3.1.4'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -24,12 +24,12 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.bz2',
     'gmp-6.1.0.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.3.tar.gz',
     'isl-0.15.tar.bz2',
 ]
 
-patches = [('mpfr-%s-allpatches-20160601.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20160601.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
 builddependencies = [
     ('binutils', '2.26'),

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-5.5.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-5.5.0.eb
@@ -9,8 +9,6 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.6'
-
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
     'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.1.0.eb
@@ -9,7 +9,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.4'
+local_mpfr_version = '3.1.4'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
@@ -25,7 +25,7 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.bz2',
     'gmp-6.1.1.tar.bz2',
-    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpfr-%s.tar.bz2' % local_mpfr_version,
     'mpc-1.0.3.tar.gz',
     'isl-0.16.1.tar.bz2',
 ]
@@ -36,7 +36,7 @@ builddependencies = [
 ]
 
 patches = [
-    ('mpfr-%s-allpatches-20160804.patch' % mpfr_version, '../mpfr-%s' % mpfr_version),
+    ('mpfr-%s-allpatches-20160804.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version),
     ('%s-%s_fix-find-isl.patch' % (name, version)),
     'GCCcore-6.x-fix-ubsan.patch',
 ]

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.2.0.eb
@@ -9,7 +9,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.4'
+local_mpfr_version = '3.1.4'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -24,7 +24,7 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.bz2',
     'gmp-6.1.1.tar.bz2',
-    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpfr-%s.tar.bz2' % local_mpfr_version,
     'mpc-1.0.3.tar.gz',
     'isl-0.16.1.tar.bz2',
 ]
@@ -35,7 +35,7 @@ builddependencies = [
 ]
 
 patches = [
-    ('mpfr-%s-allpatches-20160804.patch' % mpfr_version, '../mpfr-%s' % mpfr_version),
+    ('mpfr-%s-allpatches-20160804.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version),
     '%(name)s-%(version)s-fix-find-isl.patch',
     'GCCcore-6.x-fix-ubsan.patch',
 ]

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.3.0.eb
@@ -9,7 +9,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.5'
+local_mpfr_version = '3.1.5'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -23,12 +23,12 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.bz2',
     'gmp-6.1.1.tar.bz2',
-    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpfr-%s.tar.bz2' % local_mpfr_version,
     'mpc-1.0.3.tar.gz',
     'isl-0.16.1.tar.bz2',
 ]
 patches = [
-    ('mpfr-%s-allpatches-20161215.patch' % mpfr_version, '../mpfr-%s' % mpfr_version),
+    ('mpfr-%s-allpatches-20161215.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version),
     'GCCcore-6.2.0-fix-find-isl.patch',
     'GCCcore-6.x-fix-ubsan.patch',
     'GCCcore-6.3.0_fix-linux-unwind-fix-ucontext.patch',

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.4.0.eb
@@ -13,7 +13,7 @@ description = """
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.5'
+local_mpfr_version = '3.1.5'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -27,12 +27,12 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.gz',
     'gmp-6.1.2.tar.bz2',
-    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpfr-%s.tar.bz2' % local_mpfr_version,
     'mpc-1.0.3.tar.gz',
     'isl-0.16.1.tar.bz2',
 ]
 patches = [
-    ('mpfr-%s-allpatches-20170606.patch' % mpfr_version, '../mpfr-%s' % mpfr_version),
+    ('mpfr-%s-allpatches-20170606.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version),
     'GCCcore-6.2.0-fix-find-isl.patch',
     'GCCcore-%(version)s_fix-linux-unwind-fix-ucontext.patch',
 ]

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.5.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.5.0.eb
@@ -13,7 +13,7 @@ description = """
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.6'
+local_mpfr_version = '3.1.6'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -28,12 +28,12 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.gz',
     'gmp-6.1.2.tar.bz2',
-    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpfr-%s.tar.bz2' % local_mpfr_version,
     'mpc-1.1.0.tar.gz',
     'isl-0.20.tar.bz2',
 ]
 patches = [
-    ('mpfr-%s-allpatches-20171215.patch' % mpfr_version, '../mpfr-%s' % mpfr_version),
+    ('mpfr-%s-allpatches-20171215.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version),
     'GCCcore-6.2.0-fix-find-isl.patch',
 ]
 checksums = [

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-7.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-7.1.0.eb
@@ -9,7 +9,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.5'
+local_mpfr_version = '3.1.5'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -24,7 +24,7 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.bz2',
     'gmp-6.1.2.tar.bz2',
-    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpfr-%s.tar.bz2' % local_mpfr_version,
     'mpc-1.0.3.tar.gz',
     'isl-0.16.1.tar.bz2',
 ]
@@ -35,7 +35,7 @@ builddependencies = [
 ]
 
 patches = [
-    ('mpfr-%s-allpatches-20161219.patch' % mpfr_version, '../mpfr-%s' % mpfr_version),
+    ('mpfr-%s-allpatches-20161219.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version),
     'GCCcore-6.2.0-fix-find-isl.patch',
 ]
 

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-7.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-7.2.0.eb
@@ -9,7 +9,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '3.1.5'
+local_mpfr_version = '3.1.5'
 
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
@@ -23,12 +23,12 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.gz',
     'gmp-6.1.2.tar.bz2',
-    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpfr-%s.tar.bz2' % local_mpfr_version,
     'mpc-1.0.3.tar.gz',
     'isl-0.16.1.tar.bz2',
 ]
 patches = [
-    ('mpfr-%s-allpatches-20170801.patch' % mpfr_version, '../mpfr-%s' % mpfr_version),
+    ('mpfr-%s-allpatches-20170801.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version),
     'GCCcore-6.2.0-fix-find-isl.patch',
 ]
 checksums = [

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-7.3.0.eb
@@ -9,8 +9,6 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '4.0.1'
-
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
     'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
@@ -23,7 +21,7 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.gz',
     'gmp-6.1.2.tar.bz2',
-    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpfr-4.0.1.tar.bz2',
     'mpc-1.1.0.tar.gz',
     'isl-0.19.tar.bz2',
 ]

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-7.4.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-7.4.0.eb
@@ -9,8 +9,6 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '4.0.1'
-
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
     'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
@@ -23,7 +21,7 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.gz',
     'gmp-6.1.2.tar.bz2',
-    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpfr-4.0.1.tar.bz2',
     'mpc-1.1.0.tar.gz',
     'isl-0.20.tar.bz2',
 ]

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-8.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-8.1.0.eb
@@ -9,8 +9,6 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '4.0.1'
-
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
     'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
@@ -23,7 +21,7 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.gz',
     'gmp-6.1.2.tar.bz2',
-    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpfr-4.0.1.tar.bz2',
     'mpc-1.1.0.tar.gz',
     'isl-0.19.tar.bz2',
 ]

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-8.2.0.eb
@@ -9,8 +9,6 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '4.0.1'
-
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
     'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
@@ -23,7 +21,7 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.gz',
     'gmp-6.1.2.tar.bz2',
-    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpfr-4.0.1.tar.bz2',
     'mpc-1.1.0.tar.gz',
     'isl-0.20.tar.bz2',
 ]

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-8.3.0.eb
@@ -9,8 +9,6 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '4.0.2'
-
 source_urls = [
     'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
     'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
@@ -23,7 +21,7 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.gz',
     'gmp-6.1.2.tar.bz2',
-    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpfr-4.0.2.tar.bz2',
     'mpc-1.1.0.tar.gz',
     'isl-0.20.tar.bz2',
 ]

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-9.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-9.1.0.eb
@@ -9,8 +9,6 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = SYSTEM
 
-mpfr_version = '4.0.2'
-
 source_urls = [
     'https://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
     'https://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
@@ -23,7 +21,7 @@ source_urls = [
 sources = [
     'gcc-%(version)s.tar.gz',
     'gmp-6.1.2.tar.bz2',
-    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpfr-4.0.2.tar.bz2',
     'mpc-1.1.0.tar.gz',
     'isl-0.21.tar.bz2',
 ]


### PR DESCRIPTION
Required to avoid warnings being printed, because of changes made in https://github.com/easybuilders/easybuild-framework/pull/2938