### PR TITLE
fix names of local variables in ScaLAPACK easyconfigs

### DIFF
--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gimpi-2017b-OpenBLAS-0.2.20.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gimpi-2017b-OpenBLAS-0.2.20.eb
@@ -12,11 +12,11 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.20'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver, '', ('GCC', '6.4.0-2.28'))]
+dependencies = [(local_blaslib, local_blasver, '', ('GCC', '6.4.0-2.28'))]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gimpi-2018a-OpenBLAS-0.2.20.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gimpi-2018a-OpenBLAS-0.2.20.eb
@@ -12,11 +12,11 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.20'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver, '', ('GCC', '6.4.0-2.28'))]
+dependencies = [(local_blaslib, local_blasver, '', ('GCC', '6.4.0-2.28'))]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gimpic-2017b-OpenBLAS-0.2.20.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gimpic-2017b-OpenBLAS-0.2.20.eb
@@ -12,11 +12,11 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.20'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver, '', ('GCC', '6.4.0-2.28'))]
+dependencies = [(local_blaslib, local_blasver, '', ('GCC', '6.4.0-2.28'))]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gmpich-2016a-OpenBLAS-0.2.15-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gmpich-2016a-OpenBLAS-0.2.15-LAPACK-3.6.0.eb
@@ -12,12 +12,12 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.15'
-blassuff = '-LAPACK-3.6.0'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.15'
+local_blassuff = '-LAPACK-3.6.0'
 
-versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+versionsuffix = "-%s-%s%s" % (local_blaslib, local_blasver, local_blassuff)
 
-dependencies = [(blaslib, blasver, blassuff, ('GCC', '4.9.3-2.25'))]
+dependencies = [(local_blaslib, local_blasver, local_blassuff, ('GCC', '4.9.3-2.25'))]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gmpich-2017.08-OpenBLAS-0.2.20.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gmpich-2017.08-OpenBLAS-0.2.20.eb
@@ -12,11 +12,11 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.20'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver)]
+dependencies = [(local_blaslib, local_blasver)]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gmvapich2-1.7.20-OpenBLAS-0.2.13-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gmvapich2-1.7.20-OpenBLAS-0.2.13-LAPACK-3.5.0.eb
@@ -12,12 +12,12 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.13'
-blassuff = '-LAPACK-3.5.0'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.13'
+local_blassuff = '-LAPACK-3.5.0'
 
-versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+versionsuffix = "-%s-%s%s" % (local_blaslib, local_blasver, local_blassuff)
 
-dependencies = [(blaslib, blasver, blassuff, ('GCC', '4.8.4'))]
+dependencies = [(local_blaslib, local_blasver, local_blassuff, ('GCC', '4.8.4'))]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gmvapich2-2016a-OpenBLAS-0.2.15-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gmvapich2-2016a-OpenBLAS-0.2.15-LAPACK-3.6.0.eb
@@ -12,12 +12,12 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.15'
-blassuff = '-LAPACK-3.6.0'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.15'
+local_blassuff = '-LAPACK-3.6.0'
 
-versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+versionsuffix = "-%s-%s%s" % (local_blaslib, local_blasver, local_blassuff)
 
-dependencies = [(blaslib, blasver, blassuff, ('GCC', '4.9.3-2.25'))]
+dependencies = [(local_blaslib, local_blasver, local_blassuff, ('GCC', '4.9.3-2.25'))]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016.04-OpenBLAS-0.2.18-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016.04-OpenBLAS-0.2.18-LAPACK-3.6.0.eb
@@ -12,12 +12,12 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.18'
-blassuff = '-LAPACK-3.6.0'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.18'
+local_blassuff = '-LAPACK-3.6.0'
 
-versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+versionsuffix = "-%s-%s%s" % (local_blaslib, local_blasver, local_blassuff)
 
-dependencies = [(blaslib, blasver, blassuff, ('GCC', '5.3.0-2.26'))]
+dependencies = [(local_blaslib, local_blasver, local_blassuff, ('GCC', '5.3.0-2.26'))]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016.06-OpenBLAS-0.2.18-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016.06-OpenBLAS-0.2.18-LAPACK-3.6.0.eb
@@ -12,12 +12,12 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.18'
-blassuff = '-LAPACK-3.6.0'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.18'
+local_blassuff = '-LAPACK-3.6.0'
 
-versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+versionsuffix = "-%s-%s%s" % (local_blaslib, local_blasver, local_blassuff)
 
-dependencies = [(blaslib, blasver, blassuff, ('GCC', '5.4.0-2.26'))]
+dependencies = [(local_blaslib, local_blasver, local_blassuff, ('GCC', '5.4.0-2.26'))]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016.07-OpenBLAS-0.2.18-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016.07-OpenBLAS-0.2.18-LAPACK-3.6.1.eb
@@ -12,12 +12,12 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.18'
-blassuff = '-LAPACK-3.6.1'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.18'
+local_blassuff = '-LAPACK-3.6.1'
 
-versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+versionsuffix = "-%s-%s%s" % (local_blaslib, local_blasver, local_blassuff)
 
