### PR TITLE
ICU needs python 2.7+ to build, so add that as builddependency

### DIFF
--- a/easybuild/easyconfigs/i/ICU/ICU-64.2-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/i/ICU/ICU-64.2-GCCcore-8.2.0.eb
@@ -14,7 +14,10 @@ source_urls = ['http://download.icu-project.org/files/icu4c/%(version)s']
 sources = ['icu4c-%(version_major)s_%(version_minor)s-src.tgz']
 checksums = ['627d5d8478e6d96fc8c90fed4851239079a561a6a8b9e48b0892f24e82d31d6c']
 
-builddependencies = [('binutils', '2.31.1')]
+builddependencies = [
+    ('binutils', '2.31.1'),
+    ('Python', '2.7.15'),
+]
 
 start_dir = 'source'
 


### PR DESCRIPTION
It fails to build with system python 2.6 on CentOS 6.