### PR TITLE
use Github to download releases for MariaDB-connector-c

### DIFF
--- a/easybuild/easyconfigs/m/MariaDB-connector-c/MariaDB-connector-c-2.3.4-intel-2017b.eb
+++ b/easybuild/easyconfigs/m/MariaDB-connector-c/MariaDB-connector-c-2.3.4-intel-2017b.eb
@@ -8,9 +8,9 @@ description = "MariaDB Connector/C is used to connect applications developed in 
 
 toolchain = {'name': 'intel', 'version': '2017b'}
 
-source_urls = ['https://downloads.mariadb.org/f/connector-c-%(version)s']
-sources = ['mariadb-connector-c-%(version)s-src.tar.gz']
-checksums = ['8beb0513da8a24ed2cb47836564c8b57045c3b36f933362f74b3676567c13abc']
+source_urls = ['https://github.com/MariaDB/mariadb-connector-c/archive/']
+sources = ['v_%(version)s.tar.gz']
+checksums = ['0e7e65814a859f9f2120f17155b4eaa7bb7c3a368f63dfb924706ef5b324c552']
 
 builddependencies = [('CMake', '3.10.1')]
 

--- a/easybuild/easyconfigs/m/MariaDB-connector-c/MariaDB-connector-c-2.3.5-intel-2018a.eb
+++ b/easybuild/easyconfigs/m/MariaDB-connector-c/MariaDB-connector-c-2.3.5-intel-2018a.eb
@@ -8,9 +8,9 @@ description = "MariaDB Connector/C is used to connect applications developed in 
 
 toolchain = {'name': 'intel', 'version': '2018a'}
 
-source_urls = ['https://downloads.mariadb.org/f/connector-c-%(version)s']
-sources = ['mariadb-connector-c-%(version)s-src.tar.gz']
-checksums = ['2f3bf4c326d74284debf7099f30cf3615f7978d1ec22b8c1083676688a76746f']
+source_urls = ['https://github.com/MariaDB/mariadb-connector-c/archive/']
+sources = ['v_%(version)s.tar.gz']
+checksums = ['c075d9de2e19d826dc1d3ee015c05d77974174de31f1299625ce1659cb39edb5']
 
 builddependencies = [('CMake', '3.10.2')]
 

--- a/easybuild/easyconfigs/m/MariaDB-connector-c/MariaDB-connector-c-2.3.5-iomkl-2018a.eb
+++ b/easybuild/easyconfigs/m/MariaDB-connector-c/MariaDB-connector-c-2.3.5-iomkl-2018a.eb
@@ -8,9 +8,9 @@ description = "MariaDB Connector/C is used to connect applications developed in 
 
 toolchain = {'name': 'iomkl', 'version': '2018a'}
 
-source_urls = ['https://downloads.mariadb.org/f/connector-c-%(version)s']
-sources = ['mariadb-connector-c-%(version)s-src.tar.gz']
-checksums = ['2f3bf4c326d74284debf7099f30cf3615f7978d1ec22b8c1083676688a76746f']
+source_urls = ['https://github.com/MariaDB/mariadb-connector-c/archive/']
+sources = ['v_%(version)s.tar.gz']
+checksums = ['c075d9de2e19d826dc1d3ee015c05d77974174de31f1299625ce1659cb39edb5']
 
 builddependencies = [('CMake', '3.10.2')]
 

--- a/easybuild/easyconfigs/m/MariaDB-connector-c/MariaDB-connector-c-2.3.7-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/m/MariaDB-connector-c/MariaDB-connector-c-2.3.7-GCCcore-8.2.0.eb
@@ -8,9 +8,9 @@ description = "MariaDB Connector/C is used to connect applications developed in 
 
 toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 
-source_urls = ['https://downloads.mariadb.org/f/connector-c-%(version)s']
-sources = ['mariadb-connector-c-%(version)s-src.tar.gz']
-checksums = ['94f9582da738809ae1d9f1813185165ec7c8caf9195bdd04e511f6bdcb883f8e']
+source_urls = ['https://github.com/MariaDB/mariadb-connector-c/archive/']
+sources = ['v_%(version)s.tar.gz']
+checksums = ['4c83b75c14dc82e043bf7b2120cae87266e3e12c490f2c9aac22b7481bd4d59f']
 
 builddependencies = [
     ('binutils', '2.31.1'),

--- a/easybuild/easyconfigs/m/MariaDB-connector-c/MariaDB-connector-c-2.3.7-foss-2018b.eb
+++ b/easybuild/easyconfigs/m/MariaDB-connector-c/MariaDB-connector-c-2.3.7-foss-2018b.eb
@@ -8,9 +8,9 @@ description = "MariaDB Connector/C is used to connect applications developed in 
 
 toolchain = {'name': 'foss', 'version': '2018b'}
 
-source_urls = ['https://downloads.mariadb.org/f/connector-c-%(version)s']
-sources = ['mariadb-connector-c-%(version)s-src.tar.gz']
-checksums = ['94f9582da738809ae1d9f1813185165ec7c8caf9195bdd04e511f6bdcb883f8e']
+source_urls = ['https://github.com/MariaDB/mariadb-connector-c/archive/']
+sources = ['v_%(version)s.tar.gz']
+checksums = ['4c83b75c14dc82e043bf7b2120cae87266e3e12c490f2c9aac22b7481bd4d59f']
 
 builddependencies = [('CMake', '3.11.4')]
 


### PR DESCRIPTION
The Download links are no longer working, they use a mirror now. The Github links are more reliable hence I replaced them. I verified that there is no diff in the extracted sources, only the folder name has changed hence the new checksum. No conflict with old files though as the filename changed too