### PR TITLE
fix source URLs for ant v1.10.5 - v1.10.7

### DIFF
--- a/easybuild/easyconfigs/a/ant/ant-1.10.2-fix-doclint-error.patch
+++ b/easybuild/easyconfigs/a/ant/ant-1.10.2-fix-doclint-error.patch
@@ -1,0 +1,15 @@
+Author: Alexander Grund
+Ant 1.10.2 removed the -Xdoclint:none option which leads to build failures
+due to optional packages not beeing found during Javadoc generation
+See https://bz.apache.org/bugzilla/show_bug.cgi?id=63438
+diff -aur a/build.xml b/build.xml
+--- a/build.xml	2018-02-03 17:52:24.000000000 +0100
++++ b/build.xml	2020-01-10 13:34:56.885004000 +0100
+@@ -1456,6 +1456,7 @@
+           description="--> creates the API documentation" unless="javadoc.notrequired">
+     <mkdir dir="${build.javadocs}"/>
+     <javadoc useexternalfile="yes"
++             additionalparam="-Xdoclint:none"
+              destdir="${build.javadocs}"
+              failonerror="true"
+              author="true"

--- a/easybuild/easyconfigs/a/ant/ant-1.10.5-Java-1.8.eb
+++ b/easybuild/easyconfigs/a/ant/ant-1.10.5-Java-1.8.eb
@@ -11,7 +11,11 @@ toolchain = SYSTEM
 
 source_urls = ['https://archive.apache.org/dist/%(name)s/source/']
 sources = ['apache-%(name)s-%(version)s-src.tar.gz']
-checksums = ['5937cf11d74d75d6e8927402950b012e037e362f9f728262ce432ad289b9f6ca']
+patches = ['ant-1.10.2-fix-doclint-error.patch']
+checksums = [
+    '5937cf11d74d75d6e8927402950b012e037e362f9f728262ce432ad289b9f6ca',  # source
+    '6473b80b1baf1c3537b0ea50881a91cafe2cecb010c85d3a7490c3e429b03d87',  # ant-1.10.2-fix-doclint-error.patch
+]
 
 dependencies = [('Java', '1.8')]
 

--- a/easybuild/easyconfigs/a/ant/ant-1.10.5-Java-1.8.eb
+++ b/easybuild/easyconfigs/a/ant/ant-1.10.5-Java-1.8.eb
@@ -1,21 +1,21 @@
-easyblock = 'PackedBinary'
-
 name = 'ant'
 version = '1.10.5'
 versionsuffix = '-Java-%(javaver)s'
 
-homepage = 'http://ant.apache.org/'
+homepage = 'https://ant.apache.org/'
 description = """Apache Ant is a Java library and command-line tool whose mission is to drive processes described in
  build files as targets and extension points dependent upon each other. The main known usage of Ant is the build of
  Java applications."""
 
 toolchain = SYSTEM
 
-source_urls = ['http://apache.cu.be//ant/binaries']
-sources = ['apache-%(name)s-%(version)s-bin.tar.gz']
-checksums = ['cd52c6f77a0b1de7174addc94e5a512d86978ac9173a30cd11f4ab26f6d8deba']
+source_urls = ['https://archive.apache.org/dist/%(name)s/source/']
+sources = ['apache-%(name)s-%(version)s-src.tar.gz']
+checksums = ['5937cf11d74d75d6e8927402950b012e037e362f9f728262ce432ad289b9f6ca']
 
 dependencies = [('Java', '1.8')]
+
+builddependencies = [('JUnit', '4.12', versionsuffix)]
 
 sanity_check_paths = {
     'files': ['bin/ant', 'lib/ant.jar'],

--- a/easybuild/easyconfigs/a/ant/ant-1.10.6-Java-1.8.eb
+++ b/easybuild/easyconfigs/a/ant/ant-1.10.6-Java-1.8.eb
@@ -11,7 +11,7 @@ description = """Apache Ant is a Java library and command-line tool whose missio
 
 toolchain = SYSTEM
 
-source_urls = ['https://apache.cu.be/ant/binaries']
+source_urls = ['https://apache.mirrors.cu.be/ant/binaries']
 sources = ['apache-%(name)s-%(version)s-bin.tar.gz']
 checksums = ['ed87985be618d4be6c46ba2092a6c1fad60ef6ae0c8745c007ca9d5175c253fd']
 

--- a/easybuild/easyconfigs/a/ant/ant-1.10.7-Java-11.eb
+++ b/easybuild/easyconfigs/a/ant/ant-1.10.7-Java-11.eb
@@ -11,7 +11,7 @@ description = """Apache Ant is a Java library and command-line tool whose missio
 
 toolchain = SYSTEM
 
-source_urls = ['https://apache.cu.be/ant/binaries']
+source_urls = ['https://apache.mirrors.cu.be/ant/binaries']
 sources = ['apache-%(name)s-%(version)s-bin.tar.gz']
 checksums = ['2e0f2e0348e146b5a366de55bb97a1508c57544623f35f2432b7f6b844581341']
 


### PR DESCRIPTION
10.5 binary distribution is no longer available, 10.6/7 have https errors with wrong hostname as the url redirects to the new one