### PR TITLE
cache M4 source tarball to avoid test failures because of download problems

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -22,6 +22,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Cache source files in /tmp/sources
+      id: cache-sources
+      uses: actions/cache@v2
+      with:
+        path: /tmp/sources
+        key: eb-sourcepath
+
     - name: set up Python
       uses: actions/setup-python@v1
       with:
@@ -137,7 +144,8 @@ jobs:
           eb --search '^CVS-' | grep '/CVS-'
 
           # try installing M4 with system toolchain (requires ConfigureMake easyblock + easyconfig)
-          eb --prefix /tmp/$USER/$GITHUB_SHA M4-1.4.18.eb
+          # use /tmp/sources because that has cached downloads (see cache step above)
+          eb --prefix /tmp/$USER/$GITHUB_SHA --sourcepath /tmp/sources M4-1.4.18.eb
 
   test-sdist:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
This should help with avoiding tests failing with errors like:

```
ERROR: Build of /home/runner/work/easybuild-easyconfigs/easybuild-easyconfigs/easybuild/easyconfigs/m/M4/M4-1.4.18.eb failed (err: "build failed (first 300 chars): Unexpected error occurred when trying to download https://ftpmirror.gnu.org/gnu/m4/m4-1.4.18.tar.gz to /tmp/runner/f34bb1a5734d6a0525710aa9ddc9f6be927f2737/sources/m/M4/m4-1.4.18.tar.gz: hostname 'gnu.mirror.constant.com' doesn't match 'arch.mirror.constant.com'")
```