### PR TITLE
use apt-spy2 before using apt in GitHub Actions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,16 +30,20 @@ jobs:
 
     - name: install OS & Python packages
       run: |
-        # note: using 'apt-get -o Acquire::Retries=3' to dance around connectivity issues to Azure,
+        # use apt-spy2 to select closest apt mirror,
+        # which helps avoid connectivity issues in Azure;
         # see https://github.com/actions/virtual-environments/issues/675
-        # apt-get update is disabled, causes problems and takes quite a bit of time, for little value
-        #sudo apt-get update -o Acquire::Retries=3
+        sudo gem install apt-spy2
+        sudo apt-spy2 check
+        sudo apt-spy2 fix --commit
+        # after selecting a specific mirror, we need to run 'apt-get update'
+        sudo apt-get update
         # for modules tool
-        sudo apt-get -o Acquire::Retries=3 install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
+        sudo apt-get install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
         # fix for lua-posix packaging issue, see https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082
         sudo ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so
         # for testing OpenMPI-system*eb we need to have Open MPI installed
-        sudo apt-get -o Acquire::Retries=3 install libopenmpi-dev openmpi-bin
+        sudo apt-get install libopenmpi-dev openmpi-bin
         # required for test_dep_graph
         pip install pep8 python-graph-core python-graph-dot
 


### PR DESCRIPTION
This should help in dealing with the "`Could not connect to azure.archive.ubuntu.com`" issues that have been popping up...