### PR TITLE
{math}[foss/2019b] spatialreg v1.1-5

### DIFF
--- a/easybuild/easyconfigs/s/spatialreg/spatialreg-1.1-5-foss-2019b-R-3.6.2.eb
+++ b/easybuild/easyconfigs/s/spatialreg/spatialreg-1.1-5-foss-2019b-R-3.6.2.eb
@@ -27,8 +27,6 @@ exts_default_options = {
     'source_tmpl': '%(name)s_%(version)s.tar.gz',
 }
 
-
-# Order is important!
 exts_list = [
     ('sf', '0.8-0', {
         'checksums': ['8ee354f70b073bce124f2c138ebd2748936f890a7b4c380075c189cf36c0be15'],

--- a/easybuild/easyconfigs/s/spatialreg/spatialreg-1.1-5-foss-2019b-R-3.6.2.eb
+++ b/easybuild/easyconfigs/s/spatialreg/spatialreg-1.1-5-foss-2019b-R-3.6.2.eb
@@ -1,0 +1,51 @@
+# This easyconfig was created by James Carpenter of the BEAR Software team at the University of Birmingham.
+easyblock = 'Bundle'
+
+name = 'spatialreg'
+version = '1.1-5'
+versionsuffix = '-R-%(rver)s'
+
+homepage = "https://cran.r-project.org/package=%(name)s"
+description = """A collection of all the estimation functions for spatial cross-sectional models (on lattice/areal
+ data using spatial weights matrices) contained up to now in 'spdep', 'sphet' and 'spse'."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+dependencies = [
+    ('R', '3.6.2'),
+    ('GDAL', '3.0.2', '-Python-3.7.4'),
+]
+
+exts_defaultclass = 'RPackage'
+exts_filter = ("R -q --no-save", "library(%(ext_name)s)")
+exts_default_options = {
+    'source_urls': [
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+
+
+# Order is important!
+exts_list = [
+    ('sf', '0.8-0', {
+        'checksums': ['8ee354f70b073bce124f2c138ebd2748936f890a7b4c380075c189cf36c0be15'],
+    }),
+    ('spdep', '1.1-3', {
+        'checksums': ['335bbeac4d27379cf941e58da6f39ee25ba31838d56362c7b2d9308c9d930cb9'],
+    }),
+    (name, version, {
+        'checksums': ['ddbf0773bad2e99b306116ae99a57bf29eecf723d1735820935a6fb7f331b27d'],
+    }),
+]
+
+modextrapaths = {'R_LIBS': ''}
+
+sanity_check_paths = {
+    'files': ['spatialreg/R/spatialreg'],
+    'dirs': [],
+}
+
+moduleclass = 'math'


### PR DESCRIPTION
Requires ~~#9745~~

(created using `eb --new-pr`)
