### PR TITLE
add PETSc foss-2019b easyconfig

### DIFF
--- a/easybuild/easyconfigs/h/Hypre/Hypre-2.18.2-foss-2019b.eb
+++ b/easybuild/easyconfigs/h/Hypre/Hypre-2.18.2-foss-2019b.eb
@@ -1,0 +1,18 @@
+name = 'Hypre'
+version = '2.18.2'
+
+homepage = 'https://computation.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods'
+description = """Hypre is a library for solving large, sparse linear systems of equations on massively
+ parallel computers. The problems of interest arise in the simulation codes being developed at LLNL
+ and elsewhere to study physical phenomena in the defense, environmental, energy, and biological sciences."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/hypre-space/hypre/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['28007b5b584eaf9397f933032d8367788707a2d356d78e47b99e551ab10cc76a']
+
+start_dir = 'src'
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.11.1-foss-2019b.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.11.1-foss-2019b.eb
@@ -1,0 +1,40 @@
+name = 'PETSc'
+version = '3.11.1'
+
+homepage = 'http://www.mcs.anl.gov/petsc'
+description = """PETSc, pronounced PET-see (the S is silent), is a suite of data structures and routines for the
+ scalable (parallel) solution of scientific applications modeled by partial differential equations."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = ['http://ftp.mcs.anl.gov/pub/petsc/release-snapshots']
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'PETSc_ranlib-fix.patch',
+    'PETSc-3.9.3_fix-AVX512.patch',
+]
+checksums = [
+    'cb627f99f7ce1540ebbbf338189f89a5f1ecf3ab3b5b0e357f9e46c209f1fb23',  # petsc-3.11.1.tar.gz
+    '64cf9d5008d5e92117e65bdec5316d991b6a6b8c8ecf7ea46eb790a498266297',  # PETSc_ranlib-fix.patch
+    'f11e3d7c36ec9939b10550c9913320e0ee4b34585bdf9458977548686f90bfa8',  # PETSc-3.9.3_fix-AVX512.patch
+]
+
+builddependencies = [('CMake', '3.15.3')]
+
+dependencies = [
+    ('Boost', '1.71.0'),
+    ('METIS', '5.1.0'),
+    ('ParMETIS', '4.0.3'),
+    ('SCOTCH', '6.0.9'),
+    ('SuiteSparse', '5.6.0', '-METIS-5.1.0'),
+    ('Hypre', '2.18.2'),
+]
+
+configopts = '--LIBS="$LIBS -lrt" '
+
+# only required when building PETSc in a SLURM job environment
+# configopts += '--with-batch=1 --known-mpi-shared-libraries=1 --known-64-bit-blas-indices=0 '
+# prebuildopts = "srun ./conftest-arch-linux2-c-opt && ./reconfigure-arch-linux2-c-opt.py && "
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.11.1-foss-2019b.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.11.1-foss-2019b.eb
@@ -20,7 +20,8 @@ checksums = [
     'f11e3d7c36ec9939b10550c9913320e0ee4b34585bdf9458977548686f90bfa8',  # PETSc-3.9.3_fix-AVX512.patch
 ]
 
-builddependencies = [('CMake', '3.15.3')]
+builddependencies = [('CMake', '3.15.3'),
+                     ('Python', '3.7.4'),]
 
 dependencies = [
     ('Boost', '1.71.0'),

--- a/easybuild/easyconfigs/p/ParMETIS/ParMETIS-4.0.3-foss-2019b.eb
+++ b/easybuild/easyconfigs/p/ParMETIS/ParMETIS-4.0.3-foss-2019b.eb
@@ -1,0 +1,23 @@
+name = 'ParMETIS'
+version = '4.0.3'
+
+homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview'
+description = """ParMETIS is an MPI-based parallel library that implements a variety of algorithms for partitioning
+ unstructured graphs, meshes, and for computing fill-reducing orderings of sparse matrices. ParMETIS extends the
+ functionality provided by METIS and includes routines that are especially suited for parallel AMR computations and
+ large scale numerical simulations. The algorithms implemented in ParMETIS are based on the parallel multilevel k-way
+ graph-partitioning, adaptive repartitioning, and parallel multi-constrained partitioning schemes."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = [
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis',
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/OLD',
+]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['f2d9a231b7cf97f1fee6e8c9663113ebf6c240d407d3c118c55b3633d6be6e5f']
+
+builddependencies = [('CMake', '3.15.3')]
+
+moduleclass = 'math'


### PR DESCRIPTION
Add easyconfig file for PETSc with foss 2019b toolchain, together with related easyconfig files: ParMETIS-4.0.3, Hypre-2.18.2.