### PR TITLE
fix compilation of Qt5 v5.12.3 and v5.13.1 on Ubuntu 20.04

### DIFF
--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.12.3-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.12.3-GCCcore-8.2.0.eb
@@ -18,11 +18,15 @@ sources = ['qt-everywhere-src-%(version)s.tar.xz']
 patches = [
     'Qt5-%(version)s_fix-avx2.patch',
     'Qt5-%(version)s_fix-qmake-libdir.patch',
+    'Qt5-%(version)s_fix-webrtc.patch',
+    'Qt5-%(version)s_fix-socketcan.patch',
 ]
 checksums = [
     '6462ac74c00ff466487d8ef8d0922971aa5b1d5b33c0753308ec9d57711f5a42',  # qt-everywhere-src-5.12.3.tar.xz
     '6f46005f056bf9e6ff3e5d012a874d18ee03b33e685941f2979c970be91a9dbc',  # Qt5-5.12.3_fix-avx2.patch
     '50974f2ed761a8a70fbdf2e80b9107af68cc29ee951885e26fa0c19bdb6a9c7b',  # Qt5-5.12.3_fix-qmake-libdir.patch
+    '5006df9a4d1f687e1e32af88f5fddcf729018ae50a3a1b0340f7087cdcf8d8b8',  # Qt5-5.12.3_fix-webrtc.patch
+    'ace318c8ef1b27da5e60eeb219cb51e98dc214102d29f27a6d8438f6e616a3a6',  # Qt5-5.12.3_fix-socketcan.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.12.3_fix-socketcan.patch
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.12.3_fix-socketcan.patch
@@ -1,0 +1,37 @@
+Patch modified for Qt5 version and easybuild by A Edmondson, 5 October 2020
+Original info follows:
+* https://codereview.qt-project.org/gitweb?p=qt/qtserialbus.git;a=patch;h=43d746c2c0c87c8694e835f3b052317c8fa02482
+
+From 43d746c2c0c87c8694e835f3b052317c8fa02482 Mon Sep 17 00:00:00 2001
+From: Andre Hartmann <aha_1980@gmx.de>
+Date: Mon, 8 Jul 2019 21:35:12 +0200
+Subject: [PATCH] =?utf8?q?SocketCAN:=20Fix=20compiler=20error=20"=E2=80=98?=
+ =?utf8?q?SIOCGSTAMP=E2=80=99=20was=20not=20declared"?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf8
+Content-Transfer-Encoding: 8bit
+
+Fixes: QTBUG-76957
+Change-Id: I8c4c86aa23137d67f5d20eedfe1c46a241c0632b
+Reviewed-by: Alex Blasche <alexander.blasche@qt.io>
+Reviewed-by: Denis Shienkov <denis.shienkov@gmail.com>
+---
+ qtserialbus/src/plugins/canbus/socketcan/socketcanbackend.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/qtserialbus/src/plugins/canbus/socketcan/socketcanbackend.cpp b/qtserialbus/src/plugins/canbus/socketcan/socketcanbackend.cpp
+index 74b0d1d9..a2da146f 100644
+--- a/qtserialbus/src/plugins/canbus/socketcan/socketcanbackend.cpp
++++ b/qtserialbus/src/plugins/canbus/socketcan/socketcanbackend.cpp
+@@ -45,6 +45,7 @@
+ 
+ #include <linux/can/error.h>
+ #include <linux/can/raw.h>
++#include <linux/sockios.h>
+ #include <errno.h>
+ #include <unistd.h>
+ #include <net/if.h>
+-- 
+2.16.3
+
+

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.12.3_fix-webrtc.patch
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.12.3_fix-webrtc.patch
@@ -1,0 +1,48 @@
+Patch modified for Qt5 version and easybuild by A Edmondson, 5 October 2020
+Original info follows:
+* https://code.qt.io/cgit/qt/qtwebengine-chromium.git/commit/?id=6e2562dd1efff
+
+From 6e2562dd1efff2b96848e8ec166e8c233029d6cc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Emilio=20Cobos=20=C3=81lvarez?= <emilio@mozilla.com>
+Date: Wed, 29 May 2019 15:30:32 +0200
+Subject: Fix build with recent linux kernel.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Recent kernel commit[1] moved a bit the define for this constant. This revealed
+a missing include in WebRTC.
+
+[1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0768e17073dc5
+
+Bug: webrtc:10677
+Change-Id: I6ed69d307599d077760ae6ad74be10bfbdd1cac6
+Commit-Queue: Karl Wiberg <kwiberg@webrtc.org>
+Reviewed-by: Karl Wiberg <kwiberg@webrtc.org>
+Cr-Commit-Position: refs/heads/master@{#28108}
+See-Also: https://chromium.googlesource.com/external/webrtc/+/6806550d5d51a820104a12205d1f37ce0acebf19
+Reviewed-by: Jüri Valdmann <juri.valdmann@qt.io>
+(cherry picked from commit 74e69da92d0a895122ca65922b9a2b8b3926c882)
+Reviewed-by: Michal Klocek <michal.klocek@qt.io>
+---
+ qtwebengine/src/3rdparty/chromium/third_party/webrtc/rtc_base/physicalsocketserver.cc | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/webrtc/rtc_base/physicalsocketserver.cc b/qtwebengine/src/3rdparty/chromium/third_party/webrtc/rtc_base/physicalsocketserver.cc
+index ca78499179a..e8c1474762f 100644
+--- a/qtwebengine/src/3rdparty/chromium/third_party/webrtc/rtc_base/physicalsocketserver.cc
++++ b/qtwebengine/src/3rdparty/chromium/third_party/webrtc/rtc_base/physicalsocketserver.cc
+@@ -52,6 +52,10 @@
+ #include "rtc_base/timeutils.h"
+ #include "rtc_base/win32socketinit.h"
+ 
++#if defined(WEBRTC_LINUX)
++#include <linux/sockios.h>
++#endif
++
+ #if defined(WEBRTC_WIN)
+ #define LAST_SYSTEM_ERROR (::GetLastError())
+ #elif defined(__native_client__) && __native_client__
+-- 
+cgit v1.2.1
+

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.13.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.13.1-GCCcore-8.3.0.eb
@@ -19,12 +19,14 @@ patches = [
     'Qt5-%(version)s_fix-avx2.patch',
     'Qt5-%(version)s_fix-qmake-libdir.patch',
     'Qt5-%(version)s_fix-mantissatable.patch',
+    'Qt5-%(version)s_fix-webrtc.patch',
 ]
 checksums = [
     'adf00266dc38352a166a9739f1a24a1e36f1be9c04bf72e16e142a256436974e',  # qt-everywhere-src-5.13.1.tar.xz
     '6f46005f056bf9e6ff3e5d012a874d18ee03b33e685941f2979c970be91a9dbc',  # Qt5-5.13.1_fix-avx2.patch
     '511ca9c0599ceb1989f73d8ceea9199c041512d3a26ee8c5fd870ead2c10cb63',  # Qt5-5.13.1_fix-qmake-libdir.patch
     'cb23b917dd145b6775d7ffb3d8c143749d183d32972111f0c31133e41803f56b',  # Qt5-5.13.1_fix-mantissatable.patch
+    '0e449fce243587b9001d8060d6417c285d4ad8fe969b1a2528a3058a29bc6af6',  # Qt5-5.13.1_fix-webrtc.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.13.1_fix-webrtc.patch
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.13.1_fix-webrtc.patch
@@ -1,0 +1,48 @@
+Patch modified for Qt5 version and easybuild by A Edmondson, 5 October 2020
+Original info follows:
+* https://code.qt.io/cgit/qt/qtwebengine-chromium.git/commit/?id=6e2562dd1efff
+
+From 6e2562dd1efff2b96848e8ec166e8c233029d6cc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Emilio=20Cobos=20=C3=81lvarez?= <emilio@mozilla.com>
+Date: Wed, 29 May 2019 15:30:32 +0200
+Subject: Fix build with recent linux kernel.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Recent kernel commit[1] moved a bit the define for this constant. This revealed
+a missing include in WebRTC.
+
+[1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0768e17073dc5
+
+Bug: webrtc:10677
+Change-Id: I6ed69d307599d077760ae6ad74be10bfbdd1cac6
+Commit-Queue: Karl Wiberg <kwiberg@webrtc.org>
+Reviewed-by: Karl Wiberg <kwiberg@webrtc.org>
+Cr-Commit-Position: refs/heads/master@{#28108}
+See-Also: https://chromium.googlesource.com/external/webrtc/+/6806550d5d51a820104a12205d1f37ce0acebf19
+Reviewed-by: Jüri Valdmann <juri.valdmann@qt.io>
+(cherry picked from commit 74e69da92d0a895122ca65922b9a2b8b3926c882)
+Reviewed-by: Michal Klocek <michal.klocek@qt.io>
+---
+ qtwebengine/src/3rdparty/chromium/third_party/webrtc/rtc_base/physical_socket_server.cc | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/webrtc/rtc_base/physical_socket_server.cc b/qtwebengine/src/3rdparty/chromium/third_party/webrtc/rtc_base/physical_socket_server.cc
+index ca78499179a..e8c1474762f 100644
+--- a/qtwebengine/src/3rdparty/chromium/third_party/webrtc/rtc_base/physical_socket_server.cc
++++ b/qtwebengine/src/3rdparty/chromium/third_party/webrtc/rtc_base/physical_socket_server.cc
+@@ -52,6 +52,10 @@
+ #include "rtc_base/timeutils.h"
+ #include "rtc_base/win32socketinit.h"
+ 
++#if defined(WEBRTC_LINUX)
++#include <linux/sockios.h>
++#endif
++
+ #if defined(WEBRTC_WIN)
+ #define LAST_SYSTEM_ERROR (::GetLastError())
+ #elif defined(__native_client__) && __native_client__
+-- 
+cgit v1.2.1
+


### PR DESCRIPTION
Compiling Qt5 on Ubuntu 20.04, or other OS with a similarly up to date kernel yields:

```
socketcanbackend.cpp: In member function ‘void SocketCanBackend::readSocket()’:
socketcanbackend.cpp:697:41: error: ‘SIOCGSTAMP’ was not declared in this scope
         if (Q_UNLIKELY(ioctl(canSocket, SIOCGSTAMP, &timeStamp) < 0)) {
                                         ^~~~~~~~~~
```

EL8.2 doesn't have this problem, but perhaps 8.3 will...?