### PR TITLE
{lib}[gcccuda/2020a] NCCL v2.7.8

### DIFF
--- a/easybuild/easyconfigs/n/NCCL/NCCL-2.7.8-gcccuda-2020a.eb
+++ b/easybuild/easyconfigs/n/NCCL/NCCL-2.7.8-gcccuda-2020a.eb
@@ -1,0 +1,29 @@
+easyblock = "MakeCp"
+
+name = 'NCCL'
+version = '2.7.8'
+
+homepage = 'https://developer.nvidia.com/nccl'
+description = """The NVIDIA Collective Communications Library (NCCL) implements multi-GPU and multi-node collective
+communication primitives that are performance optimized for NVIDIA GPUs."""
+
+toolchain = {'name': 'gcccuda', 'version': '2020a'}
+toolchainopts = {'optarch': 'False'}
+
+local_cuda_version = '11.0'
+
+# Download from https://developer.nvidia.com/nccl/nccl-download (after log in) or use the redist url
+source_urls = ['https://developer.download.nvidia.com/compute/redist/nccl/v%(version_major_minor)s']
+sources = ['%%(namelower)s_%%(version)s-1+cuda%s_%%(arch)s.txz' % local_cuda_version]
+checksums = ['34000cbe6a0118bfd4ad898ebc5f59bf5d532bbf2453793891fa3f1621e25653']
+
+skipsteps = ['build']
+
+files_to_copy = ['lib', 'include']
+
+sanity_check_paths = {
+    'files': ['lib/libnccl.%s' % SHLIB_EXT, 'lib/libnccl_static.a', 'include/nccl.h'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
Adding latest NCCL with Cuda 11 pulling source from the redist url.