### PR TITLE
add alternative checksum for pkgmaker, doRNG, cobs extension in R 3.6.0

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
@@ -792,7 +792,8 @@ exts_list = [
         'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
     }),
     ('pkgmaker', '0.27', {
-        'checksums': ['17a289d8f596ba5637b07077b3bff22411a2c2263c0b7de59fe848666555ec6a'],
+        'checksums': [('17a289d8f596ba5637b07077b3bff22411a2c2263c0b7de59fe848666555ec6a',
+                       'e5eb9058e68702c15e8dc6fee6ede41cdbe8e3914d190a5a1113079db26fb003')],
     }),
     ('rngtools', '1.3.1.1', {
         'checksums': ['99e1a8fde6b81128d0946746c1ef84ec5b6c2973ad843a080098baf73aa3364c'],
@@ -1257,7 +1258,8 @@ exts_list = [
         'checksums': ['8e259c2b12446197d1152b83a81bab84ccb5a5b77021a9b5645dd4c63c804bd1'],
     }),
     ('doRNG', '1.7.1', {
-        'checksums': ['27533d54464889d1c21301594137fc0f536574e3a413d61d7df9463ab12a67e9'],
+        'checksums': [('27533d54464889d1c21301594137fc0f536574e3a413d61d7df9463ab12a67e9',
+                       'bda8143e2b5554fb39fdea81af6482f8938160fdbf5c45014f3a5de40aacf4c4')],
     }),
     ('nleqslv', '3.3.2', {
         'checksums': ['f54956cf67f9970bb3c6803684c84a27ac78165055745e444efc45cfecb63fed'],
@@ -2127,7 +2129,8 @@ exts_list = [
         'checksums': ['76cee2393757390ad91d3db3e5aeb2c2d34c0a46822b7941498571a473417142'],
     }),
     ('cobs', '1.3-3', {
-        'checksums': ['6b1e760cf8dec6b6e63f042cdc3e5e633de5f982e8bc743a891932f6d9f91bdf'],
+        'checksums': [('6b1e760cf8dec6b6e63f042cdc3e5e633de5f982e8bc743a891932f6d9f91bdf',
+                       'f3fca282c9a258cc5e4976780f4907aca1051796524d6861fc15204ab22ab7d2')],
     }),
     ('resample', '0.4', {
         'checksums': ['f0d5f735e1b812612720845d79167a19f713a438fd10a6a3206e667045fd93e5'],


### PR DESCRIPTION
I used #9789 as a reference...