### PR TITLE
define $SPARK_HOME in generated module file for Spark 2.4.0

### DIFF
--- a/easybuild/easyconfigs/s/Spark/Spark-2.4.0-Hadoop-2.7-Java-1.8.eb
+++ b/easybuild/easyconfigs/s/Spark/Spark-2.4.0-Hadoop-2.7-Java-1.8.eb
@@ -4,7 +4,7 @@ name = 'Spark'
 version = '2.4.0'
 versionsuffix = '-Hadoop-2.7-Java-%(javaver)s'
 
-homepage = 'http://spark.apache.org'
+homepage = 'https://spark.apache.org'
 description = """Spark is Hadoop MapReduce done in memory"""
 
 toolchain = SYSTEM

--- a/easybuild/easyconfigs/s/Spark/Spark-2.4.0-Hadoop-2.7-Java-1.8.eb
+++ b/easybuild/easyconfigs/s/Spark/Spark-2.4.0-Hadoop-2.7-Java-1.8.eb
@@ -26,4 +26,6 @@ sanity_check_paths = {
 
 modextrapaths = {'PYTHONPATH': 'python'}
 
+modextravars = {'SPARK_HOME': '%(installdir)s'}
+
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/s/Spark/Spark-2.4.0-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/s/Spark/Spark-2.4.0-foss-2018b-Python-2.7.15.eb
@@ -50,4 +50,6 @@ sanity_check_commands = [
 
 modextrapaths = {'PYTHONPATH': ['python', 'lib/python%(pyshortver)s/site-packages']}
 
+modextravars = {'SPARK_HOME': '%(installdir)s'}
+
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/s/Spark/Spark-2.4.0-intel-2018b-Hadoop-2.7-Java-1.8-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/s/Spark/Spark-2.4.0-intel-2018b-Hadoop-2.7-Java-1.8-Python-3.6.6.eb
@@ -5,7 +5,7 @@ version = '2.4.0'
 local_hadoopver = '2.7'
 versionsuffix = '-Hadoop-%s-Java-%%(javaver)s-Python-%%(pyver)s' % local_hadoopver
 
-homepage = 'http://spark.apache.org'
+homepage = 'https://spark.apache.org'
 description = """Spark is Hadoop MapReduce done in memory"""
 
 toolchain = {'name': 'intel', 'version': '2018b'}

--- a/easybuild/easyconfigs/s/Spark/Spark-2.4.0-intel-2018b-Hadoop-2.7-Java-1.8-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/s/Spark/Spark-2.4.0-intel-2018b-Hadoop-2.7-Java-1.8-Python-3.6.6.eb
@@ -44,6 +44,8 @@ exts_list = [
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
+modextravars = {'SPARK_HOME': '%(installdir)s'}
+
 sanity_check_paths = {
     'files': ['bin/spark-shell', 'bin/pyspark'],
     'dirs': ['python']

--- a/easybuild/easyconfigs/s/Spark/Spark-2.4.0-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/s/Spark/Spark-2.4.0-intel-2018b-Python-2.7.15.eb
@@ -50,4 +50,6 @@ sanity_check_commands = [
 
 modextrapaths = {'PYTHONPATH': ['python', 'lib/python%(pyshortver)s/site-packages']}
 
+modextravars = {'SPARK_HOME': '%(installdir)s'}
+
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/s/Spark/Spark-2.4.0-intel-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/s/Spark/Spark-2.4.0-intel-2018b-Python-3.6.6.eb
@@ -50,4 +50,6 @@ sanity_check_commands = [
 
 modextrapaths = {'PYTHONPATH': ['python', 'lib/python%(pyshortver)s/site-packages']}
 
+modextravars = {'SPARK_HOME': '%(installdir)s'}
+
 moduleclass = 'devel'


### PR DESCRIPTION
`$SPARK_HOME` is commonly relied on by that stuff that depends on `Spark`, so let's define it too next to `$EBROOTSPARK`...