### PR TITLE
{cae}[foss/2020a] OpenFOAM v2012

### DIFF
--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2012-cleanup.patch
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2012-cleanup.patch
@@ -1,0 +1,150 @@
+# Replaces OpenFOAM third-party libraries with EASYBUILD variants.
+# Uses the OpenFOAM prefs mechanism and the FOAM_CONFIG_ETC variable
+# to define the preferred settings without patching the original files
+#
+# Authors: Mark Olesen <Mark.Olesen@esi-group.com>
+# -------------------------------------------------------------------------
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/prefs.sh	2020-12-14 10:02:26.488430802 +0100
+@@ -0,0 +1,7 @@
++##Easybuild## settings -*- sh -*-
++
++export FOAM_CONFIG_ETC="etc/easybuild"
++
++export WM_MPLIB=EASYBUILDMPI
++
++##Easybuild##
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/easybuild/config.sh/CGAL	2020-12-14 10:10:55.991841204 +0100
+@@ -0,0 +1,6 @@
++##Easybuild## settings -*- sh -*-
++
++export BOOST_ARCH_PATH="$EBROOTBOOST"
++export CGAL_ARCH_PATH="$EBROOTCGAL"
++
++##Easybuild##
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/easybuild/config.sh/FFTW	2020-12-14 10:10:53.735843322 +0100
+@@ -0,0 +1,5 @@
++##Easybuild## settings -*- sh -*-
++
++export FFTW_ARCH_PATH="$EBROOTFFTW"
++
++##EasyBuild##
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/easybuild/config.sh/metis	2020-12-11 21:23:28.774934024 +0100
+@@ -0,0 +1,6 @@
++##Easybuild## settings -*- sh -*-
++
++METIS_VERSION="metis-$EBVERSIONMETIS"
++[ -d "$METIS_ARCH_PATH" ] || METIS_ARCH_PATH="$METIS_ROOT"
++
++##Easybuild##
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/easybuild/config.sh/readline	2020-12-11 21:23:22.534951043 +0100
+@@ -0,0 +1,5 @@
++##Easybuild## settings -*- sh -*-
++
++export READLINE_ARCH_PATH="$EBROOTLIBREADLINE"
++
++##Easybuild##
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/easybuild/config.sh/scotch	2020-12-11 21:23:17.586964539 +0100
+@@ -0,0 +1,7 @@
++##Easybuild## settings -*- sh -*-
++
++export SCOTCH_VERSION="scotch_$EBVERSIONSCOTCH"
++export SCOTCH_ARCH_PATH="$EBROOTSCOTCH"
++[ -d "$SCOTCH_ARCH_PATH" ] || SCOTCH_ARCH_PATH="$SCOTCH_ROOT"
++
++##Easybuild##
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/easybuild/config.sh/vtk	2020-12-11 21:22:55.463024882 +0100
+@@ -0,0 +1,9 @@
++##Easybuild## settings -*- sh -*-
++
++export VTK_DIR="$EBROOTVTK"
++export MESA_ARCH_PATH="$EBROOTMESA"
++
++# Define paraview-mesa directory as required
++unset ParaView_MESA_DIR
++
++##Easybuild##
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/easybuild/config.sh/paraview	2020-12-14 10:13:53.583674383 +0100
+@@ -0,0 +1,75 @@
++##Easybuild## settings -*- sh -*-
++#
++# Largely a knockoff of the OpenFOAM etc/config.sh/paraview-system
++# readjusted for easybuild
++#
++# Copyright (C) 2020 OpenCFD Ltd.
++#
++#------------------------------------------------------------------------------
++# Compiler-specific location for ThirdParty installations
++archDir="$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER"
++
++# Clean path and library path of previous settings
++eval \
++    "$($WM_PROJECT_DIR/bin/foamCleanPath -sh-env=PATH \
++    $ParaView_DIR $archDir/ParaView- $archDir/qt-)"
++
++eval \
++    "$($WM_PROJECT_DIR/bin/foamCleanPath -sh-env=LD_LIBRARY_PATH \
++    $ParaView_DIR $archDir/ParaView- $archDir/qt-)"
++
++
++#------------------------------------------------------------------------------
++
++##Easybuild## settings
++
++ParaView_VERSION="$EBVERSIONPARAVIEW"
++export ParaView_DIR="$EBROOTPARAVIEW"
++
++#------------------------------------------------------------------------------
++
++unset PV_PLUGIN_PATH
++
++# Set API to correspond to VERSION
++# pv_api is <digits>.<digits> from ParaView_VERSION
++#-
++# Extract API from VERSION
++pv_api=$(echo "$ParaView_VERSION" | \
++    sed -ne 's/^[^0-9]*\([0-9][0-9]*\.[0-9][0-9]*\).*$/\1/p')
++
++pv_plugin_dir="$FOAM_LIBBIN/paraview-$pv_api"
++
++# Set paths if binaries are present
++if [ -r "$ParaView_DIR" ]
++then
++    export PATH="$ParaView_DIR/bin:$PATH"
++
++    # ParaView libraries
++    # - 5.5 and later:   lib/, but could also be lib64/
++    for libDir in lib64 lib
++    do
++        pvLibDir="$libDir/paraview-$pv_api"
++        if [ -d "$ParaView_DIR/$pvLibDir" ]
++        then
++            export LD_LIBRARY_PATH="$ParaView_DIR/$libDir:$LD_LIBRARY_PATH"
++            break
++        fi
++    done
++
++    # OpenFOAM plugin directory must be the first in PV_PLUGIN_PATH
++    # and have paraview-major.minor encoded in its name
++    if [ -d "$pv_plugin_dir" ]
++    then
++        export PV_PLUGIN_PATH="$pv_plugin_dir"
++    fi
++fi
++
++
++#------------------------------------------------------------------------------
++
++unset ParaView_VERSION
++
++unset archDir libDir
++unset pv_api pv_plugin_dir pvLibDir
++
++#------------------------------------------------------------------------------

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2012-foss-2020a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2012-foss-2020a.eb
@@ -10,15 +10,14 @@ description = """OpenFOAM is a free, open source CFD software package.
 toolchain = {'name': 'foss', 'version': '2020a'}
 toolchainopts = {'cstd': 'c++11'}
 
-#source_urls = ['https://sourceforge.net/projects/openfoam/files/%(version)s/']
-source_urls = ['file:///tmp/']
+source_urls = ['https://sourceforge.net/projects/openfoam/files/%(version)s/']
 sources = [SOURCE_TGZ]
 patches = [
     'OpenFOAM-%(version)s-cleanup.patch',
     'OpenFOAM-v1906-wmake-ompi.patch',
 ]
 checksums = [
-    '005c56f6431e229c4f54ec6bf9159054d6f83e9ba977bce9caf8029d472b7816',  # OpenFOAM-v2012.tgz
+    '3d6e39e39e7ae61d321fbc6db6c3748e6e5e1c4886454207a7f1a7321469e65a',  # OpenFOAM-v2012.tgz
     'cdd2597a1ac1448e9bd33a364a8dfe17f51cc9ab5a8e0ab67cf92bba3ed9da43',  # OpenFOAM-v2012-cleanup.patch
     '518e27683c5c41400cfbc17b31effa50b31b25916dccbf85b18b0b955f642505',  # OpenFOAM-v1906-wmake-ompi.patch
 ]

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2012-foss-2020a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2012-foss-2020a.eb
@@ -1,0 +1,43 @@
+name = 'OpenFOAM'
+version = 'v2012'
+
+homepage = 'https://www.openfoam.com/'
+description = """OpenFOAM is a free, open source CFD software package.
+ OpenFOAM has an extensive range of features to solve anything from complex fluid flows
+ involving chemical reactions, turbulence and heat transfer,
+ to solid dynamics and electromagnetics."""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+toolchainopts = {'cstd': 'c++11'}
+
+#source_urls = ['https://sourceforge.net/projects/openfoam/files/%(version)s/']
+source_urls = ['file:///tmp/']
+sources = [SOURCE_TGZ]
+patches = [
+    'OpenFOAM-%(version)s-cleanup.patch',
+    'OpenFOAM-v1906-wmake-ompi.patch',
+]
+checksums = [
+    '005c56f6431e229c4f54ec6bf9159054d6f83e9ba977bce9caf8029d472b7816',  # OpenFOAM-v2012.tgz
+    'cdd2597a1ac1448e9bd33a364a8dfe17f51cc9ab5a8e0ab67cf92bba3ed9da43',  # OpenFOAM-v2012-cleanup.patch
+    '518e27683c5c41400cfbc17b31effa50b31b25916dccbf85b18b0b955f642505',  # OpenFOAM-v1906-wmake-ompi.patch
+]
+
+dependencies = [
+    ('libreadline', '8.0'),
+    ('ncurses', '6.2'),
+    # OpenFOAM requires 64 bit METIS using 32 bit indexes (array indexes)
+    ('METIS', '5.1.0'),
+    ('SCOTCH', '6.0.9'),
+    ('CGAL', '4.14.3', '-Python-3.8.2'),
+    ('ParaView', '5.8.0', '-Python-3.8.2-mpi'),
+    ('gnuplot', '5.2.8'),
+]
+
+builddependencies = [
+    ('Bison', '3.5.3'),
+    ('CMake', '3.16.4'),
+    ('flex', '2.6.4'),
+]
+
+moduleclass = 'cae'

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2012-foss-2020a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2012-foss-2020a.eb
@@ -13,7 +13,7 @@ toolchainopts = {'cstd': 'c++11'}
 source_urls = ['https://sourceforge.net/projects/openfoam/files/%(version)s/']
 sources = [SOURCE_TGZ]
 patches = [
-    'OpenFOAM-%(version)s-cleanup.patch',
+    ('OpenFOAM-%(version)s-cleanup.patch', 0),
     'OpenFOAM-v1906-wmake-ompi.patch',
 ]
 checksums = [

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2012-foss-2020a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2012-foss-2020a.eb
@@ -13,7 +13,7 @@ toolchainopts = {'cstd': 'c++11'}
 source_urls = ['https://sourceforge.net/projects/openfoam/files/%(version)s/']
 sources = [SOURCE_TGZ]
 patches = [
-    ('OpenFOAM-%(version)s-cleanup.patch', 0),
+    ('OpenFOAM-%(version)s-cleanup.patch', 1),
     'OpenFOAM-v1906-wmake-ompi.patch',
 ]
 checksums = [


### PR DESCRIPTION
Hi @boegel - a heads-up for the upcoming OpenFOAM-v2012

To help accommodate easybuild and other systems, we have an additional `FOAM_CONFIG_ETC` variable that we can hook into to quickly switch between different types of configurations (eg, intelmpi/openmpi, 64/32-bit, spdp/dp etc). It also can be used by easybuild to define its configuration, largely without patching the original sources.

The OpenFOAM internal mpi selector now recognizes "EASYBUILDMPI"  (no patching needed), and the readline discovery can be customized with the usual config.sh mechanism, which means that easybuild can generate its settings without patching into the wmake/scripts directory.  Using this approach, we are getting one step closer to being able to generate settings on-the-fly instead of patching. 

In this preliminary changeset, I did however run into issues with actually applying the patch for the build. EasyBuild complains about not being able to determine the patch level. Must be something small I guess, but figured I should provide the changeset anyhow to provide a basis and avoid duplicate effort.
