### PR TITLE
Fix #9274, Qt5/5.13.1-GCCcore-8.3.0 depends on JasPer.

### DIFF
--- a/easybuild/easyconfigs/j/JasPer/JasPer-2.0.14-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/j/JasPer/JasPer-2.0.14-GCCcore-8.3.0.eb
@@ -1,0 +1,35 @@
+easyblock = 'CMakeMake'
+
+name = 'JasPer'
+version = '2.0.14'
+
+homepage = 'https://www.ece.uvic.ca/~frodo/jasper/'
+
+description = """
+ The JasPer Project is an open-source initiative to provide a free
+ software-based reference implementation of the codec specified in
+ the JPEG-2000 Part-1 standard.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://www.ece.uvic.ca/~frodo/jasper/software/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['2a1f61e55afe8b4ce8115e1508c5d7cb314d56dfcc2dd323f90c072f88ccf57b']
+
+builddependencies = [
+    ('binutils', '2.31.1'),
+    ('CMake', '3.15.3'),
+]
+
+separate_build_dir = True
+
+configopts = '-DJAS_ENABLE_DOC=OFF '
+
+sanity_check_paths = {
+    'files': ['bin/jasper', ('lib/libjasper.%s' % SHLIB_EXT, 'lib64/libjasper.%s' % SHLIB_EXT)],
+    'dirs': ['include'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.13.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.13.1-GCCcore-8.3.0.eb
@@ -34,7 +34,8 @@ builddependencies = [
     ('gperf', '3.1'),
     ('Ninja', '1.9.0'),
     ('Python', '3.7.4'),
-    ('re2c', '1.2.1')
+    ('re2c', '1.2.1'),
+    ('JasPer', '2.0.14'),
 ]
 
 dependencies = [
@@ -50,6 +51,7 @@ dependencies = [
     ('libjpeg-turbo', '2.0.3'),
     ('NSS', '3.45'),
     ('snappy', '1.1.7'),
+    ('JasPer', '2.0.14'),
 ]
 
 # qtgamepad needs recent kernel/libevdev (fails on RHEL 6.x)


### PR DESCRIPTION
  - Qt5 depends on JasPer, which is missing from the spec.
  - Add JasPer for GCCcore-8.3.0.
  - Resolves https://github.com/easybuilders/easybuild-easyconfigs/issues/9274