### PR TITLE
update to Python 2.7.18 + minor updates for extensions

### DIFF
--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.72.0-gompi-2020a.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.72.0-gompi-2020a.eb
@@ -18,7 +18,7 @@ checksums = [
     '60e3aede2f444a3855f4efed94d1de5c2887983876e0fae21f6ca5cfdc53ea96',  # Boost-1.71.0_fix-Python3.patch
 ]
 
-multi_deps = {'Python': ['3.8.2', '2.7.17']}
+multi_deps = {'Python': ['3.8.2', '2.7.18']}
 
 dependencies = [('Boost', version)]
 

--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.72.0-iimpi-2020a.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.72.0-iimpi-2020a.eb
@@ -18,7 +18,7 @@ checksums = [
     '60e3aede2f444a3855f4efed94d1de5c2887983876e0fae21f6ca5cfdc53ea96',  # Boost-1.71.0_fix-Python3.patch
 ]
 
-multi_deps = {'Python': ['3.8.2', '2.7.17']}
+multi_deps = {'Python': ['3.8.2', '2.7.18']}
 
 dependencies = [('Boost', version)]
 

--- a/easybuild/easyconfigs/g/GATK/GATK-4.1.5.0-GCCcore-9.3.0-Java-11.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-4.1.5.0-GCCcore-9.3.0-Java-11.eb
@@ -33,7 +33,7 @@ source_urls = ['https://github.com/broadinstitute/gatk/releases/download/%(versi
 sources = ['gatk-%(version)s.zip']
 checksums = ['6fc152c2cae0cc54c7c4cfdfd865a64f7054a820f7d02ca2549511af1dd9882b']
 
-multi_deps = {'Python': ['3.8.2', '2.7.17']}
+multi_deps = {'Python': ['3.8.2', '2.7.18']}
 
 dependencies = [
     ('Java', '11', '', True),

--- a/easybuild/easyconfigs/m/Mako/Mako-1.1.2-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/m/Mako/Mako-1.1.2-GCCcore-9.3.0.eb
@@ -17,7 +17,7 @@ use_pip = True
 sanity_pip_check = True
 
 builddependencies = [('binutils', '2.34')]
-multi_deps = {'Python': ['3.8.2', '2.7.17']}
+multi_deps = {'Python': ['3.8.2', '2.7.18']}
 
 sanity_check_paths = {
     'files': ['bin/mako-render'],

--- a/easybuild/easyconfigs/p/PyYAML/PyYAML-5.3-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/p/PyYAML/PyYAML-5.3-GCCcore-9.3.0.eb
@@ -14,7 +14,7 @@ checksums = ['e9f45bd5b92c7974e59bcd2dcc8631a6b6cc380a904725fce7bc08872e691615']
 
 builddependencies = [('binutils', '2.34')]
 
-multi_deps = {'Python': ['3.8.2', '2.7.17']}
+multi_deps = {'Python': ['3.8.2', '2.7.18']}
 
 dependencies = [('libyaml', '0.2.2')]
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.18-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.18-GCCcore-9.3.0.eb
@@ -1,5 +1,5 @@
 name = 'Python'
-version = '2.7.17'
+version = '2.7.18'
 
 homepage = 'https://python.org/'
 description = """Python is a programming language that lets you work more quickly and integrate your systems
@@ -10,7 +10,7 @@ toolchainopts = {'pic': True}
 
 source_urls = ['https://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
-checksums = ['f22059d09cdf9625e0a7284d24a13062044f5bf59d93a7f3382190dfa94cecde']
+checksums = ['da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814']
 
 dependencies = [
     ('binutils', '2.34'),  # required for pip install that involves compilation
@@ -36,7 +36,7 @@ exts_default_options = {
 }
 
 # order is important!
-# package versions updated Feb 22nd 2020
+# package versions updated 23 April 2020
 exts_list = [
     # setuptools 44.0.0 is the most recent version still supporting Python 2.x
     ('setuptools', '44.0.0', {
@@ -60,11 +60,11 @@ exts_list = [
     ('paycheck', '1.0.2', {
         'checksums': ['6db7fc367c146cd59d2327ad4d2d6b0a24bc1be2d6953bb0773cbf702ee1ed34'],
     }),
-    ('pbr', '5.4.4', {
-        'checksums': ['139d2625547dbfa5fb0b81daebb39601c478c21956dc57e2e07b74450a8c506b'],
+    ('pbr', '5.4.5', {
+        'checksums': ['07f558fece33b05caf857474a366dfcc00562bca13dd8b47b2b3e22d9f9bf55c'],
     }),
-    ('Cython', '0.29.15', {
-        'checksums': ['60d859e1efa5cc80436d58aecd3718ff2e74b987db0518376046adedba97ac30'],
+    ('Cython', '0.29.16', {
+        'checksums': ['232755284f942cbb3b43a06cd85974ef3c970a021aef19b5243c03ee2b08fa05'],
     }),
     ('six', '1.14.0', {
         'checksums': ['236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a'],
@@ -79,8 +79,8 @@ exts_list = [
         'modulename': 'dateutil',
         'checksums': ['73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c'],
     }),
-    ('decorator', '4.4.1', {
-        'checksums': ['54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce'],
+    ('decorator', '4.4.2', {
+        'checksums': ['e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7'],
     }),
     ('liac-arff', '2.4.0', {
         'modulename': 'arff',
@@ -106,14 +106,14 @@ exts_list = [
     ('idna', '2.9', {
         'checksums': ['7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb'],
     }),
-    ('pycparser', '2.19', {
-        'checksums': ['a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3'],
+    ('pycparser', '2.20', {
+        'checksums': ['2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0'],
     }),
     ('cffi', '1.14.0', {
         'checksums': ['2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6'],
     }),
-    ('cryptography', '2.8', {
-        'checksums': ['3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651'],
+    ('cryptography', '2.9.2', {
+        'checksums': ['a0c30272fb4ddda5f5ffc1089d7405b7a71b0b0f51993cb4e5dbb4590b2fc229'],
     }),
     ('pyasn1', '0.4.8', {
         'checksums': ['aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba'],
@@ -128,8 +128,8 @@ exts_list = [
     ('paramiko', '2.7.1', {
         'checksums': ['920492895db8013f6cc0179293147f830b8c7b21fdfc839b6bad760c27459d9f'],
     }),
-    ('pyparsing', '2.4.6', {
-        'checksums': ['4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f'],
+    ('pyparsing', '2.4.7', {
+        'checksums': ['c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1'],
     }),
     ('netifaces', '0.10.9', {
         'checksums': ['2dee9ffdd16292878336a58d04a20f0ffe95555465fee7c9bd23b3490ef2abf3'],
@@ -160,11 +160,11 @@ exts_list = [
     ('filelock', '3.0.12', {
         'checksums': ['18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59'],
     }),
-    ('importlib_resources', '1.3.1', {
-        'checksums': ['7f0e1b2b5f3981e39c52da0f99b2955353c5a139c314994d1126c2551ace9bdf'],
+    ('importlib_resources', '1.4.0', {
+        'checksums': ['4019b6a9082d8ada9def02bece4a76b131518866790d58fdda0b5f8c603b36c2'],
     }),
-    ('virtualenv', '20.0.5', {
-        'checksums': ['531b142e300d405bb9faedad4adbeb82b4098b918e35209af2adef3129274aae'],
+    ('virtualenv', '20.0.18', {
+        'checksums': ['ac53ade75ca189bc97b6c1d9ec0f1a50efe33cbf178ae09452dcd9fd309013c1'],
     }),
     ('docopt', '0.6.2', {
         'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
@@ -175,11 +175,11 @@ exts_list = [
     ('chardet', '3.0.4', {
         'checksums': ['84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae'],
     }),
-    ('certifi', '2019.11.28', {
-        'checksums': ['25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f'],
+    ('certifi', '2020.4.5.1', {
+        'checksums': ['51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519'],
     }),
-    ('urllib3', '1.25.8', {
-        'checksums': ['87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc'],
+    ('urllib3', '1.25.9', {
+        'checksums': ['3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527'],
     }),
     ('requests', '2.23.0', {
         'checksums': ['b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6'],
@@ -190,11 +190,11 @@ exts_list = [
     ('py_expression_eval', '0.3.9', {
         'checksums': ['d80a948f91f78d08f789b0a7c3fb2bd9a34ad625f5ce88c262a6c91189a4abb9'],
     }),
-    ('tabulate', '0.8.6', {
-        'checksums': ['5470cc6687a091c7042cee89b2946d9235fe9f6d49c193a4ae2ac7bf386737c8'],
+    ('tabulate', '0.8.7', {
+        'checksums': ['db2723a20d04bcda8522165c73eea7c300eda74e0ce852d9022e0159d7895007'],
     }),
-    ('ujson', '1.35', {
-        'checksums': ['f66073e5506e91d204ab0c614a148d5aa938bdbf104751be66f8ad7a222f5f86'],
+    ('ujson', '2.0.3', {
+        'checksums': ['bd2deffc983827510e5145fb66e4cc0f577480c62fe0b4882139f8f7d27ae9a3'],
     }),
     ('atomicwrites', '1.3.0', {
         'checksums': ['75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6'],
@@ -208,17 +208,19 @@ exts_list = [
     ('pathlib2', '2.3.5', {
         'checksums': ['6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868'],
     }),
+    # zipp 1.2.0 is the most recent version still supporting Python 2.x
     ('zipp', '1.2.0', {
         'checksums': ['c70410551488251b0fee67b460fb9a536af8d6f9f008ad10ac51f615b6a521b1'],
     }),
+    # configparser 4.0.2 is the most recent version still supporting Python 2.x
     ('configparser', '4.0.2', {
         'checksums': ['c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df'],
     }),
     ('contextlib2', '0.6.0.post1', {
         'checksums': ['01f490098c18b19d2bd5bb5dc445b2054d2fa97f09a4280ba2c5f3c394c8162e'],
     }),
-    ('importlib_metadata', '1.5.0', {
-        'checksums': ['06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302'],
+    ('importlib_metadata', '1.6.0', {
+        'checksums': ['34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e'],
     }),
     ('pluggy', '0.13.1', {
         'checksums': ['15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0'],
@@ -231,21 +233,21 @@ exts_list = [
         'modulename': 'attr',
         'checksums': ['f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72'],
     }),
-    ('wcwidth', '0.1.8', {
-        'checksums': ['f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8'],
+    ('wcwidth', '0.1.9', {
+        'checksums': ['ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1'],
     }),
-    # pytest 4.6.x is the most recent version still supporting Python 2.x
+    # pytest 4.6.9 is the most recent version still supporting Python 2.x
     ('pytest', '4.6.9', {
         'checksums': ['19e8f75eac01dd3f211edd465b39efbcbdc8fc5f7866d7dd49fedb30d8adf339'],
     }),
     ('MarkupSafe', '1.1.1', {
         'checksums': ['29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b'],
     }),
-    ('Jinja2', '2.11.1', {
-        'checksums': ['93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250'],
+    ('Jinja2', '2.11.2', {
+        'checksums': ['89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0'],
     }),
-    ('packaging', '20.1', {
-        'checksums': ['e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334'],
+    ('packaging', '20.3', {
+        'checksums': ['3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3'],
     }),
     # sphinxcontrib-websupport 1.1.2 is the most recent version still supporting Python 2.x
     ('sphinxcontrib-websupport', '1.1.2', {
@@ -277,8 +279,8 @@ exts_list = [
     ('Sphinx', '1.8.5', {
         'checksums': ['c7658aab75c920288a8cf6f09f244c6cfdae30d82d803ac1634d9f223a80ca08'],
     }),
-    ('Click', '7.0', {
-        'checksums': ['5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7'],
+    ('click', '7.1.1', {
+        'checksums': ['8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc'],
     }),
     ('psutil', '5.7.0', {
         'checksums': ['685ec16ca14d079455892f25bd124df26ff9137664af445563c1bd36629b5e0e'],

--- a/easybuild/easyconfigs/s/SCons/SCons-3.1.2-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/s/SCons/SCons-3.1.2-GCCcore-9.3.0.eb
@@ -18,7 +18,7 @@ checksums = [
 
 builddependencies = [('binutils', '2.34')]
 
-multi_deps = {'Python': ['3.8.2', '2.7.17']}
+multi_deps = {'Python': ['3.8.2', '2.7.18']}
 
 download_dep_fail = True
 use_pip = True


### PR DESCRIPTION
It's time to step into the future with Python 2.7.18...

(updated extensions also done for Python 3.8.2 in #10456)