### PR TITLE
fix pyfits easyconfig by adding missing d2to1 extension

### DIFF
--- a/easybuild/easyconfigs/p/pyfits/pyfits-3.5-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/p/pyfits/pyfits-3.5-intel-2018b-Python-2.7.15.eb
@@ -1,4 +1,4 @@
-easyblock = 'PythonPackage'
+easyblock = 'PythonBundle'
 
 name = 'pyfits'
 version = '3.5'
@@ -9,21 +9,28 @@ description = """The PyFITS module is a Python library providing access to FITS 
 
 toolchain = {'name': 'intel', 'version': '2018b'}
 
-source_urls = [PYPI_SOURCE]
-sources = [SOURCE_TAR_GZ]
-
-checksums = ['4e668622d5a3c140590bc6cf8222afcd4d133dde3d6beda3b9c3c9539c5acf18']
-
 dependencies = [
     ('Python', '2.7.15')
 ]
 
-download_dep_fail = True
 use_pip = True
+
+exts_default_options = {'source_urls': [PYPI_SOURCE]}
+
+exts_list = [
+    ('d2to1', '0.2.12.post1', {
+        'checksums': ['49ef2d16862b3efdc81fc5c32eac373b984945cde5fc02bb01a0a11ff03dd825'],
+    }),
+    (name, version, {
+        'checksums': ['4e668622d5a3c140590bc6cf8222afcd4d133dde3d6beda3b9c3c9539c5acf18'],
+    }),
+]
 
 sanity_check_paths = {
     'files': ['bin/fitscheck', 'bin/fitsdiff', 'bin/fitshead'],
     'dirs': ['lib/python%(pyshortver)s/site-packages']
 }
+
+sanity_pip_check = True
 
 moduleclass = 'astro'


### PR DESCRIPTION
fix for `pyfits` that was added in #7273...

It fails now due to a detected auto-downloaded extension `d2to1`, which was probably masked before because `d2to1` was available elsewhere (see also https://github.com/easybuilders/easybuild-easyblocks/pull/1891)