### PR TITLE
add missing gnuplot dependency in easyconfig for OpenFOAM 7 and 8

### DIFF
--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-7-foss-2019b-20200508.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-7-foss-2019b-20200508.eb
@@ -35,6 +35,7 @@ dependencies = [
     ('SCOTCH', '6.0.9'),
     ('CGAL', '4.14.1', '-Python-3.7.4'),
     ('ParaView', '5.6.2', '-Python-3.7.4-mpi'),
+    ('gnuplot', '5.2.8'),
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-7-foss-2019b.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-7-foss-2019b.eb
@@ -30,6 +30,7 @@ dependencies = [
     ('SCOTCH', '6.0.9'),
     ('CGAL', '4.14.1', '-Python-3.7.4'),
     ('ParaView', '5.6.2', '-Python-3.7.4-mpi'),
+    ('gnuplot', '5.2.8'),
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-8-foss-2020a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-8-foss-2020a.eb
@@ -28,6 +28,7 @@ dependencies = [
     ('SCOTCH', '6.0.9'),
     ('CGAL', '4.14.3', '-Python-3.8.2'),
     ('ParaView', '5.8.0', '-Python-3.8.2-mpi'),
+    ('gnuplot', '5.2.8'),
 ]
 
 builddependencies = [


### PR DESCRIPTION
gnuplot is necessary to observe residuals during simulation so I suggest to include it as a dependecy.