### PR TITLE
matplotlib [2.1.2, 2.2.3]: Fix problems with mpl_toolkits namespace and Python 2

### DIFF
--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-foss-2018a-Python-2.7.14.eb
@@ -31,6 +31,14 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/C/Cycler'],
         'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
     }),
+    ('subprocess32', '3.2.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/subprocess32'],
+        'checksums': ['1e450a4a4c53bf197ad6402c564b9f7a53539385918ef8f12bdf430a61036590'],
+    }),
+    ('backports.functools_lru_cache', '1.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/backports.functools_lru_cache'],
+        'checksums': ['31f235852f88edc1558d428d890663c49eb4514ffec9f3650e7f3c9e4a12e36f'],
+    }),
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': ['725a3f12739d133adfa381e1b33bd70c6f64db453bfc536e148824816e568894'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-foss-2018a-Python-2.7.14.eb
@@ -1,18 +1,15 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'matplotlib'
 version = '2.1.2'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://matplotlib.org'
+homepage = 'https://matplotlib.org'
 description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
 
 toolchain = {'name': 'foss', 'version': '2018a'}
-
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
 
 builddependencies = [
     ('pkg-config', '0.29.2'),
@@ -24,6 +21,8 @@ dependencies = [
     ('freetype', '2.9'),
     ('Tkinter', '%(pyver)s', versionsuffix),
 ]
+
+use_pip = True
 
 exts_list = [
     ('Cycler', '0.10.0', {
@@ -45,7 +44,14 @@ sanity_check_paths = {
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
-sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-foss-2018a-Python-2.7.14.eb
@@ -53,8 +53,6 @@ sanity_check_commands = [
     "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
 ]
 
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
-
 # use non-interactive plotting backend as default
 # see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
 modextravars = {'MPLBACKEND': 'Agg'}

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-intel-2018a-Python-2.7.14.eb
@@ -31,6 +31,14 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/C/Cycler'],
         'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
     }),
+    ('subprocess32', '3.2.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/subprocess32'],
+        'checksums': ['1e450a4a4c53bf197ad6402c564b9f7a53539385918ef8f12bdf430a61036590'],
+    }),
+    ('backports.functools_lru_cache', '1.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/backports.functools_lru_cache'],
+        'checksums': ['31f235852f88edc1558d428d890663c49eb4514ffec9f3650e7f3c9e4a12e36f'],
+    }),
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
         'checksums': ['725a3f12739d133adfa381e1b33bd70c6f64db453bfc536e148824816e568894'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-intel-2018a-Python-2.7.14.eb
@@ -53,8 +53,6 @@ sanity_check_commands = [
     "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
 ]
 
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
-
 # use non-interactive plotting backend as default
 # see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
 modextravars = {'MPLBACKEND': 'Agg'}

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-intel-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.2-intel-2018a-Python-2.7.14.eb
@@ -1,18 +1,15 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'matplotlib'
 version = '2.1.2'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://matplotlib.org'
+homepage = 'https://matplotlib.org'
 description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
 
 toolchain = {'name': 'intel', 'version': '2018a'}
-
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
 
 builddependencies = [
     ('pkg-config', '0.29.2'),
@@ -24,6 +21,8 @@ dependencies = [
     ('freetype', '2.9'),
     ('Tkinter', '%(pyver)s', versionsuffix),
 ]
+
+use_pip = True
 
 exts_list = [
     ('Cycler', '0.10.0', {
@@ -45,7 +44,14 @@ sanity_check_paths = {
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
-sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-foss-2018b-Python-2.7.15.eb
@@ -31,6 +31,14 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/C/Cycler'],
         'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
     }),
+    ('subprocess32', '3.2.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/subprocess32'],
+        'checksums': ['1e450a4a4c53bf197ad6402c564b9f7a53539385918ef8f12bdf430a61036590'],
+    }),
+    ('backports.functools_lru_cache', '1.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/backports.functools_lru_cache'],
+        'checksums': ['9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a'],
+    }),
     (name, version, {
         'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-foss-2018b-Python-2.7.15.eb
@@ -53,8 +53,6 @@ sanity_check_commands = [
     "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
 ]
 
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
-
 # use non-interactive plotting backend as default
 # see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
 modextravars = {'MPLBACKEND': 'Agg'}

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-foss-2018b-Python-2.7.15.eb
@@ -1,18 +1,15 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'matplotlib'
 version = '2.2.3'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://matplotlib.org'
+homepage = 'https://matplotlib.org'
 description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
 
 toolchain = {'name': 'foss', 'version': '2018b'}
-
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
 
 builddependencies = [
     ('pkg-config', '0.29.2'),
@@ -24,6 +21,8 @@ dependencies = [
     ('freetype', '2.9.1'),
     ('Tkinter', '%(pyver)s', versionsuffix),
 ]
+
+use_pip = True
 
 exts_list = [
     ('Cycler', '0.10.0', {
@@ -45,7 +44,14 @@ sanity_check_paths = {
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
-sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-foss-2018b-Python-2.7.15.eb
@@ -39,6 +39,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/b/backports.functools_lru_cache'],
         'checksums': ['9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a'],
     }),
+    ('kiwisolver', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/k/kiwisolver'],
+        'checksums': ['ce3be5d520b4d2c3e5eeb4cd2ef62b9b9ab8ac6b6fedbaa0e39cdb6f50644278'],
+    }),
     (name, version, {
         'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-fosscuda-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-fosscuda-2018b-Python-2.7.15.eb
@@ -1,18 +1,15 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'matplotlib'
 version = '2.2.3'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://matplotlib.org'
+homepage = 'https://matplotlib.org'
 description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
 
 toolchain = {'name': 'fosscuda', 'version': '2018b'}
-
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
 
 builddependencies = [
     ('pkg-config', '0.29.2'),
@@ -24,6 +21,8 @@ dependencies = [
     ('freetype', '2.9.1'),
     ('Tkinter', '%(pyver)s', versionsuffix),
 ]
+
+use_pip = True
 
 exts_list = [
     ('Cycler', '0.10.0', {
@@ -45,7 +44,14 @@ sanity_check_paths = {
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
-sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-fosscuda-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-fosscuda-2018b-Python-2.7.15.eb
@@ -31,6 +31,14 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/C/Cycler'],
         'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
     }),
+    ('subprocess32', '3.2.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/subprocess32'],
+        'checksums': ['1e450a4a4c53bf197ad6402c564b9f7a53539385918ef8f12bdf430a61036590'],
+    }),
+    ('backports.functools_lru_cache', '1.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/backports.functools_lru_cache'],
+        'checksums': ['9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a'],
+    }),
     (name, version, {
         'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-fosscuda-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-fosscuda-2018b-Python-2.7.15.eb
@@ -53,8 +53,6 @@ sanity_check_commands = [
     "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
 ]
 
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
-
 # use non-interactive plotting backend as default
 # see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
 modextravars = {'MPLBACKEND': 'Agg'}

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-fosscuda-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-fosscuda-2018b-Python-2.7.15.eb
@@ -39,6 +39,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/b/backports.functools_lru_cache'],
         'checksums': ['9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a'],
     }),
+    ('kiwisolver', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/k/kiwisolver'],
+        'checksums': ['ce3be5d520b4d2c3e5eeb4cd2ef62b9b9ab8ac6b6fedbaa0e39cdb6f50644278'],
+    }),
     (name, version, {
         'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-intel-2018b-Python-2.7.15.eb
@@ -31,6 +31,14 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/C/Cycler'],
         'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
     }),
+    ('subprocess32', '3.2.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/subprocess32'],
+        'checksums': ['1e450a4a4c53bf197ad6402c564b9f7a53539385918ef8f12bdf430a61036590'],
+    }),
+    ('backports.functools_lru_cache', '1.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/backports.functools_lru_cache'],
+        'checksums': ['9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a'],
+    }),
     (name, version, {
         'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-intel-2018b-Python-2.7.15.eb
@@ -1,18 +1,15 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'matplotlib'
 version = '2.2.3'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://matplotlib.org'
+homepage = 'https://matplotlib.org'
 description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
 
 toolchain = {'name': 'intel', 'version': '2018b'}
-
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
 
 builddependencies = [
     ('pkg-config', '0.29.2'),
@@ -24,6 +21,8 @@ dependencies = [
     ('freetype', '2.9.1'),
     ('Tkinter', '%(pyver)s', versionsuffix),
 ]
+
+use_pip = True
 
 exts_list = [
     ('Cycler', '0.10.0', {
@@ -45,7 +44,14 @@ sanity_check_paths = {
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
-sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-intel-2018b-Python-2.7.15.eb
@@ -53,8 +53,6 @@ sanity_check_commands = [
     "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
 ]
 
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
-
 # use non-interactive plotting backend as default
 # see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
 modextravars = {'MPLBACKEND': 'Agg'}

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.3-intel-2018b-Python-2.7.15.eb
@@ -39,6 +39,10 @@ exts_list = [
         'source_urls': ['https://pypi.python.org/packages/source/b/backports.functools_lru_cache'],
         'checksums': ['9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a'],
     }),
+    ('kiwisolver', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/k/kiwisolver'],
+        'checksums': ['ce3be5d520b4d2c3e5eeb4cd2ef62b9b9ab8ac6b6fedbaa0e39cdb6f50644278'],
+    }),
     (name, version, {
         'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
         'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",


### PR DESCRIPTION
For matplotlib 2.1.2 and 2.2.3 versions.