### PR TITLE
New MCR-R2017b; Add checksums and remove Java dep for all MCR-*.eb

### DIFF
--- a/easybuild/easyconfigs/m/MCR/MCR-R2013a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2013a.eb
@@ -18,11 +18,11 @@ checksums = ['0b8aa5bae581b49e492643bb3dd0b2d78a1eff2f85d6c465c3f268a6cdfe3a65']
 # Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
 # https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
 # postinstallcmds = [
-#    'mv "%(installdir)s/v81/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v81/sys/os/glnxa64/libstdc++.so.6-backup"',
-#    'mv "%(installdir)s/v81/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v81/bin/glnxa64/libQt5Core.so.5-backup"',
-#    'mv "%(installdir)s/v81/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v81/bin/glnxa64/libQt5Network.so.5-backup"',
-#    'mv "%(installdir)s/v81/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v81/bin/glnxa64/libQt5Xml.so.5-backup"',
-#    'mv "%(installdir)s/v81/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v81/bin/glnxa64/libQt5Gui.so.5-backup"',
-#]
+#     'mv "%(installdir)s/v81/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v81/sys/os/glnxa64/libstdc++.so.6-orig"',
+#     'mv "%(installdir)s/v81/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v81/bin/glnxa64/libQt5Core.so.5-orig"',
+#     'mv "%(installdir)s/v81/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v81/bin/glnxa64/libQt5Network.so.5-orig"',
+#     'mv "%(installdir)s/v81/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v81/bin/glnxa64/libQt5Xml.so.5-orig"',
+#     'mv "%(installdir)s/v81/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v81/bin/glnxa64/libQt5Gui.so.5-orig"',
+# ]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2013a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2013a.eb
@@ -1,5 +1,5 @@
 name = 'MCR'
-version = 'R2013a'
+version = 'R2013a'  # runtime version 8.1
 
 homepage = 'http://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
@@ -9,10 +9,20 @@ description = """The MATLAB Runtime is a standalone set of shared libraries
 toolchain = SYSTEM
 
 source_urls = [
-    'http://www.mathworks.com/supportfiles/MCR_Runtime/%(version)s/',
+    'https://www.mathworks.com/supportfiles/MCR_Runtime/%(version)s/',
 ]
 sources = ['%(name)s_%(version)s_glnxa64_installer.zip']
+checksums = ['0b8aa5bae581b49e492643bb3dd0b2d78a1eff2f85d6c465c3f268a6cdfe3a65']
 
-dependencies = [('Java', '1.8.0_31')]
+#
+# Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
+# https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
+# postinstallcmds = [
+#    'mv "%(installdir)s/v81/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v81/sys/os/glnxa64/libstdc++.so.6-backup"',
+#    'mv "%(installdir)s/v81/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v81/bin/glnxa64/libQt5Core.so.5-backup"',
+#    'mv "%(installdir)s/v81/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v81/bin/glnxa64/libQt5Network.so.5-backup"',
+#    'mv "%(installdir)s/v81/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v81/bin/glnxa64/libQt5Xml.so.5-backup"',
+#    'mv "%(installdir)s/v81/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v81/bin/glnxa64/libQt5Gui.so.5-backup"',
+#]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2013a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2013a.eb
@@ -1,7 +1,7 @@
 name = 'MCR'
 version = 'R2013a'  # runtime version 8.1
 
-homepage = 'http://www.mathworks.com/products/compiler/mcr/'
+homepage = 'https://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
  that enables the execution of compiled MATLAB applications
  or components on computers that do not have MATLAB installed."""

--- a/easybuild/easyconfigs/m/MCR/MCR-R2013b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2013b.eb
@@ -1,5 +1,5 @@
 name = 'MCR'
-version = 'R2013b'
+version = 'R2013b'  # runtime version 8.2
 
 homepage = 'http://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
