### PR TITLE
fix names of local variables in icc easyconfigs

### DIFF
--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3-2.25.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp.tgz']
 
 checksums = ['f57a892fb494db3c80f20a88aa3e901f']
 
-gccver = '4.9.3'
-binutilsver = '2.25'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '4.9.3'
+local_binutilsver = '2.25'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.1.150-GCC-4.9.3-2.25.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_update
 
 checksums = ['4b93b0ff549e6bd8d1a8b9a441b235a8']
 
-gccver = '4.9.3'
-binutilsver = '2.25'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '4.9.3'
+local_binutilsver = '2.25'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-4.9.3-2.25.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_update
 
 checksums = ['d6f8529a44231e427219c8e025dec3b2']
 
-gccver = '4.9.3'
-binutilsver = '2.25'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '4.9.3'
+local_binutilsver = '2.25'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.2.181-GCC-5.3.0-2.26.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_update
 
 checksums = ['d6f8529a44231e427219c8e025dec3b2']
 
-gccver = '5.3.0'
-binutilsver = '2.26'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '5.3.0'
+local_binutilsver = '2.26'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-4.9.3-2.25.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_update
 
 checksums = ['b256c5573d4bba3692c9c4a6ac994d1c']
 
-gccver = '4.9.3'
-binutilsver = '2.25'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '4.9.3'
+local_binutilsver = '2.25'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.3.0-2.26.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_update
 
 checksums = ['b256c5573d4bba3692c9c4a6ac994d1c']
 
-gccver = '5.3.0'
-binutilsver = '2.26'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '5.3.0'
+local_binutilsver = '2.26'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.3.210-GCC-5.4.0-2.26.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_update
 
 checksums = ['b256c5573d4bba3692c9c4a6ac994d1c']
 
-gccver = '5.4.0'
-binutilsver = '2.26'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '5.4.0'
+local_binutilsver = '2.26'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.0.098-GCC-5.4.0-2.26.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp.tgz']
 
 checksums = ['c8a2fdb1501fbc93bfaad93195677d86']
 
-gccver = '5.4.0'
-binutilsver = '2.26'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '5.4.0'
+local_binutilsver = '2.26'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-5.4.0-2.26.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_compose
 
 checksums = ['41a0e8850ebb5f7169076c89be743ee2']
 
-gccver = '5.4.0'
-binutilsver = '2.26'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '5.4.0'
+local_binutilsver = '2.26'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.1.132-GCC-6.3.0-2.27.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_compose
 
 checksums = ['41a0e8850ebb5f7169076c89be743ee2']
 
-gccver = '6.3.0'
-binutilsver = '2.27'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.3.0'
+local_binutilsver = '2.27'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2017.2.174-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.2.174-GCC-6.3.0-2.27.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_compose
 
 checksums = ['1ed9e5176b30ed0f0917a7ea698021ee']
 
-gccver = '6.3.0'
-binutilsver = '2.27'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.3.0'
+local_binutilsver = '2.27'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2017.4.196-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.4.196-GCC-6.4.0-2.28.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_compose
 
 checksums = ['6b9b57dada0ec68e394866ec0a8b162c9233de18a7a6dd2dcc956d335e06acbc']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2017.5.239-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.5.239-GCC-6.4.0-2.28.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_compose
 
 checksums = ['96c60896e4cac1c5c65ee3a1f9fafd2eee43b3944465ea8591468e708a86d184']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2017.6.256-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.6.256-GCC-6.4.0-2.28.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_compose
 
 checksums = ['299ab1702048802c1986bf031ee3f13e53555d55826f599e808564f1d9102455']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2017.7.259-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.7.259-GCC-6.4.0-2.28.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_compose
 
 checksums = ['3065e3ea0e489fe6d50aea725ac095422c13aa51b88d02f6380af06b708dbb98']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2018.0.128-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2018.0.128-GCC-6.4.0-2.28.eb
@@ -12,13 +12,13 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp.tgz']
 
 checksums = ['63fa158694c06ab3a1cac3ee54f978a45921079e302d185d4057c819f4ce99ea']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2018.1.163-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2018.1.163-GCC-6.4.0-2.28.eb
