### PR TITLE
add BLAS/LAPACK check to GPAW patch adding EasyBuild configuration files

### DIFF
--- a/easybuild/easyconfigs/g/GPAW/GPAW-20.1.0-Add-Easybuild-configuration-files.patch
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-20.1.0-Add-Easybuild-configuration-files.patch
@@ -45,8 +45,12 @@ index 0000000..5be60fa
 +    libraries += static_eblibs_to_gpawlibs('SCALAPACK_STATIC_LIBS')
 +
 +# Add EasyBuild LAPACK/BLAS libs
-+libraries += static_eblibs_to_gpawlibs('LAPACK_STATIC_LIBS')
-+libraries += static_eblibs_to_gpawlibs('BLAS_STATIC_LIBS')
++lapack = os.getenv('LAPACK_STATIC_LIBS')
++if lapack:
++    libraries += static_eblibs_to_gpawlibs('LAPACK_STATIC_LIBS')
++blas = os.getenv('BLAS_STATIC_LIBS')
++if blas:
++    libraries += static_eblibs_to_gpawlibs('BLAS_STATIC_LIBS')
 +
 +# LibXC:
 +# Use EasyBuild libxc

--- a/easybuild/easyconfigs/g/GPAW/GPAW-20.1.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-20.1.0-foss-2019b-Python-3.7.4.eb
@@ -21,7 +21,7 @@ patches = [
 checksums = [
     'c84307eb9943852d78d966c0c8856fcefdefa68621139906909908fb641b8421',  # gpaw-20.1.0.tar.gz
     # GPAW-20.1.0-Add-Easybuild-configuration-files.patch
-    '1231ef113f8c46c1f37bf4e544d792fd75dd8965053f792cac5794cb84af8276',
+    'a12440bf63af70b891a63989b0f048bb8ebf4f60499020ea09259937f04cd042',
     # GPAW-20.1.0-Wrap-pragma-omp-simd-in-ifdef-_OPENMP-blocks.patch
     'bf0e0179ce9261197a10a3a934ce3a8d46489b635a3130a5ceb2fe0fee67bb14',
 ]

--- a/easybuild/easyconfigs/g/GPAW/GPAW-20.1.0-intel-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-20.1.0-intel-2019b-Python-3.7.4.eb
@@ -21,7 +21,7 @@ patches = [
 checksums = [
     'c84307eb9943852d78d966c0c8856fcefdefa68621139906909908fb641b8421',  # gpaw-20.1.0.tar.gz
     # GPAW-20.1.0-Add-Easybuild-configuration-files.patch
-    '1231ef113f8c46c1f37bf4e544d792fd75dd8965053f792cac5794cb84af8276',
+    'a12440bf63af70b891a63989b0f048bb8ebf4f60499020ea09259937f04cd042',
     # GPAW-20.1.0-Wrap-pragma-omp-simd-in-ifdef-_OPENMP-blocks.patch
     'bf0e0179ce9261197a10a3a934ce3a8d46489b635a3130a5ceb2fe0fee67bb14',
 ]


### PR DESCRIPTION
GPAW patch doesn't check if BLAS and LAPACK actually exist, so it might trigger a `AttributeError: 'NoneType' object has no attribute 'split'`