### PR TITLE
consider archive source URL for all extensions in R-tesseract easyconfig

### DIFF
--- a/easybuild/easyconfigs/r/R-tesseract/R-tesseract-4.0-foss-2018b-R-3.5.1.eb
+++ b/easybuild/easyconfigs/r/R-tesseract/R-tesseract-4.0-foss-2018b-R-3.5.1.eb
@@ -9,6 +9,8 @@ description = "The R extension for using tesseract"
 
 toolchain = {'name': 'foss', 'version': '2018b'}
 
+builddependencies = [('pkg-config', '0.29.2')]
+
 dependencies = [
     ('R', '3.5.1'),
     ('poppler', '0.70.1'),

--- a/easybuild/easyconfigs/r/R-tesseract/R-tesseract-4.0-foss-2018b-R-3.5.1.eb
+++ b/easybuild/easyconfigs/r/R-tesseract/R-tesseract-4.0-foss-2018b-R-3.5.1.eb
@@ -19,7 +19,7 @@ exts_defaultclass = 'RPackage'
 
 exts_default_options = {
     'source_urls': [
-        'https://cran.r-project.org/src/contrib/Archive/tesseract',  # package archive
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
         'https://cran.r-project.org/src/contrib/',  # current version of packages
         'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
     ],


### PR DESCRIPTION
downloading of `sys` extension fails without this change...