@@ -9,10 +9,20 @@ description = """The MATLAB Runtime is a standalone set of shared libraries
 toolchain = SYSTEM
 
 source_urls = [
-    'http://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
+    'https://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
 ]
 sources = ['%(name)s_%(version)s_glnxa64_installer.zip']
+checksums = ['b1a49140c626c62f66e133071580a6325818c4a74127fa6dc255062bea3b494e']
 
-dependencies = [('Java', '1.8.0_121')]
+#
+# Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
+# https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
+# postinstallcmds = [
+#    'mv "%(installdir)s/v82/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v82/sys/os/glnxa64/libstdc++.so.6-backup"',
+#    'mv "%(installdir)s/v82/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v82/bin/glnxa64/libQt5Core.so.5-backup"',
+#    'mv "%(installdir)s/v82/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v82/bin/glnxa64/libQt5Network.so.5-backup"',
+#    'mv "%(installdir)s/v82/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v82/bin/glnxa64/libQt5Xml.so.5-backup"',
+#    'mv "%(installdir)s/v82/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v82/bin/glnxa64/libQt5Gui.so.5-backup"',
+#]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2013b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2013b.eb
@@ -18,11 +18,11 @@ checksums = ['b1a49140c626c62f66e133071580a6325818c4a74127fa6dc255062bea3b494e']
 # Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
 # https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
 # postinstallcmds = [
-#    'mv "%(installdir)s/v82/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v82/sys/os/glnxa64/libstdc++.so.6-backup"',
-#    'mv "%(installdir)s/v82/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v82/bin/glnxa64/libQt5Core.so.5-backup"',
-#    'mv "%(installdir)s/v82/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v82/bin/glnxa64/libQt5Network.so.5-backup"',
-#    'mv "%(installdir)s/v82/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v82/bin/glnxa64/libQt5Xml.so.5-backup"',
-#    'mv "%(installdir)s/v82/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v82/bin/glnxa64/libQt5Gui.so.5-backup"',
-#]
+#     'mv "%(installdir)s/v82/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v82/sys/os/glnxa64/libstdc++.so.6-orig"',
+#     'mv "%(installdir)s/v82/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v82/bin/glnxa64/libQt5Core.so.5-orig"',
+#     'mv "%(installdir)s/v82/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v82/bin/glnxa64/libQt5Network.so.5-orig"',
+#     'mv "%(installdir)s/v82/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v82/bin/glnxa64/libQt5Xml.so.5-orig"',
+#     'mv "%(installdir)s/v82/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v82/bin/glnxa64/libQt5Gui.so.5-orig"',
+# ]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2013b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2013b.eb
@@ -1,7 +1,7 @@
 name = 'MCR'
 version = 'R2013b'  # runtime version 8.2
 
-homepage = 'http://www.mathworks.com/products/compiler/mcr/'
+homepage = 'https://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
  that enables the execution of compiled MATLAB applications
  or components on computers that do not have MATLAB installed."""

--- a/easybuild/easyconfigs/m/MCR/MCR-R2014a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2014a.eb
@@ -1,5 +1,5 @@
 name = 'MCR'
-version = 'R2014a'
+version = 'R2014a'  # runtime version 8.3
 
 homepage = 'http://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
@@ -9,10 +9,20 @@ description = """The MATLAB Runtime is a standalone set of shared libraries
 toolchain = SYSTEM
 
 source_urls = [
-    'http://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
+    'https://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
 ]
 sources = ['%(name)s_%(version)s_glnxa64_installer.zip']
+checksums = ['fba9cf6dc896bf613d92b4c1cbdb50708b1bef8514bf52a5ad14527c38824a15']
 
-dependencies = [('Java', '1.8.0_31')]
+#
+# Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
+# https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
+# postinstallcmds = [
+#    'mv "%(installdir)s/v83/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v83/sys/os/glnxa64/libstdc++.so.6-backup"',
+#    'mv "%(installdir)s/v83/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v83/bin/glnxa64/libQt5Core.so.5-backup"',
+#    'mv "%(installdir)s/v83/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v83/bin/glnxa64/libQt5Network.so.5-backup"',
+#    'mv "%(installdir)s/v83/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v83/bin/glnxa64/libQt5Xml.so.5-backup"',
+#    'mv "%(installdir)s/v83/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v83/bin/glnxa64/libQt5Gui.so.5-backup"',
+#]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2014a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2014a.eb
@@ -1,7 +1,7 @@
 name = 'MCR'
 version = 'R2014a'  # runtime version 8.3
 
-homepage = 'http://www.mathworks.com/products/compiler/mcr/'
+homepage = 'https://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
  that enables the execution of compiled MATLAB applications
  or components on computers that do not have MATLAB installed."""

--- a/easybuild/easyconfigs/m/MCR/MCR-R2014a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2014a.eb
@@ -18,11 +18,11 @@ checksums = ['fba9cf6dc896bf613d92b4c1cbdb50708b1bef8514bf52a5ad14527c38824a15']
 # Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
 # https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
 # postinstallcmds = [
-#    'mv "%(installdir)s/v83/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v83/sys/os/glnxa64/libstdc++.so.6-backup"',
-#    'mv "%(installdir)s/v83/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v83/bin/glnxa64/libQt5Core.so.5-backup"',
-#    'mv "%(installdir)s/v83/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v83/bin/glnxa64/libQt5Network.so.5-backup"',
-#    'mv "%(installdir)s/v83/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v83/bin/glnxa64/libQt5Xml.so.5-backup"',
-#    'mv "%(installdir)s/v83/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v83/bin/glnxa64/libQt5Gui.so.5-backup"',
-#]
+#     'mv "%(installdir)s/v83/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v83/sys/os/glnxa64/libstdc++.so.6-orig"',
+#     'mv "%(installdir)s/v83/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v83/bin/glnxa64/libQt5Core.so.5-orig"',
+#     'mv "%(installdir)s/v83/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v83/bin/glnxa64/libQt5Network.so.5-orig"',
+#     'mv "%(installdir)s/v83/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v83/bin/glnxa64/libQt5Xml.so.5-orig"',
+#     'mv "%(installdir)s/v83/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v83/bin/glnxa64/libQt5Gui.so.5-orig"',
+# ]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2014b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2014b.eb
@@ -1,7 +1,7 @@
 name = 'MCR'
 version = 'R2014b'  # runtime version 8.4
 
