### PR TITLE
Tensorflow 2.0 reverted gast to 0.2.2

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-foss-2019a-Python-3.7.2.eb
@@ -46,8 +46,8 @@ exts_list = [
     ('astor', '0.8.0', {
         'checksums': ['37a6eed8b371f1228db08234ed7f6cfdc7817a3ed3824797e20cbb11dc2a7862'],
     }),
-    ('gast', '0.3.2', {
-        'checksums': ['5c7617f1f6c8b8b426819642b16b9016727ddaecd16af9a07753e537eba8a3a5'],
+    ('gast', '0.2.2', {
+        'checksums': ['fe939df4583692f0512161ec1c880e0a10e71e6a232da045ab8edd3756fbadf0'],
     }),
     ('grpcio', '1.24.0', {
         'modulename': 'grpc',


### PR DESCRIPTION
On [Tensorflow's issue 32319](https://github.com/tensorflow/tensorflow/issues/32319), it was decided to pin Gast to version 0.2.2, to avoid the `module 'gast' has no attribute 'Num'` error. So I'm moving it back to the same here.

I tested both. This fixes the error for EB 4.0.1