### PR TITLE
{lang}[foss/2019a] R 3.6.0: Add second checksum for rda_1.0.2-2.1.tar.gz

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
@@ -2196,7 +2196,8 @@ exts_list = [
         'checksums': ['779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77'],
     }),
     ('rda', '1.0.2-2.1', {
-        'checksums': ['6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8'],
+        'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',
+                       'eea3a51a2e132a023146bfbc0c384f5373eb3ea2b61743d7658be86a5b04949e')],
     }),
     ('sampling', '2.8', {
         'checksums': ['356923f35971bb55f7e97b178aede3366374aa3ad3d24a97be765660553bf21a'],

--- a/easybuild/easyconfigs/r/R/R-3.6.0-fosscuda-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-fosscuda-2019a.eb
@@ -2196,7 +2196,8 @@ exts_list = [
         'checksums': ['779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77'],
     }),
     ('rda', '1.0.2-2.1', {
-        'checksums': ['6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8'],
+        'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',
+                       'eea3a51a2e132a023146bfbc0c384f5373eb3ea2b61743d7658be86a5b04949e')],
     }),
     ('sampling', '2.8', {
         'checksums': ['356923f35971bb55f7e97b178aede3366374aa3ad3d24a97be765660553bf21a'],

--- a/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
@@ -2255,7 +2255,8 @@ exts_list = [
         'checksums': ['779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77'],
     }),
     ('rda', '1.0.2-2.1', {
-        'checksums': ['6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8'],
+        'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',
+                       'eea3a51a2e132a023146bfbc0c384f5373eb3ea2b61743d7658be86a5b04949e')],
     }),
     ('sampling', '2.8', {
         'checksums': ['356923f35971bb55f7e97b178aede3366374aa3ad3d24a97be765660553bf21a'],


### PR DESCRIPTION
Similar to MASS (https://github.com/easybuilders/easybuild-easyconfigs/pull/9621), the maintainers of RDA changed a tiny bit in their R package, without changing the version:

```
diff -ur rda2/rda/DESCRIPTION rda/rda/DESCRIPTION
--- rda2/rda/DESCRIPTION	2018-07-21 17:12:01.000000000 +0000
+++ rda/rda/DESCRIPTION	2020-01-01 15:58:30.000000000 +0000
@@ -17,3 +17,5 @@
 X-CRAN-Original-Maintainer: Rob Tibshirani <tibs@stanford.edu>
 X-CRAN-Comment: Orphaned and corrected on 2018-07-21 as check problems
         were not corrected despite reminders.
+ .
+ BioC:MLInterfaces depends on this
diff -ur rda2/rda/MD5 rda/rda/MD5
--- rda2/rda/MD5	2018-07-21 17:12:01.000000000 +0000
+++ rda/rda/MD5	2020-01-01 15:58:30.000000000 +0000
@@ -1,4 +1,4 @@
-25d1293d678d5fbdf2bb20bf6fc64280 *DESCRIPTION
+2a1d3c1ed3cac2196abc5a33b27b7639 *DESCRIPTION
 61ebf1914538b6254a39f161f286069f *INDEX
 63d89739955fd7c7e2463bb9b8ad087c *NAMESPACE
 bb8590ce1b9dc15b42c525b8be97a5f4 *R/Drda1.R
```

I added a second checksum.