### PR TITLE
stop using 'remove_usr_bin'-patch in TensorFlow easyconfig, no longer required with updated TensorFlow easyblock

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.13.1-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.13.1-foss-2019a-Python-3.7.2.eb
@@ -43,55 +43,44 @@ exts_list = [
         'modulename': 'google.protobuf',
     }),
     ('absl-py', '0.7.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/absl-py'],
         'checksums': ['b943d1c567743ed0455878fcd60bc28ac9fae38d129d1ccfad58079da00b8951'],
         'modulename': 'absl',
     }),
     ('astor', '0.7.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/astor'],
         'checksums': ['95c30d87a6c2cf89aa628b87398466840f0ad8652f88eb173125a6df8533fb8d'],
     }),
     ('gast', '0.2.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/g/gast'],
         'checksums': ['fe939df4583692f0512161ec1c880e0a10e71e6a232da045ab8edd3756fbadf0'],
     }),
     ('grpcio', '1.20.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/g/grpcio'],
         'checksums': ['84eb47b1a47e206e78f453fb92a155ed0d18d2ca8747f5c67e4b50b9c37180a7'],
         'modulename': 'grpc',
     }),
     ('Markdown', '3.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/M/Markdown'],
         'checksums': ['fc4a6f69a656b8d858d7503bda633f4dd63c2d70cf80abdc6eafa64c4ae8c250'],
     }),
     ('tensorboard', version, {
-        'source_urls': ['https://pypi.python.org/packages/source/t/tensorboard'],
         'source_tmpl': 'tensorboard-%(version)s-py3-none-any.whl',
         'checksums': ['b664fe7772be5670d8b04200342e681af7795a12cd752709aed565c06c0cc196'],
         'unpack_sources': False,
     }),
     ('termcolor', '1.1.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/t/termcolor'],
         'checksums': ['1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b'],
     }),
     ('Werkzeug', '0.15.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/W/Werkzeug'],
         'checksums': ['0a73e8bb2ff2feecfc5d56e6f458f5b99290ef34f565ffb2665801ff7de6af7a'],
     }),
     ('Keras-Applications', '1.0.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/K/Keras-Applications'],
         'source_tmpl': 'Keras_Applications-%(version)s.tar.gz',
         'checksums': ['60607b2b98868983e5153bf1cc6aa468ba73adc93bc977a90edaa4bc595e69fa'],
         'modulename': 'keras_applications',
     }),
     ('Keras-Preprocessing', '1.0.9', {
-        'source_urls': ['https://pypi.python.org/packages/source/K/Keras-Preprocessing'],
         'source_tmpl': 'Keras_Preprocessing-%(version)s.tar.gz',
         'checksums': ['5e3700117981c2db762e512ed6586638124fac5842170701628088a11aeb51ac'],
         'modulename': 'keras_preprocessing',
     }),
     ('tensorflow-estimator', '1.13.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/t/tensorflow-estimator'],
         'source_tmpl': 'tensorflow_estimator-1.13.0-py2.py3-none-any.whl',
         'checksums': ['7cfdaa3e83e3532f31713713feb98be7ea9f3065722be4267e49b6c301271419'],
         'unpack_sources': False,

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.13.1-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.13.1-foss-2019a-Python-3.7.2.eb
@@ -22,6 +22,10 @@ dependencies = [
     ('h5py', '2.9.0'),
 ]
 
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'sanity_pip_check': True,
+}
 use_pip = True
 
 exts_list = [
@@ -99,7 +103,6 @@ exts_list = [
             'TensorFlow-1.11.0_swig-env.patch',
             'TensorFlow-1.11.0_remove-msse-hardcoding.patch',
             'TensorFlow-1.13.1_lrt-flag.patch',
-            'TensorFlow-1.13.1_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-1.13.1_fix_protobuf_problem.patch',
         ],
         'checksums': [
@@ -108,8 +111,6 @@ exts_list = [
             # TensorFlow-1.11.0_remove-msse-hardcoding.patch
             'a0f00ee4d03bb4fd3a645ee06045cedaf97d0b85675ec35187e9dd7e479d7bb6',
             'b388be35f2581786bcd533b1bfa375165d7f35e38a3aab74570019312816bf1b',  # TensorFlow-1.13.1_lrt-flag.patch
-            # TensorFlow-1.13.1_remove_usrbin_from_linker_bin_path_flag.patch
-            'e6122f34557fbe9e705ce1999403053b0ac4bdd058e4a31a182a16446c87bdb3',
             # TensorFlow-1.13.1_fix_protobuf_problem.patch
             'd2fab1497078a2980a68adeea4d0f8719be5bef03741ea4775163745a1e52d40',
         ],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.13.1-fosscuda-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.13.1-fosscuda-2019a-Python-3.7.2.eb
@@ -45,55 +45,44 @@ exts_list = [
         'modulename': 'google.protobuf',
     }),
     ('absl-py', '0.7.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/absl-py'],
         'checksums': ['b943d1c567743ed0455878fcd60bc28ac9fae38d129d1ccfad58079da00b8951'],
         'modulename': 'absl',
     }),
     ('astor', '0.7.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/astor'],
         'checksums': ['95c30d87a6c2cf89aa628b87398466840f0ad8652f88eb173125a6df8533fb8d'],
     }),
     ('gast', '0.2.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/g/gast'],
         'checksums': ['fe939df4583692f0512161ec1c880e0a10e71e6a232da045ab8edd3756fbadf0'],
     }),
     ('grpcio', '1.20.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/g/grpcio'],
         'checksums': ['84eb47b1a47e206e78f453fb92a155ed0d18d2ca8747f5c67e4b50b9c37180a7'],
         'modulename': 'grpc',
     }),
     ('Markdown', '3.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/M/Markdown'],
         'checksums': ['fc4a6f69a656b8d858d7503bda633f4dd63c2d70cf80abdc6eafa64c4ae8c250'],
     }),
     ('tensorboard', version, {
-        'source_urls': ['https://pypi.python.org/packages/source/t/tensorboard'],
         'source_tmpl': 'tensorboard-%(version)s-py3-none-any.whl',
         'checksums': ['b664fe7772be5670d8b04200342e681af7795a12cd752709aed565c06c0cc196'],
         'unpack_sources': False,
     }),
     ('termcolor', '1.1.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/t/termcolor'],
         'checksums': ['1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b'],
     }),
     ('Werkzeug', '0.15.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/W/Werkzeug'],
         'checksums': ['0a73e8bb2ff2feecfc5d56e6f458f5b99290ef34f565ffb2665801ff7de6af7a'],
     }),
     ('Keras-Applications', '1.0.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/K/Keras-Applications'],
         'source_tmpl': 'Keras_Applications-%(version)s.tar.gz',
         'checksums': ['60607b2b98868983e5153bf1cc6aa468ba73adc93bc977a90edaa4bc595e69fa'],
         'modulename': 'keras_applications',
     }),
     ('Keras-Preprocessing', '1.0.9', {
-        'source_urls': ['https://pypi.python.org/packages/source/K/Keras-Preprocessing'],
         'source_tmpl': 'Keras_Preprocessing-%(version)s.tar.gz',
         'checksums': ['5e3700117981c2db762e512ed6586638124fac5842170701628088a11aeb51ac'],
         'modulename': 'keras_preprocessing',
     }),
     ('tensorflow-estimator', '1.13.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/t/tensorflow-estimator'],
         'source_tmpl': 'tensorflow_estimator-1.13.0-py2.py3-none-any.whl',
         'checksums': ['7cfdaa3e83e3532f31713713feb98be7ea9f3065722be4267e49b6c301271419'],
         'unpack_sources': False,

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.13.1-fosscuda-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.13.1-fosscuda-2019a-Python-3.7.2.eb
@@ -24,6 +24,10 @@ dependencies = [
     ('NCCL', '2.4.2'),
 ]
 
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'sanity_pip_check': True,
+}
 use_pip = True
 
 exts_list = [
@@ -102,7 +106,6 @@ exts_list = [
             'TensorFlow-1.11.0_remove-msse-hardcoding.patch',
             'TensorFlow-1.13.1_lrt-flag.patch',
             'TensorFlow-1.13.1_dont_expand_cuda_cudnn_path.patch',
-            'TensorFlow-1.13.1_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-1.13.1_fix_protobuf_problem.patch',
             'TensorFlow-1.13.1_fix_cudalib_version_for_cuda10.1.patch',
         ],
@@ -114,8 +117,6 @@ exts_list = [
             'b388be35f2581786bcd533b1bfa375165d7f35e38a3aab74570019312816bf1b',  # TensorFlow-1.13.1_lrt-flag.patch
             # TensorFlow-1.13.1_dont_expand_cuda_cudnn_path.patch
             '3722764db136c58a1310aa087b6be6c34dd10c6fb5b6b215a9ae83946fd1c4ae',
-            # TensorFlow-1.13.1_remove_usrbin_from_linker_bin_path_flag.patch
-            'e6122f34557fbe9e705ce1999403053b0ac4bdd058e4a31a182a16446c87bdb3',
             # TensorFlow-1.13.1_fix_protobuf_problem.patch
             'd2fab1497078a2980a68adeea4d0f8719be5bef03741ea4775163745a1e52d40',
             # TensorFlow-1.13.1_fix_cudalib_version_for_cuda10.1.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.14.0-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.14.0-foss-2019a-Python-3.7.2.eb
@@ -29,6 +29,11 @@ exts_default_options = {
 use_pip = True
 
 exts_list = [
+    # tensorboard 1.14.0 has requirement setuptools>=41.0.0
+    ('setuptools', '41.3.0', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'checksums': ['9f5c54b529b2156c6f288e837e625581bb31ff94d4cfd116b8f271c589749556'],
+    }),
     ('protobuf-python', '3.8.0', {
         'modulename': 'google.protobuf',
         'patches': ['TensorFlow-1.13.1_protobuf-3.6.1.2_fix_26155.patch'],
@@ -48,6 +53,10 @@ exts_list = [
     }),
     ('astor', '0.8.0', {
         'checksums': ['37a6eed8b371f1228db08234ed7f6cfdc7817a3ed3824797e20cbb11dc2a7862'],
+    }),
+    ('google-pasta', '0.1.8', {
+        'checksums': ['713813a9f7d6589e5defdaf21e80e4392eb124662f8bd829acd51a4f8735c0cb'],
+        'modulename': 'pasta',
     }),
     ('gast', '0.2.2', {
         'checksums': ['fe939df4583692f0512161ec1c880e0a10e71e6a232da045ab8edd3756fbadf0'],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.14.0-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.14.0-foss-2019a-Python-3.7.2.eb
@@ -22,9 +22,11 @@ dependencies = [
     ('h5py', '2.9.0'),
 ]
 
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'sanity_pip_check': True,
+}
 use_pip = True
-
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
 
 exts_list = [
     ('protobuf-python', '3.8.0', {
@@ -93,7 +95,6 @@ exts_list = [
             'TensorFlow-%(version)s_swig-env.patch',
             'TensorFlow-1.11.0_remove-msse-hardcoding.patch',
             'TensorFlow-1.13.1_lrt-flag.patch',
-            'TensorFlow-%(version)s_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-1.13.1_fix_protobuf_problem.patch',
             'TensorFlow-%(version)s_fix-mpi-undeclared-inclusion.patch',
         ],
@@ -103,8 +104,6 @@ exts_list = [
             # TensorFlow-1.11.0_remove-msse-hardcoding.patch
             'a0f00ee4d03bb4fd3a645ee06045cedaf97d0b85675ec35187e9dd7e479d7bb6',
             'b388be35f2581786bcd533b1bfa375165d7f35e38a3aab74570019312816bf1b',  # TensorFlow-1.13.1_lrt-flag.patch
-            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             # TensorFlow-1.13.1_fix_protobuf_problem.patch
             'd2fab1497078a2980a68adeea4d0f8719be5bef03741ea4775163745a1e52d40',
             # TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.14.0-fosscuda-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.14.0-fosscuda-2019a-Python-3.7.2.eb
@@ -30,6 +30,11 @@ exts_default_options = {
 use_pip = True
 
 exts_list = [
+    # tensorboard 1.14.0 has requirement setuptools>=41.0.0
+    ('setuptools', '41.3.0', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'checksums': ['9f5c54b529b2156c6f288e837e625581bb31ff94d4cfd116b8f271c589749556'],
+    }),
     ('protobuf-python', '3.8.0', {
         'modulename': 'google.protobuf',
         'patches': ['TensorFlow-1.13.1_protobuf-3.6.1.2_fix_26155.patch'],
@@ -49,6 +54,10 @@ exts_list = [
     }),
     ('astor', '0.8.0', {
         'checksums': ['37a6eed8b371f1228db08234ed7f6cfdc7817a3ed3824797e20cbb11dc2a7862'],
+    }),
+    ('google-pasta', '0.1.8', {
+        'checksums': ['713813a9f7d6589e5defdaf21e80e4392eb124662f8bd829acd51a4f8735c0cb'],
+        'modulename': 'pasta',
     }),
     ('gast', '0.2.2', {
         'checksums': ['fe939df4583692f0512161ec1c880e0a10e71e6a232da045ab8edd3756fbadf0'],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.14.0-fosscuda-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.14.0-fosscuda-2019a-Python-3.7.2.eb
@@ -23,9 +23,11 @@ dependencies = [
     ('NCCL', '2.4.2'),
 ]
 
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'sanity_pip_check': True,
+}
 use_pip = True
-
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
 
 exts_list = [
     ('protobuf-python', '3.8.0', {
@@ -94,7 +96,6 @@ exts_list = [
             'TensorFlow-%(version)s_swig-env.patch',
             'TensorFlow-1.11.0_remove-msse-hardcoding.patch',
             'TensorFlow-1.13.1_lrt-flag.patch',
-            'TensorFlow-%(version)s_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-1.13.1_fix_protobuf_problem.patch',
             'TensorFlow-%(version)s_fix-mpi-undeclared-inclusion.patch',
             'TensorFlow-%(version)s_fix-cuda-build.patch',
@@ -106,8 +107,6 @@ exts_list = [
             # TensorFlow-1.11.0_remove-msse-hardcoding.patch
             'a0f00ee4d03bb4fd3a645ee06045cedaf97d0b85675ec35187e9dd7e479d7bb6',
             'b388be35f2581786bcd533b1bfa375165d7f35e38a3aab74570019312816bf1b',  # TensorFlow-1.13.1_lrt-flag.patch
-            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             # TensorFlow-1.13.1_fix_protobuf_problem.patch
             'd2fab1497078a2980a68adeea4d0f8719be5bef03741ea4775163745a1e52d40',
             # TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.15.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.15.0-foss-2019b-Python-3.7.4.eb
@@ -95,7 +95,6 @@ exts_list = [
             'TensorFlow-1.14.0_swig-env.patch',
             'TensorFlow-%(version)s_remove-msse-hardcoding.patch',
             'TensorFlow-%(version)s_lrt-flag.patch',
-            'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch',
         ],
         'source_tmpl': 'v%(version)s.tar.gz',
@@ -106,8 +105,6 @@ exts_list = [
             # TensorFlow-1.15.0_remove-msse-hardcoding.patch
             '59e408f1cf5a97d90f33861123d55eb1332b8fef1d5d8fdfdea413c4b481ee56',
             'b0fd4c7902be45bba18bd04192800852b140a9cf312a44ac1efb7ee653d3d886',  # TensorFlow-1.15.0_lrt-flag.patch
-            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             # TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch
             '09e5fdce89588074b3c2abb6a4705b1f141b43395c960660320cf1cb79cd1ef4',
         ],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.15.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.15.0-fosscuda-2019b-Python-3.7.4.eb
@@ -97,7 +97,6 @@ exts_list = [
             'TensorFlow-1.14.0_swig-env.patch',
             'TensorFlow-%(version)s_remove-msse-hardcoding.patch',
             'TensorFlow-%(version)s_lrt-flag.patch',
-            'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch',
             'TensorFlow-1.14.0_fix-cuda-build.patch',
             'TensorFlow-1.14.0_fix-cuda-mpi.patch',
@@ -110,8 +109,6 @@ exts_list = [
             # TensorFlow-1.15.0_remove-msse-hardcoding.patch
             '59e408f1cf5a97d90f33861123d55eb1332b8fef1d5d8fdfdea413c4b481ee56',
             'b0fd4c7902be45bba18bd04192800852b140a9cf312a44ac1efb7ee653d3d886',  # TensorFlow-1.15.0_lrt-flag.patch
-            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             # TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch
             '09e5fdce89588074b3c2abb6a4705b1f141b43395c960660320cf1cb79cd1ef4',
             # TensorFlow-1.14.0_fix-cuda-build.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.15.2-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.15.2-foss-2019b-Python-3.7.4.eb
@@ -94,7 +94,6 @@ exts_list = [
             'TensorFlow-1.14.0_swig-env.patch',
             'TensorFlow-1.15.0_remove-msse-hardcoding.patch',
             'TensorFlow-1.15.0_lrt-flag.patch',
-            'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch',
         ],
         'source_tmpl': 'v%(version)s.tar.gz',
@@ -105,8 +104,6 @@ exts_list = [
             # TensorFlow-1.15.0_remove-msse-hardcoding.patch
             '59e408f1cf5a97d90f33861123d55eb1332b8fef1d5d8fdfdea413c4b481ee56',
             'b0fd4c7902be45bba18bd04192800852b140a9cf312a44ac1efb7ee653d3d886',  # TensorFlow-1.15.0_lrt-flag.patch
-            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             # TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch
             '09e5fdce89588074b3c2abb6a4705b1f141b43395c960660320cf1cb79cd1ef4',
         ],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.15.2-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.15.2-fosscuda-2019b-Python-3.7.4.eb
@@ -96,7 +96,6 @@ exts_list = [
             'TensorFlow-1.14.0_swig-env.patch',
             'TensorFlow-1.15.0_remove-msse-hardcoding.patch',
             'TensorFlow-1.15.0_lrt-flag.patch',
-            'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch',
             'TensorFlow-1.14.0_fix-cuda-build.patch',
             'TensorFlow-1.14.0_fix-cuda-mpi.patch',
@@ -109,8 +108,6 @@ exts_list = [
             # TensorFlow-1.15.0_remove-msse-hardcoding.patch
             '59e408f1cf5a97d90f33861123d55eb1332b8fef1d5d8fdfdea413c4b481ee56',
             'b0fd4c7902be45bba18bd04192800852b140a9cf312a44ac1efb7ee653d3d886',  # TensorFlow-1.15.0_lrt-flag.patch
-            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             # TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch
             '09e5fdce89588074b3c2abb6a4705b1f141b43395c960660320cf1cb79cd1ef4',
             # TensorFlow-1.14.0_fix-cuda-build.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-foss-2019a-Python-3.7.2.eb
@@ -127,7 +127,6 @@ exts_list = [
         'patches': [
             'TensorFlow-1.14.0_swig-env.patch',
             'TensorFlow-1.13.1_lrt-flag.patch',
-            'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch',
             'TensorFlow-2.0.0_fix-build-tf-lite-avx512.patch',
         ],
@@ -137,8 +136,6 @@ exts_list = [
             '49b5f0495cd681cbcb5296a4476853d4aea19a43bdd9f179c928a977308a0617',  # v2.0.0.tar.gz
             'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',  # TensorFlow-1.14.0_swig-env.patch
             'b388be35f2581786bcd533b1bfa375165d7f35e38a3aab74570019312816bf1b',  # TensorFlow-1.13.1_lrt-flag.patch
-            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             # TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch
             '09e5fdce89588074b3c2abb6a4705b1f141b43395c960660320cf1cb79cd1ef4',
             # TensorFlow-2.0.0_fix-build-tf-lite-avx512.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-fosscuda-2019b-Python-3.7.4.eb
@@ -119,7 +119,6 @@ exts_list = [
         'patches': [
             'TensorFlow-1.14.0_swig-env.patch',
             'TensorFlow-1.13.1_lrt-flag.patch',
-            'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch',
             'TensorFlow-1.14.0_fix-cuda-build.patch',
             'TensorFlow-2.0.0_fix-build-tf-lite-avx512.patch',
@@ -130,8 +129,6 @@ exts_list = [
             '49b5f0495cd681cbcb5296a4476853d4aea19a43bdd9f179c928a977308a0617',  # v2.0.0.tar.gz
             'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',  # TensorFlow-1.14.0_swig-env.patch
             'b388be35f2581786bcd533b1bfa375165d7f35e38a3aab74570019312816bf1b',  # TensorFlow-1.13.1_lrt-flag.patch
-            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             # TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch
             '09e5fdce89588074b3c2abb6a4705b1f141b43395c960660320cf1cb79cd1ef4',
             # TensorFlow-1.14.0_fix-cuda-build.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.1-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.1-foss-2019a-Python-3.7.2.eb
@@ -127,7 +127,6 @@ exts_list = [
         'patches': [
             'TensorFlow-1.14.0_swig-env.patch',
             'TensorFlow-1.13.1_lrt-flag.patch',
-            'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch',
             'TensorFlow-2.0.0_fix-build-tf-lite-avx512.patch',
         ],
@@ -137,8 +136,6 @@ exts_list = [
             '29197d30923b9670992ee4b9c6161f50c7452e9a4158c720746e846080ac245a',  # v2.0.1.tar.gz
             'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',  # TensorFlow-1.14.0_swig-env.patch
             'b388be35f2581786bcd533b1bfa375165d7f35e38a3aab74570019312816bf1b',  # TensorFlow-1.13.1_lrt-flag.patch
-            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             # TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch
             '09e5fdce89588074b3c2abb6a4705b1f141b43395c960660320cf1cb79cd1ef4',
             # TensorFlow-2.0.0_fix-build-tf-lite-avx512.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.1-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.1-fosscuda-2019b-Python-3.7.4.eb
@@ -119,7 +119,6 @@ exts_list = [
         'patches': [
             'TensorFlow-1.14.0_swig-env.patch',
             'TensorFlow-1.13.1_lrt-flag.patch',
-            'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch',
             'TensorFlow-1.14.0_fix-cuda-build.patch',
             'TensorFlow-2.0.0_fix-build-tf-lite-avx512.patch',
@@ -130,8 +129,6 @@ exts_list = [
             '29197d30923b9670992ee4b9c6161f50c7452e9a4158c720746e846080ac245a',  # v2.0.1.tar.gz
             'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',  # TensorFlow-1.14.0_swig-env.patch
             'b388be35f2581786bcd533b1bfa375165d7f35e38a3aab74570019312816bf1b',  # TensorFlow-1.13.1_lrt-flag.patch
-            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             # TensorFlow-1.14.0_fix-mpi-undeclared-inclusion.patch
             '09e5fdce89588074b3c2abb6a4705b1f141b43395c960660320cf1cb79cd1ef4',
             # TensorFlow-1.14.0_fix-cuda-build.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0-foss-2019b-Python-3.7.4.eb
@@ -127,7 +127,6 @@ exts_list = [
         'patches': [
             'TensorFlow-1.14.0_swig-env.patch',
             'TensorFlow-1.15.0_lrt-flag.patch',
-            'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-2.1.0_fix-build-tf-lite-avx512.patch',
         ],
         'source_tmpl': 'v%(version)s.tar.gz',
@@ -140,8 +139,6 @@ exts_list = [
             'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',
             # TensorFlow-1.15.0_lrt-flag.patch
             'b0fd4c7902be45bba18bd04192800852b140a9cf312a44ac1efb7ee653d3d886',
-            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             # TensorFlow-2.1.0_fix-build-tf-lite-avx512.patch
             '022fde8f01deb08fc6d31a03ba693da7f684c6c150502ab2ace7ca02c4c0d4cf',
         ],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0-fosscuda-2019b-Python-3.7.4.eb
@@ -129,7 +129,6 @@ exts_list = [
         'patches': [
             'TensorFlow-1.14.0_swig-env.patch',
             'TensorFlow-1.15.0_lrt-flag.patch',
-            'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-2.1.0_fix-cuda-build.patch',
             'TensorFlow-2.1.0_fix-build-tf-lite-avx512.patch',
         ],
@@ -143,8 +142,6 @@ exts_list = [
             'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',
             # TensorFlow-1.15.0_lrt-flag.patch
             'b0fd4c7902be45bba18bd04192800852b140a9cf312a44ac1efb7ee653d3d886',
-            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             # TensorFlow-2.1.0_fix-cuda-build.patch
             '78c20aeaa7784b8ceb46238a81e8c2461137d28e0b576deeba8357d23fbe1f5a',
             # TensorFlow-2.1.0_fix-build-tf-lite-avx512.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-foss-2019b-Python-3.7.4.eb
@@ -123,7 +123,6 @@ exts_list = [
     (name, version, {
         'patches': [
             'TensorFlow-1.14.0_swig-env.patch',
-            'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-2.1.0_fix-cuda-build.patch',
         ],
         'source_tmpl': 'v%(version)s.tar.gz',
@@ -132,8 +131,6 @@ exts_list = [
         'checksums': [
             '69cd836f87b8c53506c4f706f655d423270f5a563b76dc1cfa60fbc3184185a3',  # v2.2.0.tar.gz
             'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',  # TensorFlow-1.14.0_swig-env.patch
-            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             '78c20aeaa7784b8ceb46238a81e8c2461137d28e0b576deeba8357d23fbe1f5a',  # TensorFlow-2.1.0_fix-cuda-build.patch
         ],
     }),

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-fosscuda-2019b-Python-3.7.4.eb
@@ -125,7 +125,6 @@ exts_list = [
     (name, version, {
         'patches': [
             'TensorFlow-1.14.0_swig-env.patch',
-            'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
             'TensorFlow-2.1.0_fix-cuda-build.patch',
         ],
         'source_tmpl': 'v%(version)s.tar.gz',
@@ -134,8 +133,6 @@ exts_list = [
         'checksums': [
             '69cd836f87b8c53506c4f706f655d423270f5a563b76dc1cfa60fbc3184185a3',  # v2.2.0.tar.gz
             'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',  # TensorFlow-1.14.0_swig-env.patch
-            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
-            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
             '78c20aeaa7784b8ceb46238a81e8c2461137d28e0b576deeba8357d23fbe1f5a',  # TensorFlow-2.1.0_fix-cuda-build.patch
         ],
     }),


### PR DESCRIPTION
Handled by the EasyBlock now in a more general way

Follow-up to ~~https://github.com/easybuilders/easybuild-easyblocks/pull/2110~~

Note: For 1.12.0 the patch is still there but I considered them too old (2018b toolchain)