### PR TITLE
fix names of local variables in ncurses easyconfigs

### DIFF
--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9-CrayGNU-2015.06.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9-CrayGNU-2015.06.eb
@@ -21,12 +21,12 @@ configopts = [
     '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses5-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9-CrayGNU-2015.11.eb
@@ -21,12 +21,12 @@ configopts = [
     '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses5-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9-CrayIntel-2015.11.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9-CrayIntel-2015.11.eb
@@ -21,12 +21,12 @@ configopts = [
     '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses5-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9-GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9-GCC-4.8.1.eb
@@ -23,12 +23,12 @@ configopts = [
     '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses5-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9-GCC-4.8.2.eb
@@ -23,12 +23,12 @@ configopts = [
     '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses5-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9-GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9-GCC-4.8.3.eb
@@ -23,12 +23,12 @@ configopts = [
     '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses5-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9-GCC-4.8.4.eb
@@ -23,12 +23,12 @@ configopts = [
     '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses5-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9-GCC-4.9.2.eb
@@ -23,12 +23,12 @@ configopts = [
     '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses5-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9-GNU-4.9.3-2.25.eb
@@ -23,12 +23,12 @@ configopts = [
     '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses5-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9.eb
@@ -29,12 +29,12 @@ configopts = [
     '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses5-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-CrayGNU-2016.03.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-CrayGNU-2016.03.eb
@@ -23,12 +23,12 @@ configopts = [
     '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses6-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCC-4.9.3-2.25.eb
@@ -19,20 +19,20 @@ checksums = [
     'f82003be6ce6b87c3dc8a91d97785aab1a76a9e8544c3a3c02283c01dd41aede',  # ncurses-6.0_gcc-5.patch
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCC-5.4.0-2.26.eb
@@ -19,20 +19,20 @@ checksums = [
     'f82003be6ce6b87c3dc8a91d97785aab1a76a9e8544c3a3c02283c01dd41aede',  # ncurses-6.0_gcc-5.patch
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-4.9.3.eb
@@ -21,20 +21,20 @@ checksums = [
 
 builddependencies = [('binutils', '2.25')]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-5.3.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-5.3.0.eb
@@ -21,20 +21,20 @@ checksums = [
 
 builddependencies = [('binutils', '2.26')]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-5.4.0.eb
@@ -21,20 +21,20 @@ checksums = [
 
 builddependencies = [('binutils', '2.26')]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-6.2.0.eb
@@ -21,20 +21,20 @@ checksums = [
 
 builddependencies = [('binutils', '2.27')]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-6.3.0.eb
@@ -22,20 +22,20 @@ checksums = [
 # use same binutils version that was used when building GCCcore toolchain
 builddependencies = [('binutils', '2.27')]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-6.4.0.eb
@@ -28,23 +28,23 @@ builddependencies = [
     ('binutils', '2.28'),
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp",
                                      "infotocap",
                                      "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput",
                                      "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GNU-4.9.3-2.25.eb
@@ -19,20 +19,20 @@ checksums = [
     'f82003be6ce6b87c3dc8a91d97785aab1a76a9e8544c3a3c02283c01dd41aede',  # ncurses-6.0_gcc-5.patch
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-foss-2016.04.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-foss-2016.04.eb
@@ -19,20 +19,20 @@ checksums = [
     'f82003be6ce6b87c3dc8a91d97785aab1a76a9e8544c3a3c02283c01dd41aede',  # ncurses-6.0_gcc-5.patch
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-foss-2016a.eb
@@ -19,20 +19,20 @@ checksums = [
     'f82003be6ce6b87c3dc8a91d97785aab1a76a9e8544c3a3c02283c01dd41aede',  # ncurses-6.0_gcc-5.patch
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-foss-2016b.eb
@@ -19,20 +19,20 @@ checksums = [
     'f82003be6ce6b87c3dc8a91d97785aab1a76a9e8544c3a3c02283c01dd41aede',  # ncurses-6.0_gcc-5.patch
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-gimkl-2017a.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-gimkl-2017a.eb
@@ -19,20 +19,20 @@ checksums = [
     'f82003be6ce6b87c3dc8a91d97785aab1a76a9e8544c3a3c02283c01dd41aede',  # ncurses-6.0_gcc-5.patch
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-intel-2016.02-GCC-4.9.eb
@@ -19,20 +19,20 @@ checksums = [
     'f82003be6ce6b87c3dc8a91d97785aab1a76a9e8544c3a3c02283c01dd41aede',  # ncurses-6.0_gcc-5.patch
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-intel-2016a.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-intel-2016a.eb
@@ -19,20 +19,20 @@ checksums = [
     'f82003be6ce6b87c3dc8a91d97785aab1a76a9e8544c3a3c02283c01dd41aede',  # ncurses-6.0_gcc-5.patch
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-intel-2016b.eb
@@ -19,20 +19,20 @@ checksums = [
     'f82003be6ce6b87c3dc8a91d97785aab1a76a9e8544c3a3c02283c01dd41aede',  # ncurses-6.0_gcc-5.patch
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-iomkl-2016.07.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-iomkl-2016.07.eb
@@ -19,20 +19,20 @@ checksums = [
     'f82003be6ce6b87c3dc8a91d97785aab1a76a9e8544c3a3c02283c01dd41aede',  # ncurses-6.0_gcc-5.patch
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -19,20 +19,20 @@ checksums = [
     'f82003be6ce6b87c3dc8a91d97785aab1a76a9e8544c3a3c02283c01dd41aede',  # ncurses-6.0_gcc-5.patch
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0.eb
@@ -18,12 +18,12 @@ checksums = [
     'f82003be6ce6b87c3dc8a91d97785aab1a76a9e8544c3a3c02283c01dd41aede',  # ncurses-6.0_gcc-5.patch
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
 # need to take care of $CFLAGS ourselves with dummy toolchain
@@ -36,12 +36,12 @@ postinstallcmds = [
     "ln -s %(installdir)s/lib/libncurses.a %(installdir)s/lib/libtinfo.a"
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.1-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.1-GCCcore-6.4.0.eb
@@ -23,23 +23,23 @@ builddependencies = [
     ('binutils', '2.28'),
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp",
                                      "infotocap",
                                      "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput",
                                      "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.1-GCCcore-7.2.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.1-GCCcore-7.2.0.eb
@@ -23,23 +23,23 @@ builddependencies = [
     ('binutils', '2.29'),
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp",
                                      "infotocap",
                                      "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput",
                                      "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.1-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.1-GCCcore-7.3.0.eb
@@ -23,23 +23,23 @@ builddependencies = [
     ('binutils', '2.30'),
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp",
                                      "infotocap",
                                      "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput",
                                      "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.1-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.1-GCCcore-8.2.0.eb
@@ -23,23 +23,23 @@ builddependencies = [
     ('binutils', '2.31.1'),
 ]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp",
                                      "infotocap",
                                      "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput",
                                      "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.1-GCCcore-8.3.0.eb
@@ -21,23 +21,23 @@ checksums = ['aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17']
 
 builddependencies = [('binutils', '2.32')]
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp",
                                      "infotocap",
                                      "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput",
                                      "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.1.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.1.eb
@@ -14,12 +14,12 @@ source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17']
 
-common_configopts = "--with-shared --enable-overwrite --without-ada "
+local_common_configopts = "--with-shared --enable-overwrite --without-ada "
 configopts = [
     # default build
-    common_configopts,
+    local_common_configopts,
     # the UTF-8 enabled version (ncursesw)
-    common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
 ]
 
 # need to take care of $CFLAGS ourselves with dummy toolchain
@@ -32,12 +32,12 @@ postinstallcmds = [
     "ln -s %(installdir)s/lib/libncurses.a %(installdir)s/lib/libtinfo.a"
 ]
 
-libs = ["form", "menu", "ncurses", "panel"]
+local_libs = ["form", "menu", "ncurses", "panel"]
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
                                      "reset", "tabs", "tic", "toe", "tput", "tset"]] +
-             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
-             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/lib%s%s.a' % (x, y) for x in local_libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in local_libs for y in ['', 'w']] +
              ['lib/libncurses++%s.a' % x for x in ['', 'w']],
     'dirs': ['include', 'include/ncursesw'],
 }


### PR DESCRIPTION
done with `--fix-deprecated-easyconfigs`, no manual changes

required to avoid warnings when these easyconfigs are parsed because of changed made in https://github.com/easybuilders/easybuild-framework/pull/2938