### PR TITLE
matplotlib: Set CPLUS_INCLUDE_PATH for older matplotlib versions, newer already have it

### DIFF
--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-2.7.14.eb
@@ -29,6 +29,14 @@ exts_list = [
             'cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8',  # cycler-0.10.0.tar.gz
         ],
     }),
+    ('subprocess32', '3.2.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/subprocess32'],
+        'checksums': ['1e450a4a4c53bf197ad6402c564b9f7a53539385918ef8f12bdf430a61036590'],
+    }),
+    ('backports.functools_lru_cache', '1.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/backports.functools_lru_cache'],
+        'checksums': ['31f235852f88edc1558d428d890663c49eb4514ffec9f3650e7f3c9e4a12e36f'],
+    }),
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': [

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-2.7.14.eb
@@ -1,4 +1,4 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'matplotlib'
 version = '2.1.0'
@@ -11,15 +11,14 @@ description = """matplotlib is a python 2D plotting library which produces publi
 
 toolchain = {'name': 'foss', 'version': '2017b'}
 
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
 dependencies = [
     ('Python', '2.7.14'),
     ('Tkinter', '%(pyver)s', versionsuffix),
     ('libpng', '1.6.32'),
     ('freetype', '2.8'),
 ]
+
+use_pip = True
 
 exts_list = [
     ('Cycler', '0.10.0', {
@@ -40,16 +39,6 @@ exts_list = [
     }),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
-sanity_check_paths = {
-    'files': [],
-    'dirs': ['lib/python%(pyshortver)s/site-packages'],
-}
-
 sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
-
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-2.7.14.eb
@@ -34,6 +34,8 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': [
             '4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387',  # matplotlib-2.1.0.tar.gz
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         ],
     }),
 ]

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-2.7.14.eb
@@ -34,9 +34,9 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': [
             '4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387',  # matplotlib-2.1.0.tar.gz
+        ],
         'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
-        ],
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.2.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.2.eb
@@ -34,6 +34,8 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': [
             '4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387',  # matplotlib-2.1.0.tar.gz
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         ],
     }),
 ]

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.2.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.2.eb
@@ -1,4 +1,4 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'matplotlib'
 version = '2.1.0'
@@ -11,15 +11,14 @@ description = """matplotlib is a python 2D plotting library which produces publi
 
 toolchain = {'name': 'foss', 'version': '2017b'}
 
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
 dependencies = [
     ('Python', '3.6.2'),
     ('Tkinter', '%(pyver)s', versionsuffix),
     ('libpng', '1.6.32'),
     ('freetype', '2.8'),
 ]
+
+use_pip = True
 
 exts_list = [
     ('Cycler', '0.10.0', {
@@ -40,13 +39,6 @@ exts_list = [
     }),
 ]
 
-sanity_check_paths = {
-    'files': [],
-    'dirs': ['lib/python%(pyshortver)s/site-packages'],
-}
-
 sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
-
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.2.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.2.eb
@@ -34,9 +34,9 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': [
             '4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387',  # matplotlib-2.1.0.tar.gz
+        ],
         'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
-        ],
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.3.eb
@@ -34,6 +34,8 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': [
             '4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387',  # matplotlib-2.1.0.tar.gz
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         ],
     }),
 ]

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.3.eb
@@ -1,4 +1,4 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'matplotlib'
 version = '2.1.0'
@@ -11,15 +11,14 @@ description = """matplotlib is a python 2D plotting library which produces publi
 
 toolchain = {'name': 'foss', 'version': '2017b'}
 
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
 dependencies = [
     ('Python', '3.6.3'),
     ('Tkinter', '%(pyver)s', versionsuffix),
     ('libpng', '1.6.32'),
     ('freetype', '2.8'),
 ]
+
+use_pip = True
 
 exts_list = [
     ('Cycler', '0.10.0', {
@@ -40,13 +39,6 @@ exts_list = [
     }),
 ]
 
-sanity_check_paths = {
-    'files': [],
-    'dirs': ['lib/python%(pyshortver)s/site-packages'],
-}
-
 sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
-
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-3.6.3.eb
@@ -34,9 +34,9 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': [
             '4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387',  # matplotlib-2.1.0.tar.gz
+        ],
         'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
-        ],
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-fosscuda-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-fosscuda-2017b-Python-2.7.14.eb
@@ -41,9 +41,9 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': [
             '4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387',  # matplotlib-2.1.0.tar.gz
+        ],
         'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
-        ],
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-fosscuda-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-fosscuda-2017b-Python-2.7.14.eb
@@ -41,6 +41,8 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': [
             '4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387',  # matplotlib-2.1.0.tar.gz
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         ],
     }),
 ]

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-fosscuda-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-fosscuda-2017b-Python-3.6.3.eb
@@ -33,9 +33,9 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': [
             '4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387',  # matplotlib-2.1.0.tar.gz
+        ],
         'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
-        ],
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-fosscuda-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-fosscuda-2017b-Python-3.6.3.eb
@@ -33,6 +33,8 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': [
             '4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387',  # matplotlib-2.1.0.tar.gz
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         ],
     }),
 ]

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-2.7.14.eb
@@ -1,4 +1,4 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'matplotlib'
 version = '2.1.0'
@@ -11,15 +11,14 @@ description = """matplotlib is a python 2D plotting library which produces publi
 
 toolchain = {'name': 'intel', 'version': '2017b'}
 
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
 dependencies = [
     ('Python', '2.7.14'),
     ('Tkinter', '%(pyver)s', versionsuffix),
     ('libpng', '1.6.32'),
     ('freetype', '2.8'),
 ]
