### PR TITLE
add patch for gettext 0.19.8* to avoid picking up global git config that could break the installation

### DIFF
--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8-GCCcore-4.9.3.eb
@@ -10,8 +10,13 @@ and documentation"""
 
 toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
 
-sources = [SOURCE_TAR_GZ]
 source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+patches = ['gettext-0.19.8_fix-git-config.patch']
+checksums = [
+    '3da4f6bd79685648ecf46dab51d66fcdddc156f41ed07e580a696a38ac61d48f',  # gettext-0.19.8.tar.gz
+    '196545e065173f558f28f32f1c153a5a590c8dd87163e92802e30f235764e179',  # gettext-0.19.8_fix-git-config.patch
+]
 
 builddependencies = [
     ('binutils', '2.25'),

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8-GCCcore-5.4.0.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCCcore', 'version': '5.4.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
-checksums = ['3da4f6bd79685648ecf46dab51d66fcdddc156f41ed07e580a696a38ac61d48f']
+patches = ['gettext-0.19.8_fix-git-config.patch']
+checksums = [
+    '3da4f6bd79685648ecf46dab51d66fcdddc156f41ed07e580a696a38ac61d48f',  # gettext-0.19.8.tar.gz
+    '196545e065173f558f28f32f1c153a5a590c8dd87163e92802e30f235764e179',  # gettext-0.19.8_fix-git-config.patch
+]
 
 dependencies = [
     ('libxml2', '2.9.4'),

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8-foss-2016.04.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8-foss-2016.04.eb
@@ -10,8 +10,13 @@ and documentation"""
 
 toolchain = {'name': 'foss', 'version': '2016.04'}
 
-sources = [SOURCE_TAR_GZ]
 source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+patches = ['gettext-0.19.8_fix-git-config.patch']
