### PR TITLE
fix names of local variables in ifort easyconfigs

### DIFF
--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3-2.25.eb
@@ -15,13 +15,13 @@ patches = ['ifort_2016_no_mpi_mic_dependency.patch']
 
 checksums = ['bce7f6a71f7e44f67956197501d00b7c']
 
-gccver = '4.9.3'
-binutilsver = '2.25'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '4.9.3'
+local_binutilsver = '2.25'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.1.150-GCC-4.9.3-2.25.eb
@@ -15,13 +15,13 @@ checksums = ['1e848c8283cf6a0210bce1d35ecd748b']
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2016_no_mpi_mic_dependency.patch']
 
-gccver = '4.9.3'
-binutilsver = '2.25'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '4.9.3'
+local_binutilsver = '2.25'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-4.9.3-2.25.eb
@@ -15,13 +15,13 @@ checksums = ['70e88db11efc59b1d8ff8b5aadf50f7f']
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2016_no_mpi_mic_dependency.patch']
 
-gccver = '4.9.3'
-binutilsver = '2.25'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '4.9.3'
+local_binutilsver = '2.25'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-5.3.0-2.26.eb
@@ -15,13 +15,13 @@ checksums = ['70e88db11efc59b1d8ff8b5aadf50f7f']
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2016_no_mpi_mic_dependency.patch']
 
-gccver = '5.3.0'
-binutilsver = '2.26'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '5.3.0'
+local_binutilsver = '2.26'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -15,13 +15,13 @@ checksums = ['70cf1ea91280e3e8ba4bc216bae63e4a']
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2016_no_mpi_mic_dependency.patch']
 
-gccver = '4.9.3'
-binutilsver = '2.25'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '4.9.3'
+local_binutilsver = '2.25'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.3.0-2.26.eb
@@ -15,13 +15,13 @@ checksums = ['70cf1ea91280e3e8ba4bc216bae63e4a']
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2016_no_mpi_mic_dependency.patch']
 
