### PR TITLE
move edlib and minibar down to iccifort toolchain

### DIFF
--- a/easybuild/easyconfigs/e/edlib/edlib-1.3.8.post1-iccifort-2019.5.281-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/e/edlib/edlib-1.3.8.post1-iccifort-2019.5.281-Python-3.7.4.eb
@@ -7,7 +7,7 @@ versionsuffix = '-Python-%(pyver)s'
 homepage = 'https://martinsos.github.io/edlib'
 description = "Lightweight, super fast library for sequence alignment using edit (Levenshtein) distance."
 
-toolchain = {'name': 'intel', 'version': '2019b'}
+toolchain = {'name': 'iccifort', 'version': '2019.5.281'}
 
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/m/minibar/minibar-20200326-iccifort-2019.5.281-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/m/minibar/minibar-20200326-iccifort-2019.5.281-Python-3.7.4.eb
@@ -8,7 +8,7 @@ versionsuffix = '-Python-%(pyver)s'
 homepage = 'https://github.com/calacademy-research/minibar'
 description = " Dual barcode and primer demultiplexing for MinION sequenced reads"
 
-toolchain = {'name': 'intel', 'version': '2019b'}
+toolchain = {'name': 'iccifort', 'version': '2019.5.281'}
 
 source_urls = ['https://github.com/calacademy-research/%(name)s/archive']
 sources = [{'download_filename': '%s.tar.gz' % local_commit_id, 'filename': SOURCE_TAR_GZ}]


### PR DESCRIPTION
follow-up for @smoors's request in #10470