### PR TITLE
re-enable checksum requirement for easyconfig files touched in PRs

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -501,9 +501,9 @@ class EasyConfigTest(TestCase):
                             self.assertTrue(False, error_msg)
 
                 # run checks on changed easyconfigs
-                #self.check_sha256_checksums(changed_ecs)
-                #self.check_python_packages(changed_ecs)
-                #self.check_sanity_check_paths(changed_ecs)
+                self.check_sha256_checksums(changed_ecs)
+                self.check_python_packages(changed_ecs)
+                self.check_sanity_check_paths(changed_ecs)
 
     def test_zzz_cleanup(self):
         """Dummy test to clean up global temporary directory."""


### PR DESCRIPTION
This reverts commit acd4f38a4c3f406a724d23e5388db7507f5d46fe (was added in #8369).

We'll leave the checksum requirement off for now, while we fix the local variable naming issues (see #8702, #8709, #8710, etc.)

This should be merged when that effort has been completed, certainly before `4.x` is collapsed into `develop`...