### PR TITLE
ELPA for 2020a

### DIFF
--- a/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-foss-2020a.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-foss-2020a.eb
@@ -1,0 +1,31 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Authors::   Inge Gutheil <i.gutheil@fz-juelich.de>, Alan O'Cais <a.ocais@fz-juelich.de>
+# License::   MIT/GPL
+#
+##
+
+name = 'ELPA'
+version = '2019.11.001'
+
+homepage = 'https://elpa.rzg.mpg.de'
+description = """Eigenvalue SoLvers for Petaflop-Applications ."""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = ['https://elpa.mpcdf.mpg.de/html/Releases/%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['10374a8f042e23c7e1094230f7e2993b6f3580908a213dbdf089792d05aff357']
+
+builddependencies = [
+    ('Autotools', '20180311'),
+]
+
+# When building in parallel, the file test_setup_mpi.mod is sometimes
+# used before it is built, leading to an error.  This must be a bug in
+# the makefile affecting parallel builds.
+maxparallel = 1
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-intel-2020a.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-intel-2020a.eb
@@ -1,0 +1,26 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Authors::   Inge Gutheil <i.gutheil@fz-juelich.de>, Alan O'Cais <a.ocais@fz-juelich.de>
+# License::   MIT/GPL
+#
+##
+
+name = 'ELPA'
+version = '2019.11.001'
+
+homepage = 'https://elpa.rzg.mpg.de'
+description = """Eigenvalue SoLvers for Petaflop-Applications ."""
+
+toolchain = {'name': 'intel', 'version': '2020a'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = ['https://elpa.mpcdf.mpg.de/html/Releases/%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['10374a8f042e23c7e1094230f7e2993b6f3580908a213dbdf089792d05aff357']
+
+builddependencies = [
+    ('Autotools', '20180311'),
+]
+
+moduleclass = 'math'


### PR DESCRIPTION
Based on information from https://elpa.rzg.mpg.de the version 2019.11.001 is the latest. Thus, only toolchain is changed.