### PR TITLE
fix names of local variables in PGI easyconfigs

### DIFF
--- a/easybuild/easyconfigs/p/PGI/PGI-15.10-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-15.10-GCC-4.9.3-2.25.eb
@@ -10,13 +10,13 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86_64.tar.gz']
 checksums = ['cae307f7ad467a1811a5d5da758048ab']
 
-gccver = '4.9.3'
-binutilsver = '2.25'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '4.9.3'
+local_binutilsver = '2.25'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-15.7-GNU-4.9.2-2.25.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-15.7-GNU-4.9.2-2.25.eb
@@ -9,11 +9,11 @@ toolchain = SYSTEM
 # needs to be downloaded manually, see http://www.pgroup.com/support/release_archive.php
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86_64.tar.gz']
 
-gnu = 'GNU'
-gnuver = '4.9.2-2.25'
-versionsuffix = '-%s-%s' % (gnu, gnuver)
+local_gnu = 'GNU'
+local_gnuver = '4.9.2-2.25'
+versionsuffix = '-%s-%s' % (local_gnu, local_gnuver)
 
-dependencies = [(gnu, gnuver)]
+dependencies = [(local_gnu, local_gnuver)]
 
 # license file
 license_file = HOME + '/licenses/pgi/license.dat'

--- a/easybuild/easyconfigs/p/PGI/PGI-15.7-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-15.7-GNU-4.9.3-2.25.eb
@@ -9,11 +9,11 @@ toolchain = SYSTEM
 # needs to be downloaded manually, see http://www.pgroup.com/support/release_archive.php
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86_64.tar.gz']
 
-gnu = 'GNU'
-gnuver = '4.9.3-2.25'
-versionsuffix = '-%s-%s' % (gnu, gnuver)
+local_gnu = 'GNU'
+local_gnuver = '4.9.3-2.25'
+versionsuffix = '-%s-%s' % (local_gnu, local_gnuver)
 
-dependencies = [(gnu, gnuver)]
+dependencies = [(local_gnu, local_gnuver)]
 
 # license file
 license_file = HOME + '/licenses/pgi/license.dat'

--- a/easybuild/easyconfigs/p/PGI/PGI-16.1-CDK-GCC-4.9.2-2.25.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-16.1-CDK-GCC-4.9.2-2.25.eb
@@ -10,14 +10,14 @@ toolchain = SYSTEM
 sources = ['pgicdk-%(version_major)s%(version_minor)s.tar.gz']
 checksums = ['442c044b9690a84b6600cd6919480bcb']
 
-gccver = '4.9.2'
-binutilsver = '2.25'
-versionsuffix = '-CDK-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '4.9.2'
+local_binutilsver = '2.25'
+versionsuffix = '-CDK-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.11', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.11', '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-16.10-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-16.10-GCC-5.4.0-2.26.eb
@@ -10,14 +10,14 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86_64.tar.gz']
 checksums = ['9bb6bfb7b1052f9e6a45829ba7a24e47']
 
-gccver = '5.4.0'
-binutilsver = '2.26'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '5.4.0'
+local_binutilsver = '2.26'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.11', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.11', '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-16.3-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-16.3-GCC-4.9.3-2.25.eb
@@ -10,14 +10,14 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86_64.tar.gz']
 checksums = ['618cb7ddbc57d4e4ed1f21a0ab25f427']
 
-gccver = '4.9.3'
-binutilsver = '2.25'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '4.9.3'
+local_binutilsver = '2.25'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.11', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.11', '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-16.4-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-16.4-GCC-5.3.0-2.26.eb
@@ -10,14 +10,14 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86_64.tar.gz']
 checksums = ['3804dc13b8cf3d50aa16fb56e2682dd7']
 
-gccver = '5.3.0'
-binutilsver = '2.26'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '5.3.0'
+local_binutilsver = '2.26'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.11', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.11', '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-16.7-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-16.7-GCC-5.4.0-2.26.eb
@@ -10,14 +10,14 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86_64.tar.gz']
 checksums = ['5594e5cab050bba07ed5f7741bc4c5e8']
 
