### PR TITLE
add CESM-deps to whitelist in check for custom sanity_check_paths

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -665,8 +665,10 @@ class EasyConfigTest(TestCase):
         # BuildEnv, ModuleRC and Toolchain easyblocks doesn't install anything so there is nothing to check.
         whitelist = ['BuildEnv', 'CrayToolchain', 'GoPackage', 'ModuleRC', 'PythonBundle', 'PythonPackage',
                      'Toolchain']
-        # Autotools & (recent) GCC are just bundles (Autotools: Autoconf+Automake+libtool, GCC: GCCcore+binutils)
-        bundles_whitelist = ['Autotools', 'GCC', 'CUDA']
+        # Bundles of dependencies without files of their own
+        # Autotools: Autoconf + Automake + libtool, (recent) GCC: GCCcore + binutils, CUDA: GCC + CUDAcore,
+        # CESM-deps: Python + Perl + netCDF + ESMF + git
+        bundles_whitelist = ['Autotools', 'CESM-deps', 'CUDA', 'GCC']
 
         failing_checks = []
 


### PR DESCRIPTION
Needed by https://github.com/easybuilders/easybuild-easyconfigs/pull/11902