### PR TITLE
fix names of local variables in gompi/foss easyconfigs

### DIFF
--- a/easybuild/easyconfigs/f/foss/foss-2016.04.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2016.04.eb
@@ -9,27 +9,27 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain, includi
 
 toolchain = SYSTEM
 
-gccver = '5.3.0-2.26'
+local_gccver = '5.3.0-2.26'
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.18'
-blas = '%s-%s' % (blaslib, blasver)
-blassuff = '-LAPACK-3.6.0'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.18'
+local_blas = '%s-%s' % (local_blaslib, local_blasver)
+local_blassuff = '-LAPACK-3.6.0'
 
 # toolchain used to build foss dependencies
-comp_mpi_tc_name = 'gompi'
-comp_mpi_tc = (comp_mpi_tc_name, version)
+local_comp_mpi_tc_name = 'gompi'
+local_comp_mpi_tc = (local_comp_mpi_tc_name, version)
 
 # compiler toolchain depencies
 # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
 # because of toolchain preperation functions
 # For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
 dependencies = [
-    ('GCC', gccver),
-    ('OpenMPI', '1.10.2', '', ('GCC', gccver)),
-    (blaslib, blasver, blassuff, ('GCC', gccver)),
-    ('FFTW', '3.3.4', '', comp_mpi_tc),
-    ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc),
+    ('GCC', local_gccver),
+    ('OpenMPI', '1.10.2', '', ('GCC', local_gccver)),
+    (local_blaslib, local_blasver, local_blassuff, ('GCC', local_gccver)),
+    ('FFTW', '3.3.4', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s%s' % (local_blas, local_blassuff), local_comp_mpi_tc),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/f/foss/foss-2016.06.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2016.06.eb
@@ -9,27 +9,27 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain, includi
 
 toolchain = SYSTEM
 
-gccver = '5.4.0-2.26'
+local_gccver = '5.4.0-2.26'
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.18'
-blas = '%s-%s' % (blaslib, blasver)
-blassuff = '-LAPACK-3.6.0'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.18'
+local_blas = '%s-%s' % (local_blaslib, local_blasver)
+local_blassuff = '-LAPACK-3.6.0'
 
 # toolchain used to build foss dependencies
-comp_mpi_tc_name = 'gompi'
-comp_mpi_tc = (comp_mpi_tc_name, version)
+local_comp_mpi_tc_name = 'gompi'
+local_comp_mpi_tc = (local_comp_mpi_tc_name, version)
 
 # compiler toolchain depencies
 # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
 # because of toolchain preperation functions
 # For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
 dependencies = [
-    ('GCC', gccver),
-    ('OpenMPI', '1.10.3', '', ('GCC', gccver)),
-    (blaslib, blasver, blassuff, ('GCC', gccver)),
-    ('FFTW', '3.3.4', '', comp_mpi_tc),
-    ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc),
+    ('GCC', local_gccver),
+    ('OpenMPI', '1.10.3', '', ('GCC', local_gccver)),
+    (local_blaslib, local_blasver, local_blassuff, ('GCC', local_gccver)),
+    ('FFTW', '3.3.4', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s%s' % (local_blas, local_blassuff), local_comp_mpi_tc),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/f/foss/foss-2016.07.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2016.07.eb
@@ -9,29 +9,27 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain, includi
 
 toolchain = SYSTEM
 
-gccver = '6.1.0'
-binutilsver = '2.27'
-gccbinver = '%s-%s' % (gccver, binutilsver)
+local_gccbinver = '6.1.0-2.27'
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.18'
-blas = '%s-%s' % (blaslib, blasver)
-blassuff = '-LAPACK-3.6.1'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.18'
+local_blas = '%s-%s' % (local_blaslib, local_blasver)
+local_blassuff = '-LAPACK-3.6.1'
 
 # toolchain used to build foss dependencies
-comp_mpi_tc_name = 'gompi'
-comp_mpi_tc = (comp_mpi_tc_name, version)
+local_comp_mpi_tc_name = 'gompi'
+local_comp_mpi_tc = (local_comp_mpi_tc_name, version)
 
 # compiler toolchain depencies
 # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
 # because of toolchain preperation functions
 # For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
 dependencies = [
-    ('GCC', gccbinver),
-    ('OpenMPI', '1.10.3', '', ('GCC', gccbinver)),
-    (blaslib, blasver, blassuff, comp_mpi_tc),
-    ('FFTW', '3.3.4', '', comp_mpi_tc),
-    ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc)
+    ('GCC', local_gccbinver),
+    ('OpenMPI', '1.10.3', '', ('GCC', local_gccbinver)),
+    (local_blaslib, local_blasver, local_blassuff, local_comp_mpi_tc),
+    ('FFTW', '3.3.4', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s%s' % (local_blas, local_blassuff), local_comp_mpi_tc)
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/f/foss/foss-2016.09.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2016.09.eb
@@ -9,27 +9,26 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain, includi
 
 toolchain = SYSTEM
 
-gccver = '6.2.0-2.27'
+local_gccver = '6.2.0-2.27'
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.19'
-blas = '%s-%s' % (blaslib, blasver)
-blassuff = '-LAPACK-3.6.1'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.19'
+local_blas = '%s-%s' % (local_blaslib, local_blasver)
+local_blassuff = '-LAPACK-3.6.1'
 
 # toolchain used to build foss dependencies
-comp_mpi_tc_name = 'gompi'
-comp_mpi_tc = (comp_mpi_tc_name, version)
+local_comp_mpi_tc = ('gompi', version)
 
 # compiler toolchain depencies
 # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
 # because of toolchain preperation functions
 # For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
 dependencies = [
-    ('GCC', gccver),
-    ('OpenMPI', '2.0.1', '', ('GCC', gccver)),
-    (blaslib, blasver, blassuff, comp_mpi_tc),
-    ('FFTW', '3.3.5', '', comp_mpi_tc),
-    ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc)
+    ('GCC', local_gccver),
+    ('OpenMPI', '2.0.1', '', ('GCC', local_gccver)),
+    (local_blaslib, local_blasver, local_blassuff, local_comp_mpi_tc),
+    ('FFTW', '3.3.5', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s%s' % (local_blas, local_blassuff), local_comp_mpi_tc)
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/f/foss/foss-2016a.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2016a.eb
@@ -9,27 +9,26 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain, includi
 
 toolchain = SYSTEM
 
-gccver = '4.9.3-2.25'
+local_gccver = '4.9.3-2.25'
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.15'
-blas = '%s-%s' % (blaslib, blasver)
-blassuff = '-LAPACK-3.6.0'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.15'
+local_blas = '%s-%s' % (local_blaslib, local_blasver)
+local_blassuff = '-LAPACK-3.6.0'
 
 # toolchain used to build foss dependencies
-comp_mpi_tc_name = 'gompi'
-comp_mpi_tc = (comp_mpi_tc_name, version)
+local_comp_mpi_tc = ('gompi', version)
 
 # compiler toolchain depencies
 # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
 # because of toolchain preperation functions
 # For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
 dependencies = [
-    ('GCC', gccver),
-    ('OpenMPI', '1.10.2', '', ('GCC', gccver)),
-    (blaslib, blasver, blassuff, ('GCC', gccver)),
-    ('FFTW', '3.3.4', '', comp_mpi_tc),
-    ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc),
+    ('GCC', local_gccver),
+    ('OpenMPI', '1.10.2', '', ('GCC', local_gccver)),
+    (local_blaslib, local_blasver, local_blassuff, ('GCC', local_gccver)),
+    ('FFTW', '3.3.4', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s%s' % (local_blas, local_blassuff), local_comp_mpi_tc),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/f/foss/foss-2016b.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2016b.eb
@@ -9,27 +9,26 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain, includi
 
 toolchain = SYSTEM
 
-gccver = '5.4.0-2.26'
+local_gccver = '5.4.0-2.26'
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.18'
-blas = '%s-%s' % (blaslib, blasver)
-blassuff = '-LAPACK-3.6.1'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.18'
+local_blas = '%s-%s' % (local_blaslib, local_blasver)
+local_blassuff = '-LAPACK-3.6.1'
 
 # toolchain used to build foss dependencies
-comp_mpi_tc_name = 'gompi'
-comp_mpi_tc = (comp_mpi_tc_name, version)
+local_comp_mpi_tc = ('gompi', version)
 
 # compiler toolchain depencies
 # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
 # because of toolchain preperation functions
 # For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
 dependencies = [
-    ('GCC', gccver),
-    ('OpenMPI', '1.10.3', '', ('GCC', gccver)),
-    (blaslib, blasver, blassuff, ('GCC', gccver)),
-    ('FFTW', '3.3.4', '', comp_mpi_tc),
-    ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc),
+    ('GCC', local_gccver),
+    ('OpenMPI', '1.10.3', '', ('GCC', local_gccver)),
+    (local_blaslib, local_blasver, local_blassuff, ('GCC', local_gccver)),
+    ('FFTW', '3.3.4', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s%s' % (local_blas, local_blassuff), local_comp_mpi_tc),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/f/foss/foss-2017a.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2017a.eb
@@ -9,27 +9,26 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain, includi
 
 toolchain = SYSTEM
 
-gccver = '6.3.0-2.27'
+local_gccver = '6.3.0-2.27'
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.19'
-blas = '%s-%s' % (blaslib, blasver)
-blassuff = '-LAPACK-3.7.0'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.19'
+local_blas = '%s-%s' % (local_blaslib, local_blasver)
+local_blassuff = '-LAPACK-3.7.0'
 
 # toolchain used to build foss dependencies
-comp_mpi_tc_name = 'gompi'
-comp_mpi_tc = (comp_mpi_tc_name, version)
+local_comp_mpi_tc = ('gompi', version)
 
 # compiler toolchain depencies
 # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
 # because of toolchain preperation functions
 # For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
 dependencies = [
-    ('GCC', gccver),
-    ('OpenMPI', '2.0.2', '', ('GCC', gccver)),
-    (blaslib, blasver, blassuff, ('GCC', gccver)),
-    ('FFTW', '3.3.6', '', comp_mpi_tc),
-    ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc),
+    ('GCC', local_gccver),
+    ('OpenMPI', '2.0.2', '', ('GCC', local_gccver)),
+    (local_blaslib, local_blasver, local_blassuff, ('GCC', local_gccver)),
+    ('FFTW', '3.3.6', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s%s' % (local_blas, local_blassuff), local_comp_mpi_tc),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/f/foss/foss-2017b.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2017b.eb
@@ -9,25 +9,24 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain, includi
 
 toolchain = SYSTEM
 
-gccver = '6.4.0-2.28'
+local_gccver = '6.4.0-2.28'
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
-blas = '%s-%s' % (blaslib, blasver)
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.20'
+local_blas = '%s-%s' % (local_blaslib, local_blasver)
 
 # toolchain used to build foss dependencies
-comp_mpi_tc_name = 'gompi'
-comp_mpi_tc = (comp_mpi_tc_name, version)
+local_comp_mpi_tc = ('gompi', version)
 
 # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
 # because of toolchain preparation functions
 # For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
 dependencies = [
-    ('GCC', gccver),
-    ('OpenMPI', '2.1.1', '', ('GCC', gccver)),
-    (blaslib, blasver, '', ('GCC', gccver)),
-    ('FFTW', '3.3.6', '', comp_mpi_tc),
-    ('ScaLAPACK', '2.0.2', '-%s' % blas, comp_mpi_tc),
+    ('GCC', local_gccver),
+    ('OpenMPI', '2.1.1', '', ('GCC', local_gccver)),
+    (local_blaslib, local_blasver, '', ('GCC', local_gccver)),
+    ('FFTW', '3.3.6', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s' % local_blas, local_comp_mpi_tc),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/f/foss/foss-2018.08.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2018.08.eb
@@ -9,25 +9,24 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain, includi
 
 toolchain = SYSTEM
 
-gccver = '8.2.0-2.31.1'
+local_gccver = '8.2.0-2.31.1'
 
-blaslib = 'OpenBLAS'
-blasver = '0.3.3'
-blas = '%s-%s' % (blaslib, blasver)
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.3.3'
+local_blas = '%s-%s' % (local_blaslib, local_blasver)
 
 # toolchain used to build foss dependencies
-comp_mpi_tc_name = 'gompi'
-comp_mpi_tc = (comp_mpi_tc_name, version)
+local_comp_mpi_tc = ('gompi', version)
 
 # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
 # because of toolchain preparation functions
 # For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
 dependencies = [
-    ('GCC', gccver),
-    ('OpenMPI', '3.1.2', '', ('GCC', gccver)),
-    (blaslib, blasver, '', ('GCC', gccver)),
-    ('FFTW', '3.3.8', '', comp_mpi_tc),
-    ('ScaLAPACK', '2.0.2', '-%s' % blas, comp_mpi_tc),
+    ('GCC', local_gccver),
+    ('OpenMPI', '3.1.2', '', ('GCC', local_gccver)),
+    (local_blaslib, local_blasver, '', ('GCC', local_gccver)),
+    ('FFTW', '3.3.8', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s' % local_blas, local_comp_mpi_tc),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/f/foss/foss-2018a.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2018a.eb
@@ -9,25 +9,24 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain, includi
 
 toolchain = SYSTEM
 
-gccver = '6.4.0-2.28'
+local_gccver = '6.4.0-2.28'
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
-blas = '%s-%s' % (blaslib, blasver)
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.20'
+local_blas = '%s-%s' % (local_blaslib, local_blasver)
 
 # toolchain used to build foss dependencies
-comp_mpi_tc_name = 'gompi'
-comp_mpi_tc = (comp_mpi_tc_name, version)
+local_comp_mpi_tc = ('gompi', version)
 
 # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
 # because of toolchain preparation functions
 # For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
 dependencies = [
-    ('GCC', gccver),
-    ('OpenMPI', '2.1.2', '', ('GCC', gccver)),
-    (blaslib, blasver, '', ('GCC', gccver)),
-    ('FFTW', '3.3.7', '', comp_mpi_tc),
-    ('ScaLAPACK', '2.0.2', '-%s' % blas, comp_mpi_tc),
+    ('GCC', local_gccver),
+    ('OpenMPI', '2.1.2', '', ('GCC', local_gccver)),
+    (local_blaslib, local_blasver, '', ('GCC', local_gccver)),
+    ('FFTW', '3.3.7', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s' % local_blas, local_comp_mpi_tc),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/f/foss/foss-2018b.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2018b.eb
@@ -9,25 +9,24 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain, includi
 
 toolchain = SYSTEM
 
-gccver = '7.3.0-2.30'
+local_gccver = '7.3.0-2.30'
 
-blaslib = 'OpenBLAS'
-blasver = '0.3.1'
-blas = '%s-%s' % (blaslib, blasver)
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.3.1'
+local_blas = '%s-%s' % (local_blaslib, local_blasver)
 
 # toolchain used to build foss dependencies
-comp_mpi_tc_name = 'gompi'
-comp_mpi_tc = (comp_mpi_tc_name, version)
+local_comp_mpi_tc = ('gompi', version)
 
 # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
 # because of toolchain preparation functions
 # For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
 dependencies = [
-    ('GCC', gccver),
-    ('OpenMPI', '3.1.1', '', ('GCC', gccver)),
-    (blaslib, blasver, '', ('GCC', gccver)),
-    ('FFTW', '3.3.8', '', comp_mpi_tc),
-    ('ScaLAPACK', '2.0.2', '-%s' % blas, comp_mpi_tc),
+    ('GCC', local_gccver),
+    ('OpenMPI', '3.1.1', '', ('GCC', local_gccver)),
+    (local_blaslib, local_blasver, '', ('GCC', local_gccver)),
+    ('FFTW', '3.3.8', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s' % local_blas, local_comp_mpi_tc),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/f/foss/foss-2019a.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2019a.eb
@@ -9,24 +9,23 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain, includi
 
 toolchain = SYSTEM
 
-gccver = '8.2.0-2.31.1'
+local_gccver = '8.2.0-2.31.1'
 
-blaslib = 'OpenBLAS'
-blasver = '0.3.5'
-blas = '%s-%s' % (blaslib, blasver)
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.3.5'
+local_blas = '%s-%s' % (local_blaslib, local_blasver)
 
 # toolchain used to build foss dependencies
-comp_mpi_tc_name = 'gompi'
-comp_mpi_tc = (comp_mpi_tc_name, version)
+local_comp_mpi_tc = ('gompi', version)
 
 # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
 # because of toolchain preparation functions
 dependencies = [
-    ('GCC', gccver),
-    ('OpenMPI', '3.1.3', '', ('GCC', gccver)),
-    (blaslib, blasver, '', ('GCC', gccver)),
-    ('FFTW', '3.3.8', '', comp_mpi_tc),
-    ('ScaLAPACK', '2.0.2', '-%s' % blas, comp_mpi_tc),
+    ('GCC', local_gccver),
+    ('OpenMPI', '3.1.3', '', ('GCC', local_gccver)),
+    (local_blaslib, local_blasver, '', ('GCC', local_gccver)),
+    ('FFTW', '3.3.8', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s' % local_blas, local_comp_mpi_tc),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2016.04.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2016.04.eb
@@ -9,12 +9,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain,
 
 toolchain = SYSTEM
 
-gccver = '5.3.0-2.26'
+local_gccver = '5.3.0-2.26'
 
 # compiler toolchain dependencies
 dependencies = [
-    ('GCC', gccver),  # includes both GCC 5.3.0 and binutils 2.26
-    ('OpenMPI', '1.10.2', '', ('GCC', gccver)),
+    ('GCC', local_gccver),  # includes both GCC 5.3.0 and binutils 2.26
+    ('OpenMPI', '1.10.2', '', ('GCC', local_gccver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2016.06.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2016.06.eb
@@ -9,12 +9,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain,
 
 toolchain = SYSTEM
 
-gccver = '5.4.0-2.26'
+local_gccver = '5.4.0-2.26'
 
 # compiler toolchain dependencies
 dependencies = [
-    ('GCC', gccver),  # includes both GCC 5.4.0 and binutils 2.26
-    ('OpenMPI', '1.10.3', '', ('GCC', gccver)),
+    ('GCC', local_gccver),  # includes both GCC 5.4.0 and binutils 2.26
+    ('OpenMPI', '1.10.3', '', ('GCC', local_gccver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2016.07.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2016.07.eb
@@ -9,14 +9,12 @@ including OpenMPI for MPI support."""
 
 toolchain = SYSTEM
 
-gccver = '6.1.0'
-binutilsver = '2.27'
-gccbinver = '%s-%s' % (gccver, binutilsver)
+local_gccver = '6.1.0-2.27'
 
 # compiler toolchain dependencies
 dependencies = [
-    ('GCC', gccbinver),  # includes both GCC and binutils
-    ('OpenMPI', '1.10.3', '', ('GCC', gccbinver)),
+    ('GCC', local_gccver),  # includes both GCC and binutils
+    ('OpenMPI', '1.10.3', '', ('GCC', local_gccver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2016.09.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2016.09.eb
@@ -9,12 +9,12 @@ including OpenMPI for MPI support."""
 
 toolchain = SYSTEM
 
-gccver = '6.2.0-2.27'
+local_gccver = '6.2.0-2.27'
 
 # compiler toolchain dependencies
 dependencies = [
-    ('GCC', gccver),  # includes both GCC and binutils
-    ('OpenMPI', '2.0.1', '', ('GCC', gccver)),
+    ('GCC', local_gccver),  # includes both GCC and binutils
+    ('OpenMPI', '2.0.1', '', ('GCC', local_gccver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2016a.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2016a.eb
@@ -9,12 +9,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain,
 
 toolchain = SYSTEM
 
-gccver = '4.9.3-2.25'
+local_gccver = '4.9.3-2.25'
 
 # compiler toolchain dependencies
 dependencies = [
-    ('GCC', gccver),  # includes both GCC 4.9.3 and binutils 2.25
-    ('OpenMPI', '1.10.2', '', ('GCC', gccver)),
+    ('GCC', local_gccver),  # includes both GCC 4.9.3 and binutils 2.25
+    ('OpenMPI', '1.10.2', '', ('GCC', local_gccver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2016b.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2016b.eb
@@ -9,12 +9,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain,
 
 toolchain = SYSTEM
 
-gccver = '5.4.0-2.26'
+local_gccver = '5.4.0-2.26'
 
 # compiler toolchain dependencies
 dependencies = [
-    ('GCC', gccver),  # includes both GCC 5.4.0 and binutils 2.26
-    ('OpenMPI', '1.10.3', '', ('GCC', gccver)),
+    ('GCC', local_gccver),  # includes both GCC 5.4.0 and binutils 2.26
+    ('OpenMPI', '1.10.3', '', ('GCC', local_gccver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2017a.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2017a.eb
@@ -9,12 +9,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain,
 
 toolchain = SYSTEM
 
-gccver = '6.3.0-2.27'
+local_gccver = '6.3.0-2.27'
 
 # compiler toolchain dependencies
 dependencies = [
-    ('GCC', gccver),  # includes both GCC 6.3.0 and binutils 2.27
-    ('OpenMPI', '2.0.2', '', ('GCC', gccver)),
+    ('GCC', local_gccver),  # includes both GCC 6.3.0 and binutils 2.27
+    ('OpenMPI', '2.0.2', '', ('GCC', local_gccver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2017b.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2017b.eb
@@ -9,12 +9,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain,
 
 toolchain = SYSTEM
 
-gccver = '6.4.0-2.28'
+local_gccver = '6.4.0-2.28'
 
 # compiler toolchain dependencies
 dependencies = [
-    ('GCC', gccver),  # includes both GCC and binutils
-    ('OpenMPI', '2.1.1', '', ('GCC', gccver)),
+    ('GCC', local_gccver),  # includes both GCC and binutils
+    ('OpenMPI', '2.1.1', '', ('GCC', local_gccver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2018.08.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2018.08.eb
@@ -9,12 +9,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain,
 
 toolchain = SYSTEM
 
-gccver = '8.2.0-2.31.1'
+local_gccver = '8.2.0-2.31.1'
 
 # compiler toolchain dependencies
 dependencies = [
-    ('GCC', gccver),  # includes both GCC and binutils
-    ('OpenMPI', '3.1.2', '', ('GCC', gccver)),
+    ('GCC', local_gccver),  # includes both GCC and binutils
+    ('OpenMPI', '3.1.2', '', ('GCC', local_gccver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2018a.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2018a.eb
@@ -9,12 +9,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain,
 
 toolchain = SYSTEM
 
-gccver = '6.4.0-2.28'
+local_gccver = '6.4.0-2.28'
 
 # compiler toolchain dependencies
 dependencies = [
-    ('GCC', gccver),  # includes both GCC and binutils
-    ('OpenMPI', '2.1.2', '', ('GCC', gccver)),
+    ('GCC', local_gccver),  # includes both GCC and binutils
+    ('OpenMPI', '2.1.2', '', ('GCC', local_gccver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2018b.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2018b.eb
@@ -9,12 +9,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain,
 
 toolchain = SYSTEM
 
-gccver = '7.3.0-2.30'
+local_gccver = '7.3.0-2.30'
 
 # compiler toolchain dependencies
 dependencies = [
-    ('GCC', gccver),  # includes both GCC and binutils
-    ('OpenMPI', '3.1.1', '', ('GCC', gccver)),
+    ('GCC', local_gccver),  # includes both GCC and binutils
+    ('OpenMPI', '3.1.1', '', ('GCC', local_gccver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2019a.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2019a.eb
@@ -9,12 +9,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain,
 
 toolchain = SYSTEM
 
-gccver = '8.2.0-2.31.1'
+local_gccver = '8.2.0-2.31.1'
 
 # compiler toolchain dependencies
 dependencies = [
-    ('GCC', gccver),  # includes both GCC and binutils
-    ('OpenMPI', '3.1.3', '', ('GCC', gccver)),
+    ('GCC', local_gccver),  # includes both GCC and binutils
+    ('OpenMPI', '3.1.3', '', ('GCC', local_gccver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-system-2.29.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-system-2.29.eb
@@ -2,9 +2,7 @@ easyblock = "Toolchain"
 
 name = 'gompi'
 version = 'system'
-
-binutilsver = '2.29'
-versionsuffix = '-%s' % binutilsver
+versionsuffix = '-2.29'
 
 homepage = '(none)'
 description = """GNU Compiler Collection (GCC) based compiler toolchain,
@@ -12,12 +10,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain,
 
 toolchain = SYSTEM
 
-gccver = '%s%s' % (version, versionsuffix)
+local_gccver = '%s%s' % (version, versionsuffix)
 
 # compiler toolchain dependencies
 dependencies = [
-    ('GCC', gccver),  # includes both GCC system and binutils 'binutilsver'
-    ('OpenMPI', version, '', ('GCC', gccver)),
+    ('GCC', local_gccver),  # includes both GCC system and binutils
+    ('OpenMPI', version, '', ('GCC', local_gccver)),
 ]
 
 moduleclass = 'toolchain'


### PR DESCRIPTION
done with `--fix-deprecated-easyconfigs`, no manual changes

required to avoid warnings when these easyconfigs are parsed because of changed made in https://github.com/easybuilders/easybuild-framework/pull/2938