### PR TITLE
also add alternative checksum for LaplacesDemon extension in R 3.6.0 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
@@ -2193,7 +2193,8 @@ exts_list = [
         'checksums': ['71750b741672a435ecf749b69c72f0681aa8bb795e317f4e3056d5e33f6d79e8'],
     }),
     ('LaplacesDemon', '16.1.1', {
-        'checksums': ['779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77'],
+        'checksums': [('779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77',
+                       '98d30fbc5594f46818632a6795febaa81df12e9598d31d17500bc7300289aea1')],
     }),
     ('rda', '1.0.2-2.1', {
         'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',

--- a/easybuild/easyconfigs/r/R/R-3.6.0-fosscuda-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-fosscuda-2019a.eb
@@ -2193,7 +2193,8 @@ exts_list = [
         'checksums': ['71750b741672a435ecf749b69c72f0681aa8bb795e317f4e3056d5e33f6d79e8'],
     }),
     ('LaplacesDemon', '16.1.1', {
-        'checksums': ['779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77'],
+        'checksums': [('779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77',
+                       '98d30fbc5594f46818632a6795febaa81df12e9598d31d17500bc7300289aea1')],
     }),
     ('rda', '1.0.2-2.1', {
         'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',

--- a/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-intel-2019a.eb
@@ -2252,7 +2252,8 @@ exts_list = [
         'checksums': ['71750b741672a435ecf749b69c72f0681aa8bb795e317f4e3056d5e33f6d79e8'],
     }),
     ('LaplacesDemon', '16.1.1', {
-        'checksums': ['779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77'],
+        'checksums': [('779ed1dbfed523a15701b4d5d891d4f1f11ab27518826a8a7725807d4c42bd77',
+                       '98d30fbc5594f46818632a6795febaa81df12e9598d31d17500bc7300289aea1')],
     }),
     ('rda', '1.0.2-2.1', {
         'checksums': [('6918b62f51252b57f2c05b99debef6136b370f594dc3ae6466268e4c35578ef8',


### PR DESCRIPTION
cfr. #9879