### PR TITLE
fix Perl shebang for RepeatMasker

### DIFF
--- a/easybuild/easyconfigs/r/RepeatMasker/RepeatMasker-4.0.9-p2-gompi-2019b-HMMER.eb
+++ b/easybuild/easyconfigs/r/RepeatMasker/RepeatMasker-4.0.9-p2-gompi-2019b-HMMER.eb
@@ -29,4 +29,6 @@ dependencies = [
     ('HMMER', '3.2.1'),
 ]
 
+fix_perl_shebang_for = ['RepeatMasker']
+
 moduleclass = 'bio'


### PR DESCRIPTION
Without this, sanity check fails with `bad interpreter: No such file or directory` if the installation prefix is too long, because the script has the full path to `perl` in the shebang...