### PR TITLE
fix names of local variables in OpenBLAS easyconfigs

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.12-GCC-4.9.2-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.12-GCC-4.9.2-LAPACK-3.5.0.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.12'
 
-lapackver = '3.5.0'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.5.0'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -22,7 +22,7 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('lapack-%s.tgz' % local_lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     ('large.tgz', '.'),
     ('timing.tgz', '.'),
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.8.4-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.8.4-LAPACK-3.5.0.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.13'
 
-lapackver = '3.5.0'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.5.0'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -22,7 +22,7 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('lapack-%s.tgz' % local_lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     ('large.tgz', '.'),
     ('timing.tgz', '.'),
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.9.2-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.13-GCC-4.9.2-LAPACK-3.5.0.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.13'
 
-lapackver = '3.5.0'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.5.0'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -22,7 +22,7 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('lapack-%s.tgz' % local_lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     ('large.tgz', '.'),
     ('timing.tgz', '.'),
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.2-2.25-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.2-2.25-LAPACK-3.5.0.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.14'
 
-lapackver = '3.5.0'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.5.0'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -22,7 +22,7 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('lapack-%s.tgz' % local_lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     ('large.tgz', '.'),
     ('timing.tgz', '.'),
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.3-2.25-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GNU-4.9.3-2.25-LAPACK-3.5.0.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.14'
 
-lapackver = '3.5.0'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.5.0'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -22,7 +22,7 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('lapack-%s.tgz' % local_lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     ('large.tgz', '.'),
     ('timing.tgz', '.'),
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.15-GCC-4.9.3-2.25-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.15-GCC-4.9.3-2.25-LAPACK-3.6.0.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.15'
 
-lapackver = '3.6.0'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.6.0'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -22,7 +22,7 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('lapack-%s.tgz' % local_lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     ('large.tgz', '.'),
     ('timing.tgz', '.'),
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-4.9.4-2.25-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-4.9.4-2.25-LAPACK-3.6.0.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.18'
 
