### PR TITLE
disable building the C++ extension in the protobuf-python v3.10.0 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/p/protobuf-python/protobuf-python-3.10.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/protobuf-python/protobuf-python-3.10.0-foss-2019b-Python-3.7.4.eb
@@ -18,8 +18,6 @@ dependencies = [
     ('protobuf', version)
 ]
 
-installopts = '--install-option="--cpp_implementation"'
-
 download_dep_fail = True
 use_pip = True
 sanity_pip_check = True
@@ -30,11 +28,6 @@ sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/google/protobuf'],
 }
-# Check that the C++ implementation is available
-sanity_check_commands = [
-    "python -c 'from google.protobuf.internal import _api_implementation'",
-    "python -c 'from google.protobuf.pyext import _message'",
-]
 
 options = {'modulename': 'google.protobuf'}
 

--- a/easybuild/easyconfigs/p/protobuf-python/protobuf-python-3.10.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/protobuf-python/protobuf-python-3.10.0-fosscuda-2019b-Python-3.7.4.eb
@@ -18,8 +18,6 @@ dependencies = [
     ('protobuf', version)
 ]
 
-installopts = '--install-option="--cpp_implementation"'
-
 download_dep_fail = True
 use_pip = True
 sanity_pip_check = True
@@ -30,11 +28,6 @@ sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/google/protobuf'],
 }
-# Check that the C++ implementation is available
-sanity_check_commands = [
-    "python -c 'from google.protobuf.internal import _api_implementation'",
-    "python -c 'from google.protobuf.pyext import _message'",
-]
 
 options = {'modulename': 'google.protobuf'}
 


### PR DESCRIPTION
Seems like the protobuf C++ extensions are not good: https://github.com/protocolbuffers/protobuf/blob/c6493970296fa5c5b4a81a37248a328579fe9662/python/google/protobuf/internal/api_implementation.py#L69-L71

I've seen reports about crashes related to this and TensorFlow and while TF 2.2 seems to work fine TF 2.3 fails to run with the following stacktrace:

```
  File "/home/s3248973/git/easybuild-easyconfigs/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.x_mnist-test.py", line 15, in <module>
    tf.keras.layers.Dense(10, activation='softmax'),
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/training/tracking/base.py", line 457, in _method_wrapper
    result = method(self, *args, **kwargs)
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/keras/engine/sequential.py", line 117, in __init__
    name=name, autocast=False)
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/training/tracking/base.py", line 457, in _method_wrapper
    result = method(self, *args, **kwargs)
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/keras/engine/training.py", line 308, in __init__
    self._init_batch_counters()
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/training/tracking/base.py", line 457, in _method_wrapper
    result = method(self, *args, **kwargs)
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/keras/engine/training.py", line 317, in _init_batch_counters
    self._train_counter = variables.Variable(0, dtype='int64', aggregation=agg)
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/ops/variables.py", line 262, in __call__
    return cls._variable_v2_call(*args, **kwargs)
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/ops/variables.py", line 256, in _variable_v2_call
    shape=shape)
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/ops/variables.py", line 237, in <lambda>
    previous_getter = lambda **kws: default_variable_creator_v2(None, **kws)
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/ops/variable_scope.py", line 2646, in default_variable_creator_v2
    shape=shape)
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/ops/variables.py", line 264, in __call__
    return super(VariableMetaclass, cls).__call__(*args, **kwargs)
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/ops/resource_variable_ops.py", line 1518, in __init__
    distribute_strategy=distribute_strategy)
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/ops/resource_variable_ops.py", line 1666, in _init_from_args
    graph_mode=self._in_graph_mode)
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/ops/resource_variable_ops.py", line 243, in eager_safe_variable_handle
    shape, dtype, shared_name, name, graph_mode, initial_value)
  File "/tmp/ebinstall/software/TensorFlow/2.3.0-foss-2019b-Python-3.7.4/lib/python3.7/site-packages/tensorflow/python/ops/resource_variable_ops.py", line 181, in _variable_handle_from_shape_and_dtype
    shape=shape.as_proto(), dtype=dtype.as_datatype_enum))
TypeError: Parameter to MergeFrom() must be instance of same class: expected tensorflow.TensorShapeProto got tensorflow.TensorShapeProto.
```

Removing the C++ extension makes the test succeed.

Hence we shouldn't enable this (the bundled protobuf in TensorFlow doesn't do it either)

edit (@boegel): reverts part of #11143