-homepage = 'http://www.mathworks.com/products/compiler/mcr/'
+homepage = 'https://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
  that enables the execution of compiled MATLAB applications
  or components on computers that do not have MATLAB installed."""

--- a/easybuild/easyconfigs/m/MCR/MCR-R2014b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2014b.eb
@@ -1,5 +1,5 @@
 name = 'MCR'
-version = 'R2014b'
+version = 'R2014b'  # runtime version 8.4
 
 homepage = 'http://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
@@ -9,10 +9,20 @@ description = """The MATLAB Runtime is a standalone set of shared libraries
 toolchain = SYSTEM
 
 source_urls = [
-    'http://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
+    'https://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
 ]
 sources = ['%(name)s_%(version)s_glnxa64_installer.zip']
+checksums = ['361bb4153fd89ff6566fcf0e822e77633bcbfda9826e6b6bbb9ca3ac8bc64d1c']
 
-dependencies = [('Java', '1.8.0_121')]
+#
+# Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
+# https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
+# postinstallcmds = [
+#    'mv "%(installdir)s/v84/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v84/sys/os/glnxa64/libstdc++.so.6-backup"',
+#    'mv "%(installdir)s/v84/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v84/bin/glnxa64/libQt5Core.so.5-backup"',
+#    'mv "%(installdir)s/v84/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v84/bin/glnxa64/libQt5Network.so.5-backup"',
+#    'mv "%(installdir)s/v84/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v84/bin/glnxa64/libQt5Xml.so.5-backup"',
+#    'mv "%(installdir)s/v84/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v84/bin/glnxa64/libQt5Gui.so.5-backup"',
+#]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2014b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2014b.eb
@@ -18,11 +18,11 @@ checksums = ['361bb4153fd89ff6566fcf0e822e77633bcbfda9826e6b6bbb9ca3ac8bc64d1c']
 # Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
 # https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
 # postinstallcmds = [
-#    'mv "%(installdir)s/v84/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v84/sys/os/glnxa64/libstdc++.so.6-backup"',
-#    'mv "%(installdir)s/v84/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v84/bin/glnxa64/libQt5Core.so.5-backup"',
-#    'mv "%(installdir)s/v84/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v84/bin/glnxa64/libQt5Network.so.5-backup"',
-#    'mv "%(installdir)s/v84/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v84/bin/glnxa64/libQt5Xml.so.5-backup"',
-#    'mv "%(installdir)s/v84/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v84/bin/glnxa64/libQt5Gui.so.5-backup"',
-#]
+#     'mv "%(installdir)s/v84/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v84/sys/os/glnxa64/libstdc++.so.6-orig"',
+#     'mv "%(installdir)s/v84/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v84/bin/glnxa64/libQt5Core.so.5-orig"',
+#     'mv "%(installdir)s/v84/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v84/bin/glnxa64/libQt5Network.so.5-orig"',
+#     'mv "%(installdir)s/v84/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v84/bin/glnxa64/libQt5Xml.so.5-orig"',
+#     'mv "%(installdir)s/v84/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v84/bin/glnxa64/libQt5Gui.so.5-orig"',
+# ]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2015a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2015a.eb
@@ -18,11 +18,11 @@ checksums = ['f7e2157db1c4c5b9f937c1186a35b425fef034c5eb9634b9ebba1588fc7934ed']
 # Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
 # https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
 # postinstallcmds = [
-#    'mv "%(installdir)s/v85/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v85/sys/os/glnxa64/libstdc++.so.6-backup"',
-#    'mv "%(installdir)s/v85/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v85/bin/glnxa64/libQt5Core.so.5-backup"',
-#    'mv "%(installdir)s/v85/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v85/bin/glnxa64/libQt5Network.so.5-backup"',
-#    'mv "%(installdir)s/v85/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v85/bin/glnxa64/libQt5Xml.so.5-backup"',
-#    'mv "%(installdir)s/v85/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v85/bin/glnxa64/libQt5Gui.so.5-backup"',
-#]
+#     'mv "%(installdir)s/v85/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v85/sys/os/glnxa64/libstdc++.so.6-orig"',
+#     'mv "%(installdir)s/v85/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v85/bin/glnxa64/libQt5Core.so.5-orig"',
+#     'mv "%(installdir)s/v85/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v85/bin/glnxa64/libQt5Network.so.5-orig"',
+#     'mv "%(installdir)s/v85/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v85/bin/glnxa64/libQt5Xml.so.5-orig"',
+#     'mv "%(installdir)s/v85/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v85/bin/glnxa64/libQt5Gui.so.5-orig"',
+# ]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2015a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2015a.eb
@@ -1,5 +1,5 @@
 name = 'MCR'
