### PR TITLE
{bio}[intel/2019b] AUGUSTUS v3.3.3 & lpsolve/BCFtools deps (+ fixed patch)

### DIFF
--- a/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.3.3-foss-2019b.eb
+++ b/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.3.3-foss-2019b.eb
@@ -21,7 +21,7 @@ patches = [
 ]
 checksums = [
     '2fc5f9fd2f0c3bba2924df42ffaf55b5c130228cea18efdb3b6dfab9efa8c9f4',  # v3.3.3.tar.gz
-    '1e158b2241aa86077ae3b1b13ec7f26fbaf3fc49632afdc564fab88ac897e9a0',  # AUGUSTUS-3.3.3_fix-hardcoding.patch
+    'e2bb1206ebdde6aa344889563a6432cb1537800f2b5d3c7033152b21db724596',  # AUGUSTUS-3.3.3_fix-hardcoding.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.3.3-intel-2019b.eb
+++ b/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.3.3-intel-2019b.eb
@@ -1,0 +1,63 @@
+# Updated by: Pavel Grochal (INUITS)
+# License: GPLv2
+
+easyblock = 'ConfigureMake'
+
+name = 'AUGUSTUS'
+version = '3.3.3'
+
+# HTTPS doesn't work
+homepage = 'http://bioinf.uni-greifswald.de/augustus/'
+description = "AUGUSTUS is a program that predicts genes in eukaryotic genomic sequences"
+
+toolchain = {'name': 'intel', 'version': '2019b'}
+
+# https://github.com/Gaius-Augustus/Augustus/archive
+github_account = 'Gaius-Augustus'
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s.tar.gz']
+patches = [
+    '%(name)s-%(version)s_fix-hardcoding.patch',
+]
+checksums = [
+    '2fc5f9fd2f0c3bba2924df42ffaf55b5c130228cea18efdb3b6dfab9efa8c9f4',  # v3.3.3.tar.gz
+    'e2bb1206ebdde6aa344889563a6432cb1537800f2b5d3c7033152b21db724596',  # AUGUSTUS-3.3.3_fix-hardcoding.patch
+]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('Boost', '1.71.0'),
+    ('GSL', '2.6'),
+    ('SAMtools', '1.10'),
+    ('HTSlib', '1.10.2'),  # also provides tabix
+    ('BCFtools', '1.10.2'),
+    ('lpsolve', '5.5.2.5'),
+    ('SuiteSparse', '5.6.0', '-METIS-5.1.0'),
+    ('BamTools', '2.5.1'),
+    ('SQLite', '3.29.0'),
+]
+
+skipsteps = ['configure']
+
+# run "make clean" to avoid using binaries included with the source tarball
+prebuildopts = "make clean && "
+
+buildopts = 'COMPGENEPRED=true SQLITE=true ZIPINPUT=true CXX="$CXX" LINK.cc="$CXX" '
+installopts = 'INSTALLDIR=%(installdir)s '
+
+sanity_check_paths = {
+    'files': ['bin/augustus', 'bin/bam2hints', 'bin/espoca', 'bin/etraining',
+              'bin/fastBlockSearch', 'bin/filterBam', 'bin/getSeq', 'bin/homGeneMapping', 'bin/joingenes',
+              'bin/load2sqlitedb', 'bin/prepareAlign'],
+    'dirs': ['config', 'scripts'],
+}
+sanity_check_commands = ['augustus --help']
+
+modextrapaths = {'PATH': 'scripts'}
+modextravars = {
+    'AUGUSTUS_BIN_PATH': '%(installdir)s/bin',
+    'AUGUSTUS_CONFIG_PATH': '%(installdir)s/config',
+    'AUGUSTUS_SCRIPTS_PATH': '%(installdir)s/scripts',
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.3.3_fix-hardcoding.patch
+++ b/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.3.3_fix-hardcoding.patch
@@ -109,3 +109,11 @@ diff Augustus-3.3.3/auxprogs/filterBam/src/Makefile{.orig,} -ru
  INCLUDES = -I$(BAMTOOLS) -Iheaders -I./bamtools
  LIBS = -lbamtools -lz
  CFLAGS = -std=c++0x
+--- Augustus-3.3.3/auxprogs/joingenes/Makefile.orig	2020-04-22 17:23:34.829927330 +0200
++++ Augustus-3.3.3/auxprogs/joingenes/Makefile	2020-04-22 17:24:14.881206231 +0200
+@@ -1,4 +1,4 @@
+-CC=g++
++CC=$(CXX)
+ CFLAGS=-Wall -std=gnu++0x
+ 
+ all: joingenes

--- a/easybuild/easyconfigs/b/BCFtools/BCFtools-1.10.2-iccifort-2019.5.281.eb
+++ b/easybuild/easyconfigs/b/BCFtools/BCFtools-1.10.2-iccifort-2019.5.281.eb
@@ -1,0 +1,38 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# 
+# Author: Jonas Demeulemeester
+# The Francis Crick Insitute, London, UK
+
+easyblock = 'ConfigureMake'
+
+name = 'BCFtools'
+version = '1.10.2'
+
+homepage = 'https://www.htslib.org/'
+description = """Samtools is a suite of programs for interacting with high-throughput sequencing data.
+ BCFtools - Reading/writing BCF2/VCF/gVCF files and calling/filtering/summarising SNP and short indel sequence
+ variants"""
+
+toolchain = {'name': 'iccifort', 'version': '2019.5.281'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/samtools/%(namelower)s/releases/download/%(version)s']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['f57301869d0055ce3b8e26d8ad880c0c1989bf25eaec8ea5db99b60e31354e2c']
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('HTSlib', '1.10.2'),
+    ('bzip2', '1.0.8'),
+    ('XZ', '5.2.4'),
+    ('GSL', '2.6'),
+]
+
+configopts = "--with-htslib=$EBROOTHTSLIB --enable-libgsl"
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['bcftools', 'plot-vcfstats', 'vcfutils.pl']],
+    'dirs': ['libexec/bcftools']
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/l/lpsolve/lpsolve-5.5.2.5-iccifort-2019.5.281.eb
+++ b/easybuild/easyconfigs/l/lpsolve/lpsolve-5.5.2.5-iccifort-2019.5.281.eb
@@ -1,0 +1,33 @@
+easyblock = 'CmdCp'
+
+name = 'lpsolve'
+version = '5.5.2.5'
+
+homepage = 'https://sourceforge.net/projects/lpsolve/'
+description = "Mixed Integer Linear Programming (MILP) solver"
+
+toolchain = {'name': 'iccifort', 'version': '2019.5.281'}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['lp_solve_%(version)s_source.tar.gz']
+checksums = ['201a7c62b8b3360c884ee2a73ed7667e5716fc1e809755053b398c2f5b0cf28a']
+
+local_lpsolve_ver = '%(version_major)s%(version_minor)s'
+start_dir = 'lpsolve%s' % local_lpsolve_ver
+
+local_comp_cmd = 'sed -i "s/^c=.*/c=\'$CC\'/g" ccc && sed -i "s/^opts=.*/opts=\'$CFLAGS\'/g" ccc && '
+local_comp_cmd += "sh ccc"
+cmds_map = [('.*', local_comp_cmd)]
+
+local_lpsolve_libname = 'liblpsolve%s' % local_lpsolve_ver
+files_to_copy = [
+    (['bin/ux64/%s.a' % local_lpsolve_libname, 'bin/ux64/%s.%s' % (local_lpsolve_libname, SHLIB_EXT)], 'lib'),
+    (['../lp*.h'], 'include'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/%s.a' % local_lpsolve_libname, 'lib/%s.%s' % (local_lpsolve_libname, SHLIB_EXT)],
+    'dirs': ['include'],
+}
+
+moduleclass = 'math'


### PR DESCRIPTION
fixed patch is required to make installation with `intel/2019b` work, since otherwise `g++` is used with compiler options for `icpc`...