### PR TITLE
add alternative checksums for nlme/mgcv/foreign/boot extensions in R 3.5.1 and 3.6.0 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b-Python-2.7.15.eb
@@ -397,10 +397,12 @@ exts_list = [
         'checksums': ['41366f777d8adb83d0bdbac1392a1ab118b36217ca648d3bb9db763aa7ff4686'],
     }),
     ('nlme', '3.1-137', {
-        'checksums': ['ac82a5d15233dfca2a1aaf9f3ceee018adfe2983344750023dd433ed49b07ba8'],
+        'checksums': [('01049bb9c53826ff4ec5ba7117d766b17a0108c85f80871a5adb0c0b58ef7e87',
+                       'ac82a5d15233dfca2a1aaf9f3ceee018adfe2983344750023dd433ed49b07ba8')],
     }),
     ('mgcv', '1.8-24', {
-        'checksums': ['a9f8e9823f6d6a4a568d151f2fa619bb2811df73c013e9a105720d9b32b4740c'],
+        'checksums': [('2ce542bcf841f722f34b936d44d859a53718a9de18ea24eb6ae843e042356795',
+                       'a9f8e9823f6d6a4a568d151f2fa619bb2811df73c013e9a105720d9b32b4740c')],
     }),
     ('ggplot2', '3.0.0', {
         'checksums': ['c768f5039ef684c3874a92210a975af52e74f00927ff31c31a73eb1fe139694d'],
@@ -505,7 +507,8 @@ exts_list = [
         'checksums': ['ff78d5f935278935f1814a69e5a913d93d6dd2ac1b5681ba86b30c6773ef64ac'],
     }),
     ('foreign', '0.8-71', {
-        'checksums': ['3bd2392fbcd9dd4f385ac1418a5e454b9769e6414a21fbb5ae1e7ce6072760d7'],
+        'checksums': [('3bd2392fbcd9dd4f385ac1418a5e454b9769e6414a21fbb5ae1e7ce6072760d7',
+                       '2f6d387f25bf4796ff00b6c678acacfca13292fb3ec2c0409161940bf0d8bef1')],
     }),
     ('psych', '1.8.4', {
         'checksums': ['eea18e479bf603e148d61431218f9a141f66f4ca1db5fe83d4c1f27c984dfbcf'],
@@ -559,7 +562,8 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': [('f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06',
+                       'adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a')],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
@@ -395,10 +395,12 @@ exts_list = [
         'checksums': ['41366f777d8adb83d0bdbac1392a1ab118b36217ca648d3bb9db763aa7ff4686'],
     }),
     ('nlme', '3.1-137', {
-        'checksums': ['ac82a5d15233dfca2a1aaf9f3ceee018adfe2983344750023dd433ed49b07ba8'],
+        'checksums': [('01049bb9c53826ff4ec5ba7117d766b17a0108c85f80871a5adb0c0b58ef7e87',
+                       'ac82a5d15233dfca2a1aaf9f3ceee018adfe2983344750023dd433ed49b07ba8')],
     }),
     ('mgcv', '1.8-24', {
-        'checksums': ['a9f8e9823f6d6a4a568d151f2fa619bb2811df73c013e9a105720d9b32b4740c'],
+        'checksums': [('2ce542bcf841f722f34b936d44d859a53718a9de18ea24eb6ae843e042356795',
+                       'a9f8e9823f6d6a4a568d151f2fa619bb2811df73c013e9a105720d9b32b4740c')],
     }),
     ('ggplot2', '3.0.0', {
         'checksums': ['c768f5039ef684c3874a92210a975af52e74f00927ff31c31a73eb1fe139694d'],
@@ -503,7 +505,8 @@ exts_list = [
         'checksums': ['ff78d5f935278935f1814a69e5a913d93d6dd2ac1b5681ba86b30c6773ef64ac'],
     }),
     ('foreign', '0.8-71', {
-        'checksums': ['3bd2392fbcd9dd4f385ac1418a5e454b9769e6414a21fbb5ae1e7ce6072760d7'],
+        'checksums': [('3bd2392fbcd9dd4f385ac1418a5e454b9769e6414a21fbb5ae1e7ce6072760d7',
+                       '2f6d387f25bf4796ff00b6c678acacfca13292fb3ec2c0409161940bf0d8bef1')],
     }),
     ('psych', '1.8.4', {
         'checksums': ['eea18e479bf603e148d61431218f9a141f66f4ca1db5fe83d4c1f27c984dfbcf'],
@@ -557,7 +560,8 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': [('f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06',
+                       'adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a')],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],