@@ -12,13 +12,13 @@ source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/1
 sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_composer_edition_for_cpp.tgz']
 checksums = ['ddbfdf88eed095817650ec0a226ef3b9c07c41c855d258e80eaade5173fedb6e']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2018.2.199-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2018.2.199-GCC-6.4.0-2.28.eb
@@ -11,13 +11,13 @@ toolchain = SYSTEM
 sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_composer_edition_for_cpp.tgz']
 checksums = ['ce2c8886b3ae2eaf6e1514c5255bd2ec9ee8506460ba68c7e8164c65716cde82']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2018.3.222-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2018.3.222-GCC-7.3.0-2.30.eb
@@ -12,13 +12,13 @@ source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/1
 sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_composer_edition_for_cpp.tgz']
 checksums = ['d8b7e6633faa2e0b7d4eebf3260cb3a200b951cb2cf7b5db957c5ae71508d34b']
 
-gccver = '7.3.0'
-binutilsver = '2.30'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '7.3.0'
+local_binutilsver = '2.30'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2018.5.274-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2018.5.274-GCC-7.3.0-2.30.eb
@@ -13,13 +13,13 @@ source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/1
 sources = ['parallel_studio_xe_%(version_major)s_update4_composer_edition_for_cpp.tgz']
 checksums = ['3850ab2a01fe8888af8fed65b7d24e0ddf45a84efe9635ff0f118c38dfc4544b']
 
-gccver = '7.3.0'
-binutilsver = '2.30'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '7.3.0'
+local_binutilsver = '2.30'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2019.0.117-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2019.0.117-GCC-8.2.0-2.31.1.eb
@@ -12,13 +12,13 @@ source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/1
 sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp.tgz']
 checksums = ['17932a54a76d04432de16e6db15a6ed80fa80ed20193f3b717fd391f623e23e1']
 
-gccver = '8.2.0'
-binutilsver = '2.31.1'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '8.2.0'
+local_binutilsver = '2.31.1'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2019.1.144-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2019.1.144-GCC-8.2.0-2.31.1.eb
@@ -12,13 +12,13 @@ source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/1
 sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_composer_edition_for_cpp.tgz']
 checksums = ['4a156bbeac9bd8d67e74b33ad6f3ae02d4c24c8444365465db6dc50d3e891946']
 
-gccver = '8.2.0'
-binutilsver = '2.31.1'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '8.2.0'
+local_binutilsver = '2.31.1'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2019.2.187-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2019.2.187-GCC-8.2.0-2.31.1.eb
@@ -12,13 +12,13 @@ source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/1
 sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_composer_edition_for_cpp.tgz']
 checksums = ['fc434a2e005af223f43d258c16f004134def726a8d2a225e830af85d553bee55']
 
-gccver = '8.2.0'
-binutilsver = '2.31.1'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '8.2.0'
+local_binutilsver = '2.31.1'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-2019.3.199-GCC-8.3.0-2.32.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2019.3.199-GCC-8.3.0-2.32.eb
@@ -12,13 +12,13 @@ source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/1
 sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_composer_edition_for_cpp.tgz']
 checksums = ['969985e83ebf7bfe3c3ac3b771a7d16ba9b5dfbda84e7c2a60ef25fb827b58ae']
 
-gccver = '8.3.0'
-binutilsver = '2.32'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '8.3.0'
+local_binutilsver = '2.32'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/icc/icc-system-GCC-system-2.29.eb
+++ b/easybuild/easyconfigs/i/icc/icc-system-GCC-system-2.29.eb
@@ -10,13 +10,13 @@ toolchain = SYSTEM
 
 generate_standalone_module = True
 
-gccver = 'system'
-binutilsver = '2.29'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = 'system'
+local_binutilsver = '2.29'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 moduleclass = 'compiler'


### PR DESCRIPTION
done with `--fix-deprecated-easyconfigs`, no manual changes

required to avoid warnings when these easyconfigs are parsed because of changed made in https://github.com/easybuilders/easybuild-framework/pull/2938