### PR TITLE
[MathGL] Don't use MPI cxx during build

### DIFF
--- a/easybuild/easyconfigs/m/MathGL/MathGL-2.4.1-foss-2018a.eb
+++ b/easybuild/easyconfigs/m/MathGL/MathGL-2.4.1-foss-2018a.eb
@@ -42,6 +42,8 @@ dependencies = [
 
 configopts = '-Denable-double=ON -Denable-openmp=ON -Denable-zlib=ON -Denable-png=ON -Denable-jpeg=ON -Denable-gsl=ON '
 configopts += '-Denable-hdf5=ON -Denable-fltk=ON -Denable-glut=ON -Denable-opengl=ON -Denable-qt5=ON '
+# Disable potentially used mpi-cxx extension causing build failure
+configopts += '-DCMAKE_CXX_FLAGS="$CXXFLAGS -DOMPI_SKIP_MPICXX" '
 
 sanity_check_paths = {
     'files': ['bin/mglconv', 'bin/mgllab', 'bin/mglview', 'bin/udav'] +


### PR DESCRIPTION
Fixes https://github.com/easybuilders/easybuild-easyconfigs/issues/9640