### PR TITLE
OpenBLAS 0.3.8: Fix inline asm in dscal: mark x, x1 as clobbered.

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.8-GCC-9.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.8-GCC-9.2.0.eb
@@ -15,11 +15,13 @@ sources = ['v%(version)s.tar.gz']
 patches = [
     ('large.tgz', '.'),
     ('timing.tgz', '.'),
+    'OpenBLAS-0.3.8_fix-dscal-inline-asm.patch',
 ]
 checksums = [
     '8f86ade36f0dbed9ac90eb62575137388359d97d8f93093b38abe166ad7ef3a8',  # v0.3.8.tar.gz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    '2e494213e6785187ab1286cda8538452f9fa897ae5110159e3bb441239f84424',  # OpenBLAS-0.3.8_fix-dscal-inline-asm.patch
 ]
 
 # extensive testing can be enabled by uncommenting the line below

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.8_fix-dscal-inline-asm.patch
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.8_fix-dscal-inline-asm.patch
@@ -1,0 +1,30 @@
+From 7ea5e07d1cb59834428d982818b7cf565dcda4df Mon Sep 17 00:00:00 2001
+From: Bart Oldeman <bart.oldeman@calculquebec.ca>
+Date: Wed, 12 Feb 2020 14:11:44 +0000
+Subject: [PATCH] Fix inline asm in dscal: mark x, x1 as clobbered. Fixes #2408
+
+The leaq instructions in dscal_kernel_inc_8 modify x and x1 so they
+must be declared as input/output constraints, otherwise the compiler
+may assume the corresponding registers are not modified.
+---
+ kernel/x86_64/dscal.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/kernel/x86_64/dscal.c b/kernel/x86_64/dscal.c
+index d0d7801fd..e2436f789 100644
+--- a/kernel/x86_64/dscal.c
++++ b/kernel/x86_64/dscal.c
+@@ -136,10 +136,10 @@ static void dscal_kernel_inc_8(BLASLONG n, FLOAT *alpha, FLOAT *x, BLASLONG inc_
+ 	"jnz    1b					    \n\t"
+ 
+         :
+-          "+r" (n)      // 0
++          "+r" (n),     // 0
++          "+r" (x),     // 1
++          "+r" (x1)     // 2
+         :
+-          "r" (x),      // 1
+-          "r" (x1),     // 2
+           "r" (alpha),  // 3
+           "r" (inc_x),  // 4
+           "r" (inc_x3)  // 5


### PR DESCRIPTION
The leaq instructions in dscal_kernel_inc_8 modify x and x1 so they
must be declared as input/output constraints, otherwise the compiler
may assume the corresponding registers are not modified.

Fixes #9861