### PR TITLE
configure OpenMPI 1.10.x with --without-ucx to avoid problems when ucx-devel is installed in the OS

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.1-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.1-GCC-4.9.3-2.25.eb
@@ -17,6 +17,7 @@ dependencies = [('hwloc', '1.11.2')]
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-4.9.3-2.25.eb
@@ -17,6 +17,7 @@ dependencies = [('hwloc', '1.11.2')]
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-5.3.0-2.26.eb
@@ -17,6 +17,7 @@ dependencies = [('hwloc', '1.11.3')]
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-6.1.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-6.1.0-2.27.eb
@@ -17,6 +17,7 @@ dependencies = [('hwloc', '1.11.3')]
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.3-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.3-GCC-4.9.3-2.25.eb
@@ -15,7 +15,8 @@ checksums = ['01db467676cb5d974166591d403a8ffe38dfac4becb67071f59971e86bef0f63']
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--with-cxxrtlib="-lgcc_s -lstdc++"'  # for vt-mpi-unify
+configopts += '--with-cxxrtlib="-lgcc_s -lstdc++" '  # for vt-mpi-unify
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 dependencies = [('hwloc', '1.11.3')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.4-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.4-GCC-5.3.0-2.26.eb
@@ -15,7 +15,8 @@ checksums = ['01db467676cb5d974166591d403a8ffe38dfac4becb67071f59971e86bef0f63']
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--with-cxxrtlib="-lgcc_s -lstdc++"'  # for vt-mpi-unify
+configopts += '--with-cxxrtlib="-lgcc_s -lstdc++" '  # for vt-mpi-unify
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 dependencies = [('hwloc', '1.11.3')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-5.4.0-2.26.eb
@@ -17,6 +17,7 @@ dependencies = [('hwloc', '1.11.3')]
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-6.1.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-6.1.0-2.27.eb
@@ -17,6 +17,7 @@ dependencies = [('hwloc', '1.11.3')]
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -15,6 +15,7 @@ checksums = ['681c2ed1c96d187a3c84f30811a2b143d26de74884a740e5d02ec265ef70ab00']
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 dependencies = [('hwloc', '1.11.3')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-PGI-16.7-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-PGI-16.7-GCC-5.4.0-2.26.eb
@@ -15,7 +15,8 @@ checksums = ['492332cd77d8af8ce37ab9d82964dae7ddfc1c2c60c0b417973ff7a70cd89991']
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
-configopts += '--with-cxxrtlib="-lgcc_s -lstdc++"'  # for vt-mpi-unify
+configopts += '--with-cxxrtlib="-lgcc_s -lstdc++" '  # for vt-mpi-unify
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 dependencies = [('hwloc', '1.11.4')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -15,6 +15,7 @@ checksums = ['492332cd77d8af8ce37ab9d82964dae7ddfc1c2c60c0b417973ff7a70cd89991']
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--without-ucx '  # hard disable UCX, to dance around bug (https://github.com/open-mpi/ompi/issues/4345)
 
 dependencies = [('hwloc', '1.11.3')]
 


### PR DESCRIPTION
`--without-ucx` was already used in recent OpenMPI easyconfigs (see #5949), but I noticed that this also affects `OpenMPI` 1.10.x after `ucx-devel` was installed on our systems