--- a/easybuild/easyconfigs/r/R/R-3.5.1-intel-2018b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-intel-2018b.eb
@@ -395,10 +395,12 @@ exts_list = [
         'checksums': ['41366f777d8adb83d0bdbac1392a1ab118b36217ca648d3bb9db763aa7ff4686'],
     }),
     ('nlme', '3.1-137', {
-        'checksums': ['ac82a5d15233dfca2a1aaf9f3ceee018adfe2983344750023dd433ed49b07ba8'],
+        'checksums': [('01049bb9c53826ff4ec5ba7117d766b17a0108c85f80871a5adb0c0b58ef7e87',
+                       'ac82a5d15233dfca2a1aaf9f3ceee018adfe2983344750023dd433ed49b07ba8')],
     }),
     ('mgcv', '1.8-24', {
-        'checksums': ['a9f8e9823f6d6a4a568d151f2fa619bb2811df73c013e9a105720d9b32b4740c'],
+        'checksums': [('2ce542bcf841f722f34b936d44d859a53718a9de18ea24eb6ae843e042356795',
+                       'a9f8e9823f6d6a4a568d151f2fa619bb2811df73c013e9a105720d9b32b4740c')],
     }),
     ('ggplot2', '3.0.0', {
         'checksums': ['c768f5039ef684c3874a92210a975af52e74f00927ff31c31a73eb1fe139694d'],
@@ -503,7 +505,8 @@ exts_list = [
         'checksums': ['ff78d5f935278935f1814a69e5a913d93d6dd2ac1b5681ba86b30c6773ef64ac'],
     }),
     ('foreign', '0.8-71', {
-        'checksums': ['3bd2392fbcd9dd4f385ac1418a5e454b9769e6414a21fbb5ae1e7ce6072760d7'],
+        'checksums': [('3bd2392fbcd9dd4f385ac1418a5e454b9769e6414a21fbb5ae1e7ce6072760d7',
+                       '2f6d387f25bf4796ff00b6c678acacfca13292fb3ec2c0409161940bf0d8bef1')],
     }),
     ('psych', '1.8.4', {
         'checksums': ['eea18e479bf603e148d61431218f9a141f66f4ca1db5fe83d4c1f27c984dfbcf'],
@@ -557,7 +560,8 @@ exts_list = [
         'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
     }),
     ('boot', '1.3-20', {
-        'checksums': ['adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a'],
+        'checksums': [('f339ddb7138ad05fe3e19852caf7d369f9c1ab827a70045ff66223e032cd0e06',
+                       'adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a')],
     }),
     ('mixtools', '1.1.0', {
         'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],

--- a/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
@@ -404,7 +404,8 @@ exts_list = [
         'checksums': ['41366f777d8adb83d0bdbac1392a1ab118b36217ca648d3bb9db763aa7ff4686'],
     }),
     ('nlme', '3.1-140', {
-        'checksums': ['1da12f04052549b7673da2ba7af9a20184b186b749b521801a097447862c3d4d'],
+        'checksums': [('1da12f04052549b7673da2ba7af9a20184b186b749b521801a097447862c3d4d',
+                       'b15046fb0b3e3c689a3b565461b7bd6e74b46f0c7cce7444b43f1bc5400dc409')],
     }),
     ('mgcv', '1.8-28', {
         'checksums': ['b55ea8227cd5c263c266c3885fa3299aa6bd23b54186517f9299bf38a7bdd3ea'],
@@ -509,7 +510,8 @@ exts_list = [
         'checksums': ['ff78d5f935278935f1814a69e5a913d93d6dd2ac1b5681ba86b30c6773ef64ac'],
     }),
     ('foreign', '0.8-71', {
-        'checksums': ['3bd2392fbcd9dd4f385ac1418a5e454b9769e6414a21fbb5ae1e7ce6072760d7'],
+        'checksums': [('3bd2392fbcd9dd4f385ac1418a5e454b9769e6414a21fbb5ae1e7ce6072760d7',
+                       '2f6d387f25bf4796ff00b6c678acacfca13292fb3ec2c0409161940bf0d8bef1')],
     }),
     ('psych', '1.8.12', {
         'checksums': ['6e175e049bc1ee5b79a9e51ccafb22b962b4e6c839ce5c9cfa1ad83967037743'],
@@ -524,7 +526,8 @@ exts_list = [
         'checksums': ['1f86e33ecde6c3b0d2098c47591a9cd0fa41fb973ebf5145859677492730df97'],
     }),
     ('boot', '1.3-22', {
-        'checksums': ['cf1f0cb1e0a7a36dcb6ae038f5d0211a0e7a009c149bc9d21acb9c58c38b4dfc'],
+        'checksums': [('cf1f0cb1e0a7a36dcb6ae038f5d0211a0e7a009c149bc9d21acb9c58c38b4dfc',
+                       'f8bf34b87a3e30113b7ba26935f4165fd68266b89d5e84a39b1c6ab7872fb9cc')],
     }),
     ('lme4', '1.1-21', {
         'checksums': ['7f5554b69ff8ce9bac21e8842131ea940fb7a7dfa2de03684f236d3e3114b20c'],


### PR DESCRIPTION
Note: requires https://github.com/easybuilders/easybuild-framework/pull/2958 (without that, `eb` will complain with `Unknown checksum type` because it'll interpret the first checksum alternative as the checksum type)