### PR TITLE
2020a

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.17-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.17-GCCcore-9.3.0.eb
@@ -1,0 +1,264 @@
+name = 'Python'
+version = '2.7.17'
+
+homepage = 'https://python.org/'
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+ more effectively."""
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+checksums = ['f22059d09cdf9625e0a7284d24a13062044f5bf59d93a7f3382190dfa94cecde']
+
+dependencies = [
+    ('binutils', '2.34'),  # required for pip install that involves compilation
+    ('bzip2', '1.0.8'),  # required for bz2 package in Python stdlib
+    ('zlib', '1.2.11'),
+    ('libreadline', '8.0'),
+    ('ncurses', '6.2'),
+    ('SQLite', '3.31.1'),
+    ('GMP', '6.2.0'),  # required for pycrypto
+    ('libffi', '3.3'),  # required for cryptography
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    # ('OpenSSL', '1.1.0j'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+exts_default_options = {
+    'download_dep_fail': True,
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True,
+    'sanity_pip_check': True,
+}
+
+# order is important!
+# package versions updated Mar 15th 2019
+exts_list = [
+    ('setuptools', '40.8.0', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'use_pip': False,
+        'checksums': ['6e4eec90337e849ade7103723b9a99631c1f0d19990d6e8412dc42f5ae8b304d'],
+    }),
+    ('pip', '19.0.3', {
+        'use_pip': False,
+        'checksums': ['6e6f197a1abfb45118dbb878b5c859a0edbdd33fd250100bc015b67fded4b9f2'],
+    }),
+    ('wheel', '0.33.1', {
+        'checksums': ['66a8fd76f28977bb664b098372daef2b27f60dc4d1688cfab7b37a09448f0e9d'],
+    }),
+    ('nose', '1.3.7', {
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
+    }),
+    ('blist', '1.3.6', {
+        'checksums': ['3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3'],
+    }),
+    ('paycheck', '1.0.2', {
+        'checksums': ['6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34'],
+    }),
+    ('pbr', '5.1.3', {
+        'checksums': ['8c361cc353d988e4f5b998555c88098b9d5964c2e11acf7b0d21925a66bb5824'],
+    }),
+    ('Cython', '0.29.6', {
+        'checksums': ['6c5d33f1b5c864382fbce810a8fd9e015447869ae42e98e6301e977b8165e7ae'],
+    }),
+    ('six', '1.12.0', {
+        'checksums': ['d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73'],
+    }),
+    ('setuptools_scm', '3.2.0', {
+        'checksums': ['52ab47715fa0fc7d8e6cd15168d1a69ba995feb1505131c3e814eb7087b57358'],
+    }),
+    ('python-dateutil', '2.8.0', {
+        'checksums': ['c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e'],
+        'modulename': 'dateutil',
+    }),
+    ('deap', '1.2.2', {
+        'checksums': ['95c63e66d755ec206c80fdb2908851c0bef420ee8651ad7be4f0578e9e909bcf'],
+    }),
+    ('decorator', '4.3.2', {
+        'checksums': ['33cd704aea07b4c28b3eb2c97d288a06918275dac0ecebdaf1bc8a48d98adb9e'],
+    }),
+    ('liac-arff', '2.4.0', {
+        'checksums': ['47afcd1fd248b2892f66075987422d0576fc2c2fd0811d0cbd32f2135b065df5'],
+        'modulename': 'arff',
+    }),
+    ('pycrypto', '2.6.1', {
+        'checksums': ['f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c'],
+        'modulename': 'Crypto',
+    }),
+    ('ecdsa', '0.13', {
+        'checksums': ['64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa'],
+    }),
+    ('enum34', '1.1.6', {
+        'checksums': ['8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1'],
+        'modulename': 'enum',
+    }),
+    ('ipaddress', '1.0.22', {
+        'checksums': ['b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c'],
+    }),
+    ('asn1crypto', '0.24.0', {
+        'checksums': ['9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49'],
+    }),
+    ('idna', '2.8', {
+        'checksums': ['c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407'],
+    }),
+    ('pycparser', '2.19', {
+        'checksums': ['a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3'],
+    }),
+    ('cffi', '1.12.2', {
+        'checksums': ['e113878a446c6228669144ae8a56e268c91b7f1fafae927adc4879d9849e0ea7'],
+    }),
+    ('cryptography', '2.6.1', {
+        'checksums': ['26c821cbeb683facb966045e2064303029d572a87ee69ca5a1bf54bf55f93ca6'],
+    }),
+    ('pyasn1', '0.4.5', {
+        'checksums': ['da2420fe13a9452d8ae97a0e478adde1dee153b11ba832a95b223a2ba01c10f7'],
+    }),
+    ('PyNaCl', '1.3.0', {
+        'checksums': ['0c6100edd16fefd1557da078c7a31e7b7d7a52ce39fdca2bec29d4f7b6e7600c'],
+        'modulename': 'nacl',
+    }),
+    ('bcrypt', '3.1.6', {
+        'checksums': ['44636759d222baa62806bbceb20e96f75a015a6381690d1bc2eda91c01ec02ea'],
+    }),
+    ('paramiko', '2.4.2', {
+        'checksums': ['a8975a7df3560c9f1e2b43dc54ebd40fd00a7017392ca5445ce7df409f900fcb'],
+    }),
+    ('pyparsing', '2.3.1', {
+        'checksums': ['66c9268862641abcac4a96ba74506e594c884e3f57690a696d21ad8210ed667a'],
+    }),
+    ('netifaces', '0.10.9', {
+        'checksums': ['2dee9ffdd16292878336a58d04a20f0ffe95555465fee7c9bd23b3490ef2abf3'],
+    }),
+    ('netaddr', '0.7.19', {
+        'checksums': ['38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd'],
+    }),
+    ('funcsigs', '1.0.2', {
+        'checksums': ['a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50'],
+    }),
+    ('mock', '2.0.0', {
+        'checksums': ['b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba'],
+    }),
+    ('pytz', '2018.9', {
+        'checksums': ['d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c'],
+    }),
+    ('bitstring', '3.1.5', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'checksums': ['c163a86fcef377c314690051885d86b47419e3e1770990c212e16723c1c08faa'],
+    }),
+    ('virtualenv', '16.4.3', {
+        'checksums': ['984d7e607b0a5d1329425dd8845bd971b957424b5ba664729fab51ab8c11bc39'],
+    }),
+    ('docopt', '0.6.2', {
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
+    }),
+    ('joblib', '0.13.2', {
+        'checksums': ['315d6b19643ec4afd4c41c671f9f2d65ea9d787da093487a81ead7b0bac94524'],
+    }),
+    ('chardet', '3.0.4', {
+        'checksums': ['84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae'],
+    }),
+    ('certifi', '2019.3.9', {
+        'checksums': ['b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae'],
+    }),
+    ('urllib3', '1.24.1', {
+        'checksums': ['de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22'],
+    }),
+    ('requests', '2.21.0', {
+        'checksums': ['502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e'],
+    }),
+    ('xlrd', '1.2.0', {
+        'checksums': ['546eb36cee8db40c3eaa46c351e67ffee6eeb5fa2650b71bc4c758a29a1b29b2'],
+    }),
+    ('py_expression_eval', '0.3.6', {
+        'checksums': ['0907cef96a7c370b2a58ea2179f88e48f421f5a41821b32f7defb81ca4e5247e'],
+    }),
+    ('tabulate', '0.8.3', {
+        'checksums': ['8af07a39377cee1103a5c8b3330a421c2d99b9141e9cc5ddd2e3263fea416943'],
+    }),
+    ('ujson', '1.35', {
+        'checksums': ['f66073e5506e91d204ab0c614a148d5aa938bdbf104751be66f8ad7a222f5f86'],
+    }),
+    ('atomicwrites', '1.3.0', {
+        'checksums': ['75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6'],
+    }),
+    ('py', '1.8.0', {
+        'checksums': ['dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53'],
+    }),
+    ('scandir', '1.10.0', {
+        'checksums': ['4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae'],
+    }),
+    ('pathlib2', '2.3.3', {
+        'checksums': ['25199318e8cc3c25dcb45cbe084cc061051336d5a9ea2a12448d3d8cb748f742'],
+    }),
+    ('pluggy', '0.9.0', {
+        'checksums': ['19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f'],
+    }),
+    ('more-itertools', '5.0.0', {
+        'checksums': ['38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4'],
+    }),
+    ('attrs', '19.1.0', {
+        'checksums': ['f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399'],
+        'modulename': 'attr',
+    }),
+    ('wcwidth', '0.1.7', {
+        'checksums': ['3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e'],
+    }),
+    ('pytest', '4.3.1', {
+        'checksums': ['592eaa2c33fae68c7d75aacf042efc9f77b27c08a6224a4f59beab8d9a420523'],
+    }),
+    ('MarkupSafe', '1.1.1', {
+        'checksums': ['29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b'],
+    }),
+    ('Jinja2', '2.10', {
+        'checksums': ['f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4'],
+    }),
+    ('packaging', '19.0', {
+        'checksums': ['0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af'],
+    }),
+    ('sphinxcontrib-websupport', '1.1.0', {
+        'checksums': ['9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9'],
+        'modulename': 'sphinxcontrib.websupport',
+    }),
+    ('Pygments', '2.3.1', {
+        'checksums': ['5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a'],
+    }),
+    ('imagesize', '1.1.0', {
+        'checksums': ['f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5'],
+    }),
+    ('docutils', '0.14', {
+        'checksums': ['51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274'],
+    }),
+    ('snowballstemmer', '1.2.1', {
+        'checksums': ['919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128'],
+    }),
+    ('Babel', '2.6.0', {
+        'checksums': ['8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23'],
+    }),
+    ('alabaster', '0.7.12', {
+        'checksums': ['a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02'],
+    }),
+    ('typing', '3.6.6', {
+        'checksums': ['4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d'],
+    }),
+    ('Sphinx', '1.8.5', {
+        'checksums': ['c7658aab75c920288a8cf6f09f244c6cfdae30d82d803ac1634d9f223a80ca08'],
+    }),
+    ('Click', '7.0', {
+        'checksums': ['5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7'],
+    }),
+    ('psutil', '5.6.1', {
+        'checksums': ['fa0a570e0a30b9dd618bffbece590ae15726b47f9f1eaf7518dfb35f4d7dcd21'],
+    }),
+    ('future', '0.17.1', {
+        'checksums': ['67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8'],
+    }),
+    ('singledispatch', '3.4.0.3', {
+        'checksums': ['5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/re2c/re2c-1.3-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/r/re2c/re2c-1.3-GCCcore-9.3.0.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 're2c'
+version = '1.3'
+
+homepage = 'https://re2c.org/'
+description = """re2c is a free and open-source lexer generator for C and C++. Its main goal is generating
+fast lexers: at least as fast as their reasonably optimized hand-coded counterparts. Instead of using
+traditional table-driven approach, re2c encodes the generated finite state automata directly in the form
+of conditional jumps and comparisons."""
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+
+source_urls = ['https://github.com/skvadrik/re2c/releases/download/%(version)s']
+sources = ['%(name)s-%(version)s.tar.xz']
+checksums = ['f37f25ff760e90088e7d03d1232002c2c2672646d5844fdf8e0d51a5cd75a503']
+
+builddependencies = [('binutils', '2.34')]
+
+sanity_check_paths = {
+    'files': ['bin/re2c'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/s/SCons/SCons-3.1.2-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/s/SCons/SCons-3.1.2-GCCcore-9.3.0.eb
@@ -1,0 +1,34 @@
+easyblock = 'PythonPackage'
+
+name = 'SCons'
+version = '3.1.2'
+
+homepage = 'https://www.scons.org/'
+description = "SCons is a software construction tool."
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+patches = ['SCons-3.0.4_fix-pip-install.patch']
+checksums = [
+    '7801f3f62f654528e272df780be10c0e9337e897650b62ddcee9f39fde13f8fb',  # scons-3.1.2.tar.gz
+    'c632a50184edbb0dc032943fd717e832577d4ad407eb7743e5331eddb842a69f',  # SCons-3.0.4_fix-pip-install.patch
+]
+
+builddependencies = [('binutils', '2.34')]
+
+multi_deps = {'Python': ['3.8.2', '2.7.17']}
+
+download_dep_fail = True
+use_pip = True
+
+sanity_check_paths = {
+    'files': ['bin/scons', 'bin/scons-time', 'bin/sconsign'],
+    'dirs': [],
+}
+
+# no Python module to import during sanity check
+options = {'modulename': False}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Some dependencies required by Qt5. The Python-2.7.17 contains just a version upgrade, all sub-packages are left as they were. Python-2.7.17 is simply needed to build SCons.