+
+use_pip = True
 
 exts_list = [
     ('Cycler', '0.10.0', {
@@ -44,13 +43,6 @@ exts_list = [
     }),
 ]
 
-sanity_check_paths = {
-    'files': [],
-    'dirs': ['lib/python%(pyshortver)s/site-packages'],
-}
-
 sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
-
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-2.7.14.eb
@@ -39,6 +39,8 @@ exts_list = [
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': ['4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387'],
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-3.6.3.eb
@@ -1,4 +1,4 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'matplotlib'
 version = '2.1.0'
@@ -11,15 +11,14 @@ description = """matplotlib is a python 2D plotting library which produces publi
 
 toolchain = {'name': 'intel', 'version': '2017b'}
 
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
 dependencies = [
     ('Python', '3.6.3'),
     ('Tkinter', '%(pyver)s', versionsuffix),
     ('libpng', '1.6.32'),
     ('freetype', '2.8'),
 ]
+
+use_pip = True
 
 exts_list = [
     ('Cycler', '0.10.0', {
@@ -36,13 +35,6 @@ exts_list = [
     }),
 ]
 
-sanity_check_paths = {
-    'files': [],
-    'dirs': ['lib/python%(pyshortver)s/site-packages'],
-}
-
 sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
-
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-3.6.3.eb
@@ -31,6 +31,8 @@ exts_list = [
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': ['4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387'],
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intelcuda-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intelcuda-2017b-Python-2.7.14.eb
@@ -38,6 +38,8 @@ exts_list = [
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': ['4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387'],
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intelcuda-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intelcuda-2017b-Python-3.6.3.eb
@@ -30,6 +30,8 @@ exts_list = [
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': ['4b5f16c9cefde553ea79975305dcaa67c8e13d927b6e55aa14b4a8d867e25387'],
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-foss-2017b-Python-3.6.3.eb
@@ -31,6 +31,8 @@ exts_list = [
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': ['659f5e1aa0e0f01488c61eff47560c43b8be511c6a29293d7f3896ae17bd8b23'],
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-foss-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-foss-2017b-Python-3.6.3.eb
@@ -1,4 +1,4 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'matplotlib'
 version = '2.1.1'
@@ -11,15 +11,14 @@ description = """matplotlib is a python 2D plotting library which produces publi
 
 toolchain = {'name': 'foss', 'version': '2017b'}
 
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
 dependencies = [
     ('Python', '3.6.3'),
     ('Tkinter', '%(pyver)s', versionsuffix),
     ('libpng', '1.6.32'),
     ('freetype', '2.8'),
 ]
+
+use_pip = True
 
 exts_list = [
     ('Cycler', '0.10.0', {
@@ -36,13 +35,6 @@ exts_list = [
     }),
 ]
 
-sanity_check_paths = {
-    'files': [],
-    'dirs': ['lib/python%(pyshortver)s/site-packages'],
-}
-
 sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
-
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-2.7.14.eb
@@ -27,6 +27,14 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/C/Cycler'],
         'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
     }),
+    ('subprocess32', '3.2.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/subprocess32'],
+        'checksums': ['1e450a4a4c53bf197ad6402c564b9f7a53539385918ef8f12bdf430a61036590'],
+    }),
+    ('backports.functools_lru_cache', '1.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/backports.functools_lru_cache'],
+        'checksums': ['31f235852f88edc1558d428d890663c49eb4514ffec9f3650e7f3c9e4a12e36f'],
+    }),
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': ['659f5e1aa0e0f01488c61eff47560c43b8be511c6a29293d7f3896ae17bd8b23'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-2.7.14.eb
@@ -1,4 +1,4 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'matplotlib'
 version = '2.1.1'
@@ -11,15 +11,14 @@ description = """matplotlib is a python 2D plotting library which produces publi
 
 toolchain = {'name': 'intel', 'version': '2017b'}
 
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
 dependencies = [
     ('Python', '2.7.14'),
     ('Tkinter', '%(pyver)s', versionsuffix),
     ('libpng', '1.6.32'),
     ('freetype', '2.8'),
 ]
+
+use_pip = True
 
 exts_list = [
     ('Cycler', '0.10.0', {
@@ -36,13 +35,6 @@ exts_list = [
     }),
 ]
 
-sanity_check_paths = {
-    'files': [],
-    'dirs': ['lib/python%(pyshortver)s/site-packages'],
-}
-
 sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
-
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-2.7.14.eb
@@ -31,6 +31,8 @@ exts_list = [
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': ['659f5e1aa0e0f01488c61eff47560c43b8be511c6a29293d7f3896ae17bd8b23'],
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-3.6.3.eb
@@ -1,4 +1,4 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'matplotlib'
 version = '2.1.1'
@@ -11,15 +11,14 @@ description = """matplotlib is a python 2D plotting library which produces publi
 
 toolchain = {'name': 'intel', 'version': '2017b'}
 
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
 dependencies = [
     ('Python', '3.6.3'),
     ('Tkinter', '%(pyver)s', versionsuffix),
     ('libpng', '1.6.32'),
     ('freetype', '2.8'),
 ]
+
+use_pip = True
 
 exts_list = [
     ('Cycler', '0.10.0', {
@@ -36,13 +35,6 @@ exts_list = [
     }),
 ]
 
-sanity_check_paths = {
-    'files': [],
-    'dirs': ['lib/python%(pyshortver)s/site-packages'],
-}
-
 sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
-
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-3.6.3.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-3.6.3.eb
@@ -31,6 +31,8 @@ exts_list = [
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': ['659f5e1aa0e0f01488c61eff47560c43b8be511c6a29293d7f3896ae17bd8b23'],
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
     }),
 ]
 


### PR DESCRIPTION
matplotlib uses CPLUS_INCLUDE_PATH to search for include files, make sure it can find freetype.