### PR TITLE
add missing Autotools build dep for fastq-tools

### DIFF
--- a/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2016b.eb
@@ -18,6 +18,8 @@ sources = ['v%(version)s.tar.gz']
 
 checksums = ['948613a7a4850cbb8ea55e93abd30b52f72c5b6c8815305a5c76620e451abd78']
 
+builddependencies = [('Autotools', '20150215')]
+
 dependencies = [
     ('PCRE', '8.38'),
     ('zlib', '1.2.8'),

--- a/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2018b.eb
+++ b/easybuild/easyconfigs/f/fastq-tools/fastq-tools-0.8-foss-2018b.eb
@@ -18,6 +18,8 @@ sources = ['v%(version)s.tar.gz']
 
 checksums = ['948613a7a4850cbb8ea55e93abd30b52f72c5b6c8815305a5c76620e451abd78']
 
+builddependencies = [('Autotools', '20180311')]
+
 dependencies = [
     ('PCRE', '8.41'),
     ('zlib', '1.2.11'),


### PR DESCRIPTION
`autogen.sh` is run via `preconfigopts`, so `Autotools` is needed

currently fails if `autoreconf` is not available in OS