### PR TITLE
use travis_wait to extend 10m timeout when no output is produced

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,9 @@ script:
     - cd $HOME
     - export PYTHONPATH=$TRAVIS_BUILD_DIR
     - export PATH=$TRAVIS_BUILD_DIR/test/bin:$PATH
-    - python -O -m test.easyconfigs.suite
+    # use travis_wait because the test suite may "hang" for a while without producing output
+    # see https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
+    - travis_wait python -O -m test.easyconfigs.suite
     # check for packaging issues by installing easybuild-easyconfigs repo,
     # and checking whether easyconfigs are found, by verifying whether "eb --search" works as expected
     - unset PYTHONPATH


### PR DESCRIPTION
I consider this a last resort for keeping Travis...
If it still causes trouble with this included, we should stop using it for this repo at least.

I'm already working on getting @boegelbot to submit comments based on the test suite results from GitHub Actions rather than Travis (for easyconfigs)...