### PR TITLE
Libfabric: fix OS deps

### DIFF
--- a/easybuild/easyconfigs/l/libfabric/libfabric-1.10.1-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/l/libfabric/libfabric-1.10.1-GCCcore-9.3.0.eb
@@ -24,7 +24,7 @@ builddependencies = [
     ('pkg-config', '0.29.2'),
 ]
 
-osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
+osdependencies = [OS_PKG_IBVERBS_DEV]
 
 # Disable deprecated "sockets" provider
 configopts = "--disable-sockets"

--- a/easybuild/easyconfigs/l/libfabric/libfabric-1.11.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/l/libfabric/libfabric-1.11.0-GCCcore-10.2.0.eb
@@ -24,7 +24,7 @@ builddependencies = [
     ('pkg-config', '0.29.2'),
 ]
 
-osdependencies = [OS_PKG_OPENSSL_DEV]
+osdependencies = [OS_PKG_IBVERBS_DEV]
 
 # Disable deprecated "sockets" provider
 configopts = "--disable-sockets"

--- a/easybuild/easyconfigs/l/libfabric/libfabric-1.11.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/l/libfabric/libfabric-1.11.0-GCCcore-9.3.0.eb
@@ -24,7 +24,7 @@ builddependencies = [
     ('pkg-config', '0.29.2'),
 ]
 
-osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
+osdependencies = [OS_PKG_IBVERBS_DEV]
 
 # Disable deprecated "sockets" provider
 configopts = "--disable-sockets"

--- a/easybuild/easyconfigs/l/libfabric/libfabric-1.9.1-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/l/libfabric/libfabric-1.9.1-GCCcore-9.3.0.eb
@@ -25,7 +25,7 @@ builddependencies = [
     ('pkg-config', '0.29.2'),
 ]
 
-osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
+osdependencies = [OS_PKG_IBVERBS_DEV]
 
 preconfigopts = "./autogen.sh && "
 


### PR DESCRIPTION
Fix bogus OS dependency on OpenSSL for `libfabric-1.11.0-GCCcore-10.2.0.eb` and consistently use `OS_PKG_IBVERBS_DEV` constant.