### PR TITLE
don't add include/node to $CPATH in nodejs easyconfigs + tweak V8 easyconfigs accordingly

### DIFF
--- a/easybuild/easyconfigs/n/nodejs/nodejs-10.15.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/n/nodejs/nodejs-10.15.1-foss-2018b.eb
@@ -37,6 +37,4 @@ sanity_check_paths = {
     'dirs': ['lib/node_modules', 'include/node']
 }
 
-modextrapaths = {'CPATH': 'include/node'}
-
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/n/nodejs/nodejs-10.15.3-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/n/nodejs/nodejs-10.15.3-GCCcore-8.2.0.eb
@@ -39,6 +39,4 @@ sanity_check_paths = {
     'dirs': ['lib/node_modules', 'include/node']
 }
 
-modextrapaths = {'CPATH': 'include/node'}
-
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/n/nodejs/nodejs-12.16.1-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/n/nodejs/nodejs-12.16.1-GCCcore-7.3.0.eb
@@ -39,6 +39,4 @@ sanity_check_paths = {
     'dirs': ['lib/node_modules', 'include/node']
 }
 
-modextrapaths = {'CPATH': 'include/node'}
-
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/n/nodejs/nodejs-12.16.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/n/nodejs/nodejs-12.16.1-GCCcore-8.3.0.eb
@@ -39,6 +39,4 @@ sanity_check_paths = {
     'dirs': ['lib/node_modules', 'include/node']
 }
 
-modextrapaths = {'CPATH': 'include/node'}
-
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/n/nodejs/nodejs-12.16.1-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/n/nodejs/nodejs-12.16.1-GCCcore-9.3.0.eb
@@ -39,6 +39,4 @@ sanity_check_paths = {
     'dirs': ['lib/node_modules', 'include/node']
 }
 
-modextrapaths = {'CPATH': 'include/node'}
-
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/n/nodejs/nodejs-12.19.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/n/nodejs/nodejs-12.19.0-GCCcore-10.2.0.eb
@@ -39,6 +39,4 @@ sanity_check_paths = {
     'dirs': ['lib/node_modules', 'include/node']
 }
 
-modextrapaths = {'CPATH': 'include/node'}
-
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/v/V8/V8-2.2-foss-2018b-R-3.5.1.eb
+++ b/easybuild/easyconfigs/v/V8/V8-2.2-foss-2018b-R-3.5.1.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('nodejs', '10.15.1'),
 ]
 
+preinstallopts = 'export CPATH="$CPATH:$EBROOTNODEJS/include/node" && '
 installopts = '--configure-vars="INCLUDE_DIR=$CPATH LIB_DIR=$LIBRARY_PATH"'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/v/V8/V8-2.3-foss-2019a-R-3.6.0.eb
+++ b/easybuild/easyconfigs/v/V8/V8-2.3-foss-2019a-R-3.6.0.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('nodejs', '10.15.3'),
 ]
 
+preinstallopts = 'export CPATH="$CPATH:$EBROOTNODEJS/include/node" && '
 installopts = '--configure-vars="INCLUDE_DIR=$CPATH LIB_DIR=$LIBRARY_PATH"'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/v/V8/V8-2.3-intel-2019a-R-3.6.0.eb
+++ b/easybuild/easyconfigs/v/V8/V8-2.3-intel-2019a-R-3.6.0.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('nodejs', '10.15.3'),
 ]
 
+preinstallopts = 'export CPATH="$CPATH:$EBROOTNODEJS/include/node" && '
 installopts = '--configure-vars="INCLUDE_DIR=$CPATH LIB_DIR=$LIBRARY_PATH"'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/v/V8/V8-3.2.0-foss-2019b-R-3.6.2.eb
+++ b/easybuild/easyconfigs/v/V8/V8-3.2.0-foss-2019b-R-3.6.2.eb
@@ -13,7 +13,10 @@ source_urls = [
     'https://cran.r-project.org/src/contrib/',
     'https://cran.r-project.org/src/contrib/Archive/%(name)s']
 sources = ['%(name)s_%(version)s.tar.gz']
-checksums = ['f575e07c6fefbc53a96e90bbb41ffdf67794cca797661eb97a6f52348ae20d7c']
+checksums = [
+    ('f575e07c6fefbc53a96e90bbb41ffdf67794cca797661eb97a6f52348ae20d7c',
+     'd2e9b8eb0e9cec76a5c3a8725f7cd50a53ac0d98d0c1ec69d2a943132a2d3eb6'),
+]
 
 dependencies = [
     ('R', '3.6.2'),

--- a/easybuild/easyconfigs/v/V8/V8-3.2.0-foss-2019b-R-3.6.2.eb
+++ b/easybuild/easyconfigs/v/V8/V8-3.2.0-foss-2019b-R-3.6.2.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('nodejs', '12.16.1'),
 ]
 
+preinstallopts = 'export CPATH="$CPATH:$EBROOTNODEJS/include/node" && '
 installopts = '--configure-vars="INCLUDE_DIR=$CPATH LIB_DIR=$LIBRARY_PATH"'
 
 sanity_check_paths = {


### PR DESCRIPTION
Because nodejs installations include OpenSSL header files, which causes trouble (see #11663 + https://github.com/jeroen/openssl/issues/84).

Other easyconfigs that depend on `nodejs` don't need to be fixed because of these changes (I'll confirm that in the test report).