### PR TITLE
fix names of local variables in intel easyconfigs

### DIFF
--- a/easybuild/easyconfigs/i/intel/intel-2016.00.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016.00.eb
@@ -10,17 +10,17 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-compver = '2016.0.109'
-gccver = '4.9.3'
-binutilsver = '2.25'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2016.0.109'
+local_gccver = '4.9.3'
+local_binutilsver = '2.25'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', '5.1.1.109', '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', '11.3.0.109', '', ('iimpi', '%s%s' % (version, gccsuff))),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', '5.1.1.109', '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', '11.3.0.109', '', ('iimpi', '%s%s' % (version, local_gccsuff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2016.01.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016.01.eb
@@ -9,17 +9,17 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-compver = '2016.1.150'
-gccver = '4.9.3'
-binutilsver = '2.25'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2016.1.150'
+local_gccver = '4.9.3'
+local_binutilsver = '2.25'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', '5.1.2.150', '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', '11.3.1.150', '', ('iimpi', '%s%s' % (version, gccsuff))),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', '5.1.2.150', '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', '11.3.1.150', '', ('iimpi', '%s%s' % (version, local_gccsuff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016.02-GCC-4.9.eb
@@ -2,8 +2,8 @@ easyblock = 'Toolchain'
 
 name = 'intel'
 version = '2016.02'
-gcc_maj_min = '4.9'
-versionsuffix = '-GCC-%s' % gcc_maj_min
+local_gcc_maj_min = '4.9'
+versionsuffix = '-GCC-%s' % local_gcc_maj_min
 
 homepage = 'https://easybuild.readthedocs.io/en/master/Common-toolchains.html#intel-toolchain'
 description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MPI &
@@ -11,17 +11,17 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-compver = '2016.2.181'
-gccver = '%s.3' % gcc_maj_min
-binutilsver = '2.25'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2016.2.181'
+local_gccver = '%s.3' % local_gcc_maj_min
+local_binutilsver = '2.25'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', '11.3.2.181', '', ('iimpi', '%s%s' % (version, gccsuff))),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', '11.3.2.181', '', ('iimpi', '%s%s' % (version, local_gccsuff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2016.02-GCC-5.3.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016.02-GCC-5.3.eb
@@ -2,8 +2,8 @@ easyblock = 'Toolchain'
 
 name = 'intel'
 version = '2016.02'
-gcc_maj_min = '5.3'
-versionsuffix = '-GCC-%s' % gcc_maj_min
+local_gcc_maj_min = '5.3'
+versionsuffix = '-GCC-%s' % local_gcc_maj_min
 
 homepage = 'https://easybuild.readthedocs.io/en/master/Common-toolchains.html#intel-toolchain'
 description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MPI &
@@ -11,17 +11,17 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-compver = '2016.2.181'
-gccver = '%s.0' % gcc_maj_min
-binutilsver = '2.26'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2016.2.181'
+local_gccver = '%s.0' % local_gcc_maj_min
+local_binutilsver = '2.26'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', '11.3.2.181', '', ('iimpi', '%s%s' % (version, gccsuff))),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', '11.3.2.181', '', ('iimpi', '%s%s' % (version, local_gccsuff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2016.03-GCC-4.9.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016.03-GCC-4.9.eb
@@ -2,8 +2,8 @@ easyblock = 'Toolchain'
 
 name = 'intel'
 version = '2016.03'
-gcc_maj_min = '4.9'
-versionsuffix = '-GCC-%s' % gcc_maj_min
+local_gcc_maj_min = '4.9'
+versionsuffix = '-GCC-%s' % local_gcc_maj_min
 
 homepage = 'https://easybuild.readthedocs.io/en/master/Common-toolchains.html#intel-toolchain'
 description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MPI &
@@ -11,17 +11,17 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-compver = '2016.3.210'
-gccver = '%s.3' % gcc_maj_min
-binutilsver = '2.25'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2016.3.210'
+local_gccver = '%s.3' % local_gcc_maj_min
+local_binutilsver = '2.25'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', '11.3.3.210', '', ('iimpi', '%s%s' % (version, gccsuff))),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', '11.3.3.210', '', ('iimpi', '%s%s' % (version, local_gccsuff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2016.03-GCC-5.3.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016.03-GCC-5.3.eb
@@ -2,8 +2,8 @@ easyblock = 'Toolchain'
 
 name = 'intel'
 version = '2016.03'
-gcc_maj_min = '5.3'
-versionsuffix = '-GCC-%s' % gcc_maj_min
+local_gcc_maj_min = '5.3'
+versionsuffix = '-GCC-%s' % local_gcc_maj_min
 
 homepage = 'https://easybuild.readthedocs.io/en/master/Common-toolchains.html#intel-toolchain'
 description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MPI &
@@ -11,17 +11,17 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-compver = '2016.3.210'
-gccver = '%s.0' % gcc_maj_min
-binutilsver = '2.26'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2016.3.210'
+local_gccver = '%s.0' % local_gcc_maj_min
+local_binutilsver = '2.26'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', '11.3.3.210', '', ('iimpi', '%s%s' % (version, gccsuff))),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', '11.3.3.210', '', ('iimpi', '%s%s' % (version, local_gccsuff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2016.03-GCC-5.4.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016.03-GCC-5.4.eb
@@ -2,8 +2,8 @@ easyblock = 'Toolchain'
 
 name = 'intel'
 version = '2016.03'
-gcc_maj_min = '5.4'
-versionsuffix = '-GCC-%s' % gcc_maj_min
+local_gcc_maj_min = '5.4'
+versionsuffix = '-GCC-%s' % local_gcc_maj_min
 
 homepage = 'https://easybuild.readthedocs.io/en/master/Common-toolchains.html#intel-toolchain'
 description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MPI &
@@ -11,17 +11,17 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-compver = '2016.3.210'
-gccver = '%s.0' % gcc_maj_min
-binutilsver = '2.26'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2016.3.210'
+local_gccver = '%s.0' % local_gcc_maj_min
+local_binutilsver = '2.26'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', '11.3.3.210', '', ('iimpi', '%s%s' % (version, gccsuff))),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', '11.3.3.210', '', ('iimpi', '%s%s' % (version, local_gccsuff))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2016a.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016a.eb
@@ -9,14 +9,14 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-compver = '2016.1.150'
-gccsuff = '-GCC-4.9.3-2.25'
+local_compver = '2016.1.150'
+local_gccsuff = '-GCC-4.9.3-2.25'
 
 dependencies = [
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', '5.1.2.150', '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', '11.3.1.150', '', ('iimpi', '8.1.5%s' % gccsuff)),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', '5.1.2.150', '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', '11.3.1.150', '', ('iimpi', '8.1.5%s' % local_gccsuff)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2016b.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016b.eb
@@ -9,16 +9,16 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-compver = '2016.3.210'
-gccver = '5.4.0'
-binutilsver = '2.26'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2016.3.210'
+local_gccver = '5.4.0'
+local_binutilsver = '2.26'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (compver, gccsuff))),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', '5.1.3.181', '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
     ('imkl', '11.3.3.210', '', ('iimpi', version)),
 ]
 

--- a/easybuild/easyconfigs/i/intel/intel-2017.00.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2017.00.eb
@@ -9,17 +9,17 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-compver = '2017.0.098'
-gccver = '5.4.0'
-binutilsver = '2.26'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2017.0.098'
+local_gccver = '5.4.0'
+local_binutilsver = '2.26'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', '2017.0.098', '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', '2017.0.098', '', ('iimpi', version + gccsuff)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', '2017.0.098', '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', '2017.0.098', '', ('iimpi', version + local_gccsuff)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2017.01.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2017.01.eb
@@ -9,17 +9,17 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-compver = '2017.1.132'
-gccver = '5.4.0'
-binutilsver = '2.26'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2017.1.132'
+local_gccver = '5.4.0'
+local_binutilsver = '2.26'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', compver, '', ('iimpi', version + gccsuff)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', local_compver, '', ('iimpi', version + local_gccsuff)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2017.02.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2017.02.eb
@@ -9,17 +9,17 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-compver = '2017.2.174'
-gccver = '6.3.0'
-binutilsver = '2.27'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2017.2.174'
+local_gccver = '6.3.0'
+local_binutilsver = '2.27'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', compver, '', ('iimpi', version + gccsuff)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', local_compver, '', ('iimpi', version + local_gccsuff)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2017.09.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2017.09.eb
@@ -8,16 +8,16 @@ description = "Compiler toolchain including Intel compilers, Intel MPI and Intel
 
 toolchain = SYSTEM
 
-compver = '2017.5.239'
-gccver = '6.4.0'
-binutilsver = '2.28'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2017.5.239'
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', '2017.4.239', '', ('iccifort', '%s%s' % (compver, gccsuff))),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', '2017.4.239', '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
     ('imkl', '2017.4.239', '', ('iimpi', version)),
 ]
 

--- a/easybuild/easyconfigs/i/intel/intel-2017a.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2017a.eb
@@ -9,17 +9,17 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-intelver = '2017.1.132'
-gccver = '6.3.0'
-binutilsver = '2.27'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_intelver = '2017.1.132'
+local_gccver = '6.3.0'
+local_binutilsver = '2.27'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', intelver, gccsuff),
-    ('ifort', intelver, gccsuff),
-    ('impi', intelver, '', ('iccifort', '%s%s' % (intelver, gccsuff))),
-    ('imkl', intelver, '', ('iimpi', version)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_intelver, local_gccsuff),
+    ('ifort', local_intelver, local_gccsuff),
+    ('impi', local_intelver, '', ('iccifort', '%s%s' % (local_intelver, local_gccsuff))),
+    ('imkl', local_intelver, '', ('iimpi', version)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2017b.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2017b.eb
@@ -8,16 +8,16 @@ description = "Compiler toolchain including Intel compilers, Intel MPI and Intel
 
 toolchain = SYSTEM
 
-compver = '2017.4.196'
-gccver = '6.4.0'
-binutilsver = '2.28'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2017.4.196'
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', '2017.3.196', '', ('iccifort', '%s%s' % (compver, gccsuff))),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', '2017.3.196', '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
     ('imkl', '2017.3.196', '', ('iimpi', version)),
 ]
 

--- a/easybuild/easyconfigs/i/intel/intel-2018.00.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2018.00.eb
@@ -8,17 +8,17 @@ description = "Compiler toolchain including Intel compilers, Intel MPI and Intel
 
 toolchain = SYSTEM
 
-compver = '2018.0.128'
-gccver = '6.4.0'
-binutilsver = '2.28'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2018.0.128'
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', compver, '', ('iimpi', version)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', local_compver, '', ('iimpi', version)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2018.01.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2018.01.eb
@@ -8,17 +8,17 @@ description = "Compiler toolchain including Intel compilers, Intel MPI and Intel
 
 toolchain = SYSTEM
 
-compver = '2018.1.163'
-gccver = '6.4.0'
-binutilsver = '2.28'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2018.1.163'
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', compver, '', ('iimpi', version)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', local_compver, '', ('iimpi', version)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2018.02.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2018.02.eb
@@ -8,17 +8,17 @@ description = "Compiler toolchain including Intel compilers, Intel MPI and Intel
 
 toolchain = SYSTEM
 
-compver = '2018.2.199'
-gccver = '6.4.0'
-binutilsver = '2.28'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2018.2.199'
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', compver, '', ('iimpi', version)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', local_compver, '', ('iimpi', version)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2018.04.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2018.04.eb
@@ -8,16 +8,16 @@ description = "Compiler toolchain including Intel compilers, Intel MPI and Intel
 
 toolchain = SYSTEM
 
-compver = '2018.5.274'
-gccver = '7.3.0'
-binutilsver = '2.30'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2018.5.274'
+local_gccver = '7.3.0'
+local_binutilsver = '2.30'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', '2018.4.274', '', ('iccifort', '%s%s' % (compver, gccsuff))),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', '2018.4.274', '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
     ('imkl', '2018.4.274', '', ('iimpi', version)),
 ]
 

--- a/easybuild/easyconfigs/i/intel/intel-2018a.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2018a.eb
@@ -8,17 +8,17 @@ description = "Compiler toolchain including Intel compilers, Intel MPI and Intel
 
 toolchain = SYSTEM
 
-compver = '2018.1.163'
-gccver = '6.4.0'
-binutilsver = '2.28'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2018.1.163'
+local_gccver = '6.4.0'
+local_binutilsver = '2.28'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', compver, '', ('iimpi', version)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', local_compver, '', ('iimpi', version)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2018b.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2018b.eb
@@ -8,17 +8,17 @@ description = "Compiler toolchain including Intel compilers, Intel MPI and Intel
 
 toolchain = SYSTEM
 
-compver = '2018.3.222'
-gccver = '7.3.0'
-binutilsver = '2.30'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2018.3.222'
+local_gccver = '7.3.0'
+local_binutilsver = '2.30'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', compver, '', ('iimpi', version)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', local_compver, '', ('iimpi', version)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2019.00.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2019.00.eb
@@ -8,17 +8,17 @@ description = "Compiler toolchain including Intel compilers, Intel MPI and Intel
 
 toolchain = SYSTEM
 
-compver = '2019.0.117'
-gccver = '8.2.0'
-binutilsver = '2.31.1'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2019.0.117'
+local_gccver = '8.2.0'
+local_binutilsver = '2.31.1'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', compver, '', ('iimpi', version)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', local_compver, '', ('iimpi', version)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2019.01.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2019.01.eb
@@ -8,17 +8,17 @@ description = "Compiler toolchain including Intel compilers, Intel MPI and Intel
 
 toolchain = SYSTEM
 
-compver = '2019.1.144'
-gccver = '8.2.0'
-binutilsver = '2.31.1'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2019.1.144'
+local_gccver = '8.2.0'
+local_binutilsver = '2.31.1'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', compver, '', ('iimpi', version)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', local_compver, '', ('iimpi', version)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2019.02.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2019.02.eb
@@ -8,17 +8,17 @@ description = "Compiler toolchain including Intel compilers, Intel MPI and Intel
 
 toolchain = SYSTEM
 
-compver = '2019.2.187'
-gccver = '8.2.0'
-binutilsver = '2.31.1'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2019.2.187'
+local_gccver = '8.2.0'
+local_binutilsver = '2.31.1'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', compver, '', ('iimpi', version)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', local_compver, '', ('iimpi', version)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2019.03.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2019.03.eb
@@ -8,17 +8,17 @@ description = "Compiler toolchain including Intel compilers, Intel MPI and Intel
 
 toolchain = SYSTEM
 
-compver = '2019.3.199'
-gccver = '8.3.0'
-binutilsver = '2.32'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2019.3.199'
+local_gccver = '8.3.0'
+local_binutilsver = '2.32'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', compver, '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', compver, '', ('iimpi', version)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', local_compver, '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', local_compver, '', ('iimpi', version)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/intel/intel-2019a.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2019a.eb
@@ -8,17 +8,17 @@ description = "Compiler toolchain including Intel compilers, Intel MPI and Intel
 
 toolchain = SYSTEM
 
-compver = '2019.1.144'
-gccver = '8.2.0'
-binutilsver = '2.31.1'
-gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+local_compver = '2019.1.144'
+local_gccver = '8.2.0'
+local_binutilsver = '2.31.1'
+local_gccsuff = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
-    ('icc', compver, gccsuff),
-    ('ifort', compver, gccsuff),
-    ('impi', '2018.4.274', '', ('iccifort', '%s%s' % (compver, gccsuff))),
-    ('imkl', compver, '', ('iimpi', version)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '-GCCcore-%s' % local_gccver),
+    ('icc', local_compver, local_gccsuff),
+    ('ifort', local_compver, local_gccsuff),
+    ('impi', '2018.4.274', '', ('iccifort', '%s%s' % (local_compver, local_gccsuff))),
+    ('imkl', local_compver, '', ('iimpi', version)),
 ]
 
 moduleclass = 'toolchain'


### PR DESCRIPTION
done with `--fix-deprecated-easyconfigs`, no manual changes

required to avoid warnings when these easyconfigs are parsed because of changed made in https://github.com/easybuilders/easybuild-framework/pull/2938