### PR TITLE
{tools} [GCCcore/8.2.0] Ghostscript 9.27: LIBS change to fix ZLIB error

### DIFF
--- a/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.27-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.27-GCCcore-8.2.0.eb
@@ -34,7 +34,7 @@ builddependencies = [
 
 # Do not use local copies of zlib, jpeg, freetype, and png
 preconfigopts = "mv zlib zlib.no && mv jpeg jpeg.no && mv freetype freetype.no && mv libpng libpng.no && "
-preconfigopts += 'export LIBS="$LIBS -lz" && '
+preconfigopts += 'export LIBS="$LIBS -L$EBROOTZLIB/lib -lz" && '
 
 configopts = "--with-system-libtiff --enable-dynamic"
 


### PR DESCRIPTION
Ghostscript was not compiling due to failing on:
`libpng/1.6.36-GCCcore-8.2.0/lib/libpng16.so.16: undefined reference to inflateValidate@ZLIB_1.2.9`

needed to add `-L$EBROOTZLIB/lib` to the
`preconfigopts += 'export LIBS="$LIBS -lz" && '`
line