-version = 'R2015a'
+version = 'R2015a'  # runtime version 8.5
 
 homepage = 'http://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
@@ -9,10 +9,20 @@ description = """The MATLAB Runtime is a standalone set of shared libraries
 toolchain = SYSTEM
 
 source_urls = [
-    'http://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
+    'https://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
 ]
 sources = ['%(name)s_%(version)s_glnxa64_installer.zip']
+checksums = ['f7e2157db1c4c5b9f937c1186a35b425fef034c5eb9634b9ebba1588fc7934ed']
 
-dependencies = [('Java', '1.8.0_31')]
+#
+# Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
+# https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
+# postinstallcmds = [
+#    'mv "%(installdir)s/v85/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v85/sys/os/glnxa64/libstdc++.so.6-backup"',
+#    'mv "%(installdir)s/v85/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v85/bin/glnxa64/libQt5Core.so.5-backup"',
+#    'mv "%(installdir)s/v85/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v85/bin/glnxa64/libQt5Network.so.5-backup"',
+#    'mv "%(installdir)s/v85/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v85/bin/glnxa64/libQt5Xml.so.5-backup"',
+#    'mv "%(installdir)s/v85/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v85/bin/glnxa64/libQt5Gui.so.5-backup"',
+#]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2015a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2015a.eb
@@ -1,7 +1,7 @@
 name = 'MCR'
 version = 'R2015a'  # runtime version 8.5
 
-homepage = 'http://www.mathworks.com/products/compiler/mcr/'
+homepage = 'https://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
  that enables the execution of compiled MATLAB applications
  or components on computers that do not have MATLAB installed."""

--- a/easybuild/easyconfigs/m/MCR/MCR-R2015b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2015b.eb
@@ -18,11 +18,11 @@ checksums = ['9f04fc7b16d4aae00bac74397cb692d9ced4c036cb5d248bf3b5397ff5471e71']
 # Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
 # https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
 # postinstallcmds = [
-#    'mv "%(installdir)s/v90/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v90/sys/os/glnxa64/libstdc++.so.6-backup"',
-#    'mv "%(installdir)s/v90/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v90/bin/glnxa64/libQt5Core.so.5-backup"',
-#    'mv "%(installdir)s/v90/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v90/bin/glnxa64/libQt5Network.so.5-backup"',
-#    'mv "%(installdir)s/v90/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v90/bin/glnxa64/libQt5Xml.so.5-backup"',
-#    'mv "%(installdir)s/v90/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v90/bin/glnxa64/libQt5Gui.so.5-backup"',
-#]
+#     'mv "%(installdir)s/v90/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v90/sys/os/glnxa64/libstdc++.so.6-orig"',
+#     'mv "%(installdir)s/v90/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v90/bin/glnxa64/libQt5Core.so.5-orig"',
+#     'mv "%(installdir)s/v90/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v90/bin/glnxa64/libQt5Network.so.5-orig"',
+#     'mv "%(installdir)s/v90/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v90/bin/glnxa64/libQt5Xml.so.5-orig"',
+#     'mv "%(installdir)s/v90/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v90/bin/glnxa64/libQt5Gui.so.5-orig"',
+# ]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2015b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2015b.eb
@@ -1,5 +1,5 @@
 name = 'MCR'
-version = 'R2015b'
+version = 'R2015b'  # runtime version 9.0
 
 homepage = 'http://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
@@ -9,10 +9,20 @@ description = """The MATLAB Runtime is a standalone set of shared libraries
 toolchain = SYSTEM
 
 source_urls = [
-    'http://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
+    'https://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
 ]
 sources = ['%(name)s_%(version)s_glnxa64_installer.zip']
+checksums = ['9f04fc7b16d4aae00bac74397cb692d9ced4c036cb5d248bf3b5397ff5471e71']
 
-dependencies = [('Java', '1.8.0_121')]
+#
+# Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
+# https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
+# postinstallcmds = [
+#    'mv "%(installdir)s/v90/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v90/sys/os/glnxa64/libstdc++.so.6-backup"',
+#    'mv "%(installdir)s/v90/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v90/bin/glnxa64/libQt5Core.so.5-backup"',
+#    'mv "%(installdir)s/v90/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v90/bin/glnxa64/libQt5Network.so.5-backup"',
+#    'mv "%(installdir)s/v90/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v90/bin/glnxa64/libQt5Xml.so.5-backup"',
+#    'mv "%(installdir)s/v90/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v90/bin/glnxa64/libQt5Gui.so.5-backup"',
+#]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2015b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2015b.eb
@@ -1,7 +1,7 @@
 name = 'MCR'
 version = 'R2015b'  # runtime version 9.0
 
-homepage = 'http://www.mathworks.com/products/compiler/mcr/'
+homepage = 'https://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
  that enables the execution of compiled MATLAB applications
  or components on computers that do not have MATLAB installed."""

