### PR TITLE
remove FFTW dependencies from LAMMPS easyconfigs, no longer needed (MKL can be used too now)

### DIFF
--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-3Mar2020-foss-2019b-Python-3.7.4-kokkos.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-3Mar2020-foss-2019b-Python-3.7.4-kokkos.eb
@@ -53,7 +53,6 @@ dependencies = [
     ('libxml2', '2.9.9'),
     ('FFmpeg', '4.2.1'),
     ('Voro++', '0.4.6'),
-    ('FFTW', '3.3.8'),
     ('kim-api', '2.1.3'),
     ('Eigen', '3.3.7', '', True),
     ('yaff', '1.6.0', local_python_versionsuffix),

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-3Mar2020-intel-2019b-Python-3.7.4-kokkos.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-3Mar2020-intel-2019b-Python-3.7.4-kokkos.eb
@@ -53,7 +53,6 @@ dependencies = [
     ('libxml2', '2.9.9'),
     ('FFmpeg', '4.2.1'),
     ('Voro++', '0.4.6'),
-    ('FFTW', '3.3.8'),
     ('kim-api', '2.1.3'),
     ('Eigen', '3.3.7', '', True),
     ('yaff', '1.6.0', local_python_versionsuffix),

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-7Aug2019-foss-2019b-Python-3.7.4-kokkos.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-7Aug2019-foss-2019b-Python-3.7.4-kokkos.eb
@@ -53,7 +53,6 @@ dependencies = [
     ('libxml2', '2.9.9'),
     ('FFmpeg', '4.2.1'),
     ('Voro++', '0.4.6'),
-    ('FFTW', '3.3.8'),
     ('kim-api', '2.1.3'),
     ('Eigen', '3.3.7', '', True),
     ('yaff', '1.6.0', local_python_versionsuffix),

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-7Aug2019-intel-2019b-Python-3.7.4-kokkos.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-7Aug2019-intel-2019b-Python-3.7.4-kokkos.eb
@@ -53,7 +53,6 @@ dependencies = [
     ('libxml2', '2.9.9'),
     ('FFmpeg', '4.2.1'),
     ('Voro++', '0.4.6'),
-    ('FFTW', '3.3.8'),
     ('kim-api', '2.1.3'),
     ('Eigen', '3.3.7', '', True),
     ('yaff', '1.6.0', local_python_versionsuffix),


### PR DESCRIPTION
since https://github.com/easybuilders/easybuild-easyblocks/pull/1997, and since these are part of the toolchain they should not be included as dep.