### PR TITLE
Revert "temporarily limit test configurations during 2020a sprint" [DO NOT MERGE YET]

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python: [3.6] #[2.7, 3.5, 3.6, 3.7]
-        modules_tool: [Lmod-8.1.14] #[Lmod-6.6.3, Lmod-7.8.22, Lmod-8.1.14]
+        python: [2.7, 3.5, 3.6, 3.7]
+        modules_tool: [Lmod-6.6.3, Lmod-7.8.22, Lmod-8.1.14]
         module_syntax: [Lua, Tcl]
         # exclude some configurations: only test Tcl module syntax with Lmod 7.x and Python 2.7 & 3.5
         exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
     # other test configurations in GitHub Actions (see .github/workflows/unit_tests.yml)
     - python: 2.7
       env: LMOD_VERSION=7.8.22
-    #- python: 3.6
-    #  env: LMOD_VERSION=7.8.22
+    - python: 3.6
+      env: LMOD_VERSION=7.8.22
 addons:
   apt:
     packages:


### PR DESCRIPTION
This reverts things back to normal after the test configurations were limited in #10084