### PR TITLE
{bio,compiler,lang}[foss/2019b] scVelo v0.1.24, numba v0.47.0, LLVM v8.0.1 w/ Python 3.7.4

### DIFF
--- a/easybuild/easyconfigs/l/LLVM/LLVM-8.0.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-8.0.1-GCCcore-8.3.0.eb
@@ -1,0 +1,45 @@
+easyblock = 'CMakeMake'
+
+name = 'LLVM'
+version = '8.0.1'
+
+homepage = "https://llvm.org/"
+description = """The LLVM Core libraries provide a modern source- and target-independent
+ optimizer, along with code generation support for many popular CPUs
+ (as well as some less common ones!) These libraries are built around a well
+ specified code representation known as the LLVM intermediate representation
+ ("LLVM IR"). The LLVM Core libraries are well documented, and it is
+ particularly easy to invent your own language (or port an existing compiler)
+ to use LLVM as an optimizer and code generator."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+toolchainopts = {'cstd': 'gnu++11'}
+
+source_urls = ['https://github.com/llvm/llvm-project/releases/download/llvmorg-%(version)s']
+sources = ['llvm-%(version)s.src.tar.xz']
+checksums = ['44787a6d02f7140f145e2250d56c9f849334e11f9ae379827510ed72f12b75e7']
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('CMake', '3.15.3'),
+    ('Python', '3.7.4'),
+]
+
+dependencies = [
+    ('ncurses', '6.1'),
+    ('zlib', '1.2.11'),
+]
+
+configopts = '-DBUILD_SHARED_LIBS=ON '
+# required to install extra tools in bin/
+configopts += '-DLLVM_INSTALL_UTILS=ON -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_ZLIB=ON -DLLVM_ENABLE_RTTI=ON '
+configopts += '-DCMAKE_BUILD_TYPE=Release '
+
+sanity_check_paths = {
+    'files': ['bin/llvm-ar', 'bin/FileCheck'],
+    'dirs': ['include/llvm', 'include/llvm-c'],
+}
+
+separate_build_dir = True
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/n/numba/llvmlite-0.31.0_fix-ffi-Makefile.patch
+++ b/easybuild/easyconfigs/n/numba/llvmlite-0.31.0_fix-ffi-Makefile.patch
@@ -1,0 +1,13 @@
+Make sure easybuild libs are used for llvmlite
+Author: Ariel Lozano (ULB)
+--- a/ffi/Makefile.linux	2019-10-10 21:15:38.000000000 +0200
++++ b/ffi/Makefile.linux	2019-11-13 12:22:07.061890000 +0100
+@@ -7,7 +7,7 @@
+ 
+ CXXFLAGS := $(CPPFLAGS) $(CXXFLAGS) $(LLVM_CXXFLAGS) $(CXX_FLTO_FLAGS)
+ LDFLAGS := $(LDFLAGS) $(LLVM_LDFLAGS) $(LD_FLTO_FLAGS)
+-LIBS = $(LLVM_LIBS)
++LIBS := $(LIBS) $(LLVM_LIBS)
+ INCLUDE = core.h
+ SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \
+ 	  executionengine.cpp transforms.cpp passmanagers.cpp targets.cpp dylib.cpp \

--- a/easybuild/easyconfigs/n/numba/numba-0.47.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.47.0-foss-2019b-Python-3.7.4.eb
@@ -1,0 +1,52 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+
+easyblock = 'PythonBundle'
+
+name = 'numba'
+version = '0.47.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://numba.pydata.org/'
+description = """Numba is an Open Source NumPy-aware optimizing compiler for
+Python sponsored by Continuum Analytics, Inc. It uses the remarkable LLVM
+compiler infrastructure to compile Python syntax to machine code."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+toolchainopts = {'pic': True}
+
+dependencies = [
+    ('Python', '3.7.4'),
+    ('SciPy-bundle', '2019.10', versionsuffix),
+    ('LLVM', '8.0.1'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_default_options = {'source_urls': [PYPI_SOURCE]}
+
+exts_list = [
+    ('llvmlite', '0.31.0', {
+        'patches': ['llvmlite-0.31.0_fix-ffi-Makefile.patch'],
+        'preinstallopts': "export LLVM_CONFIG=${EBROOTLLVM}/bin/llvm-config && ",
+        'checksums': [
+            '22ab2b9d7ec79fab66ac8b3d2133347de86addc2e2df1b3793e523ac84baa3c8',  # llvmlite-0.31.0.tar.gz
+            # llvmlite-0.31.0_fix-ffi-Makefile.patch
+            '672aba7b753dcfe5cb07c731bf1ec8bde1de148d4e0e2d10f6be81fb17f34bbc',
+        ],
+    }),
+    (name, version, {
+        'checksums': ['c0703df0a0ea2e29fbef7937d9849cc4734253066cb5820c5d6e0851876e3b0a'],
+    }),
+]
+
+fix_python_shebang_for = ['bin/*']
+
+sanity_check_paths = {
+    'files': ['bin/numba', 'bin/pycc'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["numba --help"]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/s/scVelo/scVelo-0.1.24-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/s/scVelo/scVelo-0.1.24-foss-2019b-Python-3.7.4.eb
@@ -92,13 +92,4 @@ exts_list = [
     }),
 ]
 
-sanity_check_commands = [
-    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
-    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
-]
-
-# use non-interactive plotting backend as default
-# see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
-modextravars = {'MPLBACKEND': 'Agg'}
-
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/s/scVelo/scVelo-0.1.24-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/s/scVelo/scVelo-0.1.24-foss-2019b-Python-3.7.4.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('SciPy-bundle', '2019.10', versionsuffix),
     ('scikit-learn', '0.21.3', versionsuffix),
     ('h5py', '2.10.0', versionsuffix),
+    ('matplotlib', '3.1.1', versionsuffix),
     ('networkx', '2.4', versionsuffix),
     ('numba', '0.47.0', versionsuffix),
     ('PyTables', '3.6.1', versionsuffix),
@@ -41,12 +42,6 @@ exts_list = [
     }),
     ('kiwisolver', '1.1.0', {
         'checksums': ['53eaed412477c836e1b9522c19858a8557d6e595077830146182225613b11a75'],
-    }),
-    ('matplotlib', '3.0.3', {
-        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
-        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
-        'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
-        'checksums': ['e1d33589e32f482d0a7d1957bf473d43341115d40d33f578dad44432e47df7b7'],
     }),
     ('numpy-groupies', '0.9.10', {
         'modulename': 'numpy_groupies',
@@ -74,11 +69,16 @@ exts_list = [
         'checksums': ['0940eb6e95a96469738120fd498ecd30904308f995b429e20a2ac852f25dce66'],
     }),
     ('scanpy', '1.4.5.post2', {
-        'patches': ['scanpy-1.4.5.post2_fix_h5py_version.patch'],
+        'patches': [
+            'scanpy-1.4.5.post2_fix_h5py_version.patch',
+            'scanpy-1.4.5.post2_fix_matplotlib_version.patch',
+        ],
         'checksums': [
             'e36d498ac53e21aa0de9dada579ab98570c2e8552b29206eedd0aaeac91eec96',  # scanpy-1.4.5.post2.tar.gz
             # scanpy-1.4.5.post2_fix_h5py_version.patch
             '6989a2e5cb60c76d5f025c9daa02085737b8480e8bf4847f7412a5a96ccc833b',
+            # scanpy-1.4.5.post2_fix_matplotlib_version.patch
+            '74532944043e2acf4347c803cc39dce0ed4729dbf7547dc4fc8d881ec34e6ece',
         ],
     }),
     ('umap-learn', '0.3.10', {

--- a/easybuild/easyconfigs/s/scVelo/scVelo-0.1.24-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/s/scVelo/scVelo-0.1.24-foss-2019b-Python-3.7.4.eb
@@ -35,14 +35,6 @@ sanity_pip_check = True
 exts_default_options = {'source_urls': [PYPI_SOURCE]}
 
 exts_list = [
-    ('Cycler', '0.10.0', {
-        'modulename': 'cycler',
-        'source_tmpl': 'cycler-%(version)s.tar.gz',
-        'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
-    }),
-    ('kiwisolver', '1.1.0', {
-        'checksums': ['53eaed412477c836e1b9522c19858a8557d6e595077830146182225613b11a75'],
-    }),
     ('numpy-groupies', '0.9.10', {
         'modulename': 'numpy_groupies',
         'source_tmpl': 'numpy_groupies-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/s/scVelo/scVelo-0.1.24-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/s/scVelo/scVelo-0.1.24-foss-2019b-Python-3.7.4.eb
@@ -1,0 +1,104 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonBundle'
+
+name = 'scVelo'
+version = '0.1.24'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = "https://scvelo.org"
+description = """scVelo is a scalable toolkit for estimating and analyzing RNA velocities in single cells using
+ dynamical modeling."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+builddependencies = [('pkg-config', '0.29.2')]
+
+dependencies = [
+    ('Python', '3.7.4'),
+    ('SciPy-bundle', '2019.10', versionsuffix),
+    ('scikit-learn', '0.21.3', versionsuffix),
+    ('h5py', '2.10.0', versionsuffix),
+    ('networkx', '2.4', versionsuffix),
+    ('numba', '0.47.0', versionsuffix),
+    ('PyTables', '3.6.1', versionsuffix),
+    ('statsmodels', '0.11.0', versionsuffix),
+    ('libpng', '1.6.37'),
+    ('freetype', '2.10.1'),
+    ('Tkinter', '%(pyver)s'),
+    ('tqdm', '4.41.1'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_default_options = {'source_urls': [PYPI_SOURCE]}
+
+exts_list = [
+    ('Cycler', '0.10.0', {
+        'modulename': 'cycler',
+        'source_tmpl': 'cycler-%(version)s.tar.gz',
+        'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
+    }),
+    ('kiwisolver', '1.1.0', {
+        'checksums': ['53eaed412477c836e1b9522c19858a8557d6e595077830146182225613b11a75'],
+    }),
+    ('matplotlib', '3.0.3', {
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
+        'checksums': ['e1d33589e32f482d0a7d1957bf473d43341115d40d33f578dad44432e47df7b7'],
+    }),
+    ('numpy-groupies', '0.9.10', {
+        'modulename': 'numpy_groupies',
+        'source_tmpl': 'numpy_groupies-%(version)s.tar.gz',
+        'checksums': ['a6835c252b7bd489e0f701f8bf5bc880c647ef251e3b434998b95a8aecc9b68a'],
+    }),
+    ('seaborn', '0.9.0', {
+        'checksums': ['76c83f794ca320fb6b23a7c6192d5e185a5fcf4758966a0c0a54baee46d41e2f'],
+    }),
+    ('natsort', '7.0.0', {
+        'checksums': ['7207cddc510e1d5e728a7f73a0230f20a65e3346acd54856be6252291690d3ec'],
+    }),
+    ('get_version', '2.1', {
+        'use_pip': False,
+        'checksums': ['8156b526c2557537b8ca82241fa2b82b3da25939627398f6567dee31ba9725bc'],
+    }),
+    ('legacy-api-wrap', '1.2', {
+        'use_pip': False,
+        'checksums': ['034a44612da7e9943d3964363a98937ab54d55e3301075374abe0d521eb8101b'],
+    }),
+    ('loompy', '3.0.6', {
+        'checksums': ['58e9763b8ab1af2a4a0e3805d120458b5184fd2b0f3031657ecce33c63ca4c46'],
+    }),
+    ('anndata', '0.7.1', {
+        'checksums': ['0940eb6e95a96469738120fd498ecd30904308f995b429e20a2ac852f25dce66'],
+    }),
+    ('scanpy', '1.4.5.post2', {
+        'patches': ['scanpy-1.4.5.post2_fix_h5py_version.patch'],
+        'checksums': [
+            'e36d498ac53e21aa0de9dada579ab98570c2e8552b29206eedd0aaeac91eec96',  # scanpy-1.4.5.post2.tar.gz
+            # scanpy-1.4.5.post2_fix_h5py_version.patch
+            '6989a2e5cb60c76d5f025c9daa02085737b8480e8bf4847f7412a5a96ccc833b',
+        ],
+    }),
+    ('umap-learn', '0.3.10', {
+        'modulename': 'umap',
+        'checksums': ['21ce6b6d7486905318ba6458b5a9ba2cfb935878d30c24e6fba64ee3bd504d09'],
+    }),
+    (name, version, {
+        'modulename': 'scvelo',
+        'source_tmpl': '%(namelower)s-%(version)s.tar.gz',
+        'checksums': ['a9e1842ec6a55c982a853349238a494464c447e208aa5d46d3a7d225a910113f'],
+    }),
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
+
+# use non-interactive plotting backend as default
+# see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
+modextravars = {'MPLBACKEND': 'Agg'}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/s/scVelo/scanpy-1.4.5.post2_fix_h5py_version.patch
+++ b/easybuild/easyconfigs/s/scVelo/scanpy-1.4.5.post2_fix_h5py_version.patch
@@ -1,0 +1,22 @@
+From 4f493ff585bf9faecb3105995674dab57a7d7057 Mon Sep 17 00:00:00 2001
+From: Philipp A <flying-sheep@web.de>
+Date: Thu, 23 Jan 2020 17:13:20 +0100
+Subject: [PATCH] Unlock h5py dependency (#1006)
+
+---
+ requirements.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/requirements.txt b/requirements.txt
+index 64ce791a..349c511f 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -4,7 +4,7 @@ matplotlib==3.0.*
+ pandas>=0.21
+ scipy>=1.3
+ seaborn
+-h5py!=2.10.0
++h5py>=2.10.0
+ tables
+ tqdm
+ importlib_metadata>=0.7; python_version < '3.8'

--- a/easybuild/easyconfigs/s/scVelo/scanpy-1.4.5.post2_fix_matplotlib_version.patch
+++ b/easybuild/easyconfigs/s/scVelo/scanpy-1.4.5.post2_fix_matplotlib_version.patch
@@ -1,0 +1,19 @@
+From 16101e7fe8269920d49a2b579125b0c1806d915d Mon Sep 17 00:00:00 2001
+From: Philipp A <flying-sheep@web.de>
+Date: Tue, 4 Feb 2020 10:37:19 +0100
+Subject: [PATCH] Use matplotlib 3.1 and adapt tests (#1020)
+
+diff --git a/requirements.txt b/requirements.txt
+index 349c511fa..fe8d043e9 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,6 +1,7 @@
+ anndata>=0.6.22.post1
+-# matplotlib 3.1 causes an error in 3d scatter plots. Once solved the dependency can be updated (https://github.com/matplotlib/matplotlib/issues/14298)
+-matplotlib==3.0.*
++# Matplotlib 3.1 causes an error in 3d scatter plots (https://github.com/matplotlib/matplotlib/issues/14298)
++# But matplotlib 3.0 causes one in heatmaps
++matplotlib>=3.1
+ pandas>=0.21
+ scipy>=1.3
+ seaborn

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -251,6 +251,8 @@ class EasyConfigTest(TestCase):
             # EMAN2 2.3 requires Boost(.Python) 1.64.0
             'Boost': ('1.64.0;', ['Boost.Python-1.64.0-', 'EMAN2-2.3-']),
             'Boost.Python': ('1.64.0;', ['EMAN2-2.3-']),
+            # scVelo's dependency numba requires LLVM 7x or 8x (see https://github.com/numba/llvmlite#compatibility)
+            'LLVM': (r'[78]\.', ['numba-0.47.0-', 'scVelo-0.1.24-']),
         }
         if dep in old_dep_versions and len(dep_vars) > 1:
             for key in list(dep_vars):


### PR DESCRIPTION
Requires:
~~#9802~~
~~#9803~~
~~#9804~~

(created using `eb --new-pr`)

ScanPy (required by scVelo) requires Numba, which will only compile with LLVM versions 7 & 8 (not the version 9 that's already in _GCCcore-8.3.0_).