### PR TITLE
{perf}[gompi/2020a] Backported fixes for Score-P v6.0

### DIFF
--- a/easybuild/easyconfigs/s/Score-P/Score-P-6.0-gompi-2020a.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-6.0-gompi-2020a.eb
@@ -26,7 +26,7 @@ sources = ['scorep-%(version)s.tar.gz']
 patches = ['Score-P-6.0_binutils_2.34_api_change.patch']
 checksums = [
     '5dc1023eb766ba5407f0b5e0845ec786e0021f1da757da737db1fb71fc4236b8',  # scorep-6.0.tar.gz
-    'd5a5208077f60850d61a230c3a2d5e0d46ac0b5ec962904cba3010b9a904b59f',  # Score-P-6.0_binutils_2.34_api_change.patch
+    'c64a3c0b666a75b114e29a48c8d1f5e420be3674a0fba2b37ecd50630ba2d45c',  # Score-P-6.0_binutils_2.34_api_change.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/s/Score-P/Score-P-6.0-gompi-2020a.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-6.0-gompi-2020a.eb
@@ -23,10 +23,14 @@ toolchain = {'name': 'gompi', 'version': '2020a'}
 
 source_urls = ['https://www.vi-hps.org/cms/upload/packages/scorep/']
 sources = ['scorep-%(version)s.tar.gz']
-patches = ['Score-P-6.0_binutils_2.34_api_change.patch']
+patches = [
+    'Score-P-6.0_binutils_2.34_api_change.patch',
+    'Score-P-6.0_no_PDT_for_CUDA.patch',
+]
 checksums = [
     '5dc1023eb766ba5407f0b5e0845ec786e0021f1da757da737db1fb71fc4236b8',  # scorep-6.0.tar.gz
     'c64a3c0b666a75b114e29a48c8d1f5e420be3674a0fba2b37ecd50630ba2d45c',  # Score-P-6.0_binutils_2.34_api_change.patch
+    '93e3fc5d19a89d14ce98fb772b4d9ddde4191df3ce321c9965602aa12d43fa93',  # Score-P-6.0_no_PDT_for_CUDA.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/s/Score-P/Score-P-6.0-gompic-2019b.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-6.0-gompic-2019b.eb
@@ -1,5 +1,5 @@
 ##
-# Copyright:: Copyright 2013-2019 Juelich Supercomputing Centre, Germany
+# Copyright:: Copyright 2013-2020 Juelich Supercomputing Centre, Germany
 #             Copyright 2020 TU Dresden, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 #             Markus Geimer <m.geimer@fz-juelich.de>
@@ -24,8 +24,10 @@ toolchain = {'name': 'gompic', 'version': '2019b'}
 
 source_urls = ['https://www.vi-hps.org/cms/upload/packages/scorep/']
 sources = ['scorep-%(version)s.tar.gz']
+patches = ['Score-P-6.0_no_PDT_for_CUDA.patch']
 checksums = [
     '5dc1023eb766ba5407f0b5e0845ec786e0021f1da757da737db1fb71fc4236b8',  # scorep-6.0.tar.gz
+    '93e3fc5d19a89d14ce98fb772b4d9ddde4191df3ce321c9965602aa12d43fa93',  # Score-P-6.0_no_PDT_for_CUDA.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/s/Score-P/Score-P-6.0_binutils_2.34_api_change.patch
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-6.0_binutils_2.34_api_change.patch
@@ -22,3 +22,16 @@ from upstream repo; fix will be included in releases after v6.0.
  #endif
  
  #include "scorep_unwinding_region.h"
+--- a/src/adapters/compiler/scorep_compiler_symbol_table_libbfd.c
++++ b/src/adapters/compiler/scorep_compiler_symbol_table_libbfd.c
+@@ -43,6 +43,10 @@
+ 
+ #include <bfd.h>
+ 
++#ifndef bfd_get_section
++#define bfd_get_section( asymbol ) bfd_asymbol_section( asymbol )
++#endif
++
+ #include <UTILS_Error.h>
+ #define SCOREP_DEBUG_MODULE_NAME COMPILER
+ #include <UTILS_Debug.h>

--- a/easybuild/easyconfigs/s/Score-P/Score-P-6.0_no_PDT_for_CUDA.patch
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-6.0_no_PDT_for_CUDA.patch
@@ -1,0 +1,16 @@
+Prevent PDT from instrumenting .cu files; fixes 'make installcheck' when both
+PDT and CUDA are enabled.  Patch backported from upstream repo; fix will be
+included in releases after v6.0.
+--- a/src/tools/instrumenter/scorep_instrumenter_pdt.cpp
++++ b/src/tools/instrumenter/scorep_instrumenter_pdt.cpp
+@@ -74,6 +74,10 @@ SCOREP_Instrumenter_PdtAdapter::precompile( SCOREP_Instrumenter&         instrum
+                                             SCOREP_Instrumenter_CmdLine& cmdLine,
+                                             const std::string&           source_file )
+ {
++    if ( is_cuda_file( source_file ) )
++    {
++        return source_file;
++    }
+     std::string extension = get_extension( source_file );
+     if ( is_fortran_file( source_file ) )
+     {


### PR DESCRIPTION
Amend #11123 to support the binutils 2.34 API in another source-code location (discovered recently; used when built for PGI/NVHPC compilers, for example) and add a patch to prevent PDT instrumentation of `.cu` files.  The latter fixes a `make installcheck` failure when both PDT and CUDA are configured, but can also show up in real life.