--- a/easybuild/easyconfigs/m/MCR/MCR-R2016a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2016a.eb
@@ -1,5 +1,5 @@
 name = 'MCR'
-version = 'R2016a'
+version = 'R2016a'  # runtime version 9.0.1
 
 homepage = 'http://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
@@ -9,10 +9,20 @@ description = """The MATLAB Runtime is a standalone set of shared libraries
 toolchain = SYSTEM
 
 source_urls = [
-    'http://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
+    'https://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
 ]
 sources = ['%(name)s_%(version)s_glnxa64_installer.zip']
+checksums = ['30773867eb7bbe08ebbacce9129affdb4ab284f1cfb31fc235ee9354d683833f']
 
-dependencies = [('Java', '1.8.0_92')]
+#
+# Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
+# https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
+# postinstallcmds = [
+#    'mv "%(installdir)s/v901/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v901/sys/os/glnxa64/libstdc++.so.6-backup"',
+#    'mv "%(installdir)s/v901/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v901/bin/glnxa64/libQt5Core.so.5-backup"',
+#    'mv "%(installdir)s/v901/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v901/bin/glnxa64/libQt5Network.so.5-backup"',
+#    'mv "%(installdir)s/v901/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v901/bin/glnxa64/libQt5Xml.so.5-backup"',
+#    'mv "%(installdir)s/v901/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v901/bin/glnxa64/libQt5Gui.so.5-backup"',
+#]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2016a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2016a.eb
@@ -18,11 +18,11 @@ checksums = ['30773867eb7bbe08ebbacce9129affdb4ab284f1cfb31fc235ee9354d683833f']
 # Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
 # https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
 # postinstallcmds = [
-#    'mv "%(installdir)s/v901/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v901/sys/os/glnxa64/libstdc++.so.6-backup"',
-#    'mv "%(installdir)s/v901/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v901/bin/glnxa64/libQt5Core.so.5-backup"',
-#    'mv "%(installdir)s/v901/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v901/bin/glnxa64/libQt5Network.so.5-backup"',
-#    'mv "%(installdir)s/v901/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v901/bin/glnxa64/libQt5Xml.so.5-backup"',
-#    'mv "%(installdir)s/v901/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v901/bin/glnxa64/libQt5Gui.so.5-backup"',
-#]
+#     'mv "%(installdir)s/v91/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v91/sys/os/glnxa64/libstdc++.so.6-orig"',
+#     'mv "%(installdir)s/v91/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Core.so.5-orig"',
+#     'mv "%(installdir)s/v91/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Network.so.5-orig"',
+#     'mv "%(installdir)s/v91/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Xml.so.5-orig"',
+#     'mv "%(installdir)s/v91/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Gui.so.5-orig"',
+# ]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2016a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2016a.eb
@@ -1,7 +1,7 @@
 name = 'MCR'
 version = 'R2016a'  # runtime version 9.0.1
 
-homepage = 'http://www.mathworks.com/products/compiler/mcr/'
+homepage = 'https://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
  that enables the execution of compiled MATLAB applications
  or components on computers that do not have MATLAB installed."""

--- a/easybuild/easyconfigs/m/MCR/MCR-R2016b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2016b.eb
@@ -18,11 +18,11 @@ checksums = ['2020099b1310072aced9a6c30b0eee73aace57f296b71a18b3408217a525b4e4']
 # Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
 # https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
 # postinstallcmds = [
-#    'mv "%(installdir)s/v91/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v91/sys/os/glnxa64/libstdc++.so.6-backup"',
-#    'mv "%(installdir)s/v91/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Core.so.5-backup"',
-#    'mv "%(installdir)s/v91/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Network.so.5-backup"',
-#    'mv "%(installdir)s/v91/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Xml.so.5-backup"',
-#    'mv "%(installdir)s/v91/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Gui.so.5-backup"',
-#]
+#     'mv "%(installdir)s/v91/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v91/sys/os/glnxa64/libstdc++.so.6-orig"',
+#     'mv "%(installdir)s/v91/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Core.so.5-orig"',
+#     'mv "%(installdir)s/v91/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Network.so.5-orig"',
+#     'mv "%(installdir)s/v91/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Xml.so.5-orig"',
+#     'mv "%(installdir)s/v91/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Gui.so.5-orig"',
+# ]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2016b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2016b.eb
@@ -1,7 +1,7 @@
 name = 'MCR'
-version = 'R2016b'
+version = 'R2016b'  # runtime version 9.1
 
-homepage = 'http://www.mathworks.com/products/compiler/mcr/'
+homepage = 'https://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
  that enables the execution of compiled MATLAB applications
  or components on computers that do not have MATLAB installed."""
@@ -9,10 +9,20 @@ description = """The MATLAB Runtime is a standalone set of shared libraries
 toolchain = SYSTEM
 
 source_urls = [
-    'http://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
+    'https://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
 ]
 sources = ['%(name)s_%(version)s_glnxa64_installer.zip']
