### PR TITLE
comment out installation of git docs, since it requires additional OS deps

### DIFF
--- a/easybuild/easyconfigs/g/git/git-2.12.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/g/git/git-2.12.2-foss-2016b.eb
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 # asciidoc and xmlto are required for git man/doc build
-osdependencies = ['asciidoc', 'xmlto']
+# osdependencies = ['asciidoc', 'xmlto']
 
 preconfigopts = 'make configure && '
 
@@ -33,12 +33,12 @@ preconfigopts = 'make configure && '
 configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
 
 # required to also install documentation
-buildopts = "doc"
-installopts = "install-doc"
+# buildopts = "doc"
+# installopts = "install-doc"
 
 sanity_check_paths = {
     'files': ['bin/git'],
-    'dirs': ['share/man'],
+    'dirs': ['libexec/git-core', 'share'],
 }
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/g/git/git-2.13.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/g/git/git-2.13.1-foss-2016b.eb
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 # asciidoc and xmlto are required for git man/doc build
-osdependencies = ['asciidoc', 'xmlto']
+# osdependencies = ['asciidoc', 'xmlto']
 
 preconfigopts = 'make configure && '
 
@@ -33,12 +33,12 @@ preconfigopts = 'make configure && '
 configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
 
 # required to also install documentation
-buildopts = "doc"
-installopts = "install-doc"
+# buildopts = "doc"
+# installopts = "install-doc"
 
 sanity_check_paths = {
     'files': ['bin/git'],
-    'dirs': ['share/man'],
+    'dirs': ['libexec/git-core', 'share'],
 }
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/g/git/git-2.14.1-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/g/git/git-2.14.1-GCCcore-6.4.0.eb
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 # asciidoc and xmlto are required for git man/doc build
-osdependencies = ['asciidoc', 'xmlto']
+# osdependencies = ['asciidoc', 'xmlto']
 
 preconfigopts = 'make configure && '
 
@@ -34,12 +34,12 @@ preconfigopts = 'make configure && '
 configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
 
 # required to also install documentation
-buildopts = "doc"
-installopts = "install-doc"
+# buildopts = "doc"
+# installopts = "install-doc"
 
 sanity_check_paths = {
     'files': ['bin/git'],
-    'dirs': ['share/man'],
+    'dirs': ['libexec/git-core', 'share'],
 }
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/g/git/git-2.16.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/g/git/git-2.16.1-foss-2018a.eb
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 # asciidoc and xmlto are required for git man/doc build
-osdependencies = ['asciidoc', 'xmlto']
+# osdependencies = ['asciidoc', 'xmlto']
 
 preconfigopts = 'make configure && '
 
@@ -33,12 +33,12 @@ preconfigopts = 'make configure && '
 configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
 
 # required to also install documentation
-buildopts = "doc"
-installopts = "install-doc"
+# buildopts = "doc"
+# installopts = "install-doc"
 
 sanity_check_paths = {
     'files': ['bin/git'],
-    'dirs': ['share/man'],
+    'dirs': ['libexec/git-core', 'share'],
 }
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/g/git/git-2.18.0-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/g/git/git-2.18.0-GCCcore-7.3.0.eb
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 # asciidoc and xmlto are required for git man/doc build
-osdependencies = ['asciidoc', 'xmlto']
+# osdependencies = ['asciidoc', 'xmlto']
 
 preconfigopts = 'make configure && '
 
@@ -34,12 +34,12 @@ preconfigopts = 'make configure && '
 configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
 
 # required to also install documentation
-buildopts = "doc"
-installopts = "install-doc"
+# buildopts = "doc"
+# installopts = "install-doc"
 
 sanity_check_paths = {
     'files': ['bin/git'],
-    'dirs': ['share/man'],
+    'dirs': ['libexec/git-core', 'share'],
 }
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/g/git/git-2.19.1-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/g/git/git-2.19.1-GCCcore-7.3.0.eb
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 # asciidoc and xmlto are required for git man/doc build
-osdependencies = ['asciidoc', 'xmlto']
+# osdependencies = ['asciidoc', 'xmlto']
 
 preconfigopts = 'make configure && '
 
@@ -34,12 +34,12 @@ preconfigopts = 'make configure && '
 configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
 
 # required to also install documentation
-buildopts = "doc"
-installopts = "install-doc"
+# buildopts = "doc"
+# installopts = "install-doc"
 
 sanity_check_paths = {
     'files': ['bin/git'],
-    'dirs': ['share/man'],
+    'dirs': ['libexec/git-core', 'share'],
 }
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/g/git/git-2.21.0-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/g/git/git-2.21.0-GCCcore-8.2.0.eb
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 # asciidoc and xmlto are required for git man/doc build
-osdependencies = ['asciidoc', 'xmlto']
+# osdependencies = ['asciidoc', 'xmlto']
 
 preconfigopts = 'make configure && '
 
@@ -34,12 +34,12 @@ preconfigopts = 'make configure && '
 configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
 
 # required to also install documentation
-buildopts = "doc"
-installopts = "install-doc"
+# buildopts = "doc"
+# installopts = "install-doc"
 
 sanity_check_paths = {
     'files': ['bin/git'],
-    'dirs': ['share/man'],
+    'dirs': ['libexec/git-core', 'share'],
 }
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/g/git/git-2.23.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/git/git-2.23.0-GCCcore-8.3.0.eb
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 # asciidoc and xmlto are required for git man/doc build
-osdependencies = ['asciidoc', 'xmlto']
+# osdependencies = ['asciidoc', 'xmlto']
 
 preconfigopts = 'make configure && '
 
@@ -35,12 +35,12 @@ preconfigopts = 'make configure && '
 configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
 
 # required to also install documentation
-buildopts = "doc"
-installopts = "install-doc"
+# buildopts = "doc"
+# installopts = "install-doc"
 
 sanity_check_paths = {
     'files': ['bin/git'],
-    'dirs': ['share/man'],
+    'dirs': ['libexec/git-core', 'share'],
 }
 
 moduleclass = 'tools'


### PR DESCRIPTION
We've started also installing the docs with `git` in #6751 as a response to the issue reported by @chrissamuel in #6746, but I think we should reconsider that because of the required OS dependencies it implies (see #7028), which I was not aware of initially...

The reason I bring this up now is because TensorFlow 2.0 requires a sufficiently recent `git` to be installed, which we take of by including `git` as a build dependency (see #9065).

If `asciidoc` and `xmlto` (which are not easy to provide in EasyBuild, see https://github.com/easybuilders/easybuild-easyconfigs/pull/7028#issuecomment-430185379) are required for installing `git`, then anyone who wants to build TensorFlow 2.x from source will need to install those packages in the OS first, which is silly...

For sites who want to have `git` installed with documentation included, they can opt in by putting back the lines in the `git` easyconfig I'm commenting out here...