### PR TITLE
Add GDAL 3.0.0 for Python 2.7.15 and fix the Python 3.7.2 version

### DIFF
--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.0.0-foss-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.0.0-foss-2019a-Python-2.7.15.eb
@@ -18,7 +18,7 @@ sources = [SOURCELOWER_TAR_XZ]
 checksums = ['ad316fa052d94d9606e90b20a514b92b2dd64e3142dfdbd8f10981a5fcd5c43e']
 
 dependencies = [
-    ('Python', '3.7.2'),
+    ('Python', '2.7.15'),
     ('netCDF', '4.6.2'),
     ('expat', '2.2.6'),
     ('GEOS', '3.7.2', '-Python-%(pyver)s'),
@@ -45,7 +45,8 @@ configopts += ' --with-libgeotiff=$EBROOTLIBGEOTIFF'
 modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
 
 sanity_check_paths = {
-    'files': ['lib/libgdal.a', 'lib/libgdal.%s' % SHLIB_EXT],
+    'files': ['lib/libgdal.a', 'lib/libgdal.%s' % SHLIB_EXT,
+              'lib/python%%(pyshortver)s/site-packages/osgeo/_gdal_array.%s' % SHLIB_EXT],
     'dirs': ['bin', 'include', 'lib/python%(pyshortver)s/site-packages']
 }
 

--- a/easybuild/easyconfigs/g/GEOS/GEOS-3.7.2-foss-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/g/GEOS/GEOS-3.7.2-foss-2019a-Python-2.7.15.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'GEOS'
+version = '3.7.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://trac.osgeo.org/geos'
+description = """GEOS (Geometry Engine - Open Source) is a C++ port of the  Java Topology Suite (JTS)"""
+
+toolchain = {'name': 'foss', 'version': '2019a'}
+
+source_urls = ['http://download.osgeo.org/geos/']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['2166e65be6d612317115bfec07827c11b403c3f303e0a7420a2106bc999d7707']
+
+dependencies = [('Python', '2.7.15')]
+
+builddependencies = [('SWIG', '3.0.12', versionsuffix)]
+
+configopts = '--enable-python'
+
+modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+
+sanity_check_paths = {
+    'files': ['bin/geos-config', 'lib/libgeos.%s' % SHLIB_EXT, 'lib/libgeos.a', 'include/geos.h'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/geos'],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/g/GEOS/GEOS-3.7.2-foss-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/g/GEOS/GEOS-3.7.2-foss-2019a-Python-2.7.15.eb
@@ -15,7 +15,7 @@ checksums = ['2166e65be6d612317115bfec07827c11b403c3f303e0a7420a2106bc999d7707']
 
 dependencies = [('Python', '2.7.15')]
 
-builddependencies = [('SWIG', '3.0.12', versionsuffix)]
+builddependencies = [('SWIG', '3.0.12')]
 
 configopts = '--enable-python'
 

--- a/easybuild/easyconfigs/g/GEOS/GEOS-3.7.2-foss-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/g/GEOS/GEOS-3.7.2-foss-2019a-Python-2.7.15.eb
@@ -15,10 +15,7 @@ checksums = ['2166e65be6d612317115bfec07827c11b403c3f303e0a7420a2106bc999d7707']
 
 dependencies = [('Python', '2.7.15')]
 
-builddependencies = [
-    ('Python', '2.7.15'),  # Make sure we get the Python 2.7.15 version of SWIG
-    ('SWIG', '3.0.12'),
-]
+builddependencies = [('SWIG', '3.0.12', versionsuffix)]
 
 configopts = '--enable-python'
 

--- a/easybuild/easyconfigs/g/GEOS/GEOS-3.7.2-foss-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/g/GEOS/GEOS-3.7.2-foss-2019a-Python-2.7.15.eb
@@ -15,7 +15,10 @@ checksums = ['2166e65be6d612317115bfec07827c11b403c3f303e0a7420a2106bc999d7707']
 
 dependencies = [('Python', '2.7.15')]
 
-builddependencies = [('SWIG', '3.0.12')]
+builddependencies = [
+    ('Python', '2.7.15'),  # Make sure we get the Python 2.7.15 version of SWIG
+    ('SWIG', '3.0.12'),
+]
 
 configopts = '--enable-python'
 

--- a/easybuild/easyconfigs/s/SWIG/SWIG-3.0.12-GCCcore-8.2.0-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/s/SWIG/SWIG-3.0.12-GCCcore-8.2.0-Python-2.7.15.eb
@@ -1,0 +1,23 @@
+name = 'SWIG'
+version = '3.0.12'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.swig.org/'
+description = """SWIG is a software development tool that connects programs written in C and C++ with
+ a variety of high-level programming languages."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['7cf9f447ae7ed1c51722efc45e7f14418d15d7a1e143ac9f09a668999f4fc94d']
+
+builddependencies = [('binutils', '2.31.1')]
+
+dependencies = [
+    ('Python', '2.7.15'),
+    ('PCRE', '8.43'),
+]
+
+moduleclass = 'devel'


### PR DESCRIPTION
This add GDAL 3.0.0 for Python 2.7.15 and fixes the Python 3.7.2 version. Without numpy the `_gdal_array` bindings are not generated (they live in `lib/python3.7/site-packages/osgeo`) - see https://gis.stackexchange.com/questions/153199/import-error-no-module-named-gdal-array