### PR TITLE
fix urls for Anaconda and Miniconda

### DIFF
--- a/easybuild/easyconfigs/a/Anaconda2/Anaconda2-2018.12.eb
+++ b/easybuild/easyconfigs/a/Anaconda2/Anaconda2-2018.12.eb
@@ -5,7 +5,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda2'
 version = '2018.12'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -13,7 +13,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['1821d4b623ed449e0acb6df3ecbabd3944cffa98f96a5234b7a102a7c0853dc6']
 

--- a/easybuild/easyconfigs/a/Anaconda2/Anaconda2-2019.03.eb
+++ b/easybuild/easyconfigs/a/Anaconda2/Anaconda2-2019.03.eb
@@ -6,7 +6,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda2'
 version = '2019.03'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -14,7 +14,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['cedfee5b5a3f62fcdac0a1d2d12396d0f232d2213d24d6dc893df5d8e64b8773']
 

--- a/easybuild/easyconfigs/a/Anaconda2/Anaconda2-2019.07.eb
+++ b/easybuild/easyconfigs/a/Anaconda2/Anaconda2-2019.07.eb
@@ -6,7 +6,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda2'
 version = '2019.07'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -14,7 +14,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['189e16e7adf9ba4b7b7d06ecdc10ce4ad4153e5e3505b9331f3d142243e18e97']
 

