### PR TITLE
tweak non-MPI DIRAC 19.0 easyconfig to use CMakeMake easyblock + add MPI version of DIRAC 19.0

### DIFF
--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0-intel-2020a-Python-2.7.18-int64.eb
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0-intel-2020a-Python-2.7.18-int64.eb
@@ -20,8 +20,8 @@ patches = [
 ]
 checksums = [
     'f0e3610bdd1fbcff90cdfb4cf3fd7582a4762f533af7d635c4bc4d114f402c32',  # DIRAC-19.0-Source.tar.gz
-    '5ae7ade408310a0309178876e9f5ddc80ecd6b85c862c88899fcdca386dd9c70',  # DIRAC-19.0_remove-broken-tests-intel.patch
-    '13c7b19da10a7db585fb6d57eda8474cb71cdd89d6c4844e80276d3aa05e2b4f',  # DIRAC-19.0_fix-bss_energy_test.patch
+    'cb0e07097499fe59180d79a5db9ee883b9c83e16dcc6210fd945072c3a54c8a4',  # DIRAC-19.0_remove-broken-tests-intel.patch
+    'e66be847d87ccfda23687de31a3a7c8d71c97b0accd290cf7ade4b4184f1fb93',  # DIRAC-19.0_fix-bss_energy_test.patch
     '666a9053d6c1287ee7aa471d18436133931959b3eacb7619d5197dbfb4e0c1fe',  # DIRAC-19.0_use_easybuild_opts_intel.patch
     '527680cab911a8c7a52347d7ace516a497b725043537a6274670a1aaa97bfb0f',  # DIRAC-19.0_fix_test_path.patch
 ]
@@ -49,11 +49,10 @@ configopts += '-DEXPLICIT_LIBS="${LIBLAPACK_MT}" '
 configopts += '-DENABLE_PCMSOLVER=OFF '
 configopts += '-G"Unix Makefiles" '
 
-prebuildopts = "make -j36 ; make -j36 ; make -j36 ;"
 parallel = 1
 
 pretestopts = 'export DIRAC_TMPDIR=%(builddir)s/scratch && '
