### PR TITLE
fix broken easyconfigs for cyvcf2 v0.11.5 by adding missing 'monotonic' extension

### DIFF
--- a/easybuild/easyconfigs/c/cyvcf2/cyvcf2-0.11.5-foss-2019a.eb
+++ b/easybuild/easyconfigs/c/cyvcf2/cyvcf2-0.11.5-foss-2019a.eb
@@ -21,17 +21,19 @@ fix_python_shebang_for = ['bin/*']
 
 use_pip = True
 
+exts_default_options = {'source_urls': [PYPI_SOURCE]}
+
 exts_list = [
+    ('monotonic', '1.5', {
+        'checksums': ['23953d55076df038541e648a53676fb24980f7a1be290cdda21300b3bc21dfb0'],
+    }),
     ('humanfriendly', '4.18', {
-        'source_urls': ['https://pypi.python.org/packages/source/h/humanfriendly/'],
         'checksums': ['33ee8ceb63f1db61cce8b5c800c531e1a61023ac5488ccde2ba574a85be00a85'],
     }),
     ('coloredlogs', '10.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/c/coloredlogs/'],
         'checksums': ['b869a2dda3fa88154b9dd850e27828d8755bfab5a838a1c97fbc850c6e377c36'],
     }),
     (name, version, {
-        'source_urls': ['https://pypi.python.org/packages/source/c/cyvcf2'],
         'checksums': ['20924e5b30e8308756575ac3ae8c28a8c717ed3c53b2adb297201428f43fae6e'],
         'prebuildopts': "rm -r htslib && ln -s $EBROOTHTSLIB htslib && ",
         # Runtest will fail - possibly broken test-suite. Otherwise useful.
@@ -45,5 +47,7 @@ sanity_check_paths = {
 }
 
 sanity_check_commands = ["cyvcf2 --help"]
+
+sanity_pip_check = True
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/c/cyvcf2/cyvcf2-0.11.5-intel-2019a.eb
+++ b/easybuild/easyconfigs/c/cyvcf2/cyvcf2-0.11.5-intel-2019a.eb
@@ -21,17 +21,19 @@ fix_python_shebang_for = ['bin/*']
 
 use_pip = True
 
+exts_default_options = {'source_urls': [PYPI_SOURCE]}
+
 exts_list = [
+    ('monotonic', '1.5', {
+        'checksums': ['23953d55076df038541e648a53676fb24980f7a1be290cdda21300b3bc21dfb0'],
+    }),
     ('humanfriendly', '4.18', {
-        'source_urls': ['https://pypi.python.org/packages/source/h/humanfriendly/'],
         'checksums': ['33ee8ceb63f1db61cce8b5c800c531e1a61023ac5488ccde2ba574a85be00a85'],
     }),
     ('coloredlogs', '10.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/c/coloredlogs/'],
         'checksums': ['b869a2dda3fa88154b9dd850e27828d8755bfab5a838a1c97fbc850c6e377c36'],
     }),
     (name, version, {
-        'source_urls': ['https://pypi.python.org/packages/source/c/cyvcf2'],
         'checksums': ['20924e5b30e8308756575ac3ae8c28a8c717ed3c53b2adb297201428f43fae6e'],
         'prebuildopts': 'rm -r htslib && ln -s $EBROOTHTSLIB htslib && export LDSHARED="icc -shared" &&',
         'preinstallopts': 'export LDSHARED="icc -shared" &&',
@@ -47,5 +49,7 @@ sanity_check_paths = {
 }
 
 sanity_check_commands = ["cyvcf2 --help"]
+
+sanity_pip_check = True
 
 moduleclass = 'bio'


### PR DESCRIPTION
These easyconfigs fail to install because auto-downloaded dependencies are detected (enabled by default in `PythonBundle`):

```
== FAILED: Installation ended unsuccessfully (build directory: /tmp/vsc40023/easybuild_build/cyvcf2/0.11.5/foss-2019a): build failed (first 300 chars): Sanity check failed: extensions sanity check failed for 1 extensions: cyvcf2
failing sanity check for 'cyvcf2' extension: found one or more downloaded dependencies: Downloading https://files.pythonhosted.org/packages/08/0f/7877fc42fff0b9d70b6442df62d53b3868d3a6ad1b876bdb54335b30ff23/coloredlogs-10.0 (took 2 min 33 sec)
```

This went undetected until now because `monotonic` (which is only strictly needed with Python < 3.3) was available system-wide for Python 2.7, but those Python packages are now ignored thanks to https://github.com/easybuilders/easybuild-easyblocks/pull/1891.