### PR TITLE
{lib}[GCCcore/8.2.0] ICU 64.2 - Depend on Python3 instead of 2

### DIFF
--- a/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.50-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.50-GCCcore-8.3.0.eb
@@ -1,0 +1,46 @@
+easyblock = 'ConfigureMake'
+
+name = 'Ghostscript'
+version = '9.50'
+
+homepage = 'https://ghostscript.com'
+description = """Ghostscript is a versatile processor for PostScript data with the ability to render PostScript to
+ different targets. It used to be part of the cups printing stack, but is no longer used for that."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [
+    'https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs%(version_major)s%(version_minor)s/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['0f53e89fd647815828fc5171613e860e8535b68f7afbc91bf89aee886769ce89']
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('libpng', '1.6.37'),
+    ('freetype', '2.10.1'),
+    ('libjpeg-turbo', '2.0.3'),
+    ('expat', '2.2.7'),
+    ('GLib', '2.62.0'),
+    ('cairo', '1.16.0'),
+    ('LibTIFF', '4.0.10'),
+]
+
+builddependencies = [
+    # use same binutils version that was used when building GCCcore toolchain
+    ('binutils', '2.32'),
+]
+
+# Do not use local copies of zlib, jpeg, freetype, and png
+preconfigopts = "mv zlib zlib.no && mv jpeg jpeg.no && mv freetype freetype.no && mv libpng libpng.no && "
+preconfigopts += 'export LIBS="$LIBS -lz" && '
+
+configopts = "--with-system-libtiff --enable-dynamic"
+
+sanity_check_paths = {
+    'files': ['bin/gs'],
+    'dirs': ['lib/ghostscript', 'share/man'],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/g/gradunwarp/gradunwarp-1.1.0-foss-2019a-HCP-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/g/gradunwarp/gradunwarp-1.1.0-foss-2019a-HCP-Python-3.7.2.eb
@@ -1,0 +1,31 @@
+easyblock = 'PythonPackage'
+
+name = "gradunwarp"
+version = "1.1.0"
+versionsuffix = "-HCP-Python-%(pyver)s"
+
+homepage = "https://github.com/Washington-University/gradunwarp"
+description = """Gradient Unwarping. This is the Human Connectome Project fork of the no longer maintained original."""
+
+toolchain = {'name': 'foss', 'version': '2019a'}
+
+source_urls = ['https://github.com/Washington-University/gradunwarp/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['4803b8055dbeedb0435246a525aa69f1f3425c55d57c973c045deb39bc95c955']
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+dependencies = [
+    ('Python', '3.7.2'),
+    ('SciPy-bundle', '2019.03'),
+    ('NiBabel', '2.4.0')
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/i/ICU/ICU-64.2-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/i/ICU/ICU-64.2-GCCcore-8.2.0.eb
@@ -16,7 +16,7 @@ checksums = ['627d5d8478e6d96fc8c90fed4851239079a561a6a8b9e48b0892f24e82d31d6c']
 
 builddependencies = [
     ('binutils', '2.31.1'),
-    ('Python', '2.7.15'),
+    ('Python', '3.7.2'),
 ]
 
 start_dir = 'source'

--- a/easybuild/easyconfigs/i/ICU/ICU-64.2-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/i/ICU/ICU-64.2-GCCcore-8.3.0.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'ICU'
+version = '64.2'
+
+homepage = 'http://site.icu-project.org/home'
+description = """ICU is a mature, widely used set of C/C++ and Java libraries providing Unicode and Globalization
+ support for software applications."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://download.icu-project.org/files/icu4c/%(version)s']
+sources = ['icu4c-%(version_major)s_%(version_minor)s-src.tgz']
+checksums = ['627d5d8478e6d96fc8c90fed4851239079a561a6a8b9e48b0892f24e82d31d6c']
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('Python', '2.7.16'),
+]
+
+start_dir = 'source'
+
+sanity_check_paths = {
+    'files': ['lib/libicu%s.%s' % (x, SHLIB_EXT) for x in ['data', 'i18n', 'io', 'test', 'tu', 'uc']],
+    'dirs': ['bin', 'include/unicode', 'share/icu', 'share/man'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/i/ICU/ICU-64.2-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/i/ICU/ICU-64.2-GCCcore-8.3.0.eb
@@ -16,7 +16,7 @@ checksums = ['627d5d8478e6d96fc8c90fed4851239079a561a6a8b9e48b0892f24e82d31d6c']
 
 builddependencies = [
     ('binutils', '2.32'),
-    ('Python', '2.7.16'),
+    ('Python', '3.7.2'),
 ]
 
 start_dir = 'source'

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.9-5-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.9-5-GCCcore-8.3.0.eb
@@ -1,0 +1,44 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# Author: Ravi Tripathi
+# Email: ravi89@uab.edu
+
+easyblock = 'ConfigureMake'
+
+name = 'ImageMagick'
+version = '7.0.9-5'
+
+homepage = 'https://www.imagemagick.org/'
+description = """ImageMagick is a software suite to create, edit, compose, or convert bitmap images"""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['https://github.com/ImageMagick/ImageMagick/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['d15abd31e7e18f7edec47df156773a23e5100386e55c6ce50f5353e9572d3413']
+
+dependencies = [
+    ('bzip2', '1.0.8'),
+    ('X11', '20190717'),
+    ('Ghostscript', '9.50'),
+    ('JasPer', '2.0.14'),
+    ('libjpeg-turbo', '2.0.3'),
+    ('LibTIFF', '4.0.10'),
+    ('LittleCMS', '2.9'),
+]
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('pkg-config', '0.29.2'),
+]
+
+configopts = "--with-gslib --with-x"
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['bin', 'etc/%(name)s-%(version_major)s',
+             'include/%(name)s-%(version_major)s', 'lib', 'share'],
+}
+
+modextravars = {'MAGICK_HOME': '%(installdir)s'}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/LittleCMS/LittleCMS-2.9-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/LittleCMS/LittleCMS-2.9-GCCcore-8.3.0.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'LittleCMS'
+version = '2.9'
+
+homepage = 'http://www.littlecms.com/'
+description = """ Little CMS intends to be an OPEN SOURCE small-footprint color management engine,
+ with special focus on accuracy and performance. """
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['http://sourceforge.net/projects/lcms/files/lcms/%(version)s/']
+sources = ['lcms2-%(version)s.tar.gz']
+checksums = ['48c6fdf98396fa245ed86e622028caf49b96fa22f3e5734f853f806fbc8e7d20']
+
+builddependencies = [
+    # use same binutils version that was used when building GCCcore toolchain
+    ('binutils', '2.32'),
+]
+
+dependencies = [('libjpeg-turbo', '2.0.3')]
+
+sanity_check_paths = {
+    'files': ['bin/jpgicc', 'bin/linkicc', 'bin/psicc', 'bin/transicc', 'include/lcms2.h', 'include/lcms2_plugin.h',
+              'lib/liblcms2.a', 'lib/liblcms2.%s' % SHLIB_EXT, 'lib/pkgconfig/lcms2.pc'],
+    'dirs': ['share/man'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libsndfile/libsndfile-1.0.28-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/libsndfile/libsndfile-1.0.28-GCCcore-8.3.0.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'libsndfile'
+version = '1.0.28'
+
+homepage = 'http://www.mega-nerd.com/libsndfile'
+description = """Libsndfile is a C library for reading and writing files containing sampled sound
+ (such as MS Windows WAV and the Apple/SGI AIFF format) through one standard library interface."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['http://www.mega-nerd.com/libsndfile/files/']
+sources = [SOURCE_TAR_GZ]
+checksums = ['1ff33929f042fa333aed1e8923aa628c3ee9e1eb85512686c55092d1e5a9dfa9']
+
+builddependencies = [('binutils', '2.32')]
+
+sanity_check_paths = {
+    'files': ['include/sndfile.h', 'include/sndfile.hh', 'lib/libsndfile.a', 'lib/libsndfile.%s' % SHLIB_EXT],
+    'dirs': ['bin'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libsodium/libsodium-1.0.11-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/libsodium/libsodium-1.0.11-foss-2016b.eb
@@ -3,16 +3,19 @@ easyblock = 'ConfigureMake'
 name = 'libsodium'
 version = '1.0.11'
 
-homepage = 'http://doc.libsodium.org/'
+homepage = 'https://doc.libsodium.org/'
 description = """Sodium is a modern, easy-to-use software library for encryption, decryption, signatures,
  password hashing and more."""
 
 toolchain = {'name': 'foss', 'version': '2016b'}
 
-source_urls = ['https://download.libsodium.org/libsodium/releases/']
+source_urls = [
+    'https://download.libsodium.org/libsodium/releases/',
+    'https://download.libsodium.org/libsodium/releases/old/',
+    'https://download.libsodium.org/libsodium/releases/old/unsupported/',
+]
 sources = [SOURCE_TAR_GZ]
-
-checksums = ['b58928d035064b2a46fb564937b83540']
+checksums = ['a14549db3c49f6ae2170cbbf4664bd48ace50681045e8dbea7c8d9fb96f9c765']
 
 sanity_check_paths = {
     'files': ['include/sodium.h', 'lib/libsodium.%s' % SHLIB_EXT, 'lib/libsodium.a'],

--- a/easybuild/easyconfigs/l/libsodium/libsodium-1.0.11-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libsodium/libsodium-1.0.11-intel-2016b.eb
@@ -3,14 +3,19 @@ easyblock = 'ConfigureMake'
 name = 'libsodium'
 version = '1.0.11'
 
-homepage = 'http://doc.libsodium.org/'
+homepage = 'https://doc.libsodium.org/'
 description = """Sodium is a modern, easy-to-use software library for encryption, decryption, signatures,
  password hashing and more."""
 
 toolchain = {'name': 'intel', 'version': '2016b'}
 
-source_urls = ['https://download.libsodium.org/libsodium/releases/']
+source_urls = [
+    'https://download.libsodium.org/libsodium/releases/',
+    'https://download.libsodium.org/libsodium/releases/old/',
+    'https://download.libsodium.org/libsodium/releases/old/unsupported/',
+]
 sources = [SOURCE_TAR_GZ]
+checksums = ['a14549db3c49f6ae2170cbbf4664bd48ace50681045e8dbea7c8d9fb96f9c765']
 
 sanity_check_paths = {
     'files': ['include/sodium.h', 'lib/libsodium.so', 'lib/libsodium.a'],

--- a/easybuild/easyconfigs/l/libsodium/libsodium-1.0.12-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libsodium/libsodium-1.0.12-GCCcore-6.4.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libsodium'
 version = '1.0.12'
 
-homepage = 'http://doc.libsodium.org/'
+homepage = 'https://doc.libsodium.org/'
 
 description = """
  Sodium is a modern, easy-to-use software library for encryption, decryption,
@@ -13,7 +13,11 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://download.libsodium.org/libsodium/releases/']
+source_urls = [
+    'https://download.libsodium.org/libsodium/releases/',
+    'https://download.libsodium.org/libsodium/releases/old/',
+    'https://download.libsodium.org/libsodium/releases/old/unsupported/',
+]
 sources = [SOURCE_TAR_GZ]
 checksums = ['b8648f1bb3a54b0251cf4ffa4f0d76ded13977d4fa7517d988f4c902dd8e2f95']
 

--- a/easybuild/easyconfigs/l/libsodium/libsodium-1.0.12-intel-2017a.eb
+++ b/easybuild/easyconfigs/l/libsodium/libsodium-1.0.12-intel-2017a.eb
@@ -3,14 +3,19 @@ easyblock = 'ConfigureMake'
 name = 'libsodium'
 version = '1.0.12'
 
-homepage = 'http://doc.libsodium.org/'
+homepage = 'https://doc.libsodium.org/'
 description = """Sodium is a modern, easy-to-use software library for encryption, decryption, signatures,
  password hashing and more."""
 
 toolchain = {'name': 'intel', 'version': '2017a'}
 
-source_urls = ['https://download.libsodium.org/libsodium/releases/']
+source_urls = [
+    'https://download.libsodium.org/libsodium/releases/',
+    'https://download.libsodium.org/libsodium/releases/old/',
+    'https://download.libsodium.org/libsodium/releases/old/unsupported/',
+]
 sources = [SOURCE_TAR_GZ]
+checksums = ['b8648f1bb3a54b0251cf4ffa4f0d76ded13977d4fa7517d988f4c902dd8e2f95']
 
 sanity_check_paths = {
     'files': ['include/sodium.h', 'lib/libsodium.so', 'lib/libsodium.a'],

--- a/easybuild/easyconfigs/l/libsodium/libsodium-1.0.13-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libsodium/libsodium-1.0.13-GCCcore-6.4.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libsodium'
 version = '1.0.13'
 
-homepage = 'http://doc.libsodium.org/'
+homepage = 'https://doc.libsodium.org/'
 
 description = """
  Sodium is a modern, easy-to-use software library for encryption, decryption,
@@ -13,7 +13,11 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://download.libsodium.org/libsodium/releases/old']
+source_urls = [
+    'https://download.libsodium.org/libsodium/releases/',
+    'https://download.libsodium.org/libsodium/releases/old/',
+    'https://download.libsodium.org/libsodium/releases/old/unsupported/',
+]
 sources = [SOURCE_TAR_GZ]
 checksums = ['9c13accb1a9e59ab3affde0e60ef9a2149ed4d6e8f99c93c7a5b97499ee323fd']
 

--- a/easybuild/easyconfigs/l/libsodium/libsodium-1.0.13-foss-2017a.eb
+++ b/easybuild/easyconfigs/l/libsodium/libsodium-1.0.13-foss-2017a.eb
@@ -3,13 +3,17 @@ easyblock = 'ConfigureMake'
 name = 'libsodium'
 version = '1.0.13'
 
-homepage = 'http://doc.libsodium.org/'
+homepage = 'https://doc.libsodium.org/'
 description = """Sodium is a modern, easy-to-use software library for encryption, decryption, signatures,
  password hashing and more."""
 
 toolchain = {'name': 'foss', 'version': '2017a'}
 
-source_urls = ['https://download.libsodium.org/libsodium/releases/']
+source_urls = [
+    'https://download.libsodium.org/libsodium/releases/',
+    'https://download.libsodium.org/libsodium/releases/old/',
+    'https://download.libsodium.org/libsodium/releases/old/unsupported/',
+]
 sources = [SOURCE_TAR_GZ]
 
 checksums = ['9c13accb1a9e59ab3affde0e60ef9a2149ed4d6e8f99c93c7a5b97499ee323fd']

--- a/easybuild/easyconfigs/l/libsodium/libsodium-1.0.16-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/libsodium/libsodium-1.0.16-GCCcore-6.4.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libsodium'
 version = '1.0.16'
 
-homepage = 'http://doc.libsodium.org/'
+homepage = 'https://doc.libsodium.org/'
 
 description = """
  Sodium is a modern, easy-to-use software library for encryption, decryption,
@@ -13,7 +13,11 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://download.libsodium.org/libsodium/releases/']
+source_urls = [
+    'https://download.libsodium.org/libsodium/releases/',
+    'https://download.libsodium.org/libsodium/releases/old/',
+    'https://download.libsodium.org/libsodium/releases/old/unsupported/',
+]
 sources = [SOURCE_TAR_GZ]
 checksums = ['eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533']
 

--- a/easybuild/easyconfigs/l/libsodium/libsodium-1.0.16-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/l/libsodium/libsodium-1.0.16-GCCcore-7.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libsodium'
 version = '1.0.16'
 
-homepage = 'http://doc.libsodium.org/'
+homepage = 'https://doc.libsodium.org/'
 
 description = """
  Sodium is a modern, easy-to-use software library for encryption, decryption,
@@ -13,7 +13,11 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://download.libsodium.org/libsodium/releases/']
+source_urls = [
+    'https://download.libsodium.org/libsodium/releases/',
+    'https://download.libsodium.org/libsodium/releases/old/',
+    'https://download.libsodium.org/libsodium/releases/old/unsupported/',
+]
 sources = [SOURCE_TAR_GZ]
 checksums = ['eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533']
 

--- a/easybuild/easyconfigs/l/libsodium/libsodium-1.0.17-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/l/libsodium/libsodium-1.0.17-GCCcore-8.2.0.eb
@@ -13,7 +13,11 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://download.libsodium.org/libsodium/releases/']
+source_urls = [
+    'https://download.libsodium.org/libsodium/releases/',
+    'https://download.libsodium.org/libsodium/releases/old/',
+    'https://download.libsodium.org/libsodium/releases/old/unsupported/',
+]
 sources = [SOURCE_TAR_GZ]
 checksums = ['0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1']
 

--- a/easybuild/easyconfigs/l/libsodium/libsodium-1.0.18-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/libsodium/libsodium-1.0.18-GCCcore-8.3.0.eb
@@ -13,7 +13,11 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://download.libsodium.org/libsodium/releases/']
+source_urls = [
+    'https://download.libsodium.org/libsodium/releases/',
+    'https://download.libsodium.org/libsodium/releases/old/',
+    'https://download.libsodium.org/libsodium/releases/old/unsupported/',
+]
 sources = [SOURCE_TAR_GZ]
 checksums = ['6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1']
 

--- a/easybuild/easyconfigs/l/libsodium/libsodium-1.0.6-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libsodium/libsodium-1.0.6-intel-2016a.eb
@@ -3,14 +3,19 @@ easyblock = 'ConfigureMake'
 name = 'libsodium'
 version = '1.0.6'
 
-homepage = 'http://doc.libsodium.org/'
+homepage = 'https://doc.libsodium.org/'
 description = """Sodium is a modern, easy-to-use software library for encryption, decryption, signatures,
  password hashing and more."""
 
 toolchain = {'name': 'intel', 'version': '2016a'}
 
-source_urls = ['https://download.libsodium.org/libsodium/releases/']
+source_urls = [
+    'https://download.libsodium.org/libsodium/releases/',
+    'https://download.libsodium.org/libsodium/releases/old/',
+    'https://download.libsodium.org/libsodium/releases/old/unsupported/',
+]
 sources = [SOURCE_TAR_GZ]
+checksums = ['940d03ea7d2caa7940e24564bf6d9f66d6edd1df1e0111ff8e3655f3b864fb59']
 
 sanity_check_paths = {
     'files': ['include/sodium.h', 'lib/libsodium.so', 'lib/libsodium.a'],

--- a/easybuild/easyconfigs/l/libsodium/libsodium-1.0.8-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/libsodium/libsodium-1.0.8-foss-2016a.eb
@@ -3,14 +3,19 @@ easyblock = 'ConfigureMake'
 name = 'libsodium'
 version = '1.0.8'
 
-homepage = 'http://doc.libsodium.org/'
+homepage = 'https://doc.libsodium.org/'
 description = """Sodium is a modern, easy-to-use software library for encryption, decryption, signatures,
  password hashing and more."""
 
 toolchain = {'name': 'foss', 'version': '2016a'}
 
-source_urls = ['https://download.libsodium.org/libsodium/releases/']
+source_urls = [
+    'https://download.libsodium.org/libsodium/releases/',
+    'https://download.libsodium.org/libsodium/releases/old/',
+    'https://download.libsodium.org/libsodium/releases/old/unsupported/',
+]
 sources = [SOURCE_TAR_GZ]
+checksums = ['c0f191d2527852641e0a996b7b106d2e04cbc76ea50731b2d0babd3409301926']
 
 sanity_check_paths = {
     'files': ['include/sodium.h', 'lib/libsodium.%s' % SHLIB_EXT, 'lib/libsodium.a'],

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.2-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.2-GCC-8.2.0-2.31.1.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '2.2.2'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -11,7 +11,7 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 # Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 checksums = ['6ca1d0bb5fdc341d59960707bc67f23ad54de8a6018e19e02eee2b16ea7cc642']
 

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.3-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.3-foss-2016b.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '2.2.3'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -11,8 +11,9 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 # Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+checksums = ['2f2b00b77a75c7fe8fe3f3ae70700cf28a09ff8d0ce791e47980ff7f9cde68e7']
 
 configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared --enable-fortran'
 

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016a.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '2.2.3'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -12,8 +12,9 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 # Tests also fail with Intel Compilers on Haswell when optarch is enabled.
 toolchainopts = {'lowopt': True, 'optarch': False}
 
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+checksums = ['2f2b00b77a75c7fe8fe3f3ae70700cf28a09ff8d0ce791e47980ff7f9cde68e7']
 
 configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared --enable-fortran'
 

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016b.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '2.2.3'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -12,8 +12,9 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 # Tests also fail with Intel Compilers on Haswell when optarch is enabled.
 toolchainopts = {'lowopt': True, 'optarch': False}
 
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+checksums = ['2f2b00b77a75c7fe8fe3f3ae70700cf28a09ff8d0ce791e47980ff7f9cde68e7']
 
 configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared --enable-fortran'
 

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2017b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2017b.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '2.2.3'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2017b'}
 # Tests also fail with Intel Compilers on Haswell when optarch is enabled.
 toolchainopts = {'lowopt': True, 'optarch': False}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 checksums = ['2f2b00b77a75c7fe8fe3f3ae70700cf28a09ff8d0ce791e47980ff7f9cde68e7']
 

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2018a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2018a.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '2.2.3'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2018a'}
 # Tests also fail with Intel Compilers on Haswell when optarch is enabled.
 toolchainopts = {'lowopt': True, 'optarch': False}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 checksums = ['2f2b00b77a75c7fe8fe3f3ae70700cf28a09ff8d0ce791e47980ff7f9cde68e7']
 

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.0-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.0-GCC-5.4.0-2.26.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '3.0.0'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -11,7 +11,7 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 # Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.0-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.0-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '3.0.0'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -12,7 +12,7 @@ toolchain = {'name': 'iccifort', 'version': '2016.3.210-GCC-5.4.0-2.26'}
 # Tests also fail with Intel Compilers on Haswell when optarch is enabled.
 toolchainopts = {'lowopt': True, 'optarch': False}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2016a.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '3.0.0'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 # Tests also fail with Intel Compilers on Haswell when optarch is enabled.
 toolchainopts = {'lowopt': True, 'optarch': False}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2016b.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '3.0.0'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 # Tests also fail with Intel Compilers on Haswell when optarch is enabled.
 toolchainopts = {'lowopt': True, 'optarch': False}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2017a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2017a.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '3.0.0'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2017a'}
 # Tests also fail with Intel Compilers on Haswell when optarch is enabled.
 toolchainopts = {'lowopt': True, 'optarch': False}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2017b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2017b.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '3.0.0'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2017b'}
 # Tests also fail with Intel Compilers on Haswell when optarch is enabled.
 toolchainopts = {'lowopt': True, 'optarch': False}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.1-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.1-GCC-8.2.0-2.31.1.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '3.0.1'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -11,7 +11,7 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 # Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.1-foss-2016b.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '3.0.1'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -11,7 +11,7 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 # Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.1-foss-2017a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.1-foss-2017a.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '3.0.1'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -11,7 +11,7 @@ toolchain = {'name': 'foss', 'version': '2017a'}
 # Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.1-foss-2018a.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '3.0.1'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -11,7 +11,7 @@ toolchain = {'name': 'foss', 'version': '2018a'}
 # Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.1-foss-2018b.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '3.0.1'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -11,7 +11,7 @@ toolchain = {'name': 'foss', 'version': '2018b'}
 # Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.1-gimkl-2017a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.1-gimkl-2017a.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '3.0.1'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -11,7 +11,7 @@ toolchain = {'name': 'gimkl', 'version': '2017a'}
 # Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.1-intel-2018a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.1-intel-2018a.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '3.0.1'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2018a'}
 # Tests also fail with Intel Compilers on Haswell when optarch is enabled.
 toolchainopts = {'lowopt': True, 'optarch': False}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.1-intel-2018b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.1-intel-2018b.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '3.0.1'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2018b'}
 # Tests also fail with Intel Compilers on Haswell when optarch is enabled.
 toolchainopts = {'lowopt': True, 'optarch': False}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-4.0.1-foss-2017b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.0.1-foss-2017b.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '4.0.1'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -12,7 +12,7 @@ toolchain = {'name': 'foss', 'version': '2017b'}
 # Tests also fail with Intel Compilers on Haswell when optarch is enabled.
 toolchainopts = {'lowopt': True, 'optarch': False}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-4.0.1-intel-2017b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.0.1-intel-2017b.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '4.0.1'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2017b'}
 # Tests also fail with Intel Compilers on Haswell when optarch is enabled.
 toolchainopts = {'lowopt': True, 'optarch': False}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-4.0.3-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.0.3-foss-2016b.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '4.0.3'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -11,7 +11,7 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 # Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-4.0.3-foss-2017a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.0.3-foss-2017a.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '4.0.3'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -11,7 +11,7 @@ toolchain = {'name': 'foss', 'version': '2017a'}
 # Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version_major_minor)s_no-longdouble.patch']
 checksums = [

--- a/easybuild/easyconfigs/l/libxc/libxc-4.2.3-foss-2017b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.2.3-foss-2017b.eb
@@ -3,13 +3,13 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '4.2.3'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'foss', 'version': '2017b'}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 checksums = ['02e49e9ba7d21d18df17e9e57eae861e6ce05e65e966e1e832475aa09e344256']
 

--- a/easybuild/easyconfigs/l/libxc/libxc-4.2.3-foss-2018a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.2.3-foss-2018a.eb
@@ -3,13 +3,13 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '4.2.3'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'foss', 'version': '2018a'}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 checksums = ['02e49e9ba7d21d18df17e9e57eae861e6ce05e65e966e1e832475aa09e344256']
 

--- a/easybuild/easyconfigs/l/libxc/libxc-4.2.3-foss-2018b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.2.3-foss-2018b.eb
@@ -3,13 +3,13 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '4.2.3'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'foss', 'version': '2018b'}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 checksums = ['02e49e9ba7d21d18df17e9e57eae861e6ce05e65e966e1e832475aa09e344256']
 

--- a/easybuild/easyconfigs/l/libxc/libxc-4.2.3-gimkl-2017a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.2.3-gimkl-2017a.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '4.2.3'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
@@ -11,7 +11,7 @@ toolchain = {'name': 'gimkl', 'version': '2017a'}
 # Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 checksums = ['02e49e9ba7d21d18df17e9e57eae861e6ce05e65e966e1e832475aa09e344256']
 

--- a/easybuild/easyconfigs/l/libxc/libxc-4.2.3-intel-2018a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.2.3-intel-2018a.eb
@@ -3,13 +3,13 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '4.2.3'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2018a'}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 checksums = ['02e49e9ba7d21d18df17e9e57eae861e6ce05e65e966e1e832475aa09e344256']
 

--- a/easybuild/easyconfigs/l/libxc/libxc-4.2.3-intel-2018b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.2.3-intel-2018b.eb
@@ -3,14 +3,14 @@ easyblock = 'ConfigureMake'
 name = 'libxc'
 version = '4.2.3'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2018b'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 checksums = ['02e49e9ba7d21d18df17e9e57eae861e6ce05e65e966e1e832475aa09e344256']
 
 configopts = '--enable-static --enable-shared --enable-fortran'

--- a/easybuild/easyconfigs/l/libxc/libxc-4.3.4-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.3.4-GCC-8.2.0-2.31.1.eb
@@ -3,13 +3,13 @@ easyblock = 'CMakeMake'
 name = 'libxc'
 version = '4.3.4'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = [
     'libxc-%(version)s_lm-fix.patch',

--- a/easybuild/easyconfigs/l/libxc/libxc-4.3.4-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.3.4-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb
@@ -3,13 +3,13 @@ easyblock = 'CMakeMake'
 name = 'libxc'
 version = '4.3.4'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.tddft.org/programs/libxc'
 description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'iccifort', 'version': '2019.1.144-GCC-8.2.0-2.31.1'}
 
-source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/%(version)s/']
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
 sources = [SOURCE_TAR_GZ]
 patches = ['libxc-%(version)s_rename-F03.patch']
 checksums = [

--- a/easybuild/easyconfigs/m/MRtrix/MRtrix-3.0-rc-20191217-foss-2019b-Python-2.7.16.eb
+++ b/easybuild/easyconfigs/m/MRtrix/MRtrix-3.0-rc-20191217-foss-2019b-Python-2.7.16.eb
@@ -1,5 +1,6 @@
 name = 'MRtrix'
-version = '3.0_RC4'
+local_commit = 'd411e6c'
+version = '3.0-rc-20191217'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://www.brain.org.au/software/index.html#mrtrix'
@@ -10,8 +11,8 @@ toolchain = {'name': 'foss', 'version': '2019b'}
 toolchainopts = {'cstd': 'c++11'}
 
 source_urls = ['https://github.com/MRtrix3/mrtrix3/archive/']
-sources = ['%(version)s.tar.gz']
-checksums = ['4f246e4cc6ddd5d2480d368342bcbeb9c5d21c04a3a4b5e6e2adb8c036611426']
+sources = ['%s.tar.gz' % local_commit]
+checksums = ['7140934dc653ee5edf807120a8e9cf23a0bf72f01bbe4dfbe2a15206ce6812db']
 
 builddependencies = [
     ('Eigen', '3.3.7', '', True),
@@ -19,11 +20,10 @@ builddependencies = [
 ]
 dependencies = [
     ('zlib', '1.2.11'),
-    ('Python', '3.7.4'),
+    ('Python', '2.7.16'),
     ('Mesa', '19.1.7'),
     ('Qt5', '5.13.1'),
     ('LibTIFF', '4.0.10'),
-    ('FFTW', '3.3.8'),
 ]
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/MRtrix/MRtrix-3.0-rc-20191217-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/m/MRtrix/MRtrix-3.0-rc-20191217-foss-2019b-Python-3.7.4.eb
@@ -1,5 +1,6 @@
 name = 'MRtrix'
-version = '3.0_RC4'
+local_commit = 'd411e6c'
+version = '3.0-rc-20191217'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://www.brain.org.au/software/index.html#mrtrix'
@@ -10,8 +11,8 @@ toolchain = {'name': 'foss', 'version': '2019b'}
 toolchainopts = {'cstd': 'c++11'}
 
 source_urls = ['https://github.com/MRtrix3/mrtrix3/archive/']
-sources = ['%(version)s.tar.gz']
-checksums = ['4f246e4cc6ddd5d2480d368342bcbeb9c5d21c04a3a4b5e6e2adb8c036611426']
+sources = ['%s.tar.gz' % local_commit]
+checksums = ['7140934dc653ee5edf807120a8e9cf23a0bf72f01bbe4dfbe2a15206ce6812db']
 
 builddependencies = [
     ('Eigen', '3.3.7', '', True),
@@ -19,7 +20,7 @@ builddependencies = [
 ]
 dependencies = [
     ('zlib', '1.2.11'),
-    ('Python', '2.7.16'),
+    ('Python', '3.7.4'),
     ('Mesa', '19.1.7'),
     ('Qt5', '5.13.1'),
     ('LibTIFF', '4.0.10'),

--- a/easybuild/easyconfigs/m/Mothur/Mothur-1.43.0-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/m/Mothur/Mothur-1.43.0-foss-2019a-Python-3.7.2.eb
@@ -1,0 +1,35 @@
+##
+# This is a contribution from DeepThought HPC Service, Flinders University, Adelaide, Australia
+# Homepage: 	https://staff.flinders.edu.au/research/deep-thought
+#
+# Authors::	Robert Qiao <rob.qiao@flinders.edu.au>
+# License::	GPLv3.0
+#
+# Notes::
+##
+
+name = 'Mothur'
+version = '1.43.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://www.mothur.org/'
+description = """Mothur is a single piece of open-source, expandable software
+ to fill the bioinformatics needs of the microbial ecology community."""
+
+toolchain = {'name': 'foss', 'version': '2019a'}
+toolchainopts = {'usempi': True, 'cstd': 'c++11'}
+
+source_urls = ['https://github.com/mothur/mothur/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['12ccd95a85bec3bb1564b8feabd244ea85413973740754803d01fc71ecb0a2c1']
+
+dependencies = [
+    ('Python', '3.7.2'),
+    ('Boost.Python', '1.70.0', '', ('gompi', '2019a')),
+    ('HDF5', '1.10.5', '', ('gompi', '2019a')),
+    ('libreadline', '8.0', '', ('GCCcore', '8.2.0')),
+    ('ncurses', '6.1', '', ('GCCcore', '8.2.0')),
+    ('zlib', '1.2.11'),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/p/pocl/pocl-1.2-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/p/pocl/pocl-1.2-GCC-7.3.0-2.30.eb
@@ -28,7 +28,9 @@ dependencies = [
 separate_build_dir = True
 
 # disable attempt to find an ICD loader, always build libOpenCL.so
-configopts = "-DENABLE_ICD=0 -DINSTALL_OPENCL_HEADERS=1"
+configopts = "-DENABLE_ICD=0 -DINSTALL_OPENCL_HEADERS=1 "
+# make sure we use the easybuild Clang
+configopts += "-DWITH_LLVM_CONFIG=$EBROOTCLANG/bin/llvm-config"
 
 sanity_check_paths = {
     'files': ['bin/poclcc', 'lib64/libOpenCL.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/p/pocl/pocl-1.3-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/p/pocl/pocl-1.3-GCC-8.2.0-2.31.1.eb
@@ -27,7 +27,9 @@ dependencies = [
 separate_build_dir = True
 
 # disable attempt to find an ICD loader, always build libOpenCL.so
-configopts = "-DENABLE_ICD=0 -DINSTALL_OPENCL_HEADERS=1"
+configopts = "-DENABLE_ICD=0 -DINSTALL_OPENCL_HEADERS=1 "
+# make sure we use the easybuild Clang
+configopts += "-DWITH_LLVM_CONFIG=$EBROOTCLANG/bin/llvm-config"
 
 sanity_check_paths = {
     'files': ['bin/poclcc', 'lib64/libOpenCL.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/p/pocl/pocl-1.4-GCC-8.3.0.eb
+++ b/easybuild/easyconfigs/p/pocl/pocl-1.4-GCC-8.3.0.eb
@@ -32,7 +32,9 @@ dependencies = [
 separate_build_dir = True
 
 # disable attempt to find an ICD loader, always build libOpenCL.so
-configopts = "-DENABLE_ICD=0 -DINSTALL_OPENCL_HEADERS=1"
+configopts = "-DENABLE_ICD=0 -DINSTALL_OPENCL_HEADERS=1 "
+# make sure we use the easybuild Clang
+configopts += "-DWITH_LLVM_CONFIG=$EBROOTCLANG/bin/llvm-config"
 
 sanity_check_paths = {
     'files': ['bin/poclcc', 'lib64/libOpenCL.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/p/pocl/pocl-1.4-gcccuda-2019b.eb
+++ b/easybuild/easyconfigs/p/pocl/pocl-1.4-gcccuda-2019b.eb
@@ -32,7 +32,9 @@ dependencies = [
 separate_build_dir = True
 
 # disable attempt to find an ICD loader, always build libOpenCL.so, enable CUDA
-configopts = "-DENABLE_ICD=0 -DINSTALL_OPENCL_HEADERS=1 -DENABLE_CUDA=1"
+configopts = "-DENABLE_ICD=0 -DINSTALL_OPENCL_HEADERS=1 -DENABLE_CUDA=1 "
+# make sure we use the easybuild Clang
+configopts += "-DWITH_LLVM_CONFIG=$EBROOTCLANG/bin/llvm-config"
 
 sanity_check_paths = {
     'files': ['bin/poclcc', 'lib64/libOpenCL.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
@@ -2196,7 +2196,8 @@ exts_list = [
         'checksums': ['779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77'],
     }),
     ('rda', '1.0.2-2.1', {
-        'checksums': ['6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8'],
+        'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',
+                       'eea3a51a2e132a023146bfbc0c384f5373eb3ea2b61743d7658be86a5b04949e')],
     }),
     ('sampling', '2.8', {
         'checksums': ['356923f35971bb55f7e97b178aede3366374aa3ad3d24a97be765660553bf21a'],

--- a/easybuild/easyconfigs/r/R/R-3.6.0-fosscuda-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-fosscuda-2019a.eb
@@ -2196,7 +2196,8 @@ exts_list = [
         'checksums': ['779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77'],
     }),
     ('rda', '1.0.2-2.1', {
-        'checksums': ['6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8'],
+        'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',
+                       'eea3a51a2e132a023146bfbc0c384f5373eb3ea2b61743d7658be86a5b04949e')],
     }),
     ('sampling', '2.8', {
         'checksums': ['356923f35971bb55f7e97b178aede3366374aa3ad3d24a97be765660553bf21a'],

--- a/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
@@ -2255,7 +2255,8 @@ exts_list = [
         'checksums': ['779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77'],
     }),
     ('rda', '1.0.2-2.1', {
-        'checksums': ['6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8'],
+        'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',
+                       'eea3a51a2e132a023146bfbc0c384f5373eb3ea2b61743d7658be86a5b04949e')],
     }),
     ('sampling', '2.8', {
         'checksums': ['356923f35971bb55f7e97b178aede3366374aa3ad3d24a97be765660553bf21a'],

--- a/easybuild/easyconfigs/r/R/R-3.6.2-foss-2019b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.2-foss-2019b.eb
@@ -1,0 +1,2297 @@
+name = 'R'
+version = '3.6.2'
+
+homepage = 'https://www.r-project.org/'
+description = """R is a free software environment for statistical computing
+ and graphics."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+source_urls = ['https://cloud.r-project.org/src/base/R-%(version_major)s']
+sources = [SOURCE_TAR_GZ]
+checksums = ['bd65a45cddfb88f37370fbcee4ac8dd3f1aebeebe47c2f968fd9770ba2bbc954']
+
+builddependencies = [
+    ('pkg-config', '0.29.2'),
+]
+dependencies = [
+    ('X11', '20190717'),
+    ('Mesa', '19.1.7'),
+    ('libGLU', '9.0.1'),
+    ('cairo', '1.16.0'),
+    ('libreadline', '8.0'),
+    ('ncurses', '6.1'),
+    ('bzip2', '1.0.8'),
+    ('XZ', '5.2.4'),
+    ('zlib', '1.2.11'),
+    ('SQLite', '3.29.0'),
+    ('PCRE', '8.43'),
+    ('libpng', '1.6.37'),  # for plotting in R
+    ('libjpeg-turbo', '2.0.3'),  # for plottting in R
+    ('LibTIFF', '4.0.10'),
+    ('Java', '11', '', True),
+    ('Tk', '8.6.9'),  # for tcltk
+    ('cURL', '7.66.0'),  # for RCurl
+    ('libxml2', '2.9.9'),  # for XML
+    ('GMP', '6.1.2'),  # for igraph
+    ('NLopt', '2.6.1'),  # for nloptr
+    ('FFTW', '3.3.8'),  # for fftw
+    ('libsndfile', '1.0.28'),  # for seewave
+    ('ICU', '64.2'),  # for rJava & gdsfmt
+    ('HDF5', '1.10.5'),  # for hdf5r
+    ('UDUNITS', '2.2.26'),  # for units
+    ('GSL', '2.6'),  # for RcppGSL
+    ('ImageMagick', '7.0.9-5'),  # for animation
+    # OS dependency should be preferred if the os version is more recent then
+    # this version, it's nice to have an up to date openssl for security
+    # reasons
+    # ('OpenSSL', '1.1.1b'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and
+# we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
+
+exts_default_options = {
+    'source_urls': [
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+
+# !! order of packages is important !!
+# packages updated on 16 December 2019
+exts_list = [
+    'base',
+    'datasets',
+    'graphics',
+    'grDevices',
+    'grid',
+    'methods',
+    'splines',
+    'stats',
+    'stats4',
+    'tools',
+    'utils',
+    ('Rmpi', '0.6-9', {
+        'checksums': ['b2e1eac3e56f6b26c7ce744b29d8994ab6507ac88df64ebbb5af439414651ee6'],
+    }),
+    ('abind', '1.4-5', {
+        'checksums': ['3a3ace5afbcb86e56889efcebf3bf5c3bb042a282ba7cc4412d450bb246a3f2c'],
+    }),
+    ('magic', '1.5-9', {
+        'checksums': ['fa1d5ef2d39e880f262d31b77006a2a7e76ea38e306aae4356e682b90d6cd56a'],
+    }),
+    ('Rcpp', '1.0.3', {
+        'checksums': ['2b3500dd3aca16f7b3cb5442625e76dcf4f7c974b4249d33041e9184a5ff030e'],
+    }),
+    ('RcppProgress', '0.4.1', {
+        'checksums': ['11764105922f763d4c75c502599ec7dcc2fd629a029964caf53f98b41d0c607a'],
+    }),
+    ('lpSolve', '5.6.13.3', {
+        'checksums': ['e64165428c40d730f7686d233c22936bf4b3b91a618a600bdf87acaa905f5ff5'],
+    }),
+    ('linprog', '0.9-2', {
+        'checksums': ['8937b2e30692e38de1713f1513b78f505f73da6f5b4a576d151ad60bac2221ce'],
+    }),
+    ('geometry', '0.4.5', {
+        'checksums': ['8fedd17c64468721d398e3c17a39706321ab71098b29f5e8d8039dd115a220d8'],
+    }),
+    ('bit', '1.1-14', {
+        'checksums': ['5cbaace1fb643a665a6ca69b90f7a6d624270de82420ca7a44f306753fcef254'],
+    }),
+    ('filehash', '2.4-2', {
+        'checksums': ['b6d056f75d45e315943a4618f5f62802612cd8931ba3f9f474b595140a3cfb93'],
+    }),
+    ('ff', '2.2-14', {
+        'checksums': ['1c6307847275b1b8ad9e2ffdce3f4df3c9d955dc2e8a45e3fd7bfd2b0926e2f0'],
+    }),
+    ('bnlearn', '4.5', {
+        'checksums': ['a8047625533260a855d309b3c0785cbeec0f9ec13f284b6664a1f61638138578'],
+    }),
+    ('bootstrap', '2019.6', {
+        'checksums': ['5252fdfeb944cf1fae35016d35f9333b1bd1fc8c6d4a14e33901160e21968694'],
+    }),
+    ('combinat', '0.0-8', {
+        'checksums': ['1513cf6b6ed74865bfdd9f8ca58feae12b62f38965d1a32c6130bef810ca30c1'],
+    }),
+    ('deal', '1.2-39', {
+        'checksums': ['a349db8f1c86cbd8315c068da49314ce9eb585dbb50d2e5ff09300506bd8806b'],
+    }),
+    ('fdrtool', '1.2.15', {
+        'checksums': ['65f964aa768d0703ceb7a199adc5e79ca79a6d29d7bc053a262eb533697686c0'],
+    }),
+    ('formatR', '1.7', {
+        'checksums': ['a366621b3ff5f8e86a499b6f87858ad47eefdace138341b1377ecc307a5e5ddb'],
+    }),
+    ('gtools', '3.8.1', {
+        'checksums': ['051484459bd8ad1b03425b8843d24f6828fea18f7357cfa1c192198cc3f4ba38'],
+    }),
+    ('gdata', '2.18.0', {
+        'checksums': ['4b287f59f5bbf5fcbf18db16477852faac4a605b10c5284c46b93fa6e9918d7f'],
+    }),
+    ('GSA', '1.03.1', {
+        'checksums': ['e192d4383f53680dbd556223ea5f8cad6bae62a80a337ba5fd8d05a8aee6a917'],
+    }),
+    ('highr', '0.8', {
+        'checksums': ['4bd01fba995f68c947a99bdf9aca15327a5320151e10bd0326fad50a6d8bc657'],
+    }),
+    ('infotheo', '1.2.0', {
+        'checksums': ['9b47ebc3db5708c88dc014b4ffec6734053a9c255a9241fcede30fec3e63aaa3'],
+    }),
+    ('lars', '1.2', {
+        'checksums': ['64745b568f20b2cfdae3dad02fba92ebf78ffee466a71aaaafd4f48c3921922e'],
+    }),
+    ('lazy', '1.2-16', {
+        'checksums': ['c796c8b987ed1bd9dfddd593e17312ed681fc4fa3a1ecfe51da2def0ac1e50df'],
+    }),
+    ('kernlab', '0.9-29', {
+        'checksums': ['c3da693a0041dd34f869e7b63a8d8cf7d4bc588ac601bcdddcf7d44f68b3106f'],
+    }),
+    ('mime', '0.7', {
+        'checksums': ['11083ee44c92569aadbb9baf60a2e079ab7a721c849b74d102694975cc8d778b'],
+    }),
+    ('xfun', '0.11', {
+        'checksums': ['3cc24b5a67a11204255b71e5fadbb4c303dfb34a32e79c95b787aa8997e1cc36'],
+    }),
+    ('markdown', '1.1', {
+        'checksums': ['8d8cd47472a37362e615dbb8865c3780d7b7db694d59050e19312f126e5efc1b'],
+    }),
+    ('mlbench', '2.1-1', {
+        'checksums': ['748141d56531a39dc4d37cf0a5165a40b653a04c507e916854053ed77119e0e6'],
+    }),
+    ('NLP', '0.2-0', {
+        'checksums': ['fc64c80124c4e53b20f92b60c68e2fd33ee189653d0ceea410c32dd66d9e7075'],
+    }),
+    ('mclust', '5.4.5', {
+        'checksums': ['75f2963082669485953e4306ffa93db98335ee6afdc1318b95d605d56cb30a72'],
+    }),
+    ('RANN', '2.6.1', {
+        'checksums': ['b299c3dfb7be17aa41e66eff5674fddd2992fb6dd3b10bc59ffbf0c401697182'],
+    }),
+    ('rmeta', '3.0', {
+        'checksums': ['b9f9d405935cffcd7a5697ff13b033f9725de45f4dc7b059fd68a7536eb76b6e'],
+    }),
+    ('segmented', '1.1-0', {
+        'checksums': ['d081d0efaec708d717bf1248ba3df099876389c22796aad676655efb706e9d19'],
+    }),
+    ('som', '0.3-5.1', {
+        'checksums': ['a6f4c0e5b36656b7a8ea144b057e3d7642a8b71972da387a7133f3dd65507fb9'],
+    }),
+    ('SuppDists', '1.1-9.4', {
+        'checksums': ['fcb571150af66b95dcf0627298c54f7813671d60521a00ed157f63fc2247ddb9'],
+    }),
+    ('stabledist', '0.7-1', {
+        'checksums': ['06c5704d3a3c179fa389675c537c39a006867bc6e4f23dd7e406476ed2c88a69'],
+    }),
+    ('survivalROC', '1.0.3', {
+        'checksums': ['1449e7038e048e6ad4d3f7767983c0873c9c7a7637ffa03a4cc7f0e25c31cd72'],
+    }),
+    ('pspline', '1.0-18', {
+        'checksums': ['f71cf293bd5462e510ac5ad16c4a96eda18891a0bfa6447dd881c65845e19ac7'],
+    }),
+    ('timeDate', '3043.102', {
+        'checksums': ['377cba03cddab8c6992e31d0683c1db3a73afa9834eee3e95b3b0723f02d7473'],
+    }),
+    ('longmemo', '1.1-1', {
+        'checksums': ['0dd88e84a8376141d117bba39fe44f7d3c29d46fc103557fe98357f06e17d657'],
+    }),
+    ('ADGofTest', '0.3', {
+        'checksums': ['9cd9313954f6ecd82480d373f6c5371ca84ab33e3f5c39d972d35cfcf1096846'],
+    }),
+    ('MASS', '7.3-51.4', {
+        'checksums': [('9911d546a8d29dc906b46cb53ef8aad76d23566f4fc3b52778a1201f8a9b2c74',
+                       '844270a2541eaed420871dfb61d681aa67ee57126645fb6b144b436c25698eeb')],
+    }),
+    ('ade4', '1.7-13', {
+        'checksums': ['f5d0a7356ae63f82d3adb481a39007e7b0d70211b8724aa686af0c89c994e99b'],
+    }),
+    ('AlgDesign', '1.2.0', {
+        'checksums': ['ff86c9e19505770520e7614970ad19c698664d08001ce888b8603e44c2a3b52a'],
+    }),
+    ('base64enc', '0.1-3', {
+        'checksums': ['6d856d8a364bcdc499a0bf38bfd283b7c743d08f0b288174fba7dbf0a04b688d'],
+    }),
+    ('BH', '1.69.0-1', {
+        'checksums': ['a0fd4364b7e368f09c56dec030823f52c16da0787580af7e4615eddeb99baca2'],
+    }),
+    ('brew', '1.0-6', {
+        'checksums': ['d70d1a9a01cf4a923b4f11e4374ffd887ad3ff964f35c6f9dc0f29c8d657f0ed'],
+    }),
+    ('Brobdingnag', '1.2-6', {
+        'checksums': ['19eccaed830ce9d93b70642f6f126ac66722a98bbd48586899cc613dd9966ad4'],
+    }),
+    ('corpcor', '1.6.9', {
+        'checksums': ['2e4fabd1d3936fecea67fa365233590147ca50bb45cf80efb53a10345a8a23c2'],
+    }),
+    ('longitudinal', '1.1.12', {
+        'checksums': ['d4f894c38373ba105b1bdc89e3e7c1b215838e2fb6b4470b9f23768b84e603b5'],
+    }),
+    ('backports', '1.1.5', {
+        'checksums': ['63ec38adf383b70b4cd2b661ad353afacff9c4388353578bf4302ab190e1294c'],
+    }),
+    ('checkmate', '1.9.4', {
+        'checksums': ['faa25754b757fe483b876f5d07b73f76f69a1baa971420892fadec4af4bbad21'],
+    }),
+    ('cubature', '2.0.4', {
+        'checksums': ['d97ce5eaac5e43910208e8274ddf6ff4f974d05688f0247ebccd807e24c2fe4a'],
+    }),
+    ('DEoptimR', '1.0-8', {
+        'checksums': ['846911c1b2561a9fae73a8c60a21a5680963ebb0050af3c1f1147ae9a121e5ef'],
+    }),
+    ('digest', '0.6.23', {
+        'checksums': ['b73a754df122d3c17f4976ea01328c99aa0fc08be399ae2fdce2b33637d205a2'],
+    }),
+    ('fastmatch', '1.1-0', {
+        'checksums': ['20b51aa4838dbe829e11e951444a9c77257dcaf85130807508f6d7e76797007d'],
+    }),
+    ('ffbase', '0.12.7', {
+        'checksums': ['dc16a4faf8abb778c353a5ddaf1a10a2b10b7ae867dd6d0b1be400379ce87d12'],
+    }),
+    ('iterators', '1.0.12', {
+        'checksums': ['96bf31d60ebd23aefae105d9b7790715e63327eec0deb2ddfb3d543994ea9f4b'],
+    }),
+    ('maps', '3.3.0', {
+        'checksums': ['199afe19a4edcef966ae79ef802f5dcc15a022f9c357fcb8cae8925fe8bd2216'],
+    }),
+    ('nnls', '1.4', {
+        'checksums': ['0e5d77abae12bc50639d34354f96a8e079408c9d7138a360743b73bd7bce6c1f'],
+    }),
+    ('sendmailR', '1.2-1', {
+        'checksums': ['04feb08c6c763d9c58b2db24b1222febe01e28974eac4fe87670be6fb9bff17c'],
+    }),
+    ('dotCall64', '1.0-0', {
+        'checksums': ['69318dc6b8aecc54d4f789c8105e672198363b395f1a764ebaeb54c0473d17ad'],
+    }),
+    ('spam', '2.5-1', {
+        'checksums': ['d145881a0d48351ce88678a57862c0d0f716d98f3166f6338d954acacc51c067'],
+    }),
+    ('subplex', '1.5-4', {
+        'checksums': ['ff94cf6b1560f78c31712c05bc2bc1b703339e09c7fc777ee94abf15fa7a8b81'],
+    }),
+    ('stringi', '1.4.3', {
+        'checksums': ['13cecb396b700f81af38746e97b550a1d9fda377ca70c78f6cdfc770d33379ed'],
+    }),
+    ('magrittr', '1.5', {
+        'checksums': ['05c45943ada9443134caa0ab24db4a962b629f00b755ccf039a2a2a7b2c92ae8'],
+    }),
+    ('glue', '1.3.1', {
+        'checksums': ['4fc1f2899d71a634e1f0adb7942772feb5ac73223891abe30ea9bd91d3633ea8'],
+    }),
+    ('stringr', '1.4.0', {
+        'checksums': ['87604d2d3a9ad8fd68444ce0865b59e2ffbdb548a38d6634796bbd83eeb931dd'],
+    }),
+    ('evaluate', '0.14', {
+        'checksums': ['a8c88bdbe4e60046d95ddf7e181ee15a6f41cdf92127c9678f6f3d328a3c5e28'],
+    }),
+    ('logspline', '2.1.15', {
+        'checksums': ['dfe0c89a2ae219d121ea7af788dd994097f42d2ff39f4f86f5c4288a4ec0f71e'],
+    }),
+    ('ncbit', '2013.03.29', {
+        'checksums': ['4480271f14953615c8ddc2e0666866bb1d0964398ba0fab6cc29046436820738'],
+    }),
+    ('permute', '0.9-5', {
+        'checksums': ['d2885384a07497e8df273689d6713fc7c57a7c161f6935f3572015e16ab94865'],
+    }),
+    ('plotrix', '3.7-7', {
+        'checksums': ['a4e8ebda8560ad613b9320d39673879f302da791ac3293ff3f22f8ec7cad22f5'],
+    }),
+    ('randomForest', '4.6-14', {
+        'checksums': ['f4b88920419eb0a89d0bc5744af0416d92d112988702dc726882394128a8754d'],
+    }),
+    ('scatterplot3d', '0.3-41', {
+        'checksums': ['4c8326b70a3b2d37126ca806771d71e5e9fe1201cfbe5b0d5a0a83c3d2c75d94'],
+    }),
+    ('SparseM', '1.78', {
+        'checksums': ['d6b79ec881a10c91cb03dc23e6e783080ded9db4f2cb723755aa0d7d29a8b432'],
+    }),
+    ('tripack', '1.3-8', {
+        'checksums': ['6bb340292a9629a41a0e0664335ddd97be3ad46bca225034db5dfb6efe01c75d'],
+    }),
+    ('irace', '3.3', {
+        'checksums': ['4442d968d2201194555eef69f7fbd986a3c553dd6f2f63a26415168c280b0d10'],
+    }),
+    ('rJava', '0.9-11', {
+        'checksums': ['c28ae131456a98f4d3498aa8f6eac9d4df48727008dacff1aa561fc883972c69'],
+    }),
+    ('lattice', '0.20-38', {
+        'checksums': ['fdeb5e3e50dbbd9d3c5e2fa3eef865132b3eef30fbe53a10c24c7b7dfe5c0a2d'],
+    }),
+    ('RColorBrewer', '1.1-2', {
+        'checksums': ['f3e9781e84e114b7a88eb099825936cc5ae7276bbba5af94d35adb1b3ea2ccdd'],
+    }),
+    ('latticeExtra', '0.6-28', {
+        'checksums': ['780695323dfadac108fb27000011c734e2927b1e0f069f247d65d27994c67ec2'],
+    }),
+    ('Matrix', '1.2-18', {
+        'checksums': ['f7ff018c2811946767ffd4c96d3987e859b82786ff72e1c211ab18bc03cb6119'],
+    }),
+    ('png', '0.1-7', {
+        'checksums': ['e269ff968f04384fc9421d17cfc7c10cf7756b11c2d6d126e9776f5aca65553c'],
+    }),
+    ('RcppArmadillo', '0.9.800.3.0', {
+        'checksums': ['03d671c8551a887617dc34f6bc650a8eee1a395b163ac9ec2cd1a93aded5ec4e'],
+    }),
+    ('plyr', '1.8.5', {
+        'checksums': ['ea008c59a4a7211a09dfc2e4f25d286fc109424c17f01671f72aec97c75a9574'],
+    }),
+    ('gtable', '0.3.0', {
+        'checksums': ['fd386cc4610b1cc7627dac34dba8367f7efe114b968503027fb2e1265c67d6d3'],
+    }),
+    ('reshape2', '1.4.3', {
+        'checksums': ['8aff94c935e75032344b52407593392ddd4e16a88bb206984340c816d42c710e'],
+    }),
+    ('dichromat', '2.0-0', {
+        'checksums': ['31151eaf36f70bdc1172da5ff5088ee51cc0a3db4ead59c7c38c25316d580dd1'],
+    }),
+    ('colorspace', '1.4-1', {
+        'checksums': ['693d713a050f8bfecdb7322739f04b40d99b55aed168803686e43401d5f0d673'],
+    }),
+    ('munsell', '0.5.0', {
+        'checksums': ['d0f3a9fb30e2b5d411fa61db56d4be5733a2621c0edf017d090bdfa5e377e199'],
+    }),
+    ('labeling', '0.3', {
+        'checksums': ['0d8069eb48e91f6f6d6a9148f4e2dc5026cabead15dd15fc343eff9cf33f538f'],
+    }),
+    ('R6', '2.4.1', {
+        'checksums': ['26b0fd64827655c28c903f7ff623e839447387f3ad9b04939a02f41ac82faa3e'],
+    }),
+    ('viridisLite', '0.3.0', {
+        'checksums': ['780ea12e7c4024d5ba9029f3a107321c74b8d6d9165262f6e64b79e00aa0c2af'],
+    }),
+    ('farver', '2.0.1', {
+        'checksums': ['1642ca1519ef80616ab044ae7f6eaf464118356f2a7875e9d0e3df60ca84012b'],
+    }),
+    ('rlang', '0.4.2', {
+        'checksums': ['fbd1c9cb81c94f769bd57079d7ef0682f27b971181340b2ed1e3ab79c2659f39'],
+    }),
+    ('lifecycle', '0.1.0', {
+        'checksums': ['961c28c016d54beee496572a88602fe94d8456ee6455ac88cb2e0fc3273c3387'],
+    }),
+    ('scales', '1.1.0', {
+        'checksums': ['1ee4a6fd1dbc5f52fe57dd8cce8caee4ce2fecb02d4e7d519e83f15aa45b2d03'],
+    }),
+    ('assertthat', '0.2.1', {
+        'checksums': ['85cf7fcc4753a8c86da9a6f454e46c2a58ffc70c4f47cac4d3e3bcefda2a9e9f'],
+    }),
+    ('crayon', '1.3.4', {
+        'checksums': ['fc6e9bf990e9532c4fcf1a3d2ce22d8cf12d25a95e4779adfa17713ed836fa68'],
+    }),
+    ('fansi', '0.4.0', {
+        'checksums': ['e104e9d01c7ff8a847f6b332ef544c0ef912859f9c6a514fe2e6f3b34fcfc209'],
+    }),
+    ('cli', '2.0.0', {
+        'checksums': ['713afa3c38a61d6d5d7a7463961925f8a84c1b0e51b7c2e78e49c81b1bfe63bf'],
+    }),
+    ('utf8', '1.1.4', {
+        'checksums': ['f6da9cadfc683057d45f54b43312a359cf96ec2731c0dda18a8eae31d1e31e54'],
+    }),
+    ('zeallot', '0.1.0', {
+        'checksums': ['439f1213c97c8ddef9a1e1499bdf81c2940859f78b76bc86ba476cebd88ba1e9'],
+    }),
+    ('ellipsis', '0.3.0', {
+        'checksums': ['0bf814cb7a1f0ee1f2949bdc98752a0d535f2a9489280dd4d8fcdb10067ee907'],
+    }),
+    ('vctrs', '0.2.0', {
+        'checksums': ['5bce8f228182ecaa51230d00ad8a018de9cf2579703e82244e0931fe31f20016'],
+    }),
+    ('pillar', '1.4.2', {
+        'checksums': ['bababb76b6db06dc32ccd947dbad6c164a1749ff5b558c6783ad03570f010825'],
+    }),
+    ('pkgconfig', '2.0.3', {
+        'checksums': ['330fef440ffeb842a7dcfffc8303743f1feae83e8d6131078b5a44ff11bc3850'],
+    }),
+    ('tibble', '2.1.3', {
+        'checksums': ['9a8cea9e6b5d24a7e9bf5f67ab38c40b2b6489eddb0d0edb8a48a21ba3574e1a'],
+    }),
+    ('lazyeval', '0.2.2', {
+        'checksums': ['d6904112a21056222cfcd5eb8175a78aa063afe648a562d9c42c6b960a8820d4'],
+    }),
+    ('withr', '2.1.2', {
+        'checksums': ['41366f777d8adb83d0bdbac1392a1ab118b36217ca648d3bb9db763aa7ff4686'],
+    }),
+    ('nlme', '3.1-143', {
+        'checksums': ['42b48586c3ec4eba7de0cef6312aff63f4596cd92a1f9acb618dae28f4ea318e'],
+    }),
+    ('mgcv', '1.8-31', {
+        'checksums': ['736de462a0ac43a6ed38cd57dfb0ba2942c941dfbb538128782727ab7125c3c5'],
+    }),
+    ('ggplot2', '3.2.1', {
+        'checksums': ['e39114a90af69041645b0751ac469d8919c5a7e8cb044a3b56a0728623e65a56'],
+    }),
+    ('pROC', '1.15.3', {
+        'checksums': ['b010988a646a642657ec72d908c2e0ca2f9df0898c05b9f1f5ab6b739353a8cb'],
+    }),
+    ('quadprog', '1.5-8', {
+        'checksums': ['22128dd6b08d3516c44ff89276719ad4fe46b36b23fdd585274fa3a93e7a49cd'],
+    }),
+    ('BB', '2019.10-1', {
+        'checksums': ['04d0b6ce6e5f070b109478a6005653dbe78613bb4e3ea4903203d851b5d3c94d'],
+    }),
+    ('BBmisc', '1.11', {
+        'checksums': ['1ea48c281825349d8642a661bb447e23bfd651db3599bf72593bfebe17b101d2'],
+    }),
+    ('fail', '1.3', {
+        'checksums': ['ede8aa2a9f2371aff5874cd030ac625adb35c33954835b54ab4abf7aeb34d56d'],
+    }),
+    ('rlecuyer', '0.3-5', {
+        'checksums': ['4723434ff7624d4f404a6854ffa0673fc43daa46f58f064dbeeaa17da28ab626'],
+    }),
+    ('snow', '0.4-3', {
+        'checksums': ['8512537daf334ea2b8074dbb80cf5e959a403a78d68bc1e97664e8a4f64576d8'],
+    }),
+    ('tree', '1.0-40', {
+        'checksums': ['ffab16382d7ed5b76529801ab26b4970363b2072231c6a87330326298ce626e7'],
+    }),
+    ('pls', '2.7-2', {
+        'checksums': ['67e91e36dbebeb2f2d9c9b88f310dc00f70de275e5f382f392e72dd36af42b88'],
+    }),
+    ('class', '7.3-15', {
+        'checksums': ['f6bf33d610c726d58622b6cea78a808c7d6a317d02409d27c17741dfd1c730f4'],
+    }),
+    ('e1071', '1.7-3', {
+        'checksums': ['bb2dba526b673ec3a573befe365e3500b773593f0384fd6694e0835496bcc25d'],
+    }),
+    ('nnet', '7.3-12', {
+        'checksums': ['2723523e8581cc0e2215435ac773033577a16087a3f41d111757dd96b8c5559d'],
+    }),
+    ('minqa', '1.2.4', {
+        'checksums': ['cfa193a4a9c55cb08f3faf4ab09c11b70412523767f19894e4eafc6e94cccd0c'],
+    }),
+    ('RcppEigen', '0.3.3.7.0', {
+        'checksums': ['62ea627284425bfdb56613bc315cca492ed3483a56a03c1f9dc9821a25c3e8ac'],
+    }),
+    ('MatrixModels', '0.4-1', {
+        'checksums': ['fe878e401e697992a480cd146421c3a10fa331f6b37a51bac83b5c1119dcce33'],
+    }),
+    ('quantreg', '5.54', {
+        'checksums': ['703b2c67d88e95eaf1bf3c09fc64c1964bcc1145244c8bc8c0e5ac99713ad0a6'],
+    }),
+    ('robustbase', '0.93-5', {
+        'checksums': ['bde564dbd52f04ab32f9f2f9dd09b9578f3ccd2541cf5f8ff430da42a55e7f56'],
+    }),
+    ('sp', '1.3-2', {
+        'checksums': ['940a22add254fbb5ebd80a380f4777fcd1af282975ebad400d177f3a20d6f24e'],
+    }),
+    ('zoo', '1.8-6', {
+        'checksums': ['2217a4f362f2201443b5fdbfd9a77d9a6caeecb05f02d703ee8b3b9bf2af37cc'],
+    }),
+    ('lmtest', '0.9-37', {
+        'checksums': ['ddc929f94bf055974832fa4a20fdd0c1eb3a84ee11f716c287936f2141d5ca0a'],
+    }),
+    ('vcd', '1.4-4', {
+        'checksums': ['a561adf120b5ce41b66e0c0c321542fcddc772eb12b3d7020d86e9cd014ce9d2'],
+    }),
+    ('snowfall', '1.84-6.1', {
+        'checksums': ['5c446df3a931e522a8b138cf1fb7ca5815cc82fcf486dbac964dcbc0690e248d'],
+    }),
+    ('rpart', '4.1-15', {
+        'checksums': ['2b8ebe0e9e11592debff893f93f5a44a6765abd0bd956b0eb1f70e9394cfae5c'],
+    }),
+    ('survival', '3.1-8', {
+        'checksums': ['cecf393e8e27df79f3bf4aa7bc186d161f0e4b46a8572504e6eb80c09027d295'],
+    }),
+    ('bindr', '0.1.1', {
+        'checksums': ['7c785ca77ceb3ab9282148bcecf64d1857d35f5b800531d49483622fe67505d0'],
+    }),
+    ('plogr', '0.2.0', {
+        'checksums': ['0e63ba2e1f624005fe25c67cdd403636a912e063d682eca07f2f1d65e9870d29'],
+    }),
+    ('bindrcpp', '0.2.2', {
+        'checksums': ['48130709eba9d133679a0e959e49a7b14acbce4f47c1e15c4ab46bd9e48ae467'],
+    }),
+    ('purrr', '0.3.3', {
+        'checksums': ['0f31a89a424e12e35bd6e0581dee1d160f1f8be1f0a883a7d33ccbde8ef69e9e'],
+    }),
+    ('tidyselect', '0.2.5', {
+        'checksums': ['5ce2e86230fa35cfc09aa71dcdd6e05e1554a5739c863ca354d241bfccb86c74'],
+    }),
+    ('dplyr', '0.8.3', {
+        'checksums': ['68b4aac65a69ea6390e90991d9c7ce7a011a07e5db439d60cce911a078424c0c'],
+    }),
+    ('tidyr', '1.0.0', {
+        'checksums': ['92a1a30b5636c3c1c68acbff0c1f5b301df64bf3198d23f1c9808ed43a900390'],
+    }),
+    ('mnormt', '1.5-5', {
+        'checksums': ['ff78d5f935278935f1814a69e5a913d93d6dd2ac1b5681ba86b30c6773ef64ac'],
+    }),
+    ('foreign', '0.8-72', {
+        'checksums': ['439c17c9cd387e180b1bb640efff3ed1696b1016d0f7b3b3b884e89884488c88'],
+    }),
+    ('psych', '1.8.12', {
+        'checksums': ['6e175e049bc1ee5b79a9e51ccafb22b962b4e6c839ce5c9cfa1ad83967037743'],
+    }),
+    ('generics', '0.0.2', {
+        'checksums': ['71b3d1b719ce89e71dd396ac8bc6aa5f1cd99bbbf03faff61dfbbee32fec6176'],
+    }),
+    ('broom', '0.5.3', {
+        'checksums': ['0d59b135bfa11c633c8ceec640342f026c5468c620984484bbc9adde1211f59c'],
+    }),
+    ('nloptr', '1.2.1', {
+        'checksums': ['1f86e33ecde6c3b0d2098c47591a9cd0fa41fb973ebf5145859677492730df97'],
+    }),
+    ('boot', '1.3-23', {
+        'checksums': [('30c89e19dd6490b943233e87dfe422bfef92cfbb7a7dfb5c17dfd9b2d63fa02f',
+                       '79236a5a770dc8bf5ce25d9aa303c5dc0574d94aa043fd00b8b4c8ccc877357f')],
+    }),
+    ('lme4', '1.1-21', {
+        'checksums': ['7f5554b69ff8ce9bac21e8842131ea940fb7a7dfa2de03684f236d3e3114b20c'],
+    }),
+    ('ucminf', '1.1-4', {
+        'checksums': ['a2eb382f9b24e949d982e311578518710f8242070b3aa3314a331c1e1e7f6f07'],
+    }),
+    ('numDeriv', '2016.8-1.1', {
+        'checksums': ['d8c4d19ff9aeb31b0c628bd4a16378e51c1c9a3813b525469a31fe89af00b345'],
+    }),
+    ('ordinal', '2019.12-10', {
+        'checksums': ['7a41e7b7e852a8fa3e911f8859d36e5709ccec5ca42ee3de14a813b7aaac7725'],
+    }),
+    ('jomo', '2.6-10', {
+        'checksums': ['4063d48e259e936dc0bd9dc616a09043f695703848cb1bf8faa08c07922034cd'],
+    }),
+    ('hms', '0.5.2', {
+        'checksums': ['d445c98c36b224e73c76dd4fc2a700e0b1abf0ade3d8ac8ac96c12fb946e4440'],
+    }),
+    ('clipr', '0.7.0', {
+        'checksums': ['03a4e4b72ec63bd08b53fe62673ffc19a004cc846957a335be2b30d046b8c2e2'],
+    }),
+    ('readr', '1.3.1', {
+        'checksums': ['33f94de39bb7f2a342fbb2bd4e5afcfec08798eac39672ee18042ac0b349e4f3'],
+    }),
+    ('forcats', '0.4.0', {
+        'checksums': ['7c83cb576aa6fe1379d7506dcc332f7560068b2025f9e3ab5cd0a5f28780d2b2'],
+    }),
+    ('haven', '2.2.0', {
+        'checksums': ['199ee9b14e1ff70a0b0c3b9ce33dfdec8ed3b5e857a2a36bfb82e78a7b352d3d'],
+    }),
+    ('pan', '1.6', {
+        'checksums': ['adc0df816ae38bc188bce0aef3aeb71d19c0fc26e063107eeee71a81a49463b6'],
+    }),
+    ('mitml', '0.3-7', {
+        'checksums': ['c6f796d0059f1b093b599a89d955982fa257de9c45763ecc2cbbce10fdec1e7b'],
+    }),
+    ('mice', '3.7.0', {
+        'checksums': ['4eab2959bcfe28eae068e5e697901b47b05a6c88e0a34af8303f1ec05ed0a1f3'],
+    }),
+    ('urca', '1.3-0', {
+        'checksums': ['621cc82398e25b58b4a16edf000ed0a1484d9a0bc458f734e97b6f371cc76aaa'],
+    }),
+    ('fracdiff', '1.5-0', {
+        'checksums': ['3a837326a6cdeed5ab1b8a83f57adb2e861886736fbde49fede79b6150081b70'],
+    }),
+    ('logistf', '1.23', {
+        'checksums': ['5adb22a40569883395dc048c877f849dd08d07582a991f1b160f0338f0b13838'],
+    }),
+    ('akima', '0.6-2', {
+        'checksums': ['61da3e556553eea6d1f8db7c92218254441da31e365bdef82dfe5da188cc97ce'],
+    }),
+    ('bitops', '1.0-6', {
+        'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
+    }),
+    ('mixtools', '1.1.0', {
+        'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],
+    }),
+    ('cluster', '2.1.0', {
+        'checksums': ['eaf955bef8f616ea563351ec7f597c445aec43e65991ca975e382ef1fd70aa14'],
+    }),
+    ('gclus', '1.3.2', {
+        'checksums': ['9cc61cdff206c11213e73afca3d570a7234250cf6044a9202c2589932278e0b3'],
+    }),
+    ('coda', '0.19-3', {
+        'checksums': ['d3df1fc848bcf1af8fae13d61eeab60e99a3d4b4db384bec4326f909f502c5d6'],
+    }),
+    ('codetools', '0.2-16', {
+        'checksums': ['f67a66175cb5d8882457d1e9b91ea2f16813d554fa74f80c1fd6e17cf1877501'],
+    }),
+    ('foreach', '1.4.7', {
+        'checksums': ['95632c0b1182fc01490718d82fa3b2bce864f2a011ae53282431c7c2a3f5f160'],
+    }),
+    ('doMC', '1.3.6', {
+        'checksums': ['2977fc9e2dc54d85d45b4a36cd286dff72834fbc73f38b6ee45a6eb8557fc9b2'],
+    }),
+    ('DBI', '1.1.0', {
+        'checksums': ['a96db7fa39a58f1ed34c6e78d8f5f7e4cf0882afb301323b5c6975d6729203e4'],
+    }),
+    ('gam', '1.16.1', {
+        'checksums': ['80d04102c6152143e8ed364f91eb312e413f73b8fcab7cf15d677867a16e74b9'],
+    }),
+    ('gamlss.data', '5.1-4', {
+        'checksums': ['0d3777d8c3cd76cef273aa6bde40a91688719be401195ed9bfd1e85bd7d5eeb5'],
+    }),
+    ('gamlss.dist', '5.1-5', {
+        'checksums': ['1c6f42d17e32eae848217bc5115bc440ff8f95869d7fef0756fbf6f2da8787e6'],
+    }),
+    ('gamlss', '5.1-5', {
+        'checksums': ['6ca1297418e514a7b89f59789908d040e3160cb32e7cf024cc623630997b963d'],
+    }),
+    ('gamlss.tr', '5.1-0', {
+        'checksums': ['f9e1c4935d8876bfc80dddc0a9bc2c82b4deeda9482df208297a84a638a4a9df'],
+    }),
+    ('hwriter', '1.3.2', {
+        'checksums': ['6b3531d2e7a239be9d6e3a1aa3256b2745eb68aa0bdffd2076d36552d0d7322b'],
+    }),
+    ('KernSmooth', '2.23-16', {
+        'checksums': ['b8c251fea1483a8ade005faf31dff9d85d2b6da08dcd661bf1e4a861db9a99a9'],
+    }),
+    ('xts', '0.11-2', {
+        'checksums': ['12772f6a66aab5b84b0665c470f11a3d8d8a992955c027261cfe8e6077ee13b8'],
+    }),
+    ('curl', '4.3', {
+        'checksums': ['7406d485bb50a6190e3ed201e3489063fd249b8b3b1b4f049167ac405a352edb'],
+    }),
+    ('TTR', '0.23-6', {
+        'checksums': ['afc10a89d3a18f121ddf0f7256408eeb05cc64e18ee94e654bfa803e5415e265'],
+    }),
+    ('quantmod', '0.4-15', {
+        'checksums': ['7ef2e798d4d8e4d2af0a5b2b9fecebec30568087afbd24bfd923cdeb8b53df53'],
+    }),
+    ('mvtnorm', '1.0-11', {
+        'checksums': ['0321612de99aa9bc75a45c7e029d3372736014223cbdefb80d8cae600cbc7252'],
+    }),
+    ('pcaPP', '1.9-73', {
+        'checksums': ['ca4566b0babfbe83ef9418283b08a12b3420dc362f93c6562f265df7926b53fc'],
+    }),
+    ('SQUAREM', '2017.10-1', {
+        'checksums': ['9b89905b436f1cf3faa9e3dabc585a76299e729e85ca659bfddb4b7cba11b283'],
+    }),
+    ('lava', '1.6.6', {
+        'checksums': ['7abc84dd99cce450a45ac4f232812cde3a322e432da3472f43b057fb5c59ca59'],
+    }),
+    ('prodlim', '2019.11.13', {
+        'checksums': ['6809924f503a14681de84730489cdaf9240d7951c64f5b98ca37dc1ce7809b0f'],
+    }),
+    ('pscl', '1.5.2', {
+        'checksums': ['2c9fe648485c6b54c6f95a54b6e00ffe3cf06fa8c5c68f1d669664a7b91a0ede'],
+    }),
+    ('memoise', '1.1.0', {
+        'checksums': ['b276f9452a26aeb79e12dd7227fcc8712832781a42f92d70e86040da0573980c'],
+    }),
+    ('bit64', '0.9-7', {
+        'checksums': ['7b9aaa7f971198728c3629f9ba1a1b24d53db5c7e459498b0fdf86bbd3dff61f'],
+    }),
+    ('prettyunits', '1.0.2', {
+        'checksums': ['35a4980586c20650538ae1e4fed4d80fdde3f212b98546fc3c7d9469a1207f5c'],
+    }),
+    ('blob', '1.2.0', {
+        'checksums': ['1af1cfa28607bc0e2f1f01598a00a7d5d1385ef160a9e79e568f30f56538e023'],
+    }),
+    ('RSQLite', '2.1.4', {
+        'checksums': ['64b80063833d4cdbc4b44b7d70c605bf87c2595300049a8c519e46ecbec10aee'],
+    }),
+    ('data.table', '1.12.8', {
+        'checksums': ['d3a75f3a355ff144cc20a476041617e21fcf2a9f79265fd9bbd4693f3671f9dc'],
+    }),
+    ('BatchJobs', '1.8', {
+        'checksums': ['35cc2dae31994b1df982d11939509ce965e12578418c4fbb8cd7a422afd6e4ff'],
+    }),
+    ('sandwich', '2.5-1', {
+        'checksums': ['dbef6f4d12b83e166f9a2508b7c732b04493641685d6758d29f3609e564166d6'],
+    }),
+    ('sfsmisc', '1.1-4', {
+        'checksums': ['44b6a9c859922e86b7182e54eb781d3264f3819f310343518ebc66f54f305c7d'],
+    }),
+    ('spatial', '7.3-11', {
+        'checksums': ['624448d2ac22e1798097d09fc5dc4605908a33f490b8ec971fc6ea318a445c11'],
+    }),
+    ('VGAM', '1.1-2', {
+        'checksums': ['f8071339f127121945954c98168749efcc179c67c70437d35b5d684fd4b0ca4f'],
+    }),
+    ('waveslim', '1.7.5.1', {
+        'checksums': ['b323018c92674b1b49fe01ec7e3900641a1c9ce0bd1e7497cfe8f64e96057e56'],
+    }),
+    ('xtable', '1.8-4', {
+        'checksums': ['5abec0e8c27865ef0880f1d19c9f9ca7cc0fd24eadaa72bcd270c3fb4075fd1c'],
+    }),
+    ('profileModel', '0.6.0', {
+        'checksums': ['a829ceec29c817d6d15947b818e28f9cf5a188a231b9b5d0a75018388887087b'],
+    }),
+    ('brglm', '0.6.2', {
+        'checksums': ['c2af432a43ccf37e9de50317f770b9703a4c80b4ef79ec40aa8e7ec3987e3631'],
+    }),
+    ('deSolve', '1.25', {
+        'checksums': ['773170a7b9f82db3a8dfb563942ee0e71ebdebc388e59f93e918d257eef0651c'],
+    }),
+    ('tseriesChaos', '0.1-13.1', {
+        'checksums': ['23cb5fea56409a305e02a523ff8b7642ec383942d415c9cffdc92208dacfd961'],
+    }),
+    ('tseries', '0.10-47', {
+        'checksums': ['202377df56806fe611c2e12c4d9732c71b71220726e2defa7e568d2b5b62fb7b'],
+    }),
+    ('fastICA', '1.2-2', {
+        'checksums': ['32223593374102bf54c8fdca7b57231e4f4d0dd0be02d9f3500ad41b1996f1fe'],
+    }),
+    ('R.methodsS3', '1.7.1', {
+        'checksums': ['44b840399266cd27f8f9157777b4d9d85ab7bd31bfdc143b3fc45079a2d8e687'],
+    }),
+    ('R.oo', '1.23.0', {
+        'checksums': ['f5124ce3dbb0a62e8ef1bfce2de2d1dc2f776e8c48fd8cac358f7f5feb592ea1'],
+    }),
+    ('jsonlite', '1.6', {
+        'checksums': ['88c5b425229966b7409145a6cabc72db9ed04f8c37ee95901af0146bb285db53'],
+    }),
+    ('sys', '3.3', {
+        'checksums': ['a6217c2a7240ed68614006f392c6d062247dab8b9b0d498f95e947110df19b93'],
+    }),
+    ('askpass', '1.1', {
+        'checksums': ['db40827d1bdbb90c0aa2846a2961d3bf9d76ad1b392302f9dd84cc2fd18c001f'],
+    }),
+    ('openssl', '1.4.1', {
+        'checksums': ['f7fbecc75254fc43297a95a4338c674ab9ba2ec056b59e027d16d23122161fc6'],
+    }),
+    ('httr', '1.4.1', {
+        'checksums': ['675c7e07bbe82c48284ee1ab929bb14a6e653abae2860d854dc41a3c028de156'],
+    }),
+    ('cgdsr', '1.3.0', {
+        'checksums': ['4aa2a3564cee2449c3ff39ab2ad631deb165d4c78b8107e0ff77a9095340cc1f'],
+    }),
+    ('R.utils', '2.9.2', {
+        'checksums': ['ac6b3b8e814fbb855c38fbdb89a4f0cf0ed65ce7fa308445bd74107fbc0d32cf'],
+    }),
+    ('R.matlab', version, {
+        'checksums': ['1ba338f470a24b7f6ef68cadbd04eb468ead4a689f263d2642408ad591b786bb'],
+    }),
+    ('gridExtra', '2.3', {
+        'checksums': ['81b60ce6f237ec308555471ae0119158b115463df696d2eca9b177ded8988e3b'],
+    }),
+    ('gbm', '2.1.5', {
+        'checksums': ['06fbde10639dfa886554379b40a7402d1f1236a9152eca517e97738895a4466f'],
+    }),
+    ('Formula', '1.2-3', {
+        'checksums': ['1411349b20bd09611a9fd0ee6d15f780c758ad2b0e490e908facb49433823872'],
+    }),
+    ('acepack', '1.4.1', {
+        'checksums': ['82750507926f02a696f6cc03693e8d4a5ee7e92500c8c15a16a9c12addcd28b9'],
+    }),
+    ('proto', '1.0.0', {
+        'checksums': ['9294d9a3b2b680bb6fac17000bfc97453d77c87ef68cfd609b4c4eb6d11d04d1'],
+    }),
+    ('chron', '2.3-54', {
+        'checksums': ['0df3ac3e96e0469a8fd727ef65a1edfada90c088cd74f535ff5882ce716f876d'],
+    }),
+    ('viridis', '0.5.1', {
+        'checksums': ['ddf267515838c6eb092938133035cee62ab6a78760413bfc28b8256165701918'],
+    }),
+    ('yaml', '2.2.0', {
+        'checksums': ['55bcac87eca360ab5904914fcff473a6981a1f5e6d2215d2634344d0ac30c546'],
+    }),
+    ('htmltools', '0.4.0', {
+        'checksums': ['5b18552e1183b1b90b5cca8e7f95b57e8124c9d517b22aa64783b829513b811a'],
+    }),
+    ('htmlwidgets', '1.5.1', {
+        'checksums': ['d42e59144552d9b4131f11ddd6169dfb9bd538c7996669a09acbdb400d18d781'],
+    }),
+    ('knitr', '1.26', {
+        'checksums': ['38db354bec68f25cf8a05e5162ebbac45811309c75a7bcfc8bcb5a565a5bc321'],
+    }),
+    ('rstudioapi', '0.10', {
+        'checksums': ['80c5aa3063bcab649904cb92f0b164edffa2f6b0e6a8f7ea28ae317b80e1ab96'],
+    }),
+    ('htmlTable', '1.13.3', {
+        'checksums': ['d459c43675f6ee0a1ae8232ea8819b2a842e795a833b28127081fa344d09393d'],
+    }),
+    ('Hmisc', '4.3-0', {
+        'checksums': ['7ff2f9adcfd67f2e70345e73db3608ed46f8e07e2f696d0d591f533482a96165'],
+    }),
+    ('fastcluster', '1.1.25', {
+        'checksums': ['f3661def975802f3dd3cec5b2a1379f3707eacff945cf448e33aec0da1ed4205'],
+    }),
+    ('registry', '0.5-1', {
+        'checksums': ['dfea36edb0a703ec57e111016789b47a1ba21d9c8ff30672555c81327a3372cc'],
+    }),
+    ('bibtex', '0.4.2', {
+        'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
+    }),
+    ('pkgmaker', '0.27', {
+        'checksums': ['17a289d8f596ba5637b07077b3bff22411a2c2263c0b7de59fe848666555ec6a'],
+    }),
+    ('rngtools', '1.4', {
+        'checksums': ['3aa92366e5d0500537964302f5754a750aff6b169a27611725e7d84552913bce'],
+    }),
+    ('doParallel', '1.0.15', {
+        'checksums': ['71ad7ea69616468996aefdd8d02a4a234759a21ddde9ed1657e3c537145cd86e'],
+    }),
+    ('gridBase', '0.4-7', {
+        'checksums': ['be8718d24cd10f6e323dce91b15fc40ed88bccaa26acf3192d5e38fe33e15f26'],
+    }),
+    ('NMF', '0.21.0', {
+        'checksums': ['3b30c81c66066fab4a63c5611a0313418b840d8b63414db31ef0e932872d02e3'],
+    }),
+    ('irlba', '2.3.3', {
+        'checksums': ['6ee233697bcd579813bd0af5e1f4e6dd1eea971e8919c748408130d970fef5c0'],
+    }),
+    ('igraph', '1.2.4.2', {
+        'checksums': ['ad67b58e9132128d8ea7ec0dee5c071a21f4674e8f2cbaa642555d23165e9969'],
+    }),
+    ('GeneNet', '1.2.13', {
+        'checksums': ['3798caac3bef7dc87f97b3628eb29eb12365d571ce0837b5b6285b0be655a270'],
+    }),
+    ('ape', '5.3', {
+        'checksums': ['08b0df134c523feb00a86896d1aa2a43f0f0dab20a53bc6b5d6268d867988b23'],
+    }),
+    ('RJSONIO', '1.3-1.3', {
+        'checksums': ['bc5e97dac4d6e935ba530f60be9364ea5f2aebaf5b9a907135e8d7c0d56d22b9'],
+    }),
+    ('caTools', '1.17.1.3', {
+        'checksums': ['d78735c5adb54ba31a4d529cc2fbf7d3c72a6e12fc24afda8d36acdefcdaa712'],
+    }),
+    ('gplots', '3.0.1.1', {
+        'checksums': ['7db103f903a25d174cddcdfc7b946039b61e236c95084b90ad17f1a41da3770c'],
+    }),
+    ('ROCR', '1.0-7', {
+        'checksums': ['e7ef710f847e441a48b20fdc781dbc1377f5a060a5ee635234053f7a2a435ec9'],
+    }),
+    ('later', '1.0.0', {
+        'checksums': ['277b9848ef2e5e1ac7257aefeb58f6b20cca17693460e7c4eee0477de456b287'],
+    }),
+    ('promises', '1.1.0', {
+        'checksums': ['c8ea0f3e3256cf3010439b3a6111966db419c3dcff9a561e73caf8bd65f38006'],
+    }),
+    ('httpuv', '1.5.2', {
+        'checksums': ['93b32be974e0f531a3cb343685165c0caadf30cfea07683f8d69302a34045d8d'],
+    }),
+    ('rjson', '0.2.20', {
+        'checksums': ['3a287c1e5ee7c333ed8385913c0a307daf99335fbdf803e9dcca6e3d5adb3f6c'],
+    }),
+    ('sourcetools', '0.1.7', {
+        'checksums': ['47984406efb3b3face133979ccbae9fefb7360b9a6ca1a1c11473681418ed2ca'],
+    }),
+    ('fastmap', '1.0.1', {
+        'checksums': ['4778b05dfebd356f8df980dfeff3b973a72bca14898f870e5c40c1d84db9faec'],
+    }),
+    ('shiny', '1.4.0', {
+        'checksums': ['0c070459387cea98ca7c6df7318370116df42afb5f76a8625eb4f5b681ee6c4b'],
+    }),
+    ('seqinr', '3.6-1', {
+        'checksums': ['c44fc8922ef410da3c3b5ca117cdbec55ccb546c9e6d96c01ede44398dfa6048'],
+    }),
+    ('LearnBayes', '2.15.1', {
+        'checksums': ['9b110858456523ca0b2a63f22013c4e1fbda6674b9d84dc1f4de8bffc5260532'],
+    }),
+    ('deldir', '0.1-23', {
+        'checksums': ['e0112bce9fc94daf73596a0fff9b3958b80872e3bbb487be73e157b13a6f201d'],
+    }),
+    ('gmodels', '2.18.1', {
+        'checksums': ['626140a34eb8c53dd0a06511a76c71bc61c48777fa76fcc5e6934c9c276a1369'],
+    }),
+    ('expm', '0.999-4', {
+        'checksums': ['58d06427a08c9442462b00a5531e2575800be13ed450c5a1546261251e536096'],
+    }),
+    ('spData', '0.3.2', {
+        'checksums': ['7c7d93e7b722e67695f89e1961592733393298229359768fe846087b73d615a4'],
+    }),
+    ('units', '0.6-5', {
+        'checksums': ['50b759fe0c91f7e098cabb348f3d14067f3dbeb26574a2259d27870c2ad2d40a'],
+    }),
+    ('classInt', '0.4-2', {
+        'checksums': ['bb0da1e7db779831cf5cea80722ade90bf83a9aa51b7d2bc6bee69c433042871'],
+    }),
+    ('vegan', '2.5-6', {
+        'checksums': ['b3c00aceb3db38101960515658e2b9ec1552439c3ed4e26e72989f18eccbc03c'],
+    }),
+    ('progress', '1.2.2', {
+        'checksums': ['b4a4d8ed55db99394b036a29a0fb20b5dd2a91c211a1d651c52a1023cc58ff35'],
+    }),
+    ('rncl', '0.8.3', {
+        'checksums': ['daaef6874438233c73a62b59a9ee10261e1e10d7ef18b7178d2d8b517fd4880d'],
+    }),
+    ('XML', '3.98-1.20', {
+        'checksums': ['46af86376ea9a0fb1b440cf0acdf9b89178686a05c4b77728fcff1f023aa4858'],
+    }),
+    ('praise', '1.0.0', {
+        'checksums': ['5c035e74fd05dfa59b03afe0d5f4c53fbf34144e175e90c53d09c6baedf5debd'],
+    }),
+    ('ps', '1.3.0', {
+        'checksums': ['289193d0ccd2db0b6fe8702e8c5711e935219b17f90f01a6e9684982413e98d1'],
+    }),
+    ('processx', '3.4.1', {
+        'checksums': ['f1abddb48fa78f2b176552e2ec5d808d4d87d79ce72e9b3d25c9a7d715bbd1bc'],
+    }),
+    ('callr', '3.4.0', {
+        'checksums': ['99ea44fa5b9ce3db1c3811f57021b04c172611ec6caa6e317808ff489fe07dc3'],
+    }),
+    ('rprojroot', '1.3-2', {
+        'checksums': ['df5665834941d8b0e377a8810a04f98552201678300f168de5f58a587b73238b'],
+    }),
+    ('desc', '1.2.0', {
+        'checksums': ['e66fb5d4fc7974bc558abcdc107a1f258c9177a29dcfcf9164bc6b33dd08dae8'],
+    }),
+    ('pkgbuild', '1.0.6', {
+        'checksums': ['bd736cadcb9938df9fafddd362f9f032934a93b9853b981eb3754db8a3f9d476'],
+    }),
+    ('pkgload', '1.0.2', {
+        'checksums': ['3186564e690fb05eabe76e1ac0bfd4312562c3ac8794b29f8850399515dcf27c'],
+    }),
+    ('testthat', '2.3.1', {
+        'checksums': ['7eae9574b8baf80a95b529aff982fb691794bf211c8bf58ce431d9771b641d55'],
+    }),
+    ('tinytex', '0.18', {
+        'checksums': ['39cf729b11138f55949901facd346452b17192640603f995ad7df5d8145cb712'],
+    }),
+    ('rmarkdown', '2.0', {
+        'checksums': ['87ba0499555719cf3793bfd6ff4fa3577401ac5d90577c300bee02c54fb0a3ae'],
+    }),
+    ('reshape', '0.8.8', {
+        'checksums': ['4d5597fde8511e8fe4e4d1fd7adfc7ab37ff41ac68c76a746f7487d7b106d168'],
+    }),
+    ('xml2', '1.2.2', {
+        'checksums': ['3050f147c4335be2925a576557bbda36bd52a5bba3110d47b740a2dd811a78f4'],
+    }),
+    ('triebeard', '0.3.0', {
+        'checksums': ['bf1dd6209cea1aab24e21a85375ca473ad11c2eff400d65c6202c0fb4ef91ec3'],
+    }),
+    ('urltools', '1.7.3', {
+        'checksums': ['6020355c1b16a9e3956674e5dea9ac5c035c8eb3eb6bbdd841a2b5528cafa313'],
+    }),
+    ('httpcode', '0.2.0', {
+        'checksums': ['fbc1853db742a2cc1df11285cf27ce2ea43bc0ba5f7d393ee96c7e0ee328681a'],
+    }),
+    ('crul', '0.9.0', {
+        'checksums': ['a7b42c69ca31648a419b93c618d32d0613f3ea053e45d584e84ef422ccf531c0'],
+    }),
+    ('bold', '0.9.0', {
+        'checksums': ['45e844a83f4545a2f84887e36db83113da824a8673fa039f067a3bd7ee82ed5e'],
+    }),
+    ('rredlist', '0.5.0', {
+        'checksums': ['404db668f94aea7fe8c4da75085ea82b0bc9994f023ef4a52f4d75cf198db889'],
+    }),
+    ('rentrez', '1.2.2', {
+        'checksums': ['e5cb4265fd06d2ed0e11da3667ba79f7f2c8816005ba72cf5f53b8cf02dc193e'],
+    }),
+    ('rotl', '3.0.10', {
+        'checksums': ['38b4679fe2d5407f7d0799d624ae8ea5d73ec0b6531b0e3d48246dea5575073a'],
+    }),
+    ('solrium', '1.1.4', {
+        'checksums': ['5fccdb455746493c56e4df91f01ea9e89cdf0d67cfa5f958ca246b9207d20375'],
+    }),
+    ('ritis', '0.8.0', {
+        'checksums': ['23bc11599a64c25fe7a60e86fa3cd8c4078e140bc338c6d51d8d75b81564ecbd'],
+    }),
+    ('worrms', '0.4.0', {
+        'checksums': ['8480c56a4412662a383103fef68e73fcf14e94fcb878c25df8c6d5a8c0146059'],
+    }),
+    ('natserv', '0.3.0', {
+        'checksums': ['3c207d45bbba75dfd16f40d6eaaac122e40b3d3ca05b3b98aa8ed3c092638e5e'],
+    }),
+    ('WikipediR', '1.5.0', {
+        'checksums': ['f8d0e6f04fb65f7ad9c1c068852a6a8b699ffe8d39edf1f3fa07d32d087e8ff0'],
+    }),
+    ('WikidataR', '1.4.0', {
+        'checksums': ['64b1d53d7023249b73a77a7146adc3a8957b7bf3d808ebd6734795e9f58f4b2a'],
+    }),
+    ('wikitaxa', '0.3.0', {
+        'checksums': ['10dbabac6c56c1d0f33a66ff9b4f48b0bcb470711808a86863b48dc1140ec86c'],
+    }),
+    ('phangorn', '2.5.5', {
+        'checksums': ['c58dc1ace26cb4358619a15da3ea4765dbdde1557acccc5103c85589a7571346'],
+    }),
+    ('taxize', '0.9.91', {
+        'checksums': ['ce3d05c5c7c2d2cf2612264b24b9880b587d459efa3f5b7703667e0b64a58f59'],
+    }),
+    ('uuid', '0.1-2', {
+        'checksums': ['dd71704dc336b0857981b92a75ed9877d4ca47780b1682def28839304cd3b1be'],
+    }),
+    ('RNeXML', '2.4.0', {
+        'checksums': ['e162a896f895199061a0c537f65aeae480be8190fcae2a1be2b80fbc54cb9398'],
+    }),
+    ('phylobase', '0.8.6', {
+        'checksums': ['e7117b210ef406115e5523b794d8c2c5779640cee8c06e73751dc14c69322fd9'],
+    }),
+    ('magick', '2.2', {
+        'checksums': ['05d13050be37d158e66fd895ef03a34184ed96a5a3258d790c930f3d15ac05f6'],
+    }),
+    ('animation', '2.6', {
+        'checksums': ['90293638920ac436e7e4de76ebfd92e1643ccdb0259b62128f16dd0b13245b0a'],
+    }),
+    ('bigmemory.sri', '0.1.3', {
+        'checksums': ['55403252d8bae9627476d1f553236ea5dc7aa6e54da6980526a6cdc66924e155'],
+    }),
+    ('bigmemory', '4.5.33', {
+        'checksums': ['7237d9785d8ce3eab4e36ad3ce2c95cbae926326031661b4f237b7517f4b9479'],
+    }),
+    ('calibrate', '1.7.5', {
+        'checksums': ['33f4f6874f0a979af3ce592ed1105e829d3df1fbf05c6e0cd3829a13b21d82e8'],
+    }),
+    ('clusterGeneration', '1.3.4', {
+        'checksums': ['7c591ad95a8a9d7fb0e4d5d80dfd78f7d6a63cf7d11eb53dd3c98fdfb5b868aa'],
+    }),
+    ('raster', '3.0-7', {
+        'checksums': ['764f1c3d66ad2d1242c9fad6cff30291f351bfdb41df11d7a66b760ac3d95d39'],
+    }),
+    ('dismo', '1.1-4', {
+        'checksums': ['f2110f716cd9e4cca5fd2b22130c6954658aaf61361d2fe688ba22bbfdfa97c8'],
+    }),
+    ('extrafontdb', '1.0', {
+        'checksums': ['faa1bafee5d4fbc24d03ed237f29f1179964ebac6e3a46ac25b0eceda020b684'],
+    }),
+    ('Rttf2pt1', '1.3.7', {
+        'checksums': ['4a4e50578b5c1dbfb90c289ee388c102de1f9c84f8b8ddb8d2294b58474e0e8a'],
+    }),
+    ('extrafont', '0.17', {
+        'checksums': ['2f6d7d79a890424b56ddbdced361f8b9ddede5edd33e090b816b88a99315332d'],
+    }),
+    ('fields', '10.0', {
+        'checksums': ['3406a04034429ef3a68a68782a0f73099e3e28f0f8880d706cde0c9177a97f9c'],
+    }),
+    ('shapefiles', '0.7', {
+        'checksums': ['eeb18ea4165119519a978d4a2ba1ecbb47649deb96a7f617f5b3100d63b3f021'],
+    }),
+    ('fossil', '0.3.7', {
+        'checksums': ['3feba6ceecaa6f2f68fdc1ceb0019395ccfadb0cf033e1709dddb690c7f210a1'],
+    }),
+    ('geiger', '2.0.6.2', {
+        'checksums': ['9153047b608d652821251206d1450bb3f517c8884379f498a695315574ae001d'],
+    }),
+    ('shape', '1.4.4', {
+        'checksums': ['f4cb1b7d7c84cf08d2fa97f712ea7eb53ed5fa16e5c7293b820bceabea984d41'],
+    }),
+    ('glmnet', '3.0-2', {
+        'checksums': ['f48956a75af7e2be045198873fc9eb637a549af1db83dcf76cac3774bfb3762c'],
+    }),
+    ('crosstalk', '1.0.0', {
+        'checksums': ['b31eada24cac26f24c9763d9a8cbe0adfd87b264cf57f8725027fe0c7742ca51'],
+    }),
+    ('miniUI', '0.1.1.1', {
+        'checksums': ['452b41133289f630d8026507263744e385908ca025e9a7976925c1539816b0c0'],
+    }),
+    ('webshot', '0.5.2', {
+        'checksums': ['f183dc970157075b51ac543550a7a48fa3428b9c6838abb72fe987c21982043f'],
+    }),
+    ('manipulateWidget', '0.10.0', {
+        'checksums': ['3d61a3d0cedf5c8a850a3e62ed6af38c600dc3f25b44c4ff07a5093bf9ca4ffd'],
+    }),
+    ('rgl', '0.100.30', {
+        'checksums': ['8575f51160b43057e5992f0d38480309fae3b8cca50b933d814a38cea6fef867'],
+    }),
+    ('Rtsne', '0.15', {
+        'checksums': ['56376e4f0a382fad3d3d40e2cb0562224be5265b827622bcd235e8fc63df276c'],
+    }),
+    ('labdsv', '2.0-1', {
+        'checksums': ['5a4d55e9be18222dc47e725008b450996448ab117d83e7caaa191c0f13fd3925'],
+    }),
+    ('stabs', '0.6-3', {
+        'checksums': ['e961ae21d45babc1162b6eeda874c4e3677fc286fd06f5427f071ad7a5064a9f'],
+    }),
+    ('modeltools', '0.2-22', {
+        'checksums': ['256a088fc80b0d9182f984f9bd3d6207fb7c1e743f72e2ecb480e6c1d4ac34e9'],
+    }),
+    ('strucchange', '1.5-2', {
+        'checksums': ['7d247c5ae6f5a63c80e478799d009c57fb8803943aa4286d05f71235cc1002f8'],
+    }),
+    ('TH.data', '1.0-10', {
+        'checksums': ['618a1c67a30536d54b1e48ba3af46a6edcd6c2abef17935b5d4ba526a43aff55'],
+    }),
+    ('multcomp', '1.4-11', {
+        'checksums': ['0bd22d9c978eac17ac6ed65ef15890df6730551e93ba9d3e3769100d8331894b'],
+    }),
+    ('libcoin', '1.0-5', {
+        'checksums': ['0a744164e00557d2f3e888d14cfd6108d17c14e983db620f74c7a5475be8a9b2'],
+    }),
+    ('matrixStats', '0.55.0', {
+        'checksums': ['16d6bd90eee4cee8df4c15687de0f9b72730c03e56603c2998007d4533e8db19'],
+    }),
+    ('coin', '1.3-1', {
+        'checksums': ['5de2519a6e2b059bba9d74c58085cccaff1aaaa0454586ed164a108ebd1b2062'],
+    }),
+    ('party', '1.3-3', {
+        'checksums': ['9f72eea02d43a4cee105790ae7185b0478deb6011ab049cc9d31a0df3abf7ce9'],
+    }),
+    ('inum', '1.0-1', {
+        'checksums': ['3c2f94c13c03607e05817e4859595592068b55e810fed94e29bc181ad248a099'],
+    }),
+    ('partykit', '1.2-5', {
+        'checksums': ['f48e30790f93fa5d03e68e8ce71ce33d009d107d46d45d85da2016b38b27629c'],
+    }),
+    ('mboost', '2.9-1', {
+        'checksums': ['67ed26093fc2c1e57d7fac842a51a0de0162e448d4dab09c0054baee801f2a0a'],
+    }),
+    ('msm', '1.6.7', {
+        'checksums': ['7503c0f61916033ed0efad54727368bce629ff2d370f302b71bc1cb924d2e23a'],
+    }),
+    ('nor1mix', '1.3-0', {
+        'checksums': ['9ce4ee92f889a4a4041b5ea1ff09396780785a9f12ac46f40647f74a37e327a0'],
+    }),
+    ('np', '0.60-9', {
+        'checksums': ['fe31a8985f0b1a576a7775022b7131093b1c9a8337734136d5fcad85fa6592fc'],
+    }),
+    ('polynom', '1.4-0', {
+        'checksums': ['c5b788b26f7118a18d5d8e7ba93a0abf3efa6603fa48603c70ed63c038d3d4dd'],
+    }),
+    ('polspline', '1.1.17', {
+        'checksums': ['d67b269d01105d4a6ea774737e921e66e065a859d1931ae38a70f88b6fb7ee30'],
+    }),
+    ('rms', '5.1-4', {
+        'checksums': ['38f5844c4944a95b2adebea6bb1d163111270b8662399ea0349c45c0758076a6'],
+    }),
+    ('RWekajars', '3.9.3-2', {
+        'checksums': ['16e6b019aab1646f89c5203f0d6fc1cb800129e5169b15aaef30fd6236f5da1a'],
+    }),
+    ('RWeka', '0.4-41', {
+        'checksums': ['ae3a87ee572c2207cb047490a778a7d9f9785ce63f65b6818622b23db9c13abf'],
+    }),
+    ('slam', '0.1-46', {
+        'checksums': ['0b64989a639b196b6f217b301a8a233cefa66296112efdcad09ec76a4e5f10c6'],
+    }),
+    ('tm', '0.7-7', {
+        'checksums': ['d0dbe41ff8414bdc2eee06a1b0d6db4567850135c4c6ff0a9c9ca8239166d15f'],
+    }),
+    ('TraMineR', '2.0-13', {
+        'checksums': ['679a73f4e75268a60060941f476929142b8fc4bf0ea8708b64a72635566d688d'],
+    }),
+    ('chemometrics', '1.4.2', {
+        'checksums': ['b705832fa167dc24b52b642f571ed1efd24c5f53ba60d02c7797986481b6186a'],
+    }),
+    ('FNN', '1.1.3', {
+        'checksums': ['de763a25c9cfbd19d144586b9ed158135ec49cf7b812938954be54eb2dc59432'],
+    }),
+    ('ipred', '0.9-9', {
+        'checksums': ['0da87a70730d5a60b97e46b2421088765e7d6a7cc2695757eba0f9d31d86416f'],
+    }),
+    ('statmod', '1.4.32', {
+        'checksums': ['2f67a1cfa66126e6345f8a40564a3077d08f1748f17cb8c8fb05c94ed0f57e20'],
+    }),
+    ('miscTools', '0.6-26', {
+        'checksums': ['be3c5a63ca12ce7ce4d43767a1815cd3dcf32664728ade251cfb03ea6f77fc9a'],
+    }),
+    ('maxLik', '1.3-6', {
+        'checksums': ['95e92124776d70c5aaf5af99f184b0fac0ec726a98537d32518a8d7acf43924a'],
+    }),
+    ('gbRd', '0.4-11', {
+        'checksums': ['0251f6dd6ca987a74acc4765838b858f1edb08b71dbad9e563669b58783ea91b'],
+    }),
+    ('Rdpack', '0.11-1', {
+        'checksums': ['58020f150be07209fd1fdd7f5e58c138863e850f4e4c1512d69250286e091e20'],
+    }),
+    ('mlogit', '1.0-2', {
+        'checksums': ['5cc3afefb37c065dc39a9c01ec610a66a3775f91246313a946575309f4e2b6a1'],
+    }),
+    ('getopt', '1.20.3', {
+        'checksums': ['531f5fdfdcd6b96a73df2b39928418de342160ac1b0043861e9ea844f9fbf57f'],
+    }),
+    ('gsalib', '2.1', {
+        'checksums': ['e1b23b986c18b89a94c58d9db45e552d1bce484300461803740dacdf7c937fcc'],
+    }),
+    ('optparse', '1.6.4', {
+        'checksums': ['cd7855ebc2303da4ab0615282667c7eeef5329faf51bd2bf2e4b0d250561d973'],
+    }),
+    ('labelled', '2.2.1', {
+        'checksums': ['51851d8a50acadb144e0d2300f65d0962d617aa963b2a3051fb56495bdd237d7'],
+    }),
+    ('questionr', '0.7.0', {
+        'checksums': ['c4566880a1ca8f01faad396e20d907d913f4a252acaf83a0cb508a3738874cb3'],
+    }),
+    ('klaR', '0.6-14', {
+        'checksums': ['51e9d9149ba77874ccecc816a2a75619e2f9615c091f6e8969da20615c2b29bd'],
+    }),
+    ('neuRosim', '0.2-12', {
+        'checksums': ['f4f718c7bea2f4b61a914023015f4c71312f8a180124dcbc2327b71b7be256c3'],
+    }),
+    ('locfit', '1.5-9.1', {
+        'checksums': ['f524148fdb29aac3a178618f88718d3d4ac91283014091aa11a01f1c70cd4e51'],
+    }),
+    ('GGally', '1.4.0', {
+        'checksums': ['9a47cdf004c41f5e4024327b94227707f4dad3a0ac5556d8f1fba9bf0a6355fe'],
+    }),
+    ('beanplot', '1.2', {
+        'checksums': ['49da299139a47171c5b4ccdea79ffbbc152894e05d552e676f135147c0c9b372'],
+    }),
+    ('clValid', '0.6-6', {
+        'checksums': ['c13ef1b6258e34ba53615b78f39dbe4d8ba47b976b3c24a3eedaecf5ffba19ed'],
+    }),
+    ('DiscriMiner', '0.1-29', {
+        'checksums': ['5aab7671086ef9940e030324651976456f0e84dab35edb7048693ade885228c6'],
+    }),
+    ('ellipse', '0.4.1', {
+        'checksums': ['1a9a9c52195b26c2b4d51ad159ab98aff7aa8ca25fdc6b2198818d1a0adb023d'],
+    }),
+    ('leaps', '3.0', {
+        'checksums': ['55a879cdad5a4c9bc3b5697dd4d364b3a094a49d8facb6692f5ce6af82adf285'],
+    }),
+    ('pbkrtest', '0.4-7', {
+        'checksums': ['5cbb03ad2b2468720a5a610a0ebda48ac08119a34fca77810a85f554225c23ea'],
+    }),
+    ('carData', '3.0-3', {
+        'checksums': ['986b84bdd289159eead8b050ea82600a4f77bf0bbe0293a7c7b25d607ff7e231'],
+    }),
+    ('maptools', '0.9-9', {
+        'checksums': ['69ba3b2cd50260f78fb6c25cf0557b4a0d31498d6a4f4ff00e466334fba4946c'],
+    }),
+    ('zip', '2.0.4', {
+        'checksums': ['ab5dd0c63bd30b478d0f878735e7baf36e2e76e4d12d2b4b8eddd03b665502b0'],
+    }),
+    ('openxlsx', '4.1.4', {
+        'checksums': ['07a38b21f6ce6e92d58d7a51ea9f4b5fd77db49b019a18ba9ecea69878a39dd7'],
+    }),
+    ('rematch', '1.0.1', {
+        'checksums': ['a409dec978cd02914cdddfedc974d9b45bd2975a124d8870d52cfd7d37d47578'],
+    }),
+    ('cellranger', '1.1.0', {
+        'checksums': ['5d38f288c752bbb9cea6ff830b8388bdd65a8571fd82d8d96064586bd588cf99'],
+    }),
+    ('readxl', '1.3.1', {
+        'checksums': ['24b441713e2f46a3e7c6813230ad6ea4d4ddf7e0816ad76614f33094fbaaaa96'],
+    }),
+    ('rio', '0.5.16', {
+        'checksums': ['d3eb8d5a11e0a3d26169bb9d08f834a51a6516a349854250629072d59c29d465'],
+    }),
+    ('car', '3.0-5', {
+        'checksums': ['7ed4f7e79b39089796ca07ca78de560f517967b6ad79b93ecf98037b03aaee70'],
+    }),
+    ('flashClust', '1.01-2', {
+        'checksums': ['48a7849bb86530465ff3fbfac1c273f0df4b846e67d5eee87187d250c8bf9450'],
+    }),
+    ('ggrepel', '0.8.1', {
+        'checksums': ['d5d03a77ab6d8c831934bc46e840cc4e3df487272ab591fa72767ad42bcb7283'],
+    }),
+    ('FactoMineR', '2.0', {
+        'checksums': ['48828a7491a9210aa908f77e8aaacc774b1205a269898f752f6e0d773d303c62'],
+    }),
+    ('flexclust', '1.4-0', {
+        'checksums': ['82fe445075a795c724644864c7ee803c5dd332a89ea9e6ccf7cd1ae2d1ecfc74'],
+    }),
+    ('flexmix', '2.3-15', {
+        'checksums': ['ba444c0bfe33ab87d440ab590c06b03605710acd75811c1622253171bb123f43'],
+    }),
+    ('prabclus', '2.3-1', {
+        'checksums': ['ef3294767d43bc3f72478fdaf0d1f13c8de18881bf9040c9f1add68af808b3c0'],
+    }),
+    ('diptest', '0.75-7', {
+        'checksums': ['462900100ca598ef21dbe566bf1ab2ce7c49cdeab6b7a600a50489b05f61b61b'],
+    }),
+    ('trimcluster', '0.1-2.1', {
+        'checksums': ['b64a872a6c2ad677dfeecc776c9fe5aff3e8bab6bc6a8c86957b5683fd5d2300'],
+    }),
+    ('fpc', '2.2-3', {
+        'checksums': ['8100a74e6ff96b1cd65fd22494f2d200e54ea5ea533cfca321fa494914bdc3b7'],
+    }),
+    ('BiasedUrn', '1.07', {
+        'checksums': ['2377c2e59d68e758a566452d7e07e88663ae61a182b9ee455d8b4269dda3228e'],
+    }),
+    ('TeachingDemos', '2.10', {
+        'checksums': ['2ef4c2e36ba13e32f66000e84281a3616584c86b255bca8643ff3fe4f78ed704'],
+    }),
+    ('kohonen', '3.0.10', {
+        'checksums': ['996956ea46a827c9f214e4f940a19304a0ff35bda707d4d7312f80d3479067b2'],
+    }),
+    ('base64', '2.0', {
+        'checksums': ['8e259c2b12446197d1152b83a81bab84ccb5a5b77021a9b5645dd4c63c804bd1'],
+    }),
+    ('doRNG', '1.7.1', {
+        'checksums': ['27533d54464889d1c21301594137fc0f536574e3a413d61d7df9463ab12a67e9'],
+    }),
+    ('nleqslv', '3.3.2', {
+        'checksums': ['f54956cf67f9970bb3c6803684c84a27ac78165055745e444efc45cfecb63fed'],
+    }),
+    ('Deriv', '4.0', {
+        'checksums': ['76788764177b24dc27f4e27046fa563ad97014e0d53e14a880ebff2f9177b40e'],
+    }),
+    ('RGCCA', '2.1.2', {
+        'checksums': ['20f341fca8f616c556699790814debdf2ac7aa4dd9ace2071100c66af1549d7d'],
+    }),
+    ('pheatmap', '1.0.12', {
+        'checksums': ['579d96ee0417203b85417780eca921969cda3acc210c859bf9dfeff11539b0c1'],
+    }),
+    ('pvclust', '2.2-0', {
+        'checksums': ['7892853bacd413b5a921006429641ad308a344ca171b3081c15e4c522a8b0201'],
+    }),
+    ('RCircos', '1.2.1', {
+        'checksums': ['3b9489ab05ea83ead99ca6e4a1e6830467a2064779834aff1317b42bd41bb8fd'],
+    }),
+    ('lambda.r', '1.2.4', {
+        'checksums': ['d252fee39065326c6d9f45ad798076522cec05e73b8905c1b30f95a61f7801d6'],
+    }),
+    ('futile.options', '1.0.1', {
+        'checksums': ['7a9cc974e09598077b242a1069f7fbf4fa7f85ffe25067f6c4c32314ef532570'],
+    }),
+    ('futile.logger', '1.4.3', {
+        'checksums': ['5e8b32d65f77a86d17d90fd8690fc085aa0612df8018e4d6d6c1a60fa65776e4'],
+    }),
+    ('VennDiagram', '1.6.20', {
+        'checksums': ['e51cb3fff23c6ec8191966490bf875a7415f8725d4054bae881a25febb9281c5'],
+    }),
+    ('xlsxjars', '0.6.1', {
+        'checksums': ['37c1517f95f8bca6e3514429394d2457b9e62383305eba288416fb53ab2e6ae6'],
+    }),
+    ('xlsx', '0.6.1', {
+        'checksums': ['a580bd16b5477c1c185bf681c12c1ffff4088089f97b6a37997913d93ec5a8b4'],
+    }),
+    ('uroot', '2.1-0', {
+        'checksums': ['3c02a9dadd22aa67a59e99007ab6f576dc428859fa746d3a8f3ffa2bb43d18c2'],
+    }),
+    ('forecast', '8.10', {
+        'checksums': ['798e15d15be9af0b8f505e826db83d5f09d7a7434567ec291a31eaf3b8c88c49'],
+    }),
+    ('fma', '2.3', {
+        'checksums': ['f516eff79e14d4ffefcdc2db06d97ae57f998e37e871264457078f671384fafc'],
+    }),
+    ('expsmooth', '2.3', {
+        'checksums': ['ac7da36347f983d6ec71715daefd2797fe2fc505c019f4965cff9f77ce79982a'],
+    }),
+    ('fpp', '0.5', {
+        'checksums': ['9c87dd8591b8a87327cae7a03fd362a5492495a96609e5845ccbeefb96e916cb'],
+    }),
+    ('tensor', '1.5', {
+        'checksums': ['e1dec23e3913a82e2c79e76313911db9050fb82711a0da227f94fc6df2d3aea6'],
+    }),
+    ('polyclip', '1.10-0', {
+        'checksums': ['74dabc0dfe5a527114f0bb8f3d22f5d1ae694e6ea9345912909bae885525d34b'],
+    }),
+    ('goftest', '1.2-2', {
+        'checksums': ['e497992666b002b6c6bed73bf05047ad7aa69eb58898da0ad8f1f5b2219e7647'],
+    }),
+    ('spatstat.utils', '1.15-0', {
+        'checksums': ['90e07d730b6939f47f93c939afae10874b2c82bd402960ede4133de67dca2a0c'],
+    }),
+    ('spatstat.data', '1.4-0', {
+        'checksums': ['121e5bb92beb7ccac920f921e760f429fd71bcfe11cb9b07a7e7326c7a72ec8c'],
+    }),
+    ('spatstat', '1.62-2', {
+        'checksums': ['57cc1dc51b3d74fb4e3edfa30e6441db98c99e354ff65ffc82d5419a49a8353b'],
+    }),
+    ('pracma', '2.2.9', {
+        'checksums': ['0cea0ff5e88643df121e07b9aebfe57084c61e11801680039752f371fe87bf1e'],
+    }),
+    ('RCurl', '1.95-4.12', {
+        'checksums': ['393779efafdf40823dac942a1e028905d65c34f3d41cfd21bcd225e411385ff4'],
+    }),
+    ('bio3d', '2.4-0', {
+        'checksums': ['9ab86e299adee14e9a87ec87284f4c52a0114d303f21d166aaa0dc766f987746'],
+    }),
+    ('AUC', '0.3.0', {
+        'checksums': ['e705f2c63d336249d19187f3401120d738d42d323fce905f3e157c2c56643766'],
+    }),
+    ('interpretR', '0.2.4', {
+        'checksums': ['4c08a6dffd6fd5764f27812f3a085c53e6a21d59ae82d903c9c0da93fd1dd059'],
+    }),
+    ('cvAUC', '1.1.0', {
+        'checksums': ['c4d8ed53b93869650aa2f666cf6d1076980cbfea7fa41f0b8227595be849738d'],
+    }),
+    ('SuperLearner', '2.0-26', {
+        'checksums': ['4462922c8daae2773f79ecdea7ca3cc4ea51bfd101c5e6c1ad22f9190e746081'],
+    }),
+    ('mediation', '4.5.0', {
+        'checksums': ['210206618787c395a67689be268283df044deec7199d9860ed95218ef1e60845'],
+    }),
+    ('ModelMetrics', '1.2.2', {
+        'checksums': ['66d6fc75658287fdbae4d437b51d26781e138b8baa558345fb9e5a2df86a0d95'],
+    }),
+    ('CVST', '0.2-2', {
+        'checksums': ['854b8c983427ecf9f2f7798c4fd1c1d06762b5b0bcb1045502baadece6f78316'],
+    }),
+    ('DRR', '0.0.3', {
+        'checksums': ['7493389c1fb9ddc4d4261e15bf2d4198603227275688b1d3e3994d47e976a1f9'],
+    }),
+    ('dimRed', '0.2.3', {
+        'checksums': ['e6e56e3f6999ebdc326e64ead5269f3aaf61dd587beefafb7536ac3890370d84'],
+    }),
+    ('lubridate', '1.7.4', {
+        'checksums': ['510ca87bd91631c395655ee5029b291e948b33df09e56f6be5839f43e3104891'],
+    }),
+    ('ddalpha', '1.3.10', {
+        'checksums': ['5f52e0aae9917476078daf031f2213b0b6b83d225530394bdb759e86fc79c480'],
+    }),
+    ('gower', '0.2.1', {
+        'checksums': ['af3fbe91cf818c0841b2c0ec4ddf282c182a588031228c8d88f7291b2cdff100'],
+    }),
+    ('RcppRoll', '0.3.0', {
+        'checksums': ['cbff2096443a8a38a6f1dabf8c90b9e14a43d2196b412b5bfe5390393f743f6b'],
+    }),
+    ('recipes', '0.1.7', {
+        'checksums': ['28e96953355749dd1deb6786b22ec825a6fdb9f336e2785d45611e89f7e988bf'],
+    }),
+    ('caret', '6.0-84', {
+        'checksums': ['a1831c086a9c71b469f7405649ba04517683cdf229e119c005189cf57244090d'],
+    }),
+    ('adabag', '4.2', {
+        'checksums': ['47019eb8cefc8372996fbb2642f64d4a91d7cedc192690a8d8be6e7e03cd3c81'],
+    }),
+    ('parallelMap', '1.4', {
+        'checksums': ['fb6f15e325f729f1c5218768b17c20909ee857069c6cc5d8df50e1dafe26ed5b'],
+    }),
+    ('ParamHelpers', '1.13', {
+        'checksums': ['b9b5212a485f441504716fcddf4fd7376bf3b909aae049c7394245e853424e79'],
+    }),
+    ('ggvis', '0.4.5', {
+        'checksums': ['82373c3565c299279f6849f798cc39127b2b3f7ff2deee1946528474824b3124'],
+    }),
+    ('mlr', '2.16.0', {
+        'checksums': ['3db8141d9cbb71139c9bf3a3ea995524322512221b56e6bcf44338d24f84e76a'],
+    }),
+    ('unbalanced', '2.0', {
+        'checksums': ['9be32b1ce9d972f1abfff2fbe18f5bb5ba9c3f4fb1282063dc410b82ad4d1ea2'],
+    }),
+    ('RSNNS', '0.4-12', {
+        'checksums': ['b18dfeda71573bc92c6888af72da407651bff7571967965fd3008f0d331743b9'],
+    }),
+    ('abc.data', '1.0', {
+        'checksums': ['b242f43c3d05de2e8962d25181c6b1bb6ca1852d4838868ae6241ca890b161af'],
+    }),
+    ('abc', '2.1', {
+        'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
+    }),
+    ('lhs', '1.0.1', {
+        'checksums': ['a4d5ac0c6f585f2880364c867fa94e6554698beb65d3678ba5938dd84fc6ea53'],
+    }),
+    ('tensorA', '0.36.1', {
+        'checksums': ['c7ffe12b99867675b5e9c9f31798f9521f14305c9d9f9485b171bcbd8697d09c'],
+    }),
+    ('EasyABC', '1.5', {
+        'checksums': ['1dd7b1383a7c891cafb34d9cec65d92f1511a336cff1b219e63c0aa791371b9f'],
+    }),
+    ('whisker', '0.4', {
+        'checksums': ['7a86595be4f1029ec5d7152472d11b16175737e2777134e296ae97341bf8fba8'],
+    }),
+    ('commonmark', '1.7', {
+        'checksums': ['d14a767a3ea9778d6165f44f980dd257423ca6043926e3cd8f664f7171f89108'],
+    }),
+    ('roxygen2', '7.0.2', {
+        'checksums': ['5823937df68ea558e5e85771b8b6e090775b82f7f797ca5d539e7378c4535d98'],
+    }),
+    ('git2r', '0.26.1', {
+        'checksums': ['13d609286a0af4ef75ba76f2c2f856593603b8014e311b88896243a50b417435'],
+    }),
+    ('rversions', '2.0.1', {
+        'checksums': ['51ec1f64e7d628e88d716a020d5d521eba71d472e3c9ae7b694428ef6dd786c5'],
+    }),
+    ('xopen', '1.0.0', {
+        'checksums': ['e207603844d69c226142be95281ba2f4a056b9d8cbfae7791ba60535637b3bef'],
+    }),
+    ('sessioninfo', '1.1.1', {
+        'checksums': ['166b04678448a7decd50f24afabe5e2ad613e3c55b180ef6e8dd7a870a1dae48'],
+    }),
+    ('rcmdcheck', '1.3.3', {
+        'checksums': ['1ab679eb1976d74cd3be5bcad0af7fcc673dbdfd4406bbce32591c8fddfb93b4'],
+    }),
+    ('remotes', '2.1.0', {
+        'checksums': ['8944c8f6fc9f0cd0ca04d6cf1221b716eee08facef9f4b4c4d91d0346d6d68a7'],
+    }),
+    ('fs', '1.3.1', {
+        'checksums': ['d6934dca8f835d8173e3fb9fd4d5e2740c8c04348dd2bcc57df1b711facb46bc'],
+    }),
+    ('clisymbols', '1.2.0', {
+        'checksums': ['0649f2ce39541820daee3ed408d765eddf83db5db639b493561f4e5fbf88efe0'],
+    }),
+    ('ini', '0.3.1', {
+        'checksums': ['7b191a54019c8c52d6c2211c14878c95564154ec4865f57007953742868cd813'],
+    }),
+    ('gh', '1.0.1', {
+        'checksums': ['f3c02b16637ae390c3599265852d94b3de3ef585818b260d00e7812595b391d2'],
+    }),
+    ('usethis', '1.5.1', {
+        'checksums': ['9e3920a04b0df82adf59eef2c1b2b4d835c4a757a51b3c163b8fc619172f561d'],
+    }),
+    ('DT', '0.10', {
+        'checksums': ['3cc6dfc9697b52aef21d30dcfd355831c6216edcc6dd6bfb9a106cce6ab0906f'],
+    }),
+    ('rex', '1.1.2', {
+        'checksums': ['bd3c74ceaf335336f5dd04314d0a791f6311e421a2158f321f5aab275f539a2a'],
+    }),
+    ('covr', '3.4.0', {
+        'checksums': ['e57d9c656b4ab50a7f9557dee422d8777efaf08ecde0fd8bfa5897ef4d9e845c'],
+    }),
+    ('devtools', '2.2.1', {
+        'checksums': ['2e988fb56b068ba958ea471224d2462427868ce7706e157a90c0ce0e13294e44'],
+    }),
+    ('Rook', '1.1-1', {
+        'checksums': ['00f4ecfa4c5c57018acbb749080c07154549a6ecaa8d4130dd9de79427504903'],
+    }),
+    ('Cairo', '1.5-10', {
+        'checksums': ['7837f0c384cd49bb3342cb39a916d7a80b02fffbf123913a58014e597f69b5d5'],
+    }),
+    ('RMTstat', '0.3', {
+        'checksums': ['81eb4c5434d04cb66c749a434c33ceb1c07d92ba79765d4e9233c13a092ec2da'],
+    }),
+    ('Lmoments', '1.3-1', {
+        'checksums': ['7c9d489a08f93fa5877e2f233ab9732e0d1b2761596b3f6ac91f2295e41a865d'],
+    }),
+    ('distillery', '1.0-6', {
+        'checksums': ['4910e2952f767c1062d7cbe648c90a97009e2b3da316c6b33f6d022cd38b23d6'],
+    }),
+    ('extRemes', '2.0-11', {
+        'checksums': ['75fbdeef677c81cf5661b8df3df4090c55f53e9bb96bb138b498eb0fbbf5af42'],
+    }),
+    ('pixmap', '0.4-11', {
+        'checksums': ['6fa010749a59cdf56aad9f81271473b7d55697036203f2cd5d81372bcded7412'],
+    }),
+    ('tkrplot', '0.0-24', {
+        'checksums': ['2873630a37d7ae1e09a5803d9a89ca0494edd83526c7b1860d9246543722f311'],
+    }),
+    ('misc3d', '0.8-4', {
+        'checksums': ['75de3d2237f67f9e58a36e80a6bbf7e796d43eb46789f2dd1311270007bf5f62'],
+    }),
+    ('multicool', '0.1-11', {
+        'checksums': ['1c907e64af2ac39facdf431a5691e69649f64af1f50e198ae39da5bf30026476'],
+    }),
+    ('plot3D', '1.1.1', {
+        'checksums': ['f6fe4a001387132626fc553ed1d5720d448b8064eb5a6917458a798e1d381632'],
+    }),
+    ('plot3Drgl', '1.0.1', {
+        'checksums': ['466d428d25c066c9c96d892f24da930513d42b1bdf76d3b53628c3ba13c3e48a'],
+    }),
+    ('OceanView', '1.0.4', {
+        'checksums': ['e67f6f376737e1e5cf22fdfe2769a8f674e90c886b0e43942e97d9a3e6924f1c'],
+    }),
+    ('ks', '1.11.6', {
+        'checksums': ['d8f1ccb99281eed092b8f950cfbf422330e88f2a0ce1ef6c9dbd7d8b9d648c41'],
+    }),
+    ('logcondens', '2.1.5', {
+        'checksums': ['72e61abc1f3eb28830266fbe5b0da0999eb5520586000a3024e7c26be93c02eb'],
+    }),
+    ('Iso', '0.0-18', {
+        'checksums': ['2d7e8c4452653364ee086d95cea620c50378e30acfcff129b7261e1756a99504'],
+    }),
+    ('penalized', '0.9-51', {
+        'checksums': ['eaa80dca99981fb9eb576261f30046cfe492d014cc2bf286c447b03a92e299fd'],
+    }),
+    ('clusterRepro', '0.9', {
+        'checksums': ['940d84529ff429b315cf4ad25700f93e1156ccacee7b6c38e4bdfbe2d4c6f868'],
+    }),
+    ('randomForestSRC', '2.9.2', {
+        'checksums': ['780fbc07ca0b2676fadf576d4d278887672b431ba42cd49b769ed8ccbc4e6d74'],
+    }),
+    ('sm', '2.2-5.6', {
+        'checksums': ['b890cd7ebe8ed711ab4a3792c204c4ecbe9e6ca1fd5bbc3925eba5833a839c30'],
+    }),
+    ('pbivnorm', '0.6.0', {
+        'checksums': ['07c37d507cb8f8d2d9ae51a9a6d44dfbebd8a53e93c242c4378eaddfb1cc5f16'],
+    }),
+    ('lavaan', '0.6-5', {
+        'checksums': ['feeb6e1b419aa1d54fd5af1d67260b5d13ff251c19de8136a4df565305d47b12'],
+    }),
+    ('matrixcalc', '1.0-3', {
+        'checksums': ['17e6caeeecd596b850a6caaa257984398de9ec5d2b41ce83c428f112614b9cb0'],
+    }),
+    ('arm', '1.10-1', {
+        'checksums': ['6f1158c9295e65bd649139224497d3356189b931ff143f9b374daae72548776f'],
+    }),
+    ('mi', '1.0', {
+        'checksums': ['34f44353101e8c3cb6bf59c5f4ff5b2391d884dcbb9d23066a11ee756b9987c0'],
+    }),
+    ('visNetwork', '2.0.9', {
+        'checksums': ['5e0b3dc3a91e66e0a359433f03cc856d04b981b0f9ad228d8fa9c96b7fcaa420'],
+    }),
+    ('rgexf', '0.15.3', {
+        'checksums': ['2e8a7978d1fb977318e6310ba65b70a9c8890185c819a7951ac23425c6dc8147'],
+    }),
+    ('influenceR', '0.1.0', {
+        'checksums': ['4fc9324179bd8896875fc0e879a8a96b9ef2a6cf42a296c3b7b4d9098519e98a'],
+    }),
+    ('downloader', '0.4', {
+        'checksums': ['1890e75b028775154023f2135cafb3e3eed0fe908138ab4f7eff1fc1b47dafab'],
+    }),
+    ('DiagrammeR', '1.0.1', {
+        'checksums': ['ccee8acf608fc909e73c6de4374cef5a570cb62e5f454ac55dda736f22f3f013'],
+    }),
+    ('sem', '3.1-9', {
+        'checksums': ['4a33780202506543da85877cd2813250114420d6ec5e75457bc67477cd332cb9'],
+    }),
+    ('jpeg', '0.1-8.1', {
+        'checksums': ['1db0a4976fd9b2ae27a37d3e856cca35bc2909323c7a40724846a5d3c18915a9'],
+    }),
+    ('network', '1.16.0', {
+        'checksums': ['a24f51457439c7186ffa1fe53719742c501929ac1a354e458754a83f280fce36'],
+    }),
+    ('statnet.common', '4.3.0', {
+        'checksums': ['834a3359eac967df0420eee416ae4983e3b502a3de56bb24f494a7ca4104e959'],
+    }),
+    ('sna', '2.5', {
+        'checksums': ['13b508cacb0bf1e79b55d5c8f7e9ada3b173468d4d6d5f1dc606990ac03071c8'],
+    }),
+    ('glasso', '1.11', {
+        'checksums': ['4c37844b26f55985184a734e16b8fe880b192e3d2763614b0ab3f99b4530e30a'],
+    }),
+    ('huge', '1.3.4', {
+        'checksums': ['23165f49ec9e67ca3506cc83abbbf8eb3f38c5e19c092133189b7ca17690c31e'],
+    }),
+    ('d3Network', '0.5.2.1', {
+        'checksums': ['5c798dc0c87c6d574abb7c1f1903346e6b0fec8adfd1df7aef5e4f9e7e3a09be'],
+    }),
+    ('ggm', '2.3', {
+        'checksums': ['832ffe81ff87c6f1a6644e689ebbfb172924b4c4584ac8108d1244d153219ed8'],
+    }),
+    ('BDgraph', '2.62', {
+        'checksums': ['7e5de4406f4a7873bf948852291d2851a2ab312288467687dd5c0392b2723bac'],
+    }),
+    ('pbapply', '1.4-2', {
+        'checksums': ['ac19f209f36f4fa3d0f5b14b6cc5b0c279996fb9d3e86c848c0f6d03c025b3f6'],
+    }),
+    ('graphlayouts', '0.5.0', {
+        'checksums': ['83f61ce07580c5a64c7044c12b20d98ccf138c7e78ff12855cdfc206e1fab10d'],
+    }),
+    ('tweenr', '1.0.1', {
+        'checksums': ['efd68162cd6d5a4f6d833dbf785a2bbce1cb7b9f90ba3fb060931a4bd705096b'],
+    }),
+    ('ggforce', '0.3.1', {
+        'checksums': ['a05271da9b226c12ae5fe6bc6eddb9ad7bfe19e1737e2bfcd6d7a89631332211'],
+    }),
+    ('tidygraph', '1.1.2', {
+        'checksums': ['5642001d4cccb122d66481b7c61a06c724c02007cbd356ee61cb29726a56fafe'],
+    }),
+    ('ggraph', '2.0.0', {
+        'checksums': ['4307efe85bfc6a0496797f6b86d6b174ba196538c51b1a6b6af55de0d4e04762'],
+    }),
+    ('qgraph', '1.6.4', {
+        'checksums': ['43865a096cd9af122c75594a268bac342e80626a8137539d0c94bb0349408fbe'],
+    }),
+    ('HWxtest', '1.1.9', {
+        'checksums': ['a37309bed4a99212ca104561239d834088217e6c5e5e136ff022544c706f25e6'],
+    }),
+    ('diveRsity', '1.9.90', {
+        'checksums': ['b8f49cdbfbd82805206ad293fcb2dad65b962fb5523059a3e3aecaedf5c0ee86'],
+    }),
+    ('doSNOW', '1.0.18', {
+        'checksums': ['70e7bd82186e477e3d1610676d4c6a75258ac08f104ecf0dcc971550ca174766'],
+    }),
+    ('geepack', '1.3-1', {
+        'checksums': ['823153ca28e1a8bd8a45de778279480c1c35e063d62c8955b6cea1602f28d6df'],
+    }),
+    ('biom', '0.3.12', {
+        'checksums': ['4ad17f7811c7346dc4923bd6596a007c177eebb1944a9f46e5674afcc5fdd5a1'],
+    }),
+    ('pim', '2.0.1', {
+        'checksums': ['174568a01f68b9601a4ea89ca5857bf4888242f00e4212bfb7a422d6292300d5'],
+    }),
+    ('minpack.lm', '1.2-1', {
+        'checksums': ['14cb7dba3ef2b46da0479b46d46c76198e129a31f6157cd8b37f178adb15d5a3'],
+    }),
+    ('rootSolve', '1.8.1', {
+        'checksums': ['1dde127817cfb2273724c63f662143cc7eb449a833243e0e56ef347df0d5796a'],
+    }),
+    ('diagram', '1.6.4', {
+        'checksums': ['7c2bc5d5d634c3b8ca7fea79fb463e412962d88f47a77a74c811cc62f375ce38'],
+    }),
+    ('FME', '1.3.5', {
+        'checksums': ['3619d88df2a41ca8819b93bb7dff3b8233f76ff8ab0ca67c664f530f835935e4'],
+    }),
+    ('bmp', '0.3', {
+        'checksums': ['bdf790249b932e80bc3a188a288fef079d218856cf64ffb88428d915423ea649'],
+    }),
+    ('tiff', '0.1-5', {
+        'checksums': ['9514e6a9926fcddc29ce1dd12b1072ad8265900373f738de687ef4a1f9124e2b'],
+    }),
+    ('readbitmap', '0.1.5', {
+        'checksums': ['737d7d585eb33de2c200da64d16781e3c9522400fe2af352e1460c6a402a0291'],
+    }),
+    ('imager', '0.41.2', {
+        'checksums': ['9be8bc8b3190d469fcb2883045a404d3b496a0380f887ee3caea11f0a07cd8a5'],
+    }),
+    ('signal', '0.7-6', {
+        'checksums': ['6b60277b07cf0167f8272059b128cc82f27a9bab1fd33d74c2a9e1f2abca5def'],
+    }),
+    ('tuneR', '1.3.3', {
+        'checksums': ['bdc3c2017b162d2ba0a249e80361a4f47202e763c21aecfc57380a482a3a692b'],
+    }),
+    ('pastecs', '1.3.21', {
+        'checksums': ['8c1ef2affe88627f0b23295aa5edb758b8fd6089ef09f60f37c46445128b8d7c'],
+    }),
+    ('audio', '0.1-6', {
+        'checksums': ['3f261413ba2d3e9ae58c44abffe5188cc7c21a78a0c93448c7d384d3913d73b8'],
+    }),
+    ('fftw', '1.0-5', {
+        'checksums': ['afc94fe8e5bed9195c191606239cd37f1b88e24e7422e9c5249cca0781b3f20c'],
+    }),
+    ('seewave', '2.1.5', {
+        'checksums': ['718b1fb1c289f92be50de099da36d20380d113cb1577569333fca6195f71e8e1'],
+    }),
+    ('gsw', '1.0-5', {
+        'checksums': ['eb468918ee91e429b47fbcac43269eca627b7f64b61520de5bbe8fa223e96453'],
+    }),
+    ('oce', '1.1-1', {
+        'checksums': ['2ce8f8d3adb3da5c8a09fda060e1ff79cad0f0f6f918f8fe64f51a6cd6b58e43'],
+    }),
+    ('ineq', '0.2-13', {
+        'checksums': ['e0876403f59a3dfc2ea7ffc0d965416e1ecfdecf154e5856e5f54800b3efda25'],
+    }),
+    ('soundecology', '1.3.3', {
+        'checksums': ['276164d5eb92c78726c647be16232d2443acbf7061371ddde2672b4fdb7a069a'],
+    }),
+    ('memuse', '4.0-0', {
+        'checksums': ['fbf8716a1388692ee439f69ac99643fa427eb100027d8911ff0fbfdcb5b6c3bc'],
+    }),
+    ('pinfsc50', '1.1.0', {
+        'checksums': ['b6b9b6365a3f408533264d7ec820494f57eccaf362553e8478a46a8e5b474aba'],
+    }),
+    ('vcfR', '1.8.0', {
+        'checksums': ['5ffcf9980c1936b9be41b92d5887c56a7ec6e3cf197e5ef7c78aefa8aba20499'],
+    }),
+    ('glmmML', '1.1.0', {
+        'checksums': ['34f088a73ccf6092908502a5bdaaf8209e9134d38abbbd7c4dd559832e653188'],
+    }),
+    ('cowplot', '1.0.0', {
+        'checksums': ['70f9a7c46d10f409d1599f1afc9fd3c947051cf2b430f01d903c64ef1e6c98a5'],
+    }),
+    ('tsne', '0.1-3', {
+        'checksums': ['66fdf5d73e69594af529a9c4f261d972872b9b7bffd19f85c1adcd66afd80c69'],
+    }),
+    ('sn', '1.5-4', {
+        'checksums': ['46677ebc109263a68f62b5cf53ec59916cda490e5bc5bbb08276757a677f8674'],
+    }),
+    ('tclust', '1.4-1', {
+        'checksums': ['4b0be612c8ecd7b4eb19a44ab6ac8f5d40515600ae1144c55989b6b41335ad9e'],
+    }),
+    ('ranger', '0.11.2', {
+        'checksums': ['13ac8a9433fdd92f62f66de44abc52477dcbb436b2045c1947951a266bffbeeb'],
+    }),
+    ('hexbin', '1.28.0', {
+        'checksums': ['cda0d4b637ddd63eaaed70eb7b3ced09216dbf63e7803d6dfe3c8d3fc392a82c'],
+    }),
+    ('pryr', '0.1.4', {
+        'checksums': ['d39834316504c49ecd4936cbbcaf3ee3dae6ded287af42475bf38c9e682f721b'],
+    }),
+    ('moments', '0.14', {
+        'checksums': ['2a3b81e60dafdd092d2bdd3513d7038855ca7d113dc71df1229f7518382a3e39'],
+    }),
+    ('laeken', '0.5.0', {
+        'checksums': ['ea529f9e45a3825e1f13f8dbd8e7c5f5a42933525ca529230c893eb08e1f39bd'],
+    }),
+    ('VIM', '4.8.0', {
+        'checksums': ['3c6b4fdc10c0375e3fdc56b34a8c05661155bd3166a8b3f36b0addf73d51a423'],
+    }),
+    ('proxy', '0.4-23', {
+        'checksums': ['9dd4eb0978f40e4fcb55c8a8a26266d32eff9c63ac9dfe70cf1f664ca9c3669d'],
+    }),
+    ('smoother', '1.1', {
+        'checksums': ['91b55b82f805cfa1deedacc0a4e844a2132aa59df593f3b05676954cf70a195b'],
+    }),
+    ('dynamicTreeCut', '1.63-1', {
+        'checksums': ['831307f64eddd68dcf01bbe2963be99e5cde65a636a13ce9de229777285e4db9'],
+    }),
+    ('beeswarm', '0.2.3', {
+        'checksums': ['0115425e210dced05da8e162c8455526a47314f72e441ad2a33dcab3f94ac843'],
+    }),
+    ('vipor', '0.4.5', {
+        'checksums': ['7d19251ac37639d6a0fed2d30f1af4e578785677df5e53dcdb2a22771a604f84'],
+    }),
+    ('ggbeeswarm', '0.6.0', {
+        'checksums': ['bbac8552f67ff1945180fbcda83f7f1c47908f27ba4e84921a39c45d6e123333'],
+    }),
+    ('shinydashboard', '0.7.1', {
+        'checksums': ['51a49945c6b8a684111a2ba4b2a5964e3a50610286ce0378e37ae02316620a4e'],
+    }),
+    ('rrcov', '1.4-9', {
+        'checksums': ['e757369d70de4def182f4ede8bb066b156fd1a96abeedf8a14f986455becfb87'],
+    }),
+    ('WriteXLS', '5.0.0', {
+        'checksums': ['5aeb631c7f4dee300a19ded493110d7241e1b79744be05beca770a01ffc1d7bf'],
+    }),
+    ('bst', '0.3-17', {
+        'checksums': ['1ed161d33a7304abfa2fb23daeda2f870ad8483b7fa9b91e6fc8ced21fd8f074'],
+    }),
+    ('mpath', '0.3-20', {
+        'checksums': ['0299b11bdd346a7825cd0bba302f09e7a0a15b9491f9179651b2f1154c80d392'],
+    }),
+    ('timereg', '1.9.4', {
+        'checksums': ['fbf4eeee1648fceb98773156764c32b3a9481f0fb9f8dc3a9d0331a9051cb54b'],
+    }),
+    ('peperr', '1.1-7.1', {
+        'checksums': ['5d4eff0f0b61c0b3e479c2ac2978c8e32373b9630565bf58fee48ead6166698a'],
+    }),
+    ('heatmap3', '1.1.6', {
+        'checksums': ['5d5a3d574e9e3699490c93a523ce242006257e5be110935d58c74c135a4e4a8d'],
+    }),
+    ('GlobalOptions', '0.1.1', {
+        'checksums': ['4249ef78424128050af83bbb8e71b4af82f8490c87f6a9d927782b80be830975'],
+    }),
+    ('circlize', '0.4.8', {
+        'checksums': ['22d6908b9d2e496105d9b70b73a74152398e5e9e38c60042ffe041df2b4c794b'],
+    }),
+    ('GetoptLong', '0.1.7', {
+        'checksums': ['b9a98881db407eae9b711c4fa9170168fd5f3be1f8485cd8f28d0a60ace083ba'],
+    }),
+    ('dendextend', '1.13.2', {
+        'checksums': ['79543002ab3147c283fa659c4a16a1df4c5740b5fe207565236d32cf52db94c5'],
+    }),
+    ('RInside', '0.2.15', {
+        'checksums': ['1e1d87a3584961f3aa4ca6acd4d2f3cda26abdab027ff5be2fd5cd76a98af02b'],
+    }),
+    ('limSolve', '1.5.6', {
+        'checksums': ['b97ea9930383634c8112cdbc42f71c4e93fe0e7bfaa8f401921835cb44cb49a0'],
+    }),
+    ('dbplyr', '1.4.2', {
+        'checksums': ['b783f0da2c09a1e63f41168b02c0715b08820f02a351f7ab0aaa688432754de0'],
+    }),
+    ('modelr', '0.1.5', {
+        'checksums': ['45bbee387c6ba154f9f8642e9f03ea333cce0863c324ff15d23096f33f85ce5a'],
+    }),
+    ('debugme', '1.1.0', {
+        'checksums': ['4dae0e2450d6689a6eab560e36f8a7c63853abbab64994028220b8fd4b793ab1'],
+    }),
+    ('reprex', '0.3.0', {
+        'checksums': ['203c2ae6343f6ff887e7a5a3f5d20bae465f6e8d9745c982479f5385f4effb6c'],
+    }),
+    ('selectr', '0.4-2', {
+        'checksums': ['5588aed05f3f5ee63c0d29953ef53da5dac7afccfdd04b7b22ef24e1e3b0c127'],
+    }),
+    ('rvest', '0.3.5', {
+        'checksums': ['0e7f41be4ce6501d7af50575a2532d4bfd9153ca57900ee62dbc27c0a22c0a64'],
+    }),
+    ('tidyverse', '1.3.0', {
+        'checksums': ['6d8acb81e994f9bef5e4dcf908bcea3786d108adcf982628235b6c8c80f6fe09'],
+    }),
+    ('R.cache', '0.14.0', {
+        'checksums': ['18af4e372440b9f28b4b71346c8ed9de220232f9903730ccee2bfb3c612c16d9'],
+    }),
+    ('R.rsp', '0.43.2', {
+        'checksums': ['f291a78ce9955943e0ebad1291f729dc4d9a8091f04b83fc4b1526bcb6c71f89'],
+    }),
+    ('listenv', '0.8.0', {
+        'checksums': ['fd2aaf3ff2d8d546ce33d1cb38e68401613975117c1f9eb98a7b41facf5c485f'],
+    }),
+    ('globals', '0.12.5', {
+        'checksums': ['1519a7668b4b549c081f60a5f6b71d8d1dc8833f618125f6c0e4caf8b48a48c1'],
+    }),
+    ('future', '1.15.1', {
+        'checksums': ['ed4f7f356ca1cb3294f9a5181e4087b2a7781c4ab7304393bf40e1ac388a3080'],
+    }),
+    ('gdistance', '1.2-2', {
+        'checksums': ['c8c923f02ae4e9ef8376d1b195e0246b6941356c8c790c0a5673c5009eee1753'],
+    }),
+    ('vioplot', '0.3.4', {
+        'checksums': ['4914262f2e7913ffa5741e74b20157f4a904ba31e648fa5df9ff6a1aaba753bb'],
+    }),
+    ('emulator', '1.2-20', {
+        'checksums': ['7cabf2cf74d879ad9dbaed8fdee54a5c94a8658a0645c021d160b2ef712ce287'],
+    }),
+    ('gmm', '1.6-4', {
+        'checksums': ['03ad5ff37d174e9cef13fa41d866412c57b7cbd9155312831e16a1fcda70bc95'],
+    }),
+    ('tmvtnorm', '1.4-10', {
+        'checksums': ['1a9f35e9b4899672e9c0b263affdc322ecb52ec198b2bb015af9d022faad73f0'],
+    }),
+    ('IDPmisc', '1.1.19', {
+        'checksums': ['0d5e35252c7ec2654a3d64949bdc0977cc8479f8ada97bccd0d90d70aadb0c8f'],
+    }),
+    ('gap', '1.2.1', {
+        'checksums': ['5a20adcc7e503b9a2123048510d56ce3ec9f00d5855629b4cbf0d7c7ad8c6fb5'],
+    }),
+    ('qrnn', '2.0.5', {
+        'checksums': ['3bd83ee8bd83941f9defdab1b5573d0ceca02bf06759a67665e5b9358ff92f52'],
+    }),
+    ('TMB', '1.7.15', {
+        'checksums': ['facbc7cc44f993e0d827a6eb84928f8e35b0b3f263582d885a307e150b434de4'],
+    }),
+    ('glmmTMB', '0.2.3', {
+        'checksums': ['6b6f62addaa54b32b975bc984110e245330749ebf69bed4a297f9da1b89fb00c'],
+    }),
+    ('spaMM', '3.0.0', {
+        'checksums': ['5aca7eebd38d93f3ad6bec6bb01b213879551b4320f6fc17bdebdd4d09e48fe7'],
+    }),
+    ('DHARMa', '0.2.6', {
+        'checksums': ['d2a17c994e59c4fb4c82825b97a78ac120a350bf94261511d437659a00296957'],
+    }),
+    ('mvnfast', '0.2.5', {
+        'checksums': ['21b9fa72d1e3843513908aaacd6c4d876cc7a9339782d0151b24910df2975f88'],
+    }),
+    ('bridgesampling', '0.7-2', {
+        'checksums': ['64a44e92ccc2828261a71e2298901a8064b36df1bc2b8796d47a1bf26fb9a44d'],
+    }),
+    ('BayesianTools', '0.1.7', {
+        'checksums': ['af49389bdeb794da3c39e1d63f59e6219438ecb8613c5ef523b00c6fed5a600c'],
+    }),
+    ('gomms', '1.0', {
+        'checksums': ['52828c6fe9b78d66bde5474e45ff153efdb153f2bd9f0e52a20a668e842f2dc5'],
+    }),
+    ('feather', '0.3.5', {
+        'checksums': ['50ff06d5e24d38b5d5d62f84582861bd353b82363e37623f95529b520504adbf'],
+    }),
+    ('dummies', '1.5.6', {
+        'checksums': ['7551bc2df0830b98c53582cac32145d5ce21f5a61d97e2bb69fd848e3323c805'],
+    }),
+    ('SimSeq', '1.4.0', {
+        'checksums': ['5ab9d4fe2cb1b7634432ff125a9e04d2f574fed06246a93859f8004e10790f19'],
+    }),
+    ('uniqueAtomMat', '0.1-3-2', {
+        'checksums': ['f7024e73274e1e76a870ce5e26bd58f76e8f6df0aa9775c631b861d83f4f53d7'],
+    }),
+    ('PoissonSeq', '1.1.2', {
+        'checksums': ['6f3dc30ad22e33e4fcfa37b3427c093d591c02f1b89a014d85e63203f6031dc2'],
+    }),
+    ('aod', '1.3.1', {
+        'checksums': ['052d8802500fcfdb3b37a8e3e6f3fbd5c3a54e48c3f68122402d2ea3a15403bc'],
+    }),
+    ('cghFLasso', '0.2-1', {
+        'checksums': ['6e697959b35a3ceb2baa1542ef81f0335006a5a9c937f0173c6483979cb4302c'],
+    }),
+    ('svd', '0.5', {
+        'checksums': ['d042d448671355d0664d37fd64dc90932eb780e6494c479d4431d1faae2071a1'],
+    }),
+    ('Rssa', '1.0', {
+        'checksums': ['9cc20a7101d8dff4c6cfb789f9bdc14e2b3bb128d7613a67b0f9633cf006902a'],
+    }),
+    ('JBTools', '0.7.2.9', {
+        'checksums': ['b33cfa17339df7113176ad1832cbb0533acf5d25c36b95e888f561d586c5d62f'],
+    }),
+    ('RUnit', '0.4.32', {
+        'checksums': ['23a393059989000734898685d0d5509ece219879713eb09083f7707f167f81f1'],
+    }),
+    ('DistributionUtils', '0.6-0', {
+        'checksums': ['7443d6cd154760d55b6954142908eae30385672c4f3f838dd49876ec2f297823'],
+    }),
+    ('gapfill', '0.9.6', {
+        'checksums': ['850d0be9d05e3f3620f0f5143496321f1004ed966299bffd6a67a9abd8d9040d'],
+    }),
+    ('gee', '4.13-20', {
+        'checksums': ['53014cee059bd87dc22f9679dfbf18fe6813b9ab41dfe90361921159edfbf798'],
+    }),
+    ('Matching', '4.9-6', {
+        'checksums': ['8e0dced7d1242e52de68a6e3010484bb29eb0633733549c82a06e9c6508b66dc'],
+    }),
+    ('MatchIt', '3.0.2', {
+        'checksums': ['782b159a2b5172e758e3993177930d604140ae668fd8a7c98c30792df80de9de'],
+    }),
+    ('RItools', '0.1-17', {
+        'checksums': ['75654780e9ca39cb3c43acfaca74080ad74de50f92c5e36e95694aafdfdc0cea'],
+    }),
+    ('optmatch', '0.9-13', {
+        'checksums': ['f8f327faa95c808773376570793bbabdbc185a6c7fcdce3b96a09c998134d0d8'],
+    }),
+    ('SKAT', '1.3.2.1', {
+        'checksums': ['7442408ccd1b9d2abb3f3dbd27e1b46e50b87042195bc46ce25fe0d887f98e7a'],
+    }),
+    ('GillespieSSA', '0.6.1', {
+        'checksums': ['272e9b6b26001d166fd7ce8d04f32831ba23c676075fbd1e922e27ba2c962052'],
+    }),
+    ('startupmsg', '0.9.6', {
+        'checksums': ['1d60ff13bb260630f797bde66a377a5d4cd65d78ae81a3936dc4374572ec786e'],
+    }),
+    ('distr', '2.8.0', {
+        'checksums': ['bb7df05d6b946bcdbbec2e3397c7c7e349b537cabfcbb13a34bcf6312a71ceb7'],
+    }),
+    ('distrEx', '2.8.0', {
+        'checksums': ['b064cde7d63ce93ec9969c8c4463c1e327758b6f8ea7765217d77f9ba9d590bf'],
+    }),
+    ('KODAMA', '1.5', {
+        'checksums': ['8ecf53732c1be2bd1e111b3c6de65b66caf28360306e683fe945dc76d4c267dd'],
+    }),
+    ('locfdr', '1.1-8', {
+        'checksums': ['42d6e12593ae6d541e6813a140b92591dabeb1df94432a515507fc2eee9a54b9'],
+    }),
+    ('ica', '1.0-2', {
+        'checksums': ['e721596fc6175d3270a60d5e0b5b98be103a8fd0dd93ef16680af21fe0b54179'],
+    }),
+    ('dtw', '1.21-3', {
+        'checksums': ['1aa46b285b7a31ba19759e83562671ed9076140abec79fe0df0316af43871e0a'],
+    }),
+    ('SDMTools', '1.1-221.2', {
+        'checksums': ['f0dd8c5f98d2f2c012536fa56d8f7a58aaf0c11cbe3527e66d4ee3194f6a6cf7'],
+    }),
+    ('ggridges', '0.5.1', {
+        'checksums': ['01f87cdcdf2052ed9c078d9352465cdeda920a41e2ca55bc154c1574fc651c36'],
+    }),
+    ('TFisher', '0.2.0', {
+        'checksums': ['bd9b7484d6fba0165841596275b446f85ba446d40e92f3b9cb37381a3827e76f'],
+    }),
+    ('lsei', '1.2-0', {
+        'checksums': ['4781ebd9ef93880260d5d5f23066580ac06061e95c1048fb25e4e838963380f6'],
+    }),
+    ('npsurv', '0.4-0', {
+        'checksums': ['404cf7135dc40a04e9b81224a543307057a8278e11109ba1fcaa28e87c6204f3'],
+    }),
+    ('fitdistrplus', '1.0-14', {
+        'checksums': ['85082590f62aa08d99048ea3414c5cc1e5b780d97b3779d2397c6cb435470083'],
+    }),
+    ('reticulate', '1.13', {
+        'checksums': ['adbe41d556b667c4419d563680f8608a56b0f792b8bc427b3bf4c584ff819de3'],
+    }),
+    ('hdf5r', '1.3.0', {
+        'installopts': '--configure-args="--with-hdf5=$EBROOTHDF5/bin/h5pcc"',
+        'preinstallopts': "unset LIBS && ",
+        'checksums': ['0ef18eed2683f5dda34601a20a842ab346a6c66b7277c5ed576c77ece61601df'],
+    }),
+    ('DTRreg', '1.5', {
+        'checksums': ['eb9b4d98b25eec304a447db302f618a75180f8d8fe0f5728ecd7e85957613456'],
+    }),
+    ('pulsar', '0.3.6', {
+        'checksums': ['b5851bf365003ace07542fd21ccff015c4b21ffd73e21ec3a539563e9ef53564'],
+    }),
+    ('bayesm', '3.1-4', {
+        'checksums': ['061b216c62bc72eab8d646ad4075f2f78823f9913344a781fa53ea7cf4a48f94'],
+    }),
+    ('energy', '1.7-7', {
+        'checksums': ['67b88fb33ee6e7bec2e4fe356a4efd36f70c3cf9b0ebe2f6d9da9ec96de9968f'],
+    }),
+    ('compositions', '1.40-3', {
+        'checksums': ['e42d90950a63aa7f707bc5025dbf265b63fc02a5b7137bc71836b8bc625d7080'],
+    }),
+    ('clustree', '0.4.1', {
+        'checksums': ['1d4c0c44826a656b649ce224f94a35fea808e9faef0d550646a0a9221a764e4b'],
+    }),
+    ('plotly', '4.9.1', {
+        'checksums': ['85a08c64d1bf839786951b3574986eacce78dacd589f2bef4b38208e49554d3d'],
+    }),
+    ('tweedie', '2.3.2', {
+        'checksums': ['9a6226e64e3d56eb7eb2a408f8b825c2ad6ee0ea203a9220e85e7789514adb81'],
+    }),
+    ('RcppGSL', '0.3.7', {
+        'checksums': ['45e95c4170fc8421ae9b32134b3a402f76ea9657030969723a3563c7ce14dc32'],
+    }),
+    ('mvabund', '4.0.1', {
+        'checksums': ['1399fa0a5f7a3673d788abe36b520f476c05246e21f71e3f60cee7a85f194951'],
+    }),
+    ('fishMod', '0.29', {
+        'checksums': ['5989e49ca6d6b2c5d514655e61f75b019528a8c975f0d6056143f17dc4277a5d'],
+    }),
+    ('gllvm', '1.1.7', {
+        'checksums': ['cc0331b034e14aa8d47a491cedeb76717b4085a61fb0b1cc75d424c58ca9b8d4'],
+    }),
+    ('grpreg', '3.2-1', {
+        'checksums': ['6be37719a74d59582107273385d70963b4ccc6c394948c7617e65246d713cb88'],
+    }),
+    ('trust', '0.1-7', {
+        'checksums': ['e3d15aa84a71becd2824253d4a8156bdf1ab9ac3b72ced0cd53f3bb370ac6f04'],
+    }),
+    ('ergm', '3.10.4', {
+        'checksums': ['885f0b1a23c5a2c1947962350cfab66683dfdfd1db173c115e90396d00831f22'],
+    }),
+    ('networkDynamic', '0.10.0', {
+        'checksums': ['eb31d72c73a06a145d231ad3489d450d63b9fecc069aeb19331d7417241df3b5'],
+    }),
+    ('tergm', '3.6.1', {
+        'checksums': ['21de2eca943d89ba63af14951655d626f241bafccc4b2709fa39aa130625cd0f'],
+    }),
+    ('ergm.count', '3.4.0', {
+        'checksums': ['7c24c79d0901c18991cce907306a1531cca676ae277c6b0a0e4962ad27c36baf'],
+    }),
+    ('tsna', '0.3.0', {
+        'checksums': ['29f599d3e774289614608b0fa49e05a09e76e6b15dd1d46988785eaacf2e1a35'],
+    }),
+    ('statnet', '2019.6', {
+        'checksums': ['0903e1a81ed1b6289359cefd12da1424c92456d19e062c3f74197b69e536b29d'],
+    }),
+    ('aggregation', '1.0.1', {
+        'checksums': ['86f88a02479ddc8506bafb154117ebc3b1a4a44fa308e0193c8c315109302f49'],
+    }),
+    ('ComICS', '1.0.4', {
+        'checksums': ['0af7901215876f95f309d7da6e633c38e4d7faf04112dd6fd343bc15fc593a2f'],
+    }),
+    ('dtangle', '2.0.9', {
+        'checksums': ['c375068c1877c2e8cdc5601cfd5a9c821645c3dff90ddef64817f788f372e179'],
+    }),
+    ('mcmc', '0.9-6', {
+        'checksums': ['443a189fff907830627029dd55d925db9a70562d8bda7bfae97414ab955186b9'],
+    }),
+    ('MCMCpack', '1.4-5', {
+        'checksums': ['da949cfa44f71bfff1c6ae06caf8fe4252dd6391aa4c8f0fb6e02c7d6b1cdfb5'],
+    }),
+    ('shinythemes', '1.1.2', {
+        'checksums': ['2e13d4d5317fc61082e8f3128b15e0b10ed9736ce81e152dd7ae7f6109f9b18a'],
+    }),
+    ('csSAM', '1.2.4', {
+        'checksums': ['3d6442ad8c41fa84633cbbc275cd67e88490a160927a5c55d29da55a36e148d7'],
+    }),
+    ('bridgedist', '0.1.0', {
+        'checksums': ['dc7c1c8874d6cfa34d550d9af194389e13471dfbc55049a1ab66db112fbf1343'],
+    }),
+    ('asnipe', '1.1.12', {
+        'checksums': ['3a1f166f1c71b5877a2acca1384ec6c9b430b67af67ef26125f2abbb53c66206'],
+    }),
+    ('liquidSVM', '1.2.4', {
+        'checksums': ['15a9c7f2930e2ed3f4c5bcd9b042884ea580d2b2e52e1c68041600c196046aba'],
+    }),
+    ('oddsratio', '2.0.0', {
+        'checksums': ['89bf3c68a6ded6a98f4ee8d487c29605ad00ac5f8db9b8bf1a52144e65332553'],
+    }),
+    ('mltools', '0.3.5', {
+        'checksums': ['7093ffceccdf5d4c3f045d8c8143deaa8ab79935cc6d5463973ffc7d3812bb10'],
+    }),
+    ('h2o', '3.26.0.2', {
+        'checksums': ['cabef231e65991a6fd40b83022eb6d47a0fa09548ed62ce6fe6549535f98b2d1'],
+    }),
+    ('mlegp', '3.1.7', {
+        'checksums': ['d4845eaf9260f8b8112726dd7ceb5c2f5ce75125fa313191db9de121f2ee15e0'],
+    }),
+    ('itertools', '0.1-3', {
+        'checksums': ['b69b0781318e175532ad2d4f2840553bade9637e04de215b581704b5635c45d3'],
+    }),
+    ('missForest', '1.4', {
+        'checksums': ['f785804b03bdf424e1c76095989a803afb3b47d6bebca9a6832074b6326c0278'],
+    }),
+    ('bartMachineJARs', '1.1', {
+        'checksums': ['f2c31cb94d7485174a2519771127a102e35b9fe7f665e27beda3e76a56feeef2'],
+    }),
+    ('bartMachine', '1.2.4.2', {
+        'checksums': ['28a5f7363325021bd93f9bd060cc48f20c689dae2f2f6f7100faae66d7651f80'],
+    }),
+    ('lqa', '1.0-3', {
+        'checksums': ['3889675dc4c8cbafeefe118f4f20c3bd3789d4875bb725933571f9991a133990'],
+    }),
+    ('PresenceAbsence', '1.1.9', {
+        'checksums': ['1a30b0a4317ea227d674ac873ab94f87f8326490304e5b08ad58953cdf23169f'],
+    }),
+    ('GUTS', '1.1.1', {
+        'checksums': ['094b8f51719cc36ddc56e3412dbb146eafc93c5e8fbb2c5999c2e80ea7a7d216'],
+    }),
+    ('GenSA', '1.1.7', {
+        'checksums': ['9d99d3d0a4b7770c3c3a6de44206811272d78ab94481713a8c369f7d6ae7b80f'],
+    }),
+    ('rematch2', '2.1.0', {
+        'checksums': ['78677071bd44b40e562df1da6f0c6bdeae44caf973f97ff8286b8c994db59f01'],
+    }),
+    ('parsedate', '1.2.0', {
+        'checksums': ['39ab3c507cb3efcd677c6cf453f46d6b1948662bd70c7765845e755ea1e1633d'],
+    }),
+    ('circular', '0.4-93', {
+        'checksums': ['76cee2393757390ad91d3db3e5aeb2c2d34c0a46822b7941498571a473417142'],
+    }),
+    ('cobs', '1.3-3', {
+        'checksums': ['6b1e760cf8dec6b6e63f042cdc3e5e633de5f982e8bc743a891932f6d9f91bdf'],
+    }),
+    ('resample', '0.4', {
+        'checksums': ['f0d5f735e1b812612720845d79167a19f713a438fd10a6a3206e667045fd93e5'],
+    }),
+    ('MIIVsem', '0.5.4', {
+        'checksums': ['de918d6b1820c59a7d4324342ad15444c2370ce1d843397a136c307397ed64b9'],
+    }),
+    ('medflex', '0.6-6', {
+        'checksums': ['b9d04fb5281d0ea0555ec4f327a0ee951a7f312a3af944578dc175183dc49211'],
+    }),
+    ('Rserve', '1.7-3.1', {
+        'checksums': ['3ba1e919706e16a8632def5f45d666b6e44eafa6c14b57064d6ddf3415038f99'],
+    }),
+    ('spls', '2.2-3', {
+        'checksums': ['bbd693da80487eef2939c37aba199f6d811ec289828c763d9416a05fa202ab2e'],
+    }),
+    ('Boruta', '6.0.0', {
+        'checksums': ['1c9a7aabe09f040e147f6c614f5fe1d0b951d3b0f0024161fbb4c31da8fae8de'],
+    }),
+    ('dr', '3.0.10', {
+        'checksums': ['ce523c1bdb62a9dda30afc12b1dd96975cc34695c61913012236f3b80e24bf36'],
+    }),
+    ('CovSel', '1.2.1', {
+        'checksums': ['b375d00cc567e125ff106b4357654f43bba3abcadeed2238b6dea4b7a68fda09'],
+    }),
+    ('tmle', '1.4.0.1', {
+        'checksums': ['075e7b7fe0496e02785eb35aed0db84476db756c6f14a0047808af2565b33501'],
+    }),
+    ('ctmle', '0.1.2', {
+        'checksums': ['e3fa0722cd87aa0e0b209c2dddf3fc44c6d09993f1e66a6c43285fe950948161'],
+    }),
+    ('BayesPen', '1.0', {
+        'checksums': ['772df9ae12cd8a3da1d5b7d1f1629602c7693f0eb03945784df2809e2bb061b0'],
+    }),
+    ('inline', '0.3.15', {
+        'checksums': ['ff043fe13c1991a3b285bed256ff4a9c0ba10bee764225a34b285875b7d69c68'],
+    }),
+    ('BMA', '3.18.11', {
+        'checksums': ['bf4ce8fdb21a4da754dffa4c1869efb11f6bdcfaa7f43a1b009b2695f553698d'],
+    }),
+    ('BCEE', '1.2', {
+        'checksums': ['0b1183458d625ef5dd0962fc77ca1326e77754a2c04be11fb002057abcb65a22'],
+    }),
+    ('bacr', '1.0.1', {
+        'checksums': ['c847272e2c03fd08ed79b3b739f57fe881af77404b6fd087caa0c398c90ef993'],
+    }),
+    ('clue', '0.3-57', {
+        'checksums': ['6e369d07b464a9624209a06b5078bf988f01f7963076e946649d76aea0622d17'],
+    }),
+    ('bdsmatrix', '1.3-3', {
+        'checksums': ['70ea81708c97dedd483a5d3866d2e906fa0e9098ff854c41cf0746fbc8dfad9d'],
+    }),
+    ('fftwtools', '0.9-8', {
+        'checksums': ['4641c8cd70938c2a8bde0b6da6cf7f83e96175ef52f1ca42ec3920a1dabf1bdb'],
+    }),
+    ('imagerExtra', '1.3.2', {
+        'checksums': ['0ebfa1eabb89459d774630ab73c7a97a93b9481ea5afc55482975475acebd5b8'],
+    }),
+    ('MALDIquant', '1.19.3', {
+        'checksums': ['a730327c1f8d053d29e558636736b7b66d0671a009e0004720b869d2c76ff32c'],
+    }),
+    ('threejs', '0.3.1', {
+        'checksums': ['71750b741672a435ecf749b69c72f0681aa8bb795e317f4e3056d5e33f6d79e8'],
+    }),
+    ('LaplacesDemon', '16.1.1', {
+        'checksums': ['779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77'],
+    }),
+    ('rda', '1.0.2-2.1', {
+        'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',
+                       'eea3a51a2e132a023146bfbc0c384f5373eb3ea2b61743d7658be86a5b04949e')],
+    }),
+    ('sampling', '2.8', {
+        'checksums': ['356923f35971bb55f7e97b178aede3366374aa3ad3d24a97be765660553bf21a'],
+    }),
+    ('lda', '1.4.2', {
+        'checksums': ['5606a1e1bc24706988853528023f7a004c725791ae1a7309f1aea2fc6681240f'],
+    }),
+    ('jiebaRD', '0.1', {
+        'checksums': ['045ee670f5378fe325a45b40fd55136b355cbb225e088cb229f512c51abb4df1'],
+    }),
+    ('jiebaR', '0.11', {
+        'checksums': ['adde8b0b21c01ec344735d49cd33929511086719c99f8e10dce4ca9479276623'],
+    }),
+    ('hdm', '0.3.1', {
+        'checksums': ['ba087565e9e0a8ea30a6095919141895fd76b7f3c05a03e60e9e24e602732bce'],
+    }),
+    ('abe', '3.0.1', {
+        'checksums': ['66d2e9ac78ba64b7d27b22b647fc00378ea832f868e51c18df50d6fffb8029b8'],
+    }),
+    ('SignifReg', '2.1', {
+        'checksums': ['d21959ce5b1ee20efd1483f6020b57e5f6616bd525af77a7bd325501cc670606'],
+    }),
+    ('bbmle', '1.0.20', {
+        'checksums': ['6c0fe8df7243f8a039e62d14014065df2002b9329c0e8a3c2df4e7ccf591f1f7'],
+    }),
+    ('emdbook', '1.3.11', {
+        'checksums': ['f848d4c0a2da50dc8a5af76429d8f9d4960dee3fad1e98f7b507bdfd9b2ca128'],
+    }),
+    ('SOAR', '0.99-11', {
+        'checksums': ['d5a0fba3664087308ce5295a1d57d10bad149eb9771b4fe67478deae4b7f68d8'],
+    }),
+    ('rasterVis', '0.47', {
+        'checksums': ['123ebe870895c2ba3a4b64d8a18bccab5287c831fa14bb0fe07f0d7de61e51d3'],
+    }),
+    ('tictoc', '1.0', {
+        'checksums': ['47da097c1822caa2d8e262381987cfa556ad901131eb96109752742526b2e2fe'],
+    }),
+    ('ISOcodes', '2019.04.22', {
+        'checksums': ['2386440c3bed8391ee3a029aab86c107d435d0dd6a970236512d7c105d146b6e'],
+    }),
+    ('stopwords', '1.0', {
+        'checksums': ['9b727a5d827ac8dcfa6329140d294dcf964a06d80132b4ca434330d0ee02b1da'],
+    }),
+    ('janeaustenr', '0.1.5', {
+        'checksums': ['992f6673653daf7010fe176993a01cd4127d9a88be428da8da7a28241826d6f3'],
+    }),
+    ('SnowballC', '0.6.0', {
+        'checksums': ['61617d344444235940f5b9ac1cd6b86938e74a8c76791235724b16b755c3f72c'],
+    }),
+    ('tokenizers', '0.2.1', {
+        'checksums': ['28617cdc5ddef5276abfe14a2642999833322b6c34697de1d4e9d6dc7670dd00'],
+    }),
+    ('hunspell', '3.0', {
+        'checksums': ['01fb9c87f7cf094aaad3b7098378134f2e503286224351e91d08c00b6ee19857'],
+    }),
+    ('topicmodels', '0.2-9', {
+        'checksums': ['40770fb7de6ab6bd6e3ef6a0c777fa6db65d0322e67503c26c84ea857ac9a79c'],
+    }),
+    ('tidytext', '0.2.2', {
+        'checksums': ['188f294cf3177fe6fc85e9b7e16a05211cebeab0e0f7b05a9443416790bf2ec0'],
+    }),
+    ('splitstackshape', '1.4.8', {
+        'checksums': ['656032c3f1e3dd5b8a3ee19ffcae617e07104c0e342fc3da4d863637a770fe56'],
+    }),
+    ('grImport2', '0.2-0', {
+        'checksums': ['a102a2d877e42cd4e4e346e5510a77b2f3e57b43ae3c6d5c272fdceb506b00a7'],
+    }),
+    ('preseqR', '4.0.0', {
+        'checksums': ['0143db473fb9a811f9cf582a348226a5763e62d9857ce3ef4ec41412abb559bc'],
+    }),
+    ('idr', '1.2', {
+        'checksums': ['8bbfdf82c8c2b5c73eb079127e198b6cb65c437bb36729f502c7bcd6037fdb16'],
+    }),
+    ('entropy', '1.2.1', {
+        'checksums': ['edb27144b8f855f1ef21de6b93b6b6c5cf7d4f2c3d592bf625e5158c02226f83'],
+    }),
+    ('kedd', '1.0.3', {
+        'checksums': ['38760abd8c8e8f69ad85ca7992803060acc44ce68358de1763bd2415fdf83c9f'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.6.2-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.2-fosscuda-2019b.eb
@@ -1,0 +1,2355 @@
+name = 'R'
+version = '3.6.2'
+
+homepage = 'https://www.r-project.org/'
+description = """R is a free software environment for statistical computing
+ and graphics."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['https://cloud.r-project.org/src/base/R-%(version_major)s']
+sources = [SOURCE_TAR_GZ]
+checksums = ['bd65a45cddfb88f37370fbcee4ac8dd3f1aebeebe47c2f968fd9770ba2bbc954']
+
+builddependencies = [
+    ('pkg-config', '0.29.2'),
+]
+dependencies = [
+    ('X11', '20190717'),
+    ('Mesa', '19.1.7'),
+    ('libGLU', '9.0.1'),
+    ('cairo', '1.16.0'),
+    ('libreadline', '8.0'),
+    ('ncurses', '6.1'),
+    ('bzip2', '1.0.8'),
+    ('XZ', '5.2.4'),
+    ('zlib', '1.2.11'),
+    ('SQLite', '3.29.0'),
+    ('PCRE', '8.43'),
+    ('libpng', '1.6.37'),  # for plotting in R
+    ('libjpeg-turbo', '2.0.3'),  # for plottting in R
+    ('LibTIFF', '4.0.10'),
+    ('Java', '11', '', True),
+    ('Tk', '8.6.9'),  # for tcltk
+    ('cURL', '7.66.0'),  # for RCurl
+    ('libxml2', '2.9.9'),  # for XML
+    ('GMP', '6.1.2'),  # for igraph
+    ('NLopt', '2.6.1'),  # for nloptr
+    ('FFTW', '3.3.8'),  # for fftw
+    ('libsndfile', '1.0.28'),  # for seewave
+    ('ICU', '64.2'),  # for rJava & gdsfmt
+    ('HDF5', '1.10.5'),  # for hdf5r
+    ('UDUNITS', '2.2.26'),  # for units
+    ('GSL', '2.6'),  # for RcppGSL
+    ('ImageMagick', '7.0.9-5'),  # for animation
+    ('pocl', '1.4'),  # for OpenCL support (particularly on POWER)
+    # OS dependency should be preferred if the os version is more recent then
+    # this version, it's nice to have an up to date openssl for security
+    # reasons
+    # ('OpenSSL', '1.1.1b'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+configopts = "--with-pic --enable-threads --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix), and
+# we're installing them anyway below
+configopts += " --with-recommended-packages=no"
+
+# specify that at least EasyBuild v3.5.0 is required,
+# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
+easybuild_version = '3.5.0'
+
+exts_default_options = {
+    'source_urls': [
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+
+# !! order of packages is important !!
+# packages updated on 16 December 2019
+exts_list = [
+    'base',
+    'datasets',
+    'graphics',
+    'grDevices',
+    'grid',
+    'methods',
+    'splines',
+    'stats',
+    'stats4',
+    'tools',
+    'utils',
+    ('Rmpi', '0.6-9', {
+        'checksums': ['b2e1eac3e56f6b26c7ce744b29d8994ab6507ac88df64ebbb5af439414651ee6'],
+    }),
+    ('abind', '1.4-5', {
+        'checksums': ['3a3ace5afbcb86e56889efcebf3bf5c3bb042a282ba7cc4412d450bb246a3f2c'],
+    }),
+    ('magic', '1.5-9', {
+        'checksums': ['fa1d5ef2d39e880f262d31b77006a2a7e76ea38e306aae4356e682b90d6cd56a'],
+    }),
+    ('Rcpp', '1.0.3', {
+        'checksums': ['2b3500dd3aca16f7b3cb5442625e76dcf4f7c974b4249d33041e9184a5ff030e'],
+    }),
+    ('RcppProgress', '0.4.1', {
+        'checksums': ['11764105922f763d4c75c502599ec7dcc2fd629a029964caf53f98b41d0c607a'],
+    }),
+    ('lpSolve', '5.6.13.3', {
+        'checksums': ['e64165428c40d730f7686d233c22936bf4b3b91a618a600bdf87acaa905f5ff5'],
+    }),
+    ('linprog', '0.9-2', {
+        'checksums': ['8937b2e30692e38de1713f1513b78f505f73da6f5b4a576d151ad60bac2221ce'],
+    }),
+    ('geometry', '0.4.5', {
+        'checksums': ['8fedd17c64468721d398e3c17a39706321ab71098b29f5e8d8039dd115a220d8'],
+    }),
+    ('bit', '1.1-14', {
+        'checksums': ['5cbaace1fb643a665a6ca69b90f7a6d624270de82420ca7a44f306753fcef254'],
+    }),
+    ('filehash', '2.4-2', {
+        'checksums': ['b6d056f75d45e315943a4618f5f62802612cd8931ba3f9f474b595140a3cfb93'],
+    }),
+    ('ff', '2.2-14', {
+        'checksums': ['1c6307847275b1b8ad9e2ffdce3f4df3c9d955dc2e8a45e3fd7bfd2b0926e2f0'],
+    }),
+    ('bnlearn', '4.5', {
+        'checksums': ['a8047625533260a855d309b3c0785cbeec0f9ec13f284b6664a1f61638138578'],
+    }),
+    ('bootstrap', '2019.6', {
+        'checksums': ['5252fdfeb944cf1fae35016d35f9333b1bd1fc8c6d4a14e33901160e21968694'],
+    }),
+    ('combinat', '0.0-8', {
+        'checksums': ['1513cf6b6ed74865bfdd9f8ca58feae12b62f38965d1a32c6130bef810ca30c1'],
+    }),
+    ('deal', '1.2-39', {
+        'checksums': ['a349db8f1c86cbd8315c068da49314ce9eb585dbb50d2e5ff09300506bd8806b'],
+    }),
+    ('fdrtool', '1.2.15', {
+        'checksums': ['65f964aa768d0703ceb7a199adc5e79ca79a6d29d7bc053a262eb533697686c0'],
+    }),
+    ('formatR', '1.7', {
+        'checksums': ['a366621b3ff5f8e86a499b6f87858ad47eefdace138341b1377ecc307a5e5ddb'],
+    }),
+    ('gtools', '3.8.1', {
+        'checksums': ['051484459bd8ad1b03425b8843d24f6828fea18f7357cfa1c192198cc3f4ba38'],
+    }),
+    ('gdata', '2.18.0', {
+        'checksums': ['4b287f59f5bbf5fcbf18db16477852faac4a605b10c5284c46b93fa6e9918d7f'],
+    }),
+    ('GSA', '1.03.1', {
+        'checksums': ['e192d4383f53680dbd556223ea5f8cad6bae62a80a337ba5fd8d05a8aee6a917'],
+    }),
+    ('highr', '0.8', {
+        'checksums': ['4bd01fba995f68c947a99bdf9aca15327a5320151e10bd0326fad50a6d8bc657'],
+    }),
+    ('infotheo', '1.2.0', {
+        'checksums': ['9b47ebc3db5708c88dc014b4ffec6734053a9c255a9241fcede30fec3e63aaa3'],
+    }),
+    ('lars', '1.2', {
+        'checksums': ['64745b568f20b2cfdae3dad02fba92ebf78ffee466a71aaaafd4f48c3921922e'],
+    }),
+    ('lazy', '1.2-16', {
+        'checksums': ['c796c8b987ed1bd9dfddd593e17312ed681fc4fa3a1ecfe51da2def0ac1e50df'],
+    }),
+    ('kernlab', '0.9-29', {
+        'checksums': ['c3da693a0041dd34f869e7b63a8d8cf7d4bc588ac601bcdddcf7d44f68b3106f'],
+    }),
+    ('mime', '0.7', {
+        'checksums': ['11083ee44c92569aadbb9baf60a2e079ab7a721c849b74d102694975cc8d778b'],
+    }),
+    ('xfun', '0.11', {
+        'checksums': ['3cc24b5a67a11204255b71e5fadbb4c303dfb34a32e79c95b787aa8997e1cc36'],
+    }),
+    ('markdown', '1.1', {
+        'checksums': ['8d8cd47472a37362e615dbb8865c3780d7b7db694d59050e19312f126e5efc1b'],
+    }),
+    ('mlbench', '2.1-1', {
+        'checksums': ['748141d56531a39dc4d37cf0a5165a40b653a04c507e916854053ed77119e0e6'],
+    }),
+    ('NLP', '0.2-0', {
+        'checksums': ['fc64c80124c4e53b20f92b60c68e2fd33ee189653d0ceea410c32dd66d9e7075'],
+    }),
+    ('mclust', '5.4.5', {
+        'checksums': ['75f2963082669485953e4306ffa93db98335ee6afdc1318b95d605d56cb30a72'],
+    }),
+    ('RANN', '2.6.1', {
+        'checksums': ['b299c3dfb7be17aa41e66eff5674fddd2992fb6dd3b10bc59ffbf0c401697182'],
+    }),
+    ('rmeta', '3.0', {
+        'checksums': ['b9f9d405935cffcd7a5697ff13b033f9725de45f4dc7b059fd68a7536eb76b6e'],
+    }),
+    ('segmented', '1.1-0', {
+        'checksums': ['d081d0efaec708d717bf1248ba3df099876389c22796aad676655efb706e9d19'],
+    }),
+    ('som', '0.3-5.1', {
+        'checksums': ['a6f4c0e5b36656b7a8ea144b057e3d7642a8b71972da387a7133f3dd65507fb9'],
+    }),
+    ('SuppDists', '1.1-9.4', {
+        'checksums': ['fcb571150af66b95dcf0627298c54f7813671d60521a00ed157f63fc2247ddb9'],
+    }),
+    ('stabledist', '0.7-1', {
+        'checksums': ['06c5704d3a3c179fa389675c537c39a006867bc6e4f23dd7e406476ed2c88a69'],
+    }),
+    ('survivalROC', '1.0.3', {
+        'checksums': ['1449e7038e048e6ad4d3f7767983c0873c9c7a7637ffa03a4cc7f0e25c31cd72'],
+    }),
+    ('pspline', '1.0-18', {
+        'checksums': ['f71cf293bd5462e510ac5ad16c4a96eda18891a0bfa6447dd881c65845e19ac7'],
+    }),
+    ('timeDate', '3043.102', {
+        'checksums': ['377cba03cddab8c6992e31d0683c1db3a73afa9834eee3e95b3b0723f02d7473'],
+    }),
+    ('longmemo', '1.1-1', {
+        'checksums': ['0dd88e84a8376141d117bba39fe44f7d3c29d46fc103557fe98357f06e17d657'],
+    }),
+    ('ADGofTest', '0.3', {
+        'checksums': ['9cd9313954f6ecd82480d373f6c5371ca84ab33e3f5c39d972d35cfcf1096846'],
+    }),
+    ('MASS', '7.3-51.4', {
+        'checksums': [('9911d546a8d29dc906b46cb53ef8aad76d23566f4fc3b52778a1201f8a9b2c74',
+                       '844270a2541eaed420871dfb61d681aa67ee57126645fb6b144b436c25698eeb')],
+    }),
+    ('ade4', '1.7-13', {
+        'checksums': ['f5d0a7356ae63f82d3adb481a39007e7b0d70211b8724aa686af0c89c994e99b'],
+    }),
+    ('AlgDesign', '1.2.0', {
+        'checksums': ['ff86c9e19505770520e7614970ad19c698664d08001ce888b8603e44c2a3b52a'],
+    }),
+    ('base64enc', '0.1-3', {
+        'checksums': ['6d856d8a364bcdc499a0bf38bfd283b7c743d08f0b288174fba7dbf0a04b688d'],
+    }),
+    ('BH', '1.69.0-1', {
+        'checksums': ['a0fd4364b7e368f09c56dec030823f52c16da0787580af7e4615eddeb99baca2'],
+    }),
+    ('brew', '1.0-6', {
+        'checksums': ['d70d1a9a01cf4a923b4f11e4374ffd887ad3ff964f35c6f9dc0f29c8d657f0ed'],
+    }),
+    ('Brobdingnag', '1.2-6', {
+        'checksums': ['19eccaed830ce9d93b70642f6f126ac66722a98bbd48586899cc613dd9966ad4'],
+    }),
+    ('corpcor', '1.6.9', {
+        'checksums': ['2e4fabd1d3936fecea67fa365233590147ca50bb45cf80efb53a10345a8a23c2'],
+    }),
+    ('longitudinal', '1.1.12', {
+        'checksums': ['d4f894c38373ba105b1bdc89e3e7c1b215838e2fb6b4470b9f23768b84e603b5'],
+    }),
+    ('backports', '1.1.5', {
+        'checksums': ['63ec38adf383b70b4cd2b661ad353afacff9c4388353578bf4302ab190e1294c'],
+    }),
+    ('checkmate', '1.9.4', {
+        'checksums': ['faa25754b757fe483b876f5d07b73f76f69a1baa971420892fadec4af4bbad21'],
+    }),
+    ('cubature', '2.0.4', {
+        'checksums': ['d97ce5eaac5e43910208e8274ddf6ff4f974d05688f0247ebccd807e24c2fe4a'],
+    }),
+    ('DEoptimR', '1.0-8', {
+        'checksums': ['846911c1b2561a9fae73a8c60a21a5680963ebb0050af3c1f1147ae9a121e5ef'],
+    }),
+    ('digest', '0.6.23', {
+        'checksums': ['b73a754df122d3c17f4976ea01328c99aa0fc08be399ae2fdce2b33637d205a2'],
+    }),
+    ('fastmatch', '1.1-0', {
+        'checksums': ['20b51aa4838dbe829e11e951444a9c77257dcaf85130807508f6d7e76797007d'],
+    }),
+    ('ffbase', '0.12.7', {
+        'checksums': ['dc16a4faf8abb778c353a5ddaf1a10a2b10b7ae867dd6d0b1be400379ce87d12'],
+    }),
+    ('iterators', '1.0.12', {
+        'checksums': ['96bf31d60ebd23aefae105d9b7790715e63327eec0deb2ddfb3d543994ea9f4b'],
+    }),
+    ('maps', '3.3.0', {
+        'checksums': ['199afe19a4edcef966ae79ef802f5dcc15a022f9c357fcb8cae8925fe8bd2216'],
+    }),
+    ('nnls', '1.4', {
+        'checksums': ['0e5d77abae12bc50639d34354f96a8e079408c9d7138a360743b73bd7bce6c1f'],
+    }),
+    ('sendmailR', '1.2-1', {
+        'checksums': ['04feb08c6c763d9c58b2db24b1222febe01e28974eac4fe87670be6fb9bff17c'],
+    }),
+    ('dotCall64', '1.0-0', {
+        'checksums': ['69318dc6b8aecc54d4f789c8105e672198363b395f1a764ebaeb54c0473d17ad'],
+    }),
+    ('spam', '2.5-1', {
+        'checksums': ['d145881a0d48351ce88678a57862c0d0f716d98f3166f6338d954acacc51c067'],
+    }),
+    ('subplex', '1.5-4', {
+        'checksums': ['ff94cf6b1560f78c31712c05bc2bc1b703339e09c7fc777ee94abf15fa7a8b81'],
+    }),
+    ('stringi', '1.4.3', {
+        'checksums': ['13cecb396b700f81af38746e97b550a1d9fda377ca70c78f6cdfc770d33379ed'],
+    }),
+    ('magrittr', '1.5', {
+        'checksums': ['05c45943ada9443134caa0ab24db4a962b629f00b755ccf039a2a2a7b2c92ae8'],
+    }),
+    ('glue', '1.3.1', {
+        'checksums': ['4fc1f2899d71a634e1f0adb7942772feb5ac73223891abe30ea9bd91d3633ea8'],
+    }),
+    ('stringr', '1.4.0', {
+        'checksums': ['87604d2d3a9ad8fd68444ce0865b59e2ffbdb548a38d6634796bbd83eeb931dd'],
+    }),
+    ('evaluate', '0.14', {
+        'checksums': ['a8c88bdbe4e60046d95ddf7e181ee15a6f41cdf92127c9678f6f3d328a3c5e28'],
+    }),
+    ('logspline', '2.1.15', {
+        'checksums': ['dfe0c89a2ae219d121ea7af788dd994097f42d2ff39f4f86f5c4288a4ec0f71e'],
+    }),
+    ('ncbit', '2013.03.29', {
+        'checksums': ['4480271f14953615c8ddc2e0666866bb1d0964398ba0fab6cc29046436820738'],
+    }),
+    ('permute', '0.9-5', {
+        'checksums': ['d2885384a07497e8df273689d6713fc7c57a7c161f6935f3572015e16ab94865'],
+    }),
+    ('plotrix', '3.7-7', {
+        'checksums': ['a4e8ebda8560ad613b9320d39673879f302da791ac3293ff3f22f8ec7cad22f5'],
+    }),
+    ('randomForest', '4.6-14', {
+        'checksums': ['f4b88920419eb0a89d0bc5744af0416d92d112988702dc726882394128a8754d'],
+    }),
+    ('scatterplot3d', '0.3-41', {
+        'checksums': ['4c8326b70a3b2d37126ca806771d71e5e9fe1201cfbe5b0d5a0a83c3d2c75d94'],
+    }),
+    ('SparseM', '1.78', {
+        'checksums': ['d6b79ec881a10c91cb03dc23e6e783080ded9db4f2cb723755aa0d7d29a8b432'],
+    }),
+    ('tripack', '1.3-8', {
+        'checksums': ['6bb340292a9629a41a0e0664335ddd97be3ad46bca225034db5dfb6efe01c75d'],
+    }),
+    ('irace', '3.3', {
+        'checksums': ['4442d968d2201194555eef69f7fbd986a3c553dd6f2f63a26415168c280b0d10'],
+    }),
+    ('rJava', '0.9-11', {
+        'checksums': ['c28ae131456a98f4d3498aa8f6eac9d4df48727008dacff1aa561fc883972c69'],
+    }),
+    ('lattice', '0.20-38', {
+        'checksums': ['fdeb5e3e50dbbd9d3c5e2fa3eef865132b3eef30fbe53a10c24c7b7dfe5c0a2d'],
+    }),
+    ('RColorBrewer', '1.1-2', {
+        'checksums': ['f3e9781e84e114b7a88eb099825936cc5ae7276bbba5af94d35adb1b3ea2ccdd'],
+    }),
+    ('latticeExtra', '0.6-28', {
+        'checksums': ['780695323dfadac108fb27000011c734e2927b1e0f069f247d65d27994c67ec2'],
+    }),
+    ('Matrix', '1.2-18', {
+        'checksums': ['f7ff018c2811946767ffd4c96d3987e859b82786ff72e1c211ab18bc03cb6119'],
+    }),
+    ('png', '0.1-7', {
+        'checksums': ['e269ff968f04384fc9421d17cfc7c10cf7756b11c2d6d126e9776f5aca65553c'],
+    }),
+    ('RcppArmadillo', '0.9.800.3.0', {
+        'checksums': ['03d671c8551a887617dc34f6bc650a8eee1a395b163ac9ec2cd1a93aded5ec4e'],
+    }),
+    ('plyr', '1.8.5', {
+        'checksums': ['ea008c59a4a7211a09dfc2e4f25d286fc109424c17f01671f72aec97c75a9574'],
+    }),
+    ('gtable', '0.3.0', {
+        'checksums': ['fd386cc4610b1cc7627dac34dba8367f7efe114b968503027fb2e1265c67d6d3'],
+    }),
+    ('reshape2', '1.4.3', {
+        'checksums': ['8aff94c935e75032344b52407593392ddd4e16a88bb206984340c816d42c710e'],
+    }),
+    ('dichromat', '2.0-0', {
+        'checksums': ['31151eaf36f70bdc1172da5ff5088ee51cc0a3db4ead59c7c38c25316d580dd1'],
+    }),
+    ('colorspace', '1.4-1', {
+        'checksums': ['693d713a050f8bfecdb7322739f04b40d99b55aed168803686e43401d5f0d673'],
+    }),
+    ('munsell', '0.5.0', {
+        'checksums': ['d0f3a9fb30e2b5d411fa61db56d4be5733a2621c0edf017d090bdfa5e377e199'],
+    }),
+    ('labeling', '0.3', {
+        'checksums': ['0d8069eb48e91f6f6d6a9148f4e2dc5026cabead15dd15fc343eff9cf33f538f'],
+    }),
+    ('R6', '2.4.1', {
+        'checksums': ['26b0fd64827655c28c903f7ff623e839447387f3ad9b04939a02f41ac82faa3e'],
+    }),
+    ('viridisLite', '0.3.0', {
+        'checksums': ['780ea12e7c4024d5ba9029f3a107321c74b8d6d9165262f6e64b79e00aa0c2af'],
+    }),
+    ('farver', '2.0.1', {
+        'checksums': ['1642ca1519ef80616ab044ae7f6eaf464118356f2a7875e9d0e3df60ca84012b'],
+    }),
+    ('rlang', '0.4.2', {
+        'checksums': ['fbd1c9cb81c94f769bd57079d7ef0682f27b971181340b2ed1e3ab79c2659f39'],
+    }),
+    ('lifecycle', '0.1.0', {
+        'checksums': ['961c28c016d54beee496572a88602fe94d8456ee6455ac88cb2e0fc3273c3387'],
+    }),
+    ('scales', '1.1.0', {
+        'checksums': ['1ee4a6fd1dbc5f52fe57dd8cce8caee4ce2fecb02d4e7d519e83f15aa45b2d03'],
+    }),
+    ('assertthat', '0.2.1', {
+        'checksums': ['85cf7fcc4753a8c86da9a6f454e46c2a58ffc70c4f47cac4d3e3bcefda2a9e9f'],
+    }),
+    ('crayon', '1.3.4', {
+        'checksums': ['fc6e9bf990e9532c4fcf1a3d2ce22d8cf12d25a95e4779adfa17713ed836fa68'],
+    }),
+    ('fansi', '0.4.0', {
+        'checksums': ['e104e9d01c7ff8a847f6b332ef544c0ef912859f9c6a514fe2e6f3b34fcfc209'],
+    }),
+    ('cli', '2.0.0', {
+        'checksums': ['713afa3c38a61d6d5d7a7463961925f8a84c1b0e51b7c2e78e49c81b1bfe63bf'],
+    }),
+    ('utf8', '1.1.4', {
+        'checksums': ['f6da9cadfc683057d45f54b43312a359cf96ec2731c0dda18a8eae31d1e31e54'],
+    }),
+    ('zeallot', '0.1.0', {
+        'checksums': ['439f1213c97c8ddef9a1e1499bdf81c2940859f78b76bc86ba476cebd88ba1e9'],
+    }),
+    ('ellipsis', '0.3.0', {
+        'checksums': ['0bf814cb7a1f0ee1f2949bdc98752a0d535f2a9489280dd4d8fcdb10067ee907'],
+    }),
+    ('vctrs', '0.2.0', {
+        'checksums': ['5bce8f228182ecaa51230d00ad8a018de9cf2579703e82244e0931fe31f20016'],
+    }),
+    ('pillar', '1.4.2', {
+        'checksums': ['bababb76b6db06dc32ccd947dbad6c164a1749ff5b558c6783ad03570f010825'],
+    }),
+    ('pkgconfig', '2.0.3', {
+        'checksums': ['330fef440ffeb842a7dcfffc8303743f1feae83e8d6131078b5a44ff11bc3850'],
+    }),
+    ('tibble', '2.1.3', {
+        'checksums': ['9a8cea9e6b5d24a7e9bf5f67ab38c40b2b6489eddb0d0edb8a48a21ba3574e1a'],
+    }),
+    ('lazyeval', '0.2.2', {
+        'checksums': ['d6904112a21056222cfcd5eb8175a78aa063afe648a562d9c42c6b960a8820d4'],
+    }),
+    ('withr', '2.1.2', {
+        'checksums': ['41366f777d8adb83d0bdbac1392a1ab118b36217ca648d3bb9db763aa7ff4686'],
+    }),
+    ('nlme', '3.1-143', {
+        'checksums': ['42b48586c3ec4eba7de0cef6312aff63f4596cd92a1f9acb618dae28f4ea318e'],
+    }),
+    ('mgcv', '1.8-31', {
+        'checksums': ['736de462a0ac43a6ed38cd57dfb0ba2942c941dfbb538128782727ab7125c3c5'],
+    }),
+    ('ggplot2', '3.2.1', {
+        'checksums': ['e39114a90af69041645b0751ac469d8919c5a7e8cb044a3b56a0728623e65a56'],
+    }),
+    ('pROC', '1.15.3', {
+        'checksums': ['b010988a646a642657ec72d908c2e0ca2f9df0898c05b9f1f5ab6b739353a8cb'],
+    }),
+    ('quadprog', '1.5-8', {
+        'checksums': ['22128dd6b08d3516c44ff89276719ad4fe46b36b23fdd585274fa3a93e7a49cd'],
+    }),
+    ('BB', '2019.10-1', {
+        'checksums': ['04d0b6ce6e5f070b109478a6005653dbe78613bb4e3ea4903203d851b5d3c94d'],
+    }),
+    ('BBmisc', '1.11', {
+        'checksums': ['1ea48c281825349d8642a661bb447e23bfd651db3599bf72593bfebe17b101d2'],
+    }),
+    ('fail', '1.3', {
+        'checksums': ['ede8aa2a9f2371aff5874cd030ac625adb35c33954835b54ab4abf7aeb34d56d'],
+    }),
+    ('rlecuyer', '0.3-5', {
+        'checksums': ['4723434ff7624d4f404a6854ffa0673fc43daa46f58f064dbeeaa17da28ab626'],
+    }),
+    ('snow', '0.4-3', {
+        'checksums': ['8512537daf334ea2b8074dbb80cf5e959a403a78d68bc1e97664e8a4f64576d8'],
+    }),
+    ('tree', '1.0-40', {
+        'checksums': ['ffab16382d7ed5b76529801ab26b4970363b2072231c6a87330326298ce626e7'],
+    }),
+    ('pls', '2.7-2', {
+        'checksums': ['67e91e36dbebeb2f2d9c9b88f310dc00f70de275e5f382f392e72dd36af42b88'],
+    }),
+    ('class', '7.3-15', {
+        'checksums': ['f6bf33d610c726d58622b6cea78a808c7d6a317d02409d27c17741dfd1c730f4'],
+    }),
+    ('e1071', '1.7-3', {
+        'checksums': ['bb2dba526b673ec3a573befe365e3500b773593f0384fd6694e0835496bcc25d'],
+    }),
+    ('nnet', '7.3-12', {
+        'checksums': ['2723523e8581cc0e2215435ac773033577a16087a3f41d111757dd96b8c5559d'],
+    }),
+    ('minqa', '1.2.4', {
+        'checksums': ['cfa193a4a9c55cb08f3faf4ab09c11b70412523767f19894e4eafc6e94cccd0c'],
+    }),
+    ('RcppEigen', '0.3.3.7.0', {
+        'checksums': ['62ea627284425bfdb56613bc315cca492ed3483a56a03c1f9dc9821a25c3e8ac'],
+    }),
+    ('MatrixModels', '0.4-1', {
+        'checksums': ['fe878e401e697992a480cd146421c3a10fa331f6b37a51bac83b5c1119dcce33'],
+    }),
+    ('quantreg', '5.54', {
+        'checksums': ['703b2c67d88e95eaf1bf3c09fc64c1964bcc1145244c8bc8c0e5ac99713ad0a6'],
+    }),
+    ('robustbase', '0.93-5', {
+        'checksums': ['bde564dbd52f04ab32f9f2f9dd09b9578f3ccd2541cf5f8ff430da42a55e7f56'],
+    }),
+    ('sp', '1.3-2', {
+        'checksums': ['940a22add254fbb5ebd80a380f4777fcd1af282975ebad400d177f3a20d6f24e'],
+    }),
+    ('zoo', '1.8-6', {
+        'checksums': ['2217a4f362f2201443b5fdbfd9a77d9a6caeecb05f02d703ee8b3b9bf2af37cc'],
+    }),
+    ('lmtest', '0.9-37', {
+        'checksums': ['ddc929f94bf055974832fa4a20fdd0c1eb3a84ee11f716c287936f2141d5ca0a'],
+    }),
+    ('vcd', '1.4-4', {
+        'checksums': ['a561adf120b5ce41b66e0c0c321542fcddc772eb12b3d7020d86e9cd014ce9d2'],
+    }),
+    ('snowfall', '1.84-6.1', {
+        'checksums': ['5c446df3a931e522a8b138cf1fb7ca5815cc82fcf486dbac964dcbc0690e248d'],
+    }),
+    ('rpart', '4.1-15', {
+        'checksums': ['2b8ebe0e9e11592debff893f93f5a44a6765abd0bd956b0eb1f70e9394cfae5c'],
+    }),
+    ('survival', '3.1-8', {
+        'checksums': ['cecf393e8e27df79f3bf4aa7bc186d161f0e4b46a8572504e6eb80c09027d295'],
+    }),
+    ('bindr', '0.1.1', {
+        'checksums': ['7c785ca77ceb3ab9282148bcecf64d1857d35f5b800531d49483622fe67505d0'],
+    }),
+    ('plogr', '0.2.0', {
+        'checksums': ['0e63ba2e1f624005fe25c67cdd403636a912e063d682eca07f2f1d65e9870d29'],
+    }),
+    ('bindrcpp', '0.2.2', {
+        'checksums': ['48130709eba9d133679a0e959e49a7b14acbce4f47c1e15c4ab46bd9e48ae467'],
+    }),
+    ('purrr', '0.3.3', {
+        'checksums': ['0f31a89a424e12e35bd6e0581dee1d160f1f8be1f0a883a7d33ccbde8ef69e9e'],
+    }),
+    ('tidyselect', '0.2.5', {
+        'checksums': ['5ce2e86230fa35cfc09aa71dcdd6e05e1554a5739c863ca354d241bfccb86c74'],
+    }),
+    ('dplyr', '0.8.3', {
+        'checksums': ['68b4aac65a69ea6390e90991d9c7ce7a011a07e5db439d60cce911a078424c0c'],
+    }),
+    ('tidyr', '1.0.0', {
+        'checksums': ['92a1a30b5636c3c1c68acbff0c1f5b301df64bf3198d23f1c9808ed43a900390'],
+    }),
+    ('mnormt', '1.5-5', {
+        'checksums': ['ff78d5f935278935f1814a69e5a913d93d6dd2ac1b5681ba86b30c6773ef64ac'],
+    }),
+    ('foreign', '0.8-72', {
+        'checksums': ['439c17c9cd387e180b1bb640efff3ed1696b1016d0f7b3b3b884e89884488c88'],
+    }),
+    ('psych', '1.8.12', {
+        'checksums': ['6e175e049bc1ee5b79a9e51ccafb22b962b4e6c839ce5c9cfa1ad83967037743'],
+    }),
+    ('generics', '0.0.2', {
+        'checksums': ['71b3d1b719ce89e71dd396ac8bc6aa5f1cd99bbbf03faff61dfbbee32fec6176'],
+    }),
+    ('broom', '0.5.3', {
+        'checksums': ['0d59b135bfa11c633c8ceec640342f026c5468c620984484bbc9adde1211f59c'],
+    }),
+    ('nloptr', '1.2.1', {
+        'checksums': ['1f86e33ecde6c3b0d2098c47591a9cd0fa41fb973ebf5145859677492730df97'],
+    }),
+    ('boot', '1.3-23', {
+        'checksums': [('30c89e19dd6490b943233e87dfe422bfef92cfbb7a7dfb5c17dfd9b2d63fa02f',
+                       '79236a5a770dc8bf5ce25d9aa303c5dc0574d94aa043fd00b8b4c8ccc877357f')],
+    }),
+    ('lme4', '1.1-21', {
+        'checksums': ['7f5554b69ff8ce9bac21e8842131ea940fb7a7dfa2de03684f236d3e3114b20c'],
+    }),
+    ('ucminf', '1.1-4', {
+        'checksums': ['a2eb382f9b24e949d982e311578518710f8242070b3aa3314a331c1e1e7f6f07'],
+    }),
+    ('numDeriv', '2016.8-1.1', {
+        'checksums': ['d8c4d19ff9aeb31b0c628bd4a16378e51c1c9a3813b525469a31fe89af00b345'],
+    }),
+    ('ordinal', '2019.12-10', {
+        'checksums': ['7a41e7b7e852a8fa3e911f8859d36e5709ccec5ca42ee3de14a813b7aaac7725'],
+    }),
+    ('jomo', '2.6-10', {
+        'checksums': ['4063d48e259e936dc0bd9dc616a09043f695703848cb1bf8faa08c07922034cd'],
+    }),
+    ('hms', '0.5.2', {
+        'checksums': ['d445c98c36b224e73c76dd4fc2a700e0b1abf0ade3d8ac8ac96c12fb946e4440'],
+    }),
+    ('clipr', '0.7.0', {
+        'checksums': ['03a4e4b72ec63bd08b53fe62673ffc19a004cc846957a335be2b30d046b8c2e2'],
+    }),
+    ('readr', '1.3.1', {
+        'checksums': ['33f94de39bb7f2a342fbb2bd4e5afcfec08798eac39672ee18042ac0b349e4f3'],
+    }),
+    ('forcats', '0.4.0', {
+        'checksums': ['7c83cb576aa6fe1379d7506dcc332f7560068b2025f9e3ab5cd0a5f28780d2b2'],
+    }),
+    ('haven', '2.2.0', {
+        'checksums': ['199ee9b14e1ff70a0b0c3b9ce33dfdec8ed3b5e857a2a36bfb82e78a7b352d3d'],
+    }),
+    ('pan', '1.6', {
+        'checksums': ['adc0df816ae38bc188bce0aef3aeb71d19c0fc26e063107eeee71a81a49463b6'],
+    }),
+    ('mitml', '0.3-7', {
+        'checksums': ['c6f796d0059f1b093b599a89d955982fa257de9c45763ecc2cbbce10fdec1e7b'],
+    }),
+    ('mice', '3.7.0', {
+        'checksums': ['4eab2959bcfe28eae068e5e697901b47b05a6c88e0a34af8303f1ec05ed0a1f3'],
+    }),
+    ('urca', '1.3-0', {
+        'checksums': ['621cc82398e25b58b4a16edf000ed0a1484d9a0bc458f734e97b6f371cc76aaa'],
+    }),
+    ('fracdiff', '1.5-0', {
+        'checksums': ['3a837326a6cdeed5ab1b8a83f57adb2e861886736fbde49fede79b6150081b70'],
+    }),
+    ('logistf', '1.23', {
+        'checksums': ['5adb22a40569883395dc048c877f849dd08d07582a991f1b160f0338f0b13838'],
+    }),
+    ('akima', '0.6-2', {
+        'checksums': ['61da3e556553eea6d1f8db7c92218254441da31e365bdef82dfe5da188cc97ce'],
+    }),
+    ('bitops', '1.0-6', {
+        'checksums': ['9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c'],
+    }),
+    ('mixtools', '1.1.0', {
+        'checksums': ['543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f'],
+    }),
+    ('cluster', '2.1.0', {
+        'checksums': ['eaf955bef8f616ea563351ec7f597c445aec43e65991ca975e382ef1fd70aa14'],
+    }),
+    ('gclus', '1.3.2', {
+        'checksums': ['9cc61cdff206c11213e73afca3d570a7234250cf6044a9202c2589932278e0b3'],
+    }),
+    ('coda', '0.19-3', {
+        'checksums': ['d3df1fc848bcf1af8fae13d61eeab60e99a3d4b4db384bec4326f909f502c5d6'],
+    }),
+    ('codetools', '0.2-16', {
+        'checksums': ['f67a66175cb5d8882457d1e9b91ea2f16813d554fa74f80c1fd6e17cf1877501'],
+    }),
+    ('foreach', '1.4.7', {
+        'checksums': ['95632c0b1182fc01490718d82fa3b2bce864f2a011ae53282431c7c2a3f5f160'],
+    }),
+    ('doMC', '1.3.6', {
+        'checksums': ['2977fc9e2dc54d85d45b4a36cd286dff72834fbc73f38b6ee45a6eb8557fc9b2'],
+    }),
+    ('DBI', '1.1.0', {
+        'checksums': ['a96db7fa39a58f1ed34c6e78d8f5f7e4cf0882afb301323b5c6975d6729203e4'],
+    }),
+    ('gam', '1.16.1', {
+        'checksums': ['80d04102c6152143e8ed364f91eb312e413f73b8fcab7cf15d677867a16e74b9'],
+    }),
+    ('gamlss.data', '5.1-4', {
+        'checksums': ['0d3777d8c3cd76cef273aa6bde40a91688719be401195ed9bfd1e85bd7d5eeb5'],
+    }),
+    ('gamlss.dist', '5.1-5', {
+        'checksums': ['1c6f42d17e32eae848217bc5115bc440ff8f95869d7fef0756fbf6f2da8787e6'],
+    }),
+    ('gamlss', '5.1-5', {
+        'checksums': ['6ca1297418e514a7b89f59789908d040e3160cb32e7cf024cc623630997b963d'],
+    }),
+    ('gamlss.tr', '5.1-0', {
+        'checksums': ['f9e1c4935d8876bfc80dddc0a9bc2c82b4deeda9482df208297a84a638a4a9df'],
+    }),
+    ('hwriter', '1.3.2', {
+        'checksums': ['6b3531d2e7a239be9d6e3a1aa3256b2745eb68aa0bdffd2076d36552d0d7322b'],
+    }),
+    ('KernSmooth', '2.23-16', {
+        'checksums': ['b8c251fea1483a8ade005faf31dff9d85d2b6da08dcd661bf1e4a861db9a99a9'],
+    }),
+    ('xts', '0.11-2', {
+        'checksums': ['12772f6a66aab5b84b0665c470f11a3d8d8a992955c027261cfe8e6077ee13b8'],
+    }),
+    ('curl', '4.3', {
+        'checksums': ['7406d485bb50a6190e3ed201e3489063fd249b8b3b1b4f049167ac405a352edb'],
+    }),
+    ('TTR', '0.23-6', {
+        'checksums': ['afc10a89d3a18f121ddf0f7256408eeb05cc64e18ee94e654bfa803e5415e265'],
+    }),
+    ('quantmod', '0.4-15', {
+        'checksums': ['7ef2e798d4d8e4d2af0a5b2b9fecebec30568087afbd24bfd923cdeb8b53df53'],
+    }),
+    ('mvtnorm', '1.0-11', {
+        'checksums': ['0321612de99aa9bc75a45c7e029d3372736014223cbdefb80d8cae600cbc7252'],
+    }),
+    ('pcaPP', '1.9-73', {
+        'checksums': ['ca4566b0babfbe83ef9418283b08a12b3420dc362f93c6562f265df7926b53fc'],
+    }),
+    ('SQUAREM', '2017.10-1', {
+        'checksums': ['9b89905b436f1cf3faa9e3dabc585a76299e729e85ca659bfddb4b7cba11b283'],
+    }),
+    ('lava', '1.6.6', {
+        'checksums': ['7abc84dd99cce450a45ac4f232812cde3a322e432da3472f43b057fb5c59ca59'],
+    }),
+    ('prodlim', '2019.11.13', {
+        'checksums': ['6809924f503a14681de84730489cdaf9240d7951c64f5b98ca37dc1ce7809b0f'],
+    }),
+    ('pscl', '1.5.2', {
+        'checksums': ['2c9fe648485c6b54c6f95a54b6e00ffe3cf06fa8c5c68f1d669664a7b91a0ede'],
+    }),
+    ('memoise', '1.1.0', {
+        'checksums': ['b276f9452a26aeb79e12dd7227fcc8712832781a42f92d70e86040da0573980c'],
+    }),
+    ('bit64', '0.9-7', {
+        'checksums': ['7b9aaa7f971198728c3629f9ba1a1b24d53db5c7e459498b0fdf86bbd3dff61f'],
+    }),
+    ('prettyunits', '1.0.2', {
+        'checksums': ['35a4980586c20650538ae1e4fed4d80fdde3f212b98546fc3c7d9469a1207f5c'],
+    }),
+    ('blob', '1.2.0', {
+        'checksums': ['1af1cfa28607bc0e2f1f01598a00a7d5d1385ef160a9e79e568f30f56538e023'],
+    }),
+    ('RSQLite', '2.1.4', {
+        'checksums': ['64b80063833d4cdbc4b44b7d70c605bf87c2595300049a8c519e46ecbec10aee'],
+    }),
+    ('data.table', '1.12.8', {
+        'checksums': ['d3a75f3a355ff144cc20a476041617e21fcf2a9f79265fd9bbd4693f3671f9dc'],
+    }),
+    ('BatchJobs', '1.8', {
+        'checksums': ['35cc2dae31994b1df982d11939509ce965e12578418c4fbb8cd7a422afd6e4ff'],
+    }),
+    ('sandwich', '2.5-1', {
+        'checksums': ['dbef6f4d12b83e166f9a2508b7c732b04493641685d6758d29f3609e564166d6'],
+    }),
+    ('sfsmisc', '1.1-4', {
+        'checksums': ['44b6a9c859922e86b7182e54eb781d3264f3819f310343518ebc66f54f305c7d'],
+    }),
+    ('spatial', '7.3-11', {
+        'checksums': ['624448d2ac22e1798097d09fc5dc4605908a33f490b8ec971fc6ea318a445c11'],
+    }),
+    ('VGAM', '1.1-2', {
+        'checksums': ['f8071339f127121945954c98168749efcc179c67c70437d35b5d684fd4b0ca4f'],
+    }),
+    ('waveslim', '1.7.5.1', {
+        'checksums': ['b323018c92674b1b49fe01ec7e3900641a1c9ce0bd1e7497cfe8f64e96057e56'],
+    }),
+    ('xtable', '1.8-4', {
+        'checksums': ['5abec0e8c27865ef0880f1d19c9f9ca7cc0fd24eadaa72bcd270c3fb4075fd1c'],
+    }),
+    ('profileModel', '0.6.0', {
+        'checksums': ['a829ceec29c817d6d15947b818e28f9cf5a188a231b9b5d0a75018388887087b'],
+    }),
+    ('brglm', '0.6.2', {
+        'checksums': ['c2af432a43ccf37e9de50317f770b9703a4c80b4ef79ec40aa8e7ec3987e3631'],
+    }),
+    ('deSolve', '1.25', {
+        'checksums': ['773170a7b9f82db3a8dfb563942ee0e71ebdebc388e59f93e918d257eef0651c'],
+    }),
+    ('tseriesChaos', '0.1-13.1', {
+        'checksums': ['23cb5fea56409a305e02a523ff8b7642ec383942d415c9cffdc92208dacfd961'],
+    }),
+    ('tseries', '0.10-47', {
+        'checksums': ['202377df56806fe611c2e12c4d9732c71b71220726e2defa7e568d2b5b62fb7b'],
+    }),
+    ('fastICA', '1.2-2', {
+        'checksums': ['32223593374102bf54c8fdca7b57231e4f4d0dd0be02d9f3500ad41b1996f1fe'],
+    }),
+    ('R.methodsS3', '1.7.1', {
+        'checksums': ['44b840399266cd27f8f9157777b4d9d85ab7bd31bfdc143b3fc45079a2d8e687'],
+    }),
+    ('R.oo', '1.23.0', {
+        'checksums': ['f5124ce3dbb0a62e8ef1bfce2de2d1dc2f776e8c48fd8cac358f7f5feb592ea1'],
+    }),
+    ('jsonlite', '1.6', {
+        'checksums': ['88c5b425229966b7409145a6cabc72db9ed04f8c37ee95901af0146bb285db53'],
+    }),
+    ('sys', '3.3', {
+        'checksums': ['a6217c2a7240ed68614006f392c6d062247dab8b9b0d498f95e947110df19b93'],
+    }),
+    ('askpass', '1.1', {
+        'checksums': ['db40827d1bdbb90c0aa2846a2961d3bf9d76ad1b392302f9dd84cc2fd18c001f'],
+    }),
+    ('openssl', '1.4.1', {
+        'checksums': ['f7fbecc75254fc43297a95a4338c674ab9ba2ec056b59e027d16d23122161fc6'],
+    }),
+    ('httr', '1.4.1', {
+        'checksums': ['675c7e07bbe82c48284ee1ab929bb14a6e653abae2860d854dc41a3c028de156'],
+    }),
+    ('cgdsr', '1.3.0', {
+        'checksums': ['4aa2a3564cee2449c3ff39ab2ad631deb165d4c78b8107e0ff77a9095340cc1f'],
+    }),
+    ('R.utils', '2.9.2', {
+        'checksums': ['ac6b3b8e814fbb855c38fbdb89a4f0cf0ed65ce7fa308445bd74107fbc0d32cf'],
+    }),
+    ('R.matlab', version, {
+        'checksums': ['1ba338f470a24b7f6ef68cadbd04eb468ead4a689f263d2642408ad591b786bb'],
+    }),
+    ('gridExtra', '2.3', {
+        'checksums': ['81b60ce6f237ec308555471ae0119158b115463df696d2eca9b177ded8988e3b'],
+    }),
+    ('gbm', '2.1.5', {
+        'checksums': ['06fbde10639dfa886554379b40a7402d1f1236a9152eca517e97738895a4466f'],
+    }),
+    ('Formula', '1.2-3', {
+        'checksums': ['1411349b20bd09611a9fd0ee6d15f780c758ad2b0e490e908facb49433823872'],
+    }),
+    ('acepack', '1.4.1', {
+        'checksums': ['82750507926f02a696f6cc03693e8d4a5ee7e92500c8c15a16a9c12addcd28b9'],
+    }),
+    ('proto', '1.0.0', {
+        'checksums': ['9294d9a3b2b680bb6fac17000bfc97453d77c87ef68cfd609b4c4eb6d11d04d1'],
+    }),
+    ('chron', '2.3-54', {
+        'checksums': ['0df3ac3e96e0469a8fd727ef65a1edfada90c088cd74f535ff5882ce716f876d'],
+    }),
+    ('viridis', '0.5.1', {
+        'checksums': ['ddf267515838c6eb092938133035cee62ab6a78760413bfc28b8256165701918'],
+    }),
+    ('yaml', '2.2.0', {
+        'checksums': ['55bcac87eca360ab5904914fcff473a6981a1f5e6d2215d2634344d0ac30c546'],
+    }),
+    ('htmltools', '0.4.0', {
+        'checksums': ['5b18552e1183b1b90b5cca8e7f95b57e8124c9d517b22aa64783b829513b811a'],
+    }),
+    ('htmlwidgets', '1.5.1', {
+        'checksums': ['d42e59144552d9b4131f11ddd6169dfb9bd538c7996669a09acbdb400d18d781'],
+    }),
+    ('knitr', '1.26', {
+        'checksums': ['38db354bec68f25cf8a05e5162ebbac45811309c75a7bcfc8bcb5a565a5bc321'],
+    }),
+    ('rstudioapi', '0.10', {
+        'checksums': ['80c5aa3063bcab649904cb92f0b164edffa2f6b0e6a8f7ea28ae317b80e1ab96'],
+    }),
+    ('htmlTable', '1.13.3', {
+        'checksums': ['d459c43675f6ee0a1ae8232ea8819b2a842e795a833b28127081fa344d09393d'],
+    }),
+    ('Hmisc', '4.3-0', {
+        'checksums': ['7ff2f9adcfd67f2e70345e73db3608ed46f8e07e2f696d0d591f533482a96165'],
+    }),
+    ('fastcluster', '1.1.25', {
+        'checksums': ['f3661def975802f3dd3cec5b2a1379f3707eacff945cf448e33aec0da1ed4205'],
+    }),
+    ('registry', '0.5-1', {
+        'checksums': ['dfea36edb0a703ec57e111016789b47a1ba21d9c8ff30672555c81327a3372cc'],
+    }),
+    ('bibtex', '0.4.2', {
+        'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
+    }),
+    ('pkgmaker', '0.27', {
+        'checksums': ['17a289d8f596ba5637b07077b3bff22411a2c2263c0b7de59fe848666555ec6a'],
+    }),
+    ('rngtools', '1.4', {
+        'checksums': ['3aa92366e5d0500537964302f5754a750aff6b169a27611725e7d84552913bce'],
+    }),
+    ('doParallel', '1.0.15', {
+        'checksums': ['71ad7ea69616468996aefdd8d02a4a234759a21ddde9ed1657e3c537145cd86e'],
+    }),
+    ('gridBase', '0.4-7', {
+        'checksums': ['be8718d24cd10f6e323dce91b15fc40ed88bccaa26acf3192d5e38fe33e15f26'],
+    }),
+    ('NMF', '0.21.0', {
+        'checksums': ['3b30c81c66066fab4a63c5611a0313418b840d8b63414db31ef0e932872d02e3'],
+    }),
+    ('irlba', '2.3.3', {
+        'checksums': ['6ee233697bcd579813bd0af5e1f4e6dd1eea971e8919c748408130d970fef5c0'],
+    }),
+    ('igraph', '1.2.4.2', {
+        'checksums': ['ad67b58e9132128d8ea7ec0dee5c071a21f4674e8f2cbaa642555d23165e9969'],
+    }),
+    ('GeneNet', '1.2.13', {
+        'checksums': ['3798caac3bef7dc87f97b3628eb29eb12365d571ce0837b5b6285b0be655a270'],
+    }),
+    ('ape', '5.3', {
+        'checksums': ['08b0df134c523feb00a86896d1aa2a43f0f0dab20a53bc6b5d6268d867988b23'],
+    }),
+    ('RJSONIO', '1.3-1.3', {
+        'checksums': ['bc5e97dac4d6e935ba530f60be9364ea5f2aebaf5b9a907135e8d7c0d56d22b9'],
+    }),
+    ('caTools', '1.17.1.3', {
+        'checksums': ['d78735c5adb54ba31a4d529cc2fbf7d3c72a6e12fc24afda8d36acdefcdaa712'],
+    }),
+    ('gplots', '3.0.1.1', {
+        'checksums': ['7db103f903a25d174cddcdfc7b946039b61e236c95084b90ad17f1a41da3770c'],
+    }),
+    ('ROCR', '1.0-7', {
+        'checksums': ['e7ef710f847e441a48b20fdc781dbc1377f5a060a5ee635234053f7a2a435ec9'],
+    }),
+    ('later', '1.0.0', {
+        'checksums': ['277b9848ef2e5e1ac7257aefeb58f6b20cca17693460e7c4eee0477de456b287'],
+    }),
+    ('promises', '1.1.0', {
+        'checksums': ['c8ea0f3e3256cf3010439b3a6111966db419c3dcff9a561e73caf8bd65f38006'],
+    }),
+    ('httpuv', '1.5.2', {
+        'checksums': ['93b32be974e0f531a3cb343685165c0caadf30cfea07683f8d69302a34045d8d'],
+    }),
+    ('rjson', '0.2.20', {
+        'checksums': ['3a287c1e5ee7c333ed8385913c0a307daf99335fbdf803e9dcca6e3d5adb3f6c'],
+    }),
+    ('sourcetools', '0.1.7', {
+        'checksums': ['47984406efb3b3face133979ccbae9fefb7360b9a6ca1a1c11473681418ed2ca'],
+    }),
+    ('fastmap', '1.0.1', {
+        'checksums': ['4778b05dfebd356f8df980dfeff3b973a72bca14898f870e5c40c1d84db9faec'],
+    }),
+    ('shiny', '1.4.0', {
+        'checksums': ['0c070459387cea98ca7c6df7318370116df42afb5f76a8625eb4f5b681ee6c4b'],
+    }),
+    ('seqinr', '3.6-1', {
+        'checksums': ['c44fc8922ef410da3c3b5ca117cdbec55ccb546c9e6d96c01ede44398dfa6048'],
+    }),
+    ('LearnBayes', '2.15.1', {
+        'checksums': ['9b110858456523ca0b2a63f22013c4e1fbda6674b9d84dc1f4de8bffc5260532'],
+    }),
+    ('deldir', '0.1-23', {
+        'checksums': ['e0112bce9fc94daf73596a0fff9b3958b80872e3bbb487be73e157b13a6f201d'],
+    }),
+    ('gmodels', '2.18.1', {
+        'checksums': ['626140a34eb8c53dd0a06511a76c71bc61c48777fa76fcc5e6934c9c276a1369'],
+    }),
+    ('expm', '0.999-4', {
+        'checksums': ['58d06427a08c9442462b00a5531e2575800be13ed450c5a1546261251e536096'],
+    }),
+    ('spData', '0.3.2', {
+        'checksums': ['7c7d93e7b722e67695f89e1961592733393298229359768fe846087b73d615a4'],
+    }),
+    ('units', '0.6-5', {
+        'checksums': ['50b759fe0c91f7e098cabb348f3d14067f3dbeb26574a2259d27870c2ad2d40a'],
+    }),
+    ('classInt', '0.4-2', {
+        'checksums': ['bb0da1e7db779831cf5cea80722ade90bf83a9aa51b7d2bc6bee69c433042871'],
+    }),
+    ('vegan', '2.5-6', {
+        'checksums': ['b3c00aceb3db38101960515658e2b9ec1552439c3ed4e26e72989f18eccbc03c'],
+    }),
+    ('progress', '1.2.2', {
+        'checksums': ['b4a4d8ed55db99394b036a29a0fb20b5dd2a91c211a1d651c52a1023cc58ff35'],
+    }),
+    ('rncl', '0.8.3', {
+        'checksums': ['daaef6874438233c73a62b59a9ee10261e1e10d7ef18b7178d2d8b517fd4880d'],
+    }),
+    ('XML', '3.98-1.20', {
+        'checksums': ['46af86376ea9a0fb1b440cf0acdf9b89178686a05c4b77728fcff1f023aa4858'],
+    }),
+    ('praise', '1.0.0', {
+        'checksums': ['5c035e74fd05dfa59b03afe0d5f4c53fbf34144e175e90c53d09c6baedf5debd'],
+    }),
+    ('ps', '1.3.0', {
+        'checksums': ['289193d0ccd2db0b6fe8702e8c5711e935219b17f90f01a6e9684982413e98d1'],
+    }),
+    ('processx', '3.4.1', {
+        'checksums': ['f1abddb48fa78f2b176552e2ec5d808d4d87d79ce72e9b3d25c9a7d715bbd1bc'],
+    }),
+    ('callr', '3.4.0', {
+        'checksums': ['99ea44fa5b9ce3db1c3811f57021b04c172611ec6caa6e317808ff489fe07dc3'],
+    }),
+    ('rprojroot', '1.3-2', {
+        'checksums': ['df5665834941d8b0e377a8810a04f98552201678300f168de5f58a587b73238b'],
+    }),
+    ('desc', '1.2.0', {
+        'checksums': ['e66fb5d4fc7974bc558abcdc107a1f258c9177a29dcfcf9164bc6b33dd08dae8'],
+    }),
+    ('pkgbuild', '1.0.6', {
+        'checksums': ['bd736cadcb9938df9fafddd362f9f032934a93b9853b981eb3754db8a3f9d476'],
+    }),
+    ('pkgload', '1.0.2', {
+        'checksums': ['3186564e690fb05eabe76e1ac0bfd4312562c3ac8794b29f8850399515dcf27c'],
+    }),
+    ('testthat', '2.3.1', {
+        'checksums': ['7eae9574b8baf80a95b529aff982fb691794bf211c8bf58ce431d9771b641d55'],
+    }),
+    ('tinytex', '0.18', {
+        'checksums': ['39cf729b11138f55949901facd346452b17192640603f995ad7df5d8145cb712'],
+    }),
+    ('rmarkdown', '2.0', {
+        'checksums': ['87ba0499555719cf3793bfd6ff4fa3577401ac5d90577c300bee02c54fb0a3ae'],
+    }),
+    ('reshape', '0.8.8', {
+        'checksums': ['4d5597fde8511e8fe4e4d1fd7adfc7ab37ff41ac68c76a746f7487d7b106d168'],
+    }),
+    ('xml2', '1.2.2', {
+        'checksums': ['3050f147c4335be2925a576557bbda36bd52a5bba3110d47b740a2dd811a78f4'],
+    }),
+    ('triebeard', '0.3.0', {
+        'checksums': ['bf1dd6209cea1aab24e21a85375ca473ad11c2eff400d65c6202c0fb4ef91ec3'],
+    }),
+    ('urltools', '1.7.3', {
+        'checksums': ['6020355c1b16a9e3956674e5dea9ac5c035c8eb3eb6bbdd841a2b5528cafa313'],
+    }),
+    ('httpcode', '0.2.0', {
+        'checksums': ['fbc1853db742a2cc1df11285cf27ce2ea43bc0ba5f7d393ee96c7e0ee328681a'],
+    }),
+    ('crul', '0.9.0', {
+        'checksums': ['a7b42c69ca31648a419b93c618d32d0613f3ea053e45d584e84ef422ccf531c0'],
+    }),
+    ('bold', '0.9.0', {
+        'checksums': ['45e844a83f4545a2f84887e36db83113da824a8673fa039f067a3bd7ee82ed5e'],
+    }),
+    ('rredlist', '0.5.0', {
+        'checksums': ['404db668f94aea7fe8c4da75085ea82b0bc9994f023ef4a52f4d75cf198db889'],
+    }),
+    ('rentrez', '1.2.2', {
+        'checksums': ['e5cb4265fd06d2ed0e11da3667ba79f7f2c8816005ba72cf5f53b8cf02dc193e'],
+    }),
+    ('rotl', '3.0.10', {
+        'checksums': ['38b4679fe2d5407f7d0799d624ae8ea5d73ec0b6531b0e3d48246dea5575073a'],
+    }),
+    ('solrium', '1.1.4', {
+        'checksums': ['5fccdb455746493c56e4df91f01ea9e89cdf0d67cfa5f958ca246b9207d20375'],
+    }),
+    ('ritis', '0.8.0', {
+        'checksums': ['23bc11599a64c25fe7a60e86fa3cd8c4078e140bc338c6d51d8d75b81564ecbd'],
+    }),
+    ('worrms', '0.4.0', {
+        'checksums': ['8480c56a4412662a383103fef68e73fcf14e94fcb878c25df8c6d5a8c0146059'],
+    }),
+    ('natserv', '0.3.0', {
+        'checksums': ['3c207d45bbba75dfd16f40d6eaaac122e40b3d3ca05b3b98aa8ed3c092638e5e'],
+    }),
+    ('WikipediR', '1.5.0', {
+        'checksums': ['f8d0e6f04fb65f7ad9c1c068852a6a8b699ffe8d39edf1f3fa07d32d087e8ff0'],
+    }),
+    ('WikidataR', '1.4.0', {
+        'checksums': ['64b1d53d7023249b73a77a7146adc3a8957b7bf3d808ebd6734795e9f58f4b2a'],
+    }),
+    ('wikitaxa', '0.3.0', {
+        'checksums': ['10dbabac6c56c1d0f33a66ff9b4f48b0bcb470711808a86863b48dc1140ec86c'],
+    }),
+    ('phangorn', '2.5.5', {
+        'checksums': ['c58dc1ace26cb4358619a15da3ea4765dbdde1557acccc5103c85589a7571346'],
+    }),
+    ('taxize', '0.9.91', {
+        'checksums': ['ce3d05c5c7c2d2cf2612264b24b9880b587d459efa3f5b7703667e0b64a58f59'],
+    }),
+    ('uuid', '0.1-2', {
+        'checksums': ['dd71704dc336b0857981b92a75ed9877d4ca47780b1682def28839304cd3b1be'],
+    }),
+    ('RNeXML', '2.4.0', {
+        'checksums': ['e162a896f895199061a0c537f65aeae480be8190fcae2a1be2b80fbc54cb9398'],
+    }),
+    ('phylobase', '0.8.6', {
+        'checksums': ['e7117b210ef406115e5523b794d8c2c5779640cee8c06e73751dc14c69322fd9'],
+    }),
+    ('magick', '2.2', {
+        'checksums': ['05d13050be37d158e66fd895ef03a34184ed96a5a3258d790c930f3d15ac05f6'],
+    }),
+    ('animation', '2.6', {
+        'checksums': ['90293638920ac436e7e4de76ebfd92e1643ccdb0259b62128f16dd0b13245b0a'],
+    }),
+    ('bigmemory.sri', '0.1.3', {
+        'checksums': ['55403252d8bae9627476d1f553236ea5dc7aa6e54da6980526a6cdc66924e155'],
+    }),
+    ('bigmemory', '4.5.33', {
+        'checksums': ['7237d9785d8ce3eab4e36ad3ce2c95cbae926326031661b4f237b7517f4b9479'],
+    }),
+    ('calibrate', '1.7.5', {
+        'checksums': ['33f4f6874f0a979af3ce592ed1105e829d3df1fbf05c6e0cd3829a13b21d82e8'],
+    }),
+    ('clusterGeneration', '1.3.4', {
+        'checksums': ['7c591ad95a8a9d7fb0e4d5d80dfd78f7d6a63cf7d11eb53dd3c98fdfb5b868aa'],
+    }),
+    ('raster', '3.0-7', {
+        'checksums': ['764f1c3d66ad2d1242c9fad6cff30291f351bfdb41df11d7a66b760ac3d95d39'],
+    }),
+    ('dismo', '1.1-4', {
+        'checksums': ['f2110f716cd9e4cca5fd2b22130c6954658aaf61361d2fe688ba22bbfdfa97c8'],
+    }),
+    ('extrafontdb', '1.0', {
+        'checksums': ['faa1bafee5d4fbc24d03ed237f29f1179964ebac6e3a46ac25b0eceda020b684'],
+    }),
+    ('Rttf2pt1', '1.3.7', {
+        'checksums': ['4a4e50578b5c1dbfb90c289ee388c102de1f9c84f8b8ddb8d2294b58474e0e8a'],
+    }),
+    ('extrafont', '0.17', {
+        'checksums': ['2f6d7d79a890424b56ddbdced361f8b9ddede5edd33e090b816b88a99315332d'],
+    }),
+    ('fields', '10.0', {
+        'checksums': ['3406a04034429ef3a68a68782a0f73099e3e28f0f8880d706cde0c9177a97f9c'],
+    }),
+    ('shapefiles', '0.7', {
+        'checksums': ['eeb18ea4165119519a978d4a2ba1ecbb47649deb96a7f617f5b3100d63b3f021'],
+    }),
+    ('fossil', '0.3.7', {
+        'checksums': ['3feba6ceecaa6f2f68fdc1ceb0019395ccfadb0cf033e1709dddb690c7f210a1'],
+    }),
+    ('geiger', '2.0.6.2', {
+        'checksums': ['9153047b608d652821251206d1450bb3f517c8884379f498a695315574ae001d'],
+    }),
+    ('shape', '1.4.4', {
+        'checksums': ['f4cb1b7d7c84cf08d2fa97f712ea7eb53ed5fa16e5c7293b820bceabea984d41'],
+    }),
+    ('glmnet', '3.0-2', {
+        'checksums': ['f48956a75af7e2be045198873fc9eb637a549af1db83dcf76cac3774bfb3762c'],
+    }),
+    ('crosstalk', '1.0.0', {
+        'checksums': ['b31eada24cac26f24c9763d9a8cbe0adfd87b264cf57f8725027fe0c7742ca51'],
+    }),
+    ('miniUI', '0.1.1.1', {
+        'checksums': ['452b41133289f630d8026507263744e385908ca025e9a7976925c1539816b0c0'],
+    }),
+    ('webshot', '0.5.2', {
+        'checksums': ['f183dc970157075b51ac543550a7a48fa3428b9c6838abb72fe987c21982043f'],
+    }),
+    ('manipulateWidget', '0.10.0', {
+        'checksums': ['3d61a3d0cedf5c8a850a3e62ed6af38c600dc3f25b44c4ff07a5093bf9ca4ffd'],
+    }),
+    ('rgl', '0.100.30', {
+        'checksums': ['8575f51160b43057e5992f0d38480309fae3b8cca50b933d814a38cea6fef867'],
+    }),
+    ('Rtsne', '0.15', {
+        'checksums': ['56376e4f0a382fad3d3d40e2cb0562224be5265b827622bcd235e8fc63df276c'],
+    }),
+    ('labdsv', '2.0-1', {
+        'checksums': ['5a4d55e9be18222dc47e725008b450996448ab117d83e7caaa191c0f13fd3925'],
+    }),
+    ('stabs', '0.6-3', {
+        'checksums': ['e961ae21d45babc1162b6eeda874c4e3677fc286fd06f5427f071ad7a5064a9f'],
+    }),
+    ('modeltools', '0.2-22', {
+        'checksums': ['256a088fc80b0d9182f984f9bd3d6207fb7c1e743f72e2ecb480e6c1d4ac34e9'],
+    }),
+    ('strucchange', '1.5-2', {
+        'checksums': ['7d247c5ae6f5a63c80e478799d009c57fb8803943aa4286d05f71235cc1002f8'],
+    }),
+    ('TH.data', '1.0-10', {
+        'checksums': ['618a1c67a30536d54b1e48ba3af46a6edcd6c2abef17935b5d4ba526a43aff55'],
+    }),
+    ('multcomp', '1.4-11', {
+        'checksums': ['0bd22d9c978eac17ac6ed65ef15890df6730551e93ba9d3e3769100d8331894b'],
+    }),
+    ('libcoin', '1.0-5', {
+        'checksums': ['0a744164e00557d2f3e888d14cfd6108d17c14e983db620f74c7a5475be8a9b2'],
+    }),
+    ('matrixStats', '0.55.0', {
+        'checksums': ['16d6bd90eee4cee8df4c15687de0f9b72730c03e56603c2998007d4533e8db19'],
+    }),
+    ('coin', '1.3-1', {
+        'checksums': ['5de2519a6e2b059bba9d74c58085cccaff1aaaa0454586ed164a108ebd1b2062'],
+    }),
+    ('party', '1.3-3', {
+        'checksums': ['9f72eea02d43a4cee105790ae7185b0478deb6011ab049cc9d31a0df3abf7ce9'],
+    }),
+    ('inum', '1.0-1', {
+        'checksums': ['3c2f94c13c03607e05817e4859595592068b55e810fed94e29bc181ad248a099'],
+    }),
+    ('partykit', '1.2-5', {
+        'checksums': ['f48e30790f93fa5d03e68e8ce71ce33d009d107d46d45d85da2016b38b27629c'],
+    }),
+    ('mboost', '2.9-1', {
+        'checksums': ['67ed26093fc2c1e57d7fac842a51a0de0162e448d4dab09c0054baee801f2a0a'],
+    }),
+    ('msm', '1.6.7', {
+        'checksums': ['7503c0f61916033ed0efad54727368bce629ff2d370f302b71bc1cb924d2e23a'],
+    }),
+    ('nor1mix', '1.3-0', {
+        'checksums': ['9ce4ee92f889a4a4041b5ea1ff09396780785a9f12ac46f40647f74a37e327a0'],
+    }),
+    ('np', '0.60-9', {
+        'checksums': ['fe31a8985f0b1a576a7775022b7131093b1c9a8337734136d5fcad85fa6592fc'],
+    }),
+    ('polynom', '1.4-0', {
+        'checksums': ['c5b788b26f7118a18d5d8e7ba93a0abf3efa6603fa48603c70ed63c038d3d4dd'],
+    }),
+    ('polspline', '1.1.17', {
+        'checksums': ['d67b269d01105d4a6ea774737e921e66e065a859d1931ae38a70f88b6fb7ee30'],
+    }),
+    ('rms', '5.1-4', {
+        'checksums': ['38f5844c4944a95b2adebea6bb1d163111270b8662399ea0349c45c0758076a6'],
+    }),
+    ('RWekajars', '3.9.3-2', {
+        'checksums': ['16e6b019aab1646f89c5203f0d6fc1cb800129e5169b15aaef30fd6236f5da1a'],
+    }),
+    ('RWeka', '0.4-41', {
+        'checksums': ['ae3a87ee572c2207cb047490a778a7d9f9785ce63f65b6818622b23db9c13abf'],
+    }),
+    ('slam', '0.1-46', {
+        'checksums': ['0b64989a639b196b6f217b301a8a233cefa66296112efdcad09ec76a4e5f10c6'],
+    }),
+    ('tm', '0.7-7', {
+        'checksums': ['d0dbe41ff8414bdc2eee06a1b0d6db4567850135c4c6ff0a9c9ca8239166d15f'],
+    }),
+    ('TraMineR', '2.0-13', {
+        'checksums': ['679a73f4e75268a60060941f476929142b8fc4bf0ea8708b64a72635566d688d'],
+    }),
+    ('chemometrics', '1.4.2', {
+        'checksums': ['b705832fa167dc24b52b642f571ed1efd24c5f53ba60d02c7797986481b6186a'],
+    }),
+    ('FNN', '1.1.3', {
+        'checksums': ['de763a25c9cfbd19d144586b9ed158135ec49cf7b812938954be54eb2dc59432'],
+    }),
+    ('ipred', '0.9-9', {
+        'checksums': ['0da87a70730d5a60b97e46b2421088765e7d6a7cc2695757eba0f9d31d86416f'],
+    }),
+    ('statmod', '1.4.32', {
+        'checksums': ['2f67a1cfa66126e6345f8a40564a3077d08f1748f17cb8c8fb05c94ed0f57e20'],
+    }),
+    ('miscTools', '0.6-26', {
+        'checksums': ['be3c5a63ca12ce7ce4d43767a1815cd3dcf32664728ade251cfb03ea6f77fc9a'],
+    }),
+    ('maxLik', '1.3-6', {
+        'checksums': ['95e92124776d70c5aaf5af99f184b0fac0ec726a98537d32518a8d7acf43924a'],
+    }),
+    ('gbRd', '0.4-11', {
+        'checksums': ['0251f6dd6ca987a74acc4765838b858f1edb08b71dbad9e563669b58783ea91b'],
+    }),
+    ('Rdpack', '0.11-1', {
+        'checksums': ['58020f150be07209fd1fdd7f5e58c138863e850f4e4c1512d69250286e091e20'],
+    }),
+    ('mlogit', '1.0-2', {
+        'checksums': ['5cc3afefb37c065dc39a9c01ec610a66a3775f91246313a946575309f4e2b6a1'],
+    }),
+    ('getopt', '1.20.3', {
+        'checksums': ['531f5fdfdcd6b96a73df2b39928418de342160ac1b0043861e9ea844f9fbf57f'],
+    }),
+    ('gsalib', '2.1', {
+        'checksums': ['e1b23b986c18b89a94c58d9db45e552d1bce484300461803740dacdf7c937fcc'],
+    }),
+    ('optparse', '1.6.4', {
+        'checksums': ['cd7855ebc2303da4ab0615282667c7eeef5329faf51bd2bf2e4b0d250561d973'],
+    }),
+    ('labelled', '2.2.1', {
+        'checksums': ['51851d8a50acadb144e0d2300f65d0962d617aa963b2a3051fb56495bdd237d7'],
+    }),
+    ('questionr', '0.7.0', {
+        'checksums': ['c4566880a1ca8f01faad396e20d907d913f4a252acaf83a0cb508a3738874cb3'],
+    }),
+    ('klaR', '0.6-14', {
+        'checksums': ['51e9d9149ba77874ccecc816a2a75619e2f9615c091f6e8969da20615c2b29bd'],
+    }),
+    ('neuRosim', '0.2-12', {
+        'checksums': ['f4f718c7bea2f4b61a914023015f4c71312f8a180124dcbc2327b71b7be256c3'],
+    }),
+    ('locfit', '1.5-9.1', {
+        'checksums': ['f524148fdb29aac3a178618f88718d3d4ac91283014091aa11a01f1c70cd4e51'],
+    }),
+    ('GGally', '1.4.0', {
+        'checksums': ['9a47cdf004c41f5e4024327b94227707f4dad3a0ac5556d8f1fba9bf0a6355fe'],
+    }),
+    ('beanplot', '1.2', {
+        'checksums': ['49da299139a47171c5b4ccdea79ffbbc152894e05d552e676f135147c0c9b372'],
+    }),
+    ('clValid', '0.6-6', {
+        'checksums': ['c13ef1b6258e34ba53615b78f39dbe4d8ba47b976b3c24a3eedaecf5ffba19ed'],
+    }),
+    ('DiscriMiner', '0.1-29', {
+        'checksums': ['5aab7671086ef9940e030324651976456f0e84dab35edb7048693ade885228c6'],
+    }),
+    ('ellipse', '0.4.1', {
+        'checksums': ['1a9a9c52195b26c2b4d51ad159ab98aff7aa8ca25fdc6b2198818d1a0adb023d'],
+    }),
+    ('leaps', '3.0', {
+        'checksums': ['55a879cdad5a4c9bc3b5697dd4d364b3a094a49d8facb6692f5ce6af82adf285'],
+    }),
+    ('pbkrtest', '0.4-7', {
+        'checksums': ['5cbb03ad2b2468720a5a610a0ebda48ac08119a34fca77810a85f554225c23ea'],
+    }),
+    ('carData', '3.0-3', {
+        'checksums': ['986b84bdd289159eead8b050ea82600a4f77bf0bbe0293a7c7b25d607ff7e231'],
+    }),
+    ('maptools', '0.9-9', {
+        'checksums': ['69ba3b2cd50260f78fb6c25cf0557b4a0d31498d6a4f4ff00e466334fba4946c'],
+    }),
+    ('zip', '2.0.4', {
+        'checksums': ['ab5dd0c63bd30b478d0f878735e7baf36e2e76e4d12d2b4b8eddd03b665502b0'],
+    }),
+    ('openxlsx', '4.1.4', {
+        'checksums': ['07a38b21f6ce6e92d58d7a51ea9f4b5fd77db49b019a18ba9ecea69878a39dd7'],
+    }),
+    ('rematch', '1.0.1', {
+        'checksums': ['a409dec978cd02914cdddfedc974d9b45bd2975a124d8870d52cfd7d37d47578'],
+    }),
+    ('cellranger', '1.1.0', {
+        'checksums': ['5d38f288c752bbb9cea6ff830b8388bdd65a8571fd82d8d96064586bd588cf99'],
+    }),
+    ('readxl', '1.3.1', {
+        'checksums': ['24b441713e2f46a3e7c6813230ad6ea4d4ddf7e0816ad76614f33094fbaaaa96'],
+    }),
+    ('rio', '0.5.16', {
+        'checksums': ['d3eb8d5a11e0a3d26169bb9d08f834a51a6516a349854250629072d59c29d465'],
+    }),
+    ('car', '3.0-5', {
+        'checksums': ['7ed4f7e79b39089796ca07ca78de560f517967b6ad79b93ecf98037b03aaee70'],
+    }),
+    ('flashClust', '1.01-2', {
+        'checksums': ['48a7849bb86530465ff3fbfac1c273f0df4b846e67d5eee87187d250c8bf9450'],
+    }),
+    ('ggrepel', '0.8.1', {
+        'checksums': ['d5d03a77ab6d8c831934bc46e840cc4e3df487272ab591fa72767ad42bcb7283'],
+    }),
+    ('FactoMineR', '2.0', {
+        'checksums': ['48828a7491a9210aa908f77e8aaacc774b1205a269898f752f6e0d773d303c62'],
+    }),
+    ('flexclust', '1.4-0', {
+        'checksums': ['82fe445075a795c724644864c7ee803c5dd332a89ea9e6ccf7cd1ae2d1ecfc74'],
+    }),
+    ('flexmix', '2.3-15', {
+        'checksums': ['ba444c0bfe33ab87d440ab590c06b03605710acd75811c1622253171bb123f43'],
+    }),
+    ('prabclus', '2.3-1', {
+        'checksums': ['ef3294767d43bc3f72478fdaf0d1f13c8de18881bf9040c9f1add68af808b3c0'],
+    }),
+    ('diptest', '0.75-7', {
+        'checksums': ['462900100ca598ef21dbe566bf1ab2ce7c49cdeab6b7a600a50489b05f61b61b'],
+    }),
+    ('trimcluster', '0.1-2.1', {
+        'checksums': ['b64a872a6c2ad677dfeecc776c9fe5aff3e8bab6bc6a8c86957b5683fd5d2300'],
+    }),
+    ('fpc', '2.2-3', {
+        'checksums': ['8100a74e6ff96b1cd65fd22494f2d200e54ea5ea533cfca321fa494914bdc3b7'],
+    }),
+    ('BiasedUrn', '1.07', {
+        'checksums': ['2377c2e59d68e758a566452d7e07e88663ae61a182b9ee455d8b4269dda3228e'],
+    }),
+    ('TeachingDemos', '2.10', {
+        'checksums': ['2ef4c2e36ba13e32f66000e84281a3616584c86b255bca8643ff3fe4f78ed704'],
+    }),
+    ('kohonen', '3.0.10', {
+        'checksums': ['996956ea46a827c9f214e4f940a19304a0ff35bda707d4d7312f80d3479067b2'],
+    }),
+    ('base64', '2.0', {
+        'checksums': ['8e259c2b12446197d1152b83a81bab84ccb5a5b77021a9b5645dd4c63c804bd1'],
+    }),
+    ('doRNG', '1.7.1', {
+        'checksums': ['27533d54464889d1c21301594137fc0f536574e3a413d61d7df9463ab12a67e9'],
+    }),
+    ('nleqslv', '3.3.2', {
+        'checksums': ['f54956cf67f9970bb3c6803684c84a27ac78165055745e444efc45cfecb63fed'],
+    }),
+    ('Deriv', '4.0', {
+        'checksums': ['76788764177b24dc27f4e27046fa563ad97014e0d53e14a880ebff2f9177b40e'],
+    }),
+    ('RGCCA', '2.1.2', {
+        'checksums': ['20f341fca8f616c556699790814debdf2ac7aa4dd9ace2071100c66af1549d7d'],
+    }),
+    ('pheatmap', '1.0.12', {
+        'checksums': ['579d96ee0417203b85417780eca921969cda3acc210c859bf9dfeff11539b0c1'],
+    }),
+    ('pvclust', '2.2-0', {
+        'checksums': ['7892853bacd413b5a921006429641ad308a344ca171b3081c15e4c522a8b0201'],
+    }),
+    ('RCircos', '1.2.1', {
+        'checksums': ['3b9489ab05ea83ead99ca6e4a1e6830467a2064779834aff1317b42bd41bb8fd'],
+    }),
+    ('lambda.r', '1.2.4', {
+        'checksums': ['d252fee39065326c6d9f45ad798076522cec05e73b8905c1b30f95a61f7801d6'],
+    }),
+    ('futile.options', '1.0.1', {
+        'checksums': ['7a9cc974e09598077b242a1069f7fbf4fa7f85ffe25067f6c4c32314ef532570'],
+    }),
+    ('futile.logger', '1.4.3', {
+        'checksums': ['5e8b32d65f77a86d17d90fd8690fc085aa0612df8018e4d6d6c1a60fa65776e4'],
+    }),
+    ('VennDiagram', '1.6.20', {
+        'checksums': ['e51cb3fff23c6ec8191966490bf875a7415f8725d4054bae881a25febb9281c5'],
+    }),
+    ('xlsxjars', '0.6.1', {
+        'checksums': ['37c1517f95f8bca6e3514429394d2457b9e62383305eba288416fb53ab2e6ae6'],
+    }),
+    ('xlsx', '0.6.1', {
+        'checksums': ['a580bd16b5477c1c185bf681c12c1ffff4088089f97b6a37997913d93ec5a8b4'],
+    }),
+    ('uroot', '2.1-0', {
+        'checksums': ['3c02a9dadd22aa67a59e99007ab6f576dc428859fa746d3a8f3ffa2bb43d18c2'],
+    }),
+    ('forecast', '8.10', {
+        'checksums': ['798e15d15be9af0b8f505e826db83d5f09d7a7434567ec291a31eaf3b8c88c49'],
+    }),
+    ('fma', '2.3', {
+        'checksums': ['f516eff79e14d4ffefcdc2db06d97ae57f998e37e871264457078f671384fafc'],
+    }),
+    ('expsmooth', '2.3', {
+        'checksums': ['ac7da36347f983d6ec71715daefd2797fe2fc505c019f4965cff9f77ce79982a'],
+    }),
+    ('fpp', '0.5', {
+        'checksums': ['9c87dd8591b8a87327cae7a03fd362a5492495a96609e5845ccbeefb96e916cb'],
+    }),
+    ('tensor', '1.5', {
+        'checksums': ['e1dec23e3913a82e2c79e76313911db9050fb82711a0da227f94fc6df2d3aea6'],
+    }),
+    ('polyclip', '1.10-0', {
+        'checksums': ['74dabc0dfe5a527114f0bb8f3d22f5d1ae694e6ea9345912909bae885525d34b'],
+    }),
+    ('goftest', '1.2-2', {
+        'checksums': ['e497992666b002b6c6bed73bf05047ad7aa69eb58898da0ad8f1f5b2219e7647'],
+    }),
+    ('spatstat.utils', '1.15-0', {
+        'checksums': ['90e07d730b6939f47f93c939afae10874b2c82bd402960ede4133de67dca2a0c'],
+    }),
+    ('spatstat.data', '1.4-0', {
+        'checksums': ['121e5bb92beb7ccac920f921e760f429fd71bcfe11cb9b07a7e7326c7a72ec8c'],
+    }),
+    ('spatstat', '1.62-2', {
+        'checksums': ['57cc1dc51b3d74fb4e3edfa30e6441db98c99e354ff65ffc82d5419a49a8353b'],
+    }),
+    ('pracma', '2.2.9', {
+        'checksums': ['0cea0ff5e88643df121e07b9aebfe57084c61e11801680039752f371fe87bf1e'],
+    }),
+    ('RCurl', '1.95-4.12', {
+        'checksums': ['393779efafdf40823dac942a1e028905d65c34f3d41cfd21bcd225e411385ff4'],
+    }),
+    ('bio3d', '2.4-0', {
+        'checksums': ['9ab86e299adee14e9a87ec87284f4c52a0114d303f21d166aaa0dc766f987746'],
+    }),
+    ('AUC', '0.3.0', {
+        'checksums': ['e705f2c63d336249d19187f3401120d738d42d323fce905f3e157c2c56643766'],
+    }),
+    ('interpretR', '0.2.4', {
+        'checksums': ['4c08a6dffd6fd5764f27812f3a085c53e6a21d59ae82d903c9c0da93fd1dd059'],
+    }),
+    ('cvAUC', '1.1.0', {
+        'checksums': ['c4d8ed53b93869650aa2f666cf6d1076980cbfea7fa41f0b8227595be849738d'],
+    }),
+    ('SuperLearner', '2.0-26', {
+        'checksums': ['4462922c8daae2773f79ecdea7ca3cc4ea51bfd101c5e6c1ad22f9190e746081'],
+    }),
+    ('mediation', '4.5.0', {
+        'checksums': ['210206618787c395a67689be268283df044deec7199d9860ed95218ef1e60845'],
+    }),
+    ('ModelMetrics', '1.2.2', {
+        'checksums': ['66d6fc75658287fdbae4d437b51d26781e138b8baa558345fb9e5a2df86a0d95'],
+    }),
+    ('CVST', '0.2-2', {
+        'checksums': ['854b8c983427ecf9f2f7798c4fd1c1d06762b5b0bcb1045502baadece6f78316'],
+    }),
+    ('DRR', '0.0.3', {
+        'checksums': ['7493389c1fb9ddc4d4261e15bf2d4198603227275688b1d3e3994d47e976a1f9'],
+    }),
+    ('dimRed', '0.2.3', {
+        'checksums': ['e6e56e3f6999ebdc326e64ead5269f3aaf61dd587beefafb7536ac3890370d84'],
+    }),
+    ('lubridate', '1.7.4', {
+        'checksums': ['510ca87bd91631c395655ee5029b291e948b33df09e56f6be5839f43e3104891'],
+    }),
+    ('ddalpha', '1.3.10', {
+        'checksums': ['5f52e0aae9917476078daf031f2213b0b6b83d225530394bdb759e86fc79c480'],
+    }),
+    ('gower', '0.2.1', {
+        'checksums': ['af3fbe91cf818c0841b2c0ec4ddf282c182a588031228c8d88f7291b2cdff100'],
+    }),
+    ('RcppRoll', '0.3.0', {
+        'checksums': ['cbff2096443a8a38a6f1dabf8c90b9e14a43d2196b412b5bfe5390393f743f6b'],
+    }),
+    ('recipes', '0.1.7', {
+        'checksums': ['28e96953355749dd1deb6786b22ec825a6fdb9f336e2785d45611e89f7e988bf'],
+    }),
+    ('caret', '6.0-84', {
+        'checksums': ['a1831c086a9c71b469f7405649ba04517683cdf229e119c005189cf57244090d'],
+    }),
+    ('adabag', '4.2', {
+        'checksums': ['47019eb8cefc8372996fbb2642f64d4a91d7cedc192690a8d8be6e7e03cd3c81'],
+    }),
+    ('parallelMap', '1.4', {
+        'checksums': ['fb6f15e325f729f1c5218768b17c20909ee857069c6cc5d8df50e1dafe26ed5b'],
+    }),
+    ('ParamHelpers', '1.13', {
+        'checksums': ['b9b5212a485f441504716fcddf4fd7376bf3b909aae049c7394245e853424e79'],
+    }),
+    ('ggvis', '0.4.5', {
+        'checksums': ['82373c3565c299279f6849f798cc39127b2b3f7ff2deee1946528474824b3124'],
+    }),
+    ('mlr', '2.16.0', {
+        'checksums': ['3db8141d9cbb71139c9bf3a3ea995524322512221b56e6bcf44338d24f84e76a'],
+    }),
+    ('unbalanced', '2.0', {
+        'checksums': ['9be32b1ce9d972f1abfff2fbe18f5bb5ba9c3f4fb1282063dc410b82ad4d1ea2'],
+    }),
+    ('RSNNS', '0.4-12', {
+        'checksums': ['b18dfeda71573bc92c6888af72da407651bff7571967965fd3008f0d331743b9'],
+    }),
+    ('abc.data', '1.0', {
+        'checksums': ['b242f43c3d05de2e8962d25181c6b1bb6ca1852d4838868ae6241ca890b161af'],
+    }),
+    ('abc', '2.1', {
+        'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
+    }),
+    ('lhs', '1.0.1', {
+        'checksums': ['a4d5ac0c6f585f2880364c867fa94e6554698beb65d3678ba5938dd84fc6ea53'],
+    }),
+    ('tensorA', '0.36.1', {
+        'checksums': ['c7ffe12b99867675b5e9c9f31798f9521f14305c9d9f9485b171bcbd8697d09c'],
+    }),
+    ('EasyABC', '1.5', {
+        'checksums': ['1dd7b1383a7c891cafb34d9cec65d92f1511a336cff1b219e63c0aa791371b9f'],
+    }),
+    ('whisker', '0.4', {
+        'checksums': ['7a86595be4f1029ec5d7152472d11b16175737e2777134e296ae97341bf8fba8'],
+    }),
+    ('commonmark', '1.7', {
+        'checksums': ['d14a767a3ea9778d6165f44f980dd257423ca6043926e3cd8f664f7171f89108'],
+    }),
+    ('roxygen2', '7.0.2', {
+        'checksums': ['5823937df68ea558e5e85771b8b6e090775b82f7f797ca5d539e7378c4535d98'],
+    }),
+    ('git2r', '0.26.1', {
+        'checksums': ['13d609286a0af4ef75ba76f2c2f856593603b8014e311b88896243a50b417435'],
+    }),
+    ('rversions', '2.0.1', {
+        'checksums': ['51ec1f64e7d628e88d716a020d5d521eba71d472e3c9ae7b694428ef6dd786c5'],
+    }),
+    ('xopen', '1.0.0', {
+        'checksums': ['e207603844d69c226142be95281ba2f4a056b9d8cbfae7791ba60535637b3bef'],
+    }),
+    ('sessioninfo', '1.1.1', {
+        'checksums': ['166b04678448a7decd50f24afabe5e2ad613e3c55b180ef6e8dd7a870a1dae48'],
+    }),
+    ('rcmdcheck', '1.3.3', {
+        'checksums': ['1ab679eb1976d74cd3be5bcad0af7fcc673dbdfd4406bbce32591c8fddfb93b4'],
+    }),
+    ('remotes', '2.1.0', {
+        'checksums': ['8944c8f6fc9f0cd0ca04d6cf1221b716eee08facef9f4b4c4d91d0346d6d68a7'],
+    }),
+    ('fs', '1.3.1', {
+        'checksums': ['d6934dca8f835d8173e3fb9fd4d5e2740c8c04348dd2bcc57df1b711facb46bc'],
+    }),
+    ('clisymbols', '1.2.0', {
+        'checksums': ['0649f2ce39541820daee3ed408d765eddf83db5db639b493561f4e5fbf88efe0'],
+    }),
+    ('ini', '0.3.1', {
+        'checksums': ['7b191a54019c8c52d6c2211c14878c95564154ec4865f57007953742868cd813'],
+    }),
+    ('gh', '1.0.1', {
+        'checksums': ['f3c02b16637ae390c3599265852d94b3de3ef585818b260d00e7812595b391d2'],
+    }),
+    ('usethis', '1.5.1', {
+        'checksums': ['9e3920a04b0df82adf59eef2c1b2b4d835c4a757a51b3c163b8fc619172f561d'],
+    }),
+    ('DT', '0.10', {
+        'checksums': ['3cc6dfc9697b52aef21d30dcfd355831c6216edcc6dd6bfb9a106cce6ab0906f'],
+    }),
+    ('rex', '1.1.2', {
+        'checksums': ['bd3c74ceaf335336f5dd04314d0a791f6311e421a2158f321f5aab275f539a2a'],
+    }),
+    ('covr', '3.4.0', {
+        'checksums': ['e57d9c656b4ab50a7f9557dee422d8777efaf08ecde0fd8bfa5897ef4d9e845c'],
+    }),
+    ('devtools', '2.2.1', {
+        'checksums': ['2e988fb56b068ba958ea471224d2462427868ce7706e157a90c0ce0e13294e44'],
+    }),
+    ('Rook', '1.1-1', {
+        'checksums': ['00f4ecfa4c5c57018acbb749080c07154549a6ecaa8d4130dd9de79427504903'],
+    }),
+    ('Cairo', '1.5-10', {
+        'checksums': ['7837f0c384cd49bb3342cb39a916d7a80b02fffbf123913a58014e597f69b5d5'],
+    }),
+    ('RMTstat', '0.3', {
+        'checksums': ['81eb4c5434d04cb66c749a434c33ceb1c07d92ba79765d4e9233c13a092ec2da'],
+    }),
+    ('Lmoments', '1.3-1', {
+        'checksums': ['7c9d489a08f93fa5877e2f233ab9732e0d1b2761596b3f6ac91f2295e41a865d'],
+    }),
+    ('distillery', '1.0-6', {
+        'checksums': ['4910e2952f767c1062d7cbe648c90a97009e2b3da316c6b33f6d022cd38b23d6'],
+    }),
+    ('extRemes', '2.0-11', {
+        'checksums': ['75fbdeef677c81cf5661b8df3df4090c55f53e9bb96bb138b498eb0fbbf5af42'],
+    }),
+    ('pixmap', '0.4-11', {
+        'checksums': ['6fa010749a59cdf56aad9f81271473b7d55697036203f2cd5d81372bcded7412'],
+    }),
+    ('tkrplot', '0.0-24', {
+        'checksums': ['2873630a37d7ae1e09a5803d9a89ca0494edd83526c7b1860d9246543722f311'],
+    }),
+    ('misc3d', '0.8-4', {
+        'checksums': ['75de3d2237f67f9e58a36e80a6bbf7e796d43eb46789f2dd1311270007bf5f62'],
+    }),
+    ('multicool', '0.1-11', {
+        'checksums': ['1c907e64af2ac39facdf431a5691e69649f64af1f50e198ae39da5bf30026476'],
+    }),
+    ('plot3D', '1.1.1', {
+        'checksums': ['f6fe4a001387132626fc553ed1d5720d448b8064eb5a6917458a798e1d381632'],
+    }),
+    ('plot3Drgl', '1.0.1', {
+        'checksums': ['466d428d25c066c9c96d892f24da930513d42b1bdf76d3b53628c3ba13c3e48a'],
+    }),
+    ('OceanView', '1.0.4', {
+        'checksums': ['e67f6f376737e1e5cf22fdfe2769a8f674e90c886b0e43942e97d9a3e6924f1c'],
+    }),
+    ('ks', '1.11.6', {
+        'checksums': ['d8f1ccb99281eed092b8f950cfbf422330e88f2a0ce1ef6c9dbd7d8b9d648c41'],
+    }),
+    ('logcondens', '2.1.5', {
+        'checksums': ['72e61abc1f3eb28830266fbe5b0da0999eb5520586000a3024e7c26be93c02eb'],
+    }),
+    ('Iso', '0.0-18', {
+        'checksums': ['2d7e8c4452653364ee086d95cea620c50378e30acfcff129b7261e1756a99504'],
+    }),
+    ('penalized', '0.9-51', {
+        'checksums': ['eaa80dca99981fb9eb576261f30046cfe492d014cc2bf286c447b03a92e299fd'],
+    }),
+    ('clusterRepro', '0.9', {
+        'checksums': ['940d84529ff429b315cf4ad25700f93e1156ccacee7b6c38e4bdfbe2d4c6f868'],
+    }),
+    ('randomForestSRC', '2.9.2', {
+        'checksums': ['780fbc07ca0b2676fadf576d4d278887672b431ba42cd49b769ed8ccbc4e6d74'],
+    }),
+    ('sm', '2.2-5.6', {
+        'checksums': ['b890cd7ebe8ed711ab4a3792c204c4ecbe9e6ca1fd5bbc3925eba5833a839c30'],
+    }),
+    ('pbivnorm', '0.6.0', {
+        'checksums': ['07c37d507cb8f8d2d9ae51a9a6d44dfbebd8a53e93c242c4378eaddfb1cc5f16'],
+    }),
+    ('lavaan', '0.6-5', {
+        'checksums': ['feeb6e1b419aa1d54fd5af1d67260b5d13ff251c19de8136a4df565305d47b12'],
+    }),
+    ('matrixcalc', '1.0-3', {
+        'checksums': ['17e6caeeecd596b850a6caaa257984398de9ec5d2b41ce83c428f112614b9cb0'],
+    }),
+    ('arm', '1.10-1', {
+        'checksums': ['6f1158c9295e65bd649139224497d3356189b931ff143f9b374daae72548776f'],
+    }),
+    ('mi', '1.0', {
+        'checksums': ['34f44353101e8c3cb6bf59c5f4ff5b2391d884dcbb9d23066a11ee756b9987c0'],
+    }),
+    ('visNetwork', '2.0.9', {
+        'checksums': ['5e0b3dc3a91e66e0a359433f03cc856d04b981b0f9ad228d8fa9c96b7fcaa420'],
+    }),
+    ('rgexf', '0.15.3', {
+        'checksums': ['2e8a7978d1fb977318e6310ba65b70a9c8890185c819a7951ac23425c6dc8147'],
+    }),
+    ('influenceR', '0.1.0', {
+        'checksums': ['4fc9324179bd8896875fc0e879a8a96b9ef2a6cf42a296c3b7b4d9098519e98a'],
+    }),
+    ('downloader', '0.4', {
+        'checksums': ['1890e75b028775154023f2135cafb3e3eed0fe908138ab4f7eff1fc1b47dafab'],
+    }),
+    ('DiagrammeR', '1.0.1', {
+        'checksums': ['ccee8acf608fc909e73c6de4374cef5a570cb62e5f454ac55dda736f22f3f013'],
+    }),
+    ('sem', '3.1-9', {
+        'checksums': ['4a33780202506543da85877cd2813250114420d6ec5e75457bc67477cd332cb9'],
+    }),
+    ('jpeg', '0.1-8.1', {
+        'checksums': ['1db0a4976fd9b2ae27a37d3e856cca35bc2909323c7a40724846a5d3c18915a9'],
+    }),
+    ('network', '1.16.0', {
+        'checksums': ['a24f51457439c7186ffa1fe53719742c501929ac1a354e458754a83f280fce36'],
+    }),
+    ('statnet.common', '4.3.0', {
+        'checksums': ['834a3359eac967df0420eee416ae4983e3b502a3de56bb24f494a7ca4104e959'],
+    }),
+    ('sna', '2.5', {
+        'checksums': ['13b508cacb0bf1e79b55d5c8f7e9ada3b173468d4d6d5f1dc606990ac03071c8'],
+    }),
+    ('glasso', '1.11', {
+        'checksums': ['4c37844b26f55985184a734e16b8fe880b192e3d2763614b0ab3f99b4530e30a'],
+    }),
+    ('huge', '1.3.4', {
+        'checksums': ['23165f49ec9e67ca3506cc83abbbf8eb3f38c5e19c092133189b7ca17690c31e'],
+    }),
+    ('d3Network', '0.5.2.1', {
+        'checksums': ['5c798dc0c87c6d574abb7c1f1903346e6b0fec8adfd1df7aef5e4f9e7e3a09be'],
+    }),
+    ('ggm', '2.3', {
+        'checksums': ['832ffe81ff87c6f1a6644e689ebbfb172924b4c4584ac8108d1244d153219ed8'],
+    }),
+    ('BDgraph', '2.62', {
+        'checksums': ['7e5de4406f4a7873bf948852291d2851a2ab312288467687dd5c0392b2723bac'],
+    }),
+    ('pbapply', '1.4-2', {
+        'checksums': ['ac19f209f36f4fa3d0f5b14b6cc5b0c279996fb9d3e86c848c0f6d03c025b3f6'],
+    }),
+    ('graphlayouts', '0.5.0', {
+        'checksums': ['83f61ce07580c5a64c7044c12b20d98ccf138c7e78ff12855cdfc206e1fab10d'],
+    }),
+    ('tweenr', '1.0.1', {
+        'checksums': ['efd68162cd6d5a4f6d833dbf785a2bbce1cb7b9f90ba3fb060931a4bd705096b'],
+    }),
+    ('ggforce', '0.3.1', {
+        'checksums': ['a05271da9b226c12ae5fe6bc6eddb9ad7bfe19e1737e2bfcd6d7a89631332211'],
+    }),
+    ('tidygraph', '1.1.2', {
+        'checksums': ['5642001d4cccb122d66481b7c61a06c724c02007cbd356ee61cb29726a56fafe'],
+    }),
+    ('ggraph', '2.0.0', {
+        'checksums': ['4307efe85bfc6a0496797f6b86d6b174ba196538c51b1a6b6af55de0d4e04762'],
+    }),
+    ('qgraph', '1.6.4', {
+        'checksums': ['43865a096cd9af122c75594a268bac342e80626a8137539d0c94bb0349408fbe'],
+    }),
+    ('HWxtest', '1.1.9', {
+        'checksums': ['a37309bed4a99212ca104561239d834088217e6c5e5e136ff022544c706f25e6'],
+    }),
+    ('diveRsity', '1.9.90', {
+        'checksums': ['b8f49cdbfbd82805206ad293fcb2dad65b962fb5523059a3e3aecaedf5c0ee86'],
+    }),
+    ('doSNOW', '1.0.18', {
+        'checksums': ['70e7bd82186e477e3d1610676d4c6a75258ac08f104ecf0dcc971550ca174766'],
+    }),
+    ('geepack', '1.3-1', {
+        'checksums': ['823153ca28e1a8bd8a45de778279480c1c35e063d62c8955b6cea1602f28d6df'],
+    }),
+    ('biom', '0.3.12', {
+        'checksums': ['4ad17f7811c7346dc4923bd6596a007c177eebb1944a9f46e5674afcc5fdd5a1'],
+    }),
+    ('pim', '2.0.1', {
+        'checksums': ['174568a01f68b9601a4ea89ca5857bf4888242f00e4212bfb7a422d6292300d5'],
+    }),
+    ('minpack.lm', '1.2-1', {
+        'checksums': ['14cb7dba3ef2b46da0479b46d46c76198e129a31f6157cd8b37f178adb15d5a3'],
+    }),
+    ('rootSolve', '1.8.1', {
+        'checksums': ['1dde127817cfb2273724c63f662143cc7eb449a833243e0e56ef347df0d5796a'],
+    }),
+    ('diagram', '1.6.4', {
+        'checksums': ['7c2bc5d5d634c3b8ca7fea79fb463e412962d88f47a77a74c811cc62f375ce38'],
+    }),
+    ('FME', '1.3.5', {
+        'checksums': ['3619d88df2a41ca8819b93bb7dff3b8233f76ff8ab0ca67c664f530f835935e4'],
+    }),
+    ('bmp', '0.3', {
+        'checksums': ['bdf790249b932e80bc3a188a288fef079d218856cf64ffb88428d915423ea649'],
+    }),
+    ('tiff', '0.1-5', {
+        'checksums': ['9514e6a9926fcddc29ce1dd12b1072ad8265900373f738de687ef4a1f9124e2b'],
+    }),
+    ('readbitmap', '0.1.5', {
+        'checksums': ['737d7d585eb33de2c200da64d16781e3c9522400fe2af352e1460c6a402a0291'],
+    }),
+    ('imager', '0.41.2', {
+        'checksums': ['9be8bc8b3190d469fcb2883045a404d3b496a0380f887ee3caea11f0a07cd8a5'],
+    }),
+    ('signal', '0.7-6', {
+        'checksums': ['6b60277b07cf0167f8272059b128cc82f27a9bab1fd33d74c2a9e1f2abca5def'],
+    }),
+    ('tuneR', '1.3.3', {
+        'checksums': ['bdc3c2017b162d2ba0a249e80361a4f47202e763c21aecfc57380a482a3a692b'],
+    }),
+    ('pastecs', '1.3.21', {
+        'checksums': ['8c1ef2affe88627f0b23295aa5edb758b8fd6089ef09f60f37c46445128b8d7c'],
+    }),
+    ('audio', '0.1-6', {
+        'checksums': ['3f261413ba2d3e9ae58c44abffe5188cc7c21a78a0c93448c7d384d3913d73b8'],
+    }),
+    ('fftw', '1.0-5', {
+        'checksums': ['afc94fe8e5bed9195c191606239cd37f1b88e24e7422e9c5249cca0781b3f20c'],
+    }),
+    ('seewave', '2.1.5', {
+        'checksums': ['718b1fb1c289f92be50de099da36d20380d113cb1577569333fca6195f71e8e1'],
+    }),
+    ('gsw', '1.0-5', {
+        'checksums': ['eb468918ee91e429b47fbcac43269eca627b7f64b61520de5bbe8fa223e96453'],
+    }),
+    ('oce', '1.1-1', {
+        'checksums': ['2ce8f8d3adb3da5c8a09fda060e1ff79cad0f0f6f918f8fe64f51a6cd6b58e43'],
+    }),
+    ('ineq', '0.2-13', {
+        'checksums': ['e0876403f59a3dfc2ea7ffc0d965416e1ecfdecf154e5856e5f54800b3efda25'],
+    }),
+    ('soundecology', '1.3.3', {
+        'checksums': ['276164d5eb92c78726c647be16232d2443acbf7061371ddde2672b4fdb7a069a'],
+    }),
+    ('memuse', '4.0-0', {
+        'checksums': ['fbf8716a1388692ee439f69ac99643fa427eb100027d8911ff0fbfdcb5b6c3bc'],
+    }),
+    ('pinfsc50', '1.1.0', {
+        'checksums': ['b6b9b6365a3f408533264d7ec820494f57eccaf362553e8478a46a8e5b474aba'],
+    }),
+    ('vcfR', '1.8.0', {
+        'checksums': ['5ffcf9980c1936b9be41b92d5887c56a7ec6e3cf197e5ef7c78aefa8aba20499'],
+    }),
+    ('glmmML', '1.1.0', {
+        'checksums': ['34f088a73ccf6092908502a5bdaaf8209e9134d38abbbd7c4dd559832e653188'],
+    }),
+    ('cowplot', '1.0.0', {
+        'checksums': ['70f9a7c46d10f409d1599f1afc9fd3c947051cf2b430f01d903c64ef1e6c98a5'],
+    }),
+    ('tsne', '0.1-3', {
+        'checksums': ['66fdf5d73e69594af529a9c4f261d972872b9b7bffd19f85c1adcd66afd80c69'],
+    }),
+    ('sn', '1.5-4', {
+        'checksums': ['46677ebc109263a68f62b5cf53ec59916cda490e5bc5bbb08276757a677f8674'],
+    }),
+    ('tclust', '1.4-1', {
+        'checksums': ['4b0be612c8ecd7b4eb19a44ab6ac8f5d40515600ae1144c55989b6b41335ad9e'],
+    }),
+    ('ranger', '0.11.2', {
+        'checksums': ['13ac8a9433fdd92f62f66de44abc52477dcbb436b2045c1947951a266bffbeeb'],
+    }),
+    ('hexbin', '1.28.0', {
+        'checksums': ['cda0d4b637ddd63eaaed70eb7b3ced09216dbf63e7803d6dfe3c8d3fc392a82c'],
+    }),
+    ('pryr', '0.1.4', {
+        'checksums': ['d39834316504c49ecd4936cbbcaf3ee3dae6ded287af42475bf38c9e682f721b'],
+    }),
+    ('moments', '0.14', {
+        'checksums': ['2a3b81e60dafdd092d2bdd3513d7038855ca7d113dc71df1229f7518382a3e39'],
+    }),
+    ('laeken', '0.5.0', {
+        'checksums': ['ea529f9e45a3825e1f13f8dbd8e7c5f5a42933525ca529230c893eb08e1f39bd'],
+    }),
+    ('VIM', '4.8.0', {
+        'checksums': ['3c6b4fdc10c0375e3fdc56b34a8c05661155bd3166a8b3f36b0addf73d51a423'],
+    }),
+    ('proxy', '0.4-23', {
+        'checksums': ['9dd4eb0978f40e4fcb55c8a8a26266d32eff9c63ac9dfe70cf1f664ca9c3669d'],
+    }),
+    ('smoother', '1.1', {
+        'checksums': ['91b55b82f805cfa1deedacc0a4e844a2132aa59df593f3b05676954cf70a195b'],
+    }),
+    ('dynamicTreeCut', '1.63-1', {
+        'checksums': ['831307f64eddd68dcf01bbe2963be99e5cde65a636a13ce9de229777285e4db9'],
+    }),
+    ('beeswarm', '0.2.3', {
+        'checksums': ['0115425e210dced05da8e162c8455526a47314f72e441ad2a33dcab3f94ac843'],
+    }),
+    ('vipor', '0.4.5', {
+        'checksums': ['7d19251ac37639d6a0fed2d30f1af4e578785677df5e53dcdb2a22771a604f84'],
+    }),
+    ('ggbeeswarm', '0.6.0', {
+        'checksums': ['bbac8552f67ff1945180fbcda83f7f1c47908f27ba4e84921a39c45d6e123333'],
+    }),
+    ('shinydashboard', '0.7.1', {
+        'checksums': ['51a49945c6b8a684111a2ba4b2a5964e3a50610286ce0378e37ae02316620a4e'],
+    }),
+    ('rrcov', '1.4-9', {
+        'checksums': ['e757369d70de4def182f4ede8bb066b156fd1a96abeedf8a14f986455becfb87'],
+    }),
+    ('WriteXLS', '5.0.0', {
+        'checksums': ['5aeb631c7f4dee300a19ded493110d7241e1b79744be05beca770a01ffc1d7bf'],
+    }),
+    ('bst', '0.3-17', {
+        'checksums': ['1ed161d33a7304abfa2fb23daeda2f870ad8483b7fa9b91e6fc8ced21fd8f074'],
+    }),
+    ('mpath', '0.3-20', {
+        'checksums': ['0299b11bdd346a7825cd0bba302f09e7a0a15b9491f9179651b2f1154c80d392'],
+    }),
+    ('timereg', '1.9.4', {
+        'checksums': ['fbf4eeee1648fceb98773156764c32b3a9481f0fb9f8dc3a9d0331a9051cb54b'],
+    }),
+    ('peperr', '1.1-7.1', {
+        'checksums': ['5d4eff0f0b61c0b3e479c2ac2978c8e32373b9630565bf58fee48ead6166698a'],
+    }),
+    ('heatmap3', '1.1.6', {
+        'checksums': ['5d5a3d574e9e3699490c93a523ce242006257e5be110935d58c74c135a4e4a8d'],
+    }),
+    ('GlobalOptions', '0.1.1', {
+        'checksums': ['4249ef78424128050af83bbb8e71b4af82f8490c87f6a9d927782b80be830975'],
+    }),
+    ('circlize', '0.4.8', {
+        'checksums': ['22d6908b9d2e496105d9b70b73a74152398e5e9e38c60042ffe041df2b4c794b'],
+    }),
+    ('GetoptLong', '0.1.7', {
+        'checksums': ['b9a98881db407eae9b711c4fa9170168fd5f3be1f8485cd8f28d0a60ace083ba'],
+    }),
+    ('dendextend', '1.13.2', {
+        'checksums': ['79543002ab3147c283fa659c4a16a1df4c5740b5fe207565236d32cf52db94c5'],
+    }),
+    ('RInside', '0.2.15', {
+        'checksums': ['1e1d87a3584961f3aa4ca6acd4d2f3cda26abdab027ff5be2fd5cd76a98af02b'],
+    }),
+    ('limSolve', '1.5.6', {
+        'checksums': ['b97ea9930383634c8112cdbc42f71c4e93fe0e7bfaa8f401921835cb44cb49a0'],
+    }),
+    ('dbplyr', '1.4.2', {
+        'checksums': ['b783f0da2c09a1e63f41168b02c0715b08820f02a351f7ab0aaa688432754de0'],
+    }),
+    ('modelr', '0.1.5', {
+        'checksums': ['45bbee387c6ba154f9f8642e9f03ea333cce0863c324ff15d23096f33f85ce5a'],
+    }),
+    ('debugme', '1.1.0', {
+        'checksums': ['4dae0e2450d6689a6eab560e36f8a7c63853abbab64994028220b8fd4b793ab1'],
+    }),
+    ('reprex', '0.3.0', {
+        'checksums': ['203c2ae6343f6ff887e7a5a3f5d20bae465f6e8d9745c982479f5385f4effb6c'],
+    }),
+    ('selectr', '0.4-2', {
+        'checksums': ['5588aed05f3f5ee63c0d29953ef53da5dac7afccfdd04b7b22ef24e1e3b0c127'],
+    }),
+    ('rvest', '0.3.5', {
+        'checksums': ['0e7f41be4ce6501d7af50575a2532d4bfd9153ca57900ee62dbc27c0a22c0a64'],
+    }),
+    ('tidyverse', '1.3.0', {
+        'checksums': ['6d8acb81e994f9bef5e4dcf908bcea3786d108adcf982628235b6c8c80f6fe09'],
+    }),
+    ('R.cache', '0.14.0', {
+        'checksums': ['18af4e372440b9f28b4b71346c8ed9de220232f9903730ccee2bfb3c612c16d9'],
+    }),
+    ('R.rsp', '0.43.2', {
+        'checksums': ['f291a78ce9955943e0ebad1291f729dc4d9a8091f04b83fc4b1526bcb6c71f89'],
+    }),
+    ('listenv', '0.8.0', {
+        'checksums': ['fd2aaf3ff2d8d546ce33d1cb38e68401613975117c1f9eb98a7b41facf5c485f'],
+    }),
+    ('globals', '0.12.5', {
+        'checksums': ['1519a7668b4b549c081f60a5f6b71d8d1dc8833f618125f6c0e4caf8b48a48c1'],
+    }),
+    ('future', '1.15.1', {
+        'checksums': ['ed4f7f356ca1cb3294f9a5181e4087b2a7781c4ab7304393bf40e1ac388a3080'],
+    }),
+    ('gdistance', '1.2-2', {
+        'checksums': ['c8c923f02ae4e9ef8376d1b195e0246b6941356c8c790c0a5673c5009eee1753'],
+    }),
+    ('vioplot', '0.3.4', {
+        'checksums': ['4914262f2e7913ffa5741e74b20157f4a904ba31e648fa5df9ff6a1aaba753bb'],
+    }),
+    ('emulator', '1.2-20', {
+        'checksums': ['7cabf2cf74d879ad9dbaed8fdee54a5c94a8658a0645c021d160b2ef712ce287'],
+    }),
+    ('gmm', '1.6-4', {
+        'checksums': ['03ad5ff37d174e9cef13fa41d866412c57b7cbd9155312831e16a1fcda70bc95'],
+    }),
+    ('tmvtnorm', '1.4-10', {
+        'checksums': ['1a9f35e9b4899672e9c0b263affdc322ecb52ec198b2bb015af9d022faad73f0'],
+    }),
+    ('IDPmisc', '1.1.19', {
+        'checksums': ['0d5e35252c7ec2654a3d64949bdc0977cc8479f8ada97bccd0d90d70aadb0c8f'],
+    }),
+    ('gap', '1.2.1', {
+        'checksums': ['5a20adcc7e503b9a2123048510d56ce3ec9f00d5855629b4cbf0d7c7ad8c6fb5'],
+    }),
+    ('qrnn', '2.0.5', {
+        'checksums': ['3bd83ee8bd83941f9defdab1b5573d0ceca02bf06759a67665e5b9358ff92f52'],
+    }),
+    ('TMB', '1.7.15', {
+        'checksums': ['facbc7cc44f993e0d827a6eb84928f8e35b0b3f263582d885a307e150b434de4'],
+    }),
+    ('glmmTMB', '0.2.3', {
+        'checksums': ['6b6f62addaa54b32b975bc984110e245330749ebf69bed4a297f9da1b89fb00c'],
+    }),
+    ('spaMM', '3.0.0', {
+        'checksums': ['5aca7eebd38d93f3ad6bec6bb01b213879551b4320f6fc17bdebdd4d09e48fe7'],
+    }),
+    ('DHARMa', '0.2.6', {
+        'checksums': ['d2a17c994e59c4fb4c82825b97a78ac120a350bf94261511d437659a00296957'],
+    }),
+    ('mvnfast', '0.2.5', {
+        'checksums': ['21b9fa72d1e3843513908aaacd6c4d876cc7a9339782d0151b24910df2975f88'],
+    }),
+    ('bridgesampling', '0.7-2', {
+        'checksums': ['64a44e92ccc2828261a71e2298901a8064b36df1bc2b8796d47a1bf26fb9a44d'],
+    }),
+    ('BayesianTools', '0.1.7', {
+        'checksums': ['af49389bdeb794da3c39e1d63f59e6219438ecb8613c5ef523b00c6fed5a600c'],
+    }),
+    ('gomms', '1.0', {
+        'checksums': ['52828c6fe9b78d66bde5474e45ff153efdb153f2bd9f0e52a20a668e842f2dc5'],
+    }),
+    ('feather', '0.3.5', {
+        'checksums': ['50ff06d5e24d38b5d5d62f84582861bd353b82363e37623f95529b520504adbf'],
+    }),
+    ('dummies', '1.5.6', {
+        'checksums': ['7551bc2df0830b98c53582cac32145d5ce21f5a61d97e2bb69fd848e3323c805'],
+    }),
+    ('SimSeq', '1.4.0', {
+        'checksums': ['5ab9d4fe2cb1b7634432ff125a9e04d2f574fed06246a93859f8004e10790f19'],
+    }),
+    ('uniqueAtomMat', '0.1-3-2', {
+        'checksums': ['f7024e73274e1e76a870ce5e26bd58f76e8f6df0aa9775c631b861d83f4f53d7'],
+    }),
+    ('PoissonSeq', '1.1.2', {
+        'checksums': ['6f3dc30ad22e33e4fcfa37b3427c093d591c02f1b89a014d85e63203f6031dc2'],
+    }),
+    ('aod', '1.3.1', {
+        'checksums': ['052d8802500fcfdb3b37a8e3e6f3fbd5c3a54e48c3f68122402d2ea3a15403bc'],
+    }),
+    ('cghFLasso', '0.2-1', {
+        'checksums': ['6e697959b35a3ceb2baa1542ef81f0335006a5a9c937f0173c6483979cb4302c'],
+    }),
+    ('svd', '0.5', {
+        'checksums': ['d042d448671355d0664d37fd64dc90932eb780e6494c479d4431d1faae2071a1'],
+    }),
+    ('Rssa', '1.0', {
+        'checksums': ['9cc20a7101d8dff4c6cfb789f9bdc14e2b3bb128d7613a67b0f9633cf006902a'],
+    }),
+    ('JBTools', '0.7.2.9', {
+        'checksums': ['b33cfa17339df7113176ad1832cbb0533acf5d25c36b95e888f561d586c5d62f'],
+    }),
+    ('RUnit', '0.4.32', {
+        'checksums': ['23a393059989000734898685d0d5509ece219879713eb09083f7707f167f81f1'],
+    }),
+    ('DistributionUtils', '0.6-0', {
+        'checksums': ['7443d6cd154760d55b6954142908eae30385672c4f3f838dd49876ec2f297823'],
+    }),
+    ('gapfill', '0.9.6', {
+        'checksums': ['850d0be9d05e3f3620f0f5143496321f1004ed966299bffd6a67a9abd8d9040d'],
+    }),
+    ('gee', '4.13-20', {
+        'checksums': ['53014cee059bd87dc22f9679dfbf18fe6813b9ab41dfe90361921159edfbf798'],
+    }),
+    ('Matching', '4.9-6', {
+        'checksums': ['8e0dced7d1242e52de68a6e3010484bb29eb0633733549c82a06e9c6508b66dc'],
+    }),
+    ('MatchIt', '3.0.2', {
+        'checksums': ['782b159a2b5172e758e3993177930d604140ae668fd8a7c98c30792df80de9de'],
+    }),
+    ('RItools', '0.1-17', {
+        'checksums': ['75654780e9ca39cb3c43acfaca74080ad74de50f92c5e36e95694aafdfdc0cea'],
+    }),
+    ('optmatch', '0.9-13', {
+        'checksums': ['f8f327faa95c808773376570793bbabdbc185a6c7fcdce3b96a09c998134d0d8'],
+    }),
+    ('SKAT', '1.3.2.1', {
+        'checksums': ['7442408ccd1b9d2abb3f3dbd27e1b46e50b87042195bc46ce25fe0d887f98e7a'],
+    }),
+    ('GillespieSSA', '0.6.1', {
+        'checksums': ['272e9b6b26001d166fd7ce8d04f32831ba23c676075fbd1e922e27ba2c962052'],
+    }),
+    ('startupmsg', '0.9.6', {
+        'checksums': ['1d60ff13bb260630f797bde66a377a5d4cd65d78ae81a3936dc4374572ec786e'],
+    }),
+    ('distr', '2.8.0', {
+        'checksums': ['bb7df05d6b946bcdbbec2e3397c7c7e349b537cabfcbb13a34bcf6312a71ceb7'],
+    }),
+    ('distrEx', '2.8.0', {
+        'checksums': ['b064cde7d63ce93ec9969c8c4463c1e327758b6f8ea7765217d77f9ba9d590bf'],
+    }),
+    ('KODAMA', '1.5', {
+        'checksums': ['8ecf53732c1be2bd1e111b3c6de65b66caf28360306e683fe945dc76d4c267dd'],
+    }),
+    ('locfdr', '1.1-8', {
+        'checksums': ['42d6e12593ae6d541e6813a140b92591dabeb1df94432a515507fc2eee9a54b9'],
+    }),
+    ('ica', '1.0-2', {
+        'checksums': ['e721596fc6175d3270a60d5e0b5b98be103a8fd0dd93ef16680af21fe0b54179'],
+    }),
+    ('dtw', '1.21-3', {
+        'checksums': ['1aa46b285b7a31ba19759e83562671ed9076140abec79fe0df0316af43871e0a'],
+    }),
+    ('SDMTools', '1.1-221.2', {
+        'checksums': ['f0dd8c5f98d2f2c012536fa56d8f7a58aaf0c11cbe3527e66d4ee3194f6a6cf7'],
+    }),
+    ('ggridges', '0.5.1', {
+        'checksums': ['01f87cdcdf2052ed9c078d9352465cdeda920a41e2ca55bc154c1574fc651c36'],
+    }),
+    ('TFisher', '0.2.0', {
+        'checksums': ['bd9b7484d6fba0165841596275b446f85ba446d40e92f3b9cb37381a3827e76f'],
+    }),
+    ('lsei', '1.2-0', {
+        'checksums': ['4781ebd9ef93880260d5d5f23066580ac06061e95c1048fb25e4e838963380f6'],
+    }),
+    ('npsurv', '0.4-0', {
+        'checksums': ['404cf7135dc40a04e9b81224a543307057a8278e11109ba1fcaa28e87c6204f3'],
+    }),
+    ('fitdistrplus', '1.0-14', {
+        'checksums': ['85082590f62aa08d99048ea3414c5cc1e5b780d97b3779d2397c6cb435470083'],
+    }),
+    ('reticulate', '1.13', {
+        'checksums': ['adbe41d556b667c4419d563680f8608a56b0f792b8bc427b3bf4c584ff819de3'],
+    }),
+    ('hdf5r', '1.3.0', {
+        'installopts': '--configure-args="--with-hdf5=$EBROOTHDF5/bin/h5pcc"',
+        'preinstallopts': "unset LIBS && ",
+        'checksums': ['0ef18eed2683f5dda34601a20a842ab346a6c66b7277c5ed576c77ece61601df'],
+    }),
+    ('DTRreg', '1.5', {
+        'checksums': ['eb9b4d98b25eec304a447db302f618a75180f8d8fe0f5728ecd7e85957613456'],
+    }),
+    ('pulsar', '0.3.6', {
+        'checksums': ['b5851bf365003ace07542fd21ccff015c4b21ffd73e21ec3a539563e9ef53564'],
+    }),
+    ('bayesm', '3.1-4', {
+        'checksums': ['061b216c62bc72eab8d646ad4075f2f78823f9913344a781fa53ea7cf4a48f94'],
+    }),
+    ('energy', '1.7-7', {
+        'checksums': ['67b88fb33ee6e7bec2e4fe356a4efd36f70c3cf9b0ebe2f6d9da9ec96de9968f'],
+    }),
+    ('compositions', '1.40-3', {
+        'checksums': ['e42d90950a63aa7f707bc5025dbf265b63fc02a5b7137bc71836b8bc625d7080'],
+    }),
+    ('clustree', '0.4.1', {
+        'checksums': ['1d4c0c44826a656b649ce224f94a35fea808e9faef0d550646a0a9221a764e4b'],
+    }),
+    ('plotly', '4.9.1', {
+        'checksums': ['85a08c64d1bf839786951b3574986eacce78dacd589f2bef4b38208e49554d3d'],
+    }),
+    ('tweedie', '2.3.2', {
+        'checksums': ['9a6226e64e3d56eb7eb2a408f8b825c2ad6ee0ea203a9220e85e7789514adb81'],
+    }),
+    ('RcppGSL', '0.3.7', {
+        'checksums': ['45e95c4170fc8421ae9b32134b3a402f76ea9657030969723a3563c7ce14dc32'],
+    }),
+    ('mvabund', '4.0.1', {
+        'checksums': ['1399fa0a5f7a3673d788abe36b520f476c05246e21f71e3f60cee7a85f194951'],
+    }),
+    ('fishMod', '0.29', {
+        'checksums': ['5989e49ca6d6b2c5d514655e61f75b019528a8c975f0d6056143f17dc4277a5d'],
+    }),
+    ('gllvm', '1.1.7', {
+        'checksums': ['cc0331b034e14aa8d47a491cedeb76717b4085a61fb0b1cc75d424c58ca9b8d4'],
+    }),
+    ('grpreg', '3.2-1', {
+        'checksums': ['6be37719a74d59582107273385d70963b4ccc6c394948c7617e65246d713cb88'],
+    }),
+    ('trust', '0.1-7', {
+        'checksums': ['e3d15aa84a71becd2824253d4a8156bdf1ab9ac3b72ced0cd53f3bb370ac6f04'],
+    }),
+    ('ergm', '3.10.4', {
+        'checksums': ['885f0b1a23c5a2c1947962350cfab66683dfdfd1db173c115e90396d00831f22'],
+    }),
+    ('networkDynamic', '0.10.0', {
+        'checksums': ['eb31d72c73a06a145d231ad3489d450d63b9fecc069aeb19331d7417241df3b5'],
+    }),
+    ('tergm', '3.6.1', {
+        'checksums': ['21de2eca943d89ba63af14951655d626f241bafccc4b2709fa39aa130625cd0f'],
+    }),
+    ('ergm.count', '3.4.0', {
+        'checksums': ['7c24c79d0901c18991cce907306a1531cca676ae277c6b0a0e4962ad27c36baf'],
+    }),
+    ('tsna', '0.3.0', {
+        'checksums': ['29f599d3e774289614608b0fa49e05a09e76e6b15dd1d46988785eaacf2e1a35'],
+    }),
+    ('statnet', '2019.6', {
+        'checksums': ['0903e1a81ed1b6289359cefd12da1424c92456d19e062c3f74197b69e536b29d'],
+    }),
+    ('aggregation', '1.0.1', {
+        'checksums': ['86f88a02479ddc8506bafb154117ebc3b1a4a44fa308e0193c8c315109302f49'],
+    }),
+    ('ComICS', '1.0.4', {
+        'checksums': ['0af7901215876f95f309d7da6e633c38e4d7faf04112dd6fd343bc15fc593a2f'],
+    }),
+    ('dtangle', '2.0.9', {
+        'checksums': ['c375068c1877c2e8cdc5601cfd5a9c821645c3dff90ddef64817f788f372e179'],
+    }),
+    ('mcmc', '0.9-6', {
+        'checksums': ['443a189fff907830627029dd55d925db9a70562d8bda7bfae97414ab955186b9'],
+    }),
+    ('MCMCpack', '1.4-5', {
+        'checksums': ['da949cfa44f71bfff1c6ae06caf8fe4252dd6391aa4c8f0fb6e02c7d6b1cdfb5'],
+    }),
+    ('shinythemes', '1.1.2', {
+        'checksums': ['2e13d4d5317fc61082e8f3128b15e0b10ed9736ce81e152dd7ae7f6109f9b18a'],
+    }),
+    ('csSAM', '1.2.4', {
+        'checksums': ['3d6442ad8c41fa84633cbbc275cd67e88490a160927a5c55d29da55a36e148d7'],
+    }),
+    ('bridgedist', '0.1.0', {
+        'checksums': ['dc7c1c8874d6cfa34d550d9af194389e13471dfbc55049a1ab66db112fbf1343'],
+    }),
+    ('asnipe', '1.1.12', {
+        'checksums': ['3a1f166f1c71b5877a2acca1384ec6c9b430b67af67ef26125f2abbb53c66206'],
+    }),
+    ('liquidSVM', '1.2.4', {
+        'checksums': ['15a9c7f2930e2ed3f4c5bcd9b042884ea580d2b2e52e1c68041600c196046aba'],
+    }),
+    ('oddsratio', '2.0.0', {
+        'checksums': ['89bf3c68a6ded6a98f4ee8d487c29605ad00ac5f8db9b8bf1a52144e65332553'],
+    }),
+    ('mltools', '0.3.5', {
+        'checksums': ['7093ffceccdf5d4c3f045d8c8143deaa8ab79935cc6d5463973ffc7d3812bb10'],
+    }),
+    ('h2o', '3.26.0.2', {
+        'checksums': ['cabef231e65991a6fd40b83022eb6d47a0fa09548ed62ce6fe6549535f98b2d1'],
+    }),
+    ('mlegp', '3.1.7', {
+        'checksums': ['d4845eaf9260f8b8112726dd7ceb5c2f5ce75125fa313191db9de121f2ee15e0'],
+    }),
+    ('itertools', '0.1-3', {
+        'checksums': ['b69b0781318e175532ad2d4f2840553bade9637e04de215b581704b5635c45d3'],
+    }),
+    ('missForest', '1.4', {
+        'checksums': ['f785804b03bdf424e1c76095989a803afb3b47d6bebca9a6832074b6326c0278'],
+    }),
+    ('bartMachineJARs', '1.1', {
+        'checksums': ['f2c31cb94d7485174a2519771127a102e35b9fe7f665e27beda3e76a56feeef2'],
+    }),
+    ('bartMachine', '1.2.4.2', {
+        'checksums': ['28a5f7363325021bd93f9bd060cc48f20c689dae2f2f6f7100faae66d7651f80'],
+    }),
+    ('lqa', '1.0-3', {
+        'checksums': ['3889675dc4c8cbafeefe118f4f20c3bd3789d4875bb725933571f9991a133990'],
+    }),
+    ('PresenceAbsence', '1.1.9', {
+        'checksums': ['1a30b0a4317ea227d674ac873ab94f87f8326490304e5b08ad58953cdf23169f'],
+    }),
+    ('GUTS', '1.1.1', {
+        'checksums': ['094b8f51719cc36ddc56e3412dbb146eafc93c5e8fbb2c5999c2e80ea7a7d216'],
+    }),
+    ('GenSA', '1.1.7', {
+        'checksums': ['9d99d3d0a4b7770c3c3a6de44206811272d78ab94481713a8c369f7d6ae7b80f'],
+    }),
+    ('rematch2', '2.1.0', {
+        'checksums': ['78677071bd44b40e562df1da6f0c6bdeae44caf973f97ff8286b8c994db59f01'],
+    }),
+    ('parsedate', '1.2.0', {
+        'checksums': ['39ab3c507cb3efcd677c6cf453f46d6b1948662bd70c7765845e755ea1e1633d'],
+    }),
+    ('circular', '0.4-93', {
+        'checksums': ['76cee2393757390ad91d3db3e5aeb2c2d34c0a46822b7941498571a473417142'],
+    }),
+    ('cobs', '1.3-3', {
+        'checksums': ['6b1e760cf8dec6b6e63f042cdc3e5e633de5f982e8bc743a891932f6d9f91bdf'],
+    }),
+    ('resample', '0.4', {
+        'checksums': ['f0d5f735e1b812612720845d79167a19f713a438fd10a6a3206e667045fd93e5'],
+    }),
+    ('MIIVsem', '0.5.4', {
+        'checksums': ['de918d6b1820c59a7d4324342ad15444c2370ce1d843397a136c307397ed64b9'],
+    }),
+    ('medflex', '0.6-6', {
+        'checksums': ['b9d04fb5281d0ea0555ec4f327a0ee951a7f312a3af944578dc175183dc49211'],
+    }),
+    ('Rserve', '1.7-3.1', {
+        'checksums': ['3ba1e919706e16a8632def5f45d666b6e44eafa6c14b57064d6ddf3415038f99'],
+    }),
+    ('spls', '2.2-3', {
+        'checksums': ['bbd693da80487eef2939c37aba199f6d811ec289828c763d9416a05fa202ab2e'],
+    }),
+    ('Boruta', '6.0.0', {
+        'checksums': ['1c9a7aabe09f040e147f6c614f5fe1d0b951d3b0f0024161fbb4c31da8fae8de'],
+    }),
+    ('dr', '3.0.10', {
+        'checksums': ['ce523c1bdb62a9dda30afc12b1dd96975cc34695c61913012236f3b80e24bf36'],
+    }),
+    ('CovSel', '1.2.1', {
+        'checksums': ['b375d00cc567e125ff106b4357654f43bba3abcadeed2238b6dea4b7a68fda09'],
+    }),
+    ('tmle', '1.4.0.1', {
+        'checksums': ['075e7b7fe0496e02785eb35aed0db84476db756c6f14a0047808af2565b33501'],
+    }),
+    ('ctmle', '0.1.2', {
+        'checksums': ['e3fa0722cd87aa0e0b209c2dddf3fc44c6d09993f1e66a6c43285fe950948161'],
+    }),
+    ('BayesPen', '1.0', {
+        'checksums': ['772df9ae12cd8a3da1d5b7d1f1629602c7693f0eb03945784df2809e2bb061b0'],
+    }),
+    ('inline', '0.3.15', {
+        'checksums': ['ff043fe13c1991a3b285bed256ff4a9c0ba10bee764225a34b285875b7d69c68'],
+    }),
+    ('BMA', '3.18.11', {
+        'checksums': ['bf4ce8fdb21a4da754dffa4c1869efb11f6bdcfaa7f43a1b009b2695f553698d'],
+    }),
+    ('BCEE', '1.2', {
+        'checksums': ['0b1183458d625ef5dd0962fc77ca1326e77754a2c04be11fb002057abcb65a22'],
+    }),
+    ('bacr', '1.0.1', {
+        'checksums': ['c847272e2c03fd08ed79b3b739f57fe881af77404b6fd087caa0c398c90ef993'],
+    }),
+    ('clue', '0.3-57', {
+        'checksums': ['6e369d07b464a9624209a06b5078bf988f01f7963076e946649d76aea0622d17'],
+    }),
+    ('bdsmatrix', '1.3-3', {
+        'checksums': ['70ea81708c97dedd483a5d3866d2e906fa0e9098ff854c41cf0746fbc8dfad9d'],
+    }),
+    ('fftwtools', '0.9-8', {
+        'checksums': ['4641c8cd70938c2a8bde0b6da6cf7f83e96175ef52f1ca42ec3920a1dabf1bdb'],
+    }),
+    ('imagerExtra', '1.3.2', {
+        'checksums': ['0ebfa1eabb89459d774630ab73c7a97a93b9481ea5afc55482975475acebd5b8'],
+    }),
+    ('MALDIquant', '1.19.3', {
+        'checksums': ['a730327c1f8d053d29e558636736b7b66d0671a009e0004720b869d2c76ff32c'],
+    }),
+    ('threejs', '0.3.1', {
+        'checksums': ['71750b741672a435ecf749b69c72f0681aa8bb795e317f4e3056d5e33f6d79e8'],
+    }),
+    ('LaplacesDemon', '16.1.1', {
+        'checksums': ['779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77'],
+    }),
+    ('rda', '1.0.2-2.1', {
+        'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',
+                       'eea3a51a2e132a023146bfbc0c384f5373eb3ea2b61743d7658be86a5b04949e')],
+    }),
+    ('sampling', '2.8', {
+        'checksums': ['356923f35971bb55f7e97b178aede3366374aa3ad3d24a97be765660553bf21a'],
+    }),
+    ('lda', '1.4.2', {
+        'checksums': ['5606a1e1bc24706988853528023f7a004c725791ae1a7309f1aea2fc6681240f'],
+    }),
+    ('jiebaRD', '0.1', {
+        'checksums': ['045ee670f5378fe325a45b40fd55136b355cbb225e088cb229f512c51abb4df1'],
+    }),
+    ('jiebaR', '0.11', {
+        'checksums': ['adde8b0b21c01ec344735d49cd33929511086719c99f8e10dce4ca9479276623'],
+    }),
+    ('hdm', '0.3.1', {
+        'checksums': ['ba087565e9e0a8ea30a6095919141895fd76b7f3c05a03e60e9e24e602732bce'],
+    }),
+    ('abe', '3.0.1', {
+        'checksums': ['66d2e9ac78ba64b7d27b22b647fc00378ea832f868e51c18df50d6fffb8029b8'],
+    }),
+    ('SignifReg', '2.1', {
+        'checksums': ['d21959ce5b1ee20efd1483f6020b57e5f6616bd525af77a7bd325501cc670606'],
+    }),
+    ('bbmle', '1.0.20', {
+        'checksums': ['6c0fe8df7243f8a039e62d14014065df2002b9329c0e8a3c2df4e7ccf591f1f7'],
+    }),
+    ('emdbook', '1.3.11', {
+        'checksums': ['f848d4c0a2da50dc8a5af76429d8f9d4960dee3fad1e98f7b507bdfd9b2ca128'],
+    }),
+    ('SOAR', '0.99-11', {
+        'checksums': ['d5a0fba3664087308ce5295a1d57d10bad149eb9771b4fe67478deae4b7f68d8'],
+    }),
+    ('rasterVis', '0.47', {
+        'checksums': ['123ebe870895c2ba3a4b64d8a18bccab5287c831fa14bb0fe07f0d7de61e51d3'],
+    }),
+    ('tictoc', '1.0', {
+        'checksums': ['47da097c1822caa2d8e262381987cfa556ad901131eb96109752742526b2e2fe'],
+    }),
+    ('ISOcodes', '2019.04.22', {
+        'checksums': ['2386440c3bed8391ee3a029aab86c107d435d0dd6a970236512d7c105d146b6e'],
+    }),
+    ('stopwords', '1.0', {
+        'checksums': ['9b727a5d827ac8dcfa6329140d294dcf964a06d80132b4ca434330d0ee02b1da'],
+    }),
+    ('janeaustenr', '0.1.5', {
+        'checksums': ['992f6673653daf7010fe176993a01cd4127d9a88be428da8da7a28241826d6f3'],
+    }),
+    ('SnowballC', '0.6.0', {
+        'checksums': ['61617d344444235940f5b9ac1cd6b86938e74a8c76791235724b16b755c3f72c'],
+    }),
+    ('tokenizers', '0.2.1', {
+        'checksums': ['28617cdc5ddef5276abfe14a2642999833322b6c34697de1d4e9d6dc7670dd00'],
+    }),
+    ('hunspell', '3.0', {
+        'checksums': ['01fb9c87f7cf094aaad3b7098378134f2e503286224351e91d08c00b6ee19857'],
+    }),
+    ('topicmodels', '0.2-9', {
+        'checksums': ['40770fb7de6ab6bd6e3ef6a0c777fa6db65d0322e67503c26c84ea857ac9a79c'],
+    }),
+    ('tidytext', '0.2.2', {
+        'checksums': ['188f294cf3177fe6fc85e9b7e16a05211cebeab0e0f7b05a9443416790bf2ec0'],
+    }),
+    ('splitstackshape', '1.4.8', {
+        'checksums': ['656032c3f1e3dd5b8a3ee19ffcae617e07104c0e342fc3da4d863637a770fe56'],
+    }),
+    ('grImport2', '0.2-0', {
+        'checksums': ['a102a2d877e42cd4e4e346e5510a77b2f3e57b43ae3c6d5c272fdceb506b00a7'],
+    }),
+    ('preseqR', '4.0.0', {
+        'checksums': ['0143db473fb9a811f9cf582a348226a5763e62d9857ce3ef4ec41412abb559bc'],
+    }),
+    ('idr', '1.2', {
+        'checksums': ['8bbfdf82c8c2b5c73eb079127e198b6cb65c437bb36729f502c7bcd6037fdb16'],
+    }),
+    ('entropy', '1.2.1', {
+        'checksums': ['edb27144b8f855f1ef21de6b93b6b6c5cf7d4f2c3d592bf625e5158c02226f83'],
+    }),
+    ('kedd', '1.0.3', {
+        'checksums': ['38760abd8c8e8f69ad85ca7992803060acc44ce68358de1763bd2415fdf83c9f'],
+    }),
+    ('OpenCL', '0.1-3.1', {
+        'checksums': ['daff23d777a27cd9d2e67ca8f5db1d29940cf0422708c1ea7e2d9661e3d6ae6f'],
+    }),
+    ('assertive.base', '0.0-7', {
+        'checksums': ['f02d4eca849f512500abb266a2a751d1fa2cf064f7142e5161a77c20b7f643f7'],
+    }),
+    ('assertive.properties', '0.0-4', {
+        'checksums': ['5c0663fecb4b7c30f2e1d65da8644534fcfe97fb3d8b51f74c1327cd14291a6b'],
+    }),
+    ('assertive.numbers', '0.0-2', {
+        'checksums': ['bae18c0b9e5b960a20636e127eb738ecd8a266e5fc29d8bc5ca712498cd68349'],
+    }),
+    ('assertive.types', '0.0-3', {
+        'checksums': ['ab6db2eb926e7bc885f2043fab679330aa336d07755375282d89bf9f9d0cb87f'],
+    }),
+    ('assertive.strings', '0.0-3', {
+        'checksums': ['d541d608a01640347d661cc9a67af8202904142031a20caa270f1c83d0ccd258'],
+    }),
+    ('assertive.datetimes', '0.0-2', {
+        'checksums': ['e8d4b1af89cc8b544f32092a7e8c0ee067526baf1c41af261bf98e8bba434901'],
+    }),
+    ('assertive.files', '0.0-2', {
+        'checksums': ['be6adda6f18a0427449249e44c2deff4444a123244b16fe82c92f15d24faee0a'],
+    }),
+    ('assertive.sets', '0.0-3', {
+        'checksums': ['876975a16ed911ea1ad12da284111c6eada6abfc0118585033abc0edb5801bb3'],
+    }),
+    ('assertive.matrices', '0.0-2', {
+        'checksums': ['3462a7a7e11d7cc24180330d48cc3067cf92eab1699b3e4813deec66d99f5e9b'],
+    }),
+    ('assertive.models', '0.0-2', {
+        'checksums': ['b9a6d8786f352d53371dbe8c5f2f2a62a7866e30313f268e69626d5c3691c42e'],
+    }),
+    ('assertive.data', '0.0-3', {
+        'checksums': ['5a00fb48ad870d9b3c872ce3d6aa20a7948687a980f49fe945b455339e789b01'],
+    }),
+    ('assertive.data.uk', '0.0-2', {
+        'checksums': ['ab48dab6977e8f43d6fffb33228d158865f68dde7026d123c693d77339dcf2bb'],
+    }),
+    ('assertive.data.us', '0.0-2', {
+        'checksums': ['180e64dfe6339d25dd27d7fe9e77619ef697ef6e5bb6a3cf4fb732a681bdfaad'],
+    }),
+    ('assertive.reflection', '0.0-4', {
+        'checksums': ['123672e1a99fc79e7e9e91566ee21bba1fb45fd13e353e41c52e3300ecd2f5a7'],
+    }),
+    ('assertive.code', '0.0-3', {
+        'checksums': ['ef80e8d1d683d776a7618e78ddccffca7f72ab4a0fcead90c670bb8f8cb90be2'],
+    }),
+    ('assertive', '0.3-5', {
+        'checksums': ['23ff6c8893e9c0b5b6bf4009a10de42a4a3a86eec2c48e7b73ae2cd6295c8b2e'],
+    }),
+    ('RViennaCL', '1.7.1.8', {
+        'checksums': ['adcc74537337582153d5b11d281e391e91a7f3afae116aa1b9a034ffd11b0252'],
+    }),
+    ('gpuR', '2.0.3', {
+        'checksums': ['1e6f0082c9fc89bb2094979b78dbc1aa06db793202bea3f0683a43306db6cba9'],
+    }),
+]
+
+moduleclass = 'lang'


### PR DESCRIPTION
`ICU-64.2` has a build dependency on `Python-2.7.15`, but prefers Python 3 in the build process. This is a problem, when there is a bare Python 3 installed somewhere in the System, and will break the build process:

```
Not rebuilding data/rules.mk, assuming prebuilt data in data/in
Spawning Python to generate test/testdata/rules.mk...
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/software/easybuild4/build/ICU/64.2/GCCcore-8.2.0/icu/source/data/buildtool/__main__.py", line 19, in <module>
    import BUILDRULES
  File "/software/easybuild4/build/ICU/64.2/GCCcore-8.2.0/icu/source/test/testdata/BUILDRULES.py", line 4, in <module>
    from distutils.sysconfig import parse_makefile
ModuleNotFoundError: No module named 'distutils.sysconfig'
configure: error: Python failed to run; see above error.
```

Therefore, I propose to update the `builddependencies` to `Python-3.7.2`.