### PR TITLE
avoid that easy_install installs easyconfigs package as a zipped egg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [easy_install]
 
+# never install as a zipped egg, since then easyconfig file can't be found
+zip_ok = 0


### PR DESCRIPTION
Even though we're not using `setuptools` anymore in `setup.py`, people could still use `easy_install` (provided by `setuptools`).
We need to make sure that the easyconfigs is not installed as a zipped egg, since we need the easyconfig files + patches to be accessible separately...