### PR TITLE
Fix CPPFLAGS includes for build script of libsndfile

### DIFF
--- a/easybuild/easyconfigs/l/libsndfile/libsndfile-1.0.28-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/libsndfile/libsndfile-1.0.28-GCCcore-8.3.0.eb
@@ -13,7 +13,7 @@ source_urls = ['http://www.mega-nerd.com/libsndfile/files/']
 sources = [SOURCE_TAR_GZ]
 checksums = ['1ff33929f042fa333aed1e8923aa628c3ee9e1eb85512686c55092d1e5a9dfa9']
 
-buildopts = ' CPPFLAGS="-I%(installdir)s/include/ $CPPFLAGS" '
+preconfigopts = 'CPPFLAGS="-I%(builddir)s/%(name)s-%(version)s/src/ $CPPFLAGS"'
 
 builddependencies = [('binutils', '2.32')]
 

--- a/easybuild/easyconfigs/l/libsndfile/libsndfile-1.0.28-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/libsndfile/libsndfile-1.0.28-GCCcore-8.3.0.eb
@@ -13,6 +13,8 @@ source_urls = ['http://www.mega-nerd.com/libsndfile/files/']
 sources = [SOURCE_TAR_GZ]
 checksums = ['1ff33929f042fa333aed1e8923aa628c3ee9e1eb85512686c55092d1e5a9dfa9']
 
+buildopts = ' CPPFLAGS="-I%(installdir)s/include/ $CPPFLAGS" '
+
 builddependencies = [('binutils', '2.32')]
 
 sanity_check_paths = {


### PR DESCRIPTION
libsndfile was not building for me with the two following errors occuring:
Making all in M4
make[1]: Entering directory `~/.local/easybuild/build/libsndfile/1.0.28/GCCcore-8.3.0/libsndfile-1.0.28/M4'
make[1]: Nothing to be done for `all'.
make[1]: Leaving directory `~/.local/easybuild/bu (took 28 sec)

sndfile.cc:21:10: fatal error: sndfile.h: No such file or directory
 #include "sndfile.h"

The include path for the sndfile.h needed for the make command in the build step.
Appending the Include for the build directory to the build command solved the issue for me, but please check if this is viable as I'm a beginner with easybuild.