### PR TITLE
apply fixes to ImageJ 1.51k easyconfig

### DIFF
--- a/easybuild/easyconfigs/i/ImageJ/ImageJ-1.51k.eb
+++ b/easybuild/easyconfigs/i/ImageJ/ImageJ-1.51k.eb
@@ -35,6 +35,6 @@ sanity_check_paths = {
     'dirs': ['plugins'],
 }
 
-modloadmsg = "To use ImageJ, run 'java -jar $EBROOTIMAGEJ/ij.jar -Dij1.plugins.dir=$EBROOTIMAGE/plugins'\n"
+modloadmsg = "To use ImageJ, run 'java -jar $EBROOTIMAGEJ/ij.jar -Dij1.plugins.dir=$EBROOTIMAGEJ/plugins'\n"
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/i/ImageJ/ImageJ-1.51k.eb
+++ b/easybuild/easyconfigs/i/ImageJ/ImageJ-1.51k.eb
@@ -14,15 +14,16 @@ source_urls = [
 ]
 sources = [
     'ij%(version_major)s%(version_minor)s-src.zip',
-    'morphology.zip',
+    # datestamp is determined by most recent file in zipball
+    {'download_filename': 'morphology.zip', 'filename': 'morphology-20160920.zip'},
 ]
 checksums = [
-    'e7b634bd1d46cec7694a6990180c5cd9',  # ij151k-src.zip
-    '21491b55bbef5cc50ebff495a4d2b420',  # morphology.zip
+    '186adf6756bb1008b1d9596ffb7e92efcaeca7411b19489368aa9e135751c0e1',  # ij151k-src.zip
+    'a273f53dd7f7af2692230374be7c88cb704845fa6c8bbb4b8ae48778d3226f38',  # morphology-20160920.zip
 ]
 
 dependencies = [
-    ('Java', '1.8.0_121'),
+    ('Java', '1.8'),
 ]
 
 builddependencies = [('ant', '1.10.1', '-Java-%(javaver)s')]


### PR DESCRIPTION
This is mostly about fixing the typo (`$EBROOTIMAGE` -> `$EBROOTIMAGEJ`) highlighted by @JackPerdue in #9197, but I also fixed the `Java` dep and the name of the `morphology.zip` source file to avoid name clashes with updated versions (see also #9197)