### PR TITLE
{bio}[foss/2019a] gradunwarp 1.1.0 (HCP fork): Use PIP to install

### DIFF
--- a/easybuild/easyconfigs/g/gradunwarp/gradunwarp-1.1.0-foss-2019a-HCP-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/g/gradunwarp/gradunwarp-1.1.0-foss-2019a-HCP-Python-2.7.15.eb
@@ -14,7 +14,8 @@ sources = ['v%(version)s.tar.gz']
 checksums = ['4803b8055dbeedb0435246a525aa69f1f3425c55d57c973c045deb39bc95c955']
 
 download_dep_fail = True
-use_pip = False
+use_pip = True
+sanity_pip_check = True
 
 dependencies = [
     ('Python', '2.7.15'),


### PR DESCRIPTION
As suggested in https://github.com/easybuilders/easybuild-easyconfigs/pull/9614#discussion_r364658088, we're now using PIP