### PR TITLE
add patch to fix installation of FuSeq v1.1.2 on RHEL8

### DIFF
--- a/easybuild/easyconfigs/f/FuSeq/FuSeq-1.1.2-gompi-2019b.eb
+++ b/easybuild/easyconfigs/f/FuSeq/FuSeq-1.1.2-gompi-2019b.eb
@@ -21,11 +21,15 @@ sources = [
         'filename': 'Sailfish-0.10.0.tar.gz',
     },
 ]
-patches = [('FuSeq-%(version)s_skip-included-Jellyfish.patch', '..')]
+patches = [
+    ('FuSeq-%(version)s_skip-included-Jellyfish.patch', '..'),
+    ('%(name)s-%(version)s_RHEL8.patch', '..'),
+]
 checksums = [
     'c08ad145c2e7ba24738cc779502d82063d17a860c5b8dae609e416a60bc0992a',  # FuSeq-1.1.2.tar.gz
     'dbed3d48c100cf2b97f08ef37bc66ca1fa63a1d70713fa47d0b4fe15b7062ac0',  # Sailfish-0.10.0.tar.gz
     '70991d30526a4818970b47bfb2d30f3e57b1b3c9221c721c20e88ee196bec683',  # FuSeq-1.1.2_skip-included-Jellyfish.patch
+    'd139f1b8a17fe40784d8df38e340b8f2e100ed2bffd2017c24b6016af618751e',  # FuSeq-1.1.2_RHEL8.patch
 ]
 
 builddependencies = [('CMake', '3.15.3')]

--- a/easybuild/easyconfigs/f/FuSeq/FuSeq-1.1.2_RHEL8.patch
+++ b/easybuild/easyconfigs/f/FuSeq/FuSeq-1.1.2_RHEL8.patch
@@ -1,0 +1,52 @@
+# Fix CHAR_WIDTH glibc clash 
+# see: https://github.com/Cantera/cantera/issues/369#issuecomment-254090244
+# https://github.com/gabime/spdlog/issues/300 and https://github.com/3Hren/blackhole/pull/184
+# SEP 24th 2020 by B. Hajgato (UGent)
+diff -ru sailfish-0.10.0.orig/include/spdlog/details/format.h sailfish-0.10.0/include/spdlog/details/format.h
+--- sailfish-0.10.0.orig/include/spdlog/details/format.h	2016-04-14 03:24:40.000000000 +0200
++++ sailfish-0.10.0/include/spdlog/details/format.h	2020-09-24 17:26:19.195521057 +0200
+@@ -2053,29 +2053,29 @@
+         typedef typename BasicWriter<Char>::CharPtr CharPtr;
+         Char fill = internal::CharTraits<Char>::cast(spec_.fill());
+         CharPtr out = CharPtr();
+-        const unsigned CHAR_WIDTH = 1;
+-        if (spec_.width_ > CHAR_WIDTH)
++        const unsigned CHAR_WIDTH_NOCLASH = 1;
++        if (spec_.width_ > CHAR_WIDTH_NOCLASH)
+         {
+             out = writer_.grow_buffer(spec_.width_);
+             if (spec_.align_ == ALIGN_RIGHT)
+             {
+-                std::uninitialized_fill_n(out, spec_.width_ - CHAR_WIDTH, fill);
+-                out += spec_.width_ - CHAR_WIDTH;
++                std::uninitialized_fill_n(out, spec_.width_ - CHAR_WIDTH_NOCLASH, fill);
++                out += spec_.width_ - CHAR_WIDTH_NOCLASH;
+             }
+             else if (spec_.align_ == ALIGN_CENTER)
+             {
+                 out = writer_.fill_padding(out, spec_.width_,
+-                                           internal::check(CHAR_WIDTH), fill);
++                                           internal::check(CHAR_WIDTH_NOCLASH), fill);
+             }
+             else
+             {
+-                std::uninitialized_fill_n(out + CHAR_WIDTH,
+-                                          spec_.width_ - CHAR_WIDTH, fill);
++                std::uninitialized_fill_n(out + CHAR_WIDTH_NOCLASH,
++                                          spec_.width_ - CHAR_WIDTH_NOCLASH, fill);
+             }
+         }
+         else
+         {
+-            out = writer_.grow_buffer(CHAR_WIDTH);
++            out = writer_.grow_buffer(CHAR_WIDTH_NOCLASH);
+         }
+         *out = internal::CharTraits<Char>::cast(value);
+     }
+@@ -4358,4 +4358,4 @@
+ # include "format.cc"
+ #endif
+ 
+-#endif  // FMT_FORMAT_H_
+\ No newline at end of file
++#endif  // FMT_FORMAT_H_


### PR DESCRIPTION
fixes the follwing problem:
```
/tmp/vsc40003/easybuild/FuSeq/1.1.2/gompi-2019b/sailfish-0.10.0/include/spdlog/details/format.h: In member function void fmt::internal::ArgFormatterBase<Impl, Char>::visit_char(int):
/tmp/vsc40003/easybuild/FuSeq/1.1.2/gompi-2019b/sailfish-0.10.0/include/spdlog/details/format.h:2056:24: error: expected unqualified-id before numeric constant
         const unsigned CHAR_WIDTH = 1;
                        ^~~~~~~~~~
```