### PR TITLE
add back direct dependency on METIS in PETSc 3.12.4 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.12.4-foss-2019b.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.12.4-foss-2019b.eb
@@ -26,6 +26,8 @@ builddependencies = [('CMake', '3.15.3')]
 
 dependencies = [
     ('Boost', '1.71.0'),
+    ('METIS', '5.1.0'),
+    ('SCOTCH', '6.0.9'),
     ('MUMPS', '5.2.1', '-metis'),
     ('SuiteSparse', '5.6.0', '-METIS-5.1.0'),
     ('Hypre', '2.18.2'),

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.12.4-intel-2019b.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.12.4-intel-2019b.eb
@@ -26,6 +26,8 @@ builddependencies = [('CMake', '3.15.3')]
 
 dependencies = [
     ('Boost', '1.71.0'),
+    ('METIS', '5.1.0'),
+    ('SCOTCH', '6.0.9'),
     ('MUMPS', '5.2.1', '-metis'),
     ('SuiteSparse', '5.6.0', '-METIS-5.1.0'),
     ('Hypre', '2.18.2'),


### PR DESCRIPTION
was removed in #9880 since METIS is a dep of MUMPS, but `SLEPc` build is broken if `PETSc` doesn't list `METIS` as direct dep...