### PR TITLE
add patch to Python 3.7.2 easyconfig to fix faulthandler segfault

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.7-faulthandler.patch
+++ b/easybuild/easyconfigs/p/Python/Python-3.7-faulthandler.patch
@@ -1,20 +1,21 @@
-# This pull request addresses the Issue: Python 3.7.4 segfault during
-# `make test` #8771
+# This pull request addresses the issue reported at
+# https://github.com/easybuilders/easybuild-easyconfigs/issues/8771
+# Python 3.7.4 segfault during `make test`
 # 
 # That is, the faulthander test would fail during testing if the
-# `--enable-shared` flag was used with `configure`.  The original issue was
-# reported in https://bugs.python.org/issue21131 in 2014; another variation
-# was report in May 2019, discussion of which led to the current patch.
-# See msg349768 in that bug report for the discussion of why the current
-# patch is being applied rather than the one submitted by peadar, which
-# dynamically set .
-# 
-# Upstream commit at Python source that addresses this patch can be found at
-# 
-# https://github.com/python/cpython/commit/1581d9c405f140491791a07dca3f6166bc499ec1
+# `--enable-shared` flag was used with `configure` on certain Skylake chips.
 #
-# Bennet Fauber, Thu Aug 15 13:48:06 EDT 2019
-# 
+# The original issue was reported in https://bugs.python.org/issue21131 in
+# 2014; another variation was report in May 2019, discussion of which led
+# to the current patch.
+#
+# Upstream commit at Python source that addresses this patch can be found at
+# https://github.com/python/cpython/pull/15276
+# https://github.com/python/cpython/commit/1581d9c405f140491791a07dca3f6166bc499ec1
+# The patch can be applied to all 3.7.x Python versions.
+#
+# Bennet Fauber, Sat Aug 17 07:47:54 EDT 2019
+
 diff -Nru Python-3.7.2.original/Modules/faulthandler.c Python-3.7.2/Modules/faulthandler.c
 --- Python-3.7.2.original/Modules/faulthandler.c	2018-12-23 16:37:36.000000000 -0500
 +++ Python-3.7.2/Modules/faulthandler.c	2019-08-15 09:56:35.847464392 -0400

--- a/easybuild/easyconfigs/p/Python/Python-3.7.2-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.7.2-GCCcore-8.2.0.eb
@@ -10,10 +10,10 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
-patches = ['Python-3.7.2-fix_faulthandler.patch']
+patches = ['Python-3.7-faulthandler.patch']
 checksums = [
     'f09d83c773b9cc72421abba2c317e4e6e05d919f9bcf34468e192b6a6c8e328d',  # Python-3.7.2.tgz
-    'affc4b70a0ecf62494f39b8474a8b5cc2ef1a1fde6430221c63fb0b95f3cd24b',  # Python-3.7.2-fix_faultha
+    'd061cd176a8aebb1895d84fd9134633abbdf9af26a22d649e5049df276574c08',  # Python-3.7-faulthandler.
 ]
 
 builddependencies = [('binutils', '2.31.1')]

--- a/easybuild/easyconfigs/p/Python/Python-3.7.2-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.7.2-GCCcore-8.2.0.eb
@@ -11,7 +11,10 @@ toolchainopts = {'pic': True}
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 patches = ['Python-3.7.2-fix_faulthandler.patch']
-checksums = ['f09d83c773b9cc72421abba2c317e4e6e05d919f9bcf34468e192b6a6c8e328d']
+checksums = [
+    'f09d83c773b9cc72421abba2c317e4e6e05d919f9bcf34468e192b6a6c8e328d',  # Python-3.7.2.tgz
+    'affc4b70a0ecf62494f39b8474a8b5cc2ef1a1fde6430221c63fb0b95f3cd24b',  # Python-3.7.2-fix_faultha
+]
 
 builddependencies = [('binutils', '2.31.1')]
 

--- a/easybuild/easyconfigs/p/Python/Python-3.7.2-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.7.2-GCCcore-8.2.0.eb
@@ -10,6 +10,7 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
+patches = ['Python-3.7.2-fix_faulthandler.patch']
 checksums = ['f09d83c773b9cc72421abba2c317e4e6e05d919f9bcf34468e192b6a6c8e328d']
 
 builddependencies = [('binutils', '2.31.1')]

--- a/easybuild/easyconfigs/p/Python/Python-3.7.2-fix_faulthandler.patch
+++ b/easybuild/easyconfigs/p/Python/Python-3.7.2-fix_faulthandler.patch
@@ -1,3 +1,20 @@
+# This pull request addresses the Issue: Python 3.7.4 segfault during
+# `make test` #8771
+# 
+# That is, the faulthander test would fail during testing if the
+# `--enable-shared` flag was used with `configure`.  The original issue was
+# reported in https://bugs.python.org/issue21131 in 2014; another variation
+# was report in May 2019, discussion of which led to the current patch.
+# See msg349768 in that bug report for the discussion of why the current
+# patch is being applied rather than the one submitted by peadar, which
+# dynamically set .
+# 
+# Upstream commit at Python source that addresses this patch can be found at
+# 
+# https://github.com/python/cpython/commit/1581d9c405f140491791a07dca3f6166bc499ec1
+#
+# Bennet Fauber, Thu Aug 15 13:48:06 EDT 2019
+# 
 diff -Nru Python-3.7.2.original/Modules/faulthandler.c Python-3.7.2/Modules/faulthandler.c
 --- Python-3.7.2.original/Modules/faulthandler.c	2018-12-23 16:37:36.000000000 -0500
 +++ Python-3.7.2/Modules/faulthandler.c	2019-08-15 09:56:35.847464392 -0400

--- a/easybuild/easyconfigs/p/Python/Python-3.7.2-fix_faulthandler.patch
+++ b/easybuild/easyconfigs/p/Python/Python-3.7.2-fix_faulthandler.patch
@@ -1,0 +1,16 @@
+diff -Nru Python-3.7.2.original/Modules/faulthandler.c Python-3.7.2/Modules/faulthandler.c
+--- Python-3.7.2.original/Modules/faulthandler.c	2018-12-23 16:37:36.000000000 -0500
++++ Python-3.7.2/Modules/faulthandler.c	2019-08-15 09:56:35.847464392 -0400
+@@ -1309,7 +1309,11 @@
+      * be able to allocate memory on the stack, even on a stack overflow. If it
+      * fails, ignore the error. */
+     stack.ss_flags = 0;
+-    stack.ss_size = SIGSTKSZ;
++    /* bpo-21131: allocate dedicated stack of SIGSTKSZ*2 bytes, instead of just
++       SIGSTKSZ bytes. Calling the previous signal handler in faulthandler
++       signal handler uses more than SIGSTKSZ bytes of stack memory on some
++       platforms. */
++    stack.ss_size = SIGSTKSZ * 2;
+     stack.ss_sp = PyMem_Malloc(stack.ss_size);
+     if (stack.ss_sp != NULL) {
+         err = sigaltstack(&stack, &old_stack);


### PR DESCRIPTION
This pull request addresses the Issue: Python 3.7.4 segfault during `make test` #8771

Adding patch file and patch line for Python-3.7.2 for GCCcore-8.2.0

See https://bugs.python.org/issue21131#msg349768 for discussion.

Upstream commit at Python source is at

https://github.com/python/cpython/commit/1581d9c405f140491791a07dca3f6166bc499ec1