### PR TITLE
enable NVPTX offload support in GCCcore 10.2.0 easyconfig

### DIFF
--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-10.2.0.eb
@@ -17,8 +17,8 @@ source_urls = [
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies
     'http://isl.gforge.inria.fr/',  # original HTTP source for ISL
-    'https://sourceware.org/pub/newlib/', # for newlib
-    'https://github.com/MentorEmbedded/nvptx-tools/archive', # for nvptx-tools
+    'https://sourceware.org/pub/newlib/',  # for newlib
+    'https://github.com/MentorEmbedded/nvptx-tools/archive',  # for nvptx-tools
 ]
 sources = [
     'gcc-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-10.2.0.eb
@@ -17,7 +17,7 @@ source_urls = [
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies
     'http://isl.gforge.inria.fr/',  # original HTTP source for ISL
-    'ftp://sourceware.org/pub/newlib/', # for newlib
+    'https://sourceware.org/pub/newlib/', # for newlib
     'https://github.com/MentorEmbedded/nvptx-tools/archive', # for nvptx-tools
 ]
 sources = [
@@ -27,7 +27,7 @@ sources = [
     'mpc-1.1.0.tar.gz',
     'isl-0.22.1.tar.bz2',
     'newlib-3.3.0.tar.gz',
-    '5f6f343.tar.gz', # nvptx-tools
+    {'download_filename': '5f6f343.tar.gz', 'filename': 'nvptx-tools-20180301.tar.gz'},
 ]
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
@@ -41,7 +41,7 @@ checksums = [
     '6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e',  # mpc-1.1.0.tar.gz
     '1a668ef92eb181a7c021e8531a3ca89fd71aa1b3744db56f68365ab0a224c5cd',  # isl-0.22.1.tar.bz2
     '58dd9e3eaedf519360d92d84205c3deef0b3fc286685d1c562e245914ef72c66',  # newlib-3.3.0.tar.gz
-    'a25b6f7761bb61c0d8e2a183bcf51fbaaeeac26868dcfc015e3b16a33fe11705',  # 5f6f343.tar.gz
+    'a25b6f7761bb61c0d8e2a183bcf51fbaaeeac26868dcfc015e3b16a33fe11705',  # nvptx-tools-20180301.tar.gz
     '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68',  # GCCcore-6.2.0-fix-find-isl.patch
     '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e',  # GCCcore-9.3.0_gmp-c99.patch
     'f94fa117f3401b28fda0741f3f45439c09dc956d1ed27f9a3ebe40c0e7e404b6',  # GCC-10.2_fix-has-include-Fortran.patch

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-10.2.0.eb
@@ -17,6 +17,8 @@ source_urls = [
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies
     'http://isl.gforge.inria.fr/',  # original HTTP source for ISL
+    'ftp://sourceware.org/pub/newlib/', # for newlib
+    'https://github.com/MentorEmbedded/nvptx-tools/archive', # for nvptx-tools
 ]
 sources = [
     'gcc-%(version)s.tar.gz',
@@ -24,6 +26,8 @@ sources = [
     'mpfr-4.1.0.tar.bz2',
     'mpc-1.1.0.tar.gz',
     'isl-0.22.1.tar.bz2',
+    'newlib-3.3.0.tar.gz',
+    '5f6f343.tar.gz', # nvptx-tools
 ]
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
@@ -36,6 +40,8 @@ checksums = [
     'feced2d430dd5a97805fa289fed3fc8ff2b094c02d05287fd6133e7f1f0ec926',  # mpfr-4.1.0.tar.bz2
     '6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e',  # mpc-1.1.0.tar.gz
     '1a668ef92eb181a7c021e8531a3ca89fd71aa1b3744db56f68365ab0a224c5cd',  # isl-0.22.1.tar.bz2
+    '58dd9e3eaedf519360d92d84205c3deef0b3fc286685d1c562e245914ef72c66',  # newlib-3.3.0.tar.gz
+    'a25b6f7761bb61c0d8e2a183bcf51fbaaeeac26868dcfc015e3b16a33fe11705',  # 5f6f343.tar.gz
     '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68',  # GCCcore-6.2.0-fix-find-isl.patch
     '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e',  # GCCcore-9.3.0_gmp-c99.patch
     'f94fa117f3401b28fda0741f3f45439c09dc956d1ed27f9a3ebe40c0e7e404b6',  # GCC-10.2_fix-has-include-Fortran.patch
@@ -49,5 +55,6 @@ builddependencies = [
 languages = ['c', 'c++', 'fortran']
 
 withisl = True
+withnvptx = True
 
 moduleclass = 'compiler'


### PR DESCRIPTION
Requires ~~https://github.com/easybuilders/easybuild-easyblocks/pull/2235~~