### PR TITLE
matplotlib 2.2.4: fix problems with mpl_toolkits namespace and Python 2

### DIFF
--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-foss-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-foss-2019a-Python-2.7.15.eb
@@ -4,7 +4,7 @@ name = 'matplotlib'
 version = '2.2.4'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://matplotlib.org'
+homepage = 'https://matplotlib.org'
 description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
@@ -52,7 +52,14 @@ exts_list = [
     }),
 ]
 
-sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
+
 
 # use non-interactive plotting backend as default
 # see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-foss-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-foss-2019a-Python-2.7.15.eb
@@ -52,14 +52,14 @@ exts_list = [
     }),
 ]
 
-postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
 ]
 
 sanity_check_commands = [
     """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
     "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
 ]
-
 
 # use non-interactive plotting backend as default
 # see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-fosscuda-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-fosscuda-2019a-Python-2.7.15.eb
@@ -4,7 +4,7 @@ name = 'matplotlib'
 version = '2.2.4'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://matplotlib.org'
+homepage = 'https://matplotlib.org'
 description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
@@ -52,7 +52,14 @@ exts_list = [
     }),
 ]
 
-sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
+
 
 # use non-interactive plotting backend as default
 # see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-fosscuda-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-fosscuda-2019a-Python-2.7.15.eb
@@ -52,14 +52,14 @@ exts_list = [
     }),
 ]
 
-postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
 ]
 
 sanity_check_commands = [
     """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
     "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
 ]
-
 
 # use non-interactive plotting backend as default
 # see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-intel-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-intel-2019a-Python-2.7.15.eb
@@ -4,7 +4,7 @@ name = 'matplotlib'
 version = '2.2.4'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://matplotlib.org'
+homepage = 'https://matplotlib.org'
 description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
@@ -55,7 +55,14 @@ exts_list = [
     }),
 ]
 
-sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
+
 
 # use non-interactive plotting backend as default
 # see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-intel-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-intel-2019a-Python-2.7.15.eb
@@ -55,14 +55,14 @@ exts_list = [
     }),
 ]
 
-postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
 ]
 
 sanity_check_commands = [
     """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
     "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
 ]
-
 
 # use non-interactive plotting backend as default
 # see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-intelcuda-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-intelcuda-2019a-Python-2.7.15.eb
@@ -4,7 +4,7 @@ name = 'matplotlib'
 version = '2.2.4'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://matplotlib.org'
+homepage = 'https://matplotlib.org'
 description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
@@ -55,7 +55,14 @@ exts_list = [
     }),
 ]
 
-sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
+
 
 # use non-interactive plotting backend as default
 # see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-intelcuda-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.4-intelcuda-2019a-Python-2.7.15.eb
@@ -55,14 +55,14 @@ exts_list = [
     }),
 ]
 
-postinstallcmds = [                                                                         'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
 ]
 
 sanity_check_commands = [
     """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
     "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
 ]
-
 
 # use non-interactive plotting backend as default
 # see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend


### PR DESCRIPTION
For matplotlib 2.2.4 versions.