-gccver = '5.3.0'
-binutilsver = '2.26'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '5.3.0'
+local_binutilsver = '2.26'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -20,13 +20,13 @@ checksums = [
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2016_no_mpi_mic_dependency.patch']
 
-gccver = '5.4.0'
-binutilsver = '2.26'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '5.4.0'
+local_binutilsver = '2.26'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.0.098-GCC-5.4.0-2.26.eb
@@ -15,13 +15,13 @@ checksums = ['8787795951fe10f90ce7dcdcec1b9341']
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2017_no_mpi_mic_dependency.patch']
 
-gccver = '5.4.0'
-binutilsver = '2.26'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '5.4.0'
+local_binutilsver = '2.26'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-5.4.0-2.26.eb
@@ -15,13 +15,13 @@ checksums = ['612169f4b40cdded8e212bf097925e4f']
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2017_no_mpi_mic_dependency.patch']
 
-gccver = '5.4.0'
-binutilsver = '2.26'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '5.4.0'
+local_binutilsver = '2.26'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-6.3.0-2.27.eb
@@ -15,13 +15,13 @@ checksums = ['612169f4b40cdded8e212bf097925e4f']
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2017_no_mpi_mic_dependency.patch']
 
-gccver = '6.3.0'
-binutilsver = '2.27'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.3.0'
+local_binutilsver = '2.27'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.2.174-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.2.174-GCC-6.3.0-2.27.eb
@@ -15,13 +15,13 @@ checksums = ['9d5dfa36a36b7c9e877745f3e379248b']
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2017_no_mpi_mic_dependency.patch']
 
-gccver = '6.3.0'
-binutilsver = '2.27'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.3.0'
+local_binutilsver = '2.27'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.4.196-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.4.196-GCC-6.4.0-2.28.eb
@@ -20,13 +20,13 @@ checksums = [
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2017_no_mpi_mic_dependency.patch']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.5.239-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.5.239-GCC-6.4.0-2.28.eb
@@ -15,13 +15,13 @@ checksums = ['671e08f50443272ab3885510766c38fc1da9aa109d37e435b2e663e5e46acf90']
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2017_no_mpi_mic_dependency.patch']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.6.256-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.6.256-GCC-6.4.0-2.28.eb
@@ -19,13 +19,13 @@ checksums = [
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2017_no_mpi_mic_dependency.patch']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.7.259-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.7.259-GCC-6.4.0-2.28.eb
@@ -19,13 +19,13 @@ checksums = [
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2017_no_mpi_mic_dependency.patch']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2018.0.128-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2018.0.128-GCC-6.4.0-2.28.eb
@@ -19,13 +19,13 @@ checksums = [
 # remove dependency on intel-mpi-rt-mic
 patches = ['ifort_2018_no_mpi_mic_dependency.patch']
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2018.1.163-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2018.1.163-GCC-6.4.0-2.28.eb
@@ -17,13 +17,13 @@ checksums = [
     'fdc818390643e77b3dc7ae1d9ba4547e1f1792da8674ff47747c56d97be6fb99',   # ifort_2018.1.163_no_mpi_mic_dependency.patch
 ]
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2018.2.199-GCC-6.4.0-2.28.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2018.2.199-GCC-6.4.0-2.28.eb
@@ -16,13 +16,13 @@ checksums = [
     'f1ab2ec42723124e3ca5d38589c2d9b80fde4cc25119eee73df28354d8d3a9ac',   # ifort_2018.2.199_no_mpi_mic_dependency.patch
 ]
 
-gccver = '6.4.0'
-binutilsver = '2.28'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2018.3.222-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2018.3.222-GCC-7.3.0-2.30.eb
@@ -17,13 +17,13 @@ checksums = [
     '2751935f922e975a85d8e6e8373d9d50e983af7b5017241c47249fcff2629b28',   # ifort_2018.3.222_no_mpi_mic_dependency.patch
 ]
 
-gccver = '7.3.0'
-binutilsver = '2.30'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '7.3.0'
+local_binutilsver = '2.30'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2018.5.274-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2018.5.274-GCC-7.3.0-2.30.eb
@@ -18,13 +18,13 @@ checksums = [
     '624a6f736d49000031d8b0bf65118886495f1a3c49440a3dfb88fd15471ae026',  # ifort-2018.5.274_no_mpi_mic_dependency.patch
 ]
 
-gccver = '7.3.0'
-binutilsver = '2.30'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '7.3.0'
+local_binutilsver = '2.30'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2019.0.117-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2019.0.117-GCC-8.2.0-2.31.1.eb
@@ -17,13 +17,13 @@ checksums = [
     '21ccdad74a4371ddc91471c90a4278f8f87a12b9668b829c4569df8c2fe75253',   # ifort_2019.0.117_no_mpi_mic_dependency.patch
 ]
 
-gccver = '8.2.0'
-binutilsver = '2.31.1'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '8.2.0'
+local_binutilsver = '2.31.1'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2019.1.144-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2019.1.144-GCC-8.2.0-2.31.1.eb
@@ -17,13 +17,13 @@ checksums = [
     '12910d18c9f0560aeed80e6425903039d4b3198134155b47e99ff0c03a693ecd',   # ifort_2019.1.144_no_mpi_mic_dependency.patch
 ]
 
-gccver = '8.2.0'
-binutilsver = '2.31.1'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '8.2.0'
+local_binutilsver = '2.31.1'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2019.2.187-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2019.2.187-GCC-8.2.0-2.31.1.eb
@@ -17,13 +17,13 @@ checksums = [
     'dbc6496cb2adbf34e66b73d8d75da7dec2738c1026e736bb5bc8393e879f434f',   # ifort_2019.2.187_no_mpi_mic_dependency.patch
 ]
 
-gccver = '8.2.0'
-binutilsver = '2.31.1'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '8.2.0'
+local_binutilsver = '2.31.1'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-2019.3.199-GCC-8.3.0-2.32.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2019.3.199-GCC-8.3.0-2.32.eb
@@ -17,13 +17,13 @@ checksums = [
     'fb0bbb112a47b894ff3fbcc4a254ebcd33a76189c6a1814ecf6235472a51c2c5',   # ifort_2019.3.199_no_mpi_mic_dependency.patch
 ]
 
-gccver = '8.3.0'
-binutilsver = '2.32'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '8.3.0'
+local_binutilsver = '2.32'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 # list of regex for components to install

--- a/easybuild/easyconfigs/i/ifort/ifort-system-GCC-system-2.29.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-system-GCC-system-2.29.eb
@@ -10,13 +10,13 @@ toolchain = SYSTEM
 
 generate_standalone_module = True
 
-gccver = 'system'
-binutilsver = '2.29'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = 'system'
+local_binutilsver = '2.29'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
 moduleclass = 'compiler'


### PR DESCRIPTION
done with `--fix-deprecated-easyconfigs`, no manual changes

required to avoid warnings when these easyconfigs are parsed because of changed made in https://github.com/easybuilders/easybuild-framework/pull/2938