### PR TITLE
add alternate checksum for LaplacesDemon in R 3.6.2 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.6.2-foss-2019b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.2-foss-2019b.eb
@@ -2214,7 +2214,9 @@ exts_list = [
         'checksums': ['71750b741672a435ecf749b69c72f0681aa8bb795e317f4e3056d5e33f6d79e8'],
     }),
     ('LaplacesDemon', '16.1.1', {
-        'checksums': ['98d30fbc5594f46818632a6795febaa81df12e9598d31d17500bc7300289aea1'],
+        # two alternate checksums due updated source tarball with changed package description
+        'checksums': [('779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77',
+                       '98d30fbc5594f46818632a6795febaa81df12e9598d31d17500bc7300289aea1')],
     }),
     ('rda', '1.0.2-2.1', {
         'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',

--- a/easybuild/easyconfigs/r/R/R-3.6.2-foss-2019b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.2-foss-2019b.eb
@@ -2214,7 +2214,7 @@ exts_list = [
         'checksums': ['71750b741672a435ecf749b69c72f0681aa8bb795e317f4e3056d5e33f6d79e8'],
     }),
     ('LaplacesDemon', '16.1.1', {
-        'checksums': ['779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77'],
+        'checksums': ['98d30fbc5594f46818632a6795febaa81df12e9598d31d17500bc7300289aea1'],
     }),
     ('rda', '1.0.2-2.1', {
         'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',

--- a/easybuild/easyconfigs/r/R/R-3.6.2-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.2-fosscuda-2019b.eb
@@ -2215,7 +2215,9 @@ exts_list = [
         'checksums': ['71750b741672a435ecf749b69c72f0681aa8bb795e317f4e3056d5e33f6d79e8'],
     }),
     ('LaplacesDemon', '16.1.1', {
-        'checksums': ['98d30fbc5594f46818632a6795febaa81df12e9598d31d17500bc7300289aea1'],
+        # two alternate checksums due updated source tarball with changed package description
+        'checksums': [('779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77',
+                       '98d30fbc5594f46818632a6795febaa81df12e9598d31d17500bc7300289aea1')],
     }),
     ('rda', '1.0.2-2.1', {
         'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',

--- a/easybuild/easyconfigs/r/R/R-3.6.2-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.2-fosscuda-2019b.eb
@@ -2215,7 +2215,7 @@ exts_list = [
         'checksums': ['71750b741672a435ecf749b69c72f0681aa8bb795e317f4e3056d5e33f6d79e8'],
     }),
     ('LaplacesDemon', '16.1.1', {
-        'checksums': ['779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77'],
+        'checksums': ['98d30fbc5594f46818632a6795febaa81df12e9598d31d17500bc7300289aea1'],
     }),
     ('rda', '1.0.2-2.1', {
         'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',


### PR DESCRIPTION
Checksum for LaplacesDemon CRAN package has changed. Probably some changes considered minor by the authors, and "not enough" for a version bump.