### PR TITLE
add Zip as build dependency for recent Bazel versions

### DIFF
--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.20.0-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.20.0-GCCcore-8.2.0.eb
@@ -15,7 +15,10 @@ checksums = [
     '55fd52c512a578dc8242fbf204cf42f28aa93611910a5a791e0dda4c3a1c7d60',  # Bazel-0.18.0_remove_define_DATE.patch
 ]
 
-builddependencies = [('binutils', '2.31.1')]
+builddependencies = [
+    ('binutils', '2.31.1'),
+    ('Zip', '3.0'),
+]
 dependencies = [('Java', '1.8', '', True)]
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.20.0-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.20.0-GCCcore-8.2.0.eb
@@ -1,7 +1,7 @@
 name = 'Bazel'
 version = '0.20.0'
 
-homepage = 'http://bazel.io/'
+homepage = 'https://bazel.io/'
 description = """Bazel is a build tool that builds code quickly and reliably. 
 It is used to build the majority of Google's software."""
 

--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.25.2-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.25.2-GCCcore-8.2.0.eb
@@ -11,7 +11,11 @@ source_urls = ['https://github.com/bazelbuild/bazel/releases/download/%(version)
 sources = ['%(namelower)s-%(version)s-dist.zip']
 checksums = ['7456032199852c043e6c5b3e4c71dd8089c1158f72ec554e6ec1c77007f0ab51']
 
-builddependencies = [('binutils', '2.31.1'), ('Python', '3.7.2')]
+builddependencies = [
+    ('binutils', '2.31.1'),
+    ('Python', '3.7.2'),
+    ('Zip', '3.0'),
+]
 dependencies = [('Java', '1.8', '', True)]
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.26.1-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.26.1-GCCcore-8.2.0.eb
@@ -14,6 +14,7 @@ checksums = ['c0e94f8f818759f3f67af798c38683520c540f469cb41aea8f5e5a0e43f11600']
 builddependencies = [
     ('binutils', '2.31.1'),
     ('Python', '3.7.2'),
+    ('Zip', '3.0'),
 ]
 dependencies = [('Java', '1.8', '', True)]
 

--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.26.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.26.1-GCCcore-8.3.0.eb
@@ -14,6 +14,7 @@ checksums = ['c0e94f8f818759f3f67af798c38683520c540f469cb41aea8f5e5a0e43f11600']
 builddependencies = [
     ('binutils', '2.32'),
     ('Python', '3.7.4'),
+    ('Zip', '3.0'),
 ]
 dependencies = [('Java', '1.8', '', True)]
 

--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.29.1-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.29.1-GCCcore-8.2.0.eb
@@ -22,6 +22,7 @@ checksums = [
 builddependencies = [
     ('binutils', '2.31.1'),
     ('Python', '3.7.2'),
+    ('Zip', '3.0'),
 ]
 dependencies = [('Java', '1.8', '', True)]
 

--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.29.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.29.1-GCCcore-8.3.0.eb
@@ -22,6 +22,7 @@ checksums = [
 builddependencies = [
     ('binutils', '2.32'),
     ('Python', '3.7.4'),
+    ('Zip', '3.0'),
 ]
 dependencies = [('Java', '1.8', '', True)]
 

--- a/easybuild/easyconfigs/b/Bazel/Bazel-1.1.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-1.1.0-GCCcore-8.3.0.eb
@@ -18,6 +18,7 @@ checksums = [
 builddependencies = [
     ('binutils', '2.32'),
     ('Python', '3.7.4'),
+    ('Zip', '3.0'),
 ]
 dependencies = [('Java', '1.8', '', True)]
 


### PR DESCRIPTION
fixes #9962

requires ~~#9958~~ + ~~#9971~~ for `Zip`