+checksums = ['2020099b1310072aced9a6c30b0eee73aace57f296b71a18b3408217a525b4e4']
 
-dependencies = [('Java', '1.8.0_121')]
+#
+# Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
+# https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
+# postinstallcmds = [
+#    'mv "%(installdir)s/v91/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v91/sys/os/glnxa64/libstdc++.so.6-backup"',
+#    'mv "%(installdir)s/v91/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Core.so.5-backup"',
+#    'mv "%(installdir)s/v91/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Network.so.5-backup"',
+#    'mv "%(installdir)s/v91/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Xml.so.5-backup"',
+#    'mv "%(installdir)s/v91/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v91/bin/glnxa64/libQt5Gui.so.5-backup"',
+#]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2017b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2017b.eb
@@ -1,0 +1,28 @@
+name = 'MCR'
+version = 'R2017b'  # runtime version 9.3
+
+homepage = 'https://www.mathworks.com/products/compiler/mcr/'
+description = """The MATLAB Runtime is a standalone set of shared libraries
+ that enables the execution of compiled MATLAB applications
+ or components on computers that do not have MATLAB installed."""
+
+toolchain = SYSTEM
+
+source_urls = [
+    'https://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
+]
+sources = ['%(name)s_%(version)s_glnxa64_installer.zip']
+checksums = ['a01619b30f8cfd34a9a9cefe8323a2ada22a65722fc13b823dae36086ddd259f']
+
+#
+# Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
+# https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
+# postinstallcmds = [
+#    'mv "%(installdir)s/v93/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v93/sys/os/glnxa64/libstdc++.so.6-backup"',
+#    'mv "%(installdir)s/v93/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v93/bin/glnxa64/libQt5Core.so.5-backup"',
+#    'mv "%(installdir)s/v93/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v93/bin/glnxa64/libQt5Network.so.5-backup"',
+#    'mv "%(installdir)s/v93/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v93/bin/glnxa64/libQt5Xml.so.5-backup"',
+#    'mv "%(installdir)s/v93/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v93/bin/glnxa64/libQt5Gui.so.5-backup"',
+#]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2017b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2017b.eb
@@ -18,11 +18,11 @@ checksums = ['a01619b30f8cfd34a9a9cefe8323a2ada22a65722fc13b823dae36086ddd259f']
 # Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
 # https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
 # postinstallcmds = [
-#    'mv "%(installdir)s/v93/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v93/sys/os/glnxa64/libstdc++.so.6-backup"',
-#    'mv "%(installdir)s/v93/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v93/bin/glnxa64/libQt5Core.so.5-backup"',
-#    'mv "%(installdir)s/v93/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v93/bin/glnxa64/libQt5Network.so.5-backup"',
-#    'mv "%(installdir)s/v93/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v93/bin/glnxa64/libQt5Xml.so.5-backup"',
-#    'mv "%(installdir)s/v93/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v93/bin/glnxa64/libQt5Gui.so.5-backup"',
-#]
+#     'mv "%(installdir)s/v93/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v93/sys/os/glnxa64/libstdc++.so.6-orig"',
+#     'mv "%(installdir)s/v93/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v93/bin/glnxa64/libQt5Core.so.5-orig"',
+#     'mv "%(installdir)s/v93/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v93/bin/glnxa64/libQt5Network.so.5-orig"',
+#     'mv "%(installdir)s/v93/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v93/bin/glnxa64/libQt5Xml.so.5-orig"',
+#     'mv "%(installdir)s/v93/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v93/bin/glnxa64/libQt5Gui.so.5-orig"',
+# ]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2018a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2018a.eb
@@ -1,7 +1,7 @@
 name = 'MCR'
 version = 'R2018a'  # runtime version 9.4
 
-homepage = 'http://www.mathworks.com/products/compiler/mcr/'
+homepage = 'https://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
  that enables the execution of compiled MATLAB applications
  or components on computers that do not have MATLAB installed."""

--- a/easybuild/easyconfigs/m/MCR/MCR-R2018a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2018a.eb
@@ -1,5 +1,5 @@
 name = 'MCR'
-version = 'R2018a'
+version = 'R2018a'  # runtime version 9.4
 
 homepage = 'http://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
@@ -9,11 +9,20 @@ description = """The MATLAB Runtime is a standalone set of shared libraries
 toolchain = SYSTEM
 
 source_urls = [
-    'http://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
+    'https://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
 ]
 sources = ['%(name)s_%(version)s_glnxa64_installer.zip']
 checksums = ['09bb40cd40f8f5a6ef4bb658186f67b3dc0b983d708ee27c35da65b1cf29460d']
 
