### PR TITLE
matplotlib 2.1.[01]: fix problems with mpl_toolkits namespace and Python 2

### DIFF
--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-2.7.14.eb
@@ -47,7 +47,8 @@ exts_list = [
     }),
 ]
 
-postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
 ]
 
 sanity_check_commands = [

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-foss-2017b-Python-2.7.14.eb
@@ -4,7 +4,7 @@ name = 'matplotlib'
 version = '2.1.0'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://matplotlib.org'
+homepage = 'https://matplotlib.org'
 description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
@@ -47,6 +47,12 @@ exts_list = [
     }),
 ]
 
-sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-fosscuda-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-fosscuda-2017b-Python-2.7.14.eb
@@ -47,13 +47,13 @@ exts_list = [
     }),
 ]
 
-postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
 ]
 
 sanity_check_commands = [
     """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
     "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
 ]
-
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-fosscuda-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-fosscuda-2017b-Python-2.7.14.eb
@@ -4,7 +4,7 @@ name = 'matplotlib'
 version = '2.1.0'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://matplotlib.org'
+homepage = 'https://matplotlib.org'
 description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
@@ -47,6 +47,13 @@ exts_list = [
     }),
 ]
 
-sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
+
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-2.7.14.eb
@@ -4,7 +4,7 @@ name = 'matplotlib'
 version = '2.1.0'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://matplotlib.org'
+homepage = 'https://matplotlib.org'
 description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
@@ -43,6 +43,13 @@ exts_list = [
     }),
 ]
 
-sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
+
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intel-2017b-Python-2.7.14.eb
@@ -43,13 +43,13 @@ exts_list = [
     }),
 ]
 
-postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
 ]
 
 sanity_check_commands = [
     """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
     "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
 ]
-
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intelcuda-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intelcuda-2017b-Python-2.7.14.eb
@@ -4,7 +4,7 @@ name = 'matplotlib'
 version = '2.1.0'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://matplotlib.org'
+homepage = 'https://matplotlib.org'
 description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
@@ -43,6 +43,13 @@ exts_list = [
     }),
 ]
 
-sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
+
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intelcuda-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.0-intelcuda-2017b-Python-2.7.14.eb
@@ -43,13 +43,13 @@ exts_list = [
     }),
 ]
 
-postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
 ]
 
 sanity_check_commands = [
     """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
     "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
 ]
-
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-2.7.14.eb
@@ -4,7 +4,7 @@ name = 'matplotlib'
 version = '2.1.1'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://matplotlib.org'
+homepage = 'https://matplotlib.org'
 description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
@@ -43,6 +43,13 @@ exts_list = [
     }),
 ]
 
-sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
+
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-intel-2017b-Python-2.7.14.eb
@@ -43,13 +43,13 @@ exts_list = [
     }),
 ]
 
-postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
 ]
 
 sanity_check_commands = [
     """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
     "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
 ]
-
 
 moduleclass = 'vis'


### PR DESCRIPTION
For matplotlib 2.1.0 and 2.1.1 versions.