### PR TITLE
Theano: Use a cuDNN version that has support for the CUDA version in …

### DIFF
--- a/easybuild/easyconfigs/t/Theano/Theano-1.0.4-fosscuda-2019a.eb
+++ b/easybuild/easyconfigs/t/Theano/Theano-1.0.4-fosscuda-2019a.eb
@@ -17,7 +17,7 @@ multi_deps = {'Python': ['3.7.2', '2.7.15']}
 
 dependencies = [
     ('libgpuarray', '0.7.6'),
-    ('cuDNN', '7.4.2.24'),
+    ('cuDNN', '7.6.4.38'),
 ]
 
 download_dep_fail = True


### PR DESCRIPTION
…fosscuda/2019a (CUDA 10.1)