### PR TITLE
use M4-1.4.18.eb for test installation in easyconfigs test suite

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -128,5 +128,5 @@ jobs:
           eb --search '^foss-2018b.eb' | tee eb_search_foss.out
           grep '/foss-2018b.eb$' eb_search_foss.out
 
-          # try installing bzip2 with system toolchain (requires EB_bzip2 easyblock + easyconfig)
-          eb --prefix /tmp/$USER/$GITHUB_SHA bzip2-1.0.6.eb
+          # try installing M4 with system toolchain (requires ConfigureMake easyblock + easyconfig)
+          eb --prefix /tmp/$USER/$GITHUB_SHA M4-1.4.18.eb

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,5 +65,5 @@ script:
     - grep '/TensorFlow-1.14.0-foss-2019a-Python-3.7.2.eb$' eb_search_TF.out
     - eb --search '^foss-2018b.eb' | tee eb_search_foss.out
     - grep '/foss-2018b.eb$' eb_search_foss.out
-    # try installing bzip2 with system toolchain (requires EB_bzip2 easyblock + easyconfig)
-    - eb --prefix /tmp/$USER bzip2-1.0.6.eb
+    # try installing M4 with system toolchain (requires ConfigureMake easyblock + easyconfig)
+    - eb --prefix /tmp/$USER M4-1.4.18.eb


### PR DESCRIPTION
Downloading the sources for `bzip2-1.0.6.eb` is currently troublesome, so switching to M4 (under the assumption that the GNU software mirrors are less likely to be flaky).