+checksums = [
+    '3da4f6bd79685648ecf46dab51d66fcdddc156f41ed07e580a696a38ac61d48f',  # gettext-0.19.8.tar.gz
+    '196545e065173f558f28f32f1c153a5a590c8dd87163e92802e30f235764e179',  # gettext-0.19.8_fix-git-config.patch
+]
 
 dependencies = [
     ('libxml2', '2.9.4'),

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8-foss-2016b.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8-foss-2016b.eb
@@ -10,8 +10,13 @@ and documentation"""
 
 toolchain = {'name': 'foss', 'version': '2016b'}
 
-sources = [SOURCE_TAR_GZ]
 source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+patches = ['gettext-0.19.8_fix-git-config.patch']
+checksums = [
+    '3da4f6bd79685648ecf46dab51d66fcdddc156f41ed07e580a696a38ac61d48f',  # gettext-0.19.8.tar.gz
+    '196545e065173f558f28f32f1c153a5a590c8dd87163e92802e30f235764e179',  # gettext-0.19.8_fix-git-config.patch
+]
 
 dependencies = [
     ('libxml2', '2.9.4'),

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8-intel-2016b.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8-intel-2016b.eb
@@ -10,8 +10,13 @@ and documentation"""
 
 toolchain = {'name': 'intel', 'version': '2016b'}
 
-sources = [SOURCE_TAR_GZ]
 source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+patches = ['gettext-0.19.8_fix-git-config.patch']
+checksums = [
+    '3da4f6bd79685648ecf46dab51d66fcdddc156f41ed07e580a696a38ac61d48f',  # gettext-0.19.8.tar.gz
+    '196545e065173f558f28f32f1c153a5a590c8dd87163e92802e30f235764e179',  # gettext-0.19.8_fix-git-config.patch
+]
 
 dependencies = [
     ('libxml2', '2.9.4'),

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1-GCCcore-6.3.0.eb
@@ -10,8 +10,13 @@ and documentation"""
 
 toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
 
-sources = [SOURCE_TAR_GZ]
 source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+patches = ['gettext-0.19.8_fix-git-config.patch']
+checksums = [
+    'ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43',  # gettext-0.19.8.1.tar.gz
+    '196545e065173f558f28f32f1c153a5a590c8dd87163e92802e30f235764e179',  # gettext-0.19.8_fix-git-config.patch
+]
 
 dependencies = [
     ('libxml2', '2.9.4'),

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1-GCCcore-6.4.0-libxml2-2.9.7.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1-GCCcore-6.4.0-libxml2-2.9.7.eb
@@ -14,7 +14,11 @@ toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
-checksums = ['ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43']
+patches = ['gettext-0.19.8_fix-git-config.patch']
+checksums = [
+    'ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43',  # gettext-0.19.8.1.tar.gz
+    '196545e065173f558f28f32f1c153a5a590c8dd87163e92802e30f235764e179',  # gettext-0.19.8_fix-git-config.patch
+]
 
 dependencies = [
     ('libxml2', local_libxml2_ver),

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1-GCCcore-6.4.0.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
-checksums = ['ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43']
+patches = ['gettext-0.19.8_fix-git-config.patch']
+checksums = [
+    'ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43',  # gettext-0.19.8.1.tar.gz
+    '196545e065173f558f28f32f1c153a5a590c8dd87163e92802e30f235764e179',  # gettext-0.19.8_fix-git-config.patch
+]
 
 dependencies = [
     ('libxml2', '2.9.4'),

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1-GCCcore-7.3.0.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
-checksums = ['ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43']
+patches = ['gettext-0.19.8_fix-git-config.patch']
+checksums = [
+    'ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43',  # gettext-0.19.8.1.tar.gz
+    '196545e065173f558f28f32f1c153a5a590c8dd87163e92802e30f235764e179',  # gettext-0.19.8_fix-git-config.patch
+]
 
 dependencies = [
     ('libxml2', '2.9.8'),

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1-GCCcore-8.2.0.eb
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
-checksums = ['ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43']
+patches = ['gettext-0.19.8_fix-git-config.patch']
+checksums = [
+    'ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43',  # gettext-0.19.8.1.tar.gz
+    '196545e065173f558f28f32f1c153a5a590c8dd87163e92802e30f235764e179',  # gettext-0.19.8_fix-git-config.patch
+]
 
 dependencies = [
     ('libxml2', '2.9.8'),

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1.eb
@@ -15,8 +15,13 @@ and documentation"""
 
 toolchain = SYSTEM
 
-sources = [SOURCE_TAR_GZ]
 source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+patches = ['gettext-0.19.8_fix-git-config.patch']
+checksums = [
+    'ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43',  # gettext-0.19.8.1.tar.gz
+    '196545e065173f558f28f32f1c153a5a590c8dd87163e92802e30f235764e179',  # gettext-0.19.8_fix-git-config.patch
+]
 
 dependencies = [('ncurses', '6.0')]
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8.eb
@@ -17,7 +17,11 @@ toolchain = SYSTEM
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
-checksums = ['3da4f6bd79685648ecf46dab51d66fcdddc156f41ed07e580a696a38ac61d48f']
+patches = ['gettext-0.19.8_fix-git-config.patch']
+checksums = [
+    '3da4f6bd79685648ecf46dab51d66fcdddc156f41ed07e580a696a38ac61d48f',  # gettext-0.19.8.tar.gz
+    '196545e065173f558f28f32f1c153a5a590c8dd87163e92802e30f235764e179',  # gettext-0.19.8_fix-git-config.patch
+]
 
 dependencies = [('ncurses', '6.0')]
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8_fix-git-config.patch
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8_fix-git-config.patch
@@ -1,0 +1,75 @@
+fix for "fatal: Failed to resolve 'HEAD' as a valid ref."
+see http://savannah.gnu.org/support/?107689
+--- gettext-0.19.8.1/gettext-tools/misc/autopoint.in.orig	2016-06-10 00:56:00.000000000 +0200
++++ gettext-0.19.8.1/gettext-tools/misc/autopoint.in	2019-09-21 08:47:08.277613496 +0200
+@@ -610,7 +610,12 @@
+     (git --version) >/dev/null 2>/dev/null || func_fatal_error "git program not found"
+     mkdir "$work_dir/archive"
+     gzip -d -c < "$gettext_datadir/archive.git.tar.gz" | (cd "$work_dir/archive" && tar xf -)
+-    (cd "$work_dir/archive" && git checkout -q "gettext-$ver") || {
++    (unset GIT_CONFIG
++     unset XDG_CONFIG_HOME
++     unset HOME
++     GIT_CONFIG_NOSYSTEM=1; export GIT_CONFIG_NOSYSTEM
++     cd "$work_dir/archive" && git checkout -q "gettext-$ver"
++    ) || {
+       rm -rf "$work_dir"
+       func_fatal_error "infrastructure files for version $ver not found; this is autopoint from GNU $package $version"
+     }
+--- gettext-0.19.8.1/gettext-tools/misc/convert-archive.in.orig	2016-03-20 08:37:53.000000000 +0100
++++ gettext-0.19.8.1/gettext-tools/misc/convert-archive.in	2019-09-21 08:47:08.277613496 +0200
+@@ -208,23 +208,27 @@
+ 
+     mkdir "$work_dir/master" || func_fatal_error "mkdir failed"
+     gzip -d -c < "$fromfile" | (cd "$work_dir/master" && tar xf -)
+-    cd "$work_dir"
+-    tags=`cd master && git tag`
+-    test -n "$tags" || func_fatal_error "no release tags found"
+-    for tag in $tags; do
+-      if test $tag != empty; then
+-        version=$tag
+-        (cd master && git checkout -q $tag) \
+-          || func_fatal_error "git checkout failed"
+-        rm -f master/.gitignore
+-        mv master/.git .git
+-        mkdir "$unpacked/$version" || func_fatal_error "mkdir failed"
+-        (cd master && tar cf - .) | (cd "$unpacked/$version" && tar xf -) \
+-          || func_fatal_error "file copy failed"
+-        mv .git master/.git
+-      fi
+-    done
+-    cd ..
++    (unset GIT_CONFIG
++     unset XDG_CONFIG_HOME
++     unset HOME
++     GIT_CONFIG_NOSYSTEM=1; export GIT_CONFIG_NOSYSTEM
++     cd "$work_dir"
++     tags=`cd master && git tag`
++     test -n "$tags" || func_fatal_error "no release tags found"
++     for tag in $tags; do
++       if test $tag != empty; then
++         version=$tag
++         (cd master && git checkout -q $tag) \
++           || func_fatal_error "git checkout failed"
++         rm -f master/.gitignore
++         mv master/.git .git
++         mkdir "$unpacked/$version" || func_fatal_error "mkdir failed"
++         (cd master && tar cf - .) | (cd "$unpacked/$version" && tar xf -) \
++           || func_fatal_error "file copy failed"
++         mv .git master/.git
++       fi
++     done
++    )
+     rm -rf "$work_dir"
+     ;;
+ esac
+@@ -320,6 +324,9 @@
+     git_dir=`pwd`/tmpgit$$
+     mkdir "$git_dir" || func_fatal_error "mkdir failed"
+     unset GIT_CONFIG
++    unset XDG_CONFIG_HOME
++    unset HOME
++    GIT_CONFIG_NOSYSTEM=1; export GIT_CONFIG_NOSYSTEM
+     (cd "$git_dir" && {
+       git init -q
+       git config user.name 'GNU Gettext Build'


### PR DESCRIPTION
cfr. problem reported by @sgowtham on Slack and via https://twitter.com/sgowtham/status/1175219728329166854