-gccver = '5.4.0'
-binutilsver = '2.26'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '5.4.0'
+local_binutilsver = '2.26'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.11', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.11', '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-17.1-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-17.1-GCC-6.3.0-2.27.eb
@@ -10,14 +10,14 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86_64.tar.gz']
 checksums = ['836f536ad8b0aac0234f7528fbd56b62']
 
-gccver = '6.3.0'
-binutilsver = '2.27'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.3.0'
+local_binutilsver = '2.27'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.11', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.11', '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-17.10-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-17.10-GCC-6.4.0-2.28.eb
@@ -10,14 +10,14 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86_64.tar.gz']
 checksums = ['9da8f869fb9b70c0c4423c903d40a9e22d54b997af359a43573c0841165cd1b6']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.11', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.11', '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-17.3-GCC-6.3.0-2.28.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-17.3-GCC-6.3.0-2.28.eb
@@ -10,14 +10,14 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86_64.tar.gz']
 checksums = ['6eefc42f85e756cbaba76467ed640902']
 
-gccver = '6.3.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.3.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.11', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.11', '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-17.4-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-17.4-GCC-6.4.0-2.28.eb
@@ -9,14 +9,14 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86_64.tar.gz']
 checksums = ['115c212d526695fc116fe44f1e722793e60b6f7d1b341cd7e77a95da8e7f6c34']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.11', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.11', '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-18.1-GCC-7.2.0-2.29.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-18.1-GCC-7.2.0-2.29.eb
@@ -10,14 +10,14 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86-64.tar.gz']
 checksums = ['123207b41fe9256a2f6dde31a25b370c8a4226c7203ffcf286d1e9b8917bd110']
 
-gccver = '7.2.0'
-binutilsver = '2.29'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '7.2.0'
+local_binutilsver = '2.29'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.11', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.11', '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-18.10-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-18.10-GCC-6.4.0-2.28.eb
@@ -9,14 +9,14 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86-64.tar.gz']
 checksums = ['4b3ff83d2a13de6001bed599246eff8e63ef711b8952d4a9ee12efd666b3e326']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.11', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.11', '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-18.4-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-18.4-GCC-6.4.0-2.28.eb
@@ -9,14 +9,14 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86-64.tar.gz']
 checksums = ['81e0dcf6000b026093ece180d42d77854c23269fb8409cedcf51c674ca580a0f']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.11', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.11', '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-18.7-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-18.7-GCC-7.3.0-2.30.eb
@@ -9,14 +9,14 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86-64.tar.gz']
 checksums = ['d97225585127b841075576859fc7782c9dbe3f7e1569bbce5f465046d4679d8d']
 
-gccver = '7.3.0'
-binutilsver = '2.30'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '7.3.0'
+local_binutilsver = '2.30'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.11', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.11', '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-19.1-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-19.1-GCC-8.2.0-2.31.1.eb
@@ -9,14 +9,14 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86-64.tar.gz']
 checksums = ['3e05a6db2bf80b5d15f6ff83188f20cb89dc23e233417921e5c0822e7e57d34f']
 
-gccver = '8.2.0'
-binutilsver = '2.31.1'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '8.2.0'
+local_binutilsver = '2.31.1'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.12', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.12', '', ('GCCcore', local_gccver)),
 ]
 
 # license file

--- a/easybuild/easyconfigs/p/PGI/PGI-19.4-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-19.4-GCC-8.2.0-2.31.1.eb
@@ -13,14 +13,14 @@ toolchain = SYSTEM
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86-64.tar.gz']
 checksums = ['23eee0d4da751dd6f247d624b68b03538ebd172e63a053c41bb67013f07cf68e']
 
-gccver = '8.2.0'
-binutilsver = '2.31.1'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '8.2.0'
+local_binutilsver = '2.31.1'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
-    ('numactl', '2.0.12', '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.12', '', ('GCCcore', local_gccver)),
 ]
 
 # license file


### PR DESCRIPTION
done with `--fix-deprecated-easyconfigs`, no manual changes

required to avoid warnings when these easyconfigs are parsed because of changed made in https://github.com/easybuilders/easybuild-framework/pull/2938