### PR TITLE
fix name for plotly extension in plotly.py v4.4.1 easyconfig

### DIFF
--- a/easybuild/easyconfigs/p/plotly.py/plotly.py-4.4.1-intel-2019b.eb
+++ b/easybuild/easyconfigs/p/plotly.py/plotly.py-4.4.1-intel-2019b.eb
@@ -18,7 +18,7 @@ exts_list = [
     ('retrying', '1.3.3', {
         'checksums': ['08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b'],
     }),
-    (name, version, {
+    ('plotly', version, {
         'checksums': ['acc94f17452471ca3446c2ce491c4d1affb99b9ddd9eac4e05614ac4318f8780'],
     }),
 ]


### PR DESCRIPTION
In #9480 the `'plotly'` was replaced with `name` last-minute on @verdurin's request, but this broke the easyconfig since `name = 'plotly.py`, which makes EasyBuild look for a non-existing source tarball named `plotly.py-4.4.1.tar.gz`...