### PR TITLE
remove extentions from R-bundle-Bioconductor 3.11 easyconfigs that are also included in R 4.0.0

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.11-foss-2020a-R-4.0.0.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.11-foss-2020a-R-4.0.0.eb
@@ -162,9 +162,6 @@ exts_list = [
     ('impute', '1.62.0', {
         'checksums': ['10541b1c2476ab5a78e1f4d2961710db1b98a1076ff33ead6f9c8fcb02353798'],
     }),
-    ('fs', '1.4.1', {
-        'checksums': ['ae9103dff26ca56a34901408bd650a2949f491b2a0886c686a51a179d38b7a4e'],
-    }),
     ('shinyFiles', '0.8.0', {
         'checksums': ['1ca1455c99f6559fa8a790d5f16a79485ea76ed2dc4eaf1b650665e1cee89e3f'],
     }),
@@ -176,12 +173,6 @@ exts_list = [
     }),
     ('hgu133plus2.db', '3.2.3', {
         'checksums': ['a56b247b69a6b8c81d23410e9def44f8d3e7c133aedf09fb1561798dca2c0549'],
-    }),
-    ('sys', '3.3', {
-        'checksums': ['a6217c2a7240ed68614006f392c6d062247dab8b9b0d498f95e947110df19b93'],
-    }),
-    ('askpass', '1.1', {
-        'checksums': ['db40827d1bdbb90c0aa2846a2961d3bf9d76ad1b392302f9dd84cc2fd18c001f'],
     }),
     ('illuminaio', '0.30.0', {
         'checksums': ['ec180c39921f8707c09e2226a2feaef80576f581fb872a012f42a9b2433ea844'],
@@ -497,9 +488,6 @@ exts_list = [
     ('SC3', '1.16.0', {
         'checksums': ['29918e7a78858ef6602c0f461bf33e32af5d384448029ba1368be41118c2a797'],
     }),
-    ('clue', '0.3-57', {
-        'checksums': ['6e369d07b464a9624209a06b5078bf988f01f7963076e946649d76aea0622d17'],
-    }),
     ('ComplexHeatmap', '2.4.2', {
         'checksums': ['14e4f92155aaf8d5c92aeab47b890641942b52599928f9ba5ac826073bef5d06'],
     }),
@@ -742,9 +730,6 @@ exts_list = [
     }),
     ('isoband', '0.2.1', {
         'checksums': ['18883606bea8352e04a4618bea4e5c9833269e73a46b50bc006dddf4c8b6b4d9'],
-    }),
-    ('ggplot2', '3.3.0', {
-        'checksums': ['320e3c76fe0d0397e29f4782bf85af3647518154b3900a39fd18cf024c554148'],
     }),
     ('ggcyto', '1.16.0', {
         'checksums': ['e012f204a01c6b3427a5b29050e37c8034f44a9a5a30ba50b75dcae3d57b06c6'],


### PR DESCRIPTION
All of these are in https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/r/R/R-4.0.0-foss-2020a.eb so we can remove them from here.

* fs: https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/r/R/R-4.0.0-foss-2020a.eb#L1485
* sys: https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/r/R/R-4.0.0-foss-2020a.eb#L786
* askpass: https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/r/R/R-4.0.0-foss-2020a.eb#L789
* clue: https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/r/R/R-4.0.0-foss-2020a.eb#L2224
* ggplot2: https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/r/R/R-4.0.0-foss-2020a.eb#L477