--- a/easybuild/easyconfigs/a/Anaconda2/Anaconda2-4.0.0.eb
+++ b/easybuild/easyconfigs/a/Anaconda2/Anaconda2-4.0.0.eb
@@ -12,7 +12,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['http://repo.anaconda.com/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['ae312143952ca00e061a656c2080e0e4fd3532721282ba8e2978177cad71a5f0']
 

--- a/easybuild/easyconfigs/a/Anaconda2/Anaconda2-4.0.0.eb
+++ b/easybuild/easyconfigs/a/Anaconda2/Anaconda2-4.0.0.eb
@@ -14,7 +14,7 @@ toolchain = SYSTEM
 
 source_urls = ['http://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
-checksums = ['31ed3ef07435d7068e1e03be49381b13']
+checksums = ['ae312143952ca00e061a656c2080e0e4fd3532721282ba8e2978177cad71a5f0']
 
 # a newer version of conda is required to run 'conda env create -p'
 local_prep_env = "PATH=%(installdir)s/bin:$PATH "

--- a/easybuild/easyconfigs/a/Anaconda2/Anaconda2-4.0.0.eb
+++ b/easybuild/easyconfigs/a/Anaconda2/Anaconda2-4.0.0.eb
@@ -4,7 +4,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda2'
 version = '4.0.0'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -12,7 +12,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['http://repo.continuum.io/archive/']
+source_urls = ['http://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['31ed3ef07435d7068e1e03be49381b13']
 

--- a/easybuild/easyconfigs/a/Anaconda2/Anaconda2-4.2.0.eb
+++ b/easybuild/easyconfigs/a/Anaconda2/Anaconda2-4.2.0.eb
@@ -4,7 +4,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda2'
 version = '4.2.0'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -12,7 +12,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['beee286d24fb37dd6555281bba39b3deb5804baec509a9dc5c69185098cf661a']
 

--- a/easybuild/easyconfigs/a/Anaconda2/Anaconda2-4.4.0.eb
+++ b/easybuild/easyconfigs/a/Anaconda2/Anaconda2-4.4.0.eb
@@ -5,7 +5,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda2'
 version = '4.4.0'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -13,7 +13,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['2d30b91ed4d215b6b4a15162a3389e9057b15445a0c02da71bd7bd272e7b824e']
 

--- a/easybuild/easyconfigs/a/Anaconda2/Anaconda2-5.0.1.eb
+++ b/easybuild/easyconfigs/a/Anaconda2/Anaconda2-5.0.1.eb
@@ -5,7 +5,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda2'
 version = '5.0.1'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -13,7 +13,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['23c676510bc87c95184ecaeb327c0b2c88007278e0d698622e2dd8fb14d9faa4']
 

--- a/easybuild/easyconfigs/a/Anaconda2/Anaconda2-5.1.0.eb
+++ b/easybuild/easyconfigs/a/Anaconda2/Anaconda2-5.1.0.eb
@@ -5,7 +5,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda2'
 version = '5.1.0'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -13,7 +13,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['5f26ee92860d1dffdcd20910ff2cf75572c39d2892d365f4e867a611cca2af5b']
 

--- a/easybuild/easyconfigs/a/Anaconda2/Anaconda2-5.3.0.eb
+++ b/easybuild/easyconfigs/a/Anaconda2/Anaconda2-5.3.0.eb
@@ -5,7 +5,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda2'
 version = '5.3.0'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -13,7 +13,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['50eeaab24bfa2472bc6485fe8f0e612ed67e561eda1ff9fbf07b62c96443c1be']
 

--- a/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2018.12.eb
+++ b/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2018.12.eb
@@ -6,7 +6,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda3'
 version = '2018.12'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -14,7 +14,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['1019d0857e5865f8a6861eaf15bfe535b87e92b72ce4f531000dc672be7fce00']
 

--- a/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2019.03.eb
+++ b/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2019.03.eb
@@ -7,7 +7,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda3'
 version = '2019.03'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -15,7 +15,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['45c851b7497cc14d5ca060064394569f724b67d9b5f98a926ed49b834a6bb73a']
 

--- a/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2019.07.eb
+++ b/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2019.07.eb
@@ -7,7 +7,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda3'
 version = '2019.07'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -15,7 +15,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['69581cf739365ec7fb95608eef694ba959d7d33b36eb961953f2b82cb25bdf5a']
 

--- a/easybuild/easyconfigs/a/Anaconda3/Anaconda3-4.0.0.eb
+++ b/easybuild/easyconfigs/a/Anaconda3/Anaconda3-4.0.0.eb
@@ -4,7 +4,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda3'
 version = '4.0.0'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -12,7 +12,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['http://repo.continuum.io/archive/']
+source_urls = ['http://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['546d1f02597587c685fa890c1d713b51']
 

--- a/easybuild/easyconfigs/a/Anaconda3/Anaconda3-4.0.0.eb
+++ b/easybuild/easyconfigs/a/Anaconda3/Anaconda3-4.0.0.eb
@@ -14,7 +14,7 @@ toolchain = SYSTEM
 
 source_urls = ['http://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
-checksums = ['546d1f02597587c685fa890c1d713b51']
+checksums = ['36a558a1109868661a5735f5f32607643f6dc05cf581fefb1c10fb8abbe22f39']
 
 # a newer version of conda is required to run 'conda env create -p'
 local_prep_env = "PATH=%(installdir)s/bin:$PATH "

--- a/easybuild/easyconfigs/a/Anaconda3/Anaconda3-4.0.0.eb
+++ b/easybuild/easyconfigs/a/Anaconda3/Anaconda3-4.0.0.eb
@@ -12,7 +12,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['http://repo.anaconda.com/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['36a558a1109868661a5735f5f32607643f6dc05cf581fefb1c10fb8abbe22f39']
 

--- a/easybuild/easyconfigs/a/Anaconda3/Anaconda3-4.2.0.eb
+++ b/easybuild/easyconfigs/a/Anaconda3/Anaconda3-4.2.0.eb
@@ -4,7 +4,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda3'
 version = '4.2.0'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -12,7 +12,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['73b51715a12b6382dd4df3dd1905b531bd6792d4aa7273b2377a0436d45f0e78']
 

--- a/easybuild/easyconfigs/a/Anaconda3/Anaconda3-4.4.0.eb
+++ b/easybuild/easyconfigs/a/Anaconda3/Anaconda3-4.4.0.eb
@@ -5,7 +5,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda3'
 version = '4.4.0'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -13,7 +13,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['3301b37e402f3ff3df216fe0458f1e6a4ccbb7e67b4d626eae9651de5ea3ab63']
 

--- a/easybuild/easyconfigs/a/Anaconda3/Anaconda3-5.0.1.eb
+++ b/easybuild/easyconfigs/a/Anaconda3/Anaconda3-5.0.1.eb
@@ -5,7 +5,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda3'
 version = '5.0.1'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -13,7 +13,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['55e4db1919f49c92d5abbf27a4be5986ae157f074bf9f8238963cd4582a4068a']
 

--- a/easybuild/easyconfigs/a/Anaconda3/Anaconda3-5.1.0.eb
+++ b/easybuild/easyconfigs/a/Anaconda3/Anaconda3-5.1.0.eb
@@ -6,7 +6,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda3'
 version = '5.1.0'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -14,7 +14,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['7e6785caad25e33930bc03fac4994a434a21bc8401817b7efa28f53619fa9c29']
 

--- a/easybuild/easyconfigs/a/Anaconda3/Anaconda3-5.3.0.eb
+++ b/easybuild/easyconfigs/a/Anaconda3/Anaconda3-5.3.0.eb
@@ -6,7 +6,7 @@ easyblock = 'EB_Anaconda'
 name = 'Anaconda3'
 version = '5.3.0'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://www.anaconda.com'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -14,7 +14,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/archive/']
+source_urls = ['https://repo.anaconda.com/archive/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['cfbf5fe70dd1b797ec677e63c61f8efc92dad930fd1c94d60390bb07fdc09959']
 

--- a/easybuild/easyconfigs/m/Miniconda2/Miniconda2-4.3.21.eb
+++ b/easybuild/easyconfigs/m/Miniconda2/Miniconda2-4.3.21.eb
@@ -4,10 +4,9 @@ name = 'Miniconda2'
 version = '4.3.21'
 
 homepage = 'https://docs.conda.io/en/latest/miniconda.html'
-description = """Built to complement the rich, open source Python community,
-the Anaconda platform provides an enterprise-ready data analytics platform 
-that empowers companies to adopt a modern open data science analytics architecture.
-"""
+description = """Miniconda is a free minimal installer for conda. It is a small,
+ bootstrap version of Anaconda that includes only conda, Python, the packages they
+ depend on, and a small number of other useful packages."""
 
 toolchain = SYSTEM
 

--- a/easybuild/easyconfigs/m/Miniconda2/Miniconda2-4.3.21.eb
+++ b/easybuild/easyconfigs/m/Miniconda2/Miniconda2-4.3.21.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_Anaconda'
 name = 'Miniconda2'
 version = '4.3.21'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://docs.conda.io/en/latest/miniconda.html'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -11,7 +11,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/miniconda/']
+source_urls = ['https://repo.anaconda.com/miniconda/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/m/Miniconda2/Miniconda2-4.3.21.eb
+++ b/easybuild/easyconfigs/m/Miniconda2/Miniconda2-4.3.21.eb
@@ -13,5 +13,6 @@ toolchain = SYSTEM
 
 source_urls = ['https://repo.anaconda.com/miniconda/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
+checksums = ['5097d5ec484a345c8785655113b19b88bfcd69af5f25a36c832ce498f02ea052']
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/m/Miniconda2/Miniconda2-4.6.14.eb
+++ b/easybuild/easyconfigs/m/Miniconda2/Miniconda2-4.6.14.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_Anaconda'
 name = 'Miniconda2'
 version = '4.6.14'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://docs.conda.io/en/latest/miniconda.html'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -11,7 +11,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/miniconda/']
+source_urls = ['https://repo.anaconda.com/miniconda/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['3e20425afa1a2a4c45ee30bd168b90ca30a3fdf8598b61cb68432886aadc6f4d']
 

--- a/easybuild/easyconfigs/m/Miniconda2/Miniconda2-4.6.14.eb
+++ b/easybuild/easyconfigs/m/Miniconda2/Miniconda2-4.6.14.eb
@@ -4,10 +4,9 @@ name = 'Miniconda2'
 version = '4.6.14'
 
 homepage = 'https://docs.conda.io/en/latest/miniconda.html'
-description = """Built to complement the rich, open source Python community,
-the Anaconda platform provides an enterprise-ready data analytics platform 
-that empowers companies to adopt a modern open data science analytics architecture.
-"""
+description = """Miniconda is a free minimal installer for conda. It is a small,
+ bootstrap version of Anaconda that includes only conda, Python, the packages they
+ depend on, and a small number of other useful packages."""
 
 toolchain = SYSTEM
 

--- a/easybuild/easyconfigs/m/Miniconda2/Miniconda2-4.7.10.eb
+++ b/easybuild/easyconfigs/m/Miniconda2/Miniconda2-4.7.10.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_Anaconda'
 name = 'Miniconda2'
 version = '4.7.10'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://docs.conda.io/en/latest/miniconda.html'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -11,7 +11,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/miniconda/']
+source_urls = ['https://repo.anaconda.com/miniconda/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['9b1c7899f3bfcd520203eb7d51bfe456e25e5700dfa877c09bd2dbb028c305d8']
 

--- a/easybuild/easyconfigs/m/Miniconda2/Miniconda2-4.7.10.eb
+++ b/easybuild/easyconfigs/m/Miniconda2/Miniconda2-4.7.10.eb
@@ -4,10 +4,9 @@ name = 'Miniconda2'
 version = '4.7.10'
 
 homepage = 'https://docs.conda.io/en/latest/miniconda.html'
-description = """Built to complement the rich, open source Python community,
-the Anaconda platform provides an enterprise-ready data analytics platform 
-that empowers companies to adopt a modern open data science analytics architecture.
-"""
+description = """Miniconda is a free minimal installer for conda. It is a small,
+ bootstrap version of Anaconda that includes only conda, Python, the packages they
+ depend on, and a small number of other useful packages."""
 
 toolchain = SYSTEM
 

--- a/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.4.10.eb
+++ b/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.4.10.eb
@@ -4,10 +4,9 @@ name = 'Miniconda3'
 version = '4.4.10'
 
 homepage = 'https://docs.conda.io/en/latest/miniconda.html'
-description = """Built to complement the rich, open source Python community,
-the Anaconda platform provides an enterprise-ready data analytics platform 
-that empowers companies to adopt a modern open data science analytics architecture.
-"""
+description = """Miniconda is a free minimal installer for conda. It is a small,
+ bootstrap version of Anaconda that includes only conda, Python, the packages they
+ depend on, and a small number of other useful packages."""
 
 toolchain = SYSTEM
 

--- a/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.4.10.eb
+++ b/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.4.10.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_Anaconda'
 name = 'Miniconda3'
 version = '4.4.10'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://docs.conda.io/en/latest/miniconda.html'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -11,7 +11,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/miniconda/']
+source_urls = ['https://repo.anaconda.com/miniconda/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['0c2e9b992b2edd87eddf954a96e5feae86dd66d69b1f6706a99bd7fa75e7a891']
 

--- a/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.5.12.eb
+++ b/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.5.12.eb
@@ -4,10 +4,9 @@ name = 'Miniconda3'
 version = '4.5.12'
 
 homepage = 'https://docs.conda.io/en/latest/miniconda.html'
-description = """Built to complement the rich, open source Python community,
-the Anaconda platform provides an enterprise-ready data analytics platform 
-that empowers companies to adopt a modern open data science analytics architecture.
-"""
+description = """Miniconda is a free minimal installer for conda. It is a small,
+ bootstrap version of Anaconda that includes only conda, Python, the packages they
+ depend on, and a small number of other useful packages."""
 
 toolchain = SYSTEM
 

--- a/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.5.12.eb
+++ b/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.5.12.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_Anaconda'
 name = 'Miniconda3'
 version = '4.5.12'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://docs.conda.io/en/latest/miniconda.html'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -11,7 +11,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/miniconda/']
+source_urls = ['https://repo.anaconda.com/miniconda/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['e5e5b4cd2a918e0e96b395534222773f7241dc59d776db1b9f7fedfcb489157a']
 

--- a/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.6.14.eb
+++ b/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.6.14.eb
@@ -4,10 +4,9 @@ name = 'Miniconda3'
 version = '4.6.14'
 
 homepage = 'https://docs.conda.io/en/latest/miniconda.html'
-description = """Built to complement the rich, open source Python community,
-the Anaconda platform provides an enterprise-ready data analytics platform 
-that empowers companies to adopt a modern open data science analytics architecture.
-"""
+description = """Miniconda is a free minimal installer for conda. It is a small,
+ bootstrap version of Anaconda that includes only conda, Python, the packages they
+ depend on, and a small number of other useful packages."""
 
 toolchain = SYSTEM
 

--- a/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.6.14.eb
+++ b/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.6.14.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_Anaconda'
 name = 'Miniconda3'
 version = '4.6.14'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://docs.conda.io/en/latest/miniconda.html'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -11,7 +11,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/miniconda/']
+source_urls = ['https://repo.anaconda.com/miniconda/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['0d6b23895a91294a4924bd685a3a1f48e35a17970a073cd2f684ffe2c31fc4be']
 

--- a/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.7.10.eb
+++ b/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.7.10.eb
@@ -3,7 +3,7 @@ easyblock = 'EB_Anaconda'
 name = 'Miniconda3'
 version = '4.7.10'
 
-homepage = 'https://www.continuum.io/anaconda-overview'
+homepage = 'https://docs.conda.io/en/latest/miniconda.html'
 description = """Built to complement the rich, open source Python community,
 the Anaconda platform provides an enterprise-ready data analytics platform 
 that empowers companies to adopt a modern open data science analytics architecture.
@@ -11,7 +11,7 @@ that empowers companies to adopt a modern open data science analytics architectu
 
 toolchain = SYSTEM
 
-source_urls = ['https://repo.continuum.io/miniconda/']
+source_urls = ['https://repo.anaconda.com/miniconda/']
 sources = ['%(name)s-%(version)s-Linux-x86_64.sh']
 checksums = ['8a324adcc9eaf1c09e22a992bb6234d91a94146840ee6b11c114ecadafc68121']
 

--- a/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.7.10.eb
+++ b/easybuild/easyconfigs/m/Miniconda3/Miniconda3-4.7.10.eb
@@ -4,10 +4,9 @@ name = 'Miniconda3'
 version = '4.7.10'
 
 homepage = 'https://docs.conda.io/en/latest/miniconda.html'
-description = """Built to complement the rich, open source Python community,
-the Anaconda platform provides an enterprise-ready data analytics platform 
-that empowers companies to adopt a modern open data science analytics architecture.
-"""
+description = """Miniconda is a free minimal installer for conda. It is a small,
+ bootstrap version of Anaconda that includes only conda, Python, the packages they
+ depend on, and a small number of other useful packages."""
 
 toolchain = SYSTEM
 


### PR DESCRIPTION
`Anaconda` URLs changed from `continuum.io` to `anaconda.com`.

I also changed the homepage of `Miniconda` to a documentation site specific to `Miniconda`, maybe we can also use the description from this site instead of the same description as the one for `Anaconda`.