### PR TITLE
use checkout@v2 in GitHub Actions to fix broken re-triggered tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,7 +20,7 @@ jobs:
             module_syntax: Tcl
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: set up Python
       uses: actions/setup-python@v1


### PR DESCRIPTION
see https://github.com/actions/checkout/issues/23