### PR TITLE
use protobuf 3.10.0 as build dep for TensorFlow 2.0.0 w/ fosscuda/2019b + use nodocs variant of git as build dep

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
@@ -12,9 +12,9 @@ toolchainopts = {'usempi': True}
 
 builddependencies = [
     ('Bazel', '0.26.1'),
-    ('protobuf', '3.7.1'),
+    ('protobuf', '3.10.0'),
     # git 2.x required, see also https://github.com/tensorflow/tensorflow/issues/29053
-    ('git', '2.23.0'),
+    ('git', '2.23.0', '-nodocs'),
 ]
 dependencies = [
     ('Python', '3.7.4'),


### PR DESCRIPTION
cfr. https://github.com/easybuilders/easybuild-easyconfigs/pull/9254#discussion_r346702032

cc @Flamefire

requires ~~#9280~~ (protobuf) + ~~#9294~~ (git nodocs)