### PR TITLE
bump h5py to 2.10.0 in 2019b easyconfigs

### DIFF
--- a/easybuild/easyconfigs/h/h5py/h5py-2.10.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.10.0-foss-2019b-Python-3.7.4.eb
@@ -1,7 +1,7 @@
 easyblock = 'PythonPackage'
 
 name = 'h5py'
-version = '2.9.0'
+version = '2.10.0'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://www.h5py.org/'
@@ -9,12 +9,12 @@ description = """HDF5 for Python (h5py) is a general-purpose Python interface to
  version 5. HDF5 is a versatile, mature scientific software library designed for the fast, flexible storage of enormous
  amounts of data."""
 
-toolchain = {'name': 'intel', 'version': '2019b'}
+toolchain = {'name': 'foss', 'version': '2019b'}
 toolchainopts = {'usempi': True}
 
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
-checksums = ['9d41ca62daf36d6b6515ab8765e4c8c4388ee18e2a665701fef2b41563821002']
+checksums = ['84412798925dc870ffd7107f045d7659e60f5d46d1c70c700375248bf6bf512d']
 
 builddependencies = [('pkgconfig', '1.5.1', versionsuffix)]
 

--- a/easybuild/easyconfigs/h/h5py/h5py-2.10.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.10.0-fosscuda-2019b-Python-3.7.4.eb
@@ -1,7 +1,7 @@
 easyblock = 'PythonPackage'
 
 name = 'h5py'
-version = '2.9.0'
+version = '2.10.0'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://www.h5py.org/'
@@ -9,12 +9,12 @@ description = """HDF5 for Python (h5py) is a general-purpose Python interface to
  version 5. HDF5 is a versatile, mature scientific software library designed for the fast, flexible storage of enormous
  amounts of data."""
 
-toolchain = {'name': 'foss', 'version': '2019b'}
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
 toolchainopts = {'usempi': True}
 
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
-checksums = ['9d41ca62daf36d6b6515ab8765e4c8c4388ee18e2a665701fef2b41563821002']
+checksums = ['84412798925dc870ffd7107f045d7659e60f5d46d1c70c700375248bf6bf512d']
 
 builddependencies = [('pkgconfig', '1.5.1', versionsuffix)]
 

--- a/easybuild/easyconfigs/h/h5py/h5py-2.10.0-intel-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.10.0-intel-2019b-Python-3.7.4.eb
@@ -1,7 +1,7 @@
 easyblock = 'PythonPackage'
 
 name = 'h5py'
-version = '2.9.0'
+version = '2.10.0'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://www.h5py.org/'
@@ -9,12 +9,12 @@ description = """HDF5 for Python (h5py) is a general-purpose Python interface to
  version 5. HDF5 is a versatile, mature scientific software library designed for the fast, flexible storage of enormous
  amounts of data."""
 
-toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchain = {'name': 'intel', 'version': '2019b'}
 toolchainopts = {'usempi': True}
 
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
-checksums = ['9d41ca62daf36d6b6515ab8765e4c8c4388ee18e2a665701fef2b41563821002']
+checksums = ['84412798925dc870ffd7107f045d7659e60f5d46d1c70c700375248bf6bf512d']
 
 builddependencies = [('pkgconfig', '1.5.1', versionsuffix)]
 

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.15.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.15.0-foss-2019b-Python-3.7.4.eb
@@ -21,7 +21,7 @@ builddependencies = [
 dependencies = [
     ('Python', '3.7.4'),
     ('SciPy-bundle', '2019.10', versionsuffix),
-    ('h5py', '2.9.0', versionsuffix),
+    ('h5py', '2.10.0', versionsuffix),
 ]
 
 exts_default_options = {

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.15.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.15.0-fosscuda-2019b-Python-3.7.4.eb
@@ -21,7 +21,7 @@ builddependencies = [
 dependencies = [
     ('Python', '3.7.4'),
     ('SciPy-bundle', '2019.10', versionsuffix),
-    ('h5py', '2.9.0', versionsuffix),
+    ('h5py', '2.10.0', versionsuffix),
     ('cuDNN', '7.6.4.38'),
     ('NCCL', '2.4.8'),
 ]

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
@@ -19,7 +19,7 @@ builddependencies = [
 dependencies = [
     ('Python', '3.7.4'),
     ('SciPy-bundle', '2019.10', versionsuffix),
-    ('h5py', '2.9.0', versionsuffix),
+    ('h5py', '2.10.0', versionsuffix),
     ('cuDNN', '7.6.4.38'),
     ('NCCL', '2.4.8'),
 ]


### PR DESCRIPTION
fixes #9395 (see also motivation there)

We usually don't make changes like this, but this one is still acceptable since there are no `h5py` easyconfigs using a `2019b` toolchain included in an EasyBuild release yet (only in `develop`), and all related PRs were merged fairly recently (see #9248, #9307 for `h5py`, #9382 + #9384 for TensorFlow 1.15.0 + #9254 for TensorFlow 2.0.0)

cc @Flamefire, @branfosj



