### PR TITLE
update UDUNITS source_urls to https sources

### DIFF
--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.24-intel-2017a.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.24-intel-2017a.eb
@@ -23,7 +23,7 @@ toolchain = {'name': 'intel', 'version': '2017a'}
 toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['ftp://ftp.unidata.ucar.edu/pub/udunits']
+source_urls = ['https://www.unidata.ucar.edu/downloads/udunits']
 
 dependencies = [('expat', '2.2.0')]
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.24-intel-2017a.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.24-intel-2017a.eb
@@ -24,6 +24,7 @@ toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['https://www.unidata.ucar.edu/downloads/udunits']
+checksums = ['20bac512f2656f056385429a0e44902fdf02fc7fe01c14d56f3c724336177f95']
 
 dependencies = [('expat', '2.2.0')]
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.24-intel-2017a.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.24-intel-2017a.eb
@@ -15,7 +15,7 @@ easyblock = 'ConfigureMake'
 name = 'UDUNITS'
 version = '2.2.24'
 
-homepage = 'http://www.unidata.ucar.edu/software/udunits/'
+homepage = 'https://www.unidata.ucar.edu/software/udunits/'
 description = """UDUNITS supports conversion of unit specifications between formatted and binary forms,
  arithmetic manipulation of units, and conversion of values between compatible scales of measurement."""
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.25-foss-2017b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.25-foss-2017b.eb
@@ -22,7 +22,7 @@ description = """UDUNITS supports conversion of unit specifications between form
 toolchain = {'name': 'foss', 'version': '2017b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['ftp://ftp.unidata.ucar.edu/pub/udunits']
+source_urls = ['https://www.unidata.ucar.edu/downloads/udunits']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['ad486f8f45cba915ac74a38dd15f96a661a1803287373639c17e5a9b59bfd540']
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.25-foss-2017b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.25-foss-2017b.eb
@@ -15,7 +15,7 @@ easyblock = 'ConfigureMake'
 name = 'UDUNITS'
 version = '2.2.25'
 
-homepage = 'http://www.unidata.ucar.edu/software/udunits/'
+homepage = 'https://www.unidata.ucar.edu/software/udunits/'
 description = """UDUNITS supports conversion of unit specifications between formatted and binary forms,
  arithmetic manipulation of units, and conversion of values between compatible scales of measurement."""
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.25-intel-2017b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.25-intel-2017b.eb
@@ -22,7 +22,7 @@ description = """UDUNITS supports conversion of unit specifications between form
 toolchain = {'name': 'intel', 'version': '2017b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['ftp://ftp.unidata.ucar.edu/pub/udunits']
+source_urls = ['https://www.unidata.ucar.edu/downloads/udunits']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['ad486f8f45cba915ac74a38dd15f96a661a1803287373639c17e5a9b59bfd540']
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.25-intel-2017b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.25-intel-2017b.eb
@@ -15,7 +15,7 @@ easyblock = 'ConfigureMake'
 name = 'UDUNITS'
 version = '2.2.25'
 
-homepage = 'http://www.unidata.ucar.edu/software/udunits/'
+homepage = 'https://www.unidata.ucar.edu/software/udunits/'
 description = """UDUNITS supports conversion of unit specifications between formatted and binary forms,
  arithmetic manipulation of units, and conversion of values between compatible scales of measurement."""
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-GCCcore-8.2.0.eb
@@ -15,7 +15,7 @@ easyblock = 'ConfigureMake'
 name = 'UDUNITS'
 version = '2.2.26'
 
-homepage = 'http://www.unidata.ucar.edu/software/udunits/'
+homepage = 'https://www.unidata.ucar.edu/software/udunits/'
 description = """UDUNITS supports conversion of unit specifications between formatted and binary forms,
  arithmetic manipulation of units, and conversion of values between compatible scales of measurement."""
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-GCCcore-8.2.0.eb
@@ -22,7 +22,7 @@ description = """UDUNITS supports conversion of unit specifications between form
 toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['ftp://ftp.unidata.ucar.edu/pub/udunits']
+source_urls = ['https://www.unidata.ucar.edu/downloads/udunits']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['368f4869c9c7d50d2920fa8c58654124e9ed0d8d2a8c714a9d7fdadc08c7356d']
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-GCCcore-8.3.0.eb
@@ -22,7 +22,7 @@ description = """UDUNITS supports conversion of unit specifications between form
 toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['ftp://ftp.unidata.ucar.edu/pub/udunits']
+source_urls = ['https://www.unidata.ucar.edu/downloads/udunits']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['368f4869c9c7d50d2920fa8c58654124e9ed0d8d2a8c714a9d7fdadc08c7356d']
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-GCCcore-9.3.0.eb
@@ -22,7 +22,7 @@ description = """UDUNITS supports conversion of unit specifications between form
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['ftp://ftp.unidata.ucar.edu/pub/udunits']
+source_urls = ['https://www.unidata.ucar.edu/downloads/udunits']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['368f4869c9c7d50d2920fa8c58654124e9ed0d8d2a8c714a9d7fdadc08c7356d']
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-foss-2018a.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-foss-2018a.eb
@@ -15,7 +15,7 @@ easyblock = 'ConfigureMake'
 name = 'UDUNITS'
 version = '2.2.26'
 
-homepage = 'http://www.unidata.ucar.edu/software/udunits/'
+homepage = 'https://www.unidata.ucar.edu/software/udunits/'
 description = """UDUNITS supports conversion of unit specifications between formatted and binary forms,
  arithmetic manipulation of units, and conversion of values between compatible scales of measurement."""
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-foss-2018a.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-foss-2018a.eb
@@ -22,7 +22,7 @@ description = """UDUNITS supports conversion of unit specifications between form
 toolchain = {'name': 'foss', 'version': '2018a'}
 toolchainopts = {'pic': True}
 
-source_urls = ['ftp://ftp.unidata.ucar.edu/pub/udunits']
+source_urls = ['https://www.unidata.ucar.edu/downloads/udunits']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['368f4869c9c7d50d2920fa8c58654124e9ed0d8d2a8c714a9d7fdadc08c7356d']
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-foss-2018b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-foss-2018b.eb
@@ -15,7 +15,7 @@ easyblock = 'ConfigureMake'
 name = 'UDUNITS'
 version = '2.2.26'
 
-homepage = 'http://www.unidata.ucar.edu/software/udunits/'
+homepage = 'https://www.unidata.ucar.edu/software/udunits/'
 description = """UDUNITS supports conversion of unit specifications between formatted and binary forms,
  arithmetic manipulation of units, and conversion of values between compatible scales of measurement."""
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-foss-2018b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-foss-2018b.eb
@@ -22,7 +22,7 @@ description = """UDUNITS supports conversion of unit specifications between form
 toolchain = {'name': 'foss', 'version': '2018b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['ftp://ftp.unidata.ucar.edu/pub/udunits']
+source_urls = ['https://www.unidata.ucar.edu/downloads/udunits']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['368f4869c9c7d50d2920fa8c58654124e9ed0d8d2a8c714a9d7fdadc08c7356d']
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-intel-2017b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-intel-2017b.eb
@@ -15,7 +15,7 @@ easyblock = 'ConfigureMake'
 name = 'UDUNITS'
 version = '2.2.26'
 
-homepage = 'http://www.unidata.ucar.edu/software/udunits/'
+homepage = 'https://www.unidata.ucar.edu/software/udunits/'
 description = """UDUNITS supports conversion of unit specifications between formatted and binary forms,
  arithmetic manipulation of units, and conversion of values between compatible scales of measurement."""
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-intel-2017b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-intel-2017b.eb
@@ -22,7 +22,7 @@ description = """UDUNITS supports conversion of unit specifications between form
 toolchain = {'name': 'intel', 'version': '2017b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['ftp://ftp.unidata.ucar.edu/pub/udunits']
+source_urls = ['https://www.unidata.ucar.edu/downloads/udunits']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['368f4869c9c7d50d2920fa8c58654124e9ed0d8d2a8c714a9d7fdadc08c7356d']
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-intel-2018a.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-intel-2018a.eb
@@ -15,7 +15,7 @@ easyblock = 'ConfigureMake'
 name = 'UDUNITS'
 version = '2.2.26'
 
-homepage = 'http://www.unidata.ucar.edu/software/udunits/'
+homepage = 'https://www.unidata.ucar.edu/software/udunits/'
 description = """UDUNITS supports conversion of unit specifications between formatted and binary forms,
  arithmetic manipulation of units, and conversion of values between compatible scales of measurement."""
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-intel-2018a.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-intel-2018a.eb
@@ -22,7 +22,7 @@ description = """UDUNITS supports conversion of unit specifications between form
 toolchain = {'name': 'intel', 'version': '2018a'}
 toolchainopts = {'pic': True}
 
-source_urls = ['ftp://ftp.unidata.ucar.edu/pub/udunits']
+source_urls = ['https://www.unidata.ucar.edu/downloads/udunits']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['368f4869c9c7d50d2920fa8c58654124e9ed0d8d2a8c714a9d7fdadc08c7356d']
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-intel-2018b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-intel-2018b.eb
@@ -15,7 +15,7 @@ easyblock = 'ConfigureMake'
 name = 'UDUNITS'
 version = '2.2.26'
 
-homepage = 'http://www.unidata.ucar.edu/software/udunits/'
+homepage = 'https://www.unidata.ucar.edu/software/udunits/'
 description = """UDUNITS supports conversion of unit specifications between formatted and binary forms,
  arithmetic manipulation of units, and conversion of values between compatible scales of measurement."""
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-intel-2018b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-intel-2018b.eb
@@ -22,7 +22,7 @@ description = """UDUNITS supports conversion of unit specifications between form
 toolchain = {'name': 'intel', 'version': '2018b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['ftp://ftp.unidata.ucar.edu/pub/udunits']
+source_urls = ['https://www.unidata.ucar.edu/downloads/udunits']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['368f4869c9c7d50d2920fa8c58654124e9ed0d8d2a8c714a9d7fdadc08c7356d']
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-iomkl-2018b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-iomkl-2018b.eb
@@ -15,7 +15,7 @@ easyblock = 'ConfigureMake'
 name = 'UDUNITS'
 version = '2.2.26'
 
-homepage = 'http://www.unidata.ucar.edu/software/udunits/'
+homepage = 'https://www.unidata.ucar.edu/software/udunits/'
 description = """UDUNITS supports conversion of unit specifications between formatted and binary forms,
  arithmetic manipulation of units, and conversion of values between compatible scales of measurement."""
 

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-iomkl-2018b.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26-iomkl-2018b.eb
@@ -22,7 +22,7 @@ description = """UDUNITS supports conversion of unit specifications between form
 toolchain = {'name': 'iomkl', 'version': '2018b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['ftp://ftp.unidata.ucar.edu/pub/udunits']
+source_urls = ['https://www.unidata.ucar.edu/downloads/udunits']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['368f4869c9c7d50d2920fa8c58654124e9ed0d8d2a8c714a9d7fdadc08c7356d']
 


### PR DESCRIPTION
UDUNITS provides ftp and https sources. Converting the source URLs to use https
remotes where possible.

**NOTE:** I was not able to find the `udunits-2.2.20.tar.gz` sources (FTP or HTTPS)

Should `UDUNITS-2.2.20-foss-2016a.eb` and `UDUNITS-2.2.20-intel-2016b.eb` be removed?

Currently used sources and their HTTP response code:
- ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-2.2.20.tar.gz **550**
- https://www.unidata.ucar.edu/downloads/udunits/udunits-2.2.24.tar.gz 200
- https://www.unidata.ucar.edu/downloads/udunits/udunits-2.2.25.tar.gz 200
- https://www.unidata.ucar.edu/downloads/udunits/udunits-2.2.26.tar.gz 200