### PR TITLE
VMD: Add patch to plugins/Make-arch to use the correct tcl library version.

### DIFF
--- a/easybuild/easyconfigs/v/VMD/VMD-1.9.3-foss-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/v/VMD/VMD-1.9.3-foss-2017b-Python-2.7.14.eb
@@ -24,6 +24,7 @@ sources = [
 ]
 patches = [
     'VMD-%(version)s_configure.patch',
+    'VMD-%(version)s_plugins.patch',
     'VMD-%(version)s_surf_Makefile.patch',
     'VMD-%(version)s_surf_bad_printfs.patch',
     'VMD-%(version)s_stride_Makefile.patch',
@@ -33,6 +34,7 @@ checksums = [
     '5bdc314dc836d620fe510ed4b6c3dbe3cf66525b61680ffec4e2563cf495f128',  # vmd-1.9.3.src.tar.gz
     '51a8bc2988bb184bd08216124f61725225bb1a6f563bdf8cd35154cb5d621c1a',  # stride.tar.gz
     'b203eb1af21b643d3dfb18a38af17fbd96719048a750d22e4aefbb1b00cb3765',  # VMD-1.9.3_configure.patch
+    '85760d6ae838e2b09801e34b36b484532383f7aaf2e8634b3ef808002a92baa3',  # VMD-1.9.3_plugins.patch
     'd5cfa88064b7cffbc75accd69707d4e45fda974e8127de9ab606fdad501bd68a',  # VMD-1.9.3_surf_Makefile.patch
     'f3c2a8c155e38db8e644cee6a01f6beaea5988e72ac74cde26b71670b151cc34',  # VMD-1.9.3_surf_bad_printfs.patch
     'eb194ac0d8c086b73f87b29f7d732687f902431b1cdfa139c090401fefdee51e',  # VMD-1.9.3_stride_Makefile.patch

--- a/easybuild/easyconfigs/v/VMD/VMD-1.9.3-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/v/VMD/VMD-1.9.3-intel-2016b-Python-2.7.12.eb
@@ -24,6 +24,7 @@ sources = [
 ]
 patches = [
     'VMD-%(version)s_configure.patch',
+    'VMD-%(version)s_plugins.patch',
     'VMD-%(version)s_surf_Makefile.patch',
     'VMD-%(version)s_surf_bad_printfs.patch',
     'VMD-%(version)s_stride_Makefile.patch',
@@ -33,6 +34,7 @@ checksums = [
     '5bdc314dc836d620fe510ed4b6c3dbe3cf66525b61680ffec4e2563cf495f128',  # vmd-1.9.3.src.tar.gz
     '51a8bc2988bb184bd08216124f61725225bb1a6f563bdf8cd35154cb5d621c1a',  # stride.tar.gz
     'b203eb1af21b643d3dfb18a38af17fbd96719048a750d22e4aefbb1b00cb3765',  # VMD-1.9.3_configure.patch
+    '85760d6ae838e2b09801e34b36b484532383f7aaf2e8634b3ef808002a92baa3',  # VMD-1.9.3_plugins.patch
     'd5cfa88064b7cffbc75accd69707d4e45fda974e8127de9ab606fdad501bd68a',  # VMD-1.9.3_surf_Makefile.patch
     'f3c2a8c155e38db8e644cee6a01f6beaea5988e72ac74cde26b71670b151cc34',  # VMD-1.9.3_surf_bad_printfs.patch
     'eb194ac0d8c086b73f87b29f7d732687f902431b1cdfa139c090401fefdee51e',  # VMD-1.9.3_stride_Makefile.patch

--- a/easybuild/easyconfigs/v/VMD/VMD-1.9.3-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/v/VMD/VMD-1.9.3-intel-2018a-Python-2.7.14.eb
@@ -24,6 +24,7 @@ sources = [
 ]
 patches = [
     'VMD-%(version)s_configure.patch',
+    'VMD-%(version)s_plugins.patch',
     'VMD-%(version)s_surf_Makefile.patch',
     'VMD-%(version)s_surf_bad_printfs.patch',
     'VMD-%(version)s_stride_Makefile.patch',
@@ -33,6 +34,7 @@ checksums = [
     '5bdc314dc836d620fe510ed4b6c3dbe3cf66525b61680ffec4e2563cf495f128',  # vmd-1.9.3.src.tar.gz
     '51a8bc2988bb184bd08216124f61725225bb1a6f563bdf8cd35154cb5d621c1a',  # stride.tar.gz
     'b203eb1af21b643d3dfb18a38af17fbd96719048a750d22e4aefbb1b00cb3765',  # VMD-1.9.3_configure.patch
+    '85760d6ae838e2b09801e34b36b484532383f7aaf2e8634b3ef808002a92baa3',  # VMD-1.9.3_plugins.patch
     'd5cfa88064b7cffbc75accd69707d4e45fda974e8127de9ab606fdad501bd68a',  # VMD-1.9.3_surf_Makefile.patch
     'f3c2a8c155e38db8e644cee6a01f6beaea5988e72ac74cde26b71670b151cc34',  # VMD-1.9.3_surf_bad_printfs.patch
     'eb194ac0d8c086b73f87b29f7d732687f902431b1cdfa139c090401fefdee51e',  # VMD-1.9.3_stride_Makefile.patch

--- a/easybuild/easyconfigs/v/VMD/VMD-1.9.3-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/v/VMD/VMD-1.9.3-intel-2018b-Python-2.7.15.eb
@@ -24,6 +24,7 @@ sources = [
 ]
 patches = [
     'VMD-%(version)s_configure.patch',
+    'VMD-%(version)s_plugins.patch',
     'VMD-%(version)s_surf_Makefile.patch',
     'VMD-%(version)s_surf_bad_printfs.patch',
     'VMD-%(version)s_stride_Makefile.patch',
@@ -33,6 +34,7 @@ checksums = [
     '5bdc314dc836d620fe510ed4b6c3dbe3cf66525b61680ffec4e2563cf495f128',  # vmd-1.9.3.src.tar.gz
     '51a8bc2988bb184bd08216124f61725225bb1a6f563bdf8cd35154cb5d621c1a',  # stride.tar.gz
     'b203eb1af21b643d3dfb18a38af17fbd96719048a750d22e4aefbb1b00cb3765',  # VMD-1.9.3_configure.patch
+    '85760d6ae838e2b09801e34b36b484532383f7aaf2e8634b3ef808002a92baa3',  # VMD-1.9.3_plugins.patch
     'd5cfa88064b7cffbc75accd69707d4e45fda974e8127de9ab606fdad501bd68a',  # VMD-1.9.3_surf_Makefile.patch
     'f3c2a8c155e38db8e644cee6a01f6beaea5988e72ac74cde26b71670b151cc34',  # VMD-1.9.3_surf_bad_printfs.patch
     'eb194ac0d8c086b73f87b29f7d732687f902431b1cdfa139c090401fefdee51e',  # VMD-1.9.3_stride_Makefile.patch

--- a/easybuild/easyconfigs/v/VMD/VMD-1.9.3_plugins.patch
+++ b/easybuild/easyconfigs/v/VMD/VMD-1.9.3_plugins.patch
@@ -1,0 +1,29 @@
+Fix hard coded compiler, flags and tcl lib version for plugins
+
+Ake Sandgren, 20190823
+--- plugins/Make-arch.orig	2016-10-21 23:34:39.000000000 +0200
++++ plugins/Make-arch	2019-08-23 10:45:51.403545042 +0200
+@@ -337,17 +337,17 @@
+ 	"ARCH = LINUXAMD64" \
+ 	"COPTO = -fPIC -m64 -o " \
+ 	"LOPTO = -fPIC -m64 -lstdc++ -o " \
+-	"CC = gcc" \
+-	"CXX = g++" \
++	"CC = $(CC)" \
++	"CXX = $(CXX)" \
+ 	"DEF = -D" \
+-	"CCFLAGS = -m64 -O2 -fPIC -Wall" \
+-	"CXXFLAGS = -m64 -O2 -fPIC -Wall" \
+-	"TCLLDFLAGS = -ltcl8.5 -ldl" \
++	"CCFLAGS = $(CFLAGS)" \
++	"CXXFLAGS = $(CXXFLAGS)" \
++	"TCLLDFLAGS = $(TCLLDFLAGS)" \
+ 	"NETCDFLDFLAGS = -lnetcdf " \
+ 	"AR = ar" \
+ 	"NM = nm -p" \
+ 	"RANLIB = touch" \
+-	"SHLD = gcc -shared"
++	"SHLD = $(CC) -shared"
+ 
+ LINUXCARMA:
+ 	$(MAKE) dynlibs staticlibs bins \


### PR DESCRIPTION
Also use the correct compiler and flags.

Depends on ~~https://github.com/easybuilders/easybuild-easyblocks/pull/1786~~