### PR TITLE
Add protobuf-python as a dependency and corresponding sanity check to PyTorch 1.6

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.6.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.6.0-fosscuda-2019b-Python-3.7.4.eb
@@ -265,7 +265,7 @@ builddependencies = [
 dependencies = [
     ('Ninja', '1.9.0'),  # Required for JIT compilation of C++ extensions
     ('protobuf', '3.10.0'),
-    ('protobuf-python', '3.10.0'),
+    ('protobuf-python', '3.10.0', versionsuffix),
     ('Python', '3.7.4'),
     ('pybind11', '2.4.3', versionsuffix),
     ('SciPy-bundle', '2019.10', versionsuffix),

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.6.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.6.0-fosscuda-2019b-Python-3.7.4.eb
@@ -265,6 +265,7 @@ builddependencies = [
 dependencies = [
     ('Ninja', '1.9.0'),  # Required for JIT compilation of C++ extensions
     ('protobuf', '3.10.0'),
+    ('protobuf-python', '3.10.0'),
     ('Python', '3.7.4'),
     ('pybind11', '2.4.3', versionsuffix),
     ('SciPy-bundle', '2019.10', versionsuffix),
@@ -306,6 +307,7 @@ excluded_tests = {
 
 runtest = 'cd test && %(python)s run_test.py --verbose %(excluded_tests)s'
 
+sanity_check_commands = ["python -c 'import caffe2.python'"]
 tests = ['PyTorch-check-cpp-extension.py']
 
 moduleclass = 'devel'


### PR DESCRIPTION
It seems that the `caffe2.python` module contained in pytorch requires protobuf-python