### PR TITLE
switch to final release of OpenMPI 4.0.3 for foss/2020a-rc3

### DIFF
--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.8-gompi-2020a-rc3.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.8-gompi-2020a-rc3.eb
@@ -5,7 +5,7 @@ homepage = 'http://www.fftw.org'
 description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
  in one or more dimensions, of arbitrary input size, and of both real and complex data."""
 
-toolchain = {'name': 'gompi', 'version': '2020a-rc2'}
+toolchain = {'name': 'gompi', 'version': '2020a-rc3'}
 toolchainopts = {'pic': True}
 
 source_urls = [homepage]

--- a/easybuild/easyconfigs/f/foss/foss-2020a-rc3.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2020a-rc3.eb
@@ -1,7 +1,7 @@
 easyblock = 'Toolchain'
 
 name = 'foss'
-version = '2020a-rc2'
+version = '2020a-rc3'
 
 homepage = 'https://easybuild.readthedocs.io/en/master/Common-toolchains.html#foss-toolchain'
 description = """GNU Compiler Collection (GCC) based compiler toolchain, including
@@ -18,7 +18,7 @@ local_comp_mpi_tc = ('gompi', version)
 # because of toolchain preparation functions
 dependencies = [
     ('GCC', local_gccver),
-    ('OpenMPI', '4.0.3rc4', '', ('GCC', local_gccver)),
+    ('OpenMPI', '4.0.3', '', ('GCC', local_gccver)),
     ('OpenBLAS', '0.3.8', '', ('GCC', local_gccver)),
     ('FFTW', '3.3.8', '', local_comp_mpi_tc),
     ('ScaLAPACK', '2.1.0', '', local_comp_mpi_tc),

--- a/easybuild/easyconfigs/g/gompi/gompi-2020a-rc3.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2020a-rc3.eb
@@ -1,7 +1,7 @@
 easyblock = "Toolchain"
 
 name = 'gompi'
-version = '2020a-rc2'
+version = '2020a-rc3'
 
 homepage = '(none)'
 description = """GNU Compiler Collection (GCC) based compiler toolchain,
@@ -14,7 +14,7 @@ local_gccver = '9.2.0'
 # compiler toolchain dependencies
 dependencies = [
     ('GCC', local_gccver),  # includes both GCC and binutils
-    ('OpenMPI', '4.0.3rc4', '', ('GCC', local_gccver)),
+    ('OpenMPI', '4.0.3', '', ('GCC', local_gccver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/h/HPL/HPL-2.3-foss-2020a-rc3.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.3-foss-2020a-rc3.eb
@@ -6,7 +6,7 @@ description = """HPL is a software package that solves a (random) dense linear s
  arithmetic on distributed-memory computers. It can thus be regarded as a portable as well as freely available
  implementation of the High Performance Computing Linpack Benchmark."""
 
-toolchain = {'name': 'foss', 'version': '2020a-rc2'}
+toolchain = {'name': 'foss', 'version': '2020a-rc3'}
 toolchainopts = {'usempi': True}
 
 source_urls = ['https://www.netlib.org/benchmark/%(namelower)s']

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.3-GCC-9.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.3-GCC-9.2.0.eb
@@ -1,5 +1,5 @@
 name = 'OpenMPI'
-version = '4.0.3rc4'
+version = '4.0.3'
 
 homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-3 implementation."""
@@ -8,7 +8,7 @@ toolchain = {'name': 'GCC', 'version': '9.2.0'}
 
 source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['da336cca690980a8858bd6e6a9a01fcf66fba4586645bd752bb5e29c58e169e4']
+checksums = ['6346bf976001ad274c7e018d6cc35c92bbb9426d8f7754fac00a17ea5ac8eebc']
 
 dependencies = [
     ('zlib', '1.2.11'),

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.1.0-gompi-2020a-rc3.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.1.0-gompi-2020a-rc3.eb
@@ -5,7 +5,7 @@ homepage = 'https://www.netlib.org/scalapack/'
 description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
  redesigned for distributed memory MIMD parallel computers."""
 
-toolchain = {'name': 'gompi', 'version': '2020a-rc2'}
+toolchain = {'name': 'gompi', 'version': '2020a-rc3'}
 toolchainopts = {'pic': True}
 
 source_urls = [homepage]


### PR DESCRIPTION
sticking to `foss/2020a-rc3` for now since release of GCC 9.3.0 seems imminent (see https://gcc.gnu.org/ml/gcc/2020-02/msg00240.html)