### PR TITLE
{compiler}[GCCcore/8.3.0, GCCcore/9.3.0] Update Clang 10+ deps & build extra tools

### DIFF
--- a/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-8.3.0.eb
@@ -49,6 +49,7 @@ checksums = [
 dependencies = [
     # since Clang is a compiler, binutils is a runtime dependency too
     ('binutils', '2.32'),
+    ('libxml2', '2.9.9'),
     ('ncurses', '6.1'),
     ('GMP', '6.1.2'),
 ]
@@ -56,7 +57,6 @@ dependencies = [
 builddependencies = [
     ('CMake', '3.15.3'),
     ('Python', '2.7.16'),
-    ('libxml2', '2.9.9'),
 ]
 
 assertions = True

--- a/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-8.3.0.eb
@@ -51,7 +51,7 @@ checksums = [
 dependencies = [
     # since Clang is a compiler, binutils is a runtime dependency too
     ('binutils', '2.32'),
-    ('hwloc', '2.0.3'),
+    ('hwloc', '1.11.12'),
     ('libxml2', '2.9.9'),
     ('ncurses', '6.1'),
     ('GMP', '6.1.2'),

--- a/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-8.3.0.eb
@@ -49,6 +49,7 @@ checksums = [
 dependencies = [
     # since Clang is a compiler, binutils is a runtime dependency too
     ('binutils', '2.32'),
+    ('hwloc', '2.0.3'),
     ('libxml2', '2.9.9'),
     ('ncurses', '6.1'),
     ('GMP', '6.1.2'),

--- a/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-8.3.0.eb
@@ -53,6 +53,7 @@ dependencies = [
     ('libxml2', '2.9.9'),
     ('ncurses', '6.1'),
     ('GMP', '6.1.2'),
+    ('Z3', '4.8.9'),
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-8.3.0.eb
@@ -32,6 +32,7 @@ sources = [
     'lld-%(version)s.src.tar.xz',
     'libcxx-%(version)s.src.tar.xz',
     'libcxxabi-%(version)s.src.tar.xz',
+    'clang-tools-extra-%(version)s.src.tar.xz',
 ]
 patches = ['libcxx-%(version)s-ppc64le.patch']
 checksums = [
@@ -43,6 +44,7 @@ checksums = [
     'b9a0d7c576eeef05bc06d6e954938a01c5396cee1d1e985891e0b1cf16e3d708',  # lld-10.0.0.src.tar.xz
     '270f8a3f176f1981b0f6ab8aa556720988872ec2b48ed3b605d0ced8d09156c7',  # libcxx-10.0.0.src.tar.xz
     'e71bac75a88c9dde455ad3f2a2b449bf745eafd41d2d8432253b2964e0ca14e1',  # libcxxabi-10.0.0.src.tar.xz
+    'acdf8cf6574b40e6b1dabc93e76debb84a9feb6f22970126b04d4ba18b92911c',  # clang-tools-extra-10.0.0.tar.xz
     'a424a9eb7f377b4f01d8c9b27fdd78e6a51a53819b263d2ca6d40a0e2368a330',  # libcxx-10.0.0-ppc64le.patch
 ]
 
@@ -66,6 +68,7 @@ usepolly = True
 build_lld = True
 libcxx = True
 enable_rtti = True
+build_extra_clang_tools = True
 
 skip_all_tests = True
 

--- a/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-9.3.0.eb
@@ -53,6 +53,7 @@ dependencies = [
     ('libxml2', '2.9.10'),
     ('ncurses', '6.2'),
     ('GMP', '6.2.0'),
+    ('Z3', '4.8.9'),
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-9.3.0.eb
@@ -49,6 +49,7 @@ checksums = [
 dependencies = [
     # since Clang is a compiler, binutils is a runtime dependency too
     ('binutils', '2.34'),
+    ('hwloc', '2.2.0'),
     ('libxml2', '2.9.10'),
     ('ncurses', '6.2'),
     ('GMP', '6.2.0'),

--- a/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-9.3.0.eb
@@ -49,6 +49,7 @@ checksums = [
 dependencies = [
     # since Clang is a compiler, binutils is a runtime dependency too
     ('binutils', '2.34'),
+    ('libxml2', '2.9.10'),
     ('ncurses', '6.2'),
     ('GMP', '6.2.0'),
 ]
@@ -56,7 +57,6 @@ dependencies = [
 builddependencies = [
     ('CMake', '3.16.4'),
     ('Python', '2.7.18'),
-    ('libxml2', '2.9.10'),
 ]
 
 assertions = True

--- a/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-9.3.0.eb
@@ -32,6 +32,7 @@ sources = [
     'lld-%(version)s.src.tar.xz',
     'libcxx-%(version)s.src.tar.xz',
     'libcxxabi-%(version)s.src.tar.xz',
+    'clang-tools-extra-%(version)s.src.tar.xz',
 ]
 patches = ['libcxx-%(version)s-ppc64le.patch']
 checksums = [
@@ -43,6 +44,7 @@ checksums = [
     'b9a0d7c576eeef05bc06d6e954938a01c5396cee1d1e985891e0b1cf16e3d708',  # lld-10.0.0.src.tar.xz
     '270f8a3f176f1981b0f6ab8aa556720988872ec2b48ed3b605d0ced8d09156c7',  # libcxx-10.0.0.src.tar.xz
     'e71bac75a88c9dde455ad3f2a2b449bf745eafd41d2d8432253b2964e0ca14e1',  # libcxxabi-10.0.0.src.tar.xz
+    'acdf8cf6574b40e6b1dabc93e76debb84a9feb6f22970126b04d4ba18b92911c',  # clang-tools-extra-10.0.0.tar.xz
     'a424a9eb7f377b4f01d8c9b27fdd78e6a51a53819b263d2ca6d40a0e2368a330',  # libcxx-10.0.0-ppc64le.patch
 ]
 
@@ -66,6 +68,7 @@ usepolly = True
 build_lld = True
 libcxx = True
 enable_rtti = True
+build_extra_clang_tools = True
 
 skip_all_tests = True
 

--- a/easybuild/easyconfigs/c/Clang/Clang-10.0.1-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-10.0.1-GCCcore-9.3.0.eb
@@ -53,6 +53,7 @@ dependencies = [
     ('libxml2', '2.9.10'),
     ('ncurses', '6.2'),
     ('GMP', '6.2.0'),
+    ('Z3', '4.8.9'),
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/c/Clang/Clang-10.0.1-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-10.0.1-GCCcore-9.3.0.eb
@@ -32,6 +32,7 @@ sources = [
     'lld-%(version)s.src.tar.xz',
     'libcxx-%(version)s.src.tar.xz',
     'libcxxabi-%(version)s.src.tar.xz',
+    'clang-tools-extra-%(version)s.src.tar.xz',
 ]
 patches = ['libcxx-10.0.0-ppc64le.patch']
 checksums = [
@@ -43,6 +44,7 @@ checksums = [
     '591449e0aa623a6318d5ce2371860401653c48bb540982ccdd933992cb88df7a',  # lld-10.0.1.src.tar.xz
     'def674535f22f83131353b3c382ccebfef4ba6a35c488bdb76f10b68b25be86c',  # libcxx-10.0.1.src.tar.xz
     'a97ef810b2e9fb70e8f7e317b74e646ed4944f488b02ac5ddd9c99e385381a7b',  # libcxxabi-10.0.1.src.tar.xz
+    'd093782bcfcd0c3f496b67a5c2c997ab4b85816b62a7dd5b27026634ccf5c11a',  # clang-tools-extra-10.0.1.src.xz
     'a424a9eb7f377b4f01d8c9b27fdd78e6a51a53819b263d2ca6d40a0e2368a330',  # libcxx-10.0.0-ppc64le.patch
 ]
 
@@ -66,6 +68,7 @@ usepolly = True
 build_lld = True
 libcxx = True
 enable_rtti = True
+build_extra_clang_tools = True
 
 skip_all_tests = True
 

--- a/easybuild/easyconfigs/c/Clang/Clang-10.0.1-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-10.0.1-GCCcore-9.3.0.eb
@@ -49,6 +49,7 @@ checksums = [
 dependencies = [
     # since Clang is a compiler, binutils is a runtime dependency too
     ('binutils', '2.34'),
+    ('hwloc', '2.2.0'),
     ('libxml2', '2.9.10'),
     ('ncurses', '6.2'),
     ('GMP', '6.2.0'),

--- a/easybuild/easyconfigs/c/Clang/Clang-10.0.1-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-10.0.1-GCCcore-9.3.0.eb
@@ -49,6 +49,7 @@ checksums = [
 dependencies = [
     # since Clang is a compiler, binutils is a runtime dependency too
     ('binutils', '2.34'),
+    ('libxml2', '2.9.10'),
     ('ncurses', '6.2'),
     ('GMP', '6.2.0'),
 ]
@@ -56,7 +57,6 @@ dependencies = [
 builddependencies = [
     ('CMake', '3.16.4'),
     ('Python', '2.7.18'),
-    ('libxml2', '2.9.10'),
 ]
 
 assertions = True

--- a/easybuild/easyconfigs/c/Clang/Clang-11.0.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-11.0.0-GCCcore-9.3.0.eb
@@ -45,13 +45,13 @@ checksums = [
 dependencies = [
     # since Clang is a compiler, binutils is a runtime dependency too
     ('binutils', '2.34'),
+    ('libxml2', '2.9.10'),
     ('ncurses', '6.2'),
     ('GMP', '6.2.0'),
 ]
 
 builddependencies = [
     ('CMake', '3.16.4'),
-    ('libxml2', '2.9.10'),
     ('Python', '3.8.2'),
 ]
 

--- a/easybuild/easyconfigs/c/Clang/Clang-11.0.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-11.0.0-GCCcore-9.3.0.eb
@@ -30,6 +30,7 @@ sources = [
     'lld-%(version)s.src.tar.xz',
     'libcxx-%(version)s.src.tar.xz',
     'libcxxabi-%(version)s.src.tar.xz',
+    'clang-tools-extra-%(version)s.src.tar.xz',
 ]
 checksums = [
     '913f68c898dfb4a03b397c5e11c6a2f39d0f22ed7665c9cefa87a34423a72469',  # llvm-11.0.0.src.tar.xz
@@ -40,6 +41,7 @@ checksums = [
     'efe7be4a7b7cdc6f3bcf222827c6f837439e6e656d12d6c885d5c8a80ff4fd1c',  # lld-11.0.0.src.tar.xz
     '6c1ee6690122f2711a77bc19241834a9219dda5036e1597bfa397f341a9b8b7a',  # libcxx-11.0.0.src.tar.xz
     '58697d4427b7a854ec7529337477eb4fba16407222390ad81a40d125673e4c15',  # libcxxabi-11.0.0.src.tar.xz
+    'fed318f75d560d0e0ae728e2fb8abce71e9d0c60dd120c9baac118522ce76c09',  # clang-tools-extra-11.0.0.src.tar.xz
 ]
 
 dependencies = [
@@ -62,6 +64,7 @@ usepolly = True
 build_lld = True
 libcxx = True
 enable_rtti = True
+build_extra_clang_tools = True
 
 skip_all_tests = True
 

--- a/easybuild/easyconfigs/c/Clang/Clang-11.0.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-11.0.0-GCCcore-9.3.0.eb
@@ -45,6 +45,7 @@ checksums = [
 dependencies = [
     # since Clang is a compiler, binutils is a runtime dependency too
     ('binutils', '2.34'),
+    ('hwloc', '2.2.0'),
     ('libxml2', '2.9.10'),
     ('ncurses', '6.2'),
     ('GMP', '6.2.0'),

--- a/easybuild/easyconfigs/c/Clang/Clang-11.0.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-11.0.0-GCCcore-9.3.0.eb
@@ -49,6 +49,7 @@ dependencies = [
     ('libxml2', '2.9.10'),
     ('ncurses', '6.2'),
     ('GMP', '6.2.0'),
+    ('Z3', '4.8.9'),
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/z/Z3/Z3-4.8.9-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/z/Z3/Z3-4.8.9-GCCcore-8.3.0.eb
@@ -1,0 +1,34 @@
+easyblock = 'CMakeMake'
+
+name = 'Z3'
+version = '4.8.9'
+
+homepage = 'https://github.com/Z3Prover/z3'
+description = """
+ Z3 is a theorem prover from Microsoft Research.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['https://github.com/Z3Prover/z3/archive/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['c9fd04b9b33be74fffaac3ec2bc2c320d1a4cc32e395203c55126b12a14ff3f4']
+
+builddependencies = [
+    ('CMake', '3.15.3'),
+    # use same binutils version that was used when building GCCcore toolchain
+    ('binutils', '2.32'),
+]
+
+dependencies = [
+    ('GMP', '6.1.2'),
+]
+
+configopts = '-DZ3_USE_LIB_GMP=ON -DZ3_LINK_TIME_OPTIMIZATION=ON '
+
+sanity_check_paths = {
+    'files': ['bin/z3', 'include/z3_api.h', 'lib/libz3.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/z/Z3/Z3-4.8.9-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/z/Z3/Z3-4.8.9-GCCcore-9.3.0.eb
@@ -1,0 +1,34 @@
+easyblock = 'CMakeMake'
+
+name = 'Z3'
+version = '4.8.9'
+
+homepage = 'https://github.com/Z3Prover/z3'
+description = """
+ Z3 is a theorem prover from Microsoft Research.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+
+source_urls = ['https://github.com/Z3Prover/z3/archive/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['c9fd04b9b33be74fffaac3ec2bc2c320d1a4cc32e395203c55126b12a14ff3f4']
+
+builddependencies = [
+    ('CMake', '3.16.4'),
+    # use same binutils version that was used when building GCCcore toolchain
+    ('binutils', '2.34'),
+]
+
+dependencies = [
+    ('GMP', '6.2.0'),
+]
+
+configopts = '-DZ3_USE_LIB_GMP=ON -DZ3_LINK_TIME_OPTIMIZATION=ON '
+
+sanity_check_paths = {
+    'files': ['bin/z3', 'include/z3_api.h', 'lib/libz3.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
`libxml2` is a runtime dependency rather than a build dependency. Also enable use of `hwloc` for affinity in the OpenMP runtime and `Z3` in the Clang static analyzer, and build extra Clang tools.

Depends on ~~https://github.com/easybuilders/easybuild-easyblocks/pull/2310~~