### PR TITLE
bump AnnotationDb version in bundle for Bioconductor 3.9

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.9-foss-2019a-R-3.6.0.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.9-foss-2019a-R-3.6.0.eb
@@ -57,8 +57,8 @@ exts_list = [
     ('GenomeInfoDb', '1.20.0', {
         'checksums': ['d3b779ea43763f64a265bb39ff2379f8e5806b50013d7530185f8e1590ae707e'],
     }),
-    ('AnnotationDbi', '1.46.0', {
-        'checksums': ['2c098666635a28ef7ba2cbc74895d20d2b260785e8f40ef124581b858c29d851'],
+    ('AnnotationDbi', '1.46.1', {
+        'checksums': ['eaa5458c100fcc0bcb6ffef829cd77f8c2801a7ae24b8a546315f86fc9b7ca8e'],
     }),
     ('zlibbioc', '1.30.0', {
         'checksums': ['f3fc143bc9d39defdfbf1e74f6d08e2ffc22bb1ee21e7dff5769ba2cf4150ac0'],


### PR DESCRIPTION
Download of extensions included in `R-bundle-Bioconductor-3.9-foss-2019a-R-3.6.0.eb` is broken because `AnnotationDb`  version was bumped, and source tarball for old version is not available in archive...

see my rant at https://support.bioconductor.org/p/124200/