### PR TITLE
use latest master as release candidate of MRtrix 3.0 (since 3.0_RC4 is not an official release)

### DIFF
--- a/easybuild/easyconfigs/m/MRtrix/MRtrix-3.0-rc-20191217-foss-2019b-Python-2.7.16.eb
+++ b/easybuild/easyconfigs/m/MRtrix/MRtrix-3.0-rc-20191217-foss-2019b-Python-2.7.16.eb
@@ -1,5 +1,6 @@
 name = 'MRtrix'
-version = '3.0_RC4'
+local_commit = 'd411e6c'
+version = '3.0-rc-20191217'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://www.brain.org.au/software/index.html#mrtrix'
@@ -10,8 +11,8 @@ toolchain = {'name': 'foss', 'version': '2019b'}
 toolchainopts = {'cstd': 'c++11'}
 
 source_urls = ['https://github.com/MRtrix3/mrtrix3/archive/']
-sources = ['%(version)s.tar.gz']
-checksums = ['4f246e4cc6ddd5d2480d368342bcbeb9c5d21c04a3a4b5e6e2adb8c036611426']
+sources = ['%s.tar.gz' % local_commit]
+checksums = ['7140934dc653ee5edf807120a8e9cf23a0bf72f01bbe4dfbe2a15206ce6812db']
 
 builddependencies = [
     ('Eigen', '3.3.7', '', True),
@@ -19,11 +20,10 @@ builddependencies = [
 ]
 dependencies = [
     ('zlib', '1.2.11'),
-    ('Python', '3.7.4'),
+    ('Python', '2.7.16'),
     ('Mesa', '19.1.7'),
     ('Qt5', '5.13.1'),
     ('LibTIFF', '4.0.10'),
-    ('FFTW', '3.3.8'),
 ]
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/MRtrix/MRtrix-3.0-rc-20191217-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/m/MRtrix/MRtrix-3.0-rc-20191217-foss-2019b-Python-3.7.4.eb
@@ -1,5 +1,6 @@
 name = 'MRtrix'
-version = '3.0_RC4'
+local_commit = 'd411e6c'
+version = '3.0-rc-20191217'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://www.brain.org.au/software/index.html#mrtrix'
@@ -10,8 +11,8 @@ toolchain = {'name': 'foss', 'version': '2019b'}
 toolchainopts = {'cstd': 'c++11'}
 
 source_urls = ['https://github.com/MRtrix3/mrtrix3/archive/']
-sources = ['%(version)s.tar.gz']
-checksums = ['4f246e4cc6ddd5d2480d368342bcbeb9c5d21c04a3a4b5e6e2adb8c036611426']
+sources = ['%s.tar.gz' % local_commit]
+checksums = ['7140934dc653ee5edf807120a8e9cf23a0bf72f01bbe4dfbe2a15206ce6812db']
 
 builddependencies = [
     ('Eigen', '3.3.7', '', True),
@@ -19,7 +20,7 @@ builddependencies = [
 ]
 dependencies = [
     ('zlib', '1.2.11'),
-    ('Python', '2.7.16'),
+    ('Python', '3.7.4'),
     ('Mesa', '19.1.7'),
     ('Qt5', '5.13.1'),
     ('LibTIFF', '4.0.10'),


### PR DESCRIPTION
see discussion in https://github.com/MRtrix3/mrtrix3/issues/1834

MRtrix 3.0_RC4 is only in `develop` (see #9535), so OK to change imho...