### PR TITLE
update TensorFlow 2.1.0 easyconfigs to provide more dependencies via EasyBuild

### DIFF
--- a/easybuild/easyconfigs/f/flatbuffers/flatbuffers-1.12.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/f/flatbuffers/flatbuffers-1.12.0-GCCcore-8.3.0.eb
@@ -1,0 +1,29 @@
+easyblock = 'CMakeNinja'
+
+name = 'flatbuffers'
+version = '1.12.0'
+
+homepage = 'https://github.com/google/flatbuffers/'
+description = """FlatBuffers: Memory Efficient Serialization Library"""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/google/flatbuffers/archive/v%(version)s/']
+sources = [SOURCE_TAR_GZ]
+checksums = ['62f2223fb9181d1d6338451375628975775f7522185266cd5296571ac152bc45']
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('CMake', '3.15.3'),
+    ('Ninja', '1.9.0'),
+]
+
+configopts = '-DFLATBUFFERS_ENABLE_PCH=ON '
+
+sanity_check_paths = {
+    'files': ['include/flatbuffers/flatbuffers.h', 'bin/flatc', 'lib/libflatbuffers.a'],
+    'dirs': ['lib/cmake'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/j/JsonCpp/JsonCpp-1.9.3-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/j/JsonCpp/JsonCpp-1.9.3-GCCcore-8.3.0.eb
@@ -1,0 +1,29 @@
+easyblock = "CMakeNinja"
+
+name = 'JsonCpp'
+version = '1.9.3'
+
+homepage = 'https://open-source-parsers.github.io/jsoncpp-docs/doxygen/index.html'
+description = """ JsonCpp is a C++ library that allows manipulating JSON values,
+ including serialization and deserialization to and from strings. It can also preserve existing comment in
+ unserialization/serialization steps, making it a convenient format to store user input files. """
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['https://github.com/open-source-parsers/jsoncpp/archive']
+sources = ['%(version)s.tar.gz']
+checksums = ['8593c1d69e703563d94d8c12244e2e18893eeb9a8a9f8aa3d09a327aa45c8f7d']
+
+builddependencies = [
+    ('CMake', '3.15.3'),
+    ('Ninja', '1.9.0'),
+    ('pkg-config', '0.29.2'),
+    ('binutils', '2.32'),
+]
+
+sanity_check_paths = {
+    'files': ['include/json/json.h', 'lib/libjsoncpp.a'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/nsync/nsync-1.24.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/n/nsync/nsync-1.24.0-GCCcore-8.3.0.eb
@@ -1,0 +1,26 @@
+easyblock = 'CMakeNinja'
+
+name = 'nsync'
+version = '1.24.0'
+
+homepage = 'https://github.com/google/nsync'
+description = """nsync is a C library that exports various synchronization primitives, such as mutexes"""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['https://github.com/google/nsync/archive/v%(version)s/']
+sources = [SOURCE_TAR_GZ]
+checksums = ['47a6eb2a295be5121a1904a6a775722338a20dc02ee3eec4169ed2c3f203617a']
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('CMake', '3.15.3'),
+    ('Ninja', '1.9.0'),
+]
+
+sanity_check_paths = {
+    'files': ['include/nsync.h', 'lib/libnsync.a', 'lib/libnsync_cpp.a'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0-foss-2019b-Python-3.7.4.eb
@@ -15,8 +15,6 @@ builddependencies = [
     ('protobuf', '3.10.0'),
     # git 2.x required, see also https://github.com/tensorflow/tensorflow/issues/29053
     ('git', '2.23.0', '-nodocs'),
-    # For SciPy
-    ('pybind11', '2.4.3', versionsuffix),
 ]
 dependencies = [
     ('Python', '3.7.4'),
@@ -39,6 +37,10 @@ dependencies = [
     ('snappy', '1.1.7'),
     ('SWIG', '4.0.1'),
     ('zlib', '1.2.11'),
+    # TF 2.1 requires SciPy 1.4.1 due to potential crashes with other versions
+    # See https://github.com/tensorflow/tensorflow/commit/54daf3c5700897a6062313983933ca28e92c410d
+    # Add at bottom so it will be loaded after any dependency loading the SciPy-Bundle
+    ('scipy', '1.4.1', versionsuffix),
 ]
 
 exts_default_options = {
@@ -48,15 +50,6 @@ exts_default_options = {
 use_pip = True
 
 exts_list = [
-    # TF 2.1 requires SciPy 1.4.1 due to potential crashes with other versions
-    # See https://github.com/tensorflow/tensorflow/commit/54daf3c5700897a6062313983933ca28e92c410d
-    ('scipy', '1.4.1', {
-        'patches': ['scipy-1.4.1-fix-pthread.patch'],
-        'checksums': [
-            'dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59',  # scipy-1.4.1.tar.gz
-            '4e2162a93caddce63a1aa2dfb6c181774a4f6615950e1d60c54bb4308fee3bb3',  # scipy-1.4.1-fix-pthread.patch
-        ],
-    }),
     ('Markdown', '3.1.1', {
         'checksums': ['2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a'],
     }),

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0-foss-2019b-Python-3.7.4.eb
@@ -21,6 +21,24 @@ builddependencies = [
 dependencies = [
     ('Python', '3.7.4'),
     ('h5py', '2.10.0', versionsuffix),
+    ('cURL', '7.66.0'),
+    ('double-conversion', '3.1.4'),
+    ('flatbuffers', '1.12.0'),
+    ('giflib', '5.2.1'),
+    ('hwloc', '1.11.12'),
+    ('ICU', '64.2'),
+    ('JsonCpp', '1.9.3'),
+    ('libjpeg-turbo', '2.0.3'),
+    ('LMDB', '0.9.24'),
+    ('NASM', '2.14.02'),
+    ('nsync', '1.24.0'),
+    ('SQLite', '3.29.0'),
+    ('PCRE', '8.43'),
+    ('protobuf-python', '3.10.0', versionsuffix),
+    ('libpng', '1.6.37'),
+    ('snappy', '1.1.7'),
+    ('SWIG', '4.0.1'),
+    ('zlib', '1.2.11'),
 ]
 
 exts_default_options = {
@@ -35,7 +53,7 @@ exts_list = [
     ('scipy', '1.4.1', {
         'patches': ['scipy-1.4.1-fix-pthread.patch'],
         'checksums': [
-            'dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59',
+            'dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59',  # scipy-1.4.1.tar.gz
             '4e2162a93caddce63a1aa2dfb6c181774a4f6615950e1d60c54bb4308fee3bb3',  # scipy-1.4.1-fix-pthread.patch
         ],
     }),
@@ -43,7 +61,6 @@ exts_list = [
         'checksums': ['2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a'],
     }),
     ('pyasn1-modules', '0.2.7', {
-        'modulename': 'pyasn1_modules',
         'checksums': ['0c35a52e00b672f832e5846826f1fb7507907f7d52fba6faa9e3c4cbe874fe4b'],
     }),
     ('rsa', '4.0', {
@@ -60,19 +77,13 @@ exts_list = [
         'checksums': ['bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889'],
     }),
     ('requests-oauthlib', '1.3.0', {
-        'modulename': 'requests_oauthlib',
         'checksums': ['b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a'],
     }),
     ('google-auth-oauthlib', '0.4.1', {
-        'modulename': 'google_auth_oauthlib',
         'checksums': ['88d2cd115e3391eb85e1243ac6902e76e77c5fe438b7276b297fbe68015458dd'],
     }),
     ('Werkzeug', '0.16.0', {
         'checksums': ['7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7'],
-    }),
-    ('protobuf', '3.10.0', {
-        'modulename': 'google.protobuf',
-        'checksums': ['db83b5c12c0cd30150bb568e6feb2435c49ce4e68fe2d7b903113f0e221e58fe'],
     }),
     ('absl-py', '0.8.1', {
         'modulename': 'absl',
@@ -82,7 +93,7 @@ exts_list = [
         'modulename': 'grpc',
         'checksums': ['c948c034d8997526011960db54f512756fb0b4be1b81140a15b4ef094c6594a4'],
     }),
-    ('tensorboard', '2.1.0', {
+    ('tensorboard', version, {
         'source_tmpl': 'tensorboard-%(version)s-py3-none-any.whl',
         'unpack_sources': False,
         'checksums': ['e6e64ec1e1500cc963b300895258f9605032c3a18bb40f95f2b3b12be16ff2f2'],
@@ -94,7 +105,7 @@ exts_list = [
     ('termcolor', '1.1.0', {
         'checksums': ['1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b'],
     }),
-    ('tensorflow-estimator', '2.1.0', {
+    ('tensorflow-estimator', version, {
         'source_tmpl': 'tensorflow_estimator-%(version)s-py2.py3-none-any.whl',
         'unpack_sources': False,
         'checksums': ['e5c5f648a636f18d1be4cf7ed46132b108a2f0f3fd9f1c850eba924263dc6972'],
@@ -103,7 +114,6 @@ exts_list = [
         'checksums': ['37a6eed8b371f1228db08234ed7f6cfdc7817a3ed3824797e20cbb11dc2a7862'],
     }),
     ('Keras-Applications', '1.0.8', {
-        'modulename': 'keras_applications',
         'source_tmpl': 'Keras_Applications-%(version)s.tar.gz',
         'checksums': ['5579f9a12bcde9748f4a12233925a59b93b73ae6947409ff34aa2ba258189fe5'],
     }),
@@ -119,7 +129,6 @@ exts_list = [
         'checksums': ['565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1'],
     }),
     ('Keras-Preprocessing', '1.1.0', {
-        'modulename': 'keras_preprocessing',
         'source_tmpl': 'Keras_Preprocessing-%(version)s.tar.gz',
         'checksums': ['5a8debe01d840de93d49e05ccf1c9b81ae30e210d34dacbcc47aeb3049b528e5'],
     }),
@@ -128,19 +137,31 @@ exts_list = [
             'TensorFlow-1.14.0_swig-env.patch',
             'TensorFlow-1.15.0_lrt-flag.patch',
             'TensorFlow-2.1.0_fix-build-tf-lite-avx512.patch',
+            'TensorFlow-2.1.0_fix-collective-all-reduce-strategy.patch',
+            'TensorFlow-2.1.0_fix-system-flatbuffers.patch',
+            'TensorFlow-2.1.0_fix-system-jsoncpp.patch',
+            'TensorFlow-2.1.0_fix-system-nasm.patch',
+            'TensorFlow-2.1.0_fix-system-protobuf.patch',
         ],
         'source_tmpl': 'v%(version)s.tar.gz',
         'source_urls': ['https://github.com/tensorflow/tensorflow/archive/'],
         'test_script': 'TensorFlow-2.x_mnist-test.py',
         'checksums': [
-            # v2.1.0.tar.gz
-            '638e541a4981f52c69da4a311815f1e7989bf1d67a41d204511966e1daed14f7',
-            # TensorFlow-1.14.0_swig-env.patch
-            'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',
-            # TensorFlow-1.15.0_lrt-flag.patch
-            'b0fd4c7902be45bba18bd04192800852b140a9cf312a44ac1efb7ee653d3d886',
+            '638e541a4981f52c69da4a311815f1e7989bf1d67a41d204511966e1daed14f7',  # v2.1.0.tar.gz
+            'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',  # TensorFlow-1.14.0_swig-env.patch
+            'b0fd4c7902be45bba18bd04192800852b140a9cf312a44ac1efb7ee653d3d886',  # TensorFlow-1.15.0_lrt-flag.patch
             # TensorFlow-2.1.0_fix-build-tf-lite-avx512.patch
             '022fde8f01deb08fc6d31a03ba693da7f684c6c150502ab2ace7ca02c4c0d4cf',
+            # TensorFlow-2.1.0_fix-collective-all-reduce-strategy.patch
+            '093f4dd3ec372a82d50dffe32eea6821025cd1c406911a746c4367a40bc38486',
+            # TensorFlow-2.1.0_fix-system-flatbuffers.patch
+            '0375281b87c2f5f5038621667d10e04aad0fffbbab46c91062f5c08cc56825e3',
+            # TensorFlow-2.1.0_fix-system-jsoncpp.patch
+            'd0c8ca54a9e2c232908016e08b982dbb63765de3472253cba5ae38d823d5f156',
+            # TensorFlow-2.1.0_fix-system-nasm.patch
+            '6671e40d60edaf1e57b1861aa3b2178d48f9b7dfb5b5c0d44db541116f848f2a',
+            # TensorFlow-2.1.0_fix-system-protobuf.patch
+            'cc5981cc3d766346bcaf039c1c50a23feb23e814f321146fac714cae7e4b4167',
         ],
     }),
 ]

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0-fosscuda-2019b-Python-3.7.4.eb
@@ -15,14 +15,12 @@ builddependencies = [
     ('protobuf', '3.10.0'),
     # git 2.x required, see also https://github.com/tensorflow/tensorflow/issues/29053
     ('git', '2.23.0', '-nodocs'),
-    # For SciPy
-    ('pybind11', '2.4.3', versionsuffix),
 ]
 dependencies = [
-    ('Python', '3.7.4'),
-    ('h5py', '2.10.0', versionsuffix),
     ('cuDNN', '7.6.4.38'),
     ('NCCL', '2.4.8'),
+    ('Python', '3.7.4'),
+    ('h5py', '2.10.0', versionsuffix),
     ('cURL', '7.66.0'),
     ('double-conversion', '3.1.4'),
     ('flatbuffers', '1.12.0'),
@@ -41,6 +39,10 @@ dependencies = [
     ('snappy', '1.1.7'),
     ('SWIG', '4.0.1'),
     ('zlib', '1.2.11'),
+    # TF 2.1 requires SciPy 1.4.1 due to potential crashes with other versions
+    # See https://github.com/tensorflow/tensorflow/commit/54daf3c5700897a6062313983933ca28e92c410d
+    # Add at bottom so it will be loaded after any dependency loading the SciPy-Bundle
+    ('scipy', '1.4.1', versionsuffix),
 ]
 
 exts_default_options = {
@@ -50,15 +52,6 @@ exts_default_options = {
 use_pip = True
 
 exts_list = [
-    # TF 2.1 requires SciPy 1.4.1 due to potential crashes with other versions
-    # See https://github.com/tensorflow/tensorflow/commit/54daf3c5700897a6062313983933ca28e92c410d
-    ('scipy', '1.4.1', {
-        'patches': ['scipy-1.4.1-fix-pthread.patch'],
-        'checksums': [
-            'dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59',  # scipy-1.4.1.tar.gz
-            '4e2162a93caddce63a1aa2dfb6c181774a4f6615950e1d60c54bb4308fee3bb3',  # scipy-1.4.1-fix-pthread.patch
-        ],
-    }),
     ('Markdown', '3.1.1', {
         'checksums': ['2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a'],
     }),

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0-fosscuda-2019b-Python-3.7.4.eb
@@ -23,6 +23,24 @@ dependencies = [
     ('h5py', '2.10.0', versionsuffix),
     ('cuDNN', '7.6.4.38'),
     ('NCCL', '2.4.8'),
+    ('cURL', '7.66.0'),
+    ('double-conversion', '3.1.4'),
+    ('flatbuffers', '1.12.0'),
+    ('giflib', '5.2.1'),
+    ('hwloc', '1.11.12'),
+    ('ICU', '64.2'),
+    ('JsonCpp', '1.9.3'),
+    ('libjpeg-turbo', '2.0.3'),
+    ('LMDB', '0.9.24'),
+    ('NASM', '2.14.02'),
+    ('nsync', '1.24.0'),
+    ('SQLite', '3.29.0'),
+    ('PCRE', '8.43'),
+    ('protobuf-python', '3.10.0', versionsuffix),
+    ('libpng', '1.6.37'),
+    ('snappy', '1.1.7'),
+    ('SWIG', '4.0.1'),
+    ('zlib', '1.2.11'),
 ]
 
 exts_default_options = {
@@ -37,7 +55,7 @@ exts_list = [
     ('scipy', '1.4.1', {
         'patches': ['scipy-1.4.1-fix-pthread.patch'],
         'checksums': [
-            'dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59',
+            'dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59',  # scipy-1.4.1.tar.gz
             '4e2162a93caddce63a1aa2dfb6c181774a4f6615950e1d60c54bb4308fee3bb3',  # scipy-1.4.1-fix-pthread.patch
         ],
     }),
@@ -45,7 +63,6 @@ exts_list = [
         'checksums': ['2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a'],
     }),
     ('pyasn1-modules', '0.2.7', {
-        'modulename': 'pyasn1_modules',
         'checksums': ['0c35a52e00b672f832e5846826f1fb7507907f7d52fba6faa9e3c4cbe874fe4b'],
     }),
     ('rsa', '4.0', {
@@ -62,19 +79,13 @@ exts_list = [
         'checksums': ['bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889'],
     }),
     ('requests-oauthlib', '1.3.0', {
-        'modulename': 'requests_oauthlib',
         'checksums': ['b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a'],
     }),
     ('google-auth-oauthlib', '0.4.1', {
-        'modulename': 'google_auth_oauthlib',
         'checksums': ['88d2cd115e3391eb85e1243ac6902e76e77c5fe438b7276b297fbe68015458dd'],
     }),
     ('Werkzeug', '0.16.0', {
         'checksums': ['7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7'],
-    }),
-    ('protobuf', '3.10.0', {
-        'modulename': 'google.protobuf',
-        'checksums': ['db83b5c12c0cd30150bb568e6feb2435c49ce4e68fe2d7b903113f0e221e58fe'],
     }),
     ('absl-py', '0.8.1', {
         'modulename': 'absl',
@@ -84,7 +95,7 @@ exts_list = [
         'modulename': 'grpc',
         'checksums': ['c948c034d8997526011960db54f512756fb0b4be1b81140a15b4ef094c6594a4'],
     }),
-    ('tensorboard', '2.1.0', {
+    ('tensorboard', version, {
         'source_tmpl': 'tensorboard-%(version)s-py3-none-any.whl',
         'unpack_sources': False,
         'checksums': ['e6e64ec1e1500cc963b300895258f9605032c3a18bb40f95f2b3b12be16ff2f2'],
@@ -96,7 +107,7 @@ exts_list = [
     ('termcolor', '1.1.0', {
         'checksums': ['1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b'],
     }),
-    ('tensorflow-estimator', '2.1.0', {
+    ('tensorflow-estimator', version, {
         'source_tmpl': 'tensorflow_estimator-%(version)s-py2.py3-none-any.whl',
         'unpack_sources': False,
         'checksums': ['e5c5f648a636f18d1be4cf7ed46132b108a2f0f3fd9f1c850eba924263dc6972'],
@@ -105,7 +116,6 @@ exts_list = [
         'checksums': ['37a6eed8b371f1228db08234ed7f6cfdc7817a3ed3824797e20cbb11dc2a7862'],
     }),
     ('Keras-Applications', '1.0.8', {
-        'modulename': 'keras_applications',
         'source_tmpl': 'Keras_Applications-%(version)s.tar.gz',
         'checksums': ['5579f9a12bcde9748f4a12233925a59b93b73ae6947409ff34aa2ba258189fe5'],
     }),
@@ -121,7 +131,6 @@ exts_list = [
         'checksums': ['565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1'],
     }),
     ('Keras-Preprocessing', '1.1.0', {
-        'modulename': 'keras_preprocessing',
         'source_tmpl': 'Keras_Preprocessing-%(version)s.tar.gz',
         'checksums': ['5a8debe01d840de93d49e05ccf1c9b81ae30e210d34dacbcc47aeb3049b528e5'],
     }),
@@ -129,23 +138,35 @@ exts_list = [
         'patches': [
             'TensorFlow-1.14.0_swig-env.patch',
             'TensorFlow-1.15.0_lrt-flag.patch',
-            'TensorFlow-2.1.0_fix-cuda-build.patch',
             'TensorFlow-2.1.0_fix-build-tf-lite-avx512.patch',
+            'TensorFlow-2.1.0_fix-collective-all-reduce-strategy.patch',
+            'TensorFlow-2.1.0_fix-cuda-build.patch',
+            'TensorFlow-2.1.0_fix-system-flatbuffers.patch',
+            'TensorFlow-2.1.0_fix-system-jsoncpp.patch',
+            'TensorFlow-2.1.0_fix-system-nasm.patch',
+            'TensorFlow-2.1.0_fix-system-protobuf.patch',
         ],
         'source_tmpl': 'v%(version)s.tar.gz',
         'source_urls': ['https://github.com/tensorflow/tensorflow/archive/'],
         'test_script': 'TensorFlow-2.x_mnist-test.py',
         'checksums': [
-            # v2.1.0.tar.gz
-            '638e541a4981f52c69da4a311815f1e7989bf1d67a41d204511966e1daed14f7',
-            # TensorFlow-1.14.0_swig-env.patch
-            'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',
-            # TensorFlow-1.15.0_lrt-flag.patch
-            'b0fd4c7902be45bba18bd04192800852b140a9cf312a44ac1efb7ee653d3d886',
-            # TensorFlow-2.1.0_fix-cuda-build.patch
-            '78c20aeaa7784b8ceb46238a81e8c2461137d28e0b576deeba8357d23fbe1f5a',
+            '638e541a4981f52c69da4a311815f1e7989bf1d67a41d204511966e1daed14f7',  # v2.1.0.tar.gz
+            'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',  # TensorFlow-1.14.0_swig-env.patch
+            'b0fd4c7902be45bba18bd04192800852b140a9cf312a44ac1efb7ee653d3d886',  # TensorFlow-1.15.0_lrt-flag.patch
             # TensorFlow-2.1.0_fix-build-tf-lite-avx512.patch
             '022fde8f01deb08fc6d31a03ba693da7f684c6c150502ab2ace7ca02c4c0d4cf',
+            # TensorFlow-2.1.0_fix-collective-all-reduce-strategy.patch
+            '093f4dd3ec372a82d50dffe32eea6821025cd1c406911a746c4367a40bc38486',
+            # TensorFlow-2.1.0_fix-cuda-build.patch
+            '78c20aeaa7784b8ceb46238a81e8c2461137d28e0b576deeba8357d23fbe1f5a',
+            # TensorFlow-2.1.0_fix-system-flatbuffers.patch
+            '0375281b87c2f5f5038621667d10e04aad0fffbbab46c91062f5c08cc56825e3',
+            # TensorFlow-2.1.0_fix-system-jsoncpp.patch
+            'd0c8ca54a9e2c232908016e08b982dbb63765de3472253cba5ae38d823d5f156',
+            # TensorFlow-2.1.0_fix-system-nasm.patch
+            '6671e40d60edaf1e57b1861aa3b2178d48f9b7dfb5b5c0d44db541116f848f2a',
+            # TensorFlow-2.1.0_fix-system-protobuf.patch
+            'cc5981cc3d766346bcaf039c1c50a23feb23e814f321146fac714cae7e4b4167',
         ],
     }),
 ]

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0_fix-collective-all-reduce-strategy.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0_fix-collective-all-reduce-strategy.patch
@@ -1,0 +1,22 @@
+Fix for AttributeError: 'CollectiveAllReduceExtended' object has no attribute '_cfer_fn_cache'
+See https://github.com/tensorflow/tensorflow/issues/39417
+
+Author: Alexander Grund
+--- tensorflow-2.1.0-orig/tensorflow/python/distribute/collective_all_reduce_strategy.py	2020-05-11 18:14:03.682085572 +0200
++++ tensorflow-2.1.0/tensorflow/python/distribute/collective_all_reduce_strategy.py	2020-05-11 18:15:41.623409641 +0200
+@@ -19,6 +19,7 @@
+ from __future__ import print_function
+ 
+ import copy
++import weakref
+ 
+ from tensorflow.core.protobuf import config_pb2
+ from tensorflow.core.protobuf import rewriter_config_pb2
+@@ -172,6 +173,7 @@
+         cross_device_ops_lib.CollectiveCommunication)
+     self._communication = communication
+     self._initialize_strategy(cluster_resolver)
++    self._cfer_fn_cache = weakref.WeakKeyDictionary()
+     assert isinstance(self._get_cross_device_ops(),
+                       cross_device_ops_lib.CollectiveAllReduce)
+ 

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0_fix-system-flatbuffers.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0_fix-system-flatbuffers.patch
@@ -1,0 +1,62 @@
+Extracted from https://github.com/tensorflow/tensorflow/commit/adf6e22e4af83afd55e0da3caa7e7959def1e6b6
+to allow usage with newer flatbuffers
+
+diff --git a/tensorflow/lite/kernels/BUILD b/tensorflow/lite/kernels/BUILD
+index 172a041b31b55..0d1fb476e323a 100644
+--- a/tensorflow/lite/kernels/BUILD
++++ b/tensorflow/lite/kernels/BUILD
+@@ -543,6 +543,7 @@ cc_library(
+         "//tensorflow/lite/kernels/internal:types",
+         "//third_party/eigen3",
+         "@com_google_absl//absl/memory",
++        "@com_google_absl//absl/strings",
+         "@farmhash_archive//:farmhash",
+         "@flatbuffers",
+     ],
+diff --git a/tensorflow/lite/tools/optimize/BUILD b/tensorflow/lite/tools/optimize/BUILD
+index bf7e1baafd930..878d3ae5ef081 100644
+--- a/tensorflow/lite/tools/optimize/BUILD
++++ b/tensorflow/lite/tools/optimize/BUILD
+@@ -87,6 +87,7 @@ cc_library(
+         "//tensorflow/lite/kernels/internal:types",
+         "//tensorflow/lite/schema:schema_fbs",
+         "@com_google_absl//absl/memory",
++        "@com_google_absl//absl/strings",
+     ],
+ )
+ 
+diff --git a/tensorflow/lite/tools/optimize/calibration/BUILD b/tensorflow/lite/tools/optimize/calibration/BUILD
+index 4ae881ba508db..a394156786fe2 100644
+--- a/tensorflow/lite/tools/optimize/calibration/BUILD
++++ b/tensorflow/lite/tools/optimize/calibration/BUILD
+@@ -50,6 +50,7 @@ cc_library(
+         "//tensorflow/lite/kernels:kernel_util",
+         "//tensorflow/lite/schema:schema_fbs",
+         "@com_google_absl//absl/memory",
++        "@com_google_absl//absl/strings",
+         "@flatbuffers",
+     ],
+ )
+@@ -75,6 +76,7 @@ tf_cc_test(
+         "//tensorflow/lite:framework",
+         "//tensorflow/lite/kernels:builtin_ops",
+         "@com_google_absl//absl/memory",
++        "@com_google_absl//absl/strings",
+         "@com_google_googletest//:gtest",
+     ],
+ )
+@@ -89,6 +91,7 @@ cc_library(
+         "//tensorflow/lite:framework",
+         "//tensorflow/lite/core/api",
+         "@com_google_absl//absl/memory",
++        "@com_google_absl//absl/strings",
+     ],
+ )
+ 
+@@ -112,6 +115,7 @@ cc_library(
+         ":calibration_logger",
+         "//tensorflow/lite:framework",
+         "@com_google_absl//absl/memory",
++        "@com_google_absl//absl/strings",
+     ],
+ )

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0_fix-system-jsoncpp.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0_fix-system-jsoncpp.patch
@@ -1,0 +1,15 @@
+diff --git a/third_party/systemlibs/jsoncpp.BUILD b/third_party/systemlibs/jsoncpp.BUILD
+index 7d54f9289b..ba921bdfb0 100644
+--- a/third_party/systemlibs/jsoncpp.BUILD
++++ b/third_party/systemlibs/jsoncpp.BUILD
+@@ -32,8 +32,8 @@ genrule(
+ 
+ cc_library(
+     name = "jsoncpp",
+-    hdrs = HEADERS,
+-    includes = ["."],
++    #hdrs = HEADERS,
++    #includes = ["."],
+     linkopts = ["-ljsoncpp"],
+     visibility = ["//visibility:public"],
+ )

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0_fix-system-nasm.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0_fix-system-nasm.patch
@@ -1,0 +1,28 @@
+commit 5b3b9c7fe7501acd6bd69abe26fd3f9e0f1df4ef
+Author: Alexander Grund <alexander.grund@tu-dresden.de>
+Date:   Wed Aug 12 15:48:17 2020 +0200
+
+    Use nasmlink genrule
+    
+    Avoids cyclic dependency as the name and src must not be the same
+
+diff --git a/third_party/nasm/BUILD.system b/third_party/nasm/BUILD.system
+index 7f74da7595..52f608187f 100644
+--- a/third_party/nasm/BUILD.system
++++ b/third_party/nasm/BUILD.system
+@@ -5,8 +5,14 @@ filegroup(
+     visibility = ["//visibility:public"],
+ )
+ 
++genrule(
++    name = "lnnasmlink",
++    outs = ["nasmlink"],
++    cmd = "ln -s $$(which nasm) $@",
++)
++
+ sh_binary(
+     name = "nasm",
+-    srcs = ["nasm"],
++    srcs = ["nasmlink"],
+     visibility = ["@libjpeg_turbo//:__pkg__"],
+ )

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0_fix-system-protobuf.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0_fix-system-protobuf.patch
@@ -1,0 +1,43 @@
+From 9cee90ac957f2575da2415242c5c127c0dd61430 Mon Sep 17 00:00:00 2001
+From: Jason Zaman <jason@perfinion.com>
+Date: Wed, 8 Apr 2020 03:15:14 +0800
+Subject: [PATCH] systemlibs: protobuf: update for
+ --incompatible_no_support_tools_in_action_inputs
+
+Just the minimal changes needed to work with the change instead of
+pulling the entire updated file which would be a much larger change
+
+Signed-off-by: Jason Zaman <jason@perfinion.com>
+---
+ third_party/systemlibs/protobuf.bzl | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/third_party/systemlibs/protobuf.bzl b/third_party/systemlibs/protobuf.bzl
+index bb807e904a3fc..367ac286395cb 100644
+--- a/third_party/systemlibs/protobuf.bzl
++++ b/third_party/systemlibs/protobuf.bzl
+@@ -93,6 +93,7 @@ def _proto_gen_impl(ctx):
+         args += ["--python_out=" + gen_dir]
+ 
+     inputs = srcs + deps
++    tools = [ctx.executable.protoc]
+     if ctx.executable.plugin:
+         plugin = ctx.executable.plugin
+         lang = ctx.attr.plugin_language
+@@ -106,7 +107,7 @@ def _proto_gen_impl(ctx):
+             outdir = ",".join(ctx.attr.plugin_options) + ":" + outdir
+         args += ["--plugin=protoc-gen-%s=%s" % (lang, plugin.path)]
+         args += ["--%s_out=%s" % (lang, outdir)]
+-        inputs += [plugin]
++        tools.append(plugin)
+ 
+     if args:
+         ctx.actions.run(
+@@ -115,6 +116,7 @@ def _proto_gen_impl(ctx):
+             arguments = args + import_flags + [s.path for s in srcs],
+             executable = ctx.executable.protoc,
+             mnemonic = "ProtoCompile",
++            tools = tools,
+             use_default_shell_env = True,
+         )
+ 


### PR DESCRIPTION
- [x] Requires https://github.com/easybuilders/easybuild-easyblocks/pull/2117
- [x] Requires https://github.com/easybuilders/easybuild-framework/pull/3401 and ICU rebuild
- [x] Requires https://github.com/easybuilders/easybuild-easyblocks/pull/2120
- [x] Requires ~~#11143~~ (use `pip` for `protobuf-python`)
- [x] Requires ~~#11216~~ (scipy for `fosscuda/2019b`)
- [x] Requires ~~#11218~~ (scipy 1.4.1 for `foss/2019b`)

This is basically a test run. It makes the installation faster and smaller and avoids some downloads at build time.

This approach will be required for TF 2.3.0 and I'll add PRs for the other 2.x ECs once this is merged

Reason why it is required is the TF 2.3 bundles cURL but builds it with Bazel side-stepping the (correct) configuration from cURL and introducing a bug on some systems making parts of TF unusable: https://github.com/tensorflow/tensorflow/issues/40065#issuecomment-667129086