### PR TITLE
[OTF2 & Score-P] Move builddependencies to dependencies

### DIFF
--- a/easybuild/easyconfigs/o/OTF2/OTF2-2.2-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-2.2-GCCcore-8.2.0.eb
@@ -33,6 +33,8 @@ checksums = [
 builddependencies = [
     # use same binutils version that was used when building GCCcore
     ('binutils', '2.31.1'),
+]
+dependencies = [
     # SIONlib container support (optional):
     ('SIONlib', '1.7.4', '-tools'),
 ]

--- a/easybuild/easyconfigs/o/OTF2/OTF2-2.2-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-2.2-GCCcore-8.3.0.eb
@@ -33,6 +33,8 @@ checksums = [
 builddependencies = [
     # use same binutils version that was used when building GCCcore
     ('binutils', '2.32'),
+]
+dependencies = [
     # SIONlib container support (optional):
     ('SIONlib', '1.7.6', '-tools'),
 ]

--- a/easybuild/easyconfigs/s/Score-P/Score-P-6.0-gompi-2019a.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-6.0-gompi-2019a.eb
@@ -27,16 +27,11 @@ checksums = [
     '5dc1023eb766ba5407f0b5e0845ec786e0021f1da757da737db1fb71fc4236b8',  # scorep-6.0.tar.gz
 ]
 
-builddependencies = [
+dependencies = [
     ('CubeLib', '4.4.4'),
     ('CubeWriter', '4.4.3'),
     # Unwinding/sampling support (optional):
     ('libunwind', '1.3.1'),
-]
-
-dependencies = [
-    # binutils is implicitly available via GCC toolchain
-    # ('binutils', '2.31.1'),
     ('OPARI2', '2.0.5'),
     ('OTF2', '2.2'),
     # Hardware counter support (optional):


### PR DESCRIPTION
As discussed in https://github.com/easybuilders/easybuild-easyconfigs/pull/10397#issuecomment-619363052 those should be runtime dependencies as they are used at runtime

CCing @lexming as he merged #10397