### PR TITLE
fix PyVCF easyconfig, only supports Python 2

### DIFF
--- a/easybuild/easyconfigs/b/BAMSurgeon/BAMSurgeon-1.2-GCC-8.3.0-Python-2.7.16.eb
+++ b/easybuild/easyconfigs/b/BAMSurgeon/BAMSurgeon-1.2-GCC-8.3.0-Python-2.7.16.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('Velvet', '1.2.10', '-mt-kmer_191'),
     ('Exonerate', '2.4.0'),
     ('Pysam', '0.15.3'),
-    ('PyVCF', '0.6.8'),
+    ('PyVCF', '0.6.8', versionsuffix),
 ]
 
 download_dep_fail = True

--- a/easybuild/easyconfigs/p/PyVCF/PyVCF-0.6.8-GCC-8.3.0-Python-2.7.16.eb
+++ b/easybuild/easyconfigs/p/PyVCF/PyVCF-0.6.8-GCC-8.3.0-Python-2.7.16.eb
@@ -2,6 +2,7 @@ easyblock = 'PythonPackage'
 
 name = 'PyVCF'
 version = '0.6.8'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://github.com/jamescasbon/PyVCF'
 description = "A Variant Call Format reader for Python."
@@ -12,12 +13,15 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['e9d872513d179d229ab61da47a33f42726e9613784d1cb2bac3f8e2642f6f9d9']
 
-multi_deps = {'Python': ['3.7.4', '2.7.16']}
-
-dependencies = [('Pysam', '0.15.3')]
+dependencies = [
+    ('Python', '2.7.16'),
+    ('Pysam', '0.15.3'),
+]
 
 download_dep_fail = True
 use_pip = True
+
+fix_python_shebang_for = ['bin/*.py', 'bin/vcf_melt']
 
 options = {'modulename': 'vcf'}
 


### PR DESCRIPTION
I noticed that the PyVCF scripts had a hardcoded `/software/Python/2.7.16-GCCcore-8.3.0/bin/python`, so I enabled the use of `fix_python_shebang_for` to fix the scripts.

That led to a failing sanity check, with "`vcf_sample_filter.py --help`" failing with:

```
File "/software/PyVCF/0.6.8-GCC-8.3.0/bin/vcf_sample_filter.py", line 37
    print "Samples:"
                   ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("Samples:")?
```

This shows that PyVCF is really only compatible with Python 2 (makes sense, sort of, last release was in March 2016...)