### PR TITLE
only run easyconfigs test suite with Python 2.7 & 3.6 + Lmod 7 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,12 @@ matrix:
   # mark build as finished as soon as job has failed
   fast_finish: true
   include:
-    - dist: trusty
-      python: 2.6
-      env: LMOD_VERSION=6.6.3 EASYBUILD_MODULE_SYNTAX=Tcl
-    # also test default configuration with Python 2.7
+    # only test with Python 2.7 & 3.6 + Lmod 7.x
+    # other test configurations in GitHub Actions (see .github/workflows/unit_tests.yml)
     - python: 2.7
-      env: LMOD_VERSION=6.6.3
-    # also test with Python 3.5/3.6/3.7
+      env: LMOD_VERSION=7.8.22
     - python: 3.6
-      env: LMOD_VERSION=7.8.5
-    - python: 3.5
-      env: LMOD_VERSION=7.8.5
-    - python: 3.7
-      dist: xenial
-      env: LMOD_VERSION=7.8.5
+      env: LMOD_VERSION=7.8.22
 addons:
   apt:
     packages:


### PR DESCRIPTION
More test configurations are run in GitHub CI, where test budget is significantly higher.