### PR TITLE
disable apt-get update (again) in GA workflow

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -32,7 +32,8 @@ jobs:
       run: |
         # note: using 'apt-get -o Acquire::Retries=3' to dance around connectivity issues to Azure,
         # see https://github.com/actions/virtual-environments/issues/675
-        sudo apt-get update -o Acquire::Retries=3
+        # apt-get update is disabled, causes problems and takes quite a bit of time, for little value
+        #sudo apt-get update -o Acquire::Retries=3
         # for modules tool
         sudo apt-get -o Acquire::Retries=3 install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
         # fix for lua-posix packaging issue, see https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082


### PR DESCRIPTION
seems like re-enabling `apt-get update` in #10336 is causing trouble, so disabling it again....