-runtest = 'test ARGS=-j16'
+runtest = 'test'
 
 sanity_check_paths = {
     'files': ['bin/pam-dirac', 'share/dirac/dirac.x'],

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0-intel-2020a-Python-2.7.18-mpi-int64.eb
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0-intel-2020a-Python-2.7.18-mpi-int64.eb
@@ -21,8 +21,8 @@ patches = [
 ]
 checksums = [
     'f0e3610bdd1fbcff90cdfb4cf3fd7582a4762f533af7d635c4bc4d114f402c32',  # DIRAC-19.0-Source.tar.gz
-    '5ae7ade408310a0309178876e9f5ddc80ecd6b85c862c88899fcdca386dd9c70',  # DIRAC-19.0_remove-broken-tests-intel.patch
-    '13c7b19da10a7db585fb6d57eda8474cb71cdd89d6c4844e80276d3aa05e2b4f',  # DIRAC-19.0_fix-bss_energy_test.patch
+    'cb0e07097499fe59180d79a5db9ee883b9c83e16dcc6210fd945072c3a54c8a4',  # DIRAC-19.0_remove-broken-tests-intel.patch
+    'e66be847d87ccfda23687de31a3a7c8d71c97b0accd290cf7ade4b4184f1fb93',  # DIRAC-19.0_fix-bss_energy_test.patch
     '666a9053d6c1287ee7aa471d18436133931959b3eacb7619d5197dbfb4e0c1fe',  # DIRAC-19.0_use_easybuild_opts_intel.patch
     '527680cab911a8c7a52347d7ace516a497b725043537a6274670a1aaa97bfb0f',  # DIRAC-19.0_fix_test_path.patch
     'ccc26fc320f0967211b6390244b1fa359ba5d0294071d5d2cb9e36b4652a52b2',  # DIRAC-19.0_fix_mpi_tests.patch

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0-intel-2020a-Python-2.7.18-mpi-int64.eb
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0-intel-2020a-Python-2.7.18-mpi-int64.eb
@@ -2,13 +2,13 @@ easyblock = 'CMakeMake'
 
 name = 'DIRAC'
 version = '19.0'
-versionsuffix = '-Python-%(pyver)s-int64'
+versionsuffix = '-Python-%(pyver)s-mpi-int64'
 
 homepage = 'http://www.diracprogram.org'
 description = "DIRAC: Program for Atomic and Molecular Direct Iterative Relativistic All-electron Calculations"
 
 toolchain = {'name': 'intel', 'version': '2020a'}
-toolchainopts = {'i8': True}
+toolchainopts = {'usempi': True, 'i8': True}
 
 source_urls = ['https://zenodo.org/record/3572669/files/']
 sources = ['DIRAC-%(version)s-Source.tar.gz']
@@ -17,6 +17,7 @@ patches = [
     '%(name)s-%(version)s_fix-bss_energy_test.patch',
     '%(name)s-%(version)s_use_easybuild_opts_intel.patch',
     '%(name)s-%(version)s_fix_test_path.patch',
+    '%(name)s-%(version)s_fix_mpi_tests.patch',
 ]
 checksums = [
     'f0e3610bdd1fbcff90cdfb4cf3fd7582a4762f533af7d635c4bc4d114f402c32',  # DIRAC-19.0-Source.tar.gz
@@ -24,6 +25,7 @@ checksums = [
     '13c7b19da10a7db585fb6d57eda8474cb71cdd89d6c4844e80276d3aa05e2b4f',  # DIRAC-19.0_fix-bss_energy_test.patch
     '666a9053d6c1287ee7aa471d18436133931959b3eacb7619d5197dbfb4e0c1fe',  # DIRAC-19.0_use_easybuild_opts_intel.patch
     '527680cab911a8c7a52347d7ace516a497b725043537a6274670a1aaa97bfb0f',  # DIRAC-19.0_fix_test_path.patch
+    'ccc26fc320f0967211b6390244b1fa359ba5d0294071d5d2cb9e36b4652a52b2',  # DIRAC-19.0_fix_mpi_tests.patch
 ]
 
 builddependencies = [('CMake', '3.16.4')]
@@ -38,22 +40,29 @@ configopts += '-DENABLE_LAPACK=off '
 configopts += '-DMKL_FLAG=off '
 configopts += '-DBLAS_LANG=Fortran '
 configopts += '-DLAPACK_LANG=Fortran '
-configopts += '-DENABLE_MPI=False '
+configopts += '-DENABLE_MPI=True '
 configopts += '-DENABLE_OPENMP=False '
 configopts += '-DENABLE_CODE_COVERAGE=False '
 configopts += '-DENABLE_STATIC_LINKING=False '
 configopts += '-DENABLE_PROFILING=False '
 configopts += '-DENABLE_RUNTIMECHECK=False '
 configopts += '-DENABLE_64BIT_INTEGERS=True '
-configopts += '-DEXPLICIT_LIBS="${LIBLAPACK_MT}" '
+configopts += '-DEXPLICIT_LIBS="${LIBSCALAPACK_MT}" '
 configopts += '-DENABLE_PCMSOLVER=OFF '
 configopts += '-G"Unix Makefiles" '
 
-prebuildopts = "make -j36 ; make -j36 ; make -j36 ;"
 parallel = 1
 
 pretestopts = 'export DIRAC_TMPDIR=%(builddir)s/scratch && '
-runtest = 'test ARGS=-j16'
+# WARNING!
+# running the tests with more than 1 MPI process might break some tests:
+# 18 - polprp_ph -> ERROR READING HEADER MDCINT
+# 20 - eomcc/eom_ea_h2o.out -> extra state
+# 26 - eomea_energy_symmetry/eom_ea_dc_noinv_overlap_c_oo_v_-Omega_f2_c_oo_v_turbomole-dz.out -> extra state
+# 46 - fscc_restart -> ENERGY TOTAL WRONG, maybe missing some file, like in polprp_ph?
+# Test 20/26 fails on cascadelake and not on haswell and skylake
+pretestopts += 'export DIRAC_MPI_COMMAND="mpirun -np 1 " && '
+runtest = 'test'
 
 sanity_check_paths = {
     'files': ['bin/pam-dirac', 'share/dirac/dirac.x'],

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0_fix-bss_energy_test.patch
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0_fix-bss_energy_test.patch
@@ -1,0 +1,3028 @@
+# it seems that bss_energy test is broken, the reference calculation is form 2004
+# The fact that only the SCF energy different and the consecutive post-HF correlation
+# energies are the same s a strong hnt that the HF wavefunction should be the same,
+# but the energies for some reason are different.
+# THe test was recalulated suing the following compilers/BLAS libaries on cascadelake 
+# architecture, and the results are practially the same.
+# Based on this facts, the reference test result was changed to the intel result below.
+#
+# gfortran 9.3.0 openblas 0.3.9 cascadelake:
+# @ SCF energy :                             -9505.779747269898508
+# @ MP2 correlation energy :                    -0.221846247868918
+# @ CCSD correlation energy :                   -0.222547639202710
+# @ 4th order triples correction :              -0.000001799879971
+# @ 5th order triples (T) correction :          -0.000000000059407
+# @ 5th order triples -T  correction :          -0.000000000472828
+# @ Total MP2 energy :                       -9506.001593517767105
+# @ Total CCSD energy :                      -9506.002294909101693
+# @ Total CCSD+T  energy :                   -9506.002296708980793
+# @ Total CCSD(T) energy :                   -9506.002296709040820
+# @ Total CCSD-T  energy :                   -9506.002296709453731
+# 
+# ifort 2020.1 mkl 2020.1 cascadelake:
+# @ SCF energy :                             -9505.779747269911240
+# @ MP2 correlation energy :                    -0.221846247868917
+# @ CCSD correlation energy :                   -0.222547639202709
+# @ 4th order triples correction :              -0.000001799879971
+# @ 5th order triples (T) correction :          -0.000000000059407
+# @ 5th order triples -T  correction :          -0.000000000472828
+# @ Total MP2 energy :                       -9506.001593517779838
+# @ Total CCSD energy :                      -9506.002294909114426
+# @ Total CCSD+T  energy :                   -9506.002296708993526
+# @ Total CCSD(T) energy :                   -9506.002296709053553
+# @ Total CCSD-T  energy :                   -9506.002296709466464
+# 
+# OCT 5th 2020 by B. Hajgato (UGent)
+diff -ru DIRAC-19.0-Source.orig/test/bss_energy/result/HF.bss_sfb.cc_cisd_Z80H.lsym.dir.out DIRAC-19.0-Source/test/bss_energy/result/HF.bss_sfb.cc_cisd_Z80H.lsym.dir.out
+--- DIRAC-19.0-Source.orig/test/bss_energy/result/HF.bss_sfb.cc_cisd_Z80H.lsym.dir.out	2019-12-12 17:26:14.000000000 +0100
++++ DIRAC-19.0-Source/test/bss_energy/result/HF.bss_sfb.cc_cisd_Z80H.lsym.dir.out	2020-10-05 14:16:03.472742000 +0200
+@@ -1,175 +1,342 @@
+-Master : DIRAC allocating 10000000 words of memory
+-******************************************************************************
+-*                                                                            *
+-*                                O U T P U T                                 *
+-*                                   from                                     *
+-*                                                                            *
+-*                   @@@@@    @@   @@@@@     @@@@     @@@@@                   *
+-*                   @@  @@        @@  @@   @@  @@   @@                       *
+-*                   @@  @@   @@   @@@@@    @@@@@@   @@                       *
+-*                   @@  @@   @@   @@ @@    @@  @@   @@                       *
+-*                   @@@@@    @@   @@  @@   @@  @@    @@@@@                   *
+-*                                                                            *
+-*                                                                            *
+-%}ZS)S?$=$)]S?$%%>SS$%S$ZZ6cHHMHHHHHHHHMHHM&MHbHH6$L/:<S///</:|/:|:/::!:.::--:
+-$?S$$%$$$$?%?$(SSS$SSSHMMMMMMMMMMMMMMMMMM6H&6S&SH&&k?6$r~::://///::::::.:::-::
+-(%?)Z??$$$(S%$>$)S6HMMMMMMMMMMMMMMMMMMMMMMR6M]&&$6HR$&6(i::::::|i|:::::::-:-::
+-$S?$$)$?$%?))?S/]#MMMMMMMMMMMMMMMMMMMMMMMMMMHM1HRH9R&$$$|):?:/://|:/::/:/.::.:
+-SS$%%?$%((S)?Z[6MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM&HF$$&/)S?<~::!!:::::::/:-:|.
+-SS%%%%S$%%%$$MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHHHHHHM>?/S/:/:::':/://:/::-::
+-?$SSSS?%SS$)MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM/4?:S:/:::/:::/:/:::.::
+-S$(S?S$%(?$HMMMMMMMMMMMMMMMMM#&7RH99MMMMMMMMMMMMMMMMMMHHHd$/:::::/::::::-//.:.
+-(?SS(%)S&HMMMMMMMMMMMMMMMMM#S|///???$9HHMMMMMMMMMDSZ&1S/?</>?~:///::|/!:/-:-:.
+-$S?%?<H(MMMMMMMMMMMMMMMMR?`. :.:'::<>:``?/*?##*)$:/>       `((%://::/:::::/::/
+-S$($$)HdMMMMMMMMMMMMMMMP: . `   `  `    `      `-            `Z<:>?::/:::::|:i
+-c%%%&HMMMMMMMMMMMMMMMM6:                                      `$%)>%%</>!:::::
+-S?%/MMMMMMMMMMMMMMMMMMH-                                        /ZSS>?:?~:;/::
+-$SZ?MMMMMMMMMMMMMMMMMH?.                                        "&((/?//?|::::
+-$%$%&MMMMMMMMMMMMMMMMM:.                                          ?%/S:</::/::
+-($?}&HMMMMMMMMMMMMMMMM>:                                          $%%<?/i:|i::
+-Z$($&MMMMMMMMMMMMMMMMHk(:.  . -                                   .S/??/!:/:|:
+-(??$<HMMMMMMMMMMMMMMMFk|:   -.-.                                  :%/%/(:/:ii|
+-SZ(S?]MMMMMMMMMMMMMMHS?:- -  ::.:                                  |/S:</::?||
+-$%)$$(MMMMMMMMMMMMMMR):`:. :.:::`,,/bcokb/_                       :S?%?|~:/:/:
+-%$$%$)[[?$?MMMMMMMMMM: :.:-.::::$7?<&7&MMMMMMM#/           _ .. ..:</?:(:/::::
+-$$$?Z?HHH~|/MMMMMMMMM/`.-.:.:/:%%%%?dHMMMMMMMMMMH?,-   .,bMMMM6//./i~/~:<:::/:
+-4$($S$M//::S?ZHMMMMMH/:.':::.:/%S/&MMHMMMMMMMMRM&><   ,HMMMMMMMF  :::?:///:|::
+-)[$S$S($|_i:#>::*H&?/::.::/:"://:?>>':&HMHSMMMM$:'-   MMHMMMMHHT .)i/?////:::/
+-$$[$$>$}:dHH&$$--?S::-:.:::--/-:``./::>%Zi?)&/?`:.'   `H?$T*" `  /%?>%:)://ii|
+-$&=&/ZS}$RF<:?/-.|%r/:::/:/:'.-.-..|::S//!`"``          >??:    `SS<S:)!/////|
+-Z&]>b[Z(Z?&%:::../S$$:>:::i`.`. '-.'  `                         ,>%%%:>/>/!|:/
+-$$&/F&1$c$?>:>?/,>?$$ZS/::/:-: ...                              |S?S)S?<~:::::
+-&$&$&$k&>>|?<:<?((/$[/?)i~/:/. - -                              S?:%%%?/:::/::
+-=[/Z[[Fp[MMH$>?Z&S$$$/$S///||..-           -.-                  /((S$:%<:///:/
+-$&>1MHHMMMM6M9MMMM$Z$}$S%/:::.'.            .:/,,,dcb>/:.       ((SSSS%:)!//i|
+-MMMMMMMMMMMR&&RRRHR&&($(?:|i::-             .:%&S&$[&H&''     ../>%;/?>??:<::>
+-MMMMMMMMMMMMS/}S$&&H&[$SS//:::.:.   . . .v</Jq1&&D]&M&<,      :/::/?%%)S>?://:
+-MMMMMMMMMMMM?}$/$$kMM&&$(%/?//:..'.  .|//1d/`://?*/*/"` '     .:/(SS$%(S%)):%~
+-MMMMMMMMMMMM(}$$>&&MMHR#$S%%:?::.:|-.':;&&b/D/$p=qpv//b/~'   :/~~%%??$=$)Z$S+;
+-MMMMMMMMMMMM[|S$$Z1]MMMMD[$?$:>)/::: :/?:`'???bD&{b<<-'     .,:/)|SS(}Z/$$?/<S
+-MMMMMMMMMMMM||$)&7k&MMMMH9]$$??Z%|!/:i::'  `` .             SS?SS?Z/]1$/&$c/$S
+-MMMMMMMMMMMM| -?>[&]HMMMMMMMH1[/7SS(?:/..-` ::/Sc,/_,     _<$?SS%$S/&c&&$&>//<
+-MMMMMMMMMMMMR  `$&&&HMM9MMMMMMM&&c$%%:/:/:.:.:/??/''"    _MMHk/7S/]dq&1S<&&></
+-MMMMMMMMMMMMM?  :&96MHMMMMMMMMMMMHHk[S%(<<:// '         ,MMMMMMM&/Z6H]DkH]1$&&
+-MMMMMMMMMMMMMD    99H9HMMMMMMMMMMMMMMMb&%$<:i.:....    .MMMMMMMMM6HHHRH&H&H1SF
+-MMMMMMMMMMMMMM|   `?HMMMMMMMMMMMMMMMMMMMHk6k&>$&Z$/?_.bHMMMMMMMMMMM&6HRM9H6]Zk
+-MMMMMMMMMMMMMMM/    `TMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHMH6RH&R6&
+-MMMMMMMMMMMMMMMM    -|?HMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMFHH6HMD&&
+-MMMMMMMMMMMMMMMMk  ..:~?9MMMMMMMMMMMMM#':MMMMMMMMMMMMMMMMMMMMMMMMMMMMM9MHkR6&F
+-MMMMMMMMMMMMMMMMM/  .-!:%$ZHMMMMMMMMMR' dMMMMMMMMMMMMMMMMMMMMMMMMMMMMM9MRMHH9&
+-MMMMMMMMMMMMMMMMMML,:.-|::/?&&MMMMMM' .MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHRMH&&6
+-MMMMMMMMMMMMMMMMMMMc%>/:::i<:SMMMMMMHdMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHHM&969k
+-MMMMMMMMMMMMMMMMMMMMSS/$$/(|HMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHH&HH&
+-MMMMMMMMMMMMMMMMMMMM6S/?/MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMR96H1DR1
+-MMMMMMMMMMMMMMMMMMMMM&$MHMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHMH691&&
+-MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMH&R&9Z
+-MMMMMMMMMMMMMMMMMMMMMMMMMRHMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMH&96][6
+-MMMMMMMMMMMMMMMMMMMMMMMMp?:MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM96HH1][F
+-MMMMMMMMMMMMMMMMMMMMMMMM> -HMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMH&1k&$&
+-******************************************************************************
+-*                                                                            *
+-*         =======================================================            *
+-*                     Program for Atomic and Molecular                       *
+-*          Direct Iterative Relativistic Allelectron Calculations            *
+-*         =======================================================            *
+-*                                                                            *
+-*                        VERSION 04.1    SEPTEMBER 2004                      *
+-*                                                                            *
+-******************************************************************************
+-*                                                                            *
+-*    Written by:                                                             *
+-*                                                                            *
+-*    Hans Joergen Aa. Jensen  University of Southern Denmark    Denmark      *
+-*    Trond Saue               CNRS/ULP Strasbourg               France       *
+-*    Lucas Visscher           Vrije Universiteit Amsterdam      Netherlands  *
+-*                                                                            *
+-*    with contributions from:                                                *
+-*                                                                            *
+-*    Vebjoern Bakken          University of Oslo                Norway       *
+-*    Ephraim Eliav            University of Tel Aviv            Israel       *
+-*    Thomas Enevoldsen        University of Southern Denmark    Denmark      *
+-*    Timo Fleig               University of Duesseldorf         Germany      *
+-*    Olav Fossgaard           University of Tromsoe             Norway       *
+-*    Trygve Helgaker          University of Oslo                Norway       *
+-*    Jon K. Laerdahl          University of Oslo                Norway       *
+-*    Christoffer V. Larsen    University of Southern Denmark    Denmark      *
+-*    Patrick Norman           Linkoeping University             Sweden       *
+-*    Jeppe Olsen              Aarhus University                 Denmark      *
+-*    Markus Pernpointner      Vrije Universiteit Amsterdam      Netherlands  *
+-*    Jesper K. Pedersen       University of Southern Denmark    Denmark      *
+-*    Kenneth Ruud             University of Tromsoe             Norway       *
+-*    Pawel Salek              Stockholm Inst. of Technology     Sweden       *
+-*    Joost van Stralen        Vrije Universiteit Amsterdam      Netherlands  *
+-*    Joern Thyssen            University of Southern Denmark    Denmark      *
+-*    Olivier Visser           University of Groningen           Netherlands  *
+-*    Toke Winther             University of Southern Denmark    Denmark      *
+-*                                                                            *
+-*    This is an experimental code. The authors accept no responsibility      *
+-*    for the performance of the code or for the correctness of the results.  *
+-*                                                                            *
+-*    The code (in whole or part) is not to be reproduced for further         *
+-*    distribution without the written permission of the authors or           *
+-*    their representatives.                                                  *
+-*                                                                            *
+-*    If results obtained with this code are published, an                    *
+-*    appropriate citation would be:                                          *
+-*                                                                            *
+-*    "Dirac, a relativistic ab initio electronic structure program",         *
+-*    release DIRAC04.1 (2004),                                               *
+-*    written by H. J. Aa. Jensen, T. Saue, and L. Visscher                   *
+-*    with contributions from V. Bakken, E. Eliav, T. Enevoldsen, T. Fleig,   *
+-*    O. Fossgaard, T. Helgaker, J. K. Laerdahl, C. V. Larsen, P. Norman,     *
+-*    J. Olsen, M. Pernpointner, J. K. Pedersen, K. Ruud, P. Salek,           *
+-*    J. N. P. van Stralen, J. Thyssen, O. Visser, and T. Winther             *
+-*    (http://dirac.chem.sdu.dk).                                             *
+-*                                                                            *
+-*    (for a suitable BibTEX entry, see                                       *
+-*    <URL:"http://dirac.chem.sdu.dk/doc/reference.shtml">)                   *
+-*                                                                            *
+-******************************************************************************
+- Version           : Dirac 4.1 (patchlevel 0) 
+- Hostname          : quantonakessa.u-strasbg.fr
+- Operating system  : Linux 2.6.8-1.521
+- Machine           : i686
+- Run               : Sequential
+- Last compilation  : 16:31:43 Dec  5 2004 (by ilias@)
+- FORTRAN compiler  : g77 -g  -ffast-math -fautomatic -fno-f2c -fno-globals -Wno-globals -fno-second-underscore 
+- C compiler        : gcc -ffast-math -g 
+- Basis set dir.    : /home/ilias/Dirac_main_trunk_dbg/test/37.bss.energies/:/home/ilias/Dirac_main_trunk_dbg/basis/:/home/ilias/Dirac_main_trunk_dbg/basis_dalton/
+-
+- Date and time (Linux) : Sun Dec  5 16:41:19 2004
+-
+-
+- *************************************************************************
+- *********************************   LiH *********************************
+- *************************************************************************
++DIRAC serial starts by allocating 64000000 words (    488.28 MB -      0.477 GB) of memory
++    out of the allowed maximum of 2147483648 words (  16384.00 MB -     16.000 GB)
++
++Note: maximum allocatable memory for serial run can be set by pam --aw/--ag
++
++ *******************************************************************************
++ *                                                                             *
++ *                                O U T P U T                                  *
++ *                                   from                                      *
++ *                                                                             *
++ *                   @@@@@    @@   @@@@@     @@@@     @@@@@                    *
++ *                   @@  @@        @@  @@   @@  @@   @@                        *
++ *                   @@  @@   @@   @@@@@    @@@@@@   @@                        *
++ *                   @@  @@   @@   @@ @@    @@  @@   @@                        *
++ *                   @@@@@    @@   @@  @@   @@  @@    @@@@@                    *
++ *                                                                             *
++ *                                                                             *
++ %}ZS)S?$=$)]S?$%%>SS$%S$ZZ6cHHMHHHHHHHHMHHM&MHbHH6$L/:<S///</:|/:|:/::!:.::--:%
++ $?S$$%$$$$?%?$(SSS$SSSHMMMMMMMMMMMMMMMMMM6H&6S&SH&&k?6$r~::://///::::::.:::-::$
++ (%?)Z??$$$(S%$>$)S6HMMMMMMMMMMMMMMMMMMMMMMR6M]&&$6HR$&6(i::::::|i|:::::::-:-::(
++ $S?$$)$?$%?))?S/]#MMMMMMMMMMMMMMMMMMMMMMMMMMHM1HRH9R&$$$|):?:/://|:/::/:/.::.:$
++ SS$%%?$%((S)?Z[6MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM&HF$$&/)S?<~::!!:::::::/:-:|.S
++ SS%%%%S$%%%$$MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHHHHHHM>?/S/:/:::`:/://:/::-::S
++ ?$SSSS?%SS$)MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM/4?:S:/:::/:::/:/:::.::?
++ S$(S?S$%(?$HMMMMMMMMMMMMMMMMM#&7RH99MMMMMMMMMMMMMMMMMMHHHd$/:::::/::::::-//.:.S
++ (?SS(%)S&HMMMMMMMMMMMMMMMMM#S|///???$9HHMMMMMMMMMDSZ&1S/?</>?~:///::|/!:/-:-:.(
++ $S?%?<H(MMMMMMMMMMMMMMMMR?`. :.:`::<>:``?/*?##*)$:/>       `((%://::/:::::/::/$
++ S$($$)HdMMMMMMMMMMMMMMMP: . `   `  `    `      `-            `Z<:>?::/:::::|:iS
++ c%%%&HMMMMMMMMMMMMMMMM6:                                      `$%)>%%</>!:::::c
++ S?%/MMMMMMMMMMMMMMMMMMH-                                        /ZSS>?:?~:;/::S
++ $SZ?MMMMMMMMMMMMMMMMMH?.                                        \"&((/?//?|:::$
++ $%$%&MMMMMMMMMMMMMMMMM:.                                          ?%/S:</::/::$
++ ($?}&HMMMMMMMMMMMMMMMM>:                                          $%%<?/i:|i::(
++ Z$($&MMMMMMMMMMMMMMMMHk(:.  . -                                   .S/\?\?/!:/:Z
++ (??$<HMMMMMMMMMMMMMMMFk|:   -.-.                                  :%/%/(:/:ii|(
++ SZ(S?]MMMMMMMMMMMMMMHS?:- -  ::.:                                  |/S:</::?||S
++ $%)$$(MMMMMMMMMMMMMMR):`:. :.:::`,,/bcokb/_                       :S?%?|~:/:/:$
++ %$$%$)[[?$?MMMMMMMMMM: :.:-.::::$7?<&7&MMMMMMM#/           _ .. ..:</?:(:/::::%
++ $$$?Z?HHH~|/MMMMMMMMM/`.-.:.:/:%%%%?dHMMMMMMMMMMH?,-   .,bMMMM6//./i~/~:<:::/:$
++ $($S$M//::S?ZHMMMMMH/:.`:::.:/%S/&MMHMMMMMMMMRM&><   ,HMMMMMMMF  :::?:///:|:::$
++ )[$S$S($|_i:#>::*H&?/::.::/:\"://:?>>`:&HMHSMMMM$:`-   MMHMMMMHHT .)i/?////::/)
++ $$[$$>$}:dHH&$$--?S::-:.:::--/-:``./::>%Zi?)&/?`:.`   `H?$T*\" `  /%?>%:)://ii$
++ $&=&/ZS}$RF<:?/-.|%r/:::/:/:`.-.-..|::S//!`\"``          >??:    `SS<S:)!/////$
++ Z&]>b[Z(Z?&%:::../S$$:>:::i`.`. `-.`  `                         ,>%%%:>/>/!|:/Z
++ $$&/F&1$c$?>:>?/,>?$$ZS/::/:-: ...                              |S?S)S?<~:::::$
++ &$&$&$k&>>|?<:<?((/$[/?)i~/:/. - -                              S?:%%%?/:::/::&
++ =[/Z[[Fp[MMH$>?Z&S$$$/$S///||..-           -.-                  /((S$:%<:///:/=
++ $&>1MHHMMMM6M9MMMM$Z$}$S%/:::.`.            .:/,,,dcb>/:.       ((SSSS%:)!//i|$
++ MMMMMMMMMMMR&&RRRHR&&($(?:|i::-             .:%&S&$[&H&``     ../>%;/?>??:<::>M
++ MMMMMMMMMMMMS/}S$&&H&[$SS//:::.:.   . . .v</Jq1&&D]&M&<,      :/::/?%%)S>?://:M
++ MMMMMMMMMMMM?}$/$$kMM&&$(%/?//:..`.  .|//1d/`://?*/*/\"` `     .:/(SS$%(S%)):%M
++ MMMMMMMMMMMM(}$$>&&MMHR#$S%%:?::.:|-.`:;&&b/D/$p=qpv//b/~`   :/~~%%??$=$)Z$S+;M
++ MMMMMMMMMMMM[|S$$Z1]MMMMD[$?$:>)/::: :/?:``???bD&{b<<-`     .,:/)|SS(}Z/$$?/<SM
++ MMMMMMMMMMMM||$)&7k&MMMMH9]$$??Z%|!/:i::`  `` .             SS?SS?Z/]1$/&$c/$SM
++ MMMMMMMMMMMM| -?>[&]HMMMMMMMH1[/7SS(?:/..-` ::/Sc,/_,     _<$?SS%$S/&c&&$&>//<M
++ MMMMMMMMMMMMR  `$&&&HMM9MMMMMMM&&c$%%:/:/:.:.:/\?\?/\    _MMHk/7S/]dq&1S<&&></M
++ MMMMMMMMMMMMM?  :&96MHMMMMMMMMMMMHHk[S%(<<:// `         ,MMMMMMM&/Z6H]DkH]1$&&M
++ MMMMMMMMMMMMMD    99H9HMMMMMMMMMMMMMMMb&%$<:i.:....    .MMMMMMMMM6HHHRH&H&H1SFM
++ MMMMMMMMMMMMMM|   `?HMMMMMMMMMMMMMMMMMMMHk6k&>$&Z$/?_.bHMMMMMMMMMMM&6HRM9H6]ZkM
++ MMMMMMMMMMMMMMM/    `TMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHMH6RH&R6&M
++ MMMMMMMMMMMMMMMM    -|?HMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMFHH6HMD&&M
++ MMMMMMMMMMMMMMMMk  ..:~?9MMMMMMMMMMMMM#`:MMMMMMMMMMMMMMMMMMMMMMMMMMMMM9MHkR6&FM
++ MMMMMMMMMMMMMMMMM/  .-!:%$ZHMMMMMMMMMR` dMMMMMMMMMMMMMMMMMMMMMMMMMMMMM9MRMHH9&M
++ MMMMMMMMMMMMMMMMMML,:.-|::/?&&MMMMMM` .MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHRMH&&6M
++ MMMMMMMMMMMMMMMMMMMc%>/:::i<:SMMMMMMHdMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHHM&969kM
++ MMMMMMMMMMMMMMMMMMMMSS/$$/(|HMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHH&HH&M
++ MMMMMMMMMMMMMMMMMMMM6S/?/MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMR96H1DR1M
++ MMMMMMMMMMMMMMMMMMMMM&$MHMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHMH691&&M
++ MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMH&R&9ZM
++ MMMMMMMMMMMMMMMMMMMMMMMMMRHMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMH&96][6M
++ MMMMMMMMMMMMMMMMMMMMMMMMp?:MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM96HH1][FM
++ MMMMMMMMMMMMMMMMMMMMMMMM> -HMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMH&1k&$&M
++ *******************************************************************************
++ *                                                                             *
++ *         =========================================================           *
++ *                     Program for Atomic and Molecular                        *
++ *          Direct Iterative Relativistic All-electron Calculations            *
++ *         =========================================================           *
++ *                                                                             *
++ *                                                                             *
++ *    Written by:                                                              *
++ *                                                                             *
++ *    Andre S. P. Gomes        CNRS/Universite de Lille          France        *
++ *    Trond Saue               Universite Toulouse III           France        *
++ *    Lucas Visscher           Vrije Universiteit Amsterdam      Netherlands   *
++ *    Hans Joergen Aa. Jensen  University of Southern Denmark    Denmark       *
++ *    Radovan Bast             UiT The Arctic University of      Norway        *
++ *                                                                             *
++ *    with contributions from:                                                 *
++ *                                                                             *
++ *    Ignacio Agustin Aucar    Northeast National University     Argentina     *
++ *    Vebjoern Bakken          University of Oslo                Norway        *
++ *    Kenneth G. Dyall         Schrodinger, Inc., Portland       USA           *
++ *    Sebastien Dubillard      University of Strasbourg          France        *
++ *    Ulf Ekstroem             University of Oslo                Norway        *
++ *    Ephraim Eliav            University of Tel Aviv            Israel        *
++ *    Thomas Enevoldsen        University of Southern Denmark    Denmark       *
++ *    Elke Fasshauer           University of Aarhus              Denmark       *
++ *    Timo Fleig               Universite Toulouse III           France        *
++ *    Olav Fossgaard           UiT The Arctic University of      Norway        *
++ *    Loic Halbert             Universite de Lille               France        *
++ *    Erik D. Hedegaard        Lund University                   Sweden        *
++ *    Trygve Helgaker          University of Oslo                Norway        *
++ *    Benjamin Helmich-Paris   Max Planck Institute f. Coal Res. Germany       *
++ *    Johan Henriksson         Linkoeping University             Sweden        *
++ *    Miroslav Ilias           Matej Bel University              Slovakia      *
++ *    Christoph R. Jacob       TU Braunschweig                   Germany       *
++ *    Stefan Knecht            ETH Zuerich                       Switzerland   *
++ *    Stanislav Komorovsky     UiT The Arctic University of      Norway        *
++ *    Ossama Kullie            University of Kassel              Germany       *
++ *    Jon K. Laerdahl          University of Oslo                Norway        *
++ *    Christoffer V. Larsen    University of Southern Denmark    Denmark       *
++ *    Yoon Sup Lee             KAIST, Daejeon                    South Korea   *
++ *    Huliyar S. Nataraj       BME/Budapest Univ. Tech. & Econ.  Hungary       *
++ *    Malaya Kumar Nayak       Bhabha Atomic Research Centre     India         *
++ *    Patrick Norman           Stockholm Inst. of Technology     Sweden        *
++ *    Malgorzata Olejniczak    University of Warsaw              Poland        *
++ *    Jeppe Olsen              Aarhus University                 Denmark       *
++ *    Jogvan Magnus H. Olsen   University of Southern Denmark    Denmark       *
++ *    Young Choon Park         KAIST, Daejeon                    South Korea   *
++ *    Jesper K. Pedersen       University of Southern Denmark    Denmark       *
++ *    Markus Pernpointner      University of Heidelberg          Germany       *
++ *    Roberto Di Remigio       UiT The Arctic University of      Norway        *
++ *    Kenneth Ruud             UiT The Arctic University of      Norway        *
++ *    Pawel Salek              Stockholm Inst. of Technology     Sweden        *
++ *    Bernd Schimmelpfennig    Karlsruhe Institute of Technology Germany       *
++ *    Bruno Senjean            University of Leiden              Netherlands   *
++ *    Avijit Shee              University of Michigan            USA           *
++ *    Jetze Sikkema            Vrije Universiteit Amsterdam      Netherlands   *
++ *    Andreas J. Thorvaldsen   UiT The Arctic University of      Norway        *
++ *    Joern Thyssen            University of Southern Denmark    Denmark       *
++ *    Joost van Stralen        Vrije Universiteit Amsterdam      Netherlands   *
++ *    Marta L. Vidal           Technical University of Denmark   Denmark       *
++ *    Sebastien Villaume       Linkoeping University             Sweden        *
++ *    Olivier Visser           University of Groningen           Netherlands   *
++ *    Toke Winther             University of Southern Denmark    Denmark       *
++ *    Shigeyoshi Yamamoto      Chukyo University                 Japan         *
++ *                                                                             *
++ *    For more information about the DIRAC code see http://diracprogram.org    *
++ *                                                                             *
++ *    This is an experimental code. The authors accept no responsibility       *
++ *    for the performance of the code or for the correctness of the results.   *
++ *                                                                             *
++ *    The code (in whole or part) is not to be reproduced for further          *
++ *    distribution without the written permission of the authors or            *
++ *    their representatives.                                                   *
++ *                                                                             *
++ *    If results obtained with this code are published, an                     *
++ *    appropriate citation would be:                                           *
++ *                                                                             *
++ *    DIRAC, a relativistic ab initio electronic structure program,            *
++ *    Release DIRAC19 (2019), written by                                       *
++ *    A. S. P. Gomes, T. Saue, L. Visscher, H. J. Aa. Jensen, and R. Bast,     *
++ *    with contributions from I. A. Aucar, V. Bakken, K. G. Dyall,             *
++ *    S. Dubillard, U. Ekstroem, E. Eliav, T. Enevoldsen, E. Fasshauer,        *
++ *    T. Fleig, O. Fossgaard, L. Halbert, E. D. Hedegaard, T. Helgaker,        *
++ *    J. Henriksson, M. Ilias, Ch. R. Jacob, S. Knecht, S. Komorovsky,         *
++ *    O. Kullie, J. K. Laerdahl, C. V. Larsen, Y. S. Lee, H. S. Nataraj,       *
++ *    M. K. Nayak, P. Norman, M. Olejniczak, J. Olsen, J. M. H. Olsen,         *
++ *    Y. C. Park, J. K. Pedersen, M. Pernpointner, R. Di Remigio, K. Ruud,     *
++ *    P. Salek, B. Schimmelpfennig, B. Senjean, A. Shee, J. Sikkema,           *
++ *    A. J. Thorvaldsen, J. Thyssen, J. van Stralen, M. L. Vidal, S. Villaume, *
++ *    O. Visser, T. Winther, and S. Yamamoto (see http://diracprogram.org).    *
++ *                                                                             *
++ *******************************************************************************
++
++
++Version information
++-------------------
++
++Branch        | 
++Commit hash   | 
++Commit author | 
++Commit date   | 
++
++
++Configuration and build information
++-----------------------------------
++
++Who compiled             | vsc43020
++Compiled on server       | node3403.kirlia.os
++Operating system         | Linux-3.10.0-1127.8.2.el7.ug.x86_64
++CMake version            | 3.16.4
++CMake generator          | Unix Makefiles
++CMake build type         | release
++Configuration time       | 2020-10-05 12:06:36.697767
++Python version           | 2.7.1
++Fortran compiler         | /apps/gent/CO7/cascadelake-ib/software/iccifort/2020.1.217/compilers_and_libraries_2020.1.217/linux/bin/intel64/ifort
++Fortran compiler version | 19.1
++Fortran compiler flags   |  -w -assume byterecl -g -traceback -DVAR_IFORT -i8
++C compiler               | /apps/gent/CO7/cascadelake-ib/software/iccifort/2020.1.217/compilers_and_libraries_2020.1.217/linux/bin/intel64/icc
++C compiler version       | 19.1
++C compiler flags         |  -g -wd981 -wd279 -wd383 -wd1572 -wd177
++C++ compiler             | /apps/gent/CO7/cascadelake-ib/software/iccifort/2020.1.217/compilers_and_libraries_2020.1.217/linux/bin/intel64/icpc
++C++ compiler version     | 19.1.1
++C++ compiler flags       |  -Wno-unknown-pragmas
++Static linking           | False
++64-bit integers          | True
++MPI parallelization      | False
++MPI launcher             | unknown
++Math libraries           | unknown
++Builtin BLAS library     | OFF
++Builtin LAPACK library   | OFF
++Explicit libraries       | unknown
++Compile definitions      | HAVE_MKL_BLAS;HAVE_MKL_LAPACK;SYS_LINUX;PRG_DIRAC;INT_STAR8;INSTALL_WRKMEM=64000000;HAS_PCMSOLVER;BUILD_GEN1INT;HAS_PELIB;MOD_QCORR;HAS_STIELTJES
++
++
++ LAPACK integer*4/8 selftest passed
++ Selftest of ISO_C_BINDING Fortran - C/C++ interoperability PASSED
++
++Execution time and host
++-----------------------
++
++ 
++     Date and time (Linux)  : Mon Oct  5 14:12:56 2020
++     Host name              : node3403.kirlia.os                      
++
++
++Contents of the input file
++--------------------------
++
++**DIRAC                                                                                             
++.TITLE                                                                                              
++  LiH                                                                                               
++.WAVE F ! Activate integral and wave functions modules                                              
++**GENERAL                                                                                           
++**INTEGRALS                                                                                         
++.PRINT                                                                                              
++1                                                                                                   
++.NUCMOD ! 1-Point nucleus, 2-gaussian                                                               
++2                                                                                                   
++**HAMILTONIAN                                                                                       
++.SPINFREE                                                                                           
++.BSS                                                                                                
++109                                                                                                 
++.CMPEIG                                                                                             
++.PRINT                                                                                              
++2                                                                                                   
++**WAVE FUNCTIONS ! What method (DHF,MP2,CC..)                                                       
++.SCF                                                                                                
++.RELCCSD                                                                                            
++.LUCITA                                                                                             
++*SCF                                                                                                
++.CLOSED SHELL                                                                                       
++10                                                                                                  
++.INTFLG ! Specify what 2-el.integrals to include                                                    
++1 1 0                                                                                               
++.EVCCNV ! Energy convergence...                                                                     
++1.0E-10  1.0D-7                                                                                     
++*LUCITA                                                                                             
++.INIWFC                                                                                             
++  DHFSCF                                                                                            
++.CITYPE                                                                                             
++  SDCI                                                                                              
++.MULTIP                                                                                             
++  3                                                                                                 
++**MOLTRA                                                                                            
++# needed for parallel run                                                                           
++.SCHEME                                                                                             
++4                                                                                                   
++.ACTIVE                                                                                             
++energy   -1000    999999  0.1                                                                       
++**RELCCSD                                                                                           
++.NELEC                                                                                              
++ 4 4                                                                                                
++.INTERFACE                                                                                          
++DIRAC                                                                                               
++.TIMING                                                                                             
++.PRINT                                                                                              
++ 1                                                                                                  
++*CCSORT                                                                                             
++.USEOE                                                                                              
++*END OF                                                                                             
++                                                                                                    
++
++
++Contents of the molecule file
++-----------------------------
++
++INTGRL                                                                                              
++X                                                                                                   
++X                                                                                                   
++C   2              A                                                                                
++      80.0   1                                                                                      
++X     0.0000000000        0.0000000000         2.000000000                                          
++LARGE    3    1    1    1                                                                           
++f   5    0                                                                                          
++  90000                                                                                             
++  50000                                                                                             
++   9000                                                                                             
++   4000                                                                                             
++    300                                                                                             
++f   3    0                                                                                          
++    35000                                                                                           
++     7000                                                                                           
++     900                                                                                            
++f   1    0                                                                                          
++     900                                                                                            
++        1.    1                                                                                     
++H     0.00000000000        .0000000000         .0000000000                                          
++LARGE    1    1                                                                                     
++f   2    0                                                                                          
++      1.00                                                                                          
++      0.25                                                                                          
++FINISH                                                                                              
++
++
++    *************************************************************************
++    *********************************   LiH *********************************
++    *************************************************************************
+ 
+  Jobs in this run:
+    * Wave function
+ 
+ 
+- **************************************************************************
+- ************************** General DIRAC set-up **************************
+- **************************************************************************
+-
++    **************************************************************************
++    ************************** General DIRAC set-up **************************
++    **************************************************************************
++
++   CODATA Recommended Values of the Fundamental Physical Constants: 1998  
++                Peter J. Mohr and Barry N. Taylor                         
++   Journal of Physical and Chemical Reference Data, Vol. 28, No. 6, 1999  
+  * The speed of light :        137.0359998
++ * Running in two-component mode
+  * Direct evaluation of the following two-electron integrals:
+    - LL-integrals
+-   - SL-integrals
+-   - SS-integrals
+  * Spherical transformation embedded in MO-transformation
+    for large components
+  * Transformation to scalar RKB basis embedded in
+    MO-transformation for small components
+  * Thresholds for linear dependence:
+-   Large components:   1.00E-06
+-   Small components:   1.00E-08
++   Large components:   1.00D-06
++   Small components:   1.00D-08
+  * General print level   :   0
+ 
+ 
+- *************************************************************************
+- ****************** Output from HERMIT input processing ******************
+- *************************************************************************
++    *************************************************************************
++    ****************** Output from HERMIT input processing ******************
++    *************************************************************************
+ 
+  Default print level:        1
+  Nuclear model: Gaussian charge distribution.
+@@ -181,20 +348,9 @@
+ 
+ 
+ 
+-  Set-up from HR2INP:
+-  -------------------
+-
+- Print level in TWOINT:    1
+- Extra output for the following shells:  0  0  0  0
+- * Direct calculation of Fock matrices in SO-basis.
+- * Default screening threshold in direct Fock matrix construction: 1.00E-12
+- * Separate density screening of Coulomb integral batches
+- * Separate density screening of exchange integral batches
+-
+-
+- *************************************************************************
+- ****************** Output from READIN input processing ******************
+- *************************************************************************
++   ***************************************************************************
++   ****************** Output from MOLECULE input processing ******************
++   ***************************************************************************
+ 
+ 
+ 
+@@ -207,29 +363,20 @@
+   Coordinates are entered in Angstroms and converted to atomic units.
+           - Conversion factor : 1 bohr = 0.52917721 A
+ 
+-  Nuclear Gaussian exponent for atom of charge  80.000 :    1.4011788914E+08
+-
+-  Nuclear Gaussian exponent for atom of charge   1.000 :    2.1248239171E+09
++  Nuclear Gaussian exponent for atom of charge  80.000 :    1.4011786759D+08
++  Nuclear Gaussian exponent for atom of charge   1.000 :    2.1248235902D+09
+ 
+ 
+-                  SYMADD: Requested addition of symmetry
+-                  --------------------------------------
++                     SYMADD: Detection of molecular symmetry
++                     ---------------------------------------
+ 
+- Symmetry threshold:  0.50E-05
++ Symmetry test threshold:  5.00E-06
+ 
+- Original Coordinates                    
+- --------------------                    
+-   80         0.00000000     0.00000000     3.77945227       1
+-    1         0.00000000     0.00000000     0.00000000       1
++    The molecule has been centered at center of mass
+ 
+- Symmetry class found: C(oo,v)
++ Symmetry point group found: C(oo,v)        
+ 
+- Centered and Rotated                    
+- --------------------                    
+-   80         0.00000000     0.00000000     0.01876567       1
+-    1         0.00000000     0.00000000    -3.76068660       1
+-
+- The following elements were found:   X  Y     
++ The following symmetry elements were found: X  Y     
+ 
+ 
+   Symmetry Operations
+@@ -239,8 +386,8 @@
+ 
+ 
+ 
+-                      SYMGRP:Point group information
+-                      ------------------------------
++                          SYMGRP:Point group information
++                          ------------------------------
+ 
+ Full group is:  C(oo,v)        
+ Represented as: C2v
+@@ -254,9 +401,9 @@
+ 
+         |  E   C2z  Oxz  Oyz
+    -----+--------------------
+-     E  |  E 
+-    C2z | C2z   E 
+-    Oxz | Oxz  Oyz   E 
++     E  |  E   C2z  Oxz  Oyz
++    C2z | C2z   E   Oyz  Oxz
++    Oxz | Oxz  Oyz   E   C2z
+     Oyz | Oyz  Oxz  C2z   E 
+ 
+    * Character table
+@@ -272,15 +419,15 @@
+ 
+         | A1   B1   B2   A2 
+    -----+--------------------
+-    A1  | A1 
+-    B1  | B1   A1 
+-    B2  | B2   A2   A1 
++    A1  | A1   B1   B2   A2 
++    B1  | B1   A1   A2   B2 
++    B2  | B2   A2   A1   B1 
+     A2  | A2   B2   B1   A1 
+ 
+ 
+-                        **************************
+-                        *** Output from DBLGRP ***
+-                        **************************
++                            **************************
++                            *** Output from DBLGRP ***
++                            **************************
+ 
+    * One fermion irrep:   E1 
+    * Real group. NZ = 1
+@@ -288,8 +435,8 @@
+           E1  x E1  : A1  + A2  + B1  + B2 
+ 
+ 
+-                             Spinor structure
+-                             ----------------
++                                 Spinor structure
++                                 ----------------
+ 
+ 
+    * Fermion irrep no.: 1
+@@ -299,8 +446,8 @@
+       Sb  |  B2 (3)  B1 (4)  |
+ 
+ 
+-                          Quaternion symmetries
+-                          ---------------------
++                              Quaternion symmetries
++                              ---------------------
+ 
+     Rep  T(+)
+     -----------------------------
+@@ -309,27 +456,39 @@
+     B2   k
+     A2   i
+ 
++  QM-QM nuclear repulsion energy :     21.167088332000
++
++
++
++                                 Isotopic Masses
++                                 ---------------
++
++                           X         201.970617
++                           H           1.007825
++
++                       Total mass:   202.978442 amu
++                       Natural abundance:  29.856 %
++
++ Center-of-mass coordinates (a.u.):       0.000000000000000   0.000000000000000   0.000000000000000
++
+ 
+   Atoms and basis sets
+   --------------------
+ 
+-  Number of atom types:     2
++  Number of atom types :    2
+   Total number of atoms:    2
+ 
+   label    atoms   charge   prim    cont     basis   
+   ----------------------------------------------------------------------
+-  X           1      80      20      20      L  - [5s3p1d|5s3p1d]                                    
+-                             49      49      S  - [3s6p3d1f|3s6p3d1f]                                
+-  H           1       1       2       2      L  - [2s|2s]                                            
+-                              6       6      S  - [2p|2p]                                            
++  X           1      80      20      20      L  - [5s3p1d|5s3p1d]                                                
++  H           1       1       2       2      L  - [2s|2s]                                                        
+   ----------------------------------------------------------------------
+-                             22      22   L - large components
+-                             55      55   S - small components
++                             22      22      L  - large components
+   ----------------------------------------------------------------------
+-  total:      2      81      77      77
++  total:      2      81      22      22
+ 
+   Cartesian basis used.
+-  Threshold for integrals:  1.00E-15
++  Threshold for integrals (to be written to file):  1.00D-15
+ 
+ 
+   References for the basis sets
+@@ -339,8 +498,8 @@
+   Basis set typed explicitly in input file                                        
+ 
+ 
+-  Cartesian Coordinates
+-  ---------------------
++  Cartesian Coordinates (bohr)
++  ----------------------------
+ 
+   Total number of coordinates:  6
+ 
+@@ -355,28 +514,37 @@
+ 
+ 
+ 
++  Cartesian coordinates in XYZ format (Angstrom)
++  ----------------------------------------------
++
++    2
++ 
++X      0.0000000000   0.0000000000   0.0099303649
++H      0.0000000000   0.0000000000  -1.9900696351
++
++
+   Symmetry Coordinates
+   --------------------
+ 
+-  Number of coordinates in each symmetry:   2  2  2  0
++  Number of coordinates in each symmetry:     2    2    2    0
+ 
+ 
+-  Symmetry 1
++  Symmetry  A1 ( 1)
+ 
+-   1   X     z    3
+-   2   H     z    6
++    1   X     z    3
++    2   H     z    6
+ 
+ 
+-  Symmetry 2
++  Symmetry  B1 ( 2)
+ 
+-   3   X     x    1
+-   4   H     x    4
++    3   X     x    1
++    4   H     x    4
+ 
+ 
+-  Symmetry 3
++  Symmetry  B2 ( 3)
+ 
+-   5   X     y    2
+-   6   H     y    5
++    5   X     y    2
++    6   H     y    5
+ 
+ 
+    Interatomic separations (in Angstroms):
+@@ -398,41 +566,36 @@
+   bond distance:    H          X                              2.000000
+ 
+ 
+-  Nuclear repulsion energy :   21.167088332000
++
++   Nuclear repulsion energy :   21.167088332000 Hartree
+ 
+ 
+-                            GETLAB: AO-labels
+-                            -----------------
++                                GETLAB: AO-labels
++                                -----------------
+ 
+    * Large components:   11
+-     1  L X     s        2  L X     px       3  L X     py       4  L X     pz       5  L X     dxx      6  L X     dxy 
+-     7  L X     dxz      8  L X     dyy      9  L X     dyz     10  L X     dzz     11  L H     s   
+-   * Small components:   23
+-    12  S X     s       13  S X     px      14  S X     py      15  S X     pz      16  S X     dxx     17  S X     dxy 
+-    18  S X     dxz     19  S X     dyy     20  S X     dyz     21  S X     dzz     22  S X     fxxx    23  S X     fxxy
+-    24  S X     fxxz    25  S X     fxyy    26  S X     fxyz    27  S X     fxzz    28  S X     fyyy    29  S X     fyyz
+-    30  S X     fyzz    31  S X     fzzz    32  S H     px      33  S H     py      34  S H     pz  
++     1  L X   1 s        2  L X   1 px       3  L X   1 py       4  L X   1 pz       5  L X   1 dxx      6  L X   1 dxy 
++     7  L X   1 dxz      8  L X   1 dyy      9  L X   1 dyz     10  L X   1 dzz     11  L H   1 s   
++   * Small components:    0
+ 
+ 
+-                            GETLAB: SO-labels
+-                            -----------------
++
++                                GETLAB: SO-labels
++                                -----------------
+ 
+    * Large components:   11
+      1  L A1 X  s        2  L A1 X  pz       3  L A1 X  dxx      4  L A1 X  dyy      5  L A1 X  dzz      6  L A1 H  s   
+      7  L B1 X  px       8  L B1 X  dxz      9  L B2 X  py      10  L B2 X  dyz     11  L A2 X  dxy 
+-   * Small components:   23
+-    12  S A1 X  s       13  S A1 X  pz      14  S A1 X  dxx     15  S A1 X  dyy     16  S A1 X  dzz     17  S A1 X  fxxz
+-    18  S A1 X  fyyz    19  S A1 X  fzzz    20  S A1 H  pz      21  S B1 X  px      22  S B1 X  dxz     23  S B1 X  fxxx
+-    24  S B1 X  fxyy    25  S B1 X  fxzz    26  S B1 H  px      27  S B2 X  py      28  S B2 X  dyz     29  S B2 X  fxxy
+-    30  S B2 X  fyyy    31  S B2 X  fyzz    32  S B2 H  py      33  S A2 X  dxy     34  S A2 X  fxyz
++   * Small components:    0
++
+ 
+ 
+   Symmetry Orbitals
+   -----------------
+ 
+-  Number of orbitals in each symmetry:           36    18    18     5
++  Number of orbitals in each symmetry:           13     4     4     1
+   Number of large orbitals in each symmetry:     13     4     4     1
+-  Number of small orbitals in each symmetry:     23    14    14     4
++  Number of small orbitals in each symmetry:      0     0     0     0
+ 
+ * Large component functions
+ 
+@@ -459,123 +622,90 @@
+ 
+         1 functions:    X  dxy 
+ 
+-* Small component functions
+-
+-  Symmetry  A1 ( 1)
+-
+-        3 functions:    X  s   
+-        6 functions:    X  pz  
+-        3 functions:    X  dxx 
+-        3 functions:    X  dyy 
+-        3 functions:    X  dzz 
+-        1 functions:    X  fxxz
+-        1 functions:    X  fyyz
+-        1 functions:    X  fzzz
+-        2 functions:    H  pz  
+-
+-  Symmetry  B1 ( 2)
+-
+-        6 functions:    X  px  
+-        3 functions:    X  dxz 
+-        1 functions:    X  fxxx
+-        1 functions:    X  fxyy
+-        1 functions:    X  fxzz
+-        2 functions:    H  px  
+-
+-  Symmetry  B2 ( 3)
+-
+-        6 functions:    X  py  
+-        3 functions:    X  dyz 
+-        1 functions:    X  fxxy
+-        1 functions:    X  fyyy
+-        1 functions:    X  fyzz
+-        2 functions:    H  py  
+-
+-  Symmetry  A2 ( 4)
+ 
+-        3 functions:    X  dxy 
+-        1 functions:    X  fxyz
+-
+-
+- ***************************************************************************
+- *************************** Hamiltonian defined ***************************
+- ***************************************************************************
+-
+- * Print level :    2
+-  * Barysz-Sadlej-Snijders Hamiltonian. Type code -109
++   ***************************************************************************
++   *************************** Hamiltonian defined ***************************
++   ***************************************************************************
++
++ * Print level:    2
++ * Barysz-Sadlej-Snijders Hamiltonian. Type code:  109
++   Reference: 
++    H. J. Aa. Jensen and M. Ilias,
++    "Two-component relativistic methods based on the quaternion modified Dirac equation. I:
++     from Douglas-Kroll-Hess second order method to the infinite order two-component method.",
++     J. Chem. Phys., in preparation.
++ * Running in two-component mode
+    with the following modifications:
+    - Spin-orbit interactions neglected
+  * Default integral flags passed to all modules
+-   - LL-integrals: T
+-   - LS-integrals: T
+-   - SS-integrals: T
+-   - GT-integrals: F
++   - LL-integrals:     1
++   - LS-integrals:     0
++   - SS-integrals:     0
++   - GT-integrals:     0
++ * Comparing eigenvalues between parent 4c and derived 2c one-electron Hamiltonians.
+  * Basis set:
+    - uncontracted large component basis set
+-   - uncontracted small component basis set
+-
+-
+- Information about the restricted kinetic balance scheme:
+- * Default RKB projection:
+-   1: Pre-projection in scalar basis
+-   2: Removal of unphysical solutions (via diagonalization of free particle Hamiltonian)
+-
+-
+- *********************************************************************************
+- *************************** Memory required by HERMIT ***************************
+- *********************************************************************************
+-
+-===========================================================================
+- Maximum memory load for two-electron integral processing:
+-===========================================================================
+- * LL-integrals:
+-   2(X    Lp)   2(X    Lp)   2(X    Lp)   2(X    Lp)               19958
+- * SL-integrals:
+-   8(X    Sd)   6(X    Sp)   2(X    Lp)   2(X    Lp)               74456
+- * SS-integrals:
+-   8(X    Sd)   6(X    Sp)   8(X    Sd)   6(X    Sp)              274736
+ 
+ 
+- **************************************************************************
+- ************************** Wave function module **************************
+- **************************************************************************
++    **************************************************************************
++    ************************** Wave function module **************************
++    **************************************************************************
++
++ Wave function types requested (in input order):
++     HF        
++     RELCCSD   
++     LUCITA    
+ 
+- Jobs in this run (in execution order):
++ Wave function jobs in execution order (expanded):
+  * Hartree-Fock calculation
+  * Run RELCCSD code
+  * Run LUCITA CI code
+ ===========================================================================
+- DHFINP: Set-up for Hartree-Fock calculation:
++ *SCF: Set-up for Hartree-Fock calculation:
+ ===========================================================================
+  * Number of fermion irreps: 1
+- * Closed shell DHF calculation with   10 electrons in
+-       5 orbitals in Fermion irrep 1
+- * Bare nucleus screening correction used for start guess
+- - INFO: bare nucleus correction disabled becauseabs(molecular charge) .gt. 2
++ * Closed shell SCF calculation with    10 electrons in    5 orbitals.
++ - INFO: bare nucleus correction disabled because abs(molecular charge) .gt. 10
++ * Sum of atomic potentials used for start guess
+  * General print level   :   0
+- ***** TRIAL FUNCTION *****
++
++ ***** INITIAL TRIAL SCF FUNCTION *****
+  * Trial vectors read from file DFCOEF
+- ***** CONVERGENCE CRITERIA *****
++ * Scaling of active-active block correction to open shell Fock operator    0.500000
++   to improve convergence (default value).
++   The final open-shell orbital energies are recalculated with 1.0 scaling,
++   such that all occupied orbital energies correspond to Koopmans' theorem ionization energies.
++
++ ***** SCF CONVERGENCE CRITERIA *****
+  * Convergence on norm of error vector (gradient).
+-   Desired convergence:1.000E-10
+-   Allowed convergence:1.000E-07
++   Desired convergence:1.000D-10
++   Allowed convergence:1.000D-07
+ 
+  ***** CONVERGENCE CONTROL *****
+  * Fock matrix constructed using differential density matrix
+     with optimal parameter.
+  * DIIS (in MO basis)
+- * DIIS will be activated when convergence reaches : 1.00E+20
++ * DIIS will be activated when convergence reaches : 1.00D+20
+    - Maximum size of B-matrix:   10
+  * Damping of Fock matrix when DIIS is not activated. 
+    Weight of old matrix    : 0.250
+  * Maximum number of SCF iterations  :   50
+- * Quadratic convergent Hartree-Fock
+-   - Maximum number of macro iterations: 25
+-   - Maximum number of micro iterations: 25
++ * No quadratic convergent Hartree-Fock
+  * Contributions from 2-electron integrals to Fock matrix:
+    LL-integrals.
++    ---> accepted user's setting through .INTFLG
++ * NB!!! No e-p rotations in 2nd order optimization.
+  ***** OUTPUT CONTROL *****
+  * Only electron eigenvalues written out.
++===========================================================================
++ **RELCC: Set-up for Coupled Cluster calculations
++===========================================================================
++===========================================================================
++ TRPINP: Property integral transformation
++===========================================================================
++ * Print level:    0
++ *The following operators will be transformed:
++---------------------------------------------------------------------------
+ 
+ 
+ 
+@@ -613,7 +743,6 @@
+      No explicit orbitals specified for index  2
+      No explicit orbitals specified for index  3
+      No explicit orbitals specified for index  4
+- * Size of batches for strategy 4 (parallel only):   -1
+ 
+ 
+  ********************************************************************************
+@@ -622,407 +751,540 @@
+ 
+ 
+ 
+- *************************************************************************
+- ************************ End of input processing ************************
+- *************************************************************************
++    *************************************************************************
++    ************************ End of input processing ************************
++    *************************************************************************
++
++
++
++   ***************************************************************************
++   ****************** Output from MOLECULE input processing ******************
++   ***************************************************************************
++
++
++
++  Title Cards
++  -----------
++
++  X                                                                       
++  X                                                                       
++
++  Coordinates are entered in Angstroms and converted to atomic units.
++          - Conversion factor : 1 bohr = 0.52917721 A
++
++  Nuclear Gaussian exponent for atom of charge  80.000 :    1.4011786759D+08
++  Nuclear Gaussian exponent for atom of charge   1.000 :    2.1248235902D+09
++
++
++                     SYMADD: Detection of molecular symmetry
++                     ---------------------------------------
++
++ Symmetry test threshold:  5.00E-06
++
++    The molecule has been centered at center of mass
++
++ Symmetry point group found: C(oo,v)        
+ 
++ The following symmetry elements were found: X  Y     
+ 
+ 
+-                        Generating Lowdin matrix:
+-                        -------------------------
++  Symmetry Operations
++  -------------------
+ 
+-   L   A1    * Deleted:          1(Proj:          1, Lindep:          0)
+-   L   B1    * Deleted:          0(Proj:          0, Lindep:          0)
+-   L   B2    * Deleted:          0(Proj:          0, Lindep:          0)
+-   L   A2    * Deleted:          0(Proj:          0, Lindep:          0)
+-   S   A1    * Deleted:          4(Proj:          4, Lindep:          0)
+-   S   B1    * Deleted:          1(Proj:          1, Lindep:          0)
+-   S   B2    * Deleted:          1(Proj:          1, Lindep:          0)
+-   S   A2    * Deleted:          0(Proj:          0, Lindep:          0)
++  Symmetry operations: 2
+ 
+ 
+-                       *** Output from MAKE_DKH ***
+-                       ----------------------------
+ 
+-* MAKE_DKH: Applied the restricted kinetic balance !
++                          SYMGRP:Point group information
++                          ------------------------------
+ 
+-   MAKE_DKH: All consistency checks are included for IPRHAM=  2
++Full group is:  C(oo,v)        
++Represented as: C2v
+ 
++   * The point group was generated by:
+ 
+-MAKE_DKH: Order of Douglas-Kroll : 9
++      Reflection in the yz-plane
++      Reflection in the xz-plane
+ 
+-MAKE_DKH: spinfree "before"
+-       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 1.3E+04
+-       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 8.4E+07
+-       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 8.4E+07
+-       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 1.2E+08
++   * Group multiplication table
+ 
+-  Free particle matrix in the ON basis "theta" in fermion corep 1/1
+-  *** Norm of the i,j,k imag. parts *** :0.000000E+00
++        |  E   C2z  Oxz  Oyz
++   -----+--------------------
++     E  |  E   C2z  Oxz  Oyz
++    C2z | C2z   E   Oyz  Oxz
++    Oxz | Oxz  Oyz   E   C2z
++    Oyz | Oyz  Oxz  C2z   E 
+ 
++   * Character table
+ 
+-   MAKE_DKH: Diagonalizing (Jacobi) the real part of the FP matrix in the ON "theta" basis !
++        |  E   C2z  Oxz  Oyz
++   -----+--------------------
++    A1  |   1    1    1    1
++    B1  |   1   -1    1   -1
++    B2  |   1   -1   -1    1
++    A2  |   1    1   -1   -1
+ 
++   * Direct product table
+ 
++        | A1   B1   B2   A2 
++   -----+--------------------
++    A1  | A1   B1   B2   A2 
++    B1  | B1   A1   A2   B2 
++    B2  | B2   A2   A1   B1 
++    A2  | A2   B2   B1   A1 
+ 
+-       MAKE_DKH: Free particle (in ON basis "theta") eigenvalues :
+-       -----------------------------------------------------------
+ 
+-   *** Fermion corep  1/ 1
+-Shell no    FP eigval  FP eigval+2c^2  bos.symm.   diff.
+-  1  -21 -0.129732E+06 -0.110953E+06    1   -.4802E-09
+-  2  -20 -0.836934E+05 -0.649145E+05    1   -.2256E-09
+-  3  -19 -0.836934E+05 -0.649145E+05    3   -.1892E-09
+-  4  -18 -0.836934E+05 -0.649145E+05    2   -.1892E-09
+-  5  -17 -0.822138E+05 -0.634350E+05    1   -.9895E-09
+-  6  -16 -0.545585E+05 -0.357796E+05    1   0.8004E-10
+-  7  -15 -0.510946E+05 -0.323157E+05    1   -.1128E-09
+-  8  -14 -0.510946E+05 -0.323157E+05    2   -.1364E-09
+-  9  -13 -0.510946E+05 -0.323157E+05    3   -.1364E-09
+- 10  -12 -0.425134E+05 -0.237345E+05    1   -.5957E-09
+- 11  -11 -0.404803E+05 -0.217014E+05    1   -.1096E-09
+- 12  -10 -0.404803E+05 -0.217014E+05    4   -.1501E-10
+- 13   -9 -0.404803E+05 -0.217014E+05    2   -.1546E-10
+- 14   -8 -0.404803E+05 -0.217014E+05    3   -.8640E-11
+- 15   -7 -0.404803E+05 -0.217014E+05    1   -.8640E-11
+- 16   -6 -0.396666E+05 -0.208877E+05    1   -.1378E-09
+- 17   -5 -0.396666E+05 -0.208877E+05    2   -.2674E-09
+- 18   -4 -0.396666E+05 -0.208877E+05    3   -.2674E-09
+- 19   -3 -0.379967E+05 -0.192179E+05    1   -.7850E-09
+- 20   -2 -0.375600E+05 -0.187811E+05    1   -.1429E-08
+- 21   -1 -0.375581E+05 -0.187792E+05    1   -.8020E-09
+- 22    1  0.346467E+00  0.187792E+05    1   -.8020E-09
+- 23    2  0.223659E+01  0.187811E+05    1   -.1429E-08
+- 24    3  0.439003E+03  0.192179E+05    1   -.7850E-09
+- 25    4  0.210882E+04  0.208877E+05    3   -.2674E-09
+- 26    5  0.210882E+04  0.208877E+05    2   -.2674E-09
+- 27    6  0.210882E+04  0.208877E+05    1   -.1378E-09
+- 28    7  0.292258E+04  0.217014E+05    2   -.8640E-11
+- 29    8  0.292258E+04  0.217014E+05    4   -.8640E-11
+- 30    9  0.292258E+04  0.217014E+05    3   -.1546E-10
+- 31   10  0.292258E+04  0.217014E+05    1   -.1501E-10
+- 32   11  0.292258E+04  0.217014E+05    1   -.1096E-09
+- 33   12  0.495565E+04  0.237345E+05    1   -.5957E-09
+- 34   13  0.135369E+05  0.323157E+05    3   -.1364E-09
+- 35   14  0.135369E+05  0.323157E+05    2   -.1364E-09
+- 36   15  0.135369E+05  0.323157E+05    1   -.1128E-09
+- 37   16  0.170007E+05  0.357796E+05    1   0.8004E-10
+- 38   17  0.446561E+05  0.634350E+05    1   -.9895E-09
+- 39   18  0.461356E+05  0.649145E+05    3   -.1892E-09
+- 40   19  0.461356E+05  0.649145E+05    2   -.1892E-09
+- 41   20  0.461356E+05  0.649145E+05    1   -.2256E-09
+- 42   21  0.921740E+05  0.110953E+06    1   -.4802E-09
++                            **************************
++                            *** Output from DBLGRP ***
++                            **************************
+ 
+-   MAKE_DKH: The average difference for e-p pairing of all
+-free particle eigenvalues in fermion symmetry 1/1    0.664817E-09
++   * One fermion irrep:   E1 
++   * Real group. NZ = 1
++   * Direct product decomposition:
++          E1  x E1  : A1  + A2  + B1  + B2 
+ 
+ 
+-                MAKE_DKH: Full unit <k|k>=C+.S.C matrix  
+-                -----------------------------------------
++                                 Spinor structure
++                                 ----------------
+ 
+-* Fermion irp no.1/1
+ 
+-  Sum of diagonal elements /N: 0.10000E+01
+-  Sum of off-diagonal elements : 0.36613E-13
++   * Fermion irrep no.: 1
++      La  |  A1 (1)  A2 (2)  |
++      Sa  |  A2 (1)  A1 (2)  |
++      Lb  |  B1 (3)  B2 (4)  |
++      Sb  |  B2 (3)  B1 (4)  |
+ 
+ 
+-                 MAKE_DKH: Diagonal <k_e|k_e>=A+.A matrix
+-                 ----------------------------------------
++                              Quaternion symmetries
++                              ---------------------
+ 
+-* Fermion irp no.1/1
++    Rep  T(+)
++    -----------------------------
++    A1   1
++    B1   j
++    B2   k
++    A2   i
+ 
+-  Sum of diagonal elements /N : 0.84270E+00
+-  Sum of off-diagonal elements : 0.12334E-14
++  QM-QM nuclear repulsion energy :     21.167088332000
+ 
+-         MAKE_DKH: "A" kinem. electr. factors; ferm irp:1/1
+ 
+-            A^2_ovlp          A^2_calc          diff;
+ 
+-           0.9999907753      0.9999907753    0.52180E-14
+-           0.9999404563      0.9999404563    0.99920E-14
+-           0.9885782673      0.9885782673    0.21094E-14
+-           0.9495199724      0.9495199724    0.75495E-14
+-           0.9495199724      0.9495199724    0.75495E-14
+-           0.9495199724      0.9495199724    0.85487E-14
+-           0.9326639752      0.9326639752    0.00000E+00
+-           0.9326639752      0.9326639752    0.00000E+00
+-           0.9326639752      0.9326639752    0.00000E+00
+-           0.9326639752      0.9326639752    -.11102E-15
+-           0.9326639752      0.9326639752    0.33307E-15
+-           0.8956024566      0.8956024566    0.88818E-15
+-           0.7905530164      0.7905530164    0.23315E-14
+-           0.7905530164      0.7905530164    0.23315E-14
+-           0.7905530164      0.7905530164    0.72164E-14
+-           0.7624242951      0.7624242951    0.17986E-13
+-           0.6480166494      0.6480166494    0.00000E+00
+-           0.6446430762      0.6446430762    -.88818E-15
+-           0.6446430762      0.6446430762    -.88818E-15
+-           0.6446430762      0.6446430762    0.39968E-14
+-           0.5846254366      0.5846254366    0.72164E-14
++                                 Isotopic Masses
++                                 ---------------
+ 
+-   DIFFERENCES A^2_ovlp-A^2_calc/N :0.405496E-14
++                           X         201.970617
++                           H           1.007825
+ 
+-  MAKE_DKH: Elim. spin-orbit comp. "BEFORE" from full H1 in TBUF
++                       Total mass:   202.978442 amu
++                       Natural abundance:  29.856 %
+ 
++ Center-of-mass coordinates (a.u.):       0.000000000000000   0.000000000000000   0.000000000000000
+ 
+ 
+-                      CHECK_R: A * R - B zero matrix
+-                      ------------------------------
++  Atoms and basis sets
++  --------------------
+ 
+-   * Fermion irp 1/1
+-   CHECK_R: Norm of A.R - B:.115394974462E-16
++  Number of atom types :    2
++  Total number of atoms:    2
+ 
++  label    atoms   charge   prim    cont     basis   
++  ----------------------------------------------------------------------
++  X           1      80      20      20      L  - [5s3p1d|5s3p1d]                                                
++  H           1       1       2       2      L  - [2s|2s]                                                        
++  ----------------------------------------------------------------------
++                             22      22      L  - large components
++                             55      55      S  - small components
++  ----------------------------------------------------------------------
++  total:      2      81      77      77
+ 
+-              CHECK_R: Final H(pp)*R+H(ep)-R*H(ee)-R*H(pe)*R
+-              ----------------------------------------------
++  Cartesian basis used.
++  Threshold for integrals (to be written to file):  1.00D-15
+ 
+-        Fermion corep 1/1   * norm: .149366743390E-09
+ 
++  References for the basis sets
++  -----------------------------
+ 
+-                      U1CHECK: Unit U1+ * U1 matrix
+-                      -----------------------------
++  Atom type   1   2
++  Basis set typed explicitly in input file                                        
+ 
+-   * fermion irp 1/1
+ 
+-  Sum of diagonal elements /N: 0.10000E+01
+-  Sum of off-diagonal elements :-0.29210E-14
++  Cartesian Coordinates (bohr)
++  ----------------------------
+ 
++  Total number of coordinates:  6
+ 
+-                   U1CHECK: Again unit U1+ * U1 matrix
+-                   -----------------------------------
+ 
+-   * fermion irp 1/1
++   1   X        x      0.0000000000
++   2            y      0.0000000000
++   3            z      0.0187656701
+ 
+-  Sum of diagonal elements /N: 0.10000E+01
+-  Sum of off-diagonal elements :-0.29213E-14
++   4   H        x      0.0000000000
++   5            y      0.0000000000
++   6            z     -3.7606865977
+ 
+-  U1CHECK: Elim. spin-orbit comp. "BEFORE" from  H1(ee) in |k>
+ 
+ 
++  Cartesian coordinates in XYZ format (Angstrom)
++  ----------------------------------------------
+ 
+-            U1CHECK: 2 times constructed H2c in ON |k_e> basis
+-            --------------------------------------------------
++    2
++ 
++X      0.0000000000   0.0000000000   0.0099303649
++H      0.0000000000   0.0000000000  -1.9900696351
+ 
+-  Difference between 2 H2c in |k_e> basis:  0.556080026E-10
+ 
++  Symmetry Coordinates
++  --------------------
+ 
+-       MAKE_DKH: *** 4c/2c electronic eigenvalues in |k> basis ***
+-       -----------------------------------------------------------
++  Number of coordinates in each symmetry:     2    2    2    0
+ 
+-   *** Fermion corep  1
+ 
+-                 4c |k>                  2c |k>            diff 4c-2c
++  Symmetry  A1 ( 1)
+ 
+-  1         -3236.0719838003         -3236.0719838004      0.10004E-10
+-  2          -666.1102369681          -666.1102369681     -0.70486E-11
+-  3          -484.6930272186          -484.6930272186     -0.81855E-11
+-  4          -484.6930119987          -484.6930119987     -0.88107E-11
+-  5          -484.6930119987          -484.6930119987      0.42064E-11
+-  6           -21.6367704194           -21.6367704194     -0.17444E-11
+-  7           -20.3646920050           -20.3646920050      0.32827E-11
+-  8           860.2027281682           860.2027281682      0.21600E-11
+-  9           860.2027332163           860.2027332163     -0.92086E-11
+- 10           860.2027332163           860.2027332163     -0.69349E-11
+- 11           860.2027483566           860.2027483566     -0.11482E-10
+- 12           860.2027483566           860.2027483566     -0.17394E-10
+- 13          6589.3364114013          6589.3364114013      0.20009E-10
+- 14          6589.3364145579          6589.3364145579      0.81855E-11
+- 15          6589.3364145580          6589.3364145580      0.18190E-11
+- 16          6779.9912032733          6779.9912032733     -0.27285E-11
+- 17         26566.1471385053         26566.1471385053      0.21828E-10
+- 18         29535.0133983962         29535.0133983963     -0.43656E-10
+- 19         29535.0133990459         29535.0133990459      0.54570E-10
+- 20         29535.0133990460         29535.0133990459      0.50932E-10
+- 21         59748.6160858676         59748.6160858674      0.17462E-09
++    1   X     z    3
++    2   H     z    6
+ 
+ 
+-                LOWDHAO: Full(L+S) unit C+ * S * C matrix
+-                -----------------------------------------
++  Symmetry  B1 ( 2)
+ 
+-   * fermion corep 1/1
++    3   X     x    1
++    4   H     x    4
+ 
+-  Sum of diagonal elements /N: 0.10000E+01
+-  Sum of off-diagonal elements : 0.57558E-13
+ 
++  Symmetry  B2 ( 3)
+ 
+-                   LOWDHAO: (LL) unit C+ * S * C matrix
+-                   ------------------------------------
++    5   X     y    2
++    6   H     y    5
+ 
+-   *** Fermion corep 1/1
+ 
+-  Sum of diagonal elements /N: 0.10000E+01
+-  Sum of off-diagonal elements : 0.21513E-13
++   Interatomic separations (in Angstroms):
++   ---------------------------------------
+ 
+-  LOWDHAO: Transforming H2c from AO "xhi" to ON Lowdin_L basis
++            X           H   
+ 
+-  LOWDHAO: Difference between various constructed H2c in AO basis: 0.33913E+04
++   X       0.000000
++   H       2.000000    0.000000
+ 
+ 
+-  Difference between various constructed H2c in Lowdin basis: 0.52900E+04
+ 
+ 
++  Bond distances (angstroms):
++  ---------------------------
+ 
+-         LOWDHAO: Electr. eigenv. of H(2c)/H(4c) in "theta" basis
+-         --------------------------------------------------------
++                  atom 1     atom 2                           distance
++                  ------     ------                           --------
++  bond distance:    H          X                              2.000000
+ 
+-   *** Fermion corep  1
+ 
+-    -21       -163745.9628988874
+-    -20       -109766.4091627979
+-    -19        -98263.9166309379
+-    -18        -97660.2507125821
+-    -17        -97660.2507121498
+-    -16        -62699.0373156405
+-    -15        -61337.8251471301
+-    -14        -56735.8818256817
+-    -13        -56735.8818235711
+-    -12        -46739.5121078201
+-    -11        -43934.8520198212
+-    -10        -43613.6808107422
+-     -9        -43613.6808034596
+-     -8        -42251.1320214283
+-     -7        -42251.1320136060
+-     -6        -42251.1319979688
+-     -5        -41671.9396359513
+-     -4        -41671.9396210424
+-     -3        -39401.3294452374
+-     -2        -37582.2335071497
+-     -1        -37579.6683961926
+-     1         -3236.0719838003         -3236.0719838003    0.40927E-11
+-     2          -666.1102369744          -666.1102369681    0.63131E-08
+-     3          -621.6459032252          -484.6930272186    0.13695E+03
+-     4          -417.4757122056          -484.6930119987   -0.67217E+02
+-     5          -417.4757012483          -484.6930119987   -0.67217E+02
+-     6           -21.6367704054           -21.6367704193   -0.13957E-07
+-     7           -20.3646919717           -20.3646920050   -0.33277E-07
+-     8           803.0610555687           860.2027281682    0.57142E+02
+-     9           803.0610694840           860.2027332163    0.57142E+02
+-    10           899.5011687780           860.2027332163   -0.39298E+02
+-    11           899.5011750728           860.2027483566   -0.39298E+02
+-    12           899.5011876600           860.2027483566   -0.39298E+02
+-    13          5622.9859361077          6589.3364114013    0.96635E+03
+-    14          6779.9912032728          6589.3364145579   -0.19065E+03
+-    15          7094.0397325779          6589.3364145579   -0.50470E+03
+-    16          7094.0397349051          6779.9912032733   -0.31405E+03
+-    17         26043.2377394187         26566.1471385053    0.52291E+03
+-    18         26566.1471385052         29535.0133983962    0.29689E+04
+-    19         31514.7993417130         29535.0133990459   -0.19798E+04
+-    20         31514.7993422125         29535.0133990459   -0.19798E+04
+-    21         59748.6160858669         59748.6160858677    0.76398E-09
+ 
+-  MAKE_DKH:Two-component BSS mode - positronic shells deleted !
++   Nuclear repulsion energy :   21.167088332000 Hartree
+ 
+ 
+-  GMOTRA: BSS relativistic atomic integrals and picture change
+-  transformation matrix were written to the new file BSSMAT.
++                      Nuclear contribution to dipole moments
++                      --------------------------------------
+ 
++                               au             Debye
+ 
+-  **********************************************************************
+-  ************************* Orbital dimensions *************************
+-  **********************************************************************
++                    z     -2.25943299     -5.74295899
+ 
+-No. of electronic orbitals (NESH):    21
+-No. of positronic orbitals (NPSH):     0
+-Total no. of orbitals      (NORB):    21
++                        1 Debye =   2.54177000 a.u. 
+ 
++Total time used in ONEGEN (CPU)  0.00263200s and (WALL)  0.00324607s
+ 
+- WARNING : linear symmetry is not implemented for spinfree or Levy-Leblond yet
+-           continue calculation in lower symmetry
+ 
++                       Generating Lowdin canonical matrix:
++                       -----------------------------------
+ 
+- **********************************************************************************************
+- ************************* Two-component relativistic HF calculations *************************
+- **********************************************************************************************
++       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 2.6D-02
++   L   A1    * Deleted:          1(Proj:          1, Lindep:          0) Smin: 0.26E-01
++       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 4.5D-01
++   L   B1    * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.45E+00
++       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 4.5D-01
++   L   B2    * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.45E+00
++       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 1.0D+00
++   L   A2    * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.10E+01
++       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 4.0D-02
++   S   A1    * Deleted:          4(Proj:          4, Lindep:          0) Smin: 0.40E-01
++       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 4.0D-02
++   S   B1    * Deleted:          1(Proj:          1, Lindep:          0) Smin: 0.40E-01
++       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 4.0D-02
++   S   B2    * Deleted:          1(Proj:          1, Lindep:          0) Smin: 0.40E-01
++       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 6.0D-01
++   S   A2    * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.60E+00
+ 
+ 
+-  ONEFCK: BSS transformed one-electron relativistic integrals were read from the file BSSMAT.
++                           *** Output from MAKE_BSS ***
++                           ----------------------------
+ 
+-*** INFO *** No trial vectors found. Using bare nucleus approximation for initial trial vectors.
+ 
+-########## START ITERATION NO.   1 ##########   Sun Dec  5 16:41:19 2004
+ 
+-It.   1    -10691.35545564      1.00E+20  0.00E+00  0.00E+00               0.00199999s   Bare nuc.   Sun Dec  5
++                  *** Output from the EXTR_BSS_INFO routine ***
++                  ---------------------------------------------
+ 
+-########## START ITERATION NO.   2##########   Sun Dec  5 16:41:19 2004
++  * Transforming the one-electron DIRAC bare nucleus operator.
++  * Order of the Douglas-Kroll-Hess/BSS transformation :...infinite  !
++  * Applied the preliminary free-particle ("k") basis transformation (two-step method). 
++  * R-equation solving applied : YR-equation 2 (Trond) 
++  * Elimination of spin-orbit terms from the Dirac bare nuclei in RKB/"k" basis (spinfree "BEFORE / AT THE BEGINNING")
++  * AMFI contribution is NOT included.
++  * Prepare the picture-change transformation matrixes
++      - special case - spin-free  
++  * I2COFK parameter for H2c specification set to:1
+ 
++  MAKE_BSS: 4c Lowdin AO to MO transf. matrix is  written to the BSSMAT file.
+ 
+-* GETGAB: label "GABAOXXX" not found; calling GABGEN.
++
++                                Output from MODHAM
++                                ------------------
++
++ * Applied strict kinetic balance !
++
++  HANDLE_RKB: RKB transf. matrix (TMAT, basic) has been written to the BSSMAT file.
++
++  HANDLE_RKB: BSSMAT file -  EOFLABEL added.
++
++  GET_A_FAC: Average differences for A-factors (fsym 1/1) : 0.45836351D-14
++
++  R matrix (in ON basis) was read from BSSMAT into VMAT.
++
++  H2CFINAL: H1AO_DK 
++
++   AO_LL elements were written into the BSSMAT file, EOFLABEL renewed.
++
++  GETPCTMAT: U1_ONBAS (4c ON->2c ON) read into TBUF.
++
++
++                                Output from LINSYM
++                                ------------------
++
++
++ Parity   MJ  Functions(total) Functions(LC) Functions(SC)
++     1    2/2          8            8            0
++     1    4/2          2            2            0
++
++
++        CMP_EIGVAL: Eigenvalues of H4c and H2c  Hamiltonians - comparison
++        -----------------------------------------------------------------
++
++        *** Fermion corep 1/1
++
++     -21       -163745.9628958011
++     -20       -101498.5164538892
++     -19       -101498.5164532745
++     -18       -101498.5164532736
++     -17        -98263.9166308309
++     -16        -62699.0373156246
++     -15        -58261.8837181770
++     -14        -58261.8837150353
++     -13        -58261.8837150346
++     -12        -46739.5121078193
++     -11        -42795.4291439501
++     -10        -42795.4291401592
++      -9        -42795.4291401592
++      -8        -42795.4291288378
++      -7        -42795.4291288378
++      -6        -42461.8986879892
++      -5        -42461.8986541794
++      -4        -42461.8986541793
++      -3        -39401.3294452367
++      -2        -37582.2335096555
++      -1        -37579.6684238590
++       1         -3236.0719837237         -3233.2186407425   -0.28533D+01
++       2          -666.1102369328          -664.5651063909   -0.15451D+01
++       3          -484.6930272181          -484.6930272173   -0.77148D-09
++       4          -484.6930119982           -21.6367703419   -0.46306D+03
++       5          -484.6930119982           -20.3646916349   -0.46433D+03
++       6           -21.6367704194             0.0000000000   -0.21637D+02
++       7           -20.3646920050             0.0000000000   -0.20365D+02
++       8           860.2027281682             0.0000000000    0.86020D+03
++       9           860.2027332163             0.0000000000    0.86020D+03
++      10           860.2027332164             0.0000000000    0.86020D+03
++      11           860.2027483566             0.0000000000    0.86020D+03
++      12           860.2027483566             0.0000000000    0.86020D+03
++      13          6589.3364114109             0.0000000000    0.65893D+04
++      14          6589.3364145675             0.0000000000    0.65893D+04
++      15          6589.3364145676             0.0000000000    0.65893D+04
++      16          6779.9912035175             0.0000000000    0.67800D+04
++      17         26566.1471391791          6286.2328868840    0.20280D+05
++      18         29535.0133986390          6589.3364114112    0.22946D+05
++      19         29535.0133992886         21540.9186642361    0.79941D+04
++      20         29535.0133992886         29535.0133986389    0.64972D-06
++      21         59748.6160887879         40911.9536790837    0.18837D+05
++ 
++
++  PROP2BSS: 2comp. operator (indxpr=  1) P2C_0001->Overlap matrix   was written to the BSSMAT file in LL block.
++  ...operator was NOT picture change transformed
++
++  PROP2BSS: 2comp. operator (indxpr=  2) P2C_0002->Nuc. attraction  was written to the BSSMAT file in LL block.
++  ...operator was NOT picture change transformed
++
++  PROP2BSS: 2comp. operator (indxpr=  3) P2C_0003->Beta matrix      was written to the BSSMAT file in LL block.
++  ...operator was NOT picture change transformed
++
++  PROP2BSS: 2comp. operator (indxpr=  4) P2C_0004->Kinetic energy   was written to the BSSMAT file in LL block.
++  ...operator was NOT picture change transformed
++
++  PROP2BSS: 2comp. operator (indxpr=  5) P2C_0005->Orbital z-moment was written to the BSSMAT file in LL block.
++  ...operator was NOT picture change transformed
++
++  PROP2BSS: 2comp. operator (indxpr=  6) P2C_0006->Spin z-momentum  was written to the BSSMAT file in LL block.
++  ...operator was picture change transformed
++
++  PROP2BSS: EOFLABEL was renewed after saving all 2c operators into BSSMAT.
++
++  MAKE_H2C: Two-component BSS mode - positronic shells deleted !
++
++  Coordinates are entered in Angstroms and converted to atomic units.
++          - Conversion factor : 1 bohr = 0.52917721 A
++
++  Nuclear Gaussian exponent for atom of charge  80.000 :    1.4011786759D+08
++  Nuclear Gaussian exponent for atom of charge   1.000 :    2.1248235902D+09
++
++
++                     SYMADD: Detection of molecular symmetry
++                     ---------------------------------------
++
++ Symmetry test threshold:  5.00E-06
++
++    The molecule has been centered at center of mass
++
++ Symmetry point group found: C(oo,v)        
++
++ The following symmetry elements were found: X  Y     
++
++
++                      Nuclear contribution to dipole moments
++                      --------------------------------------
++
++                               au             Debye
++
++                    z     -2.25943299     -5.74295899
++
++                        1 Debye =   2.54177000 a.u. 
++
++Total time used in ONEGEN (CPU)  0.00082800s and (WALL)  0.00096107s
++
++
++                       Generating Lowdin canonical matrix:
++                       -----------------------------------
++
++       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 2.6D-02
++   L   A1    * Deleted:          1(Proj:          1, Lindep:          0) Smin: 0.26E-01
++       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 4.5D-01
++   L   B1    * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.45E+00
++       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 4.5D-01
++   L   B2    * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.45E+00
++       LOWGEN: Smallest ".LINDEP" test value of a kept orbital: 1.0D+00
++   L   A2    * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.10E+01
++
++
++      **********************************************************************
++      ************************* Orbital dimensions *************************
++      **********************************************************************
++
++No. of positive energy orbitals (NESH):    21
++No. of negative energy orbitals (NPSH):     0
++Total no. of orbitals           (NORB):    21
++
++
++ *******************************************************************************
++ ************** Two-component BSS/DKH relativistic HF calculation **************
++ *******************************************************************************
++
++
++  GETH2CAO: asked for 2c Hamiltonian (param.I2COFK=7):H2CAO_LL
++
++*** INFO *** No trial vectors found.
++ Using bare nucleus approximation for initial trial vectors.
++             Improved by a sum of atomic screening potentials.
++
++
++########## START ITERATION NO.   1 ##########   Mon Oct  5 14:12:56 2020
++
++E_HOMO...E_LUMO, symmetry 1:     5 -58.86032    6  -0.38910
++
++=> Calculating sum of orbital energies
++It.    1    -6346.607026159      0.00D+00  0.00D+00  0.00D+00               0.00847100s   Atom. scrpot   Mon Oct  5
++
++########## START ITERATION NO.   2 ##########   Mon Oct  5 14:12:56 2020
++
++
++* GETGAB: label "GABAO1XX" not found; calling GABGEN.
+ SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00E-12    1.01%    8.21%    0.00%    0.00%   0.01499800s
+->>> Total wall time: 0.00000000s
+->>> Total CPU-time : 0.08498700s
++SOfock:LL  1.00D-12    0.00%    7.73%    0.09%    0.00%   0.00275700s
++E_HOMO...E_LUMO, symmetry 1:     5-257.42872    6 -18.99113
++>>> Total wall time:  0.01686811s, and total CPU time :  0.00808700s
+ 
+-########## END ITERATION NO.   2 ##########   Sun Dec  5 16:41:19 2004
++########## END ITERATION NO.   2 ##########   Mon Oct  5 14:12:56 2020
+ 
+-It.   2    -9503.967468302     -1.19E+03  4.19E+02  1.65E+02               0.08498700s   LL          Sun Dec  5
++It.    2    -9505.548827855      3.16D+03 -1.88D+02  5.90D+01               0.01686811s   LL             Mon Oct  5
+ 
+-########## START ITERATION NO.   3##########   Sun Dec  5 16:41:19 2004
++########## START ITERATION NO.   3 ##########   Mon Oct  5 14:12:56 2020
+ 
+-    3 *** Differential density matrix. DCOVLP     = 1.0071
++    3 *** Differential density matrix. DCOVLP     = 1.0024
+ SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00E-12    1.01%   10.87%    1.38%    1.15%   0.01499799s
+->>> Total wall time: 0.00000000s
+->>> Total CPU-time : 0.02499600s
++SOfock:LL  1.00D-12    0.00%   11.69%    0.09%    0.00%   0.00269200s
++E_HOMO...E_LUMO, symmetry 1:     5-257.50512    6 -18.99113
++>>> Total wall time:  0.01377892s, and total CPU time :  0.00509000s
+ 
+-########## END ITERATION NO.   3 ##########   Sun Dec  5 16:41:19 2004
++########## END ITERATION NO.   3 ##########   Mon Oct  5 14:12:56 2020
+ 
+-It.   3    -9505.779736187      1.81E+00 -1.49E+00  4.38E-01   DIIS   2    0.02499600s   LL          Sun Dec  5
++It.    3    -9505.779745785      2.31D-01 -5.25D-01  1.59D-01   DIIS   2    0.01377892s   LL             Mon Oct  5
+ 
+-########## START ITERATION NO.   4##########   Sun Dec  5 16:41:19 2004
++########## START ITERATION NO.   4 ##########   Mon Oct  5 14:12:56 2020
+ 
+     4 *** Differential density matrix. DCOVLP     = 1.0000
+ SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00E-12    3.14%   24.01%    1.42%    1.34%   0.01399803s
+->>> Total wall time: 0.00000000s
+->>> Total CPU-time : 0.02399498s
++SOfock:LL  1.00D-12    2.01%   24.66%    1.59%    1.43%   0.00261200s
++E_HOMO...E_LUMO, symmetry 1:     5-257.50512    6 -18.99113
++>>> Total wall time:  0.01277494s, and total CPU time :  0.00500000s
+ 
+-########## END ITERATION NO.   4 ##########   Sun Dec  5 16:41:19 2004
++########## END ITERATION NO.   4 ##########   Mon Oct  5 14:12:56 2020
+ 
+-It.   4    -9505.779747494      1.13E-05  4.13E-03  9.22E-04   DIIS   3    0.02399498s   LL          Sun Dec  5
++It.    4    -9505.779747270      1.49D-06  1.48D-03  4.27D-04   DIIS   3    0.01277494s   LL             Mon Oct  5
+ 
+-########## START ITERATION NO.   5##########   Sun Dec  5 16:41:19 2004
++########## START ITERATION NO.   5 ##########   Mon Oct  5 14:12:56 2020
+ 
+     5 *** Differential density matrix. DCOVLP     = 1.0000
+ SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00E-12    8.83%   29.82%    3.56%    4.47%   0.01399800s
+->>> Total wall time: 0.00000000s
+->>> Total CPU-time : 0.02299702s
++SOfock:LL  1.00D-12    4.75%   35.03%    1.15%    0.89%   0.00241700s
++E_HOMO...E_LUMO, symmetry 1:     5-257.50512    6 -18.99113
++>>> Total wall time:  0.01234078s, and total CPU time :  0.00468400s
+ 
+-########## END ITERATION NO.   5 ##########   Sun Dec  5 16:41:19 2004
++########## END ITERATION NO.   5 ##########   Mon Oct  5 14:12:56 2020
+ 
+-It.   5    -9505.779747494      4.73E-11  1.80E-06  1.25E-06   DIIS   4    0.02299702s   LL          Sun Dec  5
++It.    5    -9505.779747270      7.28D-12  8.55D-07  3.32D-07   DIIS   4    0.01234078s   LL             Mon Oct  5
+ 
+-########## START ITERATION NO.   6##########   Sun Dec  5 16:41:19 2004
++########## START ITERATION NO.   6 ##########   Mon Oct  5 14:12:56 2020
+ 
+     6 *** Differential density matrix. DCOVLP     = 1.0000
+ SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00E-12   25.91%   22.46%    9.41%   19.31%   0.01099795s
+->>> Total wall time: 0.00000000s
+->>> Total CPU-time : 0.02099702s
++SOfock:LL  1.00D-12   27.41%   20.03%    1.83%    4.79%   0.00145400s
++E_HOMO...E_LUMO, symmetry 1:     5-257.50512    6 -18.99113
++>>> Total wall time:  0.01191306s, and total CPU time :  0.00425000s
+ 
+-########## END ITERATION NO.   6 ##########   Sun Dec  5 16:41:19 2004
++########## END ITERATION NO.   6 ##########   Mon Oct  5 14:12:56 2020
+ 
+-It.   6    -9505.779747494      5.46E-12  2.47E-09  1.12E-09   DIIS   5    0.02099702s   LL          Sun Dec  5
++It.    6    -9505.779747270      7.28D-12  6.40D-10  3.18D-10   DIIS   4    0.01191306s   LL             Mon Oct  5
+ 
+-########## START ITERATION NO.   7##########   Sun Dec  5 16:41:19 2004
++########## START ITERATION NO.   7 ##########   Mon Oct  5 14:12:56 2020
+ 
+     7 *** Differential density matrix. DCOVLP     = 1.0000
+ SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00E-12   39.05%   47.81%    1.35%   18.30%   0.00899899s
+->>> Total wall time: 0.00000000s
+->>> Total CPU-time : 0.01799697s
++SOfock:LL  1.00D-12   52.76%   41.39%    0.69%   16.32%   0.00108500s
++>>> Total wall time:  0.01100397s, and total CPU time :  0.00366200s
+ 
+-########## END ITERATION NO.   7 ##########   Sun Dec  5 16:41:19 2004
++########## END ITERATION NO.   7 ##########   Mon Oct  5 14:12:56 2020
+ 
+-It.   7    -9505.779747494     -1.46E-11 -2.91E-11  3.65E-11   DIIS   5    0.01799697s   LL          Sun Dec  5
++It.    7    -9505.779747270      1.09D-11  8.73D-11  3.52D-11   DIIS   4    0.01100397s   LL             Mon Oct  5
+ 
+ 
+-                               SCF - CYCLE
+-                               -----------
++                                   SCF - CYCLE
++                                   -----------
+ 
+ * Convergence on norm of error vector (gradient).
+-  Desired convergence:1.000E-10
+-  Allowed convergence:1.000E-07
++  Desired convergence:1.000D-10
++  Allowed convergence:1.000D-07
+ 
+ * ERGVAL - convergence in total energy
+ * FCKVAL - convergence in maximum change in total Fock matrix
+@@ -1030,84 +1292,84 @@
+ --------------------------------------------------------------------------------------------------------------------------------
+            Energy               ERGVAL    FCKVAL    EVCVAL      Conv.acc    CPU          Integrals   Time stamp
+ --------------------------------------------------------------------------------------------------------------------------------
+-It.   1    -10691.35545564      1.00E+20  0.00E+00  0.00E+00               0.00199999s   Bare nuc.   Sun Dec  5
+-It.   2    -9503.967468302     -1.19E+03  4.19E+02  1.65E+02               0.08498700s   LL          Sun Dec  5
+-It.   3    -9505.779736187      1.81E+00 -1.49E+00  4.38E-01   DIIS   2    0.02499600s   LL          Sun Dec  5
+-It.   4    -9505.779747494      1.13E-05  4.13E-03  9.22E-04   DIIS   3    0.02399498s   LL          Sun Dec  5
+-It.   5    -9505.779747494      4.73E-11  1.80E-06  1.25E-06   DIIS   4    0.02299702s   LL          Sun Dec  5
+-It.   6    -9505.779747494      5.46E-12  2.47E-09  1.12E-09   DIIS   5    0.02099702s   LL          Sun Dec  5
+-It.   7    -9505.779747494     -1.46E-11 -2.91E-11  3.65E-11   DIIS   5    0.01799697s   LL          Sun Dec  5
++It.    1    -6346.607026159      0.00D+00  0.00D+00  0.00D+00               0.00847100s   Atom. scrpot   Mon Oct  5
++It.    2    -9505.548827855      3.16D+03 -1.88D+02  5.90D+01               0.01686811s   LL             Mon Oct  5
++It.    3    -9505.779745785      2.31D-01 -5.25D-01  1.59D-01   DIIS   2    0.01377892s   LL             Mon Oct  5
++It.    4    -9505.779747270      1.49D-06  1.48D-03  4.27D-04   DIIS   3    0.01277494s   LL             Mon Oct  5
++It.    5    -9505.779747270      7.28D-12  8.55D-07  3.32D-07   DIIS   4    0.01234078s   LL             Mon Oct  5
++It.    6    -9505.779747270      7.28D-12  6.40D-10  3.18D-10   DIIS   4    0.01191306s   LL             Mon Oct  5
++It.    7    -9505.779747270      1.09D-11  8.73D-11  3.52D-11   DIIS   4    0.01100397s   LL             Mon Oct  5
+ --------------------------------------------------------------------------------------------------------------------------------
+ * Convergence after    7 iterations.
+ * Average elapsed time per iteration: 
+-      No 2-ints :    0.00000000s
+-      LL        :    0.00000000s
++      No 2-ints    :    0.00896692s
++      LL           :    0.01311330s
+ 
+ 
+-                               TOTAL ENERGY
+-                               ------------
++                                   TOTAL ENERGY
++                                   ------------
+ 
+-   Electronic energy                        :    -9526.9468358256636
++   Electronic energy                        :    -9526.9468356019206
+ 
+    Other contributions to the total energy
+    Nuclear repulsion energy                 :       21.1670883320000
+ 
+    Sum of all contributions to the energy
+-   Total energy                             :    -9505.7797474936633
++   Total energy                             :    -9505.7797472699203
+ 
+ 
+-                               Eigenvalues
+-                               -----------
++                                   Eigenvalues
++                                   -----------
+ 
+ 
+ * Boson symmetry A1 
+   * Closed shell, f = 1.0000
+- -2941.25123226809  ( 2)     -457.80721004705  ( 2)     -257.50514000264  ( 2)
++ -2941.25123219522  ( 2)     -457.80721001068  ( 2)     -257.50514000229  ( 2)
+   * Virtual eigenvalues, f = 0.0000
+-   -18.99112858231  ( 2)      -17.71939273124  ( 2)     1077.52561948054  ( 4)     6952.39415603238  ( 2)     7144.19342453015  ( 2)
+- 27000.48461267307  ( 2)    29976.56904017511  ( 2)    60216.83941698664  ( 2)
++   -18.99112858231  ( 2)      -17.71939273125  ( 2)     1077.52561948049  ( 4)     6952.39415604068  ( 2)     7144.19342477336  ( 2)
++ 27000.48461334186  ( 2)    29976.56904041467  ( 2)    60216.83941990400  ( 2)
+ 
+ * Boson symmetry B1 
+   * Closed shell, f = 1.0000
+-  -257.50512395633  ( 2)
++  -257.50512395597  ( 2)
+   * Virtual eigenvalues, f = 0.0000
+-  1077.52562451694  ( 2)     6952.39415911992  ( 2)    29976.56904082861  ( 2)
++  1077.52562451688  ( 2)     6952.39415912822  ( 2)    29976.56904106820  ( 2)
+ 
+ * Boson symmetry B2 
+   * Closed shell, f = 1.0000
+-  -257.50512395632  ( 2)
++  -257.50512395597  ( 2)
+   * Virtual eigenvalues, f = 0.0000
+-  1077.52562451694  ( 2)     6952.39415911992  ( 2)    29976.56904082861  ( 2)
++  1077.52562451688  ( 2)     6952.39415912824  ( 2)    29976.56904106813  ( 2)
+ 
+ * Boson symmetry A2 
+   * Virtual eigenvalues, f = 0.0000
+-  1077.52563962093  ( 2)
++  1077.52563962086  ( 2)
+ 
+ * Occupation in fermion symmetry E1 
+   * Inactive orbitals
+-    A1  A1  A1  B1  B2  
++    A1  A1  A1  B2  B1  
+   * Virtual orbitals
+-    A1  A1  A1  B1  B2  A1  A2  A1  B1  B2  A1  A1  A1  B2  B1  A1  
++    A1  A1  A1  B2  B1  A2  A1  A1  B1  B2  A1  A1  A1  B2  B1  A1  
+ 
+-  Occupation of subblocks
+-                       E1 :  A1   B1   B2   A2              
++* Occupation of subblocks
++                       E1 :  A1   B1   B2   A2                                                              
+   closed shells (f=1.0000):    3    1    1    0
+  virtual shells (f=0.0000):    9    3    3    1
+-tot.num. of electr. shells:   12    4    4    1
++tot.num. of pos.erg shells:   12    4    4    1
+ 
+ 
+ * HOMO - LUMO gap:
+ 
+     E(LUMO) :   -18.99112858 au (symmetry A1 )
+-  - E(HOMO) :  -257.50512396 au (symmetry B2 )
++  - E(HOMO) :  -257.50512396 au (symmetry B1 )
+   ------------------------------------------
+     gap     :   238.51399537 au
+ 
+ 
+ 
+- **************************************************************************
+- **************** Transformation to Molecular Spinor Basis ****************
+- **************************************************************************
++    **************************************************************************
++    **************** Transformation to Molecular Spinor Basis ****************
++    **************************************************************************
+ 
+ 
+           Written by Luuk Visscher, Jon Laerdahl & Trond Saue
+@@ -1116,19 +1378,19 @@
+ 
+ 
+ 
+- ************************************************************************
+- **************** Transformation of 2-electron integrals ****************
+- ************************************************************************
++     ************************************************************************
++     **************** Transformation of 2-electron integrals ****************
++     ************************************************************************
+ 
+ 
+- Transformation started at : Sun Dec  5 16:41:19 2004
+-
+-* REACMO: Coefficients read from file DFCOEF - Total energy: -9505.77974749367786
+-* Heading :  LiH                                             Sun Dec  5 16:41:19 2004
+-     Energy selection of active orbitals :  -1000.00 < Eps. < ******** with a mininum gap of   0.1000 au.
+-     Energy selection of active orbitals :  -1000.00 < Eps. < ******** with a mininum gap of   0.1000 au.
+-     Energy selection of active orbitals :  -1000.00 < Eps. < ******** with a mininum gap of   0.1000 au.
+-     Energy selection of active orbitals :  -1000.00 < Eps. < ******** with a mininum gap of   0.1000 au.
++ Transformation started at : Mon Oct  5 14:12:56 2020
++
++* REACMO: Coefficients read from file DFCOEF - Total energy: -9505.77974726990942
++* Heading :  LiH                                             Mon Oct  5 14:12:56 2020
++     Energy selection of active orbitals :    -1000.00 < Eps. <    999999.00 with a mininum gap of     0.1000 au.
++     Energy selection of active orbitals :    -1000.00 < Eps. <    999999.00 with a mininum gap of     0.1000 au.
++     Energy selection of active orbitals :    -1000.00 < Eps. <    999999.00 with a mininum gap of     0.1000 au.
++     Energy selection of active orbitals :    -1000.00 < Eps. <    999999.00 with a mininum gap of     0.1000 au.
+ 
+ * Orbital ranges for 4-index transformation:
+ 
+@@ -1151,6 +1413,8 @@
+           2    3    4    5    6    7    8    9   10   11   12   13
+          14   15   16   17   18   19   20   21
+ 
++ (PAMTRA)  Orbitals read from DFCOEF
++
+ * Core orbital ranges for 2-index transformation:
+ 
+ 
+@@ -1160,9 +1424,9 @@
+           1
+ 
+ 
+- **************************************************************************
+- **************** Transformation to Molecular Spinor Basis ****************
+- **************************************************************************
++    **************************************************************************
++    **************** Transformation to Molecular Spinor Basis ****************
++    **************************************************************************
+ 
+ 
+           Written by Luuk Visscher, Jon Laerdahl & Trond Saue
+@@ -1171,90 +1435,95 @@
+ 
+ 
+ 
+-   ********************************************************************
+-   **************** Transformation of core Fock matrix ****************
+-   ********************************************************************
++       ********************************************************************
++       **************** Transformation of core Fock matrix ****************
++       ********************************************************************
+ 
+ 
+- Transformation started at : Sun Dec  5 16:41:19 2004
++ Transformation started at : Mon Oct  5 14:12:56 2020
+ 
+-* REACMO: Coefficients read from file DFCOEF - Total energy: -9505.77974749367786
+-* Heading :  LiH                                             Sun Dec  5 16:41:19 2004
++* REACMO: Coefficients read from file DFCOEF - Total energy: -9505.77974726990942
++* Heading :  LiH                                             Mon Oct  5 14:12:56 2020
+ SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00E-12   15.59%   20.70%    0.75%    2.21%   0.01499799s
++SOfock:LL  1.00D-12   15.59%   20.70%    0.75%    2.21%   0.00235999s
+ 
+-* REAFCK: Fock matrix read from file DFFCK1              
+-* Heading :  LiH                                             Sun Dec  5 16:41:19 2004
++* REAFCK: Fock matrix read from file /kyukon/home/gent/430/vsc43020/DIRAC_scratch_directory/vsc43
++* Heading :  LiH                                             Mon Oct  5 14:12:56 2020
+ 
+ 
+- Core energy (includes nuclear repulsion) :          -6388.2074957273
+- - Electronic part :                                 -6409.3745840593
+-   - One-electron terms :                            -6469.3406420395
+-   - Two-electron terms :                               59.9660579802
++ Core energy (includes nuclear repulsion) :          -6388.2074955762
++ - Electronic part :                                 -6409.3745839082
++   - One-electron terms :                            -6469.3406418861
++   - Two-electron terms :                               59.9660579779
+ 
+ 
+  MOLFDIR file MRCONEE is written
+  - Integral class 1 : (LL|??)
+-   - Beginning with task   1 of   4 after      0.00 seconds
+-                                and after      0.00 CPU-seconds
+-   - Beginning with task   2 of   4 after      0.00 seconds
+-                                and after      0.05 CPU-seconds
+-   - Beginning with task   3 of   4 after      0.00 seconds
+-                                and after      0.19 CPU-seconds
+-   - Beginning with task   4 of   4 after      0.00 seconds
+-                                and after      0.35 CPU-seconds
+- - Integral class 2 : (SS|??)
+- - Integral class 3 : (LS|??)
++   - Beginning task   1 of   4 after      0. seconds and      0. CPU-seconds
++   - Beginning task   2 of   4 after      0. seconds and      0. CPU-seconds
++   - Beginning task   3 of   4 after      0. seconds and      0. CPU-seconds
++   - Beginning task   4 of   4 after      0. seconds and      0. CPU-seconds
+ * Screening statistics:
+    (LL|LL)ints :   0.00%
+    Total       :   0.00%
+- - Starting symmetrization after           0.00 seconds
+- - Finished symmetrization after           0.00 seconds
+- - MOLFDIR file MDCINT was written.
+ 
+------- Timing report (in CPU seconds) of module  integral transformation      
++ - Starting symmetrization after           0.03 seconds
++ - Finished symmetrization after           0.04 seconds
++
++ - Binary  file MDCINT was written.
+ 
+- Time in  Initializing MS4IND fi       0.025 seconds
+- Time in  Computing+transform. i       0.431 seconds
+- Time in  Symmetrizing MO integr       0.038 seconds
++------ Timing report (in CPU seconds) of module  integral transformation      
+ 
++ Time in  Initializing MS4IND file            0.004 seconds
++ Time in  Computing+transform. integral       0.029 seconds
++ Time in  Symmetrizing MO integrals           0.004 seconds
+ 
+- Total wall time used in PAMTRA :   00:00:01
+- Total CPU  time used in PAMTRA (master only) :   00:00:01
+ 
++ Total wall time used in PAMTRA :   00:00:00
++ Total CPU  time used in PAMTRA (master only) :   00:00:00
+ 
++ Transformation ended at : Mon Oct  5 14:12:56 2020
+ 
+- Transformation ended at : Sun Dec  5 16:41:20 2004
+ 
+ ---< Process     1 of     1----<
+ 
+ 
+ 
+  Relativistic Coupled Cluster program RELCCSD
+- Version number 2.3 
+- Version date September 2002
+ 
+  Written by :
+- Lucas (Luuk) Visscher
++    Lucas Visscher
+ 
+- NASA Ames Research Center    (1994)
+- Rijks Universiteit Groningen (1995)
+- Odense Universitet           (1996-1997)
+- Vrije Universiteit Amsterdam (1998-2002)
++    NASA Ames Research Center    (1994)
++    Rijks Universiteit Groningen (1995)
++    Odense Universitet           (1996-1997)
++    VU University Amsterdam      (1998-present)
+ 
+ 
+  This module is documented in
+   - Initial implementation : L. Visscher, T.J. Lee and K.G. Dyall, J. Chem. Phys. 105 (1996) 8769.
+-  - Fock space formalism :   L. Visscher, E. Eliav and U. Kaldor, J. Chem. Phys. 115 (2002) 9720.
++  - Fock Space (FSCC):       L. Visscher, E. Eliav and U. Kaldor, J. Chem. Phys. 115 (2002) 9720.
++  - Intermediate Hamiltonian E. Eliav, M. J. Vilkas, Y. Ishikawa, and U. Kaldor, J. Chem. Phys. 122 (2005) 224113.
+   - Parallelization :        M. Pernpointner and L. Visscher, J. Comp. Chem. 24 (2003) 754.
++  - MP2 expectation values : J.N.P. van Stralen, L. Visscher, C.V. Larsen and H.J.Aa. Jensen," Chem. Phys. 311 (2005) 81.
++  - CC  expectation values : A. Shee, L. Visscher, and T. Saue, J. Chem. Phys. 145 (2016) 184107.
++  - EOM-IP/EA/EE energies  : A. Shee, T. Saue, L. Visscher, and A.S.P. Gomes, J. Chem. Phys. 149 (2018) 174113.
+ 
+ 
+- Today is :    5 Dec 04 
+- The time is :  16:41:20
++ Today is :     5 Oct 20
++ The time is :  14:12:56
+ 
+  Initializing word-addressable I/O : the FORTRAN-interface is used with    16 KB records
++===========================================================================
++ **RELCC: Set-up for Coupled Cluster calculations
++===========================================================================
++ * General print level   :   1
++ NEL_F1:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ 
+- Total memory available :                                76 MB
++ Total memory available :       16384.00 MB   16.000 GB
++ 
++ INFO: No old restart file(s) found!
++ 
+ 
+  Configuration in highest pointgroup
+ 
+@@ -1262,7 +1531,6 @@
+  Spinor class : occupied                   4    4
+  Spinor class : virtual                   16   16
+ 
+-
+  Configuration in abelian subgroup
+ 
+                                         A1 a B1 a B2 a A2 a A1 b B1 b B2 b A2 b
+@@ -1271,6 +1539,7 @@
+ 
+ 
+  Number of electrons :                     8
++ Total charge of the system :             71
+  Number of virtual spinors :              32
+  Complex arithmetic mode :                 F
+  Do integral sorting     :                 T
+@@ -1280,39 +1549,48 @@
+  Debug information       :                 F
+  Timing information      :                 T
+  Print level          :                    1
+- Memory limit (MWord) :                   10
++ Memory limit (MWord) :                      2048
+  Interface used       :                DIRAC     
+ 
+ 
+- Memory for reading and sorting integrals :          157514 8-byte words
+- Core used for calculating amplitudes :               34890 8-byte words
+- Core used for in core evaluation of triples :        31100 8-byte words
+- Core used for Gradient calculation :               9999998 8-byte words
+- Core used for RPA calculation :                      19533 8-byte words
+- Memory for reading and sorting integrals :         1511114 8-byte words
+- Core used for Fock space CCSD energies :           1511114 8-byte words
+- Memory used for active modules :                    157514 8-byte words
++ Leave after calculating the total memory demand :          F
++ Memory for reading and sorting integrals :               256030 8-byte words
++ Core used for calculating amplitudes :                    34680 8-byte words
++ Core used for in core evaluation of triples :             32644 8-byte words
++ Memory used for active modules :                         256030 8-byte words
+ 
+- Expanding and sorting integrals to unique types :
+- Type OOOO :        92 integrals
+- Type VOOO :       768 integrals
+- Type VVOO :      1512 integrals
+- Type VOVO :      6912 integrals
+- Type VOVV :     13440 integrals
+- Type VVVV :     26272 integrals
++ Predicted RelCC memory demand:            1.95 MB
++ Predicted RelCC memory demand:           0.002 GB
+ 
+- Sorting of first 4 classes done.
++ Expanding and sorting integrals to unique types :
++ Type OOOO :              92 integrals
++ Type VOOO :             768 integrals
++ Type VVOO :            1512 integrals
++ Type VOVO :            6912 integrals
++ Type VOVV :           13440 integrals
++ Type VVVV :           26272 integrals
++ 
++ Start sorting of integral classes at   5 Oct 20 14:12:56
++ 
++ 
++ Sorting of first 4 classes done at   5 Oct 20 14:12:56
+ 
+  Need      1 passes to sort VOVV integrals
+- VOVV sorting done.
++ 
++ Pass     1 ended at   5 Oct 20 14:12:56
++ 
++ VOVV sorting done at   5 Oct 20 14:12:56
+ 
+  Need      1 passes to sort VVVV integrals
+- VVVV sorting done.
++ 
++ Pass     1 ended at   5 Oct 20 14:12:56
++ 
++ VVVV sorting done at   5 Oct 20 14:12:56
+ 
+  Reading Coulomb integrals :
+- File date :       5Dec04  
+- File time :       16:41:20
+- # of integrals           22964
++ File date :       5 Oct 20
++ File time :       14:12:56
++ # of integrals               23323
+ 
+  Finished sorting of integrals
+ 
+@@ -1322,16 +1600,16 @@
+  are given if above a treshold or if iprnt > 1
+ 
+  Spinor   Abelian Rep.         Energy   Recalc. Energy
+-  O    1    1  A1 a     -457.8072100470 -457.8072100470
+-  O    2    2  A1 a     -257.5051400026 -257.5051400026
+-  O    1    3  B1 a     -257.5051239563 -257.5051239563
+-  O    1    4  B2 a     -257.5051239563 -257.5051239563
+-  O    1    5  A1 b     -457.8072100470 -457.8072100470
+-  O    2    6  A1 b     -257.5051400026 -257.5051400026
+-  O    1    7  B1 b     -257.5051239563 -257.5051239563
+-  O    1    8  B2 b     -257.5051239563 -257.5051239563
++  O    1    1  A1 a     -457.8072100107 -457.8072100107
++  O    2    2  A1 a     -257.5051400023 -257.5051400023
++  O    1    3  B1 a     -257.5051239560 -257.5051239560
++  O    1    4  B2 a     -257.5051239560 -257.5051239560
++  O    1    5  A1 b     -457.8072100107 -457.8072100107
++  O    2    6  A1 b     -257.5051400023 -257.5051400023
++  O    1    7  B1 b     -257.5051239560 -257.5051239560
++  O    1    8  B2 b     -257.5051239560 -257.5051239560
+ 
+- The diagonal elements of the recomputed Fock matrix (right column) are used in perturbation expressions.
++ The original energies (left column) are used in perturbation expressions.
+ 
+  Use the perturbative values (MP2, CCSD[T]/(T)/-T) with care, especially
+  in  open shell calculations because the orbitals need not always be
+@@ -1339,11 +1617,11 @@
+  The missing terms may be important !
+ 
+ 
+- Nuclear repulsion + core energy :         -6388.207495727295282
+- Zero order electronic energy :            -2460.645195924678774
+- First order electronic energy :            -656.927055841711194
+- Electronic energy :                       -3117.572251766389854
+- SCF energy :                              -9505.779747493685136
++ Nuclear repulsion + core energy :         -6388.207495576216388
++ Zero order electronic energy :            -2460.645195849844640
++ First order electronic energy :            -656.927055843850439
++ Electronic energy :                       -3117.572251693694852
++ SCF energy :                              -9505.779747269911240
+ 
+ 
+  Energy calculations
+@@ -1354,10 +1632,10 @@
+ 
+   MP2 results
+ 
+- SCF energy :                              -9505.779747493685136
+- MP2 correlation energy :                     -0.221846247868006
+- Total MP2 energy :                        -9506.001593741553734
+- T1 diagnostic :                               0.000000000000017
++ SCF energy :                              -9505.779747269911240
++ MP2 correlation energy :                     -0.221846247868917
++ Total MP2 energy :                        -9506.001593517779838
++ T1 diagnostic :                               0.000000000000010
+ 
+ 
+  CCSD options :
+@@ -1367,49 +1645,48 @@
+ 
+ 
+    NIT          ENERGY                    RMS       T1-DIAGN
+-    0       -0.221846247868006   1.000000000000000   0.00000
+-    1       -0.222543090352100   0.000169723714323   0.00000
+-    2       -0.222547639799351   0.000001146914982   0.00000
+-    3       -0.222547639196545   0.000000002916755   0.00000
+-    4       -0.222547639201801   0.000000000004730   0.00000
+-    5       -0.222547639201729   0.000000000000043   0.00000
++    0       -0.221846247868917   1.000000000000000   0.00000
++    1       -0.222543090353008   0.000001024031689   0.00000
++    2       -0.222547639800258   0.000000012409001   0.00000
++    3       -0.222547639197452   0.000000000073854   0.00000
++    4       -0.222547639202709   0.000000000000097   0.00000
+ 
+ 
+   CCSD results
+ 
+- SCF energy :                              -9505.779747493685136
+- CCSD correlation energy :                    -0.222547639201729
+- Total CCSD energy :                       -9506.002295132886502
+- T1 diagnostic :                               0.000000727335985
+- Convergence :                                 0.000000000000043
+- Number or iterations used :                                   5
++ SCF energy :                              -9505.779747269911240
++ CCSD correlation energy :                    -0.222547639202709
++ Total CCSD energy :                       -9506.002294909114426
++ T1 diagnostic :                               0.000000727335984
++ Convergence :                                 0.000000000000097
++ Number or iterations used :                                   4
+ 
+ 
+  Performance of BLAS GEMM in the largest contractions
+ 
+  Contraction type                           Performance
+- VVVV+VOVV (in B: includes I/O)             79.87   Mflop/s
+- VOVO (in H: only XGEMM)                    321.9   Mflop/s
+- VOVO (in T2EQN: includes sort)             173.3   Mflop/s
++ VVVV+VOVV (in B: includes I/O)             942.4   Mflop/s
++ VOVO (in H: only XGEMM)                    15.67   Gflop/s
++ VOVO (in T2EQN: includes sort)             3.129   Gflop/s
+ 
+ 
+   Perturbative treatment of triple excitations
+ 
+- SCF energy :                              -9505.779747493685136
+- CCSD correlation energy :                    -0.222547639201729
++ SCF energy :                              -9505.779747269911240
++ CCSD correlation energy :                    -0.222547639202709
+  4th order triples correction :               -0.000001799879971
+  5th order triples (T) correction :           -0.000000000059407
+  5th order triples -T  correction :           -0.000000000472828
+- Total CCSD+T  energy :                    -9506.002296932767422
+- Total CCSD(T) energy :                    -9506.002296932825629
+- Total CCSD-T  energy :                    -9506.002296933240359
++ Total CCSD+T  energy :                    -9506.002296708993526
++ Total CCSD(T) energy :                    -9506.002296709053553
++ Total CCSD-T  energy :                    -9506.002296709466464
+ 
+ 
+ --------------------------------------------------------------------------------
+ 
+ 
+- Today is :    5 Dec 04 
+- The time is :  16:41:20
++ Today is :     5 Oct 20
++ The time is :  14:12:56
+ 
+  Status of the calculations
+  Integral sort # 1 :                   Completed, restartable        
+@@ -1418,166 +1695,196 @@
+  MP2 energy calculation :              Completed, restartable        
+  CCSD energy calculation :             Completed, restartable        
+  CCSD(T) energy calculation :          Completed, restartable        
++ CCSD(T) energy calculation :          Completed, restartable        
+ 
+  Overview of calculated energies
+-@ SCF energy :                             -9505.779747493685136
+-@ MP2 correlation energy :                    -0.221846247868006
+-@ CCSD correlation energy :                   -0.222547639201729
++@ SCF energy :                             -9505.779747269911240
++@ MP2 correlation energy :                    -0.221846247868917
++@ CCSD correlation energy :                   -0.222547639202709
+ @ 4th order triples correction :              -0.000001799879971
+ @ 5th order triples (T) correction :          -0.000000000059407
+ @ 5th order triples -T  correction :          -0.000000000472828
+-@ Total MP2 energy :                       -9506.001593741553734
+-@ Total CCSD energy :                      -9506.002295132886502
+-@ Total CCSD+T  energy :                   -9506.002296932767422
+-@ Total CCSD(T) energy :                   -9506.002296932825629
+-@ Total CCSD-T  energy :                   -9506.002296933240359
++@ Total MP2 energy :                       -9506.001593517779838
++@ Total CCSD energy :                      -9506.002294909114426
++@ Total CCSD+T  energy :                   -9506.002296708993526
++@ Total CCSD(T) energy :                   -9506.002296709053553
++@ Total CCSD-T  energy :                   -9506.002296709466464
+ 
+ 
+ --------------------------------------------------------------------------------
+ 
+ ------ Timing report (in CPU seconds) of module  RELCCSD                      
+ 
+- Time in Sorting of integrals          0.234 seconds
+- Time in CCSD equations                0.123 seconds
+- Time in - T1 equations                0.020 seconds
+- Time in --- T1EQNS HOV*T2(A,C,I       0.001 seconds
+- Time in --- T1EQNS VOVV contrib       0.005 seconds
+- Time in --- T1EQNS VOVO * T(C,K       0.004 seconds
+- Time in - T2 equations                0.090 seconds
+- Time in -- GVINTM                     0.010 seconds
+- Time in -- AINTM                      0.003 seconds
+- Time in -- HINTM                      0.029 seconds
+- Time in --- HINTM: VOVV*T             0.011 seconds
+- Time in --- HINTM: VVOO contrib       0.007 seconds
+- Time in -- T2 EQNS                    0.028 seconds
+- Time in --- T2EQNS: TAU*AINTM c       0.002 seconds
+- Time in --- T2EQNS: VOVV*T1           0.005 seconds
+- Time in --- T2EQNS: HINTM*T2          0.013 seconds
+- Time in -- BINTM                      0.020 seconds
+- Time in - DIIS extrapolation          0.010 seconds
+- Time in CCSD(T) evaluation            0.043 seconds
+- Time in -- T3CORR: Integral res       0.002 seconds
+- Time in -- T3CORR: VOVV contrac       0.020 seconds
+- Time in -- T3CORR: energy calcu       0.019 seconds
++ Time in Sorting of integrals                 0.053 seconds
++ Time in CCSD equations                       0.010 seconds
++ Time in - T1 equations                       0.002 seconds
++ Time in --- T1EQNS T*[HOV - F]*T             0.000 seconds
++ Time in --- T1EQNS HOV*T2(A,C,I,K            0.000 seconds
++ Time in --- T1EQNS   HV*T / T*HO             0.000 seconds
++ Time in --- T1EQNS VOOO*TAU                  0.000 seconds
++ Time in --- T1EQNS VOVV contribution         0.001 seconds
++ Time in --- T1EQNS VOVO * T(C,K)             0.000 seconds
++ Time in -- GOINTM                            0.000 seconds
++ Time in -- GVINTM                            0.001 seconds
++ Time in -- AINTM                             0.000 seconds
++ Time in -- HINTM                             0.002 seconds
++ Time in --- HINTM: VOVV*T                    0.001 seconds
++ Time in --- HINTM: VVOO contribution         0.000 seconds
++ Time in -- T2 EQNS                           0.003 seconds
++ Time in --- T2EQNS: TAU*AINTM contract       0.000 seconds
++ Time in --- T2EQNS: VOVV*T1                  0.001 seconds
++ Time in --- T2EQNS: HINTM*T2                 0.001 seconds
++ Time in -- BINTM                             0.001 seconds
++ Time in - adding partial T1/T2 amplitu       0.000 seconds
++ Time in - DIIS extrapolation                 0.001 seconds
++ Time in - synchronizing T1 & T2 amplit       0.000 seconds
++ Time in CCSD(T) evaluation                   0.003 seconds
++ Time in -- T3CORR: Integral resorting        0.000 seconds
++ Time in -- T3CORR: VOVV contraction          0.001 seconds
++ Time in -- T3CORR: energy calculation        0.002 seconds
+ 
+ 
+  Timing of main modules :         Wallclock (s)       CPU on master (s)
+- Before CC driver :                  2.00                     0.89
+- Initialization :                    0.00                     0.00
+- Integral sorting :                  0.00                     0.23
+- Energy calculation :                0.00                     0.17
++ Before CC driver :          ************                     0.21
++ Initialization :                    0.10                     0.10
++ Integral sorting :                  0.05                     0.05
++ Energy calculation :                0.08                     0.07
+  First order properties :            0.00                     0.00
+  Second order properties :           0.00                     0.00
+  Fock space energies :               0.00                     0.00
++ EOMCC energies :                    0.00                     0.00
+  Untimed parts :                     0.00                     0.00
+- Total time in CC driver :             0.                     0.41
++ Total time in CC driver :             0.                     0.23
+ 
+  Statistics for the word-addressable I/O
+- Number of write calls                                 519.
+- Number of read calls                                  538.
+- Megabytes written                                    0.566
+- Megabytes read                                       5.543
+- Seconds spent in reads                               0.000
+- Seconds spent in writes                              0.000
+- average I/O speed for write (Mb/s)                   0.000
+- average I/O speed for read  (Mb/s)                   0.000
++ Number of write calls                                 409.
++ Number of read calls                                  428.
++ Megabytes written                                    0.265
++ Megabytes read                                       2.215
++ Seconds spent in reads                               0.004
++ Seconds spent in writes                              0.004
++ average I/O speed for write (Mb/s)                  74.410
++ average I/O speed for read  (Mb/s)                 598.620
+ 
+ 
+- CPU time (seconds) used in RELCCSD:                     0.4089
+- CPU time (seconds) used before RELCCSD:                 0.8869
+- CPU time (seconds) used in total sofar:                 1.2958
++ CPU time (seconds) used in RELCCSD:                     0.2306
++ CPU time (seconds) used before RELCCSD:                 0.2148
++ CPU time (seconds) used in total sofar:                 0.4454
+ 
+   --- Normal end of RELCCSD Run ---
+ 
+ 
+ ################################################################################
+-
+-
+- ********************************************************************************
+-                                                                                 
+-                                                                                 
+-                                                                                 
+- D I R L U C                                                                     
+- An interface section for LUCIA under DIRAC                                      
+-                                                                                 
+- author:                                                                         
+- T. Fleig                                                                        
+- Theoretische Chemie und Computerchemie,                                         
+- Heinrich-Heine-Universitaet Duesseldorf
+-                                                                                 
+-    Calling LUCIA version 1999                                                   
+-      author: J. Olsen, Lund/Aarhus                                              
+-                                                                                 
+-      Traditional sigma vector and density modules.                              
+-                                                                                 
+- ********************************************************************************
+-
+-
++ 
++ 
++ **********************************************************************
++ **********************************************************************
++                                                                       
++                                                                       
++ D I R L U C                                                           
++ An interface section for LUCIA under DIRAC                            
++                                                                       
++ author:                                                               
++ T. Fleig                                                              
++ Theoretische Chemie und Computerchemie,                               
++ Heinrich-Heine-Universitaet Duesseldorf                               
++                                                                       
++    Calling LUCIA version 1999                                         
++      author: J. Olsen, Lund/Aarhus                                    
++                                                                       
++      Traditional sigma vector and density modules.                    
++                                                                       
++ Citation:                                                             
++   J. Olsen, P. Joergensen, J. Simons,                                 
++           Chem. Phys. Lett. 169 (1990) 463                            
++   T. Fleig, L. Visscher,                                              
++           Chem. Phys. 311 (2005) 113                                  
++                                                                       
++                                                                       
++ Parallelization of LUCIA, Duesseldorf/Odense:                         
++ S. Knecht                                                             
++ Theoretische Chemie und Computerchemie,                               
++ Heinrich-Heine-Universitaet Duesseldorf                               
++                                                                       
++ Citation:                                                             
++   S. Knecht, H. J. Aa. Jensen and T. Fleig,                           
++           J. Chem. Phys., 128 (2008) 014108                           
++                                                                       
++ **********************************************************************
++ **********************************************************************
++ 
++ 
+  ********************************************************************************
+  *                                                                              *
+  *                                    Title:                                    *
+  *    Running LUCIA under DIRAC. No title supplied.                             *
+  *                                                                              *
+  ********************************************************************************
+-
++ 
+    Orbitals as initial wave function .... HF_SCF
+-
++ 
+    Type of calculation .................. SDCI  
+-
++ 
+    Number of roots to be obtained .......   1
+-
++ 
+    Calculation carried out in irrep .....   1
+-
++ 
+    Spin multiplicity ....................   3
+-
++ 
+    Global print level is ................ NON
+-
++ 
+    Local print level is .................   0
+-
++ 
+    Approximate size of CI calculation ... NOR
++ 
++   Running the CI calculation ........... sequenti
++ 
++   Using MPI-FILE I/O ................... No 
++ 
+ 
++  Truncation Factor .....................   0.00D+00
++ 
+    Number of active electrons ...........   8
+-
+-          Dimension of R*8 workspace :     10000000
+-
++ 
++          Dimension of R*8 workspace :           64000000
+  Integral import from DIRAC.
+  No checking of environment dims.
+-
++ 
+  *************************************
+  *  Symmetry and spin of CI vectors  *
+  *************************************
+-
+-      Point group ............ D2H
+-        Using subgroup ......... D2 
+-          (D2 equiv. C2v, C2 eq. Cs) 
+-      Spatial symmetry ....... 1
+-      2 times spinprojection   2
+-      Spin multiplicity ....   3
+-      Active electrons .....   8
+-
++ 
++     Point group ............ D2h
++       Using subgroup ......... D2 
++         (D2 equiv. C2v, C2 eq. Cs) 
++     Spatial symmetry ....... 1
++     2 times spinprojection   2
++     Spin multiplicity ....   3
++     Active electrons .....   8
++ 
+  *********************************************
+  *  Shell spaces and occupation constraints  *
+  ********************************************* 
+-
+-
++ 
++ 
+   *************************
+   Generalized active space 
+   *************************
+-
++ 
+  Orbital subspaces:
+  ================== 
+-
+-                 Irrep    1   2   3   4
+-                 =====   ================
++ 
++                Irrep    1   2   3   4
++                =====   ================
+         GAS 1             2   1   1   0
+         GAS 2             9   3   3   1
+-
++ 
+  *******************
+   Occupation spaces 
+  *******************
+-
++ 
+  Number of Occupation spaces :   1
+-
++ 
+  Bounds on accumulated occupations for space :   1
+  ====================================================== 
+ 
+@@ -1585,180 +1892,259 @@
+          ========    ======== 
+    GAS 1     6           8
+    GAS 2     8           8
+-
++ 
+   **************************************************
+   Specification of CI Spaces (combinations of above)
+   **************************************************
+-
+-
++ 
++ 
+  Number of CI spaces included :   1
+-
+-
++ 
++ 
+  Information about CI space   1
+  ==================================
+-    Number of occupation spaces included    1
++   Number of occupation spaces included    1
+     Occupation spaces included   1
+-
++ 
+   ******************************************
+   Specification of Sequence of calculations 
+   ******************************************
+-
+-
++ 
++ 
+         CI space   1
+         ==============
+-
++ 
+                  Normal CI with max. iterations = 100
+-
+-
++ 
++ 
+  ***********
+  *  Roots  *
+  *********** 
+-
+-      Number of roots to be obtained   1
+-      Roots to be obtained   1
+-
++ 
++     Number of roots to be obtained   1
++     Roots to be obtained   1
++ 
+  **************************
+  *  Run time definitions  *
+  ************************** 
+-
++ 
+       Program environment... DIRAC 
+-      All integrals stored in core
+-
+-      CI optimization performed with SD's 
+-
+-      Initial vectors obtained from diagonal
+-      No combination of degenerate initial vectors
+-
++     All integrals stored in core
++ 
++     CI optimization performed with SD's 
++ 
++     Initial vectors obtained from diagonal
++     No combination of degenerate initial vectors
++ 
+       3 symmetry-occ-occ blocks will be held in core 
+       Smallest allowed size of sigma- and C-batch     100000
+-      Dimension of block of resolution strings 1000
+-      Particle-hole separation used 
+-      Advice routine call to optimize sigma generation
+-      Strings not divided into active and passive parts
+-
+-      No calculation of density matrices  
+-
+-      CI diagonalization : 
+-      ==================== 
+-         No subspace Hamiltonian 
+-         Diagonalizer : MICDV* 
+-         No root homing 
+-         Initial energy evaluations skipped after first calc
+-         (Only active in connection with TERACI )
+-         Allowed Dimension of CI subspace 3
+-         Convergence threshold for energy 0.10000E-09
+-         No multispace method in use 
+-
+-
+-
++     Dimension of block of resolution strings 1000
++      Particle-hole separation not used 
++     Strings not divided into active and passive parts
++ 
++     No calculation of density matrices  
++ 
++     CI diagonalization : 
++     ==================== 
++        No subspace Hamiltonian 
++        Diagonalizer : MICDV* 
++        No root homing 
++        Initial energy evaluations skipped after first calc
++        (Only active in connection with TERACI )
++        Allowed Dimension of CI subspace 3
++         Convergence threshold for energy 1.00000E-08
++        No multispace method in use 
++ 
++ 
++ 
+         Final orbitals :
+         ================
+-
++ 
+            Natural orbitals
+-
+-      Print levels : 
+-       Raised  print level for string    information =   0
+-       Raised  print level for CI space  information =   0
+-       Raised  print level for orbital   information =   0
+-       Raised  print level for density matrix        =   0
+-       Raised  print level for iterative information =   0
+-       Raised  print level for External blocks       =   0
+-
+-
++ 
++     Print levels : 
++      Raised  print level for string    information =   0
++      Raised  print level for CI space  information =   0
++      Raised  print level for orbital   information =   0
++      Raised  print level for density matrix        =   0
++      Raised  print level for iterative information =   0
++      Raised  print level for External blocks       =   0
++ 
++ 
+  Integrals imported from DIRAC files
+-
++ 
+  Using spinfree Dirac Hamiltonian!
+-DIRAC core energy =   -6388.2074957273
++ DIRAC core energy =   -6388.2074955762
+  Integrals have been calculated on the
+-               5Dec04  
+-         at  16:41:20
++               5Oct20  
++         at  14:12:56
+  End of file MDCINT.
+  Only or last 2-el. integral file.
+- Complete real list of 2-el. ints processed. 
+-  Updated core energy  -9505.77975
+-
+ 
++ Complete real list of 2-el. ints processed. 
++ Updated core energy   -6388.20749557622     
++ 
++ 
+   Number of internal combinations per symmetry 
+   =========================================== 
+-  CI space  1
++  CI space                      1
+   0.928000000000000E+03 0.888000000000000E+03 0.888000000000000E+03 0.816000000000000E+03
+-
+-
+-
++ 
++ 
++ 
+                ********************************
+                 ******************************
+-
++ 
+                   Calculations in space   1
+-
++ 
+                 ******************************
+                ********************************
+-
+-
+-
+-
+-
+-  Number of determinants/combinations   928
+-  Number of blocks  12
+-  Min/Max taken zero length vector set to zero
+-
+-                   :::::::::::::::::::
+-                     Entering MICDV6  
+-                   :::::::::::::::::::
+-  Min/Max taken zero length vector set to zero
+-
++ 
++ 
++ 
++ 
++ 
++  Number of determinants/combinations                     928
++  Number of blocks                     12
++
++   ==============================================================
++   ==> allocation of two CI vectors and one resolution vector <==
++
++   current available free memory in double words:        63987889
++   allocate two CI vectors each of length:                    928
++   allocate resolution vector of length:                     2704
++   ==============================================================
++
++                                     
++           **************************************************
++               entering MICDV6 (sequential solver routine)   
++           **************************************************
++                                     
++ 
+  Info from iteration      1
+  _______________________
+- Iter RNORM EIGAPR          1   .9601356084203E+01      -9267.5303112690
+-  Min/Max taken zero length vector set to zero
+- >>>  CPU (WALL) TIME IN ITERATION:  0.15697587s( 1.00000000s)
+-
++ Iter RNORM EIGAPR          1   .9601356084089E+01      -9267.5303110455
++ >>>  CPU (WALL) TIME IN SIGMA VECTOR CALL :  0.02180900s( 0.02197480s)
++ >>>  CPU (WALL) TIME IN STEP3 OF ILOOP:  0.00572800s( 0.00975108s)
++ >>>  CPU (WALL) TIME IN ITERATION:  0.03027800s( 0.03653908s)
++ 
+  Info from iteration      2
+  _______________________
+- Iter RNORM EIGAPR          2   .3840924503079E-01      -9267.5598590200
+-  Min/Max taken zero length vector set to zero
+- >>>  CPU (WALL) TIME IN ITERATION:  0.17197502s( 0.00000000s)
+-
++ Iter RNORM EIGAPR          2   .3840924503134E-01      -9267.5598587966
++ >>>  CPU (WALL) TIME IN SIGMA VECTOR CALL :  0.02152600s( 0.02168798s)
++ >>>  CPU (WALL) TIME IN STEP3 OF ILOOP:  0.00608100s( 0.00920391s)
++ >>>  CPU (WALL) TIME IN ITERATION:  0.03194600s( 0.03669691s)
++ 
+  Info from iteration      3
+  _______________________
+- Iter RNORM EIGAPR          3   .1079759854168E-03      -9267.5598595541
+-  Min/Max taken zero length vector set to zero
+- >>>  CPU (WALL) TIME IN ITERATION:  0.17197394s( 0.00000000s)
+-
++ Iter RNORM EIGAPR          3   .1079759854208E-03      -9267.5598593307
++ >>>  CPU (WALL) TIME IN SIGMA VECTOR CALL :  0.02164600s( 0.02180982s)
++ >>>  CPU (WALL) TIME IN STEP3 OF ILOOP:  0.00616400s( 0.00909591s)
++ >>>  CPU (WALL) TIME IN ITERATION:  0.03213400s( 0.03650999s)
++ 
+  Info from iteration      4
+  _______________________
+- Iter RNORM EIGAPR          4   .6150758055566E-05      -9267.5598595541
+-
++ Iter RNORM EIGAPR          4   .6150758097328E-05      -9267.5598593307
++ 
+  ------------------------
+- Root number   1
++ Root number                       1
+  ------------------------
+-          1         -9267.5303112689671   0.96014E+01
+-          2         -9267.5598590199970   0.38409E-01
+-          3         -9267.5598595541269   0.10798E-03
+-          4         -9267.5598595541305   0.61508E-05
+-
++          1         -9267.5303110455370   0.96014E+01
++          2         -9267.5598587965669   0.38409E-01
++          3         -9267.5598593306968   0.10798E-03
++          4         -9267.5598593307004   0.61508E-05
++ 
+  ************************************************************
+     Iter  Root       Energy        RESIDUAL     RESRATIO 
+  ************************************************************
++ 
++     4    1     -9267.5598593307   0.615E-05    0.156E+07
++ Final energy   -9267.5598593307
++ 
++   **************************************************
++   Analysis of Density and occupation for ROOT =   1
++   **************************************************
++ 
++  
++   Natural occupation numbers for symmetry =   1
++   __________________________________________________
++
++   1.999985601   1.000008650   1.000000000   0.000005735   0.000000015
++   0.000000000   0.000000000   0.000000000   0.000000000   0.000000000
++   0.000000000
++
++   Sum =         4.000000001
++  
++   Natural occupation numbers for symmetry =   2
++   __________________________________________________
++
++   1.999995682   0.000004317   0.000000001   0.000000000
++
++   Sum =         1.999999999
++  
++   Natural occupation numbers for symmetry =   3
++   __________________________________________________
++
++   1.999995682   0.000004317   0.000000001   0.000000000
++
++   Sum =         1.999999999
++  
++   Natural occupation numbers for symmetry =   4
++   __________________________________________________
+ 
+-     4    1     -9267.5598595541   0.615E-05    0.156E+07
+- Final energy   -9267.5598595541
+-  Min/Max taken zero length vector set to zero
++   0.000000000
+ 
++   Sum =         0.000000000
++ 
+   Information about MATML7 calls : 
+   ================================
+-
+-  Number of calls   24093.
+-  Number of flops executed   1643840.
+-  Average row length of C   2.2880225
+-  Average column  length of C   3.41733405
+-  Average number of operations per element of  C   8.56077492
+-  Average number of operations per per call   68.2289462
+-  Number of seconds spent in MATML7  0.0569934845
+-  Average MFLOPS   28.8425952
++ 
++  Number of calls    31997.0000000000     
++  Number of flops executed    5577024.00000000     
++  Average row length of C    12.3634401503225     
++  Average column  length of C    1.93440695103564     
++  Average number of operations per element of  C    5.72710860818613     
++  Average number of operations per per call    174.298340469419     
++  Number of seconds spent in MATML7  7.342338562011719E-003
++  Average MFLOPS    759.570530955189     
++  Lucita says:
+   I am home from the loops 
+ 
+- Date and time (Linux) : Sun Dec  5 16:41:21 2004
+ *****************************************************
+->>>> Total CPU  time used in DIRAC:  1.86471600s
+->>>> Total WALL time used in DIRAC:  3.00000000s
+ ********** E N D   of   D I R A C  output  **********
++*****************************************************
++
++
++ 
++     Date and time (Linux)  : Mon Oct  5 14:12:56 2020
++     Host name              : node3403.kirlia.os                      
++
++  
++  Dynamical Memory Usage Summary for Master
++  
++  Mean allocation size (Mb) :        28.77
++  
++  Largest                    10  allocations
++  
++      488.28 Mb at subroutine pamlu_+0x8b                                for WRK in PAMLU                              
++      488.28 Mb at subroutine pamtra_+0x16b                              for WORK in PAMTRA                            
++      488.28 Mb at subroutine psiscf_+0xa9                               for WORK in PSISCF                            
++      488.28 Mb at subroutine pamset_+0x1867                             for WORK in PAMSET - 2                        
++      488.28 Mb at subroutine gmotra_+0x4ddb                             for WORK in GMOTRA                            
++      488.28 Mb at subroutine pamset_+0x97                               for WORK in PAMSET - 1                        
++      488.28 Mb at subroutine MAIN__+0x2b8                               for test allocation of work array in DIRAC mai
++        1.37 Mb at subroutine ccseti_+0x718                              for ibuf                                      
++        1.37 Mb at subroutine ccseti_+0x718                              for ibuf                                      
++        0.76 Mb at subroutine paminp_+0x8a                               for PAMINP WORK array                         
++  
++  Peak memory usage:       488.29 MB
++  Peak memory usage:        0.477 GB
++       reached at subroutine : mdscri_+0xb8                              
++              for variable   : unnamed variable                          
++  
++ MEMGET high-water mark:     0.00 MB
++
++*****************************************************
++>>>> Node 0, utime: 0, stime: 0, minflt: 6800, majflt: 0, nvcsw: 871, nivcsw: 3, maxrss: 121080
++>>>> Total WALL time used in DIRAC: 0s
++DIRAC pam run in /tmp/DIRAC-19.0-Source/build/test/bss_energy

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0_fix-bss_energy_test.patch
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0_fix-bss_energy_test.patch
@@ -1,8 +1,8 @@
-# it seems that bss_energy test is broken, the reference calculation is form 2004
+# It seems that bss_energy test is broken, the reference calculation is form 2004
 # The fact that only the SCF energy different and the consecutive post-HF correlation
-# energies are the same s a strong hnt that the HF wavefunction should be the same,
+# energies are the same is a strong hint that the HF wavefunction should be the same,
 # but the energies for some reason are different.
-# THe test was recalulated suing the following compilers/BLAS libaries on cascadelake 
+# The test was recalulated using the following compilers/BLAS libaries on cascadelake 
 # architecture, and the results are practially the same.
 # Based on this facts, the reference test result was changed to the intel result below.
 #

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0_fix_mpi_tests.patch
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0_fix_mpi_tests.patch
@@ -1,0 +1,1398 @@
+# pam_test mpi part is designed for pre-2020 Intel MPI and OpenMPI 
+# eedm_mhyp_ensps_krci gives different result with sequantial and mpi parallel.
+# although GNU 9.3.0/OpenBLAS 0.3.9 and Intel 2020.1/MKL 2020.1 gives the same result on cascadelake:
+# GNU 9.3.0/OpenBLAS 0.3.9 cascadelake:
+# EEDM  state  1(1   )         state  1(1   )        -0.000110451220          -0.000567963004
+# MHYP  state  1(1   )         state  1(1   )        -0.005905650151           0.000000009212
+# MHYP  state  1(1   )         state  1(1   )        -0.000974190577          -0.000000010813
+# MHYP  state  1(1   )         state  1(1   )        -0.005905650151           0.000000009212
+# MHYP  state  1(1   )         state  1(1   )        -0.000974190577          -0.000000010813
+# MHYP  state  1(1   )         state  1(1   )        -0.006752216685           0.000000010532
+# MHYP  state  1(1   )         state  1(1   )        -0.001232901004          -0.000000013685
+# ENSPS state  1(1   )         state  1(1   )         0.001238395771           0.001238395771
+# ENSPS state  1(1   )         state  1(1   )        -0.000041690709           0.000041690709
+# Intel 2020.1/MKL 2020.1 cascadelake:
+# EEDM  state  1(1   )         state  1(1   )        -0.000110451220          -0.000567963004
+# MHYP  state  1(1   )         state  1(1   )        -0.005905650151           0.000000009212
+# MHYP  state  1(1   )         state  1(1   )        -0.000974190577          -0.000000010813
+# MHYP  state  1(1   )         state  1(1   )        -0.005905650151           0.000000009212
+# MHYP  state  1(1   )         state  1(1   )        -0.000974190577          -0.000000010813
+# MHYP  state  1(1   )         state  1(1   )        -0.006752216685           0.000000010532
+# MHYP  state  1(1   )         state  1(1   )        -0.001232901004          -0.000000013685
+# ENSPS state  1(1   )         state  1(1   )         0.001238395771           0.001238395771
+# ENSPS state  1(1   )         state  1(1   )        -0.000041690709           0.000041690709
+# OCT 9th 2020 by B. Hajgato (UGent)
+diff -ru DIRAC-19.0-Source.orig/cmake/custom/test.cmake DIRAC-19.0-Source/cmake/custom/test.cmake
+--- DIRAC-19.0-Source.orig/cmake/custom/test.cmake	2019-12-12 17:26:15.000000000 +0100
++++ DIRAC-19.0-Source/cmake/custom/test.cmake	2020-10-09 14:32:56.939227043 +0200
+@@ -103,7 +103,7 @@
+ dirac_test(basis_input_scripted "basis;long" "3600")
+ dirac_test(bsse "basis;short" "")
+ dirac_test(bss_energy "short" "")
+-dirac_test(pam_test "short;pam" "")
++#dirac_test(pam_test "short;pam" "")
+ dirac_test(cc_essential "short;cc" "")
+ dirac_test(cc_linear "short;cc" "")
+ dirac_test(cc_gradient "cc_gradient" "")
+diff -ru DIRAC-19.0-Source.orig/test/eedm_mhyp_ensps_krci/result/BeH_BeH.out DIRAC-19.0-Source/test/eedm_mhyp_ensps_krci/result/BeH_BeH.out
+--- DIRAC-19.0-Source.orig/test/eedm_mhyp_ensps_krci/result/BeH_BeH.out	2019-12-12 17:26:14.000000000 +0100
++++ DIRAC-19.0-Source/test/eedm_mhyp_ensps_krci/result/BeH_BeH.out	2020-10-09 14:34:08.021942896 +0200
+@@ -1,8 +1,12 @@
+-DIRAC serial starts by allocating 2000000000 words (  15258.79 MB -     14.901 GB)
+- of memory    out of the allowed maximum of 2147483648 words (  16384.00 MB -     16.000 GB)
+-
+-Note: maximum allocatable memory for serial run can be set by pam --aw/--ag
++  ** interface to 64-bit integer MPI enabled **
+ 
++DIRAC master    (node3414.kirlia.os) starts by allocating       64000000 r*8 words (   0.477 GB) of memory
++DIRAC nodes 1 to 1 starts by allocating            64000000 r*8 words (   0.477 GB) of memory
++DIRAC master    (node3414.kirlia.os) to allocate at most      2147483648 r*8 words (  16.000 GB) of memory
++DIRAC nodes 1 to 1 to allocate at most           2147483648 r*8 words (  16.000 GB) of memory
++ 
++Note: maximum allocatable memory for master+nodes can be set by -aw (MW)/-ag (GB) flags in pam
++ 
+  *******************************************************************************
+  *                                                                             *
+  *                                O U T P U T                                  *
+@@ -168,52 +172,53 @@
+ Version information
+ -------------------
+ 
+-Branch        | genp_krci
+-Commit hash   | c8f8cf4
+-Commit author | mknayak72
+-Commit date   | Sat Dec 7 14:19:33 2019 +0530
++Branch        | 
++Commit hash   | 
++Commit author | 
++Commit date   | 
+ 
+ 
+ Configuration and build information
+ -----------------------------------
+ 
+-Who compiled             | mknayak
+-Compiled on server       | malaya.tcs
+-Operating system         | Linux-3.10.0-1062.7.1.el7.x86_64
+-CMake version            | 3.12.1
++Who compiled             | vsc43020
++Compiled on server       | node3414.kirlia.os
++Operating system         | Linux-3.10.0-1127.8.2.el7.ug.x86_64
++CMake version            | 3.16.4
+ CMake generator          | Unix Makefiles
+-CMake build type         | release
+-Configuration time       | 2019-12-07 08:51:29.918953
+-Python version           | 2.7.5
+-Fortran compiler         | /usr/bin/gfortran
+-Fortran compiler version | 4.8.5
+-Fortran compiler flags   |  -g -fcray-pointer -fbacktrace -fno-range-check -DVAR_GFORTRAN -DVAR_MFDS -fdefault-integer-8 -g -fcray-pointer -fbacktrace -fno-range-check -DVAR_GFORTRAN -DVAR_MFDS -fdefault-integer-8
+-C compiler               | /usr/bin/gcc
+-C compiler version       | 4.8.5
+-C compiler flags         |  -g -g
+-C++ compiler             | /usr/bin/g++
+-C++ compiler version     | 4.8.5
+-C++ compiler flags       |  -g -Wall -Wno-unknown-pragmas -Wno-sign-compare -Woverloaded-virtual -Wwrite-strings -Wno-unused -g -Wall -Wno-unknown-pragmas -Wno-sign-compare -Woverloaded-virtual -Wwrite-strings -Wno-unused
++CMake build type         | RELEASE
++Configuration time       | 2020-10-09 11:26:21.998545
++Python version           | 2.7.1
++Fortran compiler         | /apps/gent/CO7/cascadelake-ib/software/impi/2019.7.217-iccifort-2020.1.217/intel64/bin/mpiifort
++Fortran compiler version | 19.1
++Fortran compiler flags   | -O2 -ftz -fp-speculation=safe -fp-model source -i8 -w -assume byterecl -DVAR_IFORT  -i8
++C compiler               | /apps/gent/CO7/cascadelake-ib/software/impi/2019.7.217-iccifort-2020.1.217/intel64/bin/mpiicc
++C compiler version       | 19.1
++C compiler flags         | -O2 -ftz -fp-speculation=safe -fp-model source -DMKL_ILP64 -wd981 -wd279 -wd383 -wd1572 -wd177 
++C++ compiler             | /apps/gent/CO7/cascadelake-ib/software/impi/2019.7.217-iccifort-2020.1.217/intel64/bin/mpiicpc
++C++ compiler version     | 19.1.1
++C++ compiler flags       | -O2 -ftz -fp-speculation=safe -fp-model source -Wno-unknown-pragmas 
+ Static linking           | False
+ 64-bit integers          | True
+-MPI parallelization      | False
+-MPI launcher             | unknown
+-Math libraries           | -Wl,--start-group;/opt/intel/compilers_and_libraries_2017.7.259/linux/mkl/lib/intel64/libmkl_lapack95_ilp64.a;/opt/intel/compilers_and_libraries_2017.7.259/linux/mkl/lib/intel64/libmkl_gf_ilp64.so;-fopenmp;-Wl,--end-group;-Wl,--start-group;/opt/intel/compilers_and_libraries_2017.7.259/linux/mkl/lib/intel64/libmkl_gf_ilp64.so;/opt/intel/compilers_and_libraries_2017.7.259/linux/mkl/lib/intel64/libmkl_gnu_thread.so;/opt/intel/compilers_and_libraries_2017.7.259/linux/mkl/lib/intel64/libmkl_core.so;/usr/lib64/libpthread.so;/usr/lib64/libm.so;-fopenmp;-Wl,--end-group
++MPI parallelization      | True
++MPI launcher             | /apps/gent/CO7/cascadelake-ib/software/impi/2019.7.217-iccifort-2020.1.217/intel64/bin/mpiexec
++Math libraries           | unknown
+ Builtin BLAS library     | OFF
+ Builtin LAPACK library   | OFF
+-Explicit libraries       | unknown
+-Compile definitions      | MOD_UNRELEASED;SYS_LINUX;PRG_DIRAC;INT_STAR8;INSTALL_WRKMEM=64000000;HAS_PCMSOLVER;BUILD_GEN1INT;HAS_PELIB;MOD_QCORR;HAS_STIELTJES;MOD_INTEREST;MOD_LAO_REARRANGED;MOD_MCSCF_spinfree;MOD_AOOSOC;MOD_ESR;MOD_KRCC;MOD_SRDFT
++Explicit libraries       | -Wl,-Bstatic -Wl,--start-group -lmkl_scalapack_ilp64 -lmkl_blacs_intelmpi_ilp64 -lmkl_intel_ilp64 -lmkl_intel_thread -lmkl_core -Wl,--end-group -Wl,-Bdynamic -liomp5 -lpthread
++Compile definitions      | HAVE_MPI;VAR_MPI;VAR_MPI2;USE_MPI_MOD_F90;SYS_LINUX;PRG_DIRAC;INT_STAR8;INSTALL_WRKMEM=64000000;BUILD_GEN1INT;HAS_PELIB;MOD_QCORR;HAS_STIELTJES
+ 
+ 
+  LAPACK integer*4/8 selftest passed
+  Selftest of ISO_C_BINDING Fortran - C/C++ interoperability PASSED
++ MPI selftest passed with MPI_INTEGER of the size 8 bytes
+ 
+ Execution time and host
+ -----------------------
+ 
+  
+-     Date and time (Linux)  : Sat Dec  7 14:42:42 2019
+-     Host name              : malaya.tcs                              
++     Date and time (Linux)  : Fri Oct  9 13:31:22 2020
++     Host name              : node3414.kirlia.os                      
+ 
+ 
+ Contents of the input file
+@@ -325,6 +330,7 @@
+    Journal of Physical and Chemical Reference Data, Vol. 28, No. 6, 1999  
+  * The speed of light :        137.0359998
+  * Running in four-component mode
++ * Parallel run with 1 slaves.
+  * Direct evaluation of the following two-electron integrals:
+    - LL-integrals
+    - SL-integrals
+@@ -523,7 +529,7 @@
+   ----------------------------------------------
+ 
+     2
+-
++ 
+ Be     0.0000000000   0.0000000000  -0.0922128491
+ H      0.0000000000   0.0000000000   0.8245866800
+ 
+@@ -719,10 +725,10 @@
+  * Hartree-Fock calculation
+  * Kramers restricted CI calculation
+   evaluating active dbg irrep...
+-  # dbg irreps               :                   128
+-  # active MJ value (doubled):                     1
+-  # active fermion sym       :                     1
+-  # active double group irrep:                    65
++  # dbg irreps               :                    128
++  # active MJ value (doubled):                      1
++  # active fermion sym       :                      1
++  # active double group irrep:                     65
+ ===========================================================================
+  *KRCICALC: General set-up for KR-CI calculation:
+ ===========================================================================
+@@ -753,6 +759,7 @@
+ ===========================================================================
+  * Energy convergence threshold:   8.00D-13
+  * Maximum number of CI iterations for each symmetry:  50
++ * Integrals on slave nodes provided by the MASTER
+  * Property calculation for the following one-electron operators: 
+ 
+   i*BETA*GAMMA5 operator, setting IATIM=-1
+@@ -898,7 +905,7 @@
+ 
+                         1 Debye =   2.54177000 a.u. 
+ 
+-Total time used in ONEGEN (CPU)  0.03528100s and (WALL)  0.04331274s
++Total time used in ONEGEN (CPU)  0.01034300s and (WALL)  0.01038289s
+ 
+ 
+                        Generating Lowdin canonical matrix:
+@@ -950,198 +957,198 @@
+              Improved by a sum of atomic screening potentials.
+ 
+ 
+-########## START ITERATION NO.   1 ##########   Sat Dec  7 14:42:43 2019
++########## START ITERATION NO.   1 ##########   Fri Oct  9 13:31:22 2020
+ 
+ E_HOMO...E_LUMO, symmetry 1:    35  -0.71357   36  -0.26323   37  -0.24641
+ 
+ => Calculating sum of orbital energies
+-It.    1    -7.674280262185      0.00D+00  0.00D+00  0.00D+00               0.12560900s   Atom. scrpot   Sat Dec  7
++It.    1    -7.674280262172      0.00D+00  0.00D+00  0.00D+00               0.06623700s   Atom. scrpot   Fri Oct  9
+ 
+-########## START ITERATION NO.   2 ##########   Sat Dec  7 14:42:43 2019
++########## START ITERATION NO.   2 ##########   Fri Oct  9 13:31:22 2020
+ 
+ 
+ * GETGAB: label "GABAO1XX" not found; calling GABGEN.
+-SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00D-12    0.00%    1.46%    0.00%    0.00%   0.00942999s
+-SOfock:SL  1.00D-12    0.00%    3.79%    0.00%    0.00%   0.05662000s
+-SOfock:SS  1.00D-12    0.00%   20.74%    0.00%    0.01%   0.10877898s
+- >>> CPU  time used in SO Fock is   0.20 seconds
+- >>> WALL time used in SO Fock is   0.20 seconds
++SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
++SOfock:LL  1.00D-12    0.00%    1.46%    0.00%    0.00%   0.02674794s
++SOfock:SL  1.00D-12    0.00%    3.33%    0.00%    0.00%   0.04715800s
++SOfock:SS  1.00D-12    0.00%   16.16%    0.00%    0.01%   0.40942907s
++ >>> CPU  time used in SO Fock is   0.51 seconds
++ >>> WALL time used in SO Fock is   0.51 seconds
+ E_HOMO...E_LUMO, symmetry 1:    35  -0.44417   36  -0.17374   37   0.09066
+->>> Total wall time:  0.21618455s, and total CPU time :  0.20654300s
++>>> Total wall time:  0.51878285s, and total CPU time :  0.50978200s
+ 
+-########## END ITERATION NO.   2 ##########   Sat Dec  7 14:42:43 2019
++########## END ITERATION NO.   2 ##########   Fri Oct  9 13:31:23 2020
+ 
+-It.    2    -14.98358612120      7.31D+00  2.41D+00  4.55D-01               0.21618455s   LL SL SS       Sat Dec  7
++It.    2    -14.98358612120      7.31D+00  2.45D+00  4.55D-01               0.51878285s   LL SL SS       Fri Oct  9
+ 
+-########## START ITERATION NO.   3 ##########   Sat Dec  7 14:42:43 2019
++########## START ITERATION NO.   3 ##########   Fri Oct  9 13:31:23 2020
+ 
+     3 *** Differential density matrix. DCOVLP     = 0.8705
+     3 *** Differential density matrix. DVOVLP( 1) = 0.5597
+-SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00D-12    0.00%    1.61%    0.00%    0.00%   0.02192301s
+-SOfock:SL  1.00D-12    0.00%    4.22%    0.00%    0.00%   0.09345502s
+-SOfock:SS  1.00D-12    0.00%   24.94%    0.00%    0.00%   0.11746603s
+- >>> CPU  time used in SO Fock is   0.23 seconds
+- >>> WALL time used in SO Fock is   0.23 seconds
++SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
++SOfock:LL  1.00D-12    0.00%    1.61%    0.00%    0.00%   0.00927496s
++SOfock:SL  1.00D-12    0.00%    3.75%    0.00%    0.00%   0.04739094s
++SOfock:SS  1.00D-12    0.00%   19.36%    0.00%    0.00%   0.09083819s
++ >>> CPU  time used in SO Fock is   0.14 seconds
++ >>> WALL time used in SO Fock is   0.15 seconds
+ E_HOMO...E_LUMO, symmetry 1:    35  -0.53225   36  -0.19666   37   0.07238
+->>> Total wall time:  0.25093168s, and total CPU time :  0.24143000s
++>>> Total wall time:  0.16109180s, and total CPU time :  0.13990600s
+ 
+-########## END ITERATION NO.   3 ##########   Sat Dec  7 14:42:43 2019
++########## END ITERATION NO.   3 ##########   Fri Oct  9 13:31:23 2020
+ 
+-It.    3    -15.05284570594      6.93D-02 -1.41D-01  5.42D-02   DIIS   2    0.25093168s   LL SL SS       Sat Dec  7
++It.    3    -15.05284570594      6.93D-02 -1.44D-01  5.42D-02   DIIS   2    0.16109180s   LL SL SS       Fri Oct  9
+ 
+-########## START ITERATION NO.   4 ##########   Sat Dec  7 14:42:43 2019
++########## START ITERATION NO.   4 ##########   Fri Oct  9 13:31:23 2020
+ 
+     4 *** Differential density matrix. DCOVLP     = 0.9834
+     4 *** Differential density matrix. DVOVLP( 1) = 0.9515
+-SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00D-12    0.00%    1.81%    0.00%    0.00%   0.02005899s
+-SOfock:SL  1.00D-12    0.00%    4.34%    0.00%    0.00%   0.08984500s
+-SOfock:SS  1.00D-12    0.00%   32.11%    0.00%    0.01%   0.11502302s
+- >>> CPU  time used in SO Fock is   0.23 seconds
+- >>> WALL time used in SO Fock is   0.23 seconds
++SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
++SOfock:LL  1.00D-12    0.00%    1.81%    0.00%    0.00%   0.00935793s
++SOfock:SL  1.00D-12    0.00%    3.87%    0.00%    0.00%   0.04722786s
++SOfock:SS  1.00D-12    0.00%   24.66%    0.00%    0.00%   0.09067297s
++ >>> CPU  time used in SO Fock is   0.15 seconds
++ >>> WALL time used in SO Fock is   0.15 seconds
+ E_HOMO...E_LUMO, symmetry 1:    35  -0.53644   36  -0.20054   37   0.07029
+->>> Total wall time:  0.23950611s, and total CPU time :  0.23095300s
++>>> Total wall time:  0.15968394s, and total CPU time :  0.15167100s
+ 
+-########## END ITERATION NO.   4 ##########   Sat Dec  7 14:42:44 2019
++########## END ITERATION NO.   4 ##########   Fri Oct  9 13:31:23 2020
+ 
+-It.    4    -15.05510762061      2.26D-03 -1.10D-02  9.87D-03   DIIS   3    0.23950611s   LL SL SS       Sat Dec  7
++It.    4    -15.05510762061      2.26D-03 -1.16D-02  9.87D-03   DIIS   3    0.15968394s   LL SL SS       Fri Oct  9
+ 
+-########## START ITERATION NO.   5 ##########   Sat Dec  7 14:42:44 2019
++########## START ITERATION NO.   5 ##########   Fri Oct  9 13:31:23 2020
+ 
+     5 *** Differential density matrix. DCOVLP     = 0.9975
+     5 *** Differential density matrix. DVOVLP( 1) = 0.9819
+-SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00D-12    0.00%    1.93%    0.00%    0.00%   0.02133298s
+-SOfock:SL  1.00D-12    0.00%    5.03%    0.00%    0.00%   0.09153700s
+-SOfock:SS  1.00D-12    0.00%   38.49%    0.00%    0.01%   0.11206806s
+- >>> CPU  time used in SO Fock is   0.23 seconds
+- >>> WALL time used in SO Fock is   0.23 seconds
++SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
++SOfock:LL  1.00D-12    0.00%    1.93%    0.00%    0.00%   0.00927806s
++SOfock:SL  1.00D-12    0.00%    4.52%    0.00%    0.00%   0.04714084s
++SOfock:SS  1.00D-12    0.00%   29.54%    0.00%    0.01%   0.08947515s
++ >>> CPU  time used in SO Fock is   0.15 seconds
++ >>> WALL time used in SO Fock is   0.15 seconds
+ E_HOMO...E_LUMO, symmetry 1:    35  -0.53821   36  -0.20014   37   0.06997
+->>> Total wall time:  0.23837635s, and total CPU time :  0.23003500s
++>>> Total wall time:  0.15834403s, and total CPU time :  0.15030500s
+ 
+-########## END ITERATION NO.   5 ##########   Sat Dec  7 14:42:44 2019
++########## END ITERATION NO.   5 ##########   Fri Oct  9 13:31:23 2020
+ 
+-It.    5    -15.05525091501      1.43D-04 -3.58D-03  2.02D-03   DIIS   4    0.23837635s   LL SL SS       Sat Dec  7
++It.    5    -15.05525091501      1.43D-04 -3.76D-03  2.02D-03   DIIS   4    0.15834403s   LL SL SS       Fri Oct  9
+ 
+-########## START ITERATION NO.   6 ##########   Sat Dec  7 14:42:44 2019
++########## START ITERATION NO.   6 ##########   Fri Oct  9 13:31:23 2020
+ 
+     6 *** Differential density matrix. DCOVLP     = 0.9998
+     6 *** Differential density matrix. DVOVLP( 1) = 0.9966
+-SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00D-12    0.00%    2.23%    0.00%    0.00%   0.00905704s
+-SOfock:SL  1.00D-12    0.00%    6.15%    0.00%    0.00%   0.05483294s
+-SOfock:SS  1.00D-12    0.00%   48.95%    0.01%    0.04%   0.09789610s
+- >>> CPU  time used in SO Fock is   0.16 seconds
+- >>> WALL time used in SO Fock is   0.16 seconds
++SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
++SOfock:LL  1.00D-12    0.00%    2.23%    0.00%    0.00%   0.00926590s
++SOfock:SL  1.00D-12    0.00%    5.56%    0.00%    0.00%   0.04719806s
++SOfock:SS  1.00D-12    0.00%   37.52%    0.01%    0.03%   0.08690405s
++ >>> CPU  time used in SO Fock is   0.14 seconds
++ >>> WALL time used in SO Fock is   0.14 seconds
+ E_HOMO...E_LUMO, symmetry 1:    35  -0.53824   36  -0.20011   37   0.06998
+->>> Total wall time:  0.17357306s, and total CPU time :  0.16528300s
++>>> Total wall time:  0.15521312s, and total CPU time :  0.14776100s
+ 
+-########## END ITERATION NO.   6 ##########   Sat Dec  7 14:42:44 2019
++########## END ITERATION NO.   6 ##########   Fri Oct  9 13:31:23 2020
+ 
+-It.    6    -15.05525770434      6.79D-06 -3.53D-04  3.01D-04   DIIS   5    0.17357306s   LL SL SS       Sat Dec  7
++It.    6    -15.05525770434      6.79D-06 -3.61D-04  3.01D-04   DIIS   5    0.15521312s   LL SL SS       Fri Oct  9
+ 
+-########## START ITERATION NO.   7 ##########   Sat Dec  7 14:42:44 2019
++########## START ITERATION NO.   7 ##########   Fri Oct  9 13:31:23 2020
+ 
+     7 *** Differential density matrix. DCOVLP     = 1.0001
+     7 *** Differential density matrix. DVOVLP( 1) = 0.9998
+-SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00D-12    0.00%    3.25%    0.00%    0.00%   0.00905895s
+-SOfock:SL  1.00D-12    0.00%    8.74%    0.00%    0.00%   0.05451703s
+-SOfock:SS  1.00D-12    0.00%   63.88%    0.13%    0.67%   0.09414506s
+- >>> CPU  time used in SO Fock is   0.16 seconds
+- >>> WALL time used in SO Fock is   0.16 seconds
++SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
++SOfock:LL  1.00D-12    0.00%    3.25%    0.00%    0.00%   0.00925994s
++SOfock:SL  1.00D-12    0.00%    8.04%    0.00%    0.00%   0.04709005s
++SOfock:SS  1.00D-12    0.00%   49.16%    0.10%    0.50%   0.08579898s
++ >>> CPU  time used in SO Fock is   0.14 seconds
++ >>> WALL time used in SO Fock is   0.14 seconds
+ E_HOMO...E_LUMO, symmetry 1:    35  -0.53824   36  -0.20010   37   0.06998
+->>> Total wall time:  0.16939002s, and total CPU time :  0.16115200s
++>>> Total wall time:  0.15497518s, and total CPU time :  0.14641300s
+ 
+-########## END ITERATION NO.   7 ##########   Sat Dec  7 14:42:44 2019
++########## END ITERATION NO.   7 ##########   Fri Oct  9 13:31:23 2020
+ 
+-It.    7    -15.05525782410      1.20D-07 -4.18D-05  5.31D-05   DIIS   6    0.16939002s   LL SL SS       Sat Dec  7
++It.    7    -15.05525782410      1.20D-07 -4.48D-05  5.31D-05   DIIS   6    0.15497518s   LL SL SS       Fri Oct  9
+ 
+-########## START ITERATION NO.   8 ##########   Sat Dec  7 14:42:44 2019
++########## START ITERATION NO.   8 ##########   Fri Oct  9 13:31:23 2020
+ 
+     8 *** Differential density matrix. DCOVLP     = 1.0000
+     8 *** Differential density matrix. DVOVLP( 1) = 1.0000
+-SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00D-12    0.00%    4.74%    0.00%    0.00%   0.00904500s
+-SOfock:SL  1.00D-12    0.00%   13.21%    0.00%    0.08%   0.05417407s
+-SOfock:SS  1.00D-12    0.00%   77.26%    1.03%    1.70%   0.09023106s
+- >>> CPU  time used in SO Fock is   0.15 seconds
+- >>> WALL time used in SO Fock is   0.15 seconds
++SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
++SOfock:LL  1.00D-12    0.00%    4.74%    0.00%    0.00%   0.00932503s
++SOfock:SL  1.00D-12    0.00%   12.27%    0.00%    0.07%   0.04715800s
++SOfock:SS  1.00D-12    0.00%   60.13%    0.76%    1.27%   0.08434606s
++ >>> CPU  time used in SO Fock is   0.14 seconds
++ >>> WALL time used in SO Fock is   0.14 seconds
+ E_HOMO...E_LUMO, symmetry 1:    35  -0.53824   36  -0.20011   37   0.06997
+->>> Total wall time:  0.16520095s, and total CPU time :  0.15693500s
++>>> Total wall time:  0.15240192s, and total CPU time :  0.14500100s
+ 
+-########## END ITERATION NO.   8 ##########   Sat Dec  7 14:42:44 2019
++########## END ITERATION NO.   8 ##########   Fri Oct  9 13:31:23 2020
+ 
+-It.    8    -15.05525782821      4.11D-09 -1.39D-05  1.07D-05   DIIS   7    0.16520095s   LL SL SS       Sat Dec  7
++It.    8    -15.05525782821      4.11D-09 -1.45D-05  1.07D-05   DIIS   7    0.15240192s   LL SL SS       Fri Oct  9
+ 
+-########## START ITERATION NO.   9 ##########   Sat Dec  7 14:42:44 2019
++########## START ITERATION NO.   9 ##########   Fri Oct  9 13:31:23 2020
+ 
+     9 *** Differential density matrix. DCOVLP     = 1.0000
+     9 *** Differential density matrix. DVOVLP( 1) = 1.0000
+-SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00D-12    0.00%    6.65%    0.00%    0.00%   0.00903404s
+-SOfock:SL  1.00D-12    0.00%   15.69%    0.00%    0.16%   0.05398393s
+-SOfock:SS  1.00D-12    0.05%   86.49%    1.46%    2.28%   0.08701098s
+- >>> CPU  time used in SO Fock is   0.15 seconds
+- >>> WALL time used in SO Fock is   0.15 seconds
++SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
++SOfock:LL  1.00D-12    0.00%    6.65%    0.00%    0.00%   0.00931311s
++SOfock:SL  1.00D-12    0.00%   14.70%    0.00%    0.15%   0.04640913s
++SOfock:SS  1.00D-12    0.04%   67.57%    1.07%    1.72%   0.08009100s
++ >>> CPU  time used in SO Fock is   0.14 seconds
++ >>> WALL time used in SO Fock is   0.14 seconds
+ E_HOMO...E_LUMO, symmetry 1:    35  -0.53824   36  -0.20011   37   0.06997
+->>> Total wall time:  0.16172978s, and total CPU time :  0.15342500s
++>>> Total wall time:  0.15059400s, and total CPU time :  0.14014200s
+ 
+-########## END ITERATION NO.   9 ##########   Sat Dec  7 14:42:44 2019
++########## END ITERATION NO.   9 ##########   Fri Oct  9 13:31:24 2020
+ 
+-It.    9    -15.05525782849      2.85D-10 -4.04D-06  2.99D-06   DIIS   8    0.16172978s   LL SL SS       Sat Dec  7
++It.    9    -15.05525782849      2.85D-10 -4.04D-06  2.99D-06   DIIS   8    0.15059400s   LL SL SS       Fri Oct  9
+ 
+-########## START ITERATION NO.  10 ##########   Sat Dec  7 14:42:44 2019
++########## START ITERATION NO.  10 ##########   Fri Oct  9 13:31:24 2020
+ 
+    10 *** Differential density matrix. DCOVLP     = 1.0000
+    10 *** Differential density matrix. DVOVLP( 1) = 1.0000
+-SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00D-12    0.00%   10.00%    0.00%    0.00%   0.00899804s
+-SOfock:SL  1.00D-12    0.00%   19.77%    0.00%    0.96%   0.05157399s
+-SOfock:SS  1.00D-12    2.22%   92.45%    1.67%    2.10%   0.07210994s
++SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
++SOfock:LL  1.00D-12    0.00%   10.00%    0.00%    0.00%   0.00906515s
++SOfock:SL  1.00D-12    0.00%   18.73%    0.00%    0.88%   0.04602289s
++SOfock:SS  1.00D-12    1.70%   72.87%    0.93%    1.41%   0.07452011s
+  >>> CPU  time used in SO Fock is   0.13 seconds
+  >>> WALL time used in SO Fock is   0.13 seconds
+ E_HOMO...E_LUMO, symmetry 1:    35  -0.53824   36  -0.20011   37   0.06997
+->>> Total wall time:  0.14423264s, and total CPU time :  0.13602100s
++>>> Total wall time:  0.14401197s, and total CPU time :  0.13443000s
+ 
+-########## END ITERATION NO.  10 ##########   Sat Dec  7 14:42:45 2019
++########## END ITERATION NO.  10 ##########   Fri Oct  9 13:31:24 2020
+ 
+-It.   10    -15.05525782853      4.23D-11  7.89D-07  1.39D-06   DIIS   9    0.14423264s   LL SL SS       Sat Dec  7
++It.   10    -15.05525782853      4.23D-11 -1.26D-06  1.39D-06   DIIS   9    0.14401197s   LL SL SS       Fri Oct  9
+ 
+-########## START ITERATION NO.  11 ##########   Sat Dec  7 14:42:45 2019
++########## START ITERATION NO.  11 ##########   Fri Oct  9 13:31:24 2020
+ 
+    11 *** Differential density matrix. DCOVLP     = 1.0000
+    11 *** Differential density matrix. DVOVLP( 1) = 1.0000
+-SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00D-12    0.00%   10.88%    0.00%    0.00%   0.00829506s
+-SOfock:SL  1.00D-12    0.00%   20.91%    0.00%    1.37%   0.04777408s
+-SOfock:SS  1.00D-12    7.35%   88.45%    3.34%    3.78%   0.06809211s
+- >>> CPU  time used in SO Fock is   0.12 seconds
+- >>> WALL time used in SO Fock is   0.12 seconds
++SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
++SOfock:LL  1.00D-12    0.00%   10.88%    0.00%    0.00%   0.00939202s
++SOfock:SL  1.00D-12    0.00%   19.86%    0.00%    1.26%   0.04657388s
++SOfock:SS  1.00D-12    5.62%   70.00%    1.11%    1.65%   0.07107210s
++ >>> CPU  time used in SO Fock is   0.13 seconds
++ >>> WALL time used in SO Fock is   0.13 seconds
+ E_HOMO...E_LUMO, symmetry 1:    35  -0.53824   36  -0.20011   37   0.06997
+->>> Total wall time:  0.13559033s, and total CPU time :  0.12737000s
++>>> Total wall time:  0.14050508s, and total CPU time :  0.13166000s
+ 
+-########## END ITERATION NO.  11 ##########   Sat Dec  7 14:42:45 2019
++########## END ITERATION NO.  11 ##########   Fri Oct  9 13:31:24 2020
+ 
+-It.   11    -15.05525782855      1.26D-11  7.22D-07  2.76D-07   DIIS   9    0.13559033s   LL SL SS       Sat Dec  7
++It.   11    -15.05525782855      1.26D-11 -8.54D-07  2.76D-07   DIIS   9    0.14050508s   LL SL SS       Fri Oct  9
+ 
+-########## START ITERATION NO.  12 ##########   Sat Dec  7 14:42:45 2019
++########## START ITERATION NO.  12 ##########   Fri Oct  9 13:31:24 2020
+ 
+    12 *** Differential density matrix. DCOVLP     = 1.0000
+    12 *** Differential density matrix. DVOVLP( 1) = 1.0000
+-SCR        scr.thr.    Step1    Step2  Coulomb  Exchange    CPU-time
+-SOfock:LL  1.00D-12    0.00%   14.91%    0.00%    0.01%   0.00819111s
+-SOfock:SL  1.00D-12    0.00%   26.31%    0.00%    4.16%   0.04727006s
+-SOfock:SS  1.00D-12   27.72%   71.16%    7.71%   10.99%   0.05253100s
++SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
++SOfock:LL  1.00D-12    0.00%   14.91%    0.00%    0.01%   0.00926995s
++SOfock:SL  1.00D-12    0.00%   25.16%    0.00%    3.83%   0.04634213s
++SOfock:SS  1.00D-12   21.18%   57.02%    0.45%    2.31%   0.05649400s
+  >>> CPU  time used in SO Fock is   0.11 seconds
+  >>> WALL time used in SO Fock is   0.11 seconds
+->>> Total wall time:  0.11815968s, and total CPU time :  0.11058100s
++>>> Total wall time:  0.12363100s, and total CPU time :  0.11607500s
+ 
+-########## END ITERATION NO.  12 ##########   Sat Dec  7 14:42:45 2019
++########## END ITERATION NO.  12 ##########   Fri Oct  9 13:31:24 2020
+ 
+-It.   12    -15.05525782855      3.59D-13  1.43D-07  1.38D-08   DIIS   9    0.11815968s   LL SL SS       Sat Dec  7
++It.   12    -15.05525782855      3.73D-13 -1.53D-07  1.38D-08   DIIS   9    0.12363100s   LL SL SS       Fri Oct  9
+ 
+ 
+                                    SCF - CYCLE
+@@ -1157,35 +1164,35 @@
+ --------------------------------------------------------------------------------------------------------------------------------
+            Energy               ERGVAL    FCKVAL    EVCVAL      Conv.acc    CPU          Integrals   Time stamp
+ --------------------------------------------------------------------------------------------------------------------------------
+-It.    1    -7.674280262185      0.00D+00  0.00D+00  0.00D+00               0.12560900s   Atom. scrpot   Sat Dec  7
+-It.    2    -14.98358612120      7.31D+00  2.41D+00  4.55D-01               0.21618455s   LL SL SS       Sat Dec  7
+-It.    3    -15.05284570594      6.93D-02 -1.41D-01  5.42D-02   DIIS   2    0.25093168s   LL SL SS       Sat Dec  7
+-It.    4    -15.05510762061      2.26D-03 -1.10D-02  9.87D-03   DIIS   3    0.23950611s   LL SL SS       Sat Dec  7
+-It.    5    -15.05525091501      1.43D-04 -3.58D-03  2.02D-03   DIIS   4    0.23837635s   LL SL SS       Sat Dec  7
+-It.    6    -15.05525770434      6.79D-06 -3.53D-04  3.01D-04   DIIS   5    0.17357306s   LL SL SS       Sat Dec  7
+-It.    7    -15.05525782410      1.20D-07 -4.18D-05  5.31D-05   DIIS   6    0.16939002s   LL SL SS       Sat Dec  7
+-It.    8    -15.05525782821      4.11D-09 -1.39D-05  1.07D-05   DIIS   7    0.16520095s   LL SL SS       Sat Dec  7
+-It.    9    -15.05525782849      2.85D-10 -4.04D-06  2.99D-06   DIIS   8    0.16172978s   LL SL SS       Sat Dec  7
+-It.   10    -15.05525782853      4.23D-11  7.89D-07  1.39D-06   DIIS   9    0.14423264s   LL SL SS       Sat Dec  7
+-It.   11    -15.05525782855      1.26D-11  7.22D-07  2.76D-07   DIIS   9    0.13559033s   LL SL SS       Sat Dec  7
+-It.   12    -15.05525782855      3.59D-13  1.43D-07  1.38D-08   DIIS   9    0.11815968s   LL SL SS       Sat Dec  7
++It.    1    -7.674280262172      0.00D+00  0.00D+00  0.00D+00               0.06623700s   Atom. scrpot   Fri Oct  9
++It.    2    -14.98358612120      7.31D+00  2.45D+00  4.55D-01               0.51878285s   LL SL SS       Fri Oct  9
++It.    3    -15.05284570594      6.93D-02 -1.44D-01  5.42D-02   DIIS   2    0.16109180s   LL SL SS       Fri Oct  9
++It.    4    -15.05510762061      2.26D-03 -1.16D-02  9.87D-03   DIIS   3    0.15968394s   LL SL SS       Fri Oct  9
++It.    5    -15.05525091501      1.43D-04 -3.76D-03  2.02D-03   DIIS   4    0.15834403s   LL SL SS       Fri Oct  9
++It.    6    -15.05525770434      6.79D-06 -3.61D-04  3.01D-04   DIIS   5    0.15521312s   LL SL SS       Fri Oct  9
++It.    7    -15.05525782410      1.20D-07 -4.48D-05  5.31D-05   DIIS   6    0.15497518s   LL SL SS       Fri Oct  9
++It.    8    -15.05525782821      4.11D-09 -1.45D-05  1.07D-05   DIIS   7    0.15240192s   LL SL SS       Fri Oct  9
++It.    9    -15.05525782849      2.85D-10 -4.04D-06  2.99D-06   DIIS   8    0.15059400s   LL SL SS       Fri Oct  9
++It.   10    -15.05525782853      4.23D-11 -1.26D-06  1.39D-06   DIIS   9    0.14401197s   LL SL SS       Fri Oct  9
++It.   11    -15.05525782855      1.26D-11 -8.54D-07  2.76D-07   DIIS   9    0.14050508s   LL SL SS       Fri Oct  9
++It.   12    -15.05525782855      3.73D-13 -1.53D-07  1.38D-08   DIIS   9    0.12363100s   LL SL SS       Fri Oct  9
+ --------------------------------------------------------------------------------------------------------------------------------
+ * Convergence after   12 iterations.
+ * Average elapsed time per iteration: 
+-      No 2-ints    :    0.12560757s
+-      LL SL SS     :    0.18298865s
++      No 2-ints    :    0.06805897s
++      LL SL SS     :    0.18356681s
+ 
+ 
+                                    TOTAL ENERGY
+                                    ------------
+ 
+-   Electronic energy                        :    -17.364060097770729
++   Electronic energy                        :    -17.364060097770743
+ 
+    Other contributions to the total energy
+    Nuclear repulsion energy                 :      2.308802269222842
+ 
+    Sum of all contributions to the energy
+-   Total energy                             :    -15.055257828547887
++   Total energy                             :    -15.055257828547902
+ 
+ 
+                                    Eigenvalues
+@@ -1194,24 +1201,24 @@
+ 
+ * Block   1 in E1 :  Omega =  1/2
+   * Closed shell, f = 1.0000
+-   -4.679468376338  ( 2)      -0.538243701490  ( 2)
++   -4.679468376327  ( 2)      -0.538243701490  ( 2)
+   * Open shell #1, f = 0.5000
+    -0.200107364292  ( 2)
+   * Virtual eigenvalues, f = 0.0000
+-    0.069973271793  ( 2)       0.146585677662  ( 2)       0.290043259674  ( 2)       0.329894286245  ( 2)       0.443382601574  ( 2)
+-    0.636678743326  ( 2)       0.675079413170  ( 2)       1.116750847420  ( 2)       1.366626079642  ( 2)       1.477429645290  ( 2)
+-    2.022794797755  ( 2)       2.267117385980  ( 2)       3.573003609718  ( 2)       4.000999068608  ( 2)       7.165692855382  ( 2)
+-    7.349371984843  ( 2)      15.727399978192  ( 2)      22.596336602594  ( 2)      58.756173314173  ( 2)     219.560006375315  ( 2)
+-  924.777802919416  ( 2)    4979.576710887137  ( 2)
++    0.069973271798  ( 2)       0.146585677680  ( 2)       0.290043259672  ( 2)       0.329894286248  ( 2)       0.443382601571  ( 2)
++    0.636678743335  ( 2)       0.675079413169  ( 2)       1.116750847424  ( 2)       1.366626079649  ( 2)       1.477429645297  ( 2)
++    2.022794797753  ( 2)       2.267117385992  ( 2)       3.573003609720  ( 2)       4.000999068610  ( 2)       7.165692855389  ( 2)
++    7.349371984860  ( 2)      15.727399978201  ( 2)      22.596336602582  ( 2)      58.756173314180  ( 2)     219.560006375432  ( 2)
++  924.777802919401  ( 2)    4979.576710887086  ( 2)
+ 
+ * Block   2 in E1 :  Omega =  3/2
+   * Virtual eigenvalues, f = 0.0000
+-    0.069977662719  ( 2)       0.329912044238  ( 2)       0.636681004307  ( 2)       0.656492047535  ( 2)       1.366714153093  ( 2)
+-    2.022824837061  ( 2)       7.166842638253  ( 2)
++    0.069977662718  ( 2)       0.329912044241  ( 2)       0.636681004320  ( 2)       0.656492047523  ( 2)       1.366714153101  ( 2)
++    2.022824837060  ( 2)       7.166842638267  ( 2)
+ 
+ * Block   3 in E1 :  Omega =  5/2
+   * Virtual eigenvalues, f = 0.0000
+-    0.656497922027  ( 2)
++    0.656497922020  ( 2)
+ 
+ * Occupation in fermion symmetry E1 
+   * Inactive orbitals
+@@ -1321,7 +1328,7 @@
+ 
+  (RSETCI) Number of determinants:         3366 (dimension         3366)
+ 
+- CPU (Wall) time for generation of determinants:  0.22480200s( 0.22480234s)
++ CPU (Wall) time for generation of determinants:  0.21247500s( 0.21325493s)
+ 
+  (RSETWOP) Orbital classes:
+      Inactive orbitals   :                                                   
+@@ -1335,40 +1342,54 @@
+   Vector containing mj-values saved as MJVEC on KRMCSCF
+ 
+  (RTRACTL1) Starting 4-index integral transformation.
+- - Integral class 1 : (LL|??)
+-   - Beginning task   1 of   5 after      0. seconds and      0. CPU-seconds
+-   - Beginning task   2 of   5 after      0. seconds and      0. CPU-seconds
+-   - Beginning task   3 of   5 after      0. seconds and      0. CPU-seconds
+-   - Beginning task   4 of   5 after      0. seconds and      0. CPU-seconds
+-   - Beginning task   5 of   5 after      0. seconds and      0. CPU-seconds
++
++ * Max no. of B shells in a task determined to be   8
+  - Integral class 2 : (SS|??)
+-   - Beginning task   6 of  13 after      0. seconds and      0. CPU-seconds
+-   - Beginning task   7 of  13 after      0. seconds and      0. CPU-seconds
+-   - Beginning task   8 of  13 after      0. seconds and      0. CPU-seconds
+-   - Beginning task   9 of  13 after      0. seconds and      0. CPU-seconds
+-   - Beginning task  10 of  13 after      0. seconds and      0. CPU-seconds
+-   - Beginning task  11 of  13 after      0. seconds and      0. CPU-seconds
+-   - Beginning task  12 of  13 after      0. seconds and      0. CPU-seconds
+-   - Beginning task  13 of  13 after      1. seconds and      1. CPU-seconds
++   - Starting shell A no.   13 after           0.00 seconds.
++   - Starting shell A no.   12 after           0.00 seconds.
++   - Starting shell A no.   11 after           0.07 seconds.
++   - Starting shell A no.   10 after           0.15 seconds.
++   - Starting shell A no.    9 after           0.18 seconds.
++   - Starting shell A no.    8 after           0.24 seconds.
++   - Starting shell A no.    7 after           0.32 seconds.
++   - Starting shell A no.    6 after           0.33 seconds.
++ - Integral class 1 : (LL|??)
++   - Starting shell A no.    5 after           0.37 seconds.
++   - Starting shell A no.    4 after           0.38 seconds.
++   - Starting shell A no.    3 after           0.41 seconds.
++   - Starting shell A no.    2 after           0.43 seconds.
++   - Starting shell A no.    1 after           0.45 seconds.
++   - Process    1 finished at           0.48 seconds after start
+ 
+- - Starting symmetrization after           0.62 seconds
+- - Finished symmetrization after           0.62 seconds
++ - Starting symmetrization after           0.48 seconds
++ - Finished symmetrization after           0.49 seconds
+ 
+ 
+ ------ Timing report (in CPU seconds) of module  integral transformation      
+ 
+- Time in  Initializing MS4IND file            0.011 seconds
+- Time in  Computing+transform. integral       0.624 seconds
+- Time in  Symmetrizing MO integrals           0.000 seconds
++
++
++                                    Master   --------- Slaves ------------
++
++ Timer                              Master   Minimum   Maximum     Average
++
++  Initializing MS4IND file             0.0       0.0       0.0       0.0
++  Slave requesting task from ma        0.5       0.0       0.0       0.0
++  Master and slave negotiating         0.0       0.0       0.0       0.0
++  Symmetrizing MO integrals            0.0       0.0       0.0       0.0
++  Computing+transform. integral        0.0       0.5       0.5       0.5
++
++------ End of timing report ------
++
+ 
+  (RTRACTL1) Total CPU (wall) time used :   00:00:01 (   00:00:01)
+-            Transformation ended Sat Dec  7 14:42:46 2019
++            Transformation ended Fri Oct  9 13:31:25 2020
+   //  LUCIAREL called
+   //  CIRUN = KR-CI 
+   //  Running large-scale CI calculation
+ 
+-* REAFCK: Fock matrix read from file DFFCK1                                                      
+-* Heading :BeH                                               Sat Dec  7 14:42:43 2019
++* REAFCK: Fock matrix read from file /dev/shm/build/DIRAC/19.0/intel-2020a-Python-2.7.18-mpi-int6
++* Heading :BeH                                               Fri Oct  9 13:31:22 2020
+   Allocating for             3480 diagonal integrals.
+ 
+ 
+@@ -1378,14 +1399,34 @@
+  (including imaginary parts) 
+ 
+ 
++       ===================================================
++        parallel distribution setup for symmetry irrep  65
++       ===================================================
++
++  total number of processes to distribute on :                  2
++  total number of blocks                     :              13056
++  total number of active blocks              :                 29
++  size of largest TTSS block                 :                784
++  overall weighted active block length       :             214301
++  Maximum weighted block size                :              61936
++
++                    ================================
++                     Summation of even distribution 
++                    ================================
++
++  CPU    0  computes     15 blocks with a total weight of             107168
++  CPU    1  computes     14 blocks with a total weight of             107133
++
+    ==============================================================
+    ==> allocation of two CI vectors and one resolution vector <==
+   
+-   current available free memory in double words:      1999304192
++   current available free memory in double words:        63304144
+    allocate two CI vectors each of length:                   3366
+    allocate resolution vector of length:                     3366
+    ==============================================================
+ 
++   
++   
+ 
+     2 start vectors based on lowest diagonal elements of H_CI
+          1          -15.055258
+@@ -1397,270 +1438,330 @@
+ 
+   Maximum number of CI microiterations ...   50
+ 
+-
++ 
+   ----------------------------------------------
+-  I'll take you to a place 
++  I'll take you to a place
+   Where we shall find our
+-   ROOTS, BLOODY ROOTS 
+-
+-                Sepultura 
++   ROOTS, BLOODY ROOTS
++ 
++                Sepultura
+   ----------------------------------------------
++ 
+ 
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.   1
++                        Total energy       =        -15.05525783
++                        Lowering of energy =         -0.00000000
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.   1
+-                    Total energy       =        -15.05525783
+-                    Lowering of energy =         -0.00000000
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         4.37450D-01
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         4.37450D-01
++                        Wall time for microiteration       0.38906469s
+ 
+-                    CPU (Wall) time for microiteration   1.20469400s( 1.21234911s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.   2
++                        Total energy       =        -15.09785782
++                        Lowering of energy =          0.04259999
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.   2
+-                    Total energy       =        -15.09785782
+-                    Lowering of energy =          0.04259999
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         1.39990D-01
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         1.39990D-01
++                        Wall time for microiteration       0.41679055s
+ 
+-                    CPU (Wall) time for microiteration   0.95826800s( 0.96383090s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.   3
++                        Total energy       =        -15.10221442
++                        Lowering of energy =          0.00435660
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.   3
+-                    Total energy       =        -15.10221442
+-                    Lowering of energy =          0.00435660
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         6.68601D-02
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         6.68601D-02
++                        Wall time for microiteration       0.41734640s
+ 
+-                    CPU (Wall) time for microiteration   1.23481700s( 1.24102225s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.   4
++                        Total energy       =        -15.10336430
++                        Lowering of energy =          0.00114988
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.   4
+-                    Total energy       =        -15.10336430
+-                    Lowering of energy =          0.00114988
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         1.84414D-02
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         1.84414D-02
++                        Wall time for microiteration       0.41587336s
+ 
+-                    CPU (Wall) time for microiteration   0.96459800s( 0.96983010s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.   5
++                        Total energy       =        -15.10355258
++                        Lowering of energy =          0.00018829
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.   5
+-                    Total energy       =        -15.10355258
+-                    Lowering of energy =          0.00018829
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         1.86545D-02
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         1.86545D-02
++                        Wall time for microiteration       0.41766227s
+ 
+-                    CPU (Wall) time for microiteration   1.23176500s( 1.23788811s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.   6
++                        Total energy       =        -15.10365534
++                        Lowering of energy =          0.00010276
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.   6
+-                    Total energy       =        -15.10365534
+-                    Lowering of energy =          0.00010276
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         1.02051D-02
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         1.02051D-02
++                        Wall time for microiteration       0.41570181s
+ 
+-                    CPU (Wall) time for microiteration   0.96846600s( 0.97378551s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.   7
++                        Total energy       =        -15.10368496
++                        Lowering of energy =          0.00002962
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.   7
+-                    Total energy       =        -15.10368496
+-                    Lowering of energy =          0.00002962
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         6.64018D-03
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         6.64018D-03
++                        Wall time for microiteration       0.41870350s
+ 
+-                    CPU (Wall) time for microiteration   1.24741500s( 1.25294369s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.   8
++                        Total energy       =        -15.10369583
++                        Lowering of energy =          0.00001087
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.   8
+-                    Total energy       =        -15.10369583
+-                    Lowering of energy =          0.00001087
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         3.19312D-03
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         3.19312D-03
++                        Wall time for microiteration       0.41609852s
+ 
+-                    CPU (Wall) time for microiteration   0.96903700s( 0.97438777s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.   9
++                        Total energy       =        -15.10370048
++                        Lowering of energy =          0.00000465
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.   9
+-                    Total energy       =        -15.10370048
+-                    Lowering of energy =          0.00000465
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         3.23467D-03
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         3.23467D-03
++                        Wall time for microiteration       0.41777307s
+ 
+-                    CPU (Wall) time for microiteration   1.22110400s( 1.22825285s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  10
++                        Total energy       =        -15.10370322
++                        Lowering of energy =          0.00000274
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  10
+-                    Total energy       =        -15.10370322
+-                    Lowering of energy =          0.00000274
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         1.97047D-03
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         1.97047D-03
++                        Wall time for microiteration       0.41673967s
+ 
+-                    CPU (Wall) time for microiteration   0.92580700s( 0.93142437s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  11
++                        Total energy       =        -15.10370430
++                        Lowering of energy =          0.00000108
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  11
+-                    Total energy       =        -15.10370430
+-                    Lowering of energy =          0.00000108
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         1.39286D-03
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         1.39286D-03
++                        Wall time for microiteration       0.41791135s
+ 
+-                    CPU (Wall) time for microiteration   1.21935300s( 1.22573134s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  12
++                        Total energy       =        -15.10370471
++                        Lowering of energy =          0.00000041
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  12
+-                    Total energy       =        -15.10370471
+-                    Lowering of energy =          0.00000041
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         6.78879D-04
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         6.78879D-04
++                        Wall time for microiteration       0.41635790s
+ 
+-                    CPU (Wall) time for microiteration   0.96845200s( 0.97368623s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  13
++                        Total energy       =        -15.10370491
++                        Lowering of energy =          0.00000019
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  13
+-                    Total energy       =        -15.10370491
+-                    Lowering of energy =          0.00000019
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         7.08771D-04
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         7.08771D-04
++                        Wall time for microiteration       0.42354180s
+ 
+-                    CPU (Wall) time for microiteration   1.24966800s( 1.25543883s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  14
++                        Total energy       =        -15.10370502
++                        Lowering of energy =          0.00000012
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  14
+-                    Total energy       =        -15.10370502
+-                    Lowering of energy =          0.00000012
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         4.23480D-04
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         4.23480D-04
++                        Wall time for microiteration       0.41584093s
+ 
+-                    CPU (Wall) time for microiteration   0.95248500s( 0.95758762s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  15
++                        Total energy       =        -15.10370507
++                        Lowering of energy =          0.00000005
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  15
+-                    Total energy       =        -15.10370507
+-                    Lowering of energy =          0.00000005
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         3.04533D-04
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         3.04533D-04
++                        Wall time for microiteration       0.41808349s
+ 
+-                    CPU (Wall) time for microiteration   1.24777200s( 1.25355540s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  16
++                        Total energy       =        -15.10370509
++                        Lowering of energy =          0.00000002
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  16
+-                    Total energy       =        -15.10370509
+-                    Lowering of energy =          0.00000002
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         1.50921D-04
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         1.50921D-04
++                        Wall time for microiteration       0.41666777s
+ 
+-                    CPU (Wall) time for microiteration   1.01747300s( 1.05122897s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  17
++                        Total energy       =        -15.10370510
++                        Lowering of energy =          0.00000001
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  17
+-                    Total energy       =        -15.10370510
+-                    Lowering of energy =          0.00000001
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         1.53262D-04
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         1.53262D-04
++                        Wall time for microiteration       0.41730021s
+ 
+-                    CPU (Wall) time for microiteration   1.24111700s( 1.24705948s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  18
++                        Total energy       =        -15.10370510
++                        Lowering of energy =          0.00000001
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  18
+-                    Total energy       =        -15.10370510
+-                    Lowering of energy =          0.00000001
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         9.48004D-05
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         9.48004D-05
++                        Wall time for microiteration       0.41675383s
+ 
+-                    CPU (Wall) time for microiteration   0.96130400s( 0.96728180s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  19
++                        Total energy       =        -15.10370510
++                        Lowering of energy =          0.00000000
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  19
+-                    Total energy       =        -15.10370510
+-                    Lowering of energy =          0.00000000
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         6.58500D-05
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         6.58500D-05
++                        Wall time for microiteration       0.41868551s
+ 
+-                    CPU (Wall) time for microiteration   1.24445300s( 1.25093647s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  20
++                        Total energy       =        -15.10370511
++                        Lowering of energy =          0.00000000
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  20
+-                    Total energy       =        -15.10370511
+-                    Lowering of energy =          0.00000000
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         3.40204D-05
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         3.40204D-05
++                        Wall time for microiteration       0.41628122s
+ 
+-                    CPU (Wall) time for microiteration   0.96835700s( 0.97404379s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  21
++                        Total energy       =        -15.10370511
++                        Lowering of energy =          0.00000000
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  21
+-                    Total energy       =        -15.10370511
+-                    Lowering of energy =          0.00000000
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         3.33886D-05
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         3.33886D-05
++                        Wall time for microiteration       0.41618816s
+ 
+-                    CPU (Wall) time for microiteration   1.18932100s( 1.19510286s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  22
++                        Total energy       =        -15.10370511
++                        Lowering of energy =          0.00000000
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  22
+-                    Total energy       =        -15.10370511
+-                    Lowering of energy =          0.00000000
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         2.14673D-05
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         2.14673D-05
++                        Wall time for microiteration       0.41732191s
+ 
+-                    CPU (Wall) time for microiteration   0.96339800s( 0.97118922s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  23
++                        Total energy       =        -15.10370511
++                        Lowering of energy =          0.00000000
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  23
+-                    Total energy       =        -15.10370511
+-                    Lowering of energy =          0.00000000
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         1.44211D-05
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         1.44211D-05
++                        Wall time for microiteration       0.41780390s
+ 
+-                    CPU (Wall) time for microiteration   1.23398800s( 1.23978875s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  24
++                        Total energy       =        -15.10370511
++                        Lowering of energy =          0.00000000
+ 
+- (MICDV4_ENLMD_REL) CI microiteration no.  24
+-                    Total energy       =        -15.10370511
+-                    Lowering of energy =          0.00000000
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         7.72802D-06
+ 
+-                    Norm of CI residuals (thr = 1.00D-05)
+-          1         7.72802D-06
++                        Wall time for microiteration       0.41720308s
+ 
+-                    CPU (Wall) time for microiteration   0.08609000s( 0.08613085s)
+ 
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  25
++                        Total energy       =        -15.10370511
++                        Lowering of energy =          0.00000000
+ 
+- (MICDV4_ENLMD_REL) Micro iterations converged.
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         7.37801D-06
+ 
+-                    Core energy        =           2.30880227
+-                    Active energies    =         -17.41250738
+-                    Final CI energies  =         -15.10370511
++                        Wall time for microiteration       0.41947213s
+ 
+-                    root    1 ...... converged!
+ 
+-  I have completed task KR-CI  in 26.37510378s (wall time)
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  26
++                        Total energy       =        -15.10370511
++                        Lowering of energy =          0.00000000
++
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         4.89162D-06
++
++                        Wall time for microiteration       0.41700623s
++
++
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  27
++                        Total energy       =        -15.10370511
++                        Lowering of energy =          0.00000000
++
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         3.20093D-06
++
++                        Wall time for microiteration       0.41741276s
++
++
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  28
++                        Total energy       =        -15.10370511
++                        Lowering of energy =          0.00000000
++
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         1.76410D-06
++
++                        Wall time for microiteration       0.41627715s
++
++
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  29
++                        Total energy       =        -15.10370511
++                        Lowering of energy =          0.00000000
++
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         1.64937D-06
++
++                        Wall time for microiteration       0.41783292s
++
++
++ (MICDV4_ENLMD_REL_PAR) CI microiteration no.  30
++                        Total energy       =        -15.10370511
++                        Lowering of energy =          0.00000000
++
++                        Norm of CI residuals (thr = 1.00D-06)
++              1         1.11914D-06
++
++                        Wall time for microiteration       0.00072046s
++
++
++ (MICDV4_ENLMD_REL_PAR) Micro iterations converged.
++
++                        Core energy        =           2.30880227
++                        Active energies    =         -17.41250738
++                        Final CI energies  =         -15.10370511
++
++                        root    1 ...... converged!
++
++  I have completed task KR-CI  in 12.58797884s (wall time)
+ 
+  (ROPTST)  KR-CI calculation ended properly.
+ 
+->>> TOTAL CPU (WALL) TIME IN KR-CI: 27.82514200s(28.00508189s)
++>>> TOTAL CPU (WALL) TIME IN KR-CI: 14.02860500s(14.16464686s)
+ 
+ 
+ 
+@@ -1699,7 +1800,7 @@
+ 
+  (RSETCI) Number of determinants:         3366 (dimension         3366)
+ 
+- CPU (Wall) time for generation of determinants:  0.25193400s( 0.25195498s)
++ CPU (Wall) time for generation of determinants:  0.19848500s( 0.20092607s)
+ 
+  (RSETWOP) Orbital classes:
+      Inactive orbitals   :                                                   
+@@ -1745,12 +1846,12 @@
+   _________________________________
+   Total              1
+ 
+- Diagonal and Off-diagonal blocks are exchanged                    for Y1-HYP  
+- Diagonal and Off-diagonal blocks are exchanged                    for Y2-HYP  
+- Diagonal and Off-diagonal blocks are exchanged                    for X1-HYP  
+- Sign of the lower diagonal block is changed                       for X1-HYP  
+- Diagonal and Off-diagonal blocks are exchanged                    for X2-HYP  
+- Sign of the lower diagonal block is changed                       for X2-HYP  
++ Diagonal and Off-diagonal blocks are exchanged            for Y1-HYP  
++ Diagonal and Off-diagonal blocks are exchanged            for Y2-HYP  
++ Diagonal and Off-diagonal blocks are exchanged            for X1-HYP  
++ Sign of the lower diagonal block is changed            for X1-HYP  
++ Diagonal and Off-diagonal blocks are exchanged            for X2-HYP  
++ Sign of the lower diagonal block is changed            for X2-HYP  
+   //  LUCIAREL called
+   //  CIRUN = PROP1 
+   //  Computing one-electron properties.
+@@ -1770,10 +1871,28 @@
+    A1-SPS              A2                   A2 
+    A2-SPS              A2                   A2 
+ 
++       ===================================================
++        parallel distribution setup for symmetry irrep  65
++       ===================================================
++
++  total number of processes to distribute on :                  2
++  total number of blocks                     :              13056
++  total number of active blocks              :                 29
++  size of largest TTSS block                 :                784
++  overall weighted active block length       :              26784
++  Maximum weighted block size                :               7056
++
++                    ================================
++                     Summation of even distribution 
++                    ================================
++
++  CPU    0  computes     14 blocks with a total weight of              13391
++  CPU    1  computes     15 blocks with a total weight of              13393
++
+    ==============================================================
+    ==> allocation of two CI vectors and one resolution vector <==
+   
+-   current available free memory in double words:      1999885056
++   current available free memory in double words:        63885000
+    allocate two CI vectors each of length:                   3366
+    allocate resolution vector of length:                     3366
+    ==============================================================
+@@ -1803,7 +1922,7 @@
+      0          -15.1037051064  0.000000000000            0.000000000000              0.000000000000      (1   )
+   ________________________________________________________________________________________________________
+ 
+-
++ 
+ 
+                              ********************************************************
+                              ********* electron Electric Dipole Moment **************
+@@ -1812,9 +1931,9 @@
+   <state| P2-EDM  2*ic gamma0 gamma5 p^2 | state >    E_eff [a.u.]             E_eff [GV/cm]   
+ 
+   __________________       _________________    __________________________________________________________
+- EEDM  state  1(1   )         state  1(1   )        -0.000110451662          -0.000567965276
++ EEDM  state  1(1   )         state  1(1   )        -0.000110451220          -0.000567963004
+   __________________________________________    __________________________________________________________
+-
++ 
+ 
+                              ********************************************************
+                              *********  Hyperfine Structure Constants  **************
+@@ -1823,45 +1942,45 @@
+     < state | Y1-HYP [alpha x E] | state >       Hyperfine Const. [a.u.]     Delta E_HypFin [a.u.]   
+ 
+   __________________       _________________    __________________________________________________________
+-  PREFACNUC =   -1.5598078852941472E-006
+- MHYP  state  1(1   )         state  1(1   )        -0.005905849748           0.000000009212
++  PREFACNUC =  -1.559807885294147E-006
++ MHYP  state  1(1   )         state  1(1   )        -0.005905650151           0.000000009212
+   __________________________________________    __________________________________________________________
+ 
+     < state | Y2-HYP [alpha x E] | state >       Hyperfine Const. [a.u.]     Delta E_HypFin [a.u.]   
+ 
+   __________________       _________________    __________________________________________________________
+-  PREFACNUC =    1.1099508005612513E-005
+- MHYP  state  1(1   )         state  1(1   )        -0.000974096023          -0.000000010812
++  PREFACNUC =   1.109950800561251E-005
++ MHYP  state  1(1   )         state  1(1   )        -0.000974190577          -0.000000010813
+   __________________________________________    __________________________________________________________
+ 
+     < state | X1-HYP [alpha x E] | state >       Hyperfine Const. [a.u.]     Delta E_HypFin [a.u.]   
+ 
+   __________________       _________________    __________________________________________________________
+-  PREFACNUC =   -1.5598078852941472E-006
+- MHYP  state  1(1   )         state  1(1   )        -0.005905849748           0.000000009212
++  PREFACNUC =  -1.559807885294147E-006
++ MHYP  state  1(1   )         state  1(1   )        -0.005905650151           0.000000009212
+   __________________________________________    __________________________________________________________
+ 
+     < state | X2-HYP [alpha x E] | state >       Hyperfine Const. [a.u.]     Delta E_HypFin [a.u.]   
+ 
+   __________________       _________________    __________________________________________________________
+-  PREFACNUC =    1.1099508005612513E-005
+- MHYP  state  1(1   )         state  1(1   )        -0.000974096023          -0.000000010812
++  PREFACNUC =   1.109950800561251E-005
++ MHYP  state  1(1   )         state  1(1   )        -0.000974190577          -0.000000010813
+   __________________________________________    __________________________________________________________
+ 
+     < state | Z1-HYP [alpha x E] | state >       Hyperfine Const. [a.u.]     Delta E_HypFin [a.u.]   
+ 
+   __________________       _________________    __________________________________________________________
+-  PREFACNUC =   -1.5598078852941472E-006
+- MHYP  state  1(1   )         state  1(1   )        -0.006752396302           0.000000010532
++  PREFACNUC =  -1.559807885294147E-006
++ MHYP  state  1(1   )         state  1(1   )        -0.006752216685           0.000000010532
+   __________________________________________    __________________________________________________________
+ 
+     < state | Z2-HYP [alpha x E] | state >       Hyperfine Const. [a.u.]     Delta E_HypFin [a.u.]   
+ 
+   __________________       _________________    __________________________________________________________
+-  PREFACNUC =    1.1099508005612513E-005
+- MHYP  state  1(1   )         state  1(1   )        -0.001232804132          -0.000000013684
++  PREFACNUC =   1.109950800561251E-005
++ MHYP  state  1(1   )         state  1(1   )        -0.001232901004          -0.000000013685
+   __________________________________________    __________________________________________________________
+-
++ 
+ 
+                              ********************************************************
+                              *********  e-N S-PS interaction Parameter  *************
+@@ -1870,13 +1989,13 @@
+   <state| A1-SPS i[gamma0 gamma5]rho_N |state>    e-N S-PS Parameter [a.u.]        Norm [a.u.]
+ 
+   __________________       _________________    __________________________________________________________
+- ENSPS state  1(1   )         state  1(1   )         0.001238402290           0.001238402290
++ ENSPS state  1(1   )         state  1(1   )         0.001238395771           0.001238395771
+   __________________________________________    __________________________________________________________
+ 
+   <state| A2-SPS i[gamma0 gamma5]rho_N |state>    e-N S-PS Parameter [a.u.]        Norm [a.u.]
+ 
+   __________________       _________________    __________________________________________________________
+- ENSPS state  1(1   )         state  1(1   )        -0.000041687482           0.000041687482
++ ENSPS state  1(1   )         state  1(1   )        -0.000041690709           0.000041690709
+   __________________________________________    __________________________________________________________
+ 
+ *****************************************************
+@@ -1885,35 +2004,35 @@
+ 
+ 
+  
+-     Date and time (Linux)  : Sat Dec  7 14:43:18 2019
+-     Host name              : malaya.tcs                              
++     Date and time (Linux)  : Fri Oct  9 13:31:40 2020
++     Host name              : node3414.kirlia.os                      
+ 
+->>>> Node 0, utime: 33, stime: 0, minflt: 10512, majflt: 0, nvcsw: 712, nivcsw: 1212, maxrss: 192920
+->>>> Total WALL time used in DIRAC: 36s
++>>>> Node 0, utime: 17, stime: 0, minflt: 102299, majflt: 0, nvcsw: 729, nivcsw: 1895, maxrss: 647320
++>>>> Total WALL time used in DIRAC: 19s
+   
+   Dynamical Memory Usage Summary for Master
+   
+-  Mean allocation size (Mb) :       234.90
++  Mean allocation size (Mb) :         8.01
+   
+-  Largest                   10  allocations
++  Largest                    10  allocations
+   
+-    15258.79 Mb at subroutine __allocator_track_if_MOD_allocator_registe for WORK in KRCI_CALC                         
+-    15258.79 Mb at subroutine __allocator_track_if_MOD_allocator_registe for WORK in PSISCF                            
+-    15258.79 Mb at subroutine __allocator_track_if_MOD_allocator_registe for WORK in PAMSET - 2                        
+-    15258.79 Mb at subroutine __allocator_track_if_MOD_allocator_registe for WORK in GMOTRA                            
+-    15258.79 Mb at subroutine __allocator_track_if_MOD_allocator_registe for WORK in PAMSET - 1                        
+-    15258.79 Mb at subroutine __allocator_track_if_MOD_allocator_registe for test allocation of work array in DIRAC mai
+-        3.81 Mb at subroutine __allocator_track_if_MOD_allocator_registe for unnamed variable                          
+-        3.81 Mb at subroutine __allocator_track_if_MOD_allocator_registe for unnamed variable                          
+-        3.81 Mb at subroutine __allocator_track_if_MOD_allocator_registe for unnamed variable                          
+-        3.81 Mb at subroutine __allocator_track_if_MOD_allocator_registe for unnamed variable                          
++      488.28 Mb at subroutine krci_calc_+0xc4                            for WORK in KRCI_CALC                         
++      488.28 Mb at subroutine psiscf_+0xa9                               for WORK in PSISCF                            
++      488.28 Mb at subroutine pamset_+0x16ac                             for WORK in PAMSET - 2                        
++      488.28 Mb at subroutine gmotra_+0x47d0                             for WORK in GMOTRA                            
++      488.28 Mb at subroutine pamset_+0x97                               for WORK in PAMSET - 1                        
++      488.28 Mb at subroutine MAIN__+0x9af                               for test allocation of work array in DIRAC mai
++        3.81 Mb at subroutine set_hop_dbg_+0x788                         for unnamed variable                          
++        3.81 Mb at subroutine set_hop_dbg_+0x773                         for unnamed variable                          
++        3.81 Mb at subroutine set_hop_dbg_+0x75e                         for unnamed variable                          
++        3.81 Mb at subroutine set_hop_dbg_+0x749                         for unnamed variable                          
+   
+-  Peak memory usage:     15274.30 MB
+-  Peak memory usage:       14.916 GB
+-       reached at subroutine : __allocator_track_if_MOD_allocator_registe
++  Peak memory usage:       503.80 MB
++  Peak memory usage:        0.492 GB
++       reached at subroutine : set_hop_dbg_+0x788                        
+               for variable   : unnamed variable                          
+   
+  MEMGET high-water mark:     0.00 MB
+ 
+ *****************************************************
+-DIRAC pam run in /home/mknayak/dirac-repo-05-12-18/work/eedm_mhyp_ensps_krci
++DIRAC pam run in /dev/shm/build/DIRAC/19.0/intel-2020a-Python-2.7.18-mpi-int64/easybuild_obj/test/eedm_mhyp_ensps_krci

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0_fix_test_path.patch
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0_fix_test_path.patch
@@ -1,0 +1,26 @@
+# Fix hard coded DIRAC/utils path in fde_response_mag and fde_response_shield tests
+# OCT 7th 2020 by B. Hajgato (UGent)
+diff -ru DIRAC-19.0-Source.orig/test/fde_response_mag/test DIRAC-19.0-Source/test/fde_response_mag/test
+--- DIRAC-19.0-Source.orig/test/fde_response_mag/test	2019-12-12 17:26:15.000000000 +0100
++++ DIRAC-19.0-Source/test/fde_response_mag/test	2020-10-07 22:41:25.277776298 +0200
+@@ -16,7 +16,7 @@
+ 
+ 
+ test.run(['dc_pbe'],                       ['h2o-1.xyz'],    args='--get="numerical_grid"')
+-os.system('../../../utils/fde-mag/dft_to_fde_grid_convert.py')
++os.system('../../../DIRAC*/utils/fde-mag/dft_to_fde_grid_convert.py')
+ 
+ shutil.copy('numerical_grid', 'FILEEX')
+ shutil.copy('numerical_grid', 'GRIDOUT')
+diff -ru DIRAC-19.0-Source.orig/test/fde_response_shield/test DIRAC-19.0-Source/test/fde_response_shield/test
+--- DIRAC-19.0-Source.orig/test/fde_response_shield/test	2019-12-12 17:26:15.000000000 +0100
++++ DIRAC-19.0-Source/test/fde_response_shield/test	2020-10-07 22:41:45.348275614 +0200
+@@ -17,7 +17,7 @@
+ 
+ 
+ test.run(['dc_pbe'],                       ['h2o-1.xyz'],    args='--get="numerical_grid"')
+-os.system('../../../utils/fde-mag/dft_to_fde_grid_convert.py')
++os.system('../../../DIRAC*/utils/fde-mag/dft_to_fde_grid_convert.py')
+ 
+ shutil.copy('numerical_grid', 'FILEEX')
+ shutil.copy('numerical_grid', 'GRIDOUT')

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0_remove-broken-tests-intel.patch
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0_remove-broken-tests-intel.patch
@@ -5,7 +5,7 @@ Author: Pavel Grochal (INUITS)
 Comments from B. Hajgato (UGent) at OCT 5th 2020:
 In the test python program both ignore_sign and ignore_order is set to True,
 but ignore_order does not seem to work perfectly.
-Using ifort 20.1 and MKL20.1 on cascadelake a manual comparison passed, meanwhile the automatic
+Using ifort 2020.1 and MKL2020.1 on cascadelake a manual comparison passed, meanwhile the automatic
 comparison failed. Therefore, test will be disabled. 
 diff -ru DIRAC-19.0-Source.orig/cmake/custom/test.cmake DIRAC-19.0-Source/cmake/custom/test.cmake
 --- DIRAC-19.0-Source.orig/cmake/custom/test.cmake	2019-12-12 17:26:15.000000000 +0100

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0_remove-broken-tests-intel.patch
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0_remove-broken-tests-intel.patch
@@ -1,23 +1,15 @@
-Removed tests which fails on intel compilers. 
-
-"bss_energy" has slight abs difference (2.24e-07) in calculation.
-
 "operators_mo_mtx_elements" doesn't run when mpi is enabled (even if test doesn't use mpi)
 see: https://ccportal.ims.ac.jp/en/node/2411
 
 Author: Pavel Grochal (INUITS)
+Comments from B. Hajgato (UGent) at OCT 5th 2020:
+In the test python program both ignore_sign and ignore_order is set to True,
+but ignore_order does not seem to work perfectly.
+Using ifort 20.1 and MKL20.1 on cascadelake a manual comparison passed, meanwhile the automatic
+comparison failed. Therefore, test will be disabled. 
 diff -ru DIRAC-19.0-Source.orig/cmake/custom/test.cmake DIRAC-19.0-Source/cmake/custom/test.cmake
 --- DIRAC-19.0-Source.orig/cmake/custom/test.cmake	2019-12-12 17:26:15.000000000 +0100
 +++ DIRAC-19.0-Source/cmake/custom/test.cmake	2020-09-24 12:54:02.524830820 +0200
-@@ -102,7 +102,7 @@
- dirac_test(basis_input "basis;short" "")
- dirac_test(basis_input_scripted "basis;long" "3600")
- dirac_test(bsse "basis;short" "")
--dirac_test(bss_energy "short" "")
-+# dirac_test(bss_energy "short" "")
- dirac_test(pam_test "short;pam" "")
- dirac_test(cc_essential "short;cc" "")
- dirac_test(cc_linear "short;cc" "")
 @@ -158,9 +158,8 @@
  dirac_test(lucita_q_corrections "short;qcorr;ci" "")
  dirac_test(x2c-SCF_to_4c-SCF "short;x2c;4c;scf" "")

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0_use_easybuild_opts_intel.patch
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-19.0_use_easybuild_opts_intel.patch
@@ -1,0 +1,33 @@
+# Take EasyBuild compiler flags for C, C++, and Fortran
+# OCT 5th, 2020 by B. Hajgato (UGent)
+diff -ru DIRAC-19.0-Source.orig/cmake/custom/compiler_flags/Intel.C.cmake DIRAC-19.0-Source/cmake/custom/compiler_flags/Intel.C.cmake
+--- DIRAC-19.0-Source.orig/cmake/custom/compiler_flags/Intel.C.cmake	2019-12-12 17:26:15.000000000 +0100
++++ DIRAC-19.0-Source/cmake/custom/compiler_flags/Intel.C.cmake	2020-10-07 19:53:57.517988580 +0200
+@@ -1,5 +1,5 @@
+ if(CMAKE_C_COMPILER_ID MATCHES Intel)
+-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -wd981 -wd279 -wd383 -wd1572 -wd177")
++    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -wd981 -wd279 -wd383 -wd1572 -wd177")
+     set(CMAKE_C_FLAGS_RELEASE "-O2")
+     set(CMAKE_C_FLAGS_DEBUG "-O0")
+ endif()
+diff -ru DIRAC-19.0-Source.orig/cmake/custom/compiler_flags/Intel.CXX.cmake DIRAC-19.0-Source/cmake/custom/compiler_flags/Intel.CXX.cmake
+--- DIRAC-19.0-Source.orig/cmake/custom/compiler_flags/Intel.CXX.cmake	2019-12-12 17:26:15.000000000 +0100
++++ DIRAC-19.0-Source/cmake/custom/compiler_flags/Intel.CXX.cmake	2020-10-07 19:54:10.338306645 +0200
+@@ -1,5 +1,5 @@
+ if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+-    set(CMAKE_CXX_FLAGS_RELEASE "-debug -O3 -DNDEBUG")
++    set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+     set(CMAKE_CXX_FLAGS_DEBUG "-O0 -debug -DDEBUG")
+ endif()
+diff -ru DIRAC-19.0-Source.orig/cmake/custom/compiler_flags/Intel.Fortran.cmake DIRAC-19.0-Source/cmake/custom/compiler_flags/Intel.Fortran.cmake
+--- DIRAC-19.0-Source.orig/cmake/custom/compiler_flags/Intel.Fortran.cmake	2019-12-12 17:26:15.000000000 +0100
++++ DIRAC-19.0-Source/cmake/custom/compiler_flags/Intel.Fortran.cmake	2020-10-07 19:55:34.670398011 +0200
+@@ -1,5 +1,5 @@
+ if(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
+-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -w -assume byterecl -g -traceback -DVAR_IFORT")
+-    set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -ip")
++    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -w -assume byterecl -DVAR_IFORT")
++    set(CMAKE_Fortran_FLAGS_RELEASE " ")
+     set(CMAKE_Fortran_FLAGS_DEBUG "-O0")
+ endif()


### PR DESCRIPTION
Change the sequential version to work with native CMakeMake easyblock, and add mpi version.
Also, the unnecessary dependencies were removed (they only needed if PCMSOLVER is built)

PS: Dirac does not have `https` homepage