-dependencies = [(blaslib, blasver, blassuff)]
+dependencies = [(local_blaslib, local_blasver, local_blassuff)]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016.09-OpenBLAS-0.2.19-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016.09-OpenBLAS-0.2.19-LAPACK-3.6.1.eb
@@ -12,12 +12,12 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.19'
-blassuff = '-LAPACK-3.6.1'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.19'
+local_blassuff = '-LAPACK-3.6.1'
 
-versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+versionsuffix = "-%s-%s%s" % (local_blaslib, local_blasver, local_blassuff)
 
-dependencies = [(blaslib, blasver, blassuff)]
+dependencies = [(local_blaslib, local_blasver, local_blassuff)]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016a-OpenBLAS-0.2.15-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016a-OpenBLAS-0.2.15-LAPACK-3.6.0.eb
@@ -12,12 +12,12 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.15'
-blassuff = '-LAPACK-3.6.0'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.15'
+local_blassuff = '-LAPACK-3.6.0'
 
-versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+versionsuffix = "-%s-%s%s" % (local_blaslib, local_blasver, local_blassuff)
 
-dependencies = [(blaslib, blasver, blassuff, ('GCC', '4.9.3-2.25'))]
+dependencies = [(local_blaslib, local_blasver, local_blassuff, ('GCC', '4.9.3-2.25'))]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016b-OpenBLAS-0.2.18-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016b-OpenBLAS-0.2.18-LAPACK-3.6.1.eb
@@ -12,12 +12,12 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.18'
-blassuff = '-LAPACK-3.6.1'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.18'
+local_blassuff = '-LAPACK-3.6.1'
 
-versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+versionsuffix = "-%s-%s%s" % (local_blaslib, local_blasver, local_blassuff)
 
-dependencies = [(blaslib, blasver, blassuff, ('GCC', '5.4.0-2.26'))]
+dependencies = [(local_blaslib, local_blasver, local_blassuff, ('GCC', '5.4.0-2.26'))]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2017a-OpenBLAS-0.2.19-LAPACK-3.7.0.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2017a-OpenBLAS-0.2.19-LAPACK-3.7.0.eb
@@ -12,12 +12,12 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.19'
-blassuff = '-LAPACK-3.7.0'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.19'
+local_blassuff = '-LAPACK-3.7.0'
 
-versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+versionsuffix = "-%s-%s%s" % (local_blaslib, local_blasver, local_blassuff)
 
-dependencies = [(blaslib, blasver, blassuff, ('GCC', '6.3.0-2.27'))]
+dependencies = [(local_blaslib, local_blasver, local_blassuff, ('GCC', '6.3.0-2.27'))]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2017b-OpenBLAS-0.2.20.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2017b-OpenBLAS-0.2.20.eb
@@ -12,11 +12,11 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.20'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver, '', ('GCC', '6.4.0-2.28'))]
+dependencies = [(local_blaslib, local_blasver, '', ('GCC', '6.4.0-2.28'))]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2018.08-OpenBLAS-0.3.3.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2018.08-OpenBLAS-0.3.3.eb
@@ -12,11 +12,11 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.3.3'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.3.3'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver)]
+dependencies = [(local_blaslib, local_blasver)]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2018a-OpenBLAS-0.2.20.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2018a-OpenBLAS-0.2.20.eb
@@ -12,11 +12,11 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.20'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver)]
+dependencies = [(local_blaslib, local_blasver)]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2018b-OpenBLAS-0.3.1.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2018b-OpenBLAS-0.3.1.eb
@@ -12,11 +12,11 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.3.1'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.3.1'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver)]
+dependencies = [(local_blaslib, local_blasver)]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2019a-OpenBLAS-0.3.5.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2019a-OpenBLAS-0.3.5.eb
@@ -12,11 +12,11 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.3.5'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.3.5'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver)]
+dependencies = [(local_blaslib, local_blasver)]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2017b-OpenBLAS-0.2.20.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2017b-OpenBLAS-0.2.20.eb
@@ -12,11 +12,11 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.20'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver, '', ('GCC', '6.4.0-2.28'))]
+dependencies = [(local_blaslib, local_blasver, '', ('GCC', '6.4.0-2.28'))]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2018a-OpenBLAS-0.2.20.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2018a-OpenBLAS-0.2.20.eb
@@ -12,11 +12,11 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.20'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver)]
+dependencies = [(local_blaslib, local_blasver)]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2018b-OpenBLAS-0.3.1.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2018b-OpenBLAS-0.3.1.eb
@@ -12,11 +12,11 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.3.1'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.3.1'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver)]
+dependencies = [(local_blaslib, local_blasver)]
 
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2019a-OpenBLAS-0.3.5.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2019a-OpenBLAS-0.3.5.eb
@@ -12,11 +12,11 @@ source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
-blaslib = 'OpenBLAS'
-blasver = '0.3.5'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.3.5'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver)]
+dependencies = [(local_blaslib, local_blasver)]
 
 moduleclass = 'numlib'


### PR DESCRIPTION
done with --fix-deprecated-easyconfigs, no manual changes

required to avoid warnings when these easyconfigs are parsed because of changed made in easybuilders/easybuild-framework#2938