### PR TITLE
disable threading in preprocessCore extension included with Bioconductor 3.9 to work around conflict with OpenBLAS's threading

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.9-foss-2019a-R-3.6.0.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.9-foss-2019a-R-3.6.0.eb
@@ -101,6 +101,9 @@ exts_list = [
     }),
     ('preprocessCore', '1.46.0', {
         'checksums': ['a062860681595930b98c98403d44242284a0692da197b7d42eac6e0a05b13e46'],
+        # disable internal threading to avoid crash in pthread_create
+        # see also https://github.com/bmbolstad/preprocessCore/issues/1
+        'installopts': "--configure-args='--disable-threading'",
     }),
     ('BiocManager', '1.30.4', {
         'checksums': ['50093f5c8ed8fba6e68bc715784b713887bdad3538fbb92f152dcc1eaf39ba4f'],


### PR DESCRIPTION
Fix for this problem:

```
Error in preprocessCore::normalize.quantiles(t(data), copy = FALSE) :
  ERROR; return code from pthread_create() is 22
Calls: Normalization -> QuantileNormalize -> t -> <Anonymous>
Execution halted
```

see also https://github.com/bmbolstad/preprocessCore/issues/1