### PR TITLE
stick to GCCcore toolchain for RDFlib, no need for a full toolchain

### DIFF
--- a/easybuild/easyconfigs/r/RDFlib/RDFlib-4.2.2-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/r/RDFlib/RDFlib-4.2.2-GCCcore-8.3.0.eb
@@ -7,7 +7,9 @@ homepage = 'https://github.com/RDFLib/rdflib'
 description = """RDFLib is a Python library for working with RDF, a simple yet powerful language
  for representing information."""
 
-toolchain = {'name': 'foss', 'version': '2019b'}
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+builddependencies = [('binutils', '2.32')]
 
 multi_deps = {'Python': ['2.7.16', '3.7.4']}
 


### PR DESCRIPTION
follow-up for #9974