### PR TITLE
{math}[foss/2018b] fix dependencies and configuration of CoinUtils ecosystem

### DIFF
--- a/easybuild/easyconfigs/c/Cbc/Cbc-2.10.3-foss-2018b.eb
+++ b/easybuild/easyconfigs/c/Cbc/Cbc-2.10.3-foss-2018b.eb
@@ -4,32 +4,58 @@ name = 'Cbc'
 version = '2.10.3'
 
 homepage = "https://github.com/coin-or/Cbc"
-description = """Cbc (Coin-or branch and cut) is an open-source mixed integer linear programming solver written in C++.
- It can be used as a callable library or using a stand-alone executable."""
+description = """Cbc (Coin-or branch and cut) is an open-source mixed integer linear programming
+solver written in C++. It can be used as a callable library or using a
+stand-alone executable."""
 
 toolchain = {'name': 'foss', 'version': '2018b'}
+toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = ['https://www.coin-or.org/download/source/%(name)s/']
 sources = [SOURCE_TGZ]
 checksums = ['ad388357129497c1cc3be50c3707b1995fddf0a4188abc8e3669173f0179ecff']
 
 builddependencies = [
+    ('Autotools', '20180311'),
     ('Doxygen', '1.8.14'),
+    ('pkg-config', '0.29.2'),
 ]
 
 dependencies = [
     ('METIS', '5.1.0'),
     ('MUMPS', '5.2.1', '-metis'),
-    ('GLPK', '4.65'),
     ('CoinUtils', '2.11.3'),
     ('Osi', '0.108.5'),
     ('Clp', '1.17.3'),
     ('Cgl', '0.60.2'),
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
 ]
 
+# Use BLAS/LAPACK from OpenBLAS
+configopts = '--with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK" '
+# Use METIS AND MUMPS from EB
+configopts += '--with-metis-lib="-lmetis" '
+configopts += '--with-mumps-lib="-lcmumps -ldmumps -lsmumps -lzmumps -lmumps_common -lpord" '
+# Disable GLPK, dependencies have to be built with it as well
+configopts += '--without-glpk '
+# Use CoinUtils from EB
+configopts += '--with-coinutils-lib="-lCoinUtils" --with-coinutils-incdir=$EBROOTCOINUTILS/include/coin '
+configopts += '--with-coinutils-datadir=$EBROOTCOINUTILS/share/coin/Data'
+# Use Clp from EB
+configopts += '--with-clp-lib="-lOsiClp -lClpSolver -lClp" --with-clp-incdir="$EBROOTCLP/include/coin" '
+configopts += '--with-clp-datadir=$EBROOTCLP/share/coin/Data '
+# Use Osi from EB (also needs links to Clp due to OsiClpSolver)
+configopts += '--with-osi-lib="-lOsiClp -lClpSolver -lClp -lOsi" '
+configopts += '--with-osi-incdir="$EBROOTOSI/include/coin -I$EBROOTCLP/include/coin" '
+configopts += '--with-osi-datadir=$EBROOTOSI/share/coin/Data '
+# Use Cgl from EB
+configopts += '--with-cgl-lib="-lCgl" --with-cgl-incdir="$EBROOTCGL/include/coin" '
+configopts += '--with-cgl-datadir=$EBROOTCGL/share/coin/Data '
+
 sanity_check_paths = {
-    'files': ['lib/libCbc.%s' % SHLIB_EXT],
-    'dirs': ['include/coin', 'lib/pkgconfig']
+    'files': ['bin/cbc'] + ['lib/lib%s.%s' % (l, SHLIB_EXT) for l in ['Cbc', 'CbcSolver', 'OsiCbc']],
+    'dirs': ['include/coin', 'lib/pkgconfig', 'share/coin']
 }
 
 moduleclass = "math"

--- a/easybuild/easyconfigs/c/Cgl/Cgl-0.60.2-foss-2018b.eb
+++ b/easybuild/easyconfigs/c/Cgl/Cgl-0.60.2-foss-2018b.eb
@@ -4,19 +4,23 @@ name = 'Cgl'
 version = '0.60.2'
 
 homepage = "https://github.com/coin-or/Cgl"
