### PR TITLE
[double-conversion] Use CMake for building

### DIFF
--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.0.3-foss-2018a.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.0.3-foss-2018a.eb
@@ -1,3 +1,7 @@
+# NOTE:
+#    This does use the system compiler if any and WILL fail if no system compiler exists.
+#    Dependents may or may not be able to find this, e.g. Qt will silently fallback to a version included in Qt
+#    For future ECs use the CMake based build
 easyblock = 'SCons'
 
 name = 'double-conversion'

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.0.3-foss-2018a.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.0.3-foss-2018a.eb
@@ -1,4 +1,4 @@
-easyblock = 'CMakeMake'
+easyblock = 'SCons'
 
 name = 'double-conversion'
 version = '3.0.3'
@@ -13,24 +13,15 @@ sources = ['v%(version)s.tar.gz']
 checksums = ['ac84e00c19fdb5ee20c01feb18b0fa2e938bf4b8cf71d43bab62502c8b65420a']
 
 builddependencies = [
-    ('CMake', '3.12.1', '', ('GCCcore', '6.4.0')),
+    ('SCons', '3.0.1', '-Python-3.6.4'),
 ]
 
-separate_build_dir = True
-
-build_type = 'Release'
-
-# Build static lib, static lib with -fPIC and shared lib
-configopts = [
-    '',
-    '-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_STATIC_LIBRARY_SUFFIX_CXX=_pic.a',
-    '-DBUILD_SHARED_LIBS=ON'
-]
+installopts = "DESTDIR=%(installdir)s prefix='' && "
+installopts += "mkdir %(installdir)s/include && cp double-conversion/*.h %(installdir)s/include"
 
 sanity_check_paths = {
-    'files': ['include/double-conversion/double-conversion.h', 'include/double-conversion/utils.h',
-              'lib/libdouble-conversion.a', 'lib/libdouble-conversion_pic.a',
-              'lib/libdouble-conversion.%s' % SHLIB_EXT],
+    'files': ['include/double-conversion.h', 'include/utils.h', 'lib/libdouble-conversion.a',
+              'lib/libdouble-conversion.%s' % SHLIB_EXT, 'lib/libdouble-conversion_pic.a'],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.0.3-foss-2018a.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.0.3-foss-2018a.eb
@@ -1,4 +1,4 @@
-easyblock = 'SCons'
+easyblock = 'CMakeMake'
 
 name = 'double-conversion'
 version = '3.0.3'
@@ -13,15 +13,24 @@ sources = ['v%(version)s.tar.gz']
 checksums = ['ac84e00c19fdb5ee20c01feb18b0fa2e938bf4b8cf71d43bab62502c8b65420a']
 
 builddependencies = [
-    ('SCons', '3.0.1', '-Python-3.6.4'),
+    ('CMake', '3.12.1', '', ('GCCcore', '6.4.0')),
 ]
 
-installopts = "DESTDIR=%(installdir)s prefix='' && "
-installopts += "mkdir %(installdir)s/include && cp double-conversion/*.h %(installdir)s/include"
+separate_build_dir = True
+
+local_buildtype = '-DCMAKE_BUILD_TYPE=Release '
+configopts = [
+    local_buildtype + c for c in (
+        '',
+        '-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_STATIC_LIBRARY_SUFFIX_CXX=_pic.a',
+        '-DBUILD_SHARED_LIBS=ON'
+    )
+]
 
 sanity_check_paths = {
-    'files': ['include/double-conversion.h', 'include/utils.h', 'lib/libdouble-conversion.a',
-              'lib/libdouble-conversion.%s' % SHLIB_EXT, 'lib/libdouble-conversion_pic.a'],
+    'files': ['include/double-conversion/double-conversion.h', 'include/double-conversion/utils.h',
+              'lib/libdouble-conversion.a', 'lib/libdouble-conversion_pic.a',
+              'lib/libdouble-conversion.%s' % SHLIB_EXT],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.0.3-foss-2018a.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.0.3-foss-2018a.eb
@@ -20,6 +20,7 @@ separate_build_dir = True
 
 build_type = 'Release'
 
+# Build static lib, static lib with -fPIC and shared lib
 configopts = [
     '',
     '-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_STATIC_LIBRARY_SUFFIX_CXX=_pic.a',

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.0.3-foss-2018a.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.0.3-foss-2018a.eb
@@ -18,13 +18,12 @@ builddependencies = [
 
 separate_build_dir = True
 
-local_buildtype = '-DCMAKE_BUILD_TYPE=Release '
+build_type = 'Release'
+
 configopts = [
-    local_buildtype + c for c in (
-        '',
-        '-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_STATIC_LIBRARY_SUFFIX_CXX=_pic.a',
-        '-DBUILD_SHARED_LIBS=ON'
-    )
+    '',
+    '-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_STATIC_LIBRARY_SUFFIX_CXX=_pic.a',
+    '-DBUILD_SHARED_LIBS=ON'
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.2.0.eb
@@ -1,4 +1,4 @@
-easyblock = 'SCons'
+easyblock = 'CMakeMake'
 
 name = 'double-conversion'
 version = '3.1.4'
@@ -14,15 +14,24 @@ checksums = ['95004b65e43fefc6100f337a25da27bb99b9ef8d4071a36a33b5e83eb1f82021']
 
 builddependencies = [
     ('binutils', '2.31.1'),
-    ('SCons', '3.0.5'),
+    ('CMake', '3.13.3'),
 ]
 
-installopts = "DESTDIR=%(installdir)s prefix='' && "
-installopts += "mkdir %(installdir)s/include && cp double-conversion/*.h %(installdir)s/include"
+separate_build_dir = True
+
+local_buildtype = '-DCMAKE_BUILD_TYPE=Release '
+configopts = [
+    local_buildtype + c for c in (
+        '',
+        '-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_STATIC_LIBRARY_SUFFIX_CXX=_pic.a',
+        '-DBUILD_SHARED_LIBS=ON'
+    )
+]
 
 sanity_check_paths = {
-    'files': ['include/double-conversion.h', 'include/utils.h', 'lib/libdouble-conversion.a',
-              'lib/libdouble-conversion.%s' % SHLIB_EXT, 'lib/libdouble-conversion_pic.a'],
+    'files': ['include/double-conversion/double-conversion.h', 'include/double-conversion/utils.h',
+              'lib/libdouble-conversion.a', 'lib/libdouble-conversion_pic.a',
+              'lib/libdouble-conversion.%s' % SHLIB_EXT],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.2.0.eb
@@ -19,13 +19,12 @@ builddependencies = [
 
 separate_build_dir = True
 
-local_buildtype = '-DCMAKE_BUILD_TYPE=Release '
+build_type = 'Release'
+
 configopts = [
-    local_buildtype + c for c in (
-        '',
-        '-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_STATIC_LIBRARY_SUFFIX_CXX=_pic.a',
-        '-DBUILD_SHARED_LIBS=ON'
-    )
+    '',
+    '-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_STATIC_LIBRARY_SUFFIX_CXX=_pic.a',
+    '-DBUILD_SHARED_LIBS=ON'
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.2.0.eb
@@ -21,6 +21,7 @@ separate_build_dir = True
 
 build_type = 'Release'
 
+# Build static lib, static lib with -fPIC and shared lib
 configopts = [
     '',
     '-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_STATIC_LIBRARY_SUFFIX_CXX=_pic.a',

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.3.0.eb
@@ -19,13 +19,12 @@ builddependencies = [
 
 separate_build_dir = True
 
-local_buildtype = '-DCMAKE_BUILD_TYPE=Release '
+build_type = 'Release'
+
 configopts = [
-    local_buildtype + c for c in (
-        '',
-        '-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_STATIC_LIBRARY_SUFFIX_CXX=_pic.a',
-        '-DBUILD_SHARED_LIBS=ON'
-    )
+    '',
+    '-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_STATIC_LIBRARY_SUFFIX_CXX=_pic.a',
+    '-DBUILD_SHARED_LIBS=ON'
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.3.0.eb
@@ -21,6 +21,7 @@ separate_build_dir = True
 
 build_type = 'Release'
 
+# Build static lib, static lib with -fPIC and shared lib
 configopts = [
     '',
     '-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_STATIC_LIBRARY_SUFFIX_CXX=_pic.a',

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.3.0.eb
@@ -1,4 +1,4 @@
-easyblock = 'SCons'
+easyblock = 'CMakeMake'
 
 name = 'double-conversion'
 version = '3.1.4'
@@ -14,15 +14,24 @@ checksums = ['95004b65e43fefc6100f337a25da27bb99b9ef8d4071a36a33b5e83eb1f82021']
 
 builddependencies = [
     ('binutils', '2.32'),
-    ('SCons', '3.1.1'),
+    ('CMake', '3.15.3'),
 ]
 
-installopts = "DESTDIR=%(installdir)s prefix='' && "
-installopts += "mkdir %(installdir)s/include && cp double-conversion/*.h %(installdir)s/include"
+separate_build_dir = True
+
+local_buildtype = '-DCMAKE_BUILD_TYPE=Release '
+configopts = [
+    local_buildtype + c for c in (
+        '',
+        '-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_STATIC_LIBRARY_SUFFIX_CXX=_pic.a',
+        '-DBUILD_SHARED_LIBS=ON'
+    )
+]
 
 sanity_check_paths = {
-    'files': ['include/double-conversion.h', 'include/utils.h', 'lib/libdouble-conversion.a',
-              'lib/libdouble-conversion.%s' % SHLIB_EXT, 'lib/libdouble-conversion_pic.a'],
+    'files': ['include/double-conversion/double-conversion.h', 'include/double-conversion/utils.h',
+              'lib/libdouble-conversion.a', 'lib/libdouble-conversion_pic.a',
+              'lib/libdouble-conversion.%s' % SHLIB_EXT],
     'dirs': [],
 }
 


### PR DESCRIPTION
Reasoning:   
Using Scons (like currently done) will be using the system compiler instead of the toolchain set in the EasyConfig. This will completely fail during compilation when there is no system compiler (namely g++) installed. It may also fail, when this is linked into another application using a different compiler or compiler version due to different flags, ABI etc.

Furthermore Scons doesn't install the headers so that was done manually but to a wrong subdirectory. The correct path is `include/double-conversion/double-conversion.h` not  `include/double-conversion.h`. As the result dependents likely won't find it resulting in either build errors (e.g. when using plain `#include <double-conversion/double-conversion.h>`) or silently using an alternative version. E.g. Qt has a version bundled with its sources which is used when no "system installed" (in this case: by EasyBuild) version is found.

I verified that prior to this change Qt uses the bundled version and after this change the EB version.