### PR TITLE
binutils: Revert removal of AVX512 vmovd with 64-bit operands

### DIFF
--- a/easybuild/easyconfigs/b/binutils/binutils-2.32-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.32-GCCcore-8.3.0.eb
@@ -8,11 +8,16 @@ toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
-patches = ['binutils-2.31.1-gold-ignore-discarded-note-relocts.patch']
+patches = [
+    'binutils-2.31.1-gold-ignore-discarded-note-relocts.patch',
+    'binutils-2.32-readd-avx512-vmovd.patch',
+]
 checksums = [
     '9b0d97b3d30df184d302bced12f976aa1e5fbf4b0be696cdebc6cca30411a46e',  # binutils-2.32.tar.gz
     # binutils-2.31.1-gold-ignore-discarded-note-relocts.patch
     '17f22cc9136d0e81cfe8cbe310328c794a78a864e7fe7ca5827ee6678f65af32',
+    # binutils-2.32-readd-avx512-vmovd.patch
+    '9e16ba3acd9af473a882e2d4c81ca024fdd62dc332eb527cc778fc9d31f01939',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/b/binutils/binutils-2.32-GCCcore-9.1.0.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.32-GCCcore-9.1.0.eb
@@ -8,11 +8,16 @@ toolchain = {'name': 'GCCcore', 'version': '9.1.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
-patches = ['binutils-2.31.1-gold-ignore-discarded-note-relocts.patch']
+patches = [
+    'binutils-2.31.1-gold-ignore-discarded-note-relocts.patch',
+    'binutils-2.32-readd-avx512-vmovd.patch',
+]
 checksums = [
     '9b0d97b3d30df184d302bced12f976aa1e5fbf4b0be696cdebc6cca30411a46e',  # binutils-2.32.tar.gz
     # binutils-2.31.1-gold-ignore-discarded-note-relocts.patch
     '17f22cc9136d0e81cfe8cbe310328c794a78a864e7fe7ca5827ee6678f65af32',
+    # binutils-2.32-readd-avx512-vmovd.patch
+    '9e16ba3acd9af473a882e2d4c81ca024fdd62dc332eb527cc778fc9d31f01939',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/b/binutils/binutils-2.32-GCCcore-9.2.0.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.32-GCCcore-9.2.0.eb
@@ -8,11 +8,16 @@ toolchain = {'name': 'GCCcore', 'version': '9.2.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
-patches = ['binutils-2.31.1-gold-ignore-discarded-note-relocts.patch']
+patches = [
+    'binutils-2.31.1-gold-ignore-discarded-note-relocts.patch',
+    'binutils-2.32-readd-avx512-vmovd.patch',
+]
 checksums = [
     '9b0d97b3d30df184d302bced12f976aa1e5fbf4b0be696cdebc6cca30411a46e',  # binutils-2.32.tar.gz
     # binutils-2.31.1-gold-ignore-discarded-note-relocts.patch
     '17f22cc9136d0e81cfe8cbe310328c794a78a864e7fe7ca5827ee6678f65af32',
+    # binutils-2.32-readd-avx512-vmovd.patch
+    '9e16ba3acd9af473a882e2d4c81ca024fdd62dc332eb527cc778fc9d31f01939',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/b/binutils/binutils-2.32-readd-avx512-vmovd.patch
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.32-readd-avx512-vmovd.patch
@@ -1,0 +1,57 @@
+Revert removal of AVX512 vmovd with 64-bit operands
+
+This reverts parts of
+https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=commit;h=704a705d7aaab8041df76e2981e2a1efc014aad0
+from H.J. Lu <hjl.tools@gmail.com> for compatibility with the Intel compiler
+--- binutils-2.32/opcodes/i386-opc.tbl.orig	2019-01-19 16:01:34.000000000 -0000
++++ binutils-2.32/opcodes/i386-opc.tbl	2020-02-12 01:10:31.539874010 -0000
+@@ -3706,6 +3706,8 @@
+ vmovups, 2, 0x10, None, 1, CpuAVX512F, D|Modrm|MaskingMorZ|VexOpcode=0|VexW=1|Disp8ShiftVL|CheckRegSize|No_bSuf|No_wSuf|No_lSuf|No_sSuf|No_qSuf|No_ldSuf, { RegXMM|RegYMM|RegZMM|Unspecified|BaseIndex, RegXMM|RegYMM|RegZMM }
+ 
+ vmovd, 2, 0x666E, None, 1, CpuAVX512F, D|Modrm|EVex=2|VexOpcode=0|Disp8MemShift=2|IgnoreSize|No_bSuf|No_wSuf|No_lSuf|No_sSuf|No_qSuf|No_ldSuf, { Reg32|Unspecified|BaseIndex, RegXMM }
++vmovd, 2, 0x666E, None, 1, CpuAVX512F|Cpu64, Modrm|EVex=4|VexOpcode=0|VexW=1|Disp8MemShift=2|IgnoreSize|No_bSuf|No_wSuf|No_lSuf|No_sSuf|No_qSuf|No_ldSuf|Rex64, { Reg64|Qword|Unspecified|BaseIndex, RegXMM }
++vmovd, 2, 0x667E, None, 1, CpuAVX512F|Cpu64, Modrm|EVex=4|VexOpcode=0|VexW=1|Disp8MemShift=2|IgnoreSize|No_bSuf|No_wSuf|No_lSuf|No_sSuf|No_qSuf|No_ldSuf|Rex64, { RegXMM, Reg64|Qword|Unspecified|BaseIndex }
+ 
+ vmovddup, 2, 0xF212, None, 1, CpuAVX512F, Modrm|Masking=3|VexOpcode=0|VexW=2|Disp8ShiftVL|CheckRegSize|No_bSuf|No_wSuf|No_lSuf|No_sSuf|No_qSuf|No_ldSuf, { RegYMM|RegZMM|Unspecified|BaseIndex, RegYMM|RegZMM }
+ 
+--- binutils-2.32/opcodes/i386-tbl.h.orig	2019-02-02 15:49:52.000000000 -0000
++++ binutils-2.32/opcodes/i386-tbl.h	2020-02-12 01:27:59.467516620 -0000
+@@ -33942,6 +33942,38 @@
+       { { 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+ 	  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+ 	  0, 0 } } } },
++  { "vmovd", 2, 0x666E, None, 1,
++    { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
++        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        0, 0, 0, 1, 0, 0 } },
++    { 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1,
++      1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
++      1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0 },
++    { { { 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1,
++	  0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0,
++	  0, 0 } },
++      { { 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++	  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
++	  0, 0 } } } },
++  { "vmovd", 2, 0x667E, None, 1,
++    { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
++        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        0, 0, 0, 1, 0, 0 } },
++    { 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1,
++      1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
++      1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0 },
++    { { { 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++	  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
++	  0, 0 } },
++      { { 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1,
++	  0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0,
++	  0, 0 } } } },
+   { "vmovddup", 2, 0xf212, None, 1,
+     { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/easybuild/easyconfigs/b/binutils/binutils-2.32.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.32.eb
@@ -9,11 +9,16 @@ toolchain = SYSTEM
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
-patches = ['binutils-2.31.1-gold-ignore-discarded-note-relocts.patch']
+patches = [
+    'binutils-2.31.1-gold-ignore-discarded-note-relocts.patch',
+    'binutils-2.32-readd-avx512-vmovd.patch',
+]
 checksums = [
     '9b0d97b3d30df184d302bced12f976aa1e5fbf4b0be696cdebc6cca30411a46e',  # binutils-2.32.tar.gz
     # binutils-2.31.1-gold-ignore-discarded-note-relocts.patch
     '17f22cc9136d0e81cfe8cbe310328c794a78a864e7fe7ca5827ee6678f65af32',
+    # binutils-2.32-readd-avx512-vmovd.patch
+    '9e16ba3acd9af473a882e2d4c81ca024fdd62dc332eb527cc778fc9d31f01939',
 ]
 
 builddependencies = [


### PR DESCRIPTION
This reverts parts of
https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=commit;h=704a705d7aaab8041df76e2981e2a1efc014aad0
from H.J. Lu <hjl.tools@gmail.com> for compatibility with the Intel compiler

Fixes #8003