### PR TITLE
Adding faulthandler patches to Python 3.7.0 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.7.0-foss-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.7.0-foss-2018b.eb
@@ -10,7 +10,11 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
-checksums = ['85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d']
+patches = ['Python-3.7-faulthandler.patch']
+checksums = [
+    '85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d',  # Python-3.7.0.tgz
+    'd061cd176a8aebb1895d84fd9134633abbdf9af26a22d649e5049df276574c08',  # Python-3.7-faulthandler.
+]
 
 # python needs bzip2 to build the bz2 package
 dependencies = [

--- a/easybuild/easyconfigs/p/Python/Python-3.7.0-intel-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.7.0-intel-2018b.eb
@@ -10,7 +10,11 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
-checksums = ['85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d']
+patches = ['Python-3.7-faulthandler.patch']
+checksums = [
+    '85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d',  # Python-3.7.0.tgz
+    'd061cd176a8aebb1895d84fd9134633abbdf9af26a22d649e5049df276574c08',  # Python-3.7-faulthandler.
+]
 
 # python needs bzip2 to build the bz2 package
 dependencies = [

--- a/easybuild/easyconfigs/p/Python/Python-3.7.0-iomkl-2018b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.7.0-iomkl-2018b.eb
@@ -10,7 +10,11 @@ toolchainopts = {'pic': True}
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
-checksums = ['85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d']
+patches = ['Python-3.7-faulthandler.patch']
+checksums = [
+    '85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d',  # Python-3.7.0.tgz
+    'd061cd176a8aebb1895d84fd9134633abbdf9af26a22d649e5049df276574c08',  # Python-3.7-faulthandler.
+]
 
 # python needs bzip2 to build the bz2 package
 dependencies = [


### PR DESCRIPTION
This request simply adds the patch file that was approved for

    add patch to Python 3.7.2 easyconfig to fix faulthandler segfault #8781

to the three Python 3.7.0 easyconfigs.
