### PR TITLE
New EB files for autopep8 and pycodestyle for Python/3.6.4-intel-2018a

### DIFF
--- a/easybuild/easyconfigs/a/autopep8/autopep8-1.4.4-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/a/autopep8/autopep8-1.4.4-intel-2018a-Python-3.6.4.eb
@@ -18,6 +18,10 @@ dependencies = [
     ('pycodestyle', '2.5.0', versionsuffix),
 ]
 
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/a/autopep8/autopep8-1.4.4-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/a/autopep8/autopep8-1.4.4-intel-2018a-Python-3.6.4.eb
@@ -1,0 +1,26 @@
+easyblock = 'PythonPackage'
+
+name = 'autopep8'
+version = '1.4.4'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = "https://github.com/hhatto/autopep8"
+description = """A tool that automatically formats Python code to conform to the PEP 8 style guide."""
+
+toolchain = {'name': 'intel', 'version': '2018a'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['4d8eec30cc81bc5617dbf1218201d770dc35629363547f17577c61683ccfb3ee']
+
+dependencies = [
+    ('Python', '3.6.4'),
+    ('pycodestyle', '2.5.0', versionsuffix),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/pycodestyle/pycodestyle-2.5.0-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/p/pycodestyle/pycodestyle-2.5.0-intel-2018a-Python-3.6.4.eb
@@ -17,6 +17,10 @@ dependencies = [
     ('Python', '3.6.4'),
 ]
 
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],

--- a/easybuild/easyconfigs/p/pycodestyle/pycodestyle-2.5.0-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/p/pycodestyle/pycodestyle-2.5.0-intel-2018a-Python-3.6.4.eb
@@ -1,0 +1,25 @@
+easyblock = 'PythonPackage'
+
+name = 'pycodestyle'
+version = '2.5.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = "https://pycodestyle.readthedocs.io"
+description = """pycodestyle is a tool to check your Python code against some of the style conventions in PEP 8."""
+
+toolchain = {'name': 'intel', 'version': '2018a'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c']
+
+dependencies = [
+    ('Python', '3.6.4'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
As requested by developers but maybe it's felt these should be installed in the underlying OS's Python installation rather than using EasyBuild.