### PR TITLE
add patch to fix installation of LAMMPS 7Aug2019 on AMD Epyc systems

### DIFF
--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-7Aug2019-foss-2019b-Python-3.7.4-kokkos.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-7Aug2019-foss-2019b-Python-3.7.4-kokkos.eb
@@ -25,9 +25,11 @@ sources = [
     'stable_%(version)s.tar.gz',
     {'filename': 'lammps_vs_yaff_test_single_point_energy.py', 'extract_cmd': "cp %s %(builddir)s"},
 ]
+patches = ['%(name)s-%(version)s_EPYC.patch']
 checksums = [
     '5380c1689a93d7922e3d65d9c186401d429878bb3cbe9a692580d3470d6a253f',  # stable_7Aug2019.tar.gz
     'c28fa5a1ea9608e4fd8686937be501c3bed8cc03ce1956f1cf0a1efce2c75349',  # lammps_vs_yaff_test_single_point_energy.py
+    '5cc5d2498f45d46569eb325aea5c217867f1afd95ee833fd0139f22e80431b86',  # LAMMPS-7Aug2019_EPYC.patch
 ]
 
 local_source_dir_name = '%(namelower)s-%(version)s'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-7Aug2019-intel-2019b-Python-3.7.4-kokkos.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-7Aug2019-intel-2019b-Python-3.7.4-kokkos.eb
@@ -25,9 +25,11 @@ sources = [
     'stable_%(version)s.tar.gz',
     {'filename': 'lammps_vs_yaff_test_single_point_energy.py', 'extract_cmd': "cp %s %(builddir)s"},
 ]
+patches = ['%(name)s-%(version)s_EPYC.patch']
 checksums = [
     '5380c1689a93d7922e3d65d9c186401d429878bb3cbe9a692580d3470d6a253f',  # stable_7Aug2019.tar.gz
     'c28fa5a1ea9608e4fd8686937be501c3bed8cc03ce1956f1cf0a1efce2c75349',  # lammps_vs_yaff_test_single_point_energy.py
+    '5cc5d2498f45d46569eb325aea5c217867f1afd95ee833fd0139f22e80431b86',  # LAMMPS-7Aug2019_EPYC.patch
 ]
 
 local_source_dir_name = '%(namelower)s-%(version)s'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-7Aug2019_EPYC.patch
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-7Aug2019_EPYC.patch
@@ -1,0 +1,12 @@
+# see https://github.com/easybuilders/easybuild-easyblocks/pull/1975#issuecomment-591218724
+diff -ru lammps-stable_7Aug2019.org/lib/kokkos/cmake/kokkos_options.cmake lammps-stable_7Aug2019/lib/kokkos/cmake/kokkos_options.cmake
+--- lammps-stable_7Aug2019.org/lib/kokkos/cmake/kokkos_options.cmake	2019-08-06 17:17:40.000000000 +0200
++++ lammps-stable_7Aug2019/lib/kokkos/cmake/kokkos_options.cmake	2020-09-23 11:24:09.301136347 +0200
+@@ -78,6 +78,7 @@
+ list(APPEND KOKKOS_ARCH_LIST
+      None            # No architecture optimization
+      AMDAVX          # (HOST) AMD chip
++     EPYC            # (HOST) AMD EPYC Zen-Core CPU
+      ARMv80          # (HOST) ARMv8.0 Compatible CPU
+      ARMv81          # (HOST) ARMv8.1 Compatible CPU
+      ARMv8-ThunderX  # (HOST) ARMv8 Cavium ThunderX CPU


### PR DESCRIPTION
see https://github.com/easybuilders/easybuild-easyblocks/pull/1975#issuecomment-591218724