-lapackver = '3.6.0'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.6.0'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -14,9 +14,9 @@ toolchain = {'name': 'GCC', 'version': '4.9.4-2.25'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
-lapack_unpack_cmd += 'mkdir lapack-netlib;'
-lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
+local_lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
+local_lapack_unpack_cmd += 'mkdir lapack-netlib;'
+local_lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
@@ -26,7 +26,7 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
+    {'filename': 'lapack-%s.tgz' % local_lapackver, 'extract_cmd': local_lapack_unpack_cmd},
 ]
 patches = [
     ('large.tgz', '.'),

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.3.0-2.26-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.3.0-2.26-LAPACK-3.6.0.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.18'
 
-lapackver = '3.6.0'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.6.0'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -14,9 +14,9 @@ toolchain = {'name': 'GCC', 'version': '5.3.0-2.26'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
-lapack_unpack_cmd += 'mkdir lapack-netlib;'
-lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
+local_lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
+local_lapack_unpack_cmd += 'mkdir lapack-netlib;'
+local_lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
@@ -26,7 +26,7 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
+    {'filename': 'lapack-%s.tgz' % local_lapackver, 'extract_cmd': local_lapack_unpack_cmd},
 ]
 patches = [
     ('large.tgz', '.'),

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.0.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.18'
 
-lapackver = '3.6.0'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.6.0'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -14,9 +14,9 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
-lapack_unpack_cmd += 'mkdir lapack-netlib;'
-lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
+local_lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
+local_lapack_unpack_cmd += 'mkdir lapack-netlib;'
+local_lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
@@ -26,7 +26,7 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
+    {'filename': 'lapack-%s.tgz' % local_lapackver, 'extract_cmd': local_lapack_unpack_cmd},
 ]
 patches = [
     ('large.tgz', '.'),

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.18'
 
-lapackver = '3.6.1'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.6.1'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -14,9 +14,9 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
-lapack_unpack_cmd += 'mkdir lapack-netlib;'
-lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
+local_lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
+local_lapack_unpack_cmd += 'mkdir lapack-netlib;'
+local_lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
@@ -26,7 +26,7 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
+    {'filename': 'lapack-%s.tgz' % local_lapackver, 'extract_cmd': local_lapack_unpack_cmd},
 ]
 patches = [
     ('large.tgz', '.'),

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.18'
 
-lapackver = '3.6.1'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.6.1'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -14,9 +14,9 @@ toolchain = {'name': 'gompi', 'version': '2016.07'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
-lapack_unpack_cmd += 'mkdir lapack-netlib;'
-lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
+local_lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
+local_lapack_unpack_cmd += 'mkdir lapack-netlib;'
+local_lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
@@ -26,7 +26,7 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
+    {'filename': 'lapack-%s.tgz' % local_lapackver, 'extract_cmd': local_lapack_unpack_cmd},
 ]
 patches = [
     ('large.tgz', '.'),
@@ -41,9 +41,9 @@ checksums = [
 
 skipsteps = ['configure']
 
-threading = 'USE_THREAD=1'
-buildopts = 'BINARY=64 ' + threading + ' CC="$CC" FC="$F77"'
-installopts = threading + " PREFIX=%(installdir)s"
+local_threading = 'USE_THREAD=1'
+buildopts = 'BINARY=64 ' + local_threading + ' CC="$CC" FC="$F77"'
+installopts = local_threading + " PREFIX=%(installdir)s"
 
 sanity_check_paths = {
     'files': ['include/cblas.h', 'include/f77blas.h', 'include/lapacke_config.h', 'include/lapacke.h',

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-5.4.0-2.26-LAPACK-3.7.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-5.4.0-2.26-LAPACK-3.7.0.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.19'
 
-lapackver = '3.7.0'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.7.0'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -14,9 +14,9 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
-lapack_unpack_cmd += 'mkdir lapack-netlib;'
-lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
+local_lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
+local_lapack_unpack_cmd += 'mkdir lapack-netlib;'
+local_lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
@@ -26,7 +26,7 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
+    {'filename': 'lapack-%s.tgz' % local_lapackver, 'extract_cmd': local_lapack_unpack_cmd},
 ]
 patches = [
     ('large.tgz', '.'),

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-6.3.0-2.27-LAPACK-3.7.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-GCC-6.3.0-2.27-LAPACK-3.7.0.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.19'
 
-lapackver = '3.7.0'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.7.0'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -14,9 +14,9 @@ toolchain = {'name': 'GCC', 'version': '6.3.0-2.27'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
-lapack_unpack_cmd += 'mkdir lapack-netlib;'
-lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
+local_lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
+local_lapack_unpack_cmd += 'mkdir lapack-netlib;'
+local_lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
@@ -26,7 +26,7 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
+    {'filename': 'lapack-%s.tgz' % local_lapackver, 'extract_cmd': local_lapack_unpack_cmd},
 ]
 patches = [
     ('large.tgz', '.'),

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.19'
 
-lapackver = '3.6.1'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.6.1'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -14,9 +14,9 @@ toolchain = {'name': 'gompi', 'version': '2016.09'}
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/7180
 toolchainopts = {'vectorize': False}
 
-lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
-lapack_unpack_cmd += 'mkdir lapack-netlib;'
-lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
+local_lapack_unpack_cmd = 'cd %(name)s-%(version)s; rm -rf lapack-netlib;'
+local_lapack_unpack_cmd += 'mkdir lapack-netlib;'
+local_lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
 
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
@@ -26,7 +26,7 @@ source_urls = [
 ]
 sources = [
     'v%(version)s.tar.gz',
-    {'filename': 'lapack-%s.tgz' % lapackver, 'extract_cmd': lapack_unpack_cmd},
+    {'filename': 'lapack-%s.tgz' % local_lapackver, 'extract_cmd': local_lapack_unpack_cmd},
 ]
 patches = [
     ('large.tgz', '.'),
@@ -41,9 +41,9 @@ checksums = [
 
 skipsteps = ['configure']
 
-threading = 'USE_THREAD=1'
-buildopts = 'BINARY=64 ' + threading + ' CC="$CC" FC="$F77"'
-installopts = threading + " PREFIX=%(installdir)s"
+local_threading = 'USE_THREAD=1'
+buildopts = 'BINARY=64 ' + local_threading + ' CC="$CC" FC="$F77"'
+installopts = local_threading + " PREFIX=%(installdir)s"
 
 sanity_check_paths = {
     'files': ['include/cblas.h', 'include/f77blas.h', 'include/lapacke_config.h', 'include/lapacke.h',

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.9-GCC-4.8.3-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.9-GCC-4.8.3-LAPACK-3.5.0.eb
@@ -3,8 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.9'
 
-lapackver = '3.5.0'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.5.0'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
@@ -22,7 +22,7 @@ source_urls = [
 ]
 sources = ['v%(version)s.tar.gz']
 patches = [
-    ('lapack-%s.tgz' % lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    ('lapack-%s.tgz' % local_lapackver, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     ('large.tgz', '.'),
     ('timing.tgz', '.'),
 ]


### PR DESCRIPTION
done with `--fix-deprecated-easyconfigs`, no manual changes

required to avoid warnings when these easyconfigs are parsed because of changed made in https://github.com/easybuilders/easybuild-framework/pull/2938