### PR TITLE
add missing YAML extension to Perl 5.28.0 easyconfig (required by BioPerl scripts)

### DIFF
--- a/easybuild/easyconfigs/p/Perl/Perl-5.28.0-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.28.0-GCCcore-7.3.0.eb
@@ -1475,6 +1475,11 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/Y/YA/YANICK/'],
         'checksums': ['c1b2970a8bb666c3de7caac4a8f4dbcc043ab819bbc337692ec7bf27adae4404'],
     }),
+    ('YAML', '1.29', {
+        'source_tmpl': 'YAML-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TI/TINITA/'],
+        'checksums': ['9c5c57389c31fa1d863ae9235ca6d694b364c741df7856105b54aa96b7d6853e'],
+    }),
 ]
 
 moduleclass = 'lang'


### PR DESCRIPTION
see discussion in EasyBuild mailing list: https://lists.ugent.be/wws/arc/easybuild/2019-08/msg00029.html