### PR TITLE
{bio}[foss/2018b] AdapterRemoval v2.3.1

### DIFF
--- a/easybuild/easyconfigs/a/AdapterRemoval/AdapterRemoval-2.3.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/a/AdapterRemoval/AdapterRemoval-2.3.1-foss-2018b.eb
@@ -1,0 +1,39 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+
+easyblock = 'ConfigureMake'
+
+name = 'AdapterRemoval'
+version = '2.3.1'
+
+github_account = 'MikkelSchubert'
+homepage = 'https://github.com/%/(github_account)s/%(namelower)s'
+description = """AdapterRemoval searches for and removes remnant adapter sequences
+ from High-Throughput Sequencing (HTS) data and (optionally) trims low quality bases
+ from the 3' end of reads following adapter removal."""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+toolchainopts = {'pic': True}
+
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['2ce750372e1a2e786484807034b321a2593827d5a783454541e0b3c9f788eb3b']
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+]
+
+skipsteps = ['configure']
+
+installopts = "PREFIX=%(installdir)s"
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['bin/%(name)s'],
+    'dirs': ['share']
+}
+
+sanity_check_commands = [('%(name)s', '--version')]
+
+moduleclass = 'bio'


### PR DESCRIPTION
I changed the `easyblock` to `ConfigureMake` because the `Makefile` does actually have a `install` target.