### PR TITLE
add missing jupyter_contrib_core extension for IPython 7.7.0+ + consistently include jupyter_nbextensions_configurator extension

### DIFF
--- a/easybuild/easyconfigs/i/IPython/IPython-7.7.0-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.7.0-foss-2019a-Python-3.7.2.eb
@@ -135,6 +135,9 @@ exts_list = [
     ('ipywidgets', '7.5.1', {
         'checksums': ['e945f6e02854a74994c596d9db83444a1850c01648f1574adf144fbbabe05c97'],
     }),
+    ('jupyter_contrib_core', '0.3.3', {
+        'checksums': ['e65bc0e932ff31801003cef160a4665f2812efe26a53801925a634735e9a5794'],
+    }),
     ('jupyter_nbextensions_configurator', '0.4.1', {
         'checksums': ['e5e86b5d9d898e1ffb30ebb08e4ad8696999f798fef3ff3262d7b999076e4e83'],
     }),
@@ -156,5 +159,7 @@ sanity_check_commands = [
     "jupyter notebook --help",
     "iptest",
 ]
+
+sanity_pip_check = True
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/i/IPython/IPython-7.7.0-fosscuda-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.7.0-fosscuda-2019a-Python-3.7.2.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('Python', '3.7.2'),
     ('ZeroMQ', '4.3.2'),
     ('matplotlib', '3.0.3', versionsuffix),
+    ('PyYAML', '5.1'),  # required for jupyter_nbextensions_configurator
 ]
 
 use_pip = True

--- a/easybuild/easyconfigs/i/IPython/IPython-7.7.0-fosscuda-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.7.0-fosscuda-2019a-Python-3.7.2.eb
@@ -134,6 +134,12 @@ exts_list = [
     ('ipywidgets', '7.5.1', {
         'checksums': ['e945f6e02854a74994c596d9db83444a1850c01648f1574adf144fbbabe05c97'],
     }),
+    ('jupyter_contrib_core', '0.3.3', {
+        'checksums': ['e65bc0e932ff31801003cef160a4665f2812efe26a53801925a634735e9a5794'],
+    }),
+    ('jupyter_nbextensions_configurator', '0.4.1', {
+        'checksums': ['e5e86b5d9d898e1ffb30ebb08e4ad8696999f798fef3ff3262d7b999076e4e83'],
+    }),
     ('notebook', '6.0.1', {
         'checksums': ['660976fe4fe45c7aa55e04bf4bccb9f9566749ff637e9020af3422f9921f9a5d'],
     }),
@@ -152,5 +158,7 @@ sanity_check_commands = [
     "jupyter notebook --help",
     "iptest",
 ]
+
+sanity_pip_check = True
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/i/IPython/IPython-7.7.0-intel-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.7.0-intel-2019a-Python-3.7.2.eb
@@ -136,6 +136,9 @@ exts_list = [
     ('ipywidgets', '7.5.1', {
         'checksums': ['e945f6e02854a74994c596d9db83444a1850c01648f1574adf144fbbabe05c97'],
     }),
+    ('jupyter_contrib_core', '0.3.3', {
+        'checksums': ['e65bc0e932ff31801003cef160a4665f2812efe26a53801925a634735e9a5794'],
+    }),
     ('jupyter_nbextensions_configurator', '0.4.1', {
         'checksums': ['e5e86b5d9d898e1ffb30ebb08e4ad8696999f798fef3ff3262d7b999076e4e83'],
     }),
@@ -157,5 +160,7 @@ sanity_check_commands = [
     "jupyter notebook --help",
     "iptest",
 ]
+
+sanity_pip_check = True
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/i/IPython/IPython-7.9.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.9.0-foss-2019b-Python-3.7.4.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('Python', '3.7.4'),
     ('ZeroMQ', '4.3.2'),
     ('matplotlib', '3.1.1', versionsuffix),
+    ('PyYAML', '5.1.2'),  # required for jupyter_nbextensions_configurator
 ]
 
 use_pip = True

--- a/easybuild/easyconfigs/i/IPython/IPython-7.9.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.9.0-foss-2019b-Python-3.7.4.eb
@@ -134,6 +134,12 @@ exts_list = [
     ('ipywidgets', '7.5.1', {
         'checksums': ['e945f6e02854a74994c596d9db83444a1850c01648f1574adf144fbbabe05c97'],
     }),
+    ('jupyter_contrib_core', '0.3.3', {
+        'checksums': ['e65bc0e932ff31801003cef160a4665f2812efe26a53801925a634735e9a5794'],
+    }),
+    ('jupyter_nbextensions_configurator', '0.4.1', {
+        'checksums': ['e5e86b5d9d898e1ffb30ebb08e4ad8696999f798fef3ff3262d7b999076e4e83'],
+    }),
     ('notebook', '6.0.2', {
         'checksums': ['399a4411e171170173344761e7fd4491a3625659881f76ce47c50231ed714d9b'],
     }),
@@ -152,5 +158,7 @@ sanity_check_commands = [
     "jupyter notebook --help",
     "iptest",
 ]
+
+sanity_pip_check = True
 
 moduleclass = 'tools'


### PR DESCRIPTION
`pip check` fails because `jupyter_contrib_core` was not added when `jupyter_nbextensions_configurator` was added in #9133