### PR TITLE
enable running 'pip check' during sanity check for TensorFlow 2.0.0

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-foss-2019a-Python-3.7.2.eb
@@ -26,6 +26,10 @@ exts_default_options = {'source_urls': [PYPI_SOURCE]}
 use_pip = True
 
 exts_list = [
+    ('setuptools', '41.6.0', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'checksums': ['6afa61b391dcd16cb8890ec9f66cc4015a8a31a6e1c2b4e0c464514be1a3d722'],
+    }),
     ('protobuf-python', '3.9.2', {
         'modulename': 'google.protobuf',
         'patches': ['TensorFlow-1.13.1_protobuf-3.6.1.2_fix_26155.patch'],
@@ -46,8 +50,16 @@ exts_list = [
     ('astor', '0.8.0', {
         'checksums': ['37a6eed8b371f1228db08234ed7f6cfdc7817a3ed3824797e20cbb11dc2a7862'],
     }),
-    ('gast', '0.3.2', {
-        'checksums': ['5c7617f1f6c8b8b426819642b16b9016727ddaecd16af9a07753e537eba8a3a5'],
+    ('google-pasta', '0.1.8', {
+        'checksums': ['713813a9f7d6589e5defdaf21e80e4392eb124662f8bd829acd51a4f8735c0cb'],
+    }),
+    ('opt-einsum', '3.1.0', {
+        'source_tmpl': 'opt_einsum-%(version)s.tar.gz',
+        'checksums': ['edfada4b1d0b3b782ace8bc14e80618ff629abf53143e1e6bbf9bd00b11ece77'],
+    }),
+    # TensorFlow 2.0.0 requiures gast==0.2.2
+    ('gast', '0.2.2', {
+        'checksums': ['fe939df4583692f0512161ec1c880e0a10e71e6a232da045ab8edd3756fbadf0'],
     }),
     ('grpcio', '1.24.0', {
         'modulename': 'grpc',
@@ -56,6 +68,9 @@ exts_list = [
     ('Markdown', '3.1.1', {
         'checksums': ['2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a'],
     }),
+    ('Werkzeug', '0.16.0', {
+        'checksums': ['7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7'],
+    }),
     ('tensorboard', version, {
         'source_tmpl': 'tensorboard-%(version)s-py3-none-any.whl',
         'unpack_sources': False,
@@ -63,9 +78,6 @@ exts_list = [
     }),
     ('termcolor', '1.1.0', {
         'checksums': ['1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b'],
-    }),
-    ('Werkzeug', '0.16.0', {
-        'checksums': ['7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7'],
     }),
     ('Keras-Applications', '1.0.8', {
         'modulename': 'keras_applications',

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-foss-2019a-Python-3.7.2.eb
@@ -26,9 +26,12 @@ exts_default_options = {'source_urls': [PYPI_SOURCE]}
 use_pip = True
 
 exts_list = [
-    ('setuptools', '41.6.0', {
+    # tensorboard 2.0.0 requires setuptools >= 41.0;
+    # must stick to setuptools < 41.4 to avoid problems with astor,
+    # see https://github.com/berkerpeksag/astor/issues/162
+    ('setuptools', '41.3.0', {
         'source_tmpl': '%(name)s-%(version)s.zip',
-        'checksums': ['6afa61b391dcd16cb8890ec9f66cc4015a8a31a6e1c2b4e0c464514be1a3d722'],
+        'checksums': ['9f5c54b529b2156c6f288e837e625581bb31ff94d4cfd116b8f271c589749556'],
     }),
     ('protobuf-python', '3.9.2', {
         'modulename': 'google.protobuf',
@@ -119,8 +122,9 @@ exts_list = [
             'ee65c8e34b62644f426054b67386734b8bf51c43ac0da4d51331b4ba191fad17',
         ],
         'test_script': 'TensorFlow-2.x_mnist-test.py',
-        'sanity_pip_check': True,
     }),
 ]
+
+sanity_pip_check = True
 
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-foss-2019a-Python-3.7.2.eb
@@ -55,6 +55,7 @@ exts_list = [
     }),
     ('google-pasta', '0.1.8', {
         'checksums': ['713813a9f7d6589e5defdaf21e80e4392eb124662f8bd829acd51a4f8735c0cb'],
+        'modulename': 'pasta',
     }),
     ('opt-einsum', '3.1.0', {
         'source_tmpl': 'opt_einsum-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-foss-2019a-Python-3.7.2.eb
@@ -107,6 +107,7 @@ exts_list = [
             'ee65c8e34b62644f426054b67386734b8bf51c43ac0da4d51331b4ba191fad17',
         ],
         'test_script': 'TensorFlow-2.x_mnist-test.py',
+        'sanity_pip_check': True,
     }),
 ]
 

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
@@ -109,8 +109,9 @@ exts_list = [
             'ee65c8e34b62644f426054b67386734b8bf51c43ac0da4d51331b4ba191fad17',
         ],
         'test_script': 'TensorFlow-2.x_mnist-test.py',
-        'sanity_pip_check': True,
     }),
 ]
+
+sanity_pip_check = True
 
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
@@ -41,6 +41,7 @@ exts_list = [
     }),
     ('google-pasta', '0.1.8', {
         'checksums': ['713813a9f7d6589e5defdaf21e80e4392eb124662f8bd829acd51a4f8735c0cb'],
+        'modulename': 'pasta',
     }),
     ('opt-einsum', '3.1.0', {
         'source_tmpl': 'opt_einsum-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
@@ -39,12 +39,26 @@ exts_list = [
     ('astor', '0.8.0', {
         'checksums': ['37a6eed8b371f1228db08234ed7f6cfdc7817a3ed3824797e20cbb11dc2a7862'],
     }),
-    ('gast', '0.3.2', {
-        'checksums': ['5c7617f1f6c8b8b426819642b16b9016727ddaecd16af9a07753e537eba8a3a5'],
+    ('google-pasta', '0.1.8', {
+        'checksums': ['713813a9f7d6589e5defdaf21e80e4392eb124662f8bd829acd51a4f8735c0cb'],
+    }),
+    ('opt-einsum', '3.1.0', {
+        'source_tmpl': 'opt_einsum-%(version)s.tar.gz',
+        'checksums': ['edfada4b1d0b3b782ace8bc14e80618ff629abf53143e1e6bbf9bd00b11ece77'],
+    }),
+    # TensorFlow 2.0.0 requiures gast==0.2.2
+    ('gast', '0.2.2', {
+        'checksums': ['fe939df4583692f0512161ec1c880e0a10e71e6a232da045ab8edd3756fbadf0'],
     }),
     ('grpcio', '1.25.0', {
         'modulename': 'grpc',
         'checksums': ['c948c034d8997526011960db54f512756fb0b4be1b81140a15b4ef094c6594a4'],
+    }),
+    ('Markdown', '3.1.1', {
+        'checksums': ['2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a'],
+    }),
+    ('Werkzeug', '0.16.0', {
+        'checksums': ['7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7'],
     }),
     ('tensorboard', version, {
         'source_tmpl': 'tensorboard-%(version)s-py3-none-any.whl',

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
@@ -90,6 +90,7 @@ exts_list = [
     (name, version, {
         'patches': [
             'TensorFlow-1.14.0_swig-env.patch',
+            'TensorFlow-1.13.1_lrt-flag.patch',
             'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch',
             'TensorFlow-1.14.0_fix-cuda-build.patch',
@@ -100,6 +101,7 @@ exts_list = [
         'checksums': [
             '49b5f0495cd681cbcb5296a4476853d4aea19a43bdd9f179c928a977308a0617',  # v2.0.0.tar.gz
             'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',  # TensorFlow-1.14.0_swig-env.patch
+            'b388be35f2581786bcd533b1bfa375165d7f35e38a3aab74570019312816bf1b',  # TensorFlow-1.13.1_lrt-flag.patch
             # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
             'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             # TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
@@ -95,6 +95,7 @@ exts_list = [
             'ee65c8e34b62644f426054b67386734b8bf51c43ac0da4d51331b4ba191fad17',
         ],
         'test_script': 'TensorFlow-2.x_mnist-test.py',
+        'sanity_pip_check': True,
     }),
 ]
 


### PR DESCRIPTION
requires ~~https://github.com/easybuilders/easybuild-easyblocks/pull/1853~~

This will need more work, since `pip check` fails now with:

```
== 2019-11-15 20:42:53,223 build_log.py:164 ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:124 in __init__): cmd "pip check" exited with exit code 1 and output:
tensorflow 2.0.0 requires google-pasta, which is not installed.
tensorflow 2.0.0 requires opt-einsum, which is not installed.
tensorflow 2.0.0 has requirement gast==0.2.2, but you have gast 0.3.2.
tensorboard 2.0.0 has requirement setuptools>=41.0.0, but you have setuptools 40.8.0.
```

see also @Flamefire's bug report #9306