### PR TITLE
OpenBLAS-0.3.9: Fix lapack.h for use with C++

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.9-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.9-GCC-9.3.0.eb
@@ -15,11 +15,13 @@ sources = ['v%(version)s.tar.gz']
 patches = [
     ('large.tgz', '.'),
     ('timing.tgz', '.'),
+    'OpenBLAS-0.3.9_fix-lapack_h.patch',
 ]
 checksums = [
     '17d4677264dfbc4433e97076220adc79b050e4f8a083ea3f853a53af253bc380',  # v0.3.9.tar.gz
     'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
     '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
+    '9210a94ae418b4ce6d9f7fab4e00dd3155451f5ef3769536a4d954a2149ca733',  # OpenBLAS-0.3.9_fix-lapack_h.patch
 ]
 
 # extensive testing can be enabled by uncommenting the line below

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.9_fix-lapack_h.patch
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.9_fix-lapack_h.patch
@@ -1,0 +1,73 @@
+From ee2e758278b5d82b7242f505ea694f082ef65879 Mon Sep 17 00:00:00 2001
+From: Martin Kroeker <martin@ruby.chemie.uni-freiburg.de>
+Date: Fri, 13 Mar 2020 20:34:13 +0100
+Subject: [PATCH] Move declarations of lapack_complex_custom types outside the
+ extern C
+
+fixes #2510
+---
+ lapack-netlib/LAPACKE/include/lapack.h | 44 ++++++++++++++------------
+ 1 file changed, 23 insertions(+), 21 deletions(-)
+
+diff --git a/lapack-netlib/LAPACKE/include/lapack.h b/lapack-netlib/LAPACKE/include/lapack.h
+index 0a6226fe4..36e53ec24 100644
+--- a/lapack-netlib/LAPACKE/include/lapack.h
++++ b/lapack-netlib/LAPACKE/include/lapack.h
+@@ -12,27 +12,6 @@
+ 
+ #include <stdlib.h>
+ 
+-#ifdef __cplusplus
+-extern "C" {
+-#endif
+-
+-/*----------------------------------------------------------------------------*/
+-#ifndef lapack_int
+-#define lapack_int     int
+-#endif
+-
+-#ifndef lapack_logical
+-#define lapack_logical lapack_int
+-#endif
+-
+-/* f2c, hence clapack and MacOS Accelerate, returns double instead of float
+- * for sdot, slange, clange, etc. */
+-#if defined(LAPACK_F2C)
+-    typedef double lapack_float_return;
+-#else
+-    typedef float lapack_float_return;
+-#endif
+-
+ /* Complex types are structures equivalent to the
+ * Fortran complex types COMPLEX(4) and COMPLEX(8).
+ *
+@@ -88,6 +67,29 @@ extern "C" {
+ 
+ #endif /* LAPACK_COMPLEX_CUSTOM */
+ 
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++/*----------------------------------------------------------------------------*/
++#ifndef lapack_int
++#define lapack_int     int
++#endif
++
++#ifndef lapack_logical
++#define lapack_logical lapack_int
++#endif
++
++/* f2c, hence clapack and MacOS Accelerate, returns double instead of float
++ * for sdot, slange, clange, etc. */
++#if defined(LAPACK_F2C)
++    typedef double lapack_float_return;
++#else
++    typedef float lapack_float_return;
++#endif
++
++
+ /* Callback logical functions of one, two, or three arguments are used
+ *  to select eigenvalues to sort to the top left of the Schur form.
+ *  The value is selected if function returns TRUE (non-zero). */


### PR DESCRIPTION
OpenBLAS 0.3.9 has a bug which does not allow to use LAPACK functionality from C++:
https://github.com/xianyi/OpenBLAS/issues/2510
https://github.com/xianyi/OpenBLAS/issues/2600

The fix is a relatively straightforward change of the lapack.h header file:
https://github.com/xianyi/OpenBLAS/pull/2512/files

Include that patch here so that the foss/2020a toolchain allows use of LAPACK from C++.