### PR TITLE
fix broken worker easyconfigs

### DIFF
--- a/easybuild/easyconfigs/w/worker/worker-1.6.11-intel-2019b.eb
+++ b/easybuild/easyconfigs/w/worker/worker-1.6.11-intel-2019b.eb
@@ -61,6 +61,8 @@ exts_list = [
     }),
 ]
 
+preconfigopts = "export CC=mpiicc && "
+
 modextrapaths = {
     'PERL5LIB': ['share/perl5', 'lib64/perl5'],
 }

--- a/easybuild/easyconfigs/w/worker/worker-1.6.7-intel-2016b.eb
+++ b/easybuild/easyconfigs/w/worker/worker-1.6.7-intel-2016b.eb
@@ -61,6 +61,8 @@ exts_list = [
     }),
 ]
 
+preconfigopts = "export CC=mpiicc && "
+
 modextrapaths = {
     'PERL5LIB': ['share/perl5', 'lib64/perl5'],
 }

--- a/easybuild/easyconfigs/w/worker/worker-1.6.7-intel-2017a.eb
+++ b/easybuild/easyconfigs/w/worker/worker-1.6.7-intel-2017a.eb
@@ -61,6 +61,8 @@ exts_list = [
     }),
 ]
 
+preconfigopts = "export CC=mpiicc && "
+
 modextrapaths = {
     'PERL5LIB': ['share/perl5', 'lib64/perl5'],
 }

--- a/easybuild/easyconfigs/w/worker/worker-1.6.7-intel-2017a.eb
+++ b/easybuild/easyconfigs/w/worker/worker-1.6.7-intel-2017a.eb
@@ -36,7 +36,7 @@ exts_list = [
     }),
     ('Text::CSV', '1.95', {
         'source_tmpl': 'Text-CSV-%(version)s.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/I/IS/ISHIGAKI'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI'],
         'checksums': ['7e0a11d9c1129a55b68a26aa4b37c894279df255aa63ec8341d514ab848dbf61'],
     }),
     ('DBI', '1.637', {

--- a/easybuild/easyconfigs/w/worker/worker-1.6.7-intel-2017b.eb
+++ b/easybuild/easyconfigs/w/worker/worker-1.6.7-intel-2017b.eb
@@ -61,6 +61,8 @@ exts_list = [
     }),
 ]
 
+preconfigopts = "export CC=mpiicc && "
+
 modextrapaths = {
     'PERL5LIB': ['share/perl5', 'lib64/perl5'],
 }

--- a/easybuild/easyconfigs/w/worker/worker-1.6.7-intel-2017b.eb
+++ b/easybuild/easyconfigs/w/worker/worker-1.6.7-intel-2017b.eb
@@ -36,7 +36,7 @@ exts_list = [
     }),
     ('Text::CSV', '1.95', {
         'source_tmpl': 'Text-CSV-%(version)s.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/I/IS/ISHIGAKI'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI'],
         'checksums': ['7e0a11d9c1129a55b68a26aa4b37c894279df255aa63ec8341d514ab848dbf61'],
     }),
     ('DBI', '1.637', {

--- a/easybuild/easyconfigs/w/worker/worker-1.6.8-intel-2018a.eb
+++ b/easybuild/easyconfigs/w/worker/worker-1.6.8-intel-2018a.eb
@@ -38,7 +38,7 @@ exts_list = [
     }),
     ('Text::CSV', '1.95', {
         'source_tmpl': 'Text-CSV-%(version)s.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/I/IS/ISHIGAKI'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI'],
         'checksums': ['7e0a11d9c1129a55b68a26aa4b37c894279df255aa63ec8341d514ab848dbf61'],
     }),
     ('DBI', '1.640', {

--- a/easybuild/easyconfigs/w/worker/worker-1.6.8-intel-2018a.eb
+++ b/easybuild/easyconfigs/w/worker/worker-1.6.8-intel-2018a.eb
@@ -63,6 +63,8 @@ exts_list = [
     }),
 ]
 
+preconfigopts = "export CC=mpiicc && "
+
 modextrapaths = {
     'PERL5LIB': ['share/perl5', 'lib64/perl5'],
 }

--- a/easybuild/easyconfigs/w/worker/worker-1.6.8-intel-2018b.eb
+++ b/easybuild/easyconfigs/w/worker/worker-1.6.8-intel-2018b.eb
@@ -38,7 +38,7 @@ exts_list = [
     }),
     ('Text::CSV', '1.97', {
         'source_tmpl': 'Text-CSV-%(version)s.tar.gz',
-        'source_urls': ['http://search.cpan.org/CPAN/authors/id/I/IS/ISHIGAKI'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI'],
         'checksums': ['cc350462efa8d39d5c8a1da5f205bc31620cd52d9865a769c8e3ed1b41640fd5'],
     }),
     ('DBI', '1.642', {

--- a/easybuild/easyconfigs/w/worker/worker-1.6.8-intel-2018b.eb
+++ b/easybuild/easyconfigs/w/worker/worker-1.6.8-intel-2018b.eb
@@ -63,6 +63,8 @@ exts_list = [
     }),
 ]
 
+preconfigopts = "export CC=mpiicc && "
+
 modextrapaths = {
     'PERL5LIB': ['share/perl5', 'lib64/perl5'],
 }


### PR DESCRIPTION
Worker with system toolchain have to be fixed due to https://github.com/easybuilders/easybuild-framework/pull/3399

It seems that worker with system toolchain breaks in some RHEL8 system (annobin in Perl, see https://bugzilla.redhat.com/show_bug.cgi?id=1792997 )

The annobin flag `-specs=/usr/lib/rpm/redhat/redhat-annobin-cc1` inherited from Perl, when something builds against Perl

`Linux node3502.doduo.os 4.18.0-193.14.3.el8_2.x86_64 #1 SMP Mon Jul 20 15:02:29 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux` and `perl-5.26.3-416.el8.x86_64`, 

Note that annobin plugin is not a dependency for Perl.

For the annobin problems, a follow-up PR will come (if this PR passes), if  not RHEL8 problems will be fixed here, but it will takes some time.