### PR TITLE
add GitHub Actions workflow to run easybuild-easyconfigs test suite

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,125 @@
+name: easyconfigs unit tests
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python: [2.7, 3.5, 3.6, 3.7]
+        modules_tool: [Lmod-6.6.3, Lmod-7.8.22, Lmod-8.1.14]
+        module_syntax: [Lua, Tcl]
+        # exclude some configurations: only test Tcl module syntax with Lmod 7.x
+        exclude:
+          - modules_tool: Lmod-6.6.3
+            module_syntax: Tcl
+          - modules_tool: Lmod-8.1.14
+            module_syntax: Tcl
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{matrix.python}}
+        architecture: x64
+
+    - name: install OS & Python packages
+      run: |
+        sudo apt-get update
+        # for modules tool
+        sudo apt-get install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
+        # fix for lua-posix packaging issue, see https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082
+        sudo ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so
+        # for testing OpenMPI-system*eb we need to have Open MPI installed
+        sudo apt-get install libopenmpi-dev openmpi-bin
+        # required for test_dep_graph
+        pip install pep8 python-graph-core python-graph-dot
+
+    - name: install EasyBuild framework
+      run: |
+          cd $HOME
+          # first determine which branch of easybuild-framework repo to install
+          BRANCH=develop
+          if [ "x$GITHUB_BASE_REF" = 'xmaster' ]; then BRANCH=master; fi
+          if [ "x$GITHUB_BASE_REF" = 'x4.x' ]; then BRANCH=4.x; fi
+          echo "Using easybuild-framework branch $BRANCH (\$GITHUB_BASE_REF $GITHUB_BASE_REF)"
+
+          git clone -b $BRANCH --depth 10 --single-branch https://github.com/easybuilders/easybuild-framework.git
+          cd easybuild-framework; git log -n 1; cd -
+          pip install $PWD/easybuild-framework
+
+          git clone -b $BRANCH --depth 10 --single-branch https://github.com/hpcugent/easybuild-easyblocks.git
+          cd easybuild-easyblocks; git log -n 1; cd -
+          pip install $PWD/easybuild-easyblocks
+
+    - name: install modules tool
+      run: |
+          cd $HOME
+          # use install_eb_dep.sh script provided with easybuild-framework
+          export INSTALL_DEP=$(which install_eb_dep.sh)
+          echo "Found install_eb_dep.sh script: $INSTALL_DEP"
+
+          # install modules tool
+          source $INSTALL_DEP ${{matrix.modules_tool}} $HOME
+
+          # changes in environment are not passed to other steps, so need to create files...
+          echo $MOD_INIT > mod_init
+          echo $PATH > path
+          if [ ! -z $MODULESHOME ]; then echo $MODULESHOME > moduleshome; fi
+
+    - name: run test suite
+      env:
+        EB_VERBOSE: 1
+        EASYBUILD_MODULE_SYNTAX: ${{matrix.module_syntax}}
+      run: |
+          # pull in target so we can diff against it to obtain list of touched files
+          if [ "x$GITHUB_BASE_REF" != 'xmaster' ]; then git fetch -v origin ${GITHUB_BASE_REF}:${GITHUB_BASE_REF}; fi
+
+          # initialize environment for modules tool
+          if [ -f $HOME/moduleshome ]; then export MODULESHOME=$(cat $HOME/moduleshome); fi
+          source $(cat $HOME/mod_init); type module
+
+          # make sure 'eb' is available via $PATH, and that $PYTHONPATH is set (some tests expect that);
+          # also pick up changes to $PATH set by sourcing $MOD_INIT
+          WORKDIR=$GITHUB_WORKSPACE/easybuild-easyconfigs
+          export PATH=$WORKDIR/test/bin:$(cat $HOME/path)
+          export PYTHONPATH=$WORKDIR
+
+          # tell EasyBuild which modules tool is available
+          if [[ ${{matrix.modules_tool}} =~ ^modules-tcl- ]]; then
+            export EASYBUILD_MODULES_TOOL=EnvironmentModulesTcl
+          elif [[ ${{matrix.modules_tool}} =~ ^modules-3 ]]; then
+            export EASYBUILD_MODULES_TOOL=EnvironmentModulesC
+          elif [[ ${{matrix.modules_tool}} =~ ^modules-4 ]]; then
+            export EASYBUILD_MODULES_TOOL=EnvironmentModules
+          else
+            export EASYBUILD_MODULES_TOOL=Lmod
+          fi
+
+          eb --version
+          eb --show-config
+          # gather some useful info on test system
+          eb --show-system-info
+
+          # run test suite
+          python -O -m test.easyconfigs.suite
+
+          unset PYTHONPATH
+
+          # install easyconfigs via distribution package
+          python setup.py sdist
+          ls dist
+          pip install dist/easybuild-easyconfigs*tar.gz
+
+          # robot-paths value should not be empty, but have an entry that includes easybuild/easyconfigs subdir
+          eb --show-config | tee eb_show_config.out
+          grep "^robot-paths .*/easybuild/easyconfigs" eb_show_config.out
+          # check whether some specific easyconfig files are found
+          eb --search 'TensorFlow-1.14.*.eb' | tee eb_search_TF.out
+          grep '/TensorFlow-1.14.0-foss-2019a-Python-3.7.2.eb$' eb_search_TF.out
+          eb --search '^foss-2018b.eb' | tee eb_search_foss.out
+          grep '/foss-2018b.eb$' eb_search_foss.out
+
+          # try installing bzip2 with system toolchain (requires EB_bzip2 easyblock + easyconfig)
+          eb --prefix /tmp/$USER/$GITHUB_SHA bzip2-1.0.6.eb

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,11 +8,15 @@ jobs:
         python: [2.7, 3.5, 3.6, 3.7]
         modules_tool: [Lmod-6.6.3, Lmod-7.8.22, Lmod-8.1.14]
         module_syntax: [Lua, Tcl]
-        # exclude some configurations: only test Tcl module syntax with Lmod 7.x
+        # exclude some configurations: only test Tcl module syntax with Lmod 7.x and Python 2.7 & 3.5
         exclude:
           - modules_tool: Lmod-6.6.3
             module_syntax: Tcl
           - modules_tool: Lmod-8.1.14
+            module_syntax: Tcl
+          - python: 3.6
+            module_syntax: Tcl
+          - python: 3.7
             module_syntax: Tcl
       fail-fast: false
     steps:


### PR DESCRIPTION
Adding a configuration file to run the easyconfigs unit tests natively in GitHub, just like for framework (https://github.com/easybuilders/easybuild-framework/pull/3039) and easyblocks (https://github.com/easybuilders/easybuild-easyblocks/pull/1844), with the prospect of switching away from Travis CI...

Works as expected, see https://github.com/boegel/easybuild-easyconfigs/commit/61bca035d914e4adce48e4c7172358714b4144c7/checks?check_suite_id=299862067