### PR TITLE
fix names of local variables in iimpi easyconfigs

### DIFF
--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.00-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.00-GCC-4.9.3-2.25.eb
@@ -11,11 +11,11 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2016.0.109'
+local_compver = '2016.0.109'
 dependencies = [
-    ('icc', compver, versionsuffix),
-    ('ifort', compver, versionsuffix),
-    ('impi', '5.1.1.109', '', ('iccifort', '%s%s' % (compver, versionsuffix))),
+    ('icc', local_compver, versionsuffix),
+    ('ifort', local_compver, versionsuffix),
+    ('impi', '5.1.1.109', '', ('iccifort', '%s%s' % (local_compver, versionsuffix))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.01-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.01-GCC-4.9.3-2.25.eb
@@ -10,13 +10,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-suff = '1.150'
-compver = '2016.%s' % suff
+local_compver = '2016.1.150'
 
 dependencies = [
-    ('icc', compver, versionsuffix),
-    ('ifort', compver, versionsuffix),
-    ('impi', '5.1.2.150', '', ('iccifort', '%s%s' % (compver, versionsuffix))),
+    ('icc', local_compver, versionsuffix),
+    ('ifort', local_compver, versionsuffix),
+    ('impi', '5.1.2.150', '', ('iccifort', '%s%s' % (local_compver, versionsuffix))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.02-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.02-GCC-4.9.3-2.25.eb
@@ -10,13 +10,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-suff = '2.181'
-compver = '2016.%s' % suff
+local_compver = '2016.2.181'
 
 dependencies = [
-    ('icc', compver, versionsuffix),
-    ('ifort', compver, versionsuffix),
-    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (compver, versionsuffix))),
+    ('icc', local_compver, versionsuffix),
+    ('ifort', local_compver, versionsuffix),
+    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (local_compver, versionsuffix))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.02-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.02-GCC-5.3.0-2.26.eb
@@ -10,13 +10,13 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-suff = '2.181'
-compver = '2016.%s' % suff
+local_suff = '2.181'
+local_compver = '2016.%s' % local_suff
 
 dependencies = [
-    ('icc', compver, versionsuffix),
-    ('ifort', compver, versionsuffix),
-    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (compver, versionsuffix))),
+    ('icc', local_compver, versionsuffix),
+    ('ifort', local_compver, versionsuffix),
+    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (local_compver, versionsuffix))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-4.9.3-2.25.eb
@@ -10,11 +10,11 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2016.3.210'
+local_compver = '2016.3.210'
 dependencies = [
-    ('icc', compver, versionsuffix),
-    ('ifort', compver, versionsuffix),
-    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (compver, versionsuffix))),
+    ('icc', local_compver, versionsuffix),
+    ('ifort', local_compver, versionsuffix),
+    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (local_compver, versionsuffix))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-5.3.0-2.26.eb
@@ -10,11 +10,11 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2016.3.210'
+local_compver = '2016.3.210'
 dependencies = [
-    ('icc', compver, versionsuffix),
-    ('ifort', compver, versionsuffix),
-    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (compver, versionsuffix))),
+    ('icc', local_compver, versionsuffix),
+    ('ifort', local_compver, versionsuffix),
+    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (local_compver, versionsuffix))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.03-GCC-5.4.0-2.26.eb
@@ -10,11 +10,11 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2016.3.210'
+local_compver = '2016.3.210'
 dependencies = [
-    ('icc', compver, versionsuffix),
-    ('ifort', compver, versionsuffix),
-    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (compver, versionsuffix))),
+    ('icc', local_compver, versionsuffix),
+    ('ifort', local_compver, versionsuffix),
+    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (local_compver, versionsuffix))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016b.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016b.eb
@@ -9,12 +9,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2016.3.210'
-suff = '-GCC-5.4.0-2.26'
+local_compver = '2016.3.210'
+local_suff = '-GCC-5.4.0-2.26'
 dependencies = [
-    ('icc', compver, suff),
-    ('ifort', compver, suff),
-    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (compver, suff))),
+    ('icc', local_compver, local_suff),
+    ('ifort', local_compver, local_suff),
+    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (local_compver, local_suff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017.00-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017.00-GCC-5.4.0-2.26.eb
@@ -10,11 +10,11 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2017.0.098'
+local_compver = '2017.0.098'
 dependencies = [
-    ('icc', compver, versionsuffix),
-    ('ifort', compver, versionsuffix),
-    ('impi', '2017.0.098', '', ('iccifort', '%s%s' % (compver, versionsuffix))),
+    ('icc', local_compver, versionsuffix),
+    ('ifort', local_compver, versionsuffix),
+    ('impi', '2017.0.098', '', ('iccifort', '%s%s' % (local_compver, versionsuffix))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017.01-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017.01-GCC-5.4.0-2.26.eb
@@ -10,11 +10,11 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2017.1.132'
+local_compver = '2017.1.132'
 dependencies = [
-    ('icc', compver, versionsuffix),
-    ('ifort', compver, versionsuffix),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, versionsuffix))),
+    ('icc', local_compver, versionsuffix),
+    ('ifort', local_compver, versionsuffix),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, versionsuffix))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017.02-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017.02-GCC-6.3.0-2.27.eb
@@ -10,11 +10,11 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2017.2.174'
+local_compver = '2017.2.174'
 dependencies = [
-    ('icc', compver, versionsuffix),
-    ('ifort', compver, versionsuffix),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, versionsuffix))),
+    ('icc', local_compver, versionsuffix),
+    ('ifort', local_compver, versionsuffix),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, versionsuffix))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017.09.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017.09.eb
@@ -9,12 +9,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2017.5.239'
-compsuff = '-GCC-6.4.0-2.28'
+local_compver = '2017.5.239'
+local_compsuff = '-GCC-6.4.0-2.28'
 dependencies = [
-    ('icc', compver, compsuff),
-    ('ifort', compver, compsuff),
-    ('impi', '2017.4.239', '', ('iccifort', '%s%s' % (compver, compsuff))),
+    ('icc', local_compver, local_compsuff),
+    ('ifort', local_compver, local_compsuff),
+    ('impi', '2017.4.239', '', ('iccifort', '%s%s' % (local_compver, local_compsuff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017a.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017a.eb
@@ -9,12 +9,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2017.1.132'
-suff = '-GCC-6.3.0-2.27'
+local_compver = '2017.1.132'
+local_suff = '-GCC-6.3.0-2.27'
 dependencies = [
-    ('icc', compver, suff),
-    ('ifort', compver, suff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, suff))),
+    ('icc', local_compver, local_suff),
+    ('ifort', local_compver, local_suff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_suff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017b.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017b.eb
@@ -9,12 +9,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2017.4.196'
-suff = '-GCC-6.4.0-2.28'
+local_compver = '2017.4.196'
+local_suff = '-GCC-6.4.0-2.28'
 dependencies = [
-    ('icc', compver, suff),
-    ('ifort', compver, suff),
-    ('impi', '2017.3.196', '', ('iccifort', '%s%s' % (compver, suff))),
+    ('icc', local_compver, local_suff),
+    ('ifort', local_compver, local_suff),
+    ('impi', '2017.3.196', '', ('iccifort', '%s%s' % (local_compver, local_suff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2018.00.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2018.00.eb
@@ -9,12 +9,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2018.0.128'
-suff = '-GCC-6.4.0-2.28'
+local_compver = '2018.0.128'
+local_suff = '-GCC-6.4.0-2.28'
 dependencies = [
-    ('icc', compver, suff),
-    ('ifort', compver, suff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, suff))),
+    ('icc', local_compver, local_suff),
+    ('ifort', local_compver, local_suff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_suff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2018.01.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2018.01.eb
@@ -9,12 +9,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2018.1.163'
-suff = '-GCC-6.4.0-2.28'
+local_compver = '2018.1.163'
+local_suff = '-GCC-6.4.0-2.28'
 dependencies = [
-    ('icc', compver, suff),
-    ('ifort', compver, suff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, suff))),
+    ('icc', local_compver, local_suff),
+    ('ifort', local_compver, local_suff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_suff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2018.02.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2018.02.eb
@@ -9,12 +9,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2018.2.199'
-suff = '-GCC-6.4.0-2.28'
+local_compver = '2018.2.199'
+local_suff = '-GCC-6.4.0-2.28'
 dependencies = [
-    ('icc', compver, suff),
-    ('ifort', compver, suff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, suff))),
+    ('icc', local_compver, local_suff),
+    ('ifort', local_compver, local_suff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_suff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2018.04.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2018.04.eb
@@ -9,12 +9,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2018.5.274'
-suff = '-GCC-7.3.0-2.30'
+local_compver = '2018.5.274'
+local_suff = '-GCC-7.3.0-2.30'
 dependencies = [
-    ('icc', compver, suff),
-    ('ifort', compver, suff),
-    ('impi', '2018.4.274', '', ('iccifort', '%s%s' % (compver, suff))),
+    ('icc', local_compver, local_suff),
+    ('ifort', local_compver, local_suff),
+    ('impi', '2018.4.274', '', ('iccifort', '%s%s' % (local_compver, local_suff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2018a.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2018a.eb
@@ -9,12 +9,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2018.1.163'
-suff = '-GCC-6.4.0-2.28'
+local_compver = '2018.1.163'
+local_suff = '-GCC-6.4.0-2.28'
 dependencies = [
-    ('icc', compver, suff),
-    ('ifort', compver, suff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, suff))),
+    ('icc', local_compver, local_suff),
+    ('ifort', local_compver, local_suff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_suff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2018b.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2018b.eb
@@ -9,12 +9,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2018.3.222'
-suff = '-GCC-7.3.0-2.30'
+local_compver = '2018.3.222'
+local_suff = '-GCC-7.3.0-2.30'
 dependencies = [
-    ('icc', compver, suff),
-    ('ifort', compver, suff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, suff))),
+    ('icc', local_compver, local_suff),
+    ('ifort', local_compver, local_suff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_suff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2019.00.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2019.00.eb
@@ -9,12 +9,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2019.0.117'
-suff = '-GCC-8.2.0-2.31.1'
+local_compver = '2019.0.117'
+local_suff = '-GCC-8.2.0-2.31.1'
 dependencies = [
-    ('icc', compver, suff),
-    ('ifort', compver, suff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, suff))),
+    ('icc', local_compver, local_suff),
+    ('ifort', local_compver, local_suff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_suff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2019.01.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2019.01.eb
@@ -9,12 +9,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2019.1.144'
-suff = '-GCC-8.2.0-2.31.1'
+local_compver = '2019.1.144'
+local_suff = '-GCC-8.2.0-2.31.1'
 dependencies = [
-    ('icc', compver, suff),
-    ('ifort', compver, suff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, suff))),
+    ('icc', local_compver, local_suff),
+    ('ifort', local_compver, local_suff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_suff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2019.02.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2019.02.eb
@@ -9,12 +9,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2019.2.187'
-suff = '-GCC-8.2.0-2.31.1'
+local_compver = '2019.2.187'
+local_suff = '-GCC-8.2.0-2.31.1'
 dependencies = [
-    ('icc', compver, suff),
-    ('ifort', compver, suff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, suff))),
+    ('icc', local_compver, local_suff),
+    ('ifort', local_compver, local_suff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_suff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2019.03.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2019.03.eb
@@ -9,12 +9,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2019.3.199'
-suff = '-GCC-8.3.0-2.32'
+local_compver = '2019.3.199'
+local_suff = '-GCC-8.3.0-2.32'
 dependencies = [
-    ('icc', compver, suff),
-    ('ifort', compver, suff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, suff))),
+    ('icc', local_compver, local_suff),
+    ('ifort', local_compver, local_suff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_suff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2019a.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2019a.eb
@@ -8,12 +8,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2019.1.144'
-suff = '-GCC-8.2.0-2.31.1'
+local_compver = '2019.1.144'
+local_suff = '-GCC-8.2.0-2.31.1'
 dependencies = [
-    ('icc', compver, suff),
-    ('ifort', compver, suff),
-    ('impi', '2018.4.274', '', ('iccifort', '%s%s' % (compver, suff))),
+    ('icc', local_compver, local_suff),
+    ('ifort', local_compver, local_suff),
+    ('impi', '2018.4.274', '', ('iccifort', '%s%s' % (local_compver, local_suff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-8.1.5-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-8.1.5-GCC-4.9.3-2.25.eb
@@ -9,11 +9,11 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2016.1.150'
+local_compver = '2016.1.150'
 dependencies = [
-    ('icc', compver, versionsuffix),
-    ('ifort', compver, versionsuffix),
-    ('impi', '5.1.2.150', '', ('iccifort', '%s%s' % (compver, versionsuffix))),
+    ('icc', local_compver, versionsuffix),
+    ('ifort', local_compver, versionsuffix),
+    ('impi', '5.1.2.150', '', ('iccifort', '%s%s' % (local_compver, versionsuffix))),
 ]
 
 moduleclass = 'toolchain'


### PR DESCRIPTION
done with `--fix-deprecated-easyconfigs`, no manual changes

required to avoid warnings when these easyconfigs are parsed because of changed made in https://github.com/easybuilders/easybuild-framework/pull/2938