### PR TITLE
{data}[GCC/8.2.0-2.31.1] savvy v1.3.0 + shrinkwrap v1.0.0-beta

### DIFF
--- a/easybuild/easyconfigs/s/savvy/savvy-1.3.0-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/s/savvy/savvy-1.3.0-GCC-8.2.0-2.31.1.eb
@@ -1,0 +1,40 @@
+# This easyconfig was created by Simon Branford of the BEAR Software team at the University of Birmingham.
+easyblock = 'CMakeMake'
+
+name = 'savvy'
+version = '1.3.0'
+
+homepage = "https://github.com/statgen/savvy"
+description = """Interface to various variant calling formats."""
+
+toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/statgen/savvy/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['5fbf25ff0793de769f12d2a9e0a0f0f40dc3d315cbdbcd16fc6ab90949bfa172']
+
+builddependencies = [
+    ('binutils', '2.31.1'),
+    ('CMake', '3.13.3'),
+]
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('cURL', '7.63.0'),
+    ('HTSlib', '1.9'),
+    ('shrinkwrap', '1.0.0-beta'),
+    ('XZ', '5.2.4'),
+    ('zstd', '1.4.0'),
+]
+
+preconfigopts = "export LDFLAGS='-lcurl -lhts' && "
+
+sanity_check_paths = {
+    'files': ['bin/sav'],
+    'dirs': [],
+}
+
+sanity_check_commands = ['sav --help']
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/s/shrinkwrap/shrinkwrap-1.0.0-beta-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/s/shrinkwrap/shrinkwrap-1.0.0-beta-GCCcore-8.2.0.eb
@@ -9,7 +9,7 @@ description = """A std::streambuf wrapper for compression formats."""
 
 toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 
-source_urls = ['https://github.com/statgen/savvy/archive']
+source_urls = ['https://github.com/jonathonl/shrinkwrap/releases']
 sources = ['v%(version)s.tar.gz']
 checksums = ['c9e7e7eb4ea7ea85ddffd0d7ecdc2febdcac8486d178cdc99d762404fe3bb8dd']
 

--- a/easybuild/easyconfigs/s/shrinkwrap/shrinkwrap-1.0.0-beta-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/s/shrinkwrap/shrinkwrap-1.0.0-beta-GCCcore-8.2.0.eb
@@ -9,7 +9,7 @@ description = """A std::streambuf wrapper for compression formats."""
 
 toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 
-source_urls = ['https://github.com/jonathonl/shrinkwrap/releases']
+source_urls = ['https://github.com/jonathonl/shrinkwrap/archive']
 sources = ['v%(version)s.tar.gz']
 checksums = ['c9e7e7eb4ea7ea85ddffd0d7ecdc2febdcac8486d178cdc99d762404fe3bb8dd']
 

--- a/easybuild/easyconfigs/s/shrinkwrap/shrinkwrap-1.0.0-beta-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/s/shrinkwrap/shrinkwrap-1.0.0-beta-GCCcore-8.2.0.eb
@@ -1,0 +1,31 @@
+# This easyconfig was created by Simon Branford of the BEAR Software team at the University of Birmingham.
+easyblock = 'CMakeMake'
+
+name = 'shrinkwrap'
+version = '1.0.0-beta'
+
+homepage = "https://github.com/jonathonl/shrinkwrap"
+description = """A std::streambuf wrapper for compression formats."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
+
+source_urls = ['https://github.com/statgen/savvy/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['c9e7e7eb4ea7ea85ddffd0d7ecdc2febdcac8486d178cdc99d762404fe3bb8dd']
+
+builddependencies = [
+    ('binutils', '2.31.1'),
+    ('CMake', '3.13.3'),
+]
+
+dependencies = [
+    ('XZ', '5.2.4'),
+    ('zstd', '1.4.0'),
+]
+
+sanity_check_paths = {
+    'files': ['include/%%(name)s/%s.hpp' % i for i in ['gz', 'istream', 'xz', 'zstd']],
+    'dirs': [],
+}
+
+moduleclass = 'data'


### PR DESCRIPTION
The toolchain for `savvy` is `toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}` as it depends on `HTSlib` which has that toolchain - otherwise I'd have put them both at `GCCcore`.