### PR TITLE
use Bison 3.3.2 as build dep for flex 2.6.4

### DIFF
--- a/easybuild/easyconfigs/f/flex/flex-2.6.4.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4.eb
@@ -17,7 +17,7 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995']
 
 builddependencies = [
-    ('Bison', '3.0.4'),
+    ('Bison', '3.3.2'),
     ('help2man', '1.47.4'),
 ]
 


### PR DESCRIPTION
make flex/2.6.4 depend on Bison 3.3.2 to streamline the bootstrap process of a toolchain

Currently flex depends on an older Bison which results in Bison and older M4 being built twice as first steps in the toolchain creation process
https://i.imgur.com/r9yVGpM.png