### PR TITLE
{chem}[GCCcore/9.3.0] XCFun 2.1.0

### DIFF
--- a/easybuild/easyconfigs/x/XCFun/XCFun-2.1.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/x/XCFun/XCFun-2.1.0-GCCcore-9.3.0.eb
@@ -6,7 +6,7 @@ version = '2.1.0'
 homepage = 'xcfun.readthedocs.io'
 description = """Arbitrary order exchange-correlation functional library"""
 
-toolchain = {'name': 'foss', 'version': '2020a'}
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
 source_urls = ['https://github.com/dftlibs/xcfun/archive/']
 sources = ['v%(version)s.tar.gz']

--- a/easybuild/easyconfigs/x/XCFun/XCFun-2.1.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/x/XCFun/XCFun-2.1.0-GCCcore-9.3.0.eb
@@ -13,6 +13,7 @@ sources = ['v%(version)s.tar.gz']
 checksums = ['64aac8c933cc129ce6326f3827e342abfd10b94ea4a302aaca9f10d342ad7656']
 
 builddependencies = [
+    ('binutils', '2.34'),
     ('CMake', '3.16.4')
 ]
 

--- a/easybuild/easyconfigs/x/XCFun/XCFun-2.1.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/x/XCFun/XCFun-2.1.0-GCCcore-9.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'CMakeMake'
 name = 'XCFun'
 version = '2.1.0'
 
-homepage = 'xcfun.readthedocs.io'
+homepage = 'https://xcfun.readthedocs.io'
 description = """Arbitrary order exchange-correlation functional library"""
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}

--- a/easybuild/easyconfigs/x/XCFun/XCFun-2.1.0-foss-2020a.eb
+++ b/easybuild/easyconfigs/x/XCFun/XCFun-2.1.0-foss-2020a.eb
@@ -13,7 +13,7 @@ sources = ['v%(version)s.tar.gz']
 checksums = ['64aac8c933cc129ce6326f3827e342abfd10b94ea4a302aaca9f10d342ad7656']
 
 builddependencies = [
-    ('CMake', '3.16.4', '', ('GCCcore', '9.3.0'))
+    ('CMake', '3.16.4')
 ]
 
 separate_build_dir = True

--- a/easybuild/easyconfigs/x/XCFun/XCFun-2.1.0-foss-2020a.eb
+++ b/easybuild/easyconfigs/x/XCFun/XCFun-2.1.0-foss-2020a.eb
@@ -1,0 +1,29 @@
+easyblock = 'CMakeMake'
+
+name = 'XCFun'
+version = '2.1.0'
+
+homepage = 'xcfun.readthedocs.io'
+description = """Arbitrary order exchange-correlation functional library"""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+
+source_urls = ['https://github.com/dftlibs/xcfun/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['64aac8c933cc129ce6326f3827e342abfd10b94ea4a302aaca9f10d342ad7656']
+
+builddependencies = [
+    ('CMake', '3.16.4', '', ('GCCcore', '9.3.0'))
+]
+
+separate_build_dir = True
+build_type = 'release'
+
+modextravars = {'XCFun_DIR': '%(installdir)s/share/cmake/XCFun/'}
+
+sanity_check_paths = {
+    'files': ['lib/libxcfun.%s' % SHLIB_EXT],
+    'dirs': ['include/XCFun']
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
There exists an old version under the name `XCfun`, but the name really should be [XCFun](https://xcfun.readthedocs.io/en/latest/index.html), so where do you want me to put this, @boegel?