### PR TITLE
fix names of local variables in FFTW easyconfigs

### DIFF
--- a/easybuild/easyconfigs/f/FFTW/FFTW-2.1.5-intel-2016b.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-2.1.5-intel-2016b.eb
@@ -15,11 +15,11 @@ source_urls = [homepage]
 
 patches = ['FFTW-%(version)s_fix-configure-Fortran-linking.patch']
 
-common_configopts = "--enable-shared --enable-type-prefix --enable-threads --with-pic"
+local_common_configopts = "--enable-shared --enable-type-prefix --enable-threads --with-pic"
 
 configopts = [
-    common_configopts + " --enable-float --enable-mpi",
-    common_configopts + " --enable-mpi",  # default as last
+    local_common_configopts + " --enable-float --enable-mpi",
+    local_common_configopts + " --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FFTW/FFTW-2.1.5-intel-2017a.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-2.1.5-intel-2017a.eb
@@ -15,11 +15,11 @@ source_urls = [homepage]
 
 patches = ['FFTW-%(version)s_fix-configure-Fortran-linking.patch']
 
-common_configopts = "--enable-shared --enable-type-prefix --enable-threads --with-pic"
+local_common_configopts = "--enable-shared --enable-type-prefix --enable-threads --with-pic"
 
 configopts = [
-    common_configopts + " --enable-float --enable-mpi",
-    common_configopts + " --enable-mpi",  # default as last
+    local_common_configopts + " --enable-float --enable-mpi",
+    local_common_configopts + " --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FFTW/FFTW-2.1.5-intel-2018b.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-2.1.5-intel-2018b.eb
@@ -19,11 +19,11 @@ checksums = [
     '414e88a6a705a155756123e8b4609289022c7dca5def22886c8716cdc2d95885',
 ]
 
-common_configopts = "--enable-shared --enable-type-prefix --enable-threads --with-pic"
+local_common_configopts = "--enable-shared --enable-type-prefix --enable-threads --with-pic"
 
 configopts = [
-    common_configopts + " --enable-float --enable-mpi",
-    common_configopts + " --enable-mpi",  # default as last
+    local_common_configopts + " --enable-float --enable-mpi",
+    local_common_configopts + " --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gmpich-2016a.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gmpich-2016a.eb
@@ -13,13 +13,13 @@ toolchainopts = {'optarch': True, 'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage]
 
-common_configopts = "--enable-threads --enable-openmp --with-pic"
+local_common_configopts = "--enable-threads --enable-openmp --with-pic"
 
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
-    common_configopts + " --enable-long-double --enable-mpi",
-    common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+    local_common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    local_common_configopts + " --enable-long-double --enable-mpi",
+    local_common_configopts + " --enable-quad-precision",
+    local_common_configopts + " --enable-sse2 --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gmvapich2-1.7.20.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gmvapich2-1.7.20.eb
@@ -13,13 +13,13 @@ toolchainopts = {'optarch': True, 'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage]
 
-common_configopts = "--enable-threads --enable-openmp --with-pic"
+local_common_configopts = "--enable-threads --enable-openmp --with-pic"
 
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
-    common_configopts + " --enable-long-double --enable-mpi",
-    common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+    local_common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    local_common_configopts + " --enable-long-double --enable-mpi",
+    local_common_configopts + " --enable-quad-precision",
+    local_common_configopts + " --enable-sse2 --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gmvapich2-2016a.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gmvapich2-2016a.eb
@@ -13,13 +13,13 @@ toolchainopts = {'optarch': True, 'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage]
 
-common_configopts = "--enable-threads --enable-openmp --with-pic"
+local_common_configopts = "--enable-threads --enable-openmp --with-pic"
 
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
-    common_configopts + " --enable-long-double --enable-mpi",
-    common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+    local_common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    local_common_configopts + " --enable-long-double --enable-mpi",
+    local_common_configopts + " --enable-quad-precision",
+    local_common_configopts + " --enable-sse2 --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2016.04.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2016.04.eb
@@ -13,13 +13,13 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage]
 
-common_configopts = "--enable-threads --enable-openmp --with-pic"
+local_common_configopts = "--enable-threads --enable-openmp --with-pic"
 
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
-    common_configopts + " --enable-long-double --enable-mpi",
-    common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+    local_common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    local_common_configopts + " --enable-long-double --enable-mpi",
+    local_common_configopts + " --enable-quad-precision",
+    local_common_configopts + " --enable-sse2 --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2016.06.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2016.06.eb
@@ -13,13 +13,13 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage]
 
-common_configopts = "--enable-threads --enable-openmp --with-pic"
+local_common_configopts = "--enable-threads --enable-openmp --with-pic"
 
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
-    common_configopts + " --enable-long-double --enable-mpi",
-    common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+    local_common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    local_common_configopts + " --enable-long-double --enable-mpi",
+    local_common_configopts + " --enable-quad-precision",
+    local_common_configopts + " --enable-sse2 --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2016.07.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2016.07.eb
@@ -13,13 +13,13 @@ toolchainopts = {'optarch': True, 'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage]
 
-common_configopts = "--enable-threads --enable-openmp --with-pic"
+local_common_configopts = "--enable-threads --enable-openmp --with-pic"
 
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
-    common_configopts + " --enable-long-double --enable-mpi",
-    common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+    local_common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    local_common_configopts + " --enable-long-double --enable-mpi",
+    local_common_configopts + " --enable-quad-precision",
+    local_common_configopts + " --enable-sse2 --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2016a.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2016a.eb
@@ -13,13 +13,13 @@ toolchainopts = {'optarch': True, 'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage]
 
-common_configopts = "--enable-threads --enable-openmp --with-pic"
+local_common_configopts = "--enable-threads --enable-openmp --with-pic"
 
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
-    common_configopts + " --enable-long-double --enable-mpi",
-    common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+    local_common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    local_common_configopts + " --enable-long-double --enable-mpi",
+    local_common_configopts + " --enable-quad-precision",
+    local_common_configopts + " --enable-sse2 --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2016b.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2016b.eb
@@ -14,13 +14,13 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['8f0cde90929bc05587c3368d2f15cd0530a60b8a9912a8e2979a72dbe5af0982']
 
-common_configopts = "--enable-threads --enable-openmp --with-pic"
+local_common_configopts = "--enable-threads --enable-openmp --with-pic"
 
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
-    common_configopts + " --enable-long-double --enable-mpi",
-    common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+    local_common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    local_common_configopts + " --enable-long-double --enable-mpi",
+    local_common_configopts + " --enable-quad-precision",
+    local_common_configopts + " --enable-sse2 --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-intel-2016a.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-intel-2016a.eb
@@ -13,14 +13,14 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage]
 
-common_configopts = "--enable-threads --enable-openmp --with-pic"
+local_common_configopts = "--enable-threads --enable-openmp --with-pic"
 
 # no quad precision, requires GCC v4.6 or higher
 # see also http://www.fftw.org/doc/Extended-and-quadruple-precision-in-Fortran.html
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
-    common_configopts + " --enable-long-double --enable-mpi",
-    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+    local_common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    local_common_configopts + " --enable-long-double --enable-mpi",
+    local_common_configopts + " --enable-sse2 --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {


### PR DESCRIPTION
done with --fix-deprecated-easyconfigs, no manual changes

required to avoid warnings when these easyconfigs are parsed because of changed made in easybuilders/easybuild-framework#2938