### PR TITLE
add missing 'wheel' extensions to Spark 2.4.0 easyconfig using intel/2018b toolchain

### DIFF
--- a/easybuild/easyconfigs/s/Spark/Spark-2.4.0-intel-2018b-Hadoop-2.7-Java-1.8-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/s/Spark/Spark-2.4.0-intel-2018b-Hadoop-2.7-Java-1.8-Python-3.6.6.eb
@@ -10,12 +10,12 @@ description = """Spark is Hadoop MapReduce done in memory"""
 
 toolchain = {'name': 'intel', 'version': '2018b'}
 
-sources = ['%%(namelower)s-%%(version)s-bin-hadoop%s.tgz' % local_hadoopver]
 source_urls = [
     'http://apache.belnet.be/%(namelower)s/%(namelower)s-%(version)s/',
     'http://www.eu.apache.org/dist/%(namelower)s/%(namelower)s-%(version)s/',
     'http://www.us.apache.org/dist/%(namelower)s/%(namelower)s-%(version)s/',
 ]
+sources = ['%%(namelower)s-%%(version)s-bin-hadoop%s.tgz' % local_hadoopver]
 checksums = ['c93c096c8d64062345b26b34c85127a6848cff95a4bb829333a06b83222a5cfa']
 
 dependencies = [
@@ -31,9 +31,13 @@ exts_default_options = {
 }
 
 exts_list = [
+    ('wheel', '0.33.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/w/wheel'],
+        'checksums': ['10c9da68765315ed98850f8e048347c3eb06dd81822dc2ab1d4fde9dc9702646'],
+    }),
     ('py4j', '0.10.8.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/py4j'],
         'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/p/py4j'],
         'checksums': ['8329bb156a0cf37be9642a2a060dbdb627b5fcb827919be65d95102daccca274'],
     }),
     ('pyspark', version, {

--- a/easybuild/easyconfigs/s/Spark/Spark-2.4.0-intel-2018b-Hadoop-2.7-Java-1.8-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/s/Spark/Spark-2.4.0-intel-2018b-Hadoop-2.7-Java-1.8-Python-3.6.6.eb
@@ -27,17 +27,16 @@ exts_defaultclass = 'PythonPackage'
 
 exts_default_options = {
     'download_dep_fail': True,
+    'source_urls': [PYPI_SOURCE],
     'use_pip': True,
 }
 
 exts_list = [
     ('wheel', '0.33.6', {
-        'source_urls': ['https://pypi.python.org/packages/source/w/wheel'],
         'checksums': ['10c9da68765315ed98850f8e048347c3eb06dd81822dc2ab1d4fde9dc9702646'],
     }),
     ('py4j', '0.10.8.1', {
         'source_tmpl': '%(name)s-%(version)s.zip',
-        'source_urls': ['https://pypi.python.org/packages/source/p/py4j'],
         'checksums': ['8329bb156a0cf37be9642a2a060dbdb627b5fcb827919be65d95102daccca274'],
     }),
     ('pyspark', version, {


### PR DESCRIPTION
Installation fails now due to auto-downloaded dependency being detected (because `download_dep_fail` is set via `exts_default_options`).

When this easyconfig was added it went undetected because of a bug (which was fixed in https://github.com/easybuilders/easybuild-easyblocks/pull/1530)...