### PR TITLE
use https in homepage/source_urls of zlib-1.2.11.eb

### DIFF
--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.11.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.11.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'zlib'
 version = '1.2.11'
 
-homepage = 'http://www.zlib.net/'
+homepage = 'https://www.zlib.net/'
 
 description = """
  zlib is designed to be a free, general-purpose, legally unencumbered -- that
@@ -14,7 +14,7 @@ description = """
 toolchain = SYSTEM
 toolchainopts = {'pic': True}
 
-source_urls = ['http://zlib.net/fossils/']
+source_urls = ['https://zlib.net/fossils/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1']
 


### PR DESCRIPTION
This is a silly PR, but it'll serve as a test case for the fix for https://github.com/easybuilders/easybuild-framework/issues/3233 (via https://github.com/boegelbot/easybuild-easyconfigs/pull/1)...

edit: well, probably not, since getting the fix in https://github.com/easybuilders/easybuild-framework/pull/3234 covered by the tests is not so straightforward... Still, it's a valid change/fix, so good to go...