### PR TITLE
fix checksum in OpenMPI 1.8.8 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.8-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.8-GNU-4.9.3-2.25.eb
@@ -10,7 +10,7 @@ toolchain = {'name': 'GNU', 'version': '4.9.3-2.25'}
 
 source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['56764d8eea8fd1812be4e7e71314e3c60e300be9bb59eafe866348db1ac4e306']
+checksums = ['ac0893811fdcc62f75036cb8ce266e7e5e3d8ce82a7adc2f333870a0da171bff']
 
 dependencies = [('hwloc', '1.11.0')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.8-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.8-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
@@ -10,7 +10,7 @@ toolchain = {'name': 'iccifort', 'version': '2015.3.187-GNU-4.9.3-2.25'}
 
 source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['56764d8eea8fd1812be4e7e71314e3c60e300be9bb59eafe866348db1ac4e306']
+checksums = ['ac0893811fdcc62f75036cb8ce266e7e5e3d8ce82a7adc2f333870a0da171bff']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path


### PR DESCRIPTION
I'm not sure how this happened, but a faulty checksum for OpenMPI 1.8.8 was added in #8016 somehow.

When you now download `openmpi-1.8.8.tar.gz`, you get the exact same tarball as the one we have which was downloaded on Sept 4th 2015.

Since both @migueldiascosta and myself verified the checksums using `eb --fetch` in a test report for #8016, I'm not quite sure what happened, maybe the source tarball that was served was temporarily corrupted somehow? 🤷‍♂