### PR TITLE
fix issue where 'print_qiime_config.py -t' sanity check command fails for QIIME 1.9.1 because of subdir missing in $PYTHONPATH

### DIFF
--- a/easybuild/easyconfigs/q/QIIME/QIIME-1.9.1.eb
+++ b/easybuild/easyconfigs/q/QIIME/QIIME-1.9.1.eb
@@ -26,4 +26,6 @@ sanity_check_paths = {
 
 sanity_check_commands = ['print_qiime_config.py -t']
 
+modextrapaths = {'PYTHONPATH': 'site-packages'}
+
 moduleclass = 'bio'


### PR DESCRIPTION
It's unclear to me why we need to add `site-packages` to `$PYTHONPATH` now, and not before (see test reports in #3868)