### PR TITLE
{devel}[GCCcore/8.2.0] Meld v3.20.1 w/ Python 3.7.2

### DIFF
--- a/easybuild/easyconfigs/m/Meld/Meld-3.20.1-GCCcore-8.2.0-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/m/Meld/Meld-3.20.1-GCCcore-8.2.0-Python-3.7.2.eb
@@ -1,0 +1,47 @@
+easyblock = 'PythonPackage'
+
+name = 'Meld'
+version = '3.20.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://meldmerge.org/'
+description = """
+  Meld is a visual diff and merge tool targeted at developers.
+  Meld helps you compare files, directories, and version controlled projects.
+  It provides two- and three-way comparison of both files and directories, and has support
+  for many popular version control systems.
+  """
+
+toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
+
+dependencies = [
+    ('Python', '3.7.2'),
+    ('PyCairo', '1.18.0', versionsuffix),
+    ('PyGObject', '3.34.0', versionsuffix),
+    ('gsettings-desktop-schemas', '3.34.0'),
+    ('GLib', '2.60.1'),
+    ('Pango', '1.43.0'),
+    ('GTK+', '3.24.8'),
+    ('GtkSourceView', '3.24.11'),
+]
+
+builddependencies = [
+    ('binutils', '2.31.1'),
+    ('intltool', '0.51.0'),
+    ('ITSTool', '2.0.6', versionsuffix),
+    ('libxml2', '2.9.8'),  # For xmllint
+]
+
+sources = [SOURCELOWER_TAR_XZ]
+source_urls = [FTPGNOME_SOURCE]
+checksums = ['a54843bc4d6cb1d31d0a58aa725091622194d50c32ef67026b35c86dda3cb249']
+
+download_dep_fail = True
+sanity_pip_check = True
+
+sanity_check_paths = {
+    'files': ['bin/meld'],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -533,8 +533,8 @@ class EasyConfigTest(TestCase):
     def check_python_packages(self, changed_ecs):
         """Several checks for easyconfigs that install (bundles of) Python packages."""
 
-        # MATLAB-Engine, PyTorch do not support installation with 'pip'
-        whitelist_pip = ['MATLAB-Engine-*', 'PyTorch-*']
+        # These packages do not support installation with 'pip'
+        whitelist_pip = [r'MATLAB-Engine-.*', r'PyTorch-.*', r'Meld-.*']
 
         failing_checks = []
 


### PR DESCRIPTION
Meld is really good when resolving merge conflicts with git. This EC (finally) allows to build it with EB.

Usage suggestion: Add the following in your gitconfig:
```
[merge]
    tool = meld
[mergetool "meld"]
    cmd = meld --auto-merge \"$LOCAL\" \"$BASE\" \"$REMOTE\" --output \"$MERGED\"
    trustExitCode = false
[mergetool]
    keepBackup = false
```


Requires
- [x]  https://github.com/easybuilders/easybuild-easyconfigs/pull/9529
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/9526
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/9522
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/9521
- [x] #9541

Notes:
- meld does not support `pip install` but will support meson
- a good sanity check is `meld --help` which checks dependent packages but if X-fowarding is not set up then it fails with:
```
2019-12-20 12:12:59,639 CRITICAL Gtk: gtk_icon_theme_get_for_screen: assertion 'GDK_IS_SCREEN (screen)' failed
Traceback (most recent call last):
  File "..../meld", line 287, in <module>
    setup_resources()
  File "..../meld", line 193, in setup_resources
    Gtk.IconTheme.get_default().append_search_path(icon_dir)
AttributeError: 'NoneType' object has no attribute 'append_search_path'
```
