### PR TITLE
Remove GLog and GFlags from PyTorch 1.2.0

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.2.0-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.2.0-foss-2019a-Python-3.7.2.eb
@@ -284,8 +284,6 @@ dependencies = [
     ('GMP', '6.1.2'),
     ('numactl', '2.0.12'),
     ('FFmpeg', '4.1.3'),
-    ('gflags', '2.2.2'),
-    ('glog', '0.4.0'),
     ('Pillow', '6.0.0'),
 ]
 
@@ -294,7 +292,7 @@ download_dep_fail = True
 prebuildopts = 'PYTORCH_BUILD_VERSION=%(version)s PYTORCH_BUILD_NUMBER=1 VERBOSE=1 '
 prebuildopts += 'MAX_JOBS=%(parallel)s '
 prebuildopts += 'LDFLAGS="$LDFLAGS -ldl" '
-prebuildopts += 'USE_FFMPEG=ON USE_GLOO_IBVERBS=1 USE_GFLAGS=ON USE_GLOG=ON '
+prebuildopts += 'USE_FFMPEG=ON USE_GLOO_IBVERBS=1 '
 
 preinstallopts = prebuildopts
 

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.2.0-fosscuda-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.2.0-fosscuda-2019a-Python-3.7.2.eb
@@ -286,8 +286,6 @@ dependencies = [
     ('FFmpeg', '4.1.3'),
     ('cuDNN', '7.6.4.38'),
     ('magma', '2.5.1'),
-    ('gflags', '2.2.2'),
-    ('glog', '0.4.0'),
     ('Pillow', '6.0.0'),
 ]
 
@@ -296,7 +294,7 @@ download_dep_fail = True
 prebuildopts = 'PYTORCH_BUILD_VERSION=%(version)s PYTORCH_BUILD_NUMBER=1 VERBOSE=1 '
 prebuildopts += 'MAX_JOBS=%(parallel)s '
 prebuildopts += 'LDFLAGS="$LDFLAGS -ldl" '
-prebuildopts += 'USE_FFMPEG=ON USE_GLOO_IBVERBS=1 USE_GFLAGS=ON USE_GLOG=ON '
+prebuildopts += 'USE_FFMPEG=ON USE_GLOO_IBVERBS=1 '
 prebuildopts += 'CUDNN_LIB_DIR=$EBROOTCUDNN/lib64 CUDNN_INCLUDE_DIR=$EBROOTCUDNN/include '
 prebuildopts += 'TORCH_CUDA_ARCH_LIST="3.5 3.7 5.2 6.0 6.1 7.0" '
 


### PR DESCRIPTION
As discussed in Slack and confirmed in https://github.com/pytorch/pytorch/issues/44948 using those 2 is not officially tested and known to cause problems at least on POWER architectures

Hence the removal