### PR TITLE
[easybuild] dummy toolchain is deprecated

### DIFF
--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-4.2.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-4.2.0.eb
@@ -8,7 +8,7 @@ description = """EasyBuild is a software build and installation framework
  written in Python that allows you to install software in a structured,
  repeatable and robust way."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'system', 'version': ''}
 
 source_urls = [
     # easybuild-framework


### PR DESCRIPTION
get rid of deprecation warnings during bootstrap