### PR TITLE
use more EasyBuild installed dependencies for TensorFlow 2.2.0

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-foss-2019b-Python-3.7.4.eb
@@ -12,15 +12,37 @@ toolchainopts = {'usempi': True, 'pic': True}
 
 builddependencies = [
     ('Bazel', '2.0.0'),
+    ('protobuf', '3.10.0'),
     # git 2.x required, see also https://github.com/tensorflow/tensorflow/issues/29053
     ('git', '2.23.0', '-nodocs'),
-    # For SciPy
     ('pybind11', '2.4.3', versionsuffix),
 ]
 dependencies = [
     ('Python', '3.7.4'),
     ('SciPy-bundle', '2019.10', versionsuffix),
     ('h5py', '2.10.0', versionsuffix),
+    ('cURL', '7.66.0'),
+    ('double-conversion', '3.1.4'),
+    ('flatbuffers', '1.12.0'),
+    ('giflib', '5.2.1'),
+    ('hwloc', '1.11.12'),
+    ('ICU', '64.2'),
+    ('JsonCpp', '1.9.3'),
+    ('libjpeg-turbo', '2.0.3'),
+    ('LMDB', '0.9.24'),
+    ('NASM', '2.14.02'),
+    ('nsync', '1.24.0'),
+    ('SQLite', '3.29.0'),
+    ('PCRE', '8.43'),
+    ('protobuf-python', '3.10.0', versionsuffix),
+    ('libpng', '1.6.37'),
+    ('snappy', '1.1.7'),
+    ('SWIG', '4.0.1'),
+    ('zlib', '1.2.11'),
+    # TF 2.2 requires SciPy 1.4.1 due to potential crashes with other versions
+    # See https://github.com/tensorflow/tensorflow/commit/54daf3c5700897a6062313983933ca28e92c410d
+    # Add at bottom so it will be loaded after any dependency loading the SciPy-Bundle
+    ('scipy', '1.4.1', versionsuffix),
 ]
 
 exts_default_options = {
@@ -30,18 +52,10 @@ exts_default_options = {
 use_pip = True
 
 exts_list = [
-    ('scipy', '1.4.1', {
-        'patches': ['scipy-1.4.1-fix-pthread.patch'],
-        'checksums': [
-            'dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59',  # scipy-1.4.1.tar.gz
-            '4e2162a93caddce63a1aa2dfb6c181774a4f6615950e1d60c54bb4308fee3bb3',  # scipy-1.4.1-fix-pthread.patch
-        ],
-    }),
     ('Markdown', '3.2.1', {
         'checksums': ['90fee683eeabe1a92e149f7ba74e5ccdc81cd397bd6c516d93a8da0ef90b6902'],
     }),
     ('pyasn1-modules', '0.2.8', {
-        'modulename': 'pyasn1_modules',
         'checksums': ['905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e'],
     }),
     ('rsa', '4.0', {
@@ -58,19 +72,13 @@ exts_list = [
         'checksums': ['bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889'],
     }),
     ('requests-oauthlib', '1.3.0', {
-        'modulename': 'requests_oauthlib',
         'checksums': ['b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a'],
     }),
     ('google-auth-oauthlib', '0.4.1', {
-        'modulename': 'google_auth_oauthlib',
         'checksums': ['88d2cd115e3391eb85e1243ac6902e76e77c5fe438b7276b297fbe68015458dd'],
     }),
     ('Werkzeug', '1.0.1', {
         'checksums': ['6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c'],
-    }),
-    ('protobuf', '3.11.3', {
-        'modulename': 'google.protobuf',
-        'checksums': ['c77c974d1dadf246d789f6dad1c24426137c9091e930dbf50e0a29c1fcf00b1f'],
     }),
     ('absl-py', '0.9.0', {
         'modulename': 'absl',
@@ -116,19 +124,18 @@ exts_list = [
         'checksums': ['b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7'],
     }),
     ('Keras-Applications', '1.0.8', {
-        'modulename': 'keras_applications',
         'source_tmpl': 'Keras_Applications-%(version)s.tar.gz',
         'checksums': ['5579f9a12bcde9748f4a12233925a59b93b73ae6947409ff34aa2ba258189fe5'],
     }),
     ('Keras-Preprocessing', '1.1.0', {
-        'modulename': 'keras_preprocessing',
         'source_tmpl': 'Keras_Preprocessing-%(version)s.tar.gz',
         'checksums': ['5a8debe01d840de93d49e05ccf1c9b81ae30e210d34dacbcc47aeb3049b528e5'],
     }),
     (name, version, {
         'patches': [
             'TensorFlow-1.14.0_swig-env.patch',
-            'TensorFlow-2.1.0_fix-cuda-build.patch',
+            'TensorFlow-2.1.0_fix-system-jsoncpp.patch',
+            'TensorFlow-2.1.0_fix-system-nasm.patch',
             'TensorFlow-2.1.0_fix-collective-all-reduce-strategy.patch',
         ],
         'source_tmpl': 'v%(version)s.tar.gz',
@@ -137,7 +144,10 @@ exts_list = [
         'checksums': [
             '69cd836f87b8c53506c4f706f655d423270f5a563b76dc1cfa60fbc3184185a3',  # v2.2.0.tar.gz
             'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',  # TensorFlow-1.14.0_swig-env.patch
-            '78c20aeaa7784b8ceb46238a81e8c2461137d28e0b576deeba8357d23fbe1f5a',  # TensorFlow-2.1.0_fix-cuda-build.patch
+            # TensorFlow-2.1.0_fix-system-jsoncpp.patch
+            'd0c8ca54a9e2c232908016e08b982dbb63765de3472253cba5ae38d823d5f156',
+            # TensorFlow-2.1.0_fix-system-nasm.patch
+            '6671e40d60edaf1e57b1861aa3b2178d48f9b7dfb5b5c0d44db541116f848f2a',
             # TensorFlow-2.1.0_fix-collective-all-reduce-strategy.patch
             '093f4dd3ec372a82d50dffe32eea6821025cd1c406911a746c4367a40bc38486',
         ],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-foss-2019b-Python-3.7.4.eb
@@ -123,10 +123,6 @@ exts_list = [
     ('wrapt', '1.12.1', {
         'checksums': ['b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7'],
     }),
-    ('Keras-Applications', '1.0.8', {
-        'source_tmpl': 'Keras_Applications-%(version)s.tar.gz',
-        'checksums': ['5579f9a12bcde9748f4a12233925a59b93b73ae6947409ff34aa2ba258189fe5'],
-    }),
     ('Keras-Preprocessing', '1.1.0', {
         'source_tmpl': 'Keras_Preprocessing-%(version)s.tar.gz',
         'checksums': ['5a8debe01d840de93d49e05ccf1c9b81ae30e210d34dacbcc47aeb3049b528e5'],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-fosscuda-2019b-Python-3.7.4.eb
@@ -125,10 +125,6 @@ exts_list = [
     ('wrapt', '1.12.1', {
         'checksums': ['b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7'],
     }),
-    ('Keras-Applications', '1.0.8', {
-        'source_tmpl': 'Keras_Applications-%(version)s.tar.gz',
-        'checksums': ['5579f9a12bcde9748f4a12233925a59b93b73ae6947409ff34aa2ba258189fe5'],
-    }),
     ('Keras-Preprocessing', '1.1.0', {
         'source_tmpl': 'Keras_Preprocessing-%(version)s.tar.gz',
         'checksums': ['5a8debe01d840de93d49e05ccf1c9b81ae30e210d34dacbcc47aeb3049b528e5'],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-fosscuda-2019b-Python-3.7.4.eb
@@ -12,17 +12,39 @@ toolchainopts = {'usempi': True, 'pic': True}
 
 builddependencies = [
     ('Bazel', '2.0.0'),
+    ('protobuf', '3.10.0'),
     # git 2.x required, see also https://github.com/tensorflow/tensorflow/issues/29053
     ('git', '2.23.0', '-nodocs'),
-    # For SciPy
     ('pybind11', '2.4.3', versionsuffix),
 ]
 dependencies = [
+    ('cuDNN', '7.6.4.38'),
+    ('NCCL', '2.4.8'),
     ('Python', '3.7.4'),
     ('SciPy-bundle', '2019.10', versionsuffix),
     ('h5py', '2.10.0', versionsuffix),
-    ('cuDNN', '7.6.4.38'),
-    ('NCCL', '2.4.8'),
+    ('cURL', '7.66.0'),
+    ('double-conversion', '3.1.4'),
+    ('flatbuffers', '1.12.0'),
+    ('giflib', '5.2.1'),
+    ('hwloc', '1.11.12'),
+    ('ICU', '64.2'),
+    ('JsonCpp', '1.9.3'),
+    ('libjpeg-turbo', '2.0.3'),
+    ('LMDB', '0.9.24'),
+    ('NASM', '2.14.02'),
+    ('nsync', '1.24.0'),
+    ('SQLite', '3.29.0'),
+    ('PCRE', '8.43'),
+    ('protobuf-python', '3.10.0', versionsuffix),
+    ('libpng', '1.6.37'),
+    ('snappy', '1.1.7'),
+    ('SWIG', '4.0.1'),
+    ('zlib', '1.2.11'),
+    # TF 2.2 requires SciPy 1.4.1 due to potential crashes with other versions
+    # See https://github.com/tensorflow/tensorflow/commit/54daf3c5700897a6062313983933ca28e92c410d
+    # Add at bottom so it will be loaded after any dependency loading the SciPy-Bundle
+    ('scipy', '1.4.1', versionsuffix),
 ]
 
 exts_default_options = {
@@ -32,18 +54,10 @@ exts_default_options = {
 use_pip = True
 
 exts_list = [
-    ('scipy', '1.4.1', {
-        'patches': ['scipy-1.4.1-fix-pthread.patch'],
-        'checksums': [
-            'dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59',  # scipy-1.4.1.tar.gz
-            '4e2162a93caddce63a1aa2dfb6c181774a4f6615950e1d60c54bb4308fee3bb3',  # scipy-1.4.1-fix-pthread.patch
-        ],
-    }),
     ('Markdown', '3.2.1', {
         'checksums': ['90fee683eeabe1a92e149f7ba74e5ccdc81cd397bd6c516d93a8da0ef90b6902'],
     }),
     ('pyasn1-modules', '0.2.8', {
-        'modulename': 'pyasn1_modules',
         'checksums': ['905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e'],
     }),
     ('rsa', '4.0', {
@@ -60,19 +74,13 @@ exts_list = [
         'checksums': ['bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889'],
     }),
     ('requests-oauthlib', '1.3.0', {
-        'modulename': 'requests_oauthlib',
         'checksums': ['b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a'],
     }),
     ('google-auth-oauthlib', '0.4.1', {
-        'modulename': 'google_auth_oauthlib',
         'checksums': ['88d2cd115e3391eb85e1243ac6902e76e77c5fe438b7276b297fbe68015458dd'],
     }),
     ('Werkzeug', '1.0.1', {
         'checksums': ['6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c'],
-    }),
-    ('protobuf', '3.11.3', {
-        'modulename': 'google.protobuf',
-        'checksums': ['c77c974d1dadf246d789f6dad1c24426137c9091e930dbf50e0a29c1fcf00b1f'],
     }),
     ('absl-py', '0.9.0', {
         'modulename': 'absl',
@@ -118,18 +126,18 @@ exts_list = [
         'checksums': ['b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7'],
     }),
     ('Keras-Applications', '1.0.8', {
-        'modulename': 'keras_applications',
         'source_tmpl': 'Keras_Applications-%(version)s.tar.gz',
         'checksums': ['5579f9a12bcde9748f4a12233925a59b93b73ae6947409ff34aa2ba258189fe5'],
     }),
     ('Keras-Preprocessing', '1.1.0', {
-        'modulename': 'keras_preprocessing',
         'source_tmpl': 'Keras_Preprocessing-%(version)s.tar.gz',
         'checksums': ['5a8debe01d840de93d49e05ccf1c9b81ae30e210d34dacbcc47aeb3049b528e5'],
     }),
     (name, version, {
         'patches': [
             'TensorFlow-1.14.0_swig-env.patch',
+            'TensorFlow-2.1.0_fix-system-jsoncpp.patch',
+            'TensorFlow-2.1.0_fix-system-nasm.patch',
             'TensorFlow-2.1.0_fix-cuda-build.patch',
             'TensorFlow-2.1.0_fix-collective-all-reduce-strategy.patch',
         ],
@@ -139,6 +147,10 @@ exts_list = [
         'checksums': [
             '69cd836f87b8c53506c4f706f655d423270f5a563b76dc1cfa60fbc3184185a3',  # v2.2.0.tar.gz
             'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',  # TensorFlow-1.14.0_swig-env.patch
+            # TensorFlow-2.1.0_fix-system-jsoncpp.patch
+            'd0c8ca54a9e2c232908016e08b982dbb63765de3472253cba5ae38d823d5f156',
+            # TensorFlow-2.1.0_fix-system-nasm.patch
+            '6671e40d60edaf1e57b1861aa3b2178d48f9b7dfb5b5c0d44db541116f848f2a',
             '78c20aeaa7784b8ceb46238a81e8c2461137d28e0b576deeba8357d23fbe1f5a',  # TensorFlow-2.1.0_fix-cuda-build.patch
             # TensorFlow-2.1.0_fix-collective-all-reduce-strategy.patch
             '093f4dd3ec372a82d50dffe32eea6821025cd1c406911a746c4367a40bc38486',


### PR DESCRIPTION
Similar to #11109 this updates the TensorFlow 2.2.0 ECs to use more dependencies provided by EB