### PR TITLE
fall back to using PR target branch when determining "merge base" between PR branch & target branch fails in test suite

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -704,8 +704,17 @@ class EasyConfigTest(TestCase):
     def test_changed_files_pull_request(self):
         """Specific checks only done for the (easyconfig) files that were changed in a pull request."""
         def get_eb_files_from_diff(diff_filter):
-            cmd = "git diff --name-only --diff-filter=%s %s...HEAD" % (diff_filter, target_branch)
-            out, ec = run_cmd(cmd, simple=False)
+
+            # first determine the 'merge base' between target branch and PR branch
+            # cfr. https://git-scm.com/docs/git-merge-base
+            cmd = "git merge-base %s HEAD" % target_branch
+            out, _ = run_cmd(cmd, simple=False)
+            merge_base = out.strip()
+            print("Merge base for %s and HEAD: %s" % (target_branch, merge_base))
+
+            # determine list of changed files using 'git diff' and merge base determined above
+            cmd = "git diff --name-only --diff-filter=%s %s..HEAD" % (diff_filter, merge_base)
+            out, _ = run_cmd(cmd, simple=False)
             return [os.path.basename(f) for f in out.strip().split('\n') if f.endswith('.eb')]
 
         # $TRAVIS_PULL_REQUEST should be a PR number, otherwise we're not running tests for a PR

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -708,9 +708,15 @@ class EasyConfigTest(TestCase):
             # first determine the 'merge base' between target branch and PR branch
             # cfr. https://git-scm.com/docs/git-merge-base
             cmd = "git merge-base %s HEAD" % target_branch
-            out, _ = run_cmd(cmd, simple=False)
-            merge_base = out.strip()
-            print("Merge base for %s and HEAD: %s" % (target_branch, merge_base))
+            out, ec = run_cmd(cmd, simple=False, log_ok=False)
+            if ec == 0:
+                merge_base = out.strip()
+                print("Merge base for %s and HEAD: %s" % (target_branch, merge_base))
+            else:
+                msg = "Failed to determine merge base (ec: %s, output: '%s'), "
+                msg += "falling back to specifying target branch %s"
+                print(msg % (ec, out, target_branch))
+                merge_base = target_branch
 
             # determine list of changed files using 'git diff' and merge base determined above
             cmd = "git diff --name-only --diff-filter=%s %s..HEAD" % (diff_filter, merge_base)


### PR DESCRIPTION
Some changes were made in Git 2.28.0 that break how we determine the list of changed files in PRs.

For example (from tests for https://github.com/easybuilders/easybuild-easyconfigs/pull/11068):

```
ERROR: test_changed_files_pull_request (test.easyconfigs.easyconfigs.EasyConfigTest)
Specific checks only done for the (easyconfig) files that were changed in a pull request.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/easyconfigs/easyconfigs.py", line 739, in test_changed_files_pull_request
    changed_ecs_filenames = get_eb_files_from_diff(diff_filter='M')
  File "test/easyconfigs/easyconfigs.py", line 708, in get_eb_files_from_diff
    out, ec = run_cmd(cmd, simple=False)
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/easybuild/tools/run.py", line 88, in cache_aware_func
    res = func(cmd, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/easybuild/tools/run.py", line 269, in run_cmd
    return parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp)
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/easybuild/tools/run.py", line 533, in parse_cmd_output
    raise EasyBuildError('cmd "%s" exited with exit code %s and output:\n%s', cmd, ec, stdouterr)
EasyBuildError: 'cmd "git diff --name-only --diff-filter=M develop...HEAD" exited with exit code 128 and output:\nfatal: develop...HEAD: no merge base\n'
```

From https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.28.0.txt:

```
"git diff" used to take arguments in random and nonsense range
   notation, e.g. "git diff A..B C", "git diff A..B C...D", etc.,
   which has been cleaned up.
```

(hat tip @branfosj)

That basically means the triple dot (`...`) notation we were relying on is no longer working.

Can be fixed by determining the "merge base" between both branches first using `git merge-base` before using `git diff`.

edit: the changes to `git diff` may not actually be the cause of the problem here, it seems like determining the "merge base" is failing sometimes (reason unclear), see below