### PR TITLE
Fix undefined reference to 'qfloat16::mantissatable' in Qt5-5.13.1-GCCcore-8.3.0

### DIFF
--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.13.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.13.1-GCCcore-8.3.0.eb
@@ -18,11 +18,13 @@ sources = ['qt-everywhere-src-%(version)s.tar.xz']
 patches = [
     'Qt5-%(version)s_fix-avx2.patch',
     'Qt5-%(version)s_fix-qmake-libdir.patch',
+    'Qt5-%(version)s_fix-mantissatable.patch',
 ]
 checksums = [
     'adf00266dc38352a166a9739f1a24a1e36f1be9c04bf72e16e142a256436974e',  # qt-everywhere-src-5.13.1.tar.xz
     '6f46005f056bf9e6ff3e5d012a874d18ee03b33e685941f2979c970be91a9dbc',  # Qt5-5.13.1_fix-avx2.patch
     '511ca9c0599ceb1989f73d8ceea9199c041512d3a26ee8c5fd870ead2c10cb63',  # Qt5-5.13.1_fix-qmake-libdir.patch
+    'cb23b917dd145b6775d7ffb3d8c143749d183d32972111f0c31133e41803f56b',  # Qt5-5.13.1_fix-mantissatable.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.13.1_fix-mantissatable.patch
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.13.1_fix-mantissatable.patch
@@ -1,0 +1,22 @@
+replaces F16C preprocessor conditional directives in gen_qfloat16_tables.cpp 
+author: Zdenek Matej, fix taken from Qt5.14, see pr #10332
+--- qtbase/src/tools/qfloat16-tables/gen_qfloat16_tables.cpp
++++ qtbase/src/tools/qfloat16-tables/gen_qfloat16_tables.cpp
+@@ -79,7 +79,7 @@
+     fid.write("#include <QtCore/qfloat16.h>\n\n");
+ 
+     fid.write("QT_BEGIN_NAMESPACE\n\n");
+-    fid.write("#if !defined(__F16C__) && !defined(__ARM_FP16_FORMAT_IEEE)\n\n");
++    fid.write("#if !defined(__ARM_FP16_FORMAT_IEEE)\n\n");
+ 
+     fid.write("const quint32 qfloat16::mantissatable[2048] = {\n");
+     fid.write("0,\n");
+@@ -156,7 +156,7 @@
+ 
+     fid.write("};\n\n");
+ 
+-    fid.write("#endif // !__F16C__ && !__ARM_FP16_FORMAT_IEEE\n\n");
++    fid.write("#endif // !__ARM_FP16_FORMAT_IEEE\n\n");
+     fid.write("QT_END_NAMESPACE\n");
+     fid.close();
+     return 0;


### PR DESCRIPTION
Add patch for Qt5-5.13.1-GCCcore-8.3.0.eb fixing #10332, i.e. undefined reference to 'qfloat16::mantissatable' in Qt5.13.