### PR TITLE
R-3.6.0-foss-2019a: add intrinsicDimension extension

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.0-foss-2019a.eb
@@ -2281,6 +2281,12 @@ exts_list = [
     ('HiddenMarkov', '1.8-11', {
         'checksums': ['4a1614249eee9f428bc182ea9ced443dff4eafa7babf4259c720e5b4da2d08fa'],
     }),
+    ('yaImpute', '1.0-32', {
+        'checksums': ['08eee5d851b80aad9c7c80f9531aadd50d60e4b16b3a80657a50212269cd73ff'],
+    }),
+    ('intrinsicDimension', '1.2.0', {
+        'checksums': ['6cc9180a83aa0d123f1e420136bb959c0d5877867fa170b79536f5ee22106a32'],
+    }),
 ]
 
 moduleclass = 'lang'


### PR DESCRIPTION
Add intrinsicDimension and its dependency yaImpute to R-6.3.0 extensions. This
extension is part of R-4.0.0 so I figured it wasn't a problem to include it
into R-6.3.0.

Is there a policy as to which extensions are included by default?