### PR TITLE
Add Clang-8.0.1-GCC-8.2.0-CUDA-10.1.105

### DIFF
--- a/easybuild/easyconfigs/c/Clang/Clang-8.0.0-GCC-8.2.0-2.31.1-CUDA-10.1.105.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-8.0.0-GCC-8.2.0-2.31.1-CUDA-10.1.105.eb
@@ -24,7 +24,7 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 # Do not set optarch to True: it will cause the build to fail
 toolchainopts = {'optarch': False}
 
-source_urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-%(version)s"]
+source_urls = ["https://llvm.org/releases/%(version)s"]
 sources = [
     'llvm-%(version)s.src.tar.xz',
     'cfe-%(version)s.src.tar.xz',

--- a/easybuild/easyconfigs/c/Clang/Clang-8.0.0-GCC-8.2.0-2.31.1-CUDA-10.1.105.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-8.0.0-GCC-8.2.0-2.31.1-CUDA-10.1.105.eb
@@ -1,0 +1,73 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2013-2015 Dmitri Gribenko, Ward Poelmans
+# Authors:: Dmitri Gribenko <gribozavr@gmail.com>
+# Authors:: Ward Poelmans <wpoely86@gmail.com>
+# License:: GPLv2 or later, MIT, three-clause BSD.
+# $Id$
+##
+
+name = 'Clang'
+version = '8.0.0'
+
+local_cudaver = '10.1.105'
+versionsuffix = '-CUDA-%s' % (local_cudaver)
+
+homepage = 'https://clang.llvm.org/'
+description = """C, C++, Objective-C compiler, based on LLVM.  Does not
+ include C++ standard library -- use libstdc++ from GCC."""
+
+# Clang also depends on libstdc++ during runtime, but this dependency is
+# already specified as the toolchain.
+toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
+# Do not set optarch to True: it will cause the build to fail
+toolchainopts = {'optarch': False}
+
+source_urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-%(version)s"]
+sources = [
+    'llvm-%(version)s.src.tar.xz',
+    'cfe-%(version)s.src.tar.xz',
+    'compiler-rt-%(version)s.src.tar.xz',
+    'polly-%(version)s.src.tar.xz',
+    'openmp-%(version)s.src.tar.xz',
+    # Also include the LLVM linker
+    'lld-%(version)s.src.tar.xz',
+    'libcxx-%(version)s.src.tar.xz',
+    'libcxxabi-%(version)s.src.tar.xz',
+]
+patches = ['libcxx-%(version)s-ppc64le.patch']
+checksums = [
+    '8872be1b12c61450cacc82b3d153eab02be2546ef34fa3580ed14137bb26224c',  # llvm-8.0.0.src.tar.xz
+    '084c115aab0084e63b23eee8c233abb6739c399e29966eaeccfc6e088e0b736b',  # cfe-8.0.0.src.tar.xz
+    'b435c7474f459e71b2831f1a4e3f1d21203cb9c0172e94e9d9b69f50354f21b1',  # compiler-rt-8.0.0.src.tar.xz
+    'e3f5a3d6794ef8233af302c45ceb464b74cdc369c1ac735b6b381b21e4d89df4',  # polly-8.0.0.src.tar.xz
+    'f7b1705d2f16c4fc23d6531f67d2dd6fb78a077dd346b02fed64f4b8df65c9d5',  # openmp-8.0.0.src.tar.xz
+    '9caec8ec922e32ffa130f0fb08e4c5a242d7e68ce757631e425e9eba2e1a6e37',  # lld-8.0.0.src.tar.xz
+    'c2902675e7c84324fb2c1e45489220f250ede016cc3117186785d9dc291f9de2',  # libcxx-8.0.0.src.tar.xz
+    'c2d6de9629f7c072ac20ada776374e9e3168142f20a46cdb9d6df973922b07cd',  # libcxxabi-8.0.0.src.tar.xz
+    '173da6b7831a66d2f7d064f0ec3f6c56645a7f1352b709ceb9a55416fe6c93ce',  # libcxx-8.0.0-ppc64le.patch
+]
+
+dependencies = [
+    # since Clang is a compiler, binutils is a runtime dependency too
+    ('binutils', '2.31.1'),
+    ('GMP', '6.1.2'),
+    ('CUDA', local_cudaver),
+]
+
+builddependencies = [
+    ('CMake', '3.13.3'),
+    ('Python', '2.7.15'),
+    ('libxml2', '2.9.8'),
+]
+
+assertions = True
+usepolly = True
+build_lld = True
+libcxx = True
+enable_rtti = True
+
+skip_all_tests = True
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/c/Clang/Clang-8.0.0-GCC-8.2.0-2.31.1-CUDA-10.1.105.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-8.0.0-GCC-8.2.0-2.31.1-CUDA-10.1.105.eb
@@ -62,6 +62,9 @@ builddependencies = [
     ('libxml2', '2.9.8'),
 ]
 
+# Set the c++ std for NVCC or the build fails on ppc64le looking for __ieee128
+configopts = "-DCUDA_NVCC_FLAGS=-std=c++11"
+
 assertions = True
 usepolly = True
 build_lld = True

--- a/easybuild/easyconfigs/c/Clang/Clang-8.0.1-GCC-8.2.0-2.31.1-CUDA-10.1.105.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-8.0.1-GCC-8.2.0-2.31.1-CUDA-10.1.105.eb
@@ -9,7 +9,7 @@
 ##
 
 name = 'Clang'
-version = '8.0.0'
+version = '8.0.1'
 
 local_cudaver = '10.1.105'
 versionsuffix = '-CUDA-%s' % (local_cudaver)
@@ -24,7 +24,7 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 # Do not set optarch to True: it will cause the build to fail
 toolchainopts = {'optarch': False}
 
-source_urls = ["https://llvm.org/releases/%(version)s"]
+source_urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-%(version)s"]
 sources = [
     'llvm-%(version)s.src.tar.xz',
     'cfe-%(version)s.src.tar.xz',
@@ -36,16 +36,16 @@ sources = [
     'libcxx-%(version)s.src.tar.xz',
     'libcxxabi-%(version)s.src.tar.xz',
 ]
-patches = ['libcxx-%(version)s-ppc64le.patch']
+patches = ['libcxx-8.0.0-ppc64le.patch']
 checksums = [
-    '8872be1b12c61450cacc82b3d153eab02be2546ef34fa3580ed14137bb26224c',  # llvm-8.0.0.src.tar.xz
-    '084c115aab0084e63b23eee8c233abb6739c399e29966eaeccfc6e088e0b736b',  # cfe-8.0.0.src.tar.xz
-    'b435c7474f459e71b2831f1a4e3f1d21203cb9c0172e94e9d9b69f50354f21b1',  # compiler-rt-8.0.0.src.tar.xz
-    'e3f5a3d6794ef8233af302c45ceb464b74cdc369c1ac735b6b381b21e4d89df4',  # polly-8.0.0.src.tar.xz
-    'f7b1705d2f16c4fc23d6531f67d2dd6fb78a077dd346b02fed64f4b8df65c9d5',  # openmp-8.0.0.src.tar.xz
-    '9caec8ec922e32ffa130f0fb08e4c5a242d7e68ce757631e425e9eba2e1a6e37',  # lld-8.0.0.src.tar.xz
-    'c2902675e7c84324fb2c1e45489220f250ede016cc3117186785d9dc291f9de2',  # libcxx-8.0.0.src.tar.xz
-    'c2d6de9629f7c072ac20ada776374e9e3168142f20a46cdb9d6df973922b07cd',  # libcxxabi-8.0.0.src.tar.xz
+    '44787a6d02f7140f145e2250d56c9f849334e11f9ae379827510ed72f12b75e7',  # llvm-8.0.1.src.tar.xz
+    '70effd69f7a8ab249f66b0a68aba8b08af52aa2ab710dfb8a0fba102685b1646',  # cfe-8.0.1.src.tar.xz
+    '11828fb4823387d820c6715b25f6b2405e60837d12a7469e7a8882911c721837',  # compiler-rt-8.0.1.src.tar.xz
+    'e8a1f7e8af238b32ce39ab5de1f3317a2e3f7d71a8b1b8bbacbd481ac76fd2d1',  # polly-8.0.1.src.tar.xz
+    '3e85dd3cad41117b7c89a41de72f2e6aa756ea7b4ef63bb10dcddf8561a7722c',  # openmp-8.0.1.src.tar.xz
+    '9fba1e94249bd7913e8a6c3aadcb308b76c8c3d83c5ce36c99c3f34d73873d88',  # lld-8.0.1.src.tar.xz
+    '7f0652c86a0307a250b5741ab6e82bb10766fb6f2b5a5602a63f30337e629b78',  # libcxx-8.0.1.src.tar.xz
+    'b75bf3c8dc506e7d950d877eefc8b6120a4651aaa110f5805308861f2cfaf6ef',  # libcxxabi-8.0.1.src.tar.xz
     '173da6b7831a66d2f7d064f0ec3f6c56645a7f1352b709ceb9a55416fe6c93ce',  # libcxx-8.0.0-ppc64le.patch
 ]
 


### PR DESCRIPTION
As suggested by @lexming at https://github.com/easybuilders/easybuild-easyconfigs/pull/11157#pullrequestreview-474470339 this adds a Clang with dependency on GCC instead of GCCCore to avoid 2 different CUDA versions in dependency chains