### PR TITLE
add patch for h5py 2.10.0 with 2020a toolchains to avoid MPI_Init at import

### DIFF
--- a/easybuild/easyconfigs/h/h5py/h5py-2.10.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.10.0-foss-2020a-Python-3.8.2.eb
@@ -14,7 +14,11 @@ toolchainopts = {'usempi': True}
 
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
-checksums = ['84412798925dc870ffd7107f045d7659e60f5d46d1c70c700375248bf6bf512d']
+patches = ['h5py-%(version)s_fix-import-mpi.patch']
+checksums = [
+    '84412798925dc870ffd7107f045d7659e60f5d46d1c70c700375248bf6bf512d',  # h5py-2.10.0.tar.gz
+    'eb14f2983e84a05a5e04c42c0bf00d9d1d128fb0bed105d0b6bf574f82e246cd',  # h5py-2.10.0_fix-import-mpi.patch
+]
 
 builddependencies = [('pkgconfig', '1.5.1', versionsuffix)]
 
@@ -29,9 +33,5 @@ download_dep_fail = True
 
 # to really use mpi enabled hdf5 we now seem to need a configure step, which is the reason we can't use pip
 prebuildopts = 'python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
-
-# skip regular 'import h5py', and run it via mpirun (since 'import h5py' results in an MPI_Init call)
-options = {'modulename': False}
-sanity_check_commands = ["%(mpi_cmd_prefix)s python -c 'import %(name)s'"]
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.10.0-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.10.0-intel-2020a-Python-3.8.2.eb
@@ -14,7 +14,11 @@ toolchainopts = {'usempi': True}
 
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
-checksums = ['84412798925dc870ffd7107f045d7659e60f5d46d1c70c700375248bf6bf512d']
+patches = ['h5py-%(version)s_fix-import-mpi.patch']
+checksums = [
+    '84412798925dc870ffd7107f045d7659e60f5d46d1c70c700375248bf6bf512d',  # h5py-2.10.0.tar.gz
+    'eb14f2983e84a05a5e04c42c0bf00d9d1d128fb0bed105d0b6bf574f82e246cd',  # h5py-2.10.0_fix-import-mpi.patch
+]
 
 builddependencies = [('pkgconfig', '1.5.1', versionsuffix)]
 
@@ -29,9 +33,5 @@ download_dep_fail = True
 
 # to really use mpi enabled hdf5 we now seem to need a configure step, which is the reason we can't use pip
 prebuildopts = 'python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
-
-# skip regular 'import h5py', and run it via mpirun (since 'import h5py' results in an MPI_Init call)
-options = {'modulename': False}
-sanity_check_commands = ["%(mpi_cmd_prefix)s python -c 'import %(name)s'"]
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.10.0_fix-import-mpi.patch
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.10.0_fix-import-mpi.patch
@@ -1,0 +1,35 @@
+avoid that mpi4py initializes MPI at import,
+only initialize when needed
+cfr. https://github.com/h5py/h5py/pull/1544
+author: Kenneth Hoste (HPC-UGent)
+diff -ru h5py-2.10.0.orig/h5py/_hl/files.py h5py-2.10.0/h5py/_hl/files.py
+--- h5py-2.10.0.orig/h5py/_hl/files.py	2019-09-06 23:29:33.000000000 +0200
++++ h5py-2.10.0/h5py/_hl/files.py	2020-05-12 17:56:43.503885936 +0200
+@@ -44,6 +44,8 @@
+ 
+ def _set_fapl_mpio(plist, **kwargs):
+     import mpi4py
++    if not mpi4py.MPI.Is_initialized():
++        mpi4py.MPI.Init()
+     kwargs.setdefault('info', mpi4py.MPI.Info())
+     plist.set_fapl_mpio(**kwargs)
+ 
+diff -ru h5py-2.10.0.orig/h5py/__init__.py h5py-2.10.0/h5py/__init__.py
+--- h5py-2.10.0.orig/h5py/__init__.py	2019-09-06 23:33:01.000000000 +0200
++++ h5py-2.10.0/h5py/__init__.py	2020-05-12 17:56:12.603359778 +0200
+@@ -16,6 +16,15 @@
+ 
+ from warnings import warn as _warn
+ 
++# Tell mpi4py to not automatically initialize MPI at import;
++# required to avoid problems with 'import h5py' in some environment
++# when h5py was built with MPI support
++try:
++    import mpi4py
++    mpi4py.rc.initialize = False
++    mpi4py.rc.finalize = True
++except ImportError:
++    pass
+ 
+ # --- Library setup -----------------------------------------------------------
+ 

--- a/easybuild/easyconfigs/y/yaff/yaff-1.6.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/y/yaff/yaff-1.6.0-foss-2020a-Python-3.8.2.eb
@@ -39,9 +39,4 @@ check_ldshared = True
 runtest = "export MATPLOTLIBRC=$PWD; echo 'backend: agg' > $MATPLOTLIBRC/matplotlibrc; "
 runtest += "python setup.py build_ext -i; nosetests -v"
 
-sanity_check_paths = {
-    'files': [],
-    'dirs': ['lib/python%(pyshortver)s/site-packages'],
-}
-
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/y/yaff/yaff-1.6.0-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/y/yaff/yaff-1.6.0-intel-2020a-Python-3.8.2.eb
@@ -42,15 +42,4 @@ check_ldshared = True
 # runtest = "export MATPLOTLIBRC=$PWD; echo 'backend: agg' > $MATPLOTLIBRC/matplotlibrc; "
 # runtest += "python setup.py build_ext -i; %(mpi_cmd_prefix)s nosetests -v"
 
-sanity_check_paths = {
-    'files': [],
-    'dirs': ['lib/python%(pyshortver)s/site-packages'],
-}
-
-# skip regular 'import yaff', and run it via mpirun (since 'import yaff' results in an MPI_Init call via h5py)
-# this is only needed because of a bug in Intel MPI 2019 update 7 ("Fatal error in PMPI_Init_thread")
-# see https://github.com/easybuilders/easybuild-easyconfigs/issues/10213
-options = {'modulename': False}
-sanity_check_commands = ["%(mpi_cmd_prefix)s python -c 'import %(name)s'"]
-
 moduleclass = 'chem'


### PR DESCRIPTION
This fix was also proposed upstream, see https://github.com/h5py/h5py/pull/1544 .

It may get merged in slightly different form since the `h5py` developers don't seem to favor the top-level `try` + `import mpi4py`, but it's good enough to fix the h5py 2.10.0 release we're using.

I've verified that the Parallel HDF5 capabilities of `h5py` are preserved with this patch (using the example from https://docs.h5py.org/en/stable/mpi.html.

This should unblock #10191...