### PR TITLE
{data,devel,lib,math}[GCCcore/8.3.0,foss/2019b] Blosc v1.17.1, LZO v2.10, numexpr v2.7.1, ... w/ Python 3.7.4

### DIFF
--- a/easybuild/easyconfigs/b/Blosc/Blosc-1.17.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/b/Blosc/Blosc-1.17.1-GCCcore-8.3.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'CMakeMake'
+
+name = 'Blosc'
+version = '1.17.1'
+
+homepage = 'https://www.blosc.org/'
+
+description = "Blosc, an extremely fast, multi-threaded, meta-compressor library"
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+toolchainopts = {'pic': True, 'cstd': 'c++11'}
+
+source_urls = ['https://github.com/Blosc/c-blosc/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['19a6948b579c27e8ac440b4f077f99fc90e7292b1d9cb896bec0fd781d68fba2']
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('CMake', '3.15.3'),
+]
+
+sanity_check_paths = {
+    'files': ['include/blosc-export.h', 'include/blosc.h', 'lib/libblosc.a',
+              'lib/libblosc.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/LZO/LZO-2.10-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/LZO/LZO-2.10-GCCcore-8.3.0.eb
@@ -1,0 +1,36 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'LZO'
+version = '2.10'
+
+homepage = 'https://www.oberhumer.com/opensource/lzo/'
+description = "Portable lossless data compression library"
+
+source_urls = [homepage + 'download/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072']
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+toolchainopts = {'pic': True}
+
+builddependencies = [('binutils', '2.32')]
+
+configopts = '--enable-shared'
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['lib/liblzo2.a', 'lib/liblzo2.%s' % SHLIB_EXT],
+    'dirs': ['include']
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/n/numexpr/numexpr-2.7.1-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/n/numexpr/numexpr-2.7.1-foss-2019b-Python-3.7.4.eb
@@ -1,0 +1,22 @@
+name = 'numexpr'
+version = '2.7.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://numexpr.readthedocs.io/en/latest/'
+description = """The numexpr package evaluates multiple-operator array expressions many times faster than NumPy can.
+ It accepts the expression as a string, analyzes it, rewrites it more efficiently, and compiles it on the fly into
+ code for its internal virtual machine (VM). Due to its integrated just-in-time (JIT) compiler, it does not require a
+ compiler at runtime."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+source_urls = ['https://github.com/pydata/numexpr/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['5c6ae3bb5688184b922b43fc47de49d642576d0feec55a1b679caa66efae90a1']
+
+dependencies = [
+    ('Python', '3.7.4'),
+    ('SciPy-bundle', '2019.10', versionsuffix),
+]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/PyTables/PyTables-3.6.1-fix-libs.patch
+++ b/easybuild/easyconfigs/p/PyTables/PyTables-3.6.1-fix-libs.patch
@@ -1,0 +1,15 @@
+# pyTables expects that LIBS is a list of library names and will add
+# a -l by itself.
+# original patch by ward.poelmans@ugent.be, ported to PyTables 3.5.2 by Kenneth Hoste (HPC-UGent)
+--- PyTables-3.5.2/setup.py.orig	2019-08-23 10:35:55.467589283 +0200
++++ PyTables-3.5.2/setup.py	2019-08-23 10:36:39.408195074 +0200
+@@ -478,6 +478,9 @@
+     # is not a good idea.
+     CFLAGS = os.environ.get('CFLAGS', '').split()
+     LIBS = os.environ.get('LIBS', '').split()
++    for idx, lib in enumerate(LIBS):
++        if lib.startswith("-l"):
++            LIBS[idx] = lib.replace("-l", "")
+     CONDA_PREFIX = os.environ.get('CONDA_PREFIX', '')
+     # We start using pkg-config since some distributions are putting HDF5
+     # (and possibly other libraries) in exotic locations.  See issue #442.

--- a/easybuild/easyconfigs/p/PyTables/PyTables-3.6.1-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/PyTables/PyTables-3.6.1-foss-2019b-Python-3.7.4.eb
@@ -34,6 +34,7 @@ dependencies = [
 
 use_pip = True
 download_dep_fail = True
+sanity_pip_check = False
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['pt2to3', 'ptdump', 'ptrepack']],

--- a/easybuild/easyconfigs/p/PyTables/PyTables-3.6.1-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/PyTables/PyTables-3.6.1-foss-2019b-Python-3.7.4.eb
@@ -34,7 +34,7 @@ dependencies = [
 
 use_pip = True
 download_dep_fail = True
-sanity_pip_check = False
+sanity_pip_check = True
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['pt2to3', 'ptdump', 'ptrepack']],

--- a/easybuild/easyconfigs/p/PyTables/PyTables-3.6.1-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/PyTables/PyTables-3.6.1-foss-2019b-Python-3.7.4.eb
@@ -1,0 +1,45 @@
+easyblock = 'PythonPackage'
+
+name = 'PyTables'
+version = '3.6.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://www.pytables.org'
+description = """PyTables is a package for managing hierarchical datasets and designed to efficiently and easily cope
+ with extremely large amounts of data. PyTables is built on top of the HDF5 library, using the Python language and the
+ NumPy package. It features an object-oriented interface that, combined with C extensions for the performance-critical
+ parts of the code (generated using Cython), makes it a fast, yet extremely easy to use tool for interactively browse,
+ process and search very large amounts of data. One important feature of PyTables is that it optimizes memory and disk
+ resources so that data takes much less space (specially if on-flight compression is used) than other solutions such as
+ relational or object oriented databases."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/PyTables/PyTables/archive/']
+sources = ['v%(version)s.tar.gz']
+patches = ['%(name)s-%(version)s-fix-libs.patch']
+checksums = [
+    '4cea86bab5bcb5423a07c7951b8c65e24b674e0dcec0e448d434829eff5f18d0',  # v3.6.1.tar.gz
+    '8df2a6379a9e4a941cb939ed1257a7d6105792d9c5e9dd0abd4bba3ece767c3a',  # PyTables-3.6.1-fix-libs.patch
+]
+
+dependencies = [
+    ('Python', '3.7.4'),
+    ('numexpr', '2.7.1', versionsuffix),
+    ('HDF5', '1.10.5'),
+    ('LZO', '2.10'),
+    ('Blosc', '1.17.1'),
+]
+
+use_pip = True
+download_dep_fail = True
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['pt2to3', 'ptdump', 'ptrepack']],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+options = {'modulename': 'tables'}
+
+moduleclass = 'data'


### PR DESCRIPTION
Required for #9805

(created using `eb --new-pr`)
