### PR TITLE
fix OpenFOAM 2.3.1-intel-2019b installation on RHEL8

### DIFF
--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-2.3.1-intel-2019b.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-2.3.1-intel-2019b.eb
@@ -17,6 +17,7 @@ sources = [
 patches = [
     'OpenFOAM-%(version)s_cleanup.patch',
     'OpenFOAM-2.3.0_libreadline.patch',
+    'OpenFOAM-2.3.1_RHEL8.patch',
     ('ThirdParty-%(version)s_cleanup.patch', ".."),  # patch should not be applied in OpenFOAM subdir
 ]
 checksums = [
@@ -24,6 +25,7 @@ checksums = [
     'f19820ce88e91397d7d4d00869438141c265872348ab7d83f6688741ff037b09',  # ThirdParty-2.3.1.tgz
     'e045204878472e6b3e68466a4b64818a6941ac727d16d54738b9c9f93b77e749',  # OpenFOAM-2.3.1_cleanup.patch
     'f1c94764fe07a43877d85497d5c7958a3f162d1b5f1370232084912a6d606181',  # OpenFOAM-2.3.0_libreadline.patch
+    'a7d95f23aa64eb84f406d95a08633f79b100e4c8fc4e189cb63265d9e3c61dd1',  # OpenFOAM-2.3.1_RHEL8.patch
     '7d213f2c5a33ced70a1b50c44cd8f7db303a2494c0ece4a181e430c9b6ab4e24',  # ThirdParty-2.3.1_cleanup.patch
 ]
 

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-2.3.1_RHEL8.patch
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-2.3.1_RHEL8.patch
@@ -1,0 +1,35 @@
+# https://bugs.openfoam.org/view.php?id=2041
+# SEP 30th 2020 by B. Hajgato (UGent)
+diff -ru OpenFOAM-2.3.1.orig/src/conversion/ensight/part/ensightPart.C OpenFOAM-2.3.1/src/conversion/ensight/part/ensightPart.C
+--- OpenFOAM-2.3.1.orig/src/conversion/ensight/part/ensightPart.C	2014-12-04 18:52:43.000000000 +0100
++++ OpenFOAM-2.3.1/src/conversion/ensight/part/ensightPart.C	2020-09-30 10:49:21.224963571 +0200
+@@ -51,7 +51,7 @@
+         {
+             const label id = idList[i];
+ 
+-            if (id >= field.size() || isnan(field[id]))
++            if (id >= field.size() || std::isnan(field[id]))
+             {
+                 return false;
+             }
+diff -ru OpenFOAM-2.3.1.orig/src/conversion/ensight/part/ensightPartIO.C OpenFOAM-2.3.1/src/conversion/ensight/part/ensightPartIO.C
+--- OpenFOAM-2.3.1.orig/src/conversion/ensight/part/ensightPartIO.C	2014-12-04 18:52:43.000000000 +0100
++++ OpenFOAM-2.3.1/src/conversion/ensight/part/ensightPartIO.C	2020-09-30 10:48:35.957662437 +0200
+@@ -63,7 +63,7 @@
+     {
+         forAll(idList, i)
+         {
+-            if (idList[i] >= field.size() || isnan(field[idList[i]]))
++            if (idList[i] >= field.size() || std::isnan(field[idList[i]]))
+             {
+                 os.writeUndef();
+             }
+@@ -80,7 +80,7 @@
+         // no idList => perNode
+         forAll(field, i)
+         {
+-            if (isnan(field[i]))
++            if (std::isnan(field[i]))
+             {
+                 os.writeUndef();
+             }


### PR DESCRIPTION
fixes:
```
ensight/part/ensightPartIO.C(66): error: identifier "isnan" is undefined
              if (idList[i] >= field.size() || isnan(field[idList[i]]))
                                               ^

ensight/part/ensightPartIO.C(83): error: identifier "isnan" is undefined
              if (isnan(field[i]))
                  ^
```

and 

```
ensight/part/ensightPart.C(54): error: identifier "isnan" is undefined
              if (id >= field.size() || isnan(field[id]))
                                        ^
```
