### PR TITLE
{lib}[GCCcore/9.3.0] Qt5 v5.14.1: disable qtwayland

### DIFF
--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.14.1-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.14.1-GCCcore-9.3.0.eb
@@ -54,7 +54,8 @@ dependencies = [
 ]
 
 # qtgamepad needs recent kernel/libevdev (fails on RHEL 6.x)
-configopts = '-skip qtgamepad'
+# qtwayland fails to build on (some) Centos 7 systems
+configopts = '-skip qtgamepad  -skip qtwayland'
 
 # make sure QtWebEngine component is being built & installed
 check_qtwebengine = True


### PR DESCRIPTION
Building the qtwayland component gives grief on (some?) Centos 7 systems.  Changed config to disable qtwayland being build