### PR TITLE
add URL in comment to explain why UCX is included as a dep for impi 2019.7.217

### DIFF
--- a/easybuild/easyconfigs/i/impi/impi-2019.7.217-iccifort-2020.1.217.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2019.7.217-iccifort-2020.1.217.eb
@@ -13,7 +13,9 @@ sources = ['l_mpi_%(version)s.tgz']
 checksums = ['90383b0023f84ac003a55d8bb29dbcf0c639f43a25a2d8d8698a16e770ac9c07']
 
 dependencies = [
-    ('UCX', '1.8.0'),  # needed by libfabric provider MLX introduced in Intel MPI v2019.6
+    # needed by libfabric provider MLX introduced in Intel MPI v2019.6,
+    # https://software.intel.com/en-us/articles/improve-performance-and-stability-with-intel-mpi-library-on-infiniband
+    ('UCX', '1.8.0'),
 ]
 
 dontcreateinstalldir = True


### PR DESCRIPTION
@lexming should have been part of #10280 ;)