### PR TITLE
added only gomkl, iomkl, iompi, and imkl compiled at the MPI level

### DIFF
--- a/easybuild/easyconfigs/g/gomkl/gomkl-2020a.eb
+++ b/easybuild/easyconfigs/g/gomkl/gomkl-2020a.eb
@@ -1,0 +1,19 @@
+easyblock = "Toolchain"
+
+name = 'gomkl'
+version = '2020a'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain with OpenMPI and MKL"""
+
+toolchain = SYSTEM
+
+local_comp = ('GCC', '9.3.0')
+
+dependencies = [
+    local_comp,
+    ('OpenMPI', '4.0.3', '', local_comp),
+    ('imkl', '2020.1.217', '', ('gompi', version)),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/imkl/imkl-2020.1.217-gompi-2020a.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2020.1.217-gompi-2020a.eb
@@ -1,0 +1,39 @@
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
+
+name = 'imkl'
+version = '2020.1.217'
+
+homepage = 'https://software.intel.com/mkl'
+description = """Intel Math Kernel Library is a library of highly optimized,
+ extensively threaded math routines for science, engineering, and financial
+ applications that require maximum performance. Core math functions include
+ BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
+
+toolchain = {'name': 'gompi', 'version': '2020a'}
+
+source_urls = ['https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16533/']
+sources = ['l_mkl_%(version)s.tgz']
+checksums = ['082a4be30bf4f6998e4d6e3da815a77560a5e66a68e254d161ab96f07086066d']
+
+dontcreateinstalldir = True
+
+components = ['intel-mkl']
+
+license_file = HOME + '/licenses/intel/license.lic'
+
+interfaces = True
+
+postinstallcmds = [
+    # extract the examples
+    'tar xvzf %(installdir)s/mkl/examples/examples_cluster_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_cluster_f.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_f.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_f95.tgz -C %(installdir)s/mkl/examples/',
+]
+
+modextravars = {
+    'MKL_EXAMPLES': '%(installdir)s/mkl/examples/',
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/i/imkl/imkl-2020.1.217-iompi-2020a.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2020.1.217-iompi-2020a.eb
@@ -1,0 +1,39 @@
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
+
+name = 'imkl'
+version = '2020.1.217'
+
+homepage = 'https://software.intel.com/mkl'
+description = """Intel Math Kernel Library is a library of highly optimized,
+ extensively threaded math routines for science, engineering, and financial
+ applications that require maximum performance. Core math functions include
+ BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
+
+toolchain = {'name': 'iompi', 'version': '2020a'}
+
+source_urls = ['https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16533/']
+sources = ['l_mkl_%(version)s.tgz']
+checksums = ['082a4be30bf4f6998e4d6e3da815a77560a5e66a68e254d161ab96f07086066d']
+
+dontcreateinstalldir = True
+
+components = ['intel-mkl']
+
+license_file = HOME + '/licenses/intel/license.lic'
+
+interfaces = True
+
+postinstallcmds = [
+    # extract the examples
+    'tar xvzf %(installdir)s/mkl/examples/examples_cluster_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_cluster_f.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_f.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_f95.tgz -C %(installdir)s/mkl/examples/',
+]
+
+modextravars = {
+    'MKL_EXAMPLES': '%(installdir)s/mkl/examples/',
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/i/iomkl/iomkl-2020a.eb
+++ b/easybuild/easyconfigs/i/iomkl/iomkl-2020a.eb
@@ -1,0 +1,20 @@
+easyblock = "Toolchain"
+
+name = 'iomkl'
+version = '2020a'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Intel Cluster Toolchain Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MKL &
+ OpenMPI."""
+
+toolchain = SYSTEM
+
+local_compver = '2020.1.217'
+
+dependencies = [
+    ('iccifort', local_compver),
+    ('OpenMPI', '4.0.3', '', ('iccifort', local_compver)),
+    ('imkl', local_compver, '', ('iompi', version)),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iomkl/iomkl-2020a.eb
+++ b/easybuild/easyconfigs/i/iomkl/iomkl-2020a.eb
@@ -3,7 +3,7 @@ easyblock = "Toolchain"
 name = 'iomkl'
 version = '2020a'
 
-homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+homepage = 'https://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
 description = """Intel Cluster Toolchain Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MKL &
  OpenMPI."""
 

--- a/easybuild/easyconfigs/i/iompi/iompi-2020a.eb
+++ b/easybuild/easyconfigs/i/iompi/iompi-2020a.eb
@@ -4,7 +4,7 @@ easyblock = "Toolchain"
 name = 'iompi'
 version = '2020a'
 
-homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+homepage = 'https://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
 description = """Intel C/C++ and Fortran compilers, alongside Open MPI."""
 
 toolchain = SYSTEM

--- a/easybuild/easyconfigs/i/iompi/iompi-2020a.eb
+++ b/easybuild/easyconfigs/i/iompi/iompi-2020a.eb
@@ -1,0 +1,19 @@
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild/
+easyblock = "Toolchain"
+
+name = 'iompi'
+version = '2020a'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Intel C/C++ and Fortran compilers, alongside Open MPI."""
+
+toolchain = SYSTEM
+
+local_compver = '2020.1.217'
+
+dependencies = [
+    ('iccifort', local_compver),
+    ('OpenMPI', '4.0.3', '', ('iccifort', local_compver)),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.3-iccifort-2020.1.217.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.3-iccifort-2020.1.217.eb
@@ -1,0 +1,25 @@
+name = 'OpenMPI'
+version = '4.0.3'
+
+homepage = 'https://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-3 implementation."""
+
+toolchain = {'name': 'iccifort', 'version': '2020.1.217'}
+
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['6346bf976001ad274c7e018d6cc35c92bbb9426d8f7754fac00a17ea5ac8eebc']
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('hwloc', '2.2.0'),
+    ('UCX', '1.8.0'),
+]
+
+# disable MPI1 compatibility for now, see what breaks...
+# configopts = '--enable-mpi1-compatibility '
+
+# to enable SLURM integration (site-specific)
+# configopts += '--with-slurm --with-pmi=/usr/include/slurm --with-pmi-libdir=/usr'
+
+moduleclass = 'mpi'


### PR DESCRIPTION
This PR splits the `gmkl` and `iimkl` out of the PR https://github.com/easybuilders/easybuild-easyconfigs/pull/11035  and assumes that `imkl` is installed at the MPI level. 