-description = """The COIN-OR Cut Generation Library (Cgl) is a collection of cut generators that can be used with
- other COIN-OR packages that make use of cuts, such as, among others, the linear solver Clp or
- the mixed integer linear programming solvers Cbc or BCP. Cgl uses the abstract class OsiSolverInterface (see Osi)
- to use or communicate with a solver. It does not directly call a solver."""
+description = """The COIN-OR Cut Generation Library (Cgl) is a collection of cut generators that
+can be used with other COIN-OR packages that make use of cuts, such as, among
+others, the linear solver Clp or the mixed integer linear programming solvers
+Cbc or BCP. Cgl uses the abstract class OsiSolverInterface (see Osi) to use or
+communicate with a solver. It does not directly call a solver."""
 
 toolchain = {'name': 'foss', 'version': '2018b'}
+toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = ['https://www.coin-or.org/download/source/%(name)s/']
 sources = [SOURCE_TGZ]
 checksums = ['500892762cf3c1d28885b03a6c742a678dfcfde06af957377112f1b154888001']
 
 builddependencies = [
+    ('Autotools', '20180311'),
     ('Doxygen', '1.8.14'),
+    ('pkg-config', '0.29.2'),
 ]
 
 dependencies = [
@@ -25,9 +29,20 @@ dependencies = [
     ('Clp', '1.17.3'),
 ]
 
+# Use CoinUtils from EB
+configopts = '--with-coinutils-lib="-lCoinUtils" --with-coinutils-incdir=$EBROOTCOINUTILS/include/coin '
+configopts += '--with-coinutils-datadir=$EBROOTCOINUTILS/share/coin/Data'
+# Use Clp from EB
+configopts += '--with-clp-lib="-lOsiClp -lClpSolver -lClp" --with-clp-incdir="$EBROOTCLP/include/coin" '
+configopts += '--with-clp-datadir=$EBROOTCLP/share/coin/Data '
+# Use Osi from EB (also needs links to Clp due to OsiClpSolver)
+configopts += '--with-osi-lib="-lOsiClp -lClpSolver -lClp -lOsi" '
+configopts += '--with-osi-incdir="$EBROOTOSI/include/coin -I$EBROOTCLP/include/coin" '
+configopts += '--with-osi-datadir=$EBROOTOSI/share/coin/Data '
+
 sanity_check_paths = {
     'files': ['lib/libCgl.%s' % SHLIB_EXT],
-    'dirs': ['include/coin', 'lib/pkgconfig']
+    'dirs': ['include/coin', 'lib/pkgconfig', 'share/coin']
 }
 
 moduleclass = "math"

--- a/easybuild/easyconfigs/c/Clp/Clp-1.17.3-foss-2018b.eb
+++ b/easybuild/easyconfigs/c/Clp/Clp-1.17.3-foss-2018b.eb
@@ -5,30 +5,48 @@ version = '1.17.3'
 
 homepage = "https://github.com/coin-or/Clp"
 description = """Clp (Coin-or linear programming) is an open-source linear programming solver.
- It is primarily meant to be used as a callable library, but a basic, 
- stand-alone executable version is also available."""
+It is primarily meant to be used as a callable library, but a basic,
+stand-alone executable version is also available."""
 
 toolchain = {'name': 'foss', 'version': '2018b'}
+toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = ['https://www.coin-or.org/download/source/%(name)s/']
 sources = [SOURCE_TGZ]
 checksums = ['a13bf54291ad503cf76f5f93f2643d2add4faa5d0e60ff2db902ef715c094573']
 
 builddependencies = [
+    ('Autotools', '20180311'),
     ('Doxygen', '1.8.14'),
+    ('pkg-config', '0.29.2'),
 ]
 
 dependencies = [
     ('METIS', '5.1.0'),
     ('MUMPS', '5.2.1', '-metis'),
-    ('GLPK', '4.65'),
     ('CoinUtils', '2.11.3'),
     ('Osi', '0.108.5'),
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
 ]
 
+# Use BLAS/LAPACK from OpenBLAS
+configopts = '--with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK" '
+# Use METIS AND MUMPS from EB
+configopts += '--with-metis-lib="-lmetis" '
+configopts += '--with-mumps-lib="-lcmumps -ldmumps -lsmumps -lzmumps -lmumps_common -lpord" '
+# Disable GLPK because Clp requires headers from its sources
+configopts += '--without-glpk '
+# Use CoinUtils from EB
+configopts += '--with-coinutils-lib="-lCoinUtils" --with-coinutils-incdir=$EBROOTCOINUTILS/include/coin '
+configopts += '--with-coinutils-datadir=$EBROOTCOINUTILS/share/coin/Data'
+# Use Osi from EB
+configopts += '--with-osi-lib="-lOsi" --with-osi-incdir=$EBROOTOSI/include/coin '
+configopts += '--with-osi-datadir=$EBROOTOSI/share/coin/Data '
+
 sanity_check_paths = {
-    'files': ['lib/libClp.%s' % SHLIB_EXT],
-    'dirs': ['include/coin', 'lib/pkgconfig']
+    'files': ['bin/clp'] + ['lib/lib%s.%s' % (l, SHLIB_EXT) for l in ['Clp', 'ClpSolver', 'OsiClp']],
+    'dirs': ['include/coin', 'lib/pkgconfig', 'share/coin']
 }
 
 moduleclass = "math"

--- a/easybuild/easyconfigs/c/CoinUtils/CoinUtils-2.11.3-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/c/CoinUtils/CoinUtils-2.11.3-GCCcore-7.3.0.eb
@@ -4,23 +4,32 @@ name = 'CoinUtils'
 version = '2.11.3'
 
 homepage = "https://github.com/coin-or/CoinUtils"
-description = """CoinUtils (Coin-OR Utilities) is an open-source collection of classes and functions that are generally
- useful to more than one COIN-OR project."""
+description = """CoinUtils (Coin-OR Utilities) is an open-source collection of classes and
+functions that are generally useful to more than one COIN-OR project."""
+
 
 source_urls = ['https://www.coin-or.org/download/source/%(name)s/']
 sources = [SOURCE_TGZ]
 checksums = ['7c364792effe89d78b9b5385f30eaccc0fe92aab1caf5a1a835d81680639911f']
 
+# NOTE: this esyconfig for CoinUtils provides a minimal build not using BLAS/LAPACK or MPI
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 
 builddependencies = [
+    ('Autotools', '20180311'),
     ('binutils', '2.30'),
     ('Doxygen', '1.8.14'),
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
 ]
 
 sanity_check_paths = {
     'files': ['lib/libCoinUtils.%s' % SHLIB_EXT],
-    'dirs': ['include/coin', 'lib/pkgconfig']
+    'dirs': ['include/coin', 'lib/pkgconfig', 'share/coin']
 }
 
 moduleclass = "math"

--- a/easybuild/easyconfigs/c/CoinUtils/CoinUtils-2.11.3-foss-2018b.eb
+++ b/easybuild/easyconfigs/c/CoinUtils/CoinUtils-2.11.3-foss-2018b.eb
@@ -1,0 +1,36 @@
+easyblock = "ConfigureMake"
+
+name = 'CoinUtils'
+version = '2.11.3'
+
+homepage = "https://github.com/coin-or/CoinUtils"
+description = """CoinUtils (Coin-OR Utilities) is an open-source collection of classes and
+functions that are generally useful to more than one COIN-OR project."""
+
+source_urls = ['https://www.coin-or.org/download/source/%(name)s/']
+sources = [SOURCE_TGZ]
+checksums = ['7c364792effe89d78b9b5385f30eaccc0fe92aab1caf5a1a835d81680639911f']
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+builddependencies = [
+    ('Autotools', '20180311'),
+    ('Doxygen', '1.8.14'),
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+]
+
+# Use BLAS/LAPACK from OpenBLAS
+configopts = '--with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK" '
+
+sanity_check_paths = {
+    'files': ['lib/libCoinUtils.%s' % SHLIB_EXT],
+    'dirs': ['include/coin', 'lib/pkgconfig', 'share/coin']
+}
+
+moduleclass = "math"

--- a/easybuild/easyconfigs/o/Osi/Osi-0.108.5-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/o/Osi/Osi-0.108.5-GCCcore-7.3.0.eb
@@ -4,14 +4,16 @@ name = 'Osi'
 version = '0.108.5'
 
 homepage = "https://github.com/coin-or/Osi"
-description = """Osi (Open Solver Interface) provides an abstract base class to
- a generic linear programming (LP) solver, along with derived classes for specific solvers.
- Many applications may be able to use the Osi to insulate themselves from a specific LP solver.
- That is, programs written to the OSI standard may be linked to any solver with an OSI interface
- and should produce correct results.
- The OSI has been significantly extended compared to its first incarnation. 
- Currently, the OSI supports linear programming solvers and has rudimentary support for integer programming."""
+description = """Osi (Open Solver Interface) provides an abstract base class to a generic linear
+programming (LP) solver, along with derived classes for specific solvers. Many
+applications may be able to use the Osi to insulate themselves from a specific
+LP solver. That is, programs written to the OSI standard may be linked to any
+solver with an OSI interface and should produce correct results. The OSI has
+been significantly extended compared to its first incarnation. Currently, the
+OSI supports linear programming solvers and has rudimentary support for integer
+programming."""
 
+# NOTE: this esyconfig for CoinUtils provides a minimal build not using BLAS/LAPACK or MPI
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 
 source_urls = ['https://www.coin-or.org/download/source/%(name)s/']
@@ -19,17 +21,27 @@ sources = [SOURCE_TGZ]
 checksums = ['8efabdb3d5c89837d73fa6f9e7b764dce7450c579037964b64a996757f4d7d2c']
 
 builddependencies = [
+    ('Autotools', '20180311'),
     ('binutils', '2.30'),
     ('Doxygen', '1.8.14'),
+    ('pkg-config', '0.29.2'),
 ]
 
 dependencies = [
     ('CoinUtils', '2.11.3'),
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
 ]
 
+# Disable GLPK because Osi requires GLPK<=4.48
+configopts = '--without-glpk '
+# Use CoinUtils from EB
+configopts += '--with-coinutils-lib="-lCoinUtils" --with-coinutils-incdir=$EBROOTCOINUTILS/include/coin '
+configopts += '--with-coinutils-datadir=$EBROOTCOINUTILS/share/coin/Data'
+
 sanity_check_paths = {
-    'files': ['lib/libOsi.%s' % SHLIB_EXT],
-    'dirs': ['include/coin', 'lib/pkgconfig']
+    'files': ['lib/libOsi.%s' % SHLIB_EXT, 'lib/libOsiCommonTests.%s' % SHLIB_EXT],
+    'dirs': ['include/coin', 'lib/pkgconfig', 'share/coin']
 }
 
 moduleclass = "math"

--- a/easybuild/easyconfigs/o/Osi/Osi-0.108.5-foss-2018b.eb
+++ b/easybuild/easyconfigs/o/Osi/Osi-0.108.5-foss-2018b.eb
@@ -1,0 +1,48 @@
+easyblock = "ConfigureMake"
+
+name = 'Osi'
+version = '0.108.5'
+
+homepage = "https://github.com/coin-or/Osi"
+description = """Osi (Open Solver Interface) provides an abstract base class to a generic linear
+programming (LP) solver, along with derived classes for specific solvers. Many
+applications may be able to use the Osi to insulate themselves from a specific
+LP solver. That is, programs written to the OSI standard may be linked to any
+solver with an OSI interface and should produce correct results. The OSI has
+been significantly extended compared to its first incarnation. Currently, the
+OSI supports linear programming solvers and has rudimentary support for integer
+programming."""
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['https://www.coin-or.org/download/source/%(name)s/']
+sources = [SOURCE_TGZ]
+checksums = ['8efabdb3d5c89837d73fa6f9e7b764dce7450c579037964b64a996757f4d7d2c']
+
+builddependencies = [
+    ('Autotools', '20180311'),
+    ('Doxygen', '1.8.14'),
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('CoinUtils', '2.11.3'),
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+]
+
+# Use BLAS/LAPACK from OpenBLAS
+configopts = '--with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK" '
+# Disable GLPK because Osi requires GLPK<=4.48
+configopts += '--without-glpk '
+# Use CoinUtils from EB
+configopts += '--with-coinutils-lib="-lCoinUtils" --with-coinutils-incdir=$EBROOTCOINUTILS/include/coin '
+configopts += '--with-coinutils-datadir=$EBROOTCOINUTILS/share/coin/Data'
+
+sanity_check_paths = {
+    'files': ['lib/libOsi.%s' % SHLIB_EXT, 'lib/libOsiCommonTests.%s' % SHLIB_EXT],
+    'dirs': ['include/coin', 'lib/pkgconfig', 'share/coin']
+}
+
+moduleclass = "math"


### PR DESCRIPTION
This PR fixes several issues with CoinUtils and packages depending on it
* None of these packages is actually using the dependencies established in the easyconfig. All libraries are being rebuild again within each package, which translates to having, for instance, the `libCoinUtils.so` file replicated in the install path of CoinUtils, Osi, Clp, Cgl, and Cbg.
* Most of these packages support BLAS/LAPACK but were not linking to it. Easyconfigs in `foss/2018b` are fixed and new ones are added into `foss` for those that were not in it.
* These packages also support MPI, so I added the corresponding `toolchainopts`
* Easyconfigs with GLPK as a dependency were not using it. Moreover, the packages that do support GLPK cannot use the GLPK installation from Easybuild because it is either to high a version or because they need the source files of GLPK. Therefore, this PR explicitly disables GLPK, because this is what is already being done and this will avoid potential issues if GLPK from EB is loaded in the environment.
* Sanity checks have been revised