-dependencies = [('Java', '1.8')]
+#
+# Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
+# https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
+# postinstallcmds = [
+#    'mv "%(installdir)s/v94/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v94/sys/os/glnxa64/libstdc++.so.6-backup"',
+#    'mv "%(installdir)s/v94/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v94/bin/glnxa64/libQt5Core.so.5-backup"',
+#    'mv "%(installdir)s/v94/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v94/bin/glnxa64/libQt5Network.so.5-backup"',
+#    'mv "%(installdir)s/v94/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v94/bin/glnxa64/libQt5Xml.so.5-backup"',
+#    'mv "%(installdir)s/v94/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v94/bin/glnxa64/libQt5Gui.so.5-backup"',
+#]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2018a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2018a.eb
@@ -18,11 +18,11 @@ checksums = ['09bb40cd40f8f5a6ef4bb658186f67b3dc0b983d708ee27c35da65b1cf29460d']
 # Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
 # https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
 # postinstallcmds = [
-#    'mv "%(installdir)s/v94/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v94/sys/os/glnxa64/libstdc++.so.6-backup"',
-#    'mv "%(installdir)s/v94/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v94/bin/glnxa64/libQt5Core.so.5-backup"',
-#    'mv "%(installdir)s/v94/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v94/bin/glnxa64/libQt5Network.so.5-backup"',
-#    'mv "%(installdir)s/v94/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v94/bin/glnxa64/libQt5Xml.so.5-backup"',
-#    'mv "%(installdir)s/v94/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v94/bin/glnxa64/libQt5Gui.so.5-backup"',
-#]
+#     'mv "%(installdir)s/v94/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v94/sys/os/glnxa64/libstdc++.so.6-orig"',
+#     'mv "%(installdir)s/v94/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v94/bin/glnxa64/libQt5Core.so.5-orig"',
+#     'mv "%(installdir)s/v94/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v94/bin/glnxa64/libQt5Network.so.5-orig"',
+#     'mv "%(installdir)s/v94/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v94/bin/glnxa64/libQt5Xml.so.5-orig"',
+#     'mv "%(installdir)s/v94/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v94/bin/glnxa64/libQt5Gui.so.5-orig"',
+# ]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2018b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2018b.eb
@@ -1,5 +1,5 @@
 name = 'MCR'
-version = 'R2018b'
+version = 'R2018b'  # runtime version 9.5
 
 homepage = 'http://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
@@ -9,11 +9,20 @@ description = """The MATLAB Runtime is a standalone set of shared libraries
 toolchain = SYSTEM
 
 source_urls = [
-    'http://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
+    'https://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
 ]
 sources = ['%(name)s_%(version)s_glnxa64_installer.zip']
 checksums = ['cc7f6e042c1b2edd5ae384c77d0b2c860e8dcfd7c5e23dbe07bf04d3a921e459']
 
-dependencies = [('Java', '1.8')]
+#
+# Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
+# https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
+# postinstallcmds = [
+#    'mv "%(installdir)s/v95/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v95/sys/os/glnxa64/libstdc++.so.6-backup"',
+#    'mv "%(installdir)s/v95/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v95/bin/glnxa64/libQt5Core.so.5-backup"',
+#    'mv "%(installdir)s/v95/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v95/bin/glnxa64/libQt5Network.so.5-backup"',
+#    'mv "%(installdir)s/v95/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v95/bin/glnxa64/libQt5Xml.so.5-backup"',
+#    'mv "%(installdir)s/v95/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v95/bin/glnxa64/libQt5Gui.so.5-backup"',
+#]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2018b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2018b.eb
@@ -1,7 +1,7 @@
 name = 'MCR'
 version = 'R2018b'  # runtime version 9.5
 
-homepage = 'http://www.mathworks.com/products/compiler/mcr/'
+homepage = 'https://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
  that enables the execution of compiled MATLAB applications
  or components on computers that do not have MATLAB installed."""

--- a/easybuild/easyconfigs/m/MCR/MCR-R2018b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2018b.eb
@@ -18,11 +18,11 @@ checksums = ['cc7f6e042c1b2edd5ae384c77d0b2c860e8dcfd7c5e23dbe07bf04d3a921e459']
 # Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
 # https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
 # postinstallcmds = [
-#    'mv "%(installdir)s/v95/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v95/sys/os/glnxa64/libstdc++.so.6-backup"',
-#    'mv "%(installdir)s/v95/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v95/bin/glnxa64/libQt5Core.so.5-backup"',
-#    'mv "%(installdir)s/v95/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v95/bin/glnxa64/libQt5Network.so.5-backup"',
-#    'mv "%(installdir)s/v95/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v95/bin/glnxa64/libQt5Xml.so.5-backup"',
-#    'mv "%(installdir)s/v95/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v95/bin/glnxa64/libQt5Gui.so.5-backup"',
-#]
+#     'mv "%(installdir)s/v95/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v95/sys/os/glnxa64/libstdc++.so.6-orig"',
+#     'mv "%(installdir)s/v95/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v95/bin/glnxa64/libQt5Core.so.5-orig"',
+#     'mv "%(installdir)s/v95/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v95/bin/glnxa64/libQt5Network.so.5-orig"',
+#     'mv "%(installdir)s/v95/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v95/bin/glnxa64/libQt5Xml.so.5-orig"',
+#     'mv "%(installdir)s/v95/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v95/bin/glnxa64/libQt5Gui.so.5-orig"',
+# ]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2019a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2019a.eb
@@ -1,7 +1,7 @@
 name = 'MCR'
 version = 'R2019a'  # runtime version 9.6
 
