### PR TITLE
Fix missing m4

### DIFF
--- a/easybuild/easyconfigs/n/netCDF-Fortran/netCDF-Fortran-4.5.2-gompi-2020a.eb
+++ b/easybuild/easyconfigs/n/netCDF-Fortran/netCDF-Fortran-4.5.2-gompi-2020a.eb
@@ -13,6 +13,10 @@ source_urls = ['https://github.com/Unidata/netcdf-fortran/archive/']
 sources = ['v%(version)s.tar.gz']
 checksums = ['0b05c629c70d6d224a3be28699c066bfdfeae477aea211fbf034d973a8309b49']
 
+builddependencies = [
+    ('M4', '1.4.18'),
+]
+
 dependencies = [('netCDF', '4.7.4')]
 
 # (too) parallel build fails, but single-core build is fairly quick anyway (~1min)


### PR DESCRIPTION
Build fails in systems where m4 is not there by default