### PR TITLE
Python: Promote binutils to a runtime dependency for GCCcore based builds.

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.13-GCCcore-6.3.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.13-GCCcore-6.3.0-bare.eb
@@ -16,11 +16,8 @@ source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 checksums = ['a4f05a0720ce0fd92626f0278b6b433eee9a6173ddf2bced7957dfb599a5ece1']
 
-builddependencies = [
-    ('binutils', '2.27'),
-]
-
 dependencies = [
+    ('binutils', '2.27'),  # required for pip install that involves compilation
     ('bzip2', '1.0.6'),
     ('libreadline', '7.0'),
     ('ncurses', '6.0'),

--- a/easybuild/easyconfigs/p/Python/Python-2.7.13-GCCcore-6.3.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.13-GCCcore-6.3.0-bare.eb
@@ -2,7 +2,7 @@ name = 'Python'
 version = '2.7.13'
 versionsuffix = '-bare'
 
-homepage = 'http://python.org/'
+homepage = 'https://python.org/'
 
 description = """
  Python is a programming language that lets you work more quickly and
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+source_urls = ['https://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 checksums = ['a4f05a0720ce0fd92626f0278b6b433eee9a6173ddf2bced7957dfb599a5ece1']
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-GCCcore-6.4.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-GCCcore-6.4.0-bare.eb
@@ -15,11 +15,8 @@ checksums = ['304c9b202ea6fbd0a4a8e0ad3733715fbd4749f2204a9173a58ec53c32ea73e8']
 
 # python needs bzip2 to build the bz2 package
 
-builddependencies = [
-    ('binutils', '2.28'),
-]
-
 dependencies = [
+    ('binutils', '2.28'),  # required for pip install that involves compilation
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.11'),
     ('libreadline', '7.0'),

--- a/easybuild/easyconfigs/p/Python/Python-2.7.14-GCCcore-6.4.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.14-GCCcore-6.4.0-bare.eb
@@ -2,14 +2,14 @@ name = 'Python'
 version = '2.7.14'
 versionsuffix = '-bare'
 
-homepage = 'http://python.org/'
+homepage = 'https://python.org/'
 description = """Python is a programming language that lets you work more quickly and integrate your systems
  more effectively."""
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+source_urls = ['https://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 checksums = ['304c9b202ea6fbd0a4a8e0ad3733715fbd4749f2204a9173a58ec53c32ea73e8']
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-7.2.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-7.2.0-bare.eb
@@ -15,11 +15,8 @@ checksums = ['18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db']
 
 # python needs bzip2 to build the bz2 package
 
-builddependencies = [
-    ('binutils', '2.29'),
-]
-
 dependencies = [
+    ('binutils', '2.29'),  # required for pip install that involves compilation
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.11'),
     ('libreadline', '7.0'),

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-7.2.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-7.2.0-bare.eb
@@ -2,14 +2,14 @@ name = 'Python'
 version = '2.7.15'
 versionsuffix = '-bare'
 
-homepage = 'http://python.org/'
+homepage = 'https://python.org/'
 description = """Python is a programming language that lets you work more quickly and integrate your systems
  more effectively."""
 
 toolchain = {'name': 'GCCcore', 'version': '7.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+source_urls = ['https://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 checksums = ['18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db']
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-7.3.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-7.3.0-bare.eb
@@ -15,11 +15,8 @@ checksums = ['18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db']
 
 # python needs bzip2 to build the bz2 package
 
-builddependencies = [
-    ('binutils', '2.30'),
-]
-
 dependencies = [
+    ('binutils', '2.30'),  # required for pip install that involves compilation
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.11'),
     ('libreadline', '7.0'),

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-7.3.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-7.3.0-bare.eb
@@ -2,14 +2,14 @@ name = 'Python'
 version = '2.7.15'
 versionsuffix = '-bare'
 
-homepage = 'http://python.org/'
+homepage = 'https://python.org/'
 description = """Python is a programming language that lets you work more quickly and integrate your systems
  more effectively."""
 
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+source_urls = ['https://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 checksums = ['18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db']
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-8.2.0.eb
@@ -12,9 +12,8 @@ source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 checksums = ['18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db']
 
-builddependencies = [('binutils', '2.31.1')]
-
 dependencies = [
+    ('binutils', '2.31.1'),  # required for pip install that involves compilation
     ('bzip2', '1.0.6'),  # required for bz2 package in Python stdlib
     ('zlib', '1.2.11'),
     ('libreadline', '8.0'),

--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-GCCcore-8.2.0.eb
@@ -1,14 +1,14 @@
 name = 'Python'
 version = '2.7.15'
 
-homepage = 'http://python.org/'
+homepage = 'https://python.org/'
 description = """Python is a programming language that lets you work more quickly and integrate your systems
  more effectively."""
 
 toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+source_urls = ['https://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 checksums = ['18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db']
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.16-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.16-GCCcore-8.3.0.eb
@@ -12,9 +12,8 @@ source_urls = ['https://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 checksums = ['01da813a3600876f03f46db11cc5c408175e99f03af2ba942ef324389a83bad5']
 
-builddependencies = [('binutils', '2.32')]
-
 dependencies = [
+    ('binutils', '2.32'),  # required for pip install that involves compilation
     ('bzip2', '1.0.8'),  # required for bz2 package in Python stdlib
     ('zlib', '1.2.11'),
     ('libreadline', '8.0'),

--- a/easybuild/easyconfigs/p/Python/Python-2.7.16-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.16-GCCcore-8.3.0.eb
@@ -1,7 +1,7 @@
 name = 'Python'
 version = '2.7.16'
 
-homepage = 'http://python.org/'
+homepage = 'https://python.org/'
 description = """Python is a programming language that lets you work more quickly and integrate your systems
  more effectively."""
 

--- a/easybuild/easyconfigs/p/Python/Python-3.7.2-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.7.2-GCCcore-8.2.0.eb
@@ -16,9 +16,8 @@ checksums = [
     'd061cd176a8aebb1895d84fd9134633abbdf9af26a22d649e5049df276574c08',  # Python-3.7-faulthandler.patch
 ]
 
-builddependencies = [('binutils', '2.31.1')]
-
 dependencies = [
+    ('binutils', '2.31.1'),  # required for pip install that involves compilation
     ('bzip2', '1.0.6'),  # required for bz2 package in Python stdlib
     ('zlib', '1.2.11'),
     ('libreadline', '8.0'),

--- a/easybuild/easyconfigs/p/Python/Python-3.7.4-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.7.4-GCCcore-8.3.0.eb
@@ -16,9 +16,8 @@ checksums = [
     'd061cd176a8aebb1895d84fd9134633abbdf9af26a22d649e5049df276574c08',  # Python-3.7-faulthandler.patch
 ]
 
-builddependencies = [('binutils', '2.32')]
-
 dependencies = [
+    ('binutils', '2.32'),  # required for pip install that involves compilation
     ('bzip2', '1.0.8'),  # required for bz2 package in Python stdlib
     ('zlib', '1.2.11'),
     ('libreadline', '8.0'),


### PR DESCRIPTION
It's required for pip install that involves compilation.

edit: fixes #9227