### PR TITLE
fix build of recent Bazel versions on Power9 + stick to Java/1.8 as dependency

### DIFF
--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.26.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.26.1-GCCcore-8.3.0.eb
@@ -15,6 +15,6 @@ builddependencies = [
     ('binutils', '2.32'),
     ('Python', '3.7.4'),
 ]
-dependencies = [('Java', '11', '', True)]
+dependencies = [('Java', '1.8', '', True)]
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.29.1-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.29.1-GCCcore-8.2.0.eb
@@ -9,10 +9,14 @@ toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 
 source_urls = ['https://github.com/bazelbuild/bazel/releases/download/%(version)s']
 sources = ['%(namelower)s-%(version)s-dist.zip']
-patches = ['Bazel-%(version)s_fix-gold-flag.patch']
+patches = [
+    'Bazel-%(version)s_fix-gold-flag.patch',
+    'Bazel-%(version)s_fix-zip-d-on-power.patch',
+]
 checksums = [
     '872a52cff208676e1169b3e1cae71b1fe572c4109cbd66eab107d8607c378de5',  # bazel-0.29.1-dist.zip
     '99928d0902beeaf962a8ad14db8432f8e5114645e3caf64c7ee2fa136c31609f',  # Bazel-0.29.1_fix-gold-flag.patch
+    '0089567af6a991084d5628a8b6fa92b68402ff4b7a0ef8fa944e629e7be63b93',  # Bazel-0.29.1_fix-zip-d-on-power.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.29.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.29.1-GCCcore-8.3.0.eb
@@ -19,6 +19,6 @@ builddependencies = [
     ('binutils', '2.32'),
     ('Python', '3.7.4'),
 ]
-dependencies = [('Java', '11', '', True)]
+dependencies = [('Java', '1.8', '', True)]
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.29.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.29.1-GCCcore-8.3.0.eb
@@ -9,10 +9,14 @@ toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
 
 source_urls = ['https://github.com/bazelbuild/bazel/releases/download/%(version)s']
 sources = ['%(namelower)s-%(version)s-dist.zip']
-patches = ['Bazel-%(version)s_fix-gold-flag.patch']
+patches = [
+    'Bazel-%(version)s_fix-gold-flag.patch',
+    'Bazel-%(version)s_fix-zip-d-on-power.patch',
+]
 checksums = [
     '872a52cff208676e1169b3e1cae71b1fe572c4109cbd66eab107d8607c378de5',  # bazel-0.29.1-dist.zip
     '99928d0902beeaf962a8ad14db8432f8e5114645e3caf64c7ee2fa136c31609f',  # Bazel-0.29.1_fix-gold-flag.patch
+    '0089567af6a991084d5628a8b6fa92b68402ff4b7a0ef8fa944e629e7be63b93',  # Bazel-0.29.1_fix-zip-d-on-power.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.29.1_fix-zip-d-on-power.patch
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.29.1_fix-zip-d-on-power.patch
@@ -1,0 +1,43 @@
+From 99775df8356ab6c7dd77493b35e59de5f6a773f8 Mon Sep 17 00:00:00 2001
+From: Christy Norman <christy@linux.vnet.ibm.com>
+Date: Wed, 4 Sep 2019 18:41:37 -0400
+Subject: [PATCH] fix build for Power
+
+The zip -d flag will error if it doesn't find that extension.
+This is a fix for Power, but doesn't fix the default case.
+
+Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>
+---
+ src/conditions/BUILD | 6 ++++++
+ third_party/BUILD    | 1 +
+ 2 files changed, 7 insertions(+)
+
+diff --git a/src/conditions/BUILD b/src/conditions/BUILD
+index 2b28e280576..faa41a439d4 100644
+--- a/src/conditions/BUILD
++++ b/src/conditions/BUILD
+@@ -10,6 +10,12 @@ filegroup(
+     visibility = ["//src:__pkg__"],
+ )
+ 
++config_setting(
++    name = "linux_ppc",
++    values = {"cpu": "ppc"},
++    visibility = ["//visibility:public"],
++)
++
+ config_setting(
+     name = "linux_x86_64",
+     values = {"cpu": "k8"},
+diff --git a/third_party/BUILD b/third_party/BUILD
+index 7545b3df33a..b4115b2988c 100644
+--- a/third_party/BUILD
++++ b/third_party/BUILD
+@@ -528,6 +528,7 @@ UNNECESSARY_DYNAMIC_LIBRARIES = select({
+     # The .so file is an x86 one, so we can just remove it if the CPU is not x86
+     "//src/conditions:arm": "*.so *.jnilib *.dll",
+     "//src/conditions:linux_aarch64": "*.so *.jnilib *.dll",
++    "//src/conditions:linux_ppc": "*.so *.jnilib *.dll",
+     # Play it safe -- better have a big binary than a slow binary
+     # zip -d does require an argument. Supply something bogus.
+     "//conditions:default": "*.bogusextension",

--- a/easybuild/easyconfigs/b/Bazel/Bazel-1.1.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-1.1.0-GCCcore-8.3.0.eb
@@ -19,6 +19,6 @@ builddependencies = [
     ('binutils', '2.32'),
     ('Python', '3.7.4'),
 ]
-dependencies = [('Java', '11', '', True)]
+dependencies = [('Java', '1.8', '', True)]
 
 moduleclass = 'devel'


### PR DESCRIPTION
- Stay with JDK8 (Java 1.8) as stated by Bazel docus
- Include patch from https://github.com/bazelbuild/bazel/issues/9263

Fixes https://github.com/easybuilders/easybuild-easyconfigs/issues/9450