-homepage = 'http://www.mathworks.com/products/compiler/mcr/'
+homepage = 'https://www.mathworks.com/products/compiler/mcr/'
 description = """The MATLAB Runtime is a standalone set of shared libraries
  that enables the execution of compiled MATLAB applications
  or components on computers that do not have MATLAB installed."""

--- a/easybuild/easyconfigs/m/MCR/MCR-R2019a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2019a.eb
@@ -8,9 +8,20 @@ description = """The MATLAB Runtime is a standalone set of shared libraries
 
 toolchain = SYSTEM
 
-source_urls = ['http://ssd.mathworks.com/supportfiles/downloads/%(version)s/Release/1/deployment_files/installer/'
+source_urls = ['https://ssd.mathworks.com/supportfiles/downloads/%(version)s/Release/1/deployment_files/installer/'
                'complete/glnxa64/']
 sources = ['MATLAB_Runtime_%(version)s_Update_1_glnxa64.zip']
 checksums = ['2408fc2ad3dc1376be9655596c46f13d400e680a2da916f47a142027bb4e4acd']
+
+#
+# Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
+# https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
+# postinstallcmds = [
+#    'mv "%(installdir)s/v96/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v96/sys/os/glnxa64/libstdc++.so.6-backup"',
+#    'mv "%(installdir)s/v96/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v96/bin/glnxa64/libQt5Core.so.5-backup"',
+#    'mv "%(installdir)s/v96/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v96/bin/glnxa64/libQt5Network.so.5-backup"',
+#    'mv "%(installdir)s/v96/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v96/bin/glnxa64/libQt5Xml.so.5-backup"',
+#    'mv "%(installdir)s/v96/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v96/bin/glnxa64/libQt5Gui.so.5-backup"',
+#]
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2019a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2019a.eb
@@ -17,11 +17,11 @@ checksums = ['2408fc2ad3dc1376be9655596c46f13d400e680a2da916f47a142027bb4e4acd']
 # Depending on your environment: Disable MCR's stock libstdc++.so.6 and Qt5 libraries
 # https://www.mathworks.com/matlabcentral/answers/329796-issue-with-libstdc-so-6
 # postinstallcmds = [
-#    'mv "%(installdir)s/v96/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v96/sys/os/glnxa64/libstdc++.so.6-backup"',
-#    'mv "%(installdir)s/v96/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v96/bin/glnxa64/libQt5Core.so.5-backup"',
-#    'mv "%(installdir)s/v96/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v96/bin/glnxa64/libQt5Network.so.5-backup"',
-#    'mv "%(installdir)s/v96/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v96/bin/glnxa64/libQt5Xml.so.5-backup"',
-#    'mv "%(installdir)s/v96/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v96/bin/glnxa64/libQt5Gui.so.5-backup"',
-#]
+#     'mv "%(installdir)s/v96/sys/os/glnxa64/libstdc++.so.6" "%(installdir)s/v96/sys/os/glnxa64/libstdc++.so.6-orig"',
+#     'mv "%(installdir)s/v96/bin/glnxa64/libQt5Core.so.5" "%(installdir)s/v96/bin/glnxa64/libQt5Core.so.5-orig"',
+#     'mv "%(installdir)s/v96/bin/glnxa64/libQt5Network.so.5" "%(installdir)s/v96/bin/glnxa64/libQt5Network.so.5-orig"',
+#     'mv "%(installdir)s/v96/bin/glnxa64/libQt5Xml.so.5" "%(installdir)s/v96/bin/glnxa64/libQt5Xml.so.5-orig"',
+#     'mv "%(installdir)s/v96/bin/glnxa64/libQt5Gui.so.5" "%(installdir)s/v96/bin/glnxa64/libQt5Gui.so.5-orig"',
+# ]
 
 moduleclass = 'math'


### PR DESCRIPTION
This PR
- Adds MCR-R2017b

and, for all `MCR-*.eb`:
- Add checksums for all MCR sources
- Add option to remove libraries, which could conflict with system libraries
- Remove Java dependencies (see https://de.mathworks.com/matlabcentral/answers/102180-which-java-virtual-machine-is-used-by-an-application-compiled-using-the-matlab-compiler-4-3-r14sp3. It should then use MCR's JVM, but I cannot double check without `mcc`.)