### PR TITLE
add additional extensions to R v4.0.3 easyconfig

### DIFF
--- a/easybuild/easyconfigs/r/R/R-4.0.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.3-foss-2020b.eb
@@ -2731,6 +2731,36 @@ exts_list = [
     ('DescTools', '0.99.38', {
         'checksums': ['bd8edce64a8f9e295611959295b85cf8d7bbf915093158016169bd334e0e1104'],
     }),
+    ('orthopolynom', '1.0-5', {
+        'checksums': ['6da4f437aae5c8fafdf791ce3c6a66f68198df4054af3aab8406402a4dc770bf'],
+    }),
+    ('gaussquad', '1.0-2', {
+        'checksums': ['ba3a1ab6ffe92f592c9f2bb1d4070f1fb1019325226dcb4863cf725eb59e9b2d'],
+    }),
+    ('nlsem', '0.8', {
+        'checksums': ['495a5d07aa5f59efdcd43acf429ae842453abd6c0720a80e2102d663fa997c60'],
+    }),
+    ('mitools', '2.4', {
+        'checksums': ['f204f3774e29d79810f579f128de892539518f2cbe6ed237e08c8e7283155d30'],
+    }),
+    ('survey', '4.0', {
+        'checksums': ['b053f40f4cfa90507ca524f72d3b3a4b4869def52f11f907a14f1c6d90063de1'],
+    }),
+    ('tableone', '0.12.0', {
+        'checksums': ['6a5cc16f7d2303c8f42b8adcad0fc41e1ba74f24ada4e7ad3a16effb63d3575e'],
+    }),
+    ('jstable', '1.0.1', {
+        'checksums': ['2e4cfce264a2353e4655d0faafc93969222d67a21c0c9cc61a2454abd99c5cdc'],
+    }),
+    ('RCAL', '2.0', {
+        'checksums': ['10f5f938a8322d8737159e1e49ce9d12419a5130699b8a19c6ca53d6508da8cc'],
+    }),
+    ('stargazer', '5.2.2', {
+        'checksums': ['70eb4a13a6ac1bfb35af07cb8a63d501ad38dfd9817fc3fba6724260b23932de'],
+    }),
+    ('sensemakr', '0.1.3', {
+        'checksums': ['2eccda4ac3752266779d9c8ae87154c9fbaf0f73e0a768692a836a29ceaeffdd'],
+    }),
     ('RcppParallel', '5.0.2', {
         'checksums': ['8ca200908c6365aafb2063be1789f0894969adc03c0f523c6cc45434b8236f81'],
     }),


### PR DESCRIPTION
Some extensions were missing from #11663:

* nlsem (#11733)
* mitools, survey, tableone, jstable (see #11841)
* RCAL, sensemakr (see #11921)