### PR TITLE
Remove duplicate extensions in R 3.5.x easyconfigs, and add test to detect such issues

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
@@ -3,7 +3,7 @@ version = '3.5.0'
 local_x11ver = '20180131'
 versionsuffix = '-X11-%s' % local_x11ver
 
-homepage = 'http://www.r-project.org/'
+homepage = 'https://www.r-project.org/'
 description = """R is a free software environment for statistical computing and graphics."""
 
 toolchain = {'name': 'iomkl', 'version': '2018a'}
@@ -60,9 +60,9 @@ easybuild_version = '3.5.0'
 
 exts_default_options = {
     'source_urls': [
-        'http://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
-        'http://cran.r-project.org/src/contrib/',  # current version of packages
-        'http://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
     ],
     'source_tmpl': '%(name)s_%(version)s.tar.gz',
 }
@@ -794,8 +794,8 @@ exts_list = [
     ('ROCR', '1.0-7', {
         'checksums': ['e7ef710f847e441a48b20fdc781dbc1377f5a060a5ee635234053f7a2a435ec9'],
     }),
-    ('later', '0.7.3', {
-        'checksums': ['5c57148c255ee5da61cb748550b73bad7094f4e045b99b362473be5e3dbc4212'],
+    ('later', '0.7.4', {
+        'checksums': ['c4d49aa91f5154ef54ea0498b17f230b8bf99da62541b64417e0c8971261bf88'],
     }),
     ('promises', '1.0.1', {
         'checksums': ['c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558'],
@@ -1920,17 +1920,8 @@ exts_list = [
     ('SDMTools', '1.1-221', {
         'checksums': ['a6da297a670f756ee964ffd99c3b212c55c297d385583fd0e767435dd5cd4ccd'],
     }),
-    ('later', '0.7.4', {
-        'checksums': ['c4d49aa91f5154ef54ea0498b17f230b8bf99da62541b64417e0c8971261bf88'],
-    }),
-    ('promises', '1.0.1', {
-        'checksums': ['c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558'],
-    }),
     ('ggridges', '0.5.0', {
         'checksums': ['124bc84044e56728fa965682f8232fc868f2af7d3eb7276f6b0df53be8d2dbfe'],
-    }),
-    ('bibtex', '0.4.2', {
-        'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
     }),
     ('gbRd', '0.4-11', {
         'checksums': ['0251f6dd6ca987a74acc4765838b858f1edb08b71dbad9e563669b58783ea91b'],

--- a/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
@@ -756,7 +756,8 @@ exts_list = [
         'checksums': ['41366f777d8adb83d0bdbac1392a1ab118b36217ca648d3bb9db763aa7ff4686'],
     }),
     ('pkgmaker', '0.27', {
-        'checksums': ['17a289d8f596ba5637b07077b3bff22411a2c2263c0b7de59fe848666555ec6a'],
+        'checksums': [('17a289d8f596ba5637b07077b3bff22411a2c2263c0b7de59fe848666555ec6a',
+                       'e5eb9058e68702c15e8dc6fee6ede41cdbe8e3914d190a5a1113079db26fb003')],
     }),
     ('rngtools', '1.3.1', {
         'checksums': ['763fc493cb821a4d3e514c0dc876d602a692c528e1d67f295dde70c77009e224'],

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b-Python-2.7.15.eb
@@ -770,7 +770,8 @@ exts_list = [
         'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
     }),
     ('pkgmaker', '0.27', {
-        'checksums': ['17a289d8f596ba5637b07077b3bff22411a2c2263c0b7de59fe848666555ec6a'],
+        'checksums': [('17a289d8f596ba5637b07077b3bff22411a2c2263c0b7de59fe848666555ec6a',
+                       'e5eb9058e68702c15e8dc6fee6ede41cdbe8e3914d190a5a1113079db26fb003')],
     }),
     ('rngtools', '1.3.1', {
         'checksums': ['763fc493cb821a4d3e514c0dc876d602a692c528e1d67f295dde70c77009e224'],
@@ -1227,7 +1228,8 @@ exts_list = [
         'checksums': ['8e259c2b12446197d1152b83a81bab84ccb5a5b77021a9b5645dd4c63c804bd1'],
     }),
     ('doRNG', '1.7.1', {
-        'checksums': ['27533d54464889d1c21301594137fc0f536574e3a413d61d7df9463ab12a67e9'],
+        'checksums': [('27533d54464889d1c21301594137fc0f536574e3a413d61d7df9463ab12a67e9',
+                       'bda8143e2b5554fb39fdea81af6482f8938160fdbf5c45014f3a5de40aacf4c4')],
     }),
     ('nleqslv', '3.3.2', {
         'checksums': ['f54956cf67f9970bb3c6803684c84a27ac78165055745e444efc45cfecb63fed'],
@@ -2105,7 +2107,8 @@ exts_list = [
         'checksums': ['76cee2393757390ad91d3db3e5aeb2c2d34c0a46822b7941498571a473417142'],
     }),
     ('cobs', '1.3-3', {
-        'checksums': ['6b1e760cf8dec6b6e63f042cdc3e5e633de5f982e8bc743a891932f6d9f91bdf'],
+        'checksums': [('6b1e760cf8dec6b6e63f042cdc3e5e633de5f982e8bc743a891932f6d9f91bdf',
+                       'f3fca282c9a258cc5e4976780f4907aca1051796524d6861fc15204ab22ab7d2')],
     }),
     ('resample', '0.4', {
         'checksums': ['f0d5f735e1b812612720845d79167a19f713a438fd10a6a3206e667045fd93e5'],

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b-Python-2.7.15.eb
@@ -2,7 +2,7 @@ name = 'R'
 version = '3.5.1'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://www.r-project.org/'
+homepage = 'https://www.r-project.org/'
 description = """R is a free software environment for statistical computing and graphics."""
 
 toolchain = {'name': 'foss', 'version': '2018b'}
@@ -61,9 +61,9 @@ easybuild_version = '3.5.0'
 
 exts_default_options = {
     'source_urls': [
-        'http://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
-        'http://cran.r-project.org/src/contrib/',  # current version of packages
-        'http://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
     ],
     'source_tmpl': '%(name)s_%(version)s.tar.gz',
 }
@@ -808,8 +808,8 @@ exts_list = [
     ('ROCR', '1.0-7', {
         'checksums': ['e7ef710f847e441a48b20fdc781dbc1377f5a060a5ee635234053f7a2a435ec9'],
     }),
-    ('later', '0.7.3', {
-        'checksums': ['5c57148c255ee5da61cb748550b73bad7094f4e045b99b362473be5e3dbc4212'],
+    ('later', '0.7.4', {
+        'checksums': ['c4d49aa91f5154ef54ea0498b17f230b8bf99da62541b64417e0c8971261bf88'],
     }),
     ('promises', '1.0.1', {
         'checksums': ['c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558'],
@@ -1921,17 +1921,8 @@ exts_list = [
     ('SDMTools', '1.1-221', {
         'checksums': ['a6da297a670f756ee964ffd99c3b212c55c297d385583fd0e767435dd5cd4ccd'],
     }),
-    ('later', '0.7.4', {
-        'checksums': ['c4d49aa91f5154ef54ea0498b17f230b8bf99da62541b64417e0c8971261bf88'],
-    }),
-    ('promises', '1.0.1', {
-        'checksums': ['c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558'],
-    }),
     ('ggridges', '0.5.0', {
         'checksums': ['124bc84044e56728fa965682f8232fc868f2af7d3eb7276f6b0df53be8d2dbfe'],
-    }),
-    ('bibtex', '0.4.2', {
-        'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
     }),
     ('gbRd', '0.4-11', {
         'checksums': ['0251f6dd6ca987a74acc4765838b858f1edb08b71dbad9e563669b58783ea91b'],
@@ -2043,9 +2034,6 @@ exts_list = [
     }),
     ('aggregation', '1.0.1', {
         'checksums': ['86f88a02479ddc8506bafb154117ebc3b1a4a44fa308e0193c8c315109302f49'],
-    }),
-    ('NMF', '0.21.0', {
-        'checksums': ['3b30c81c66066fab4a63c5611a0313418b840d8b63414db31ef0e932872d02e3'],
     }),
     ('ComICS', '1.0.4', {
         'checksums': ['0af7901215876f95f309d7da6e633c38e4d7faf04112dd6fd343bc15fc593a2f'],

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
@@ -768,7 +768,8 @@ exts_list = [
         'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
     }),
     ('pkgmaker', '0.27', {
-        'checksums': ['17a289d8f596ba5637b07077b3bff22411a2c2263c0b7de59fe848666555ec6a'],
+        'checksums': [('17a289d8f596ba5637b07077b3bff22411a2c2263c0b7de59fe848666555ec6a',
+                       'e5eb9058e68702c15e8dc6fee6ede41cdbe8e3914d190a5a1113079db26fb003')],
     }),
     ('rngtools', '1.3.1', {
         'checksums': ['763fc493cb821a4d3e514c0dc876d602a692c528e1d67f295dde70c77009e224'],
@@ -1225,7 +1226,8 @@ exts_list = [
         'checksums': ['8e259c2b12446197d1152b83a81bab84ccb5a5b77021a9b5645dd4c63c804bd1'],
     }),
     ('doRNG', '1.7.1', {
-        'checksums': ['27533d54464889d1c21301594137fc0f536574e3a413d61d7df9463ab12a67e9'],
+        'checksums': [('27533d54464889d1c21301594137fc0f536574e3a413d61d7df9463ab12a67e9',
+                       'bda8143e2b5554fb39fdea81af6482f8938160fdbf5c45014f3a5de40aacf4c4')],
     }),
     ('nleqslv', '3.3.2', {
         'checksums': ['f54956cf67f9970bb3c6803684c84a27ac78165055745e444efc45cfecb63fed'],
@@ -2103,7 +2105,8 @@ exts_list = [
         'checksums': ['76cee2393757390ad91d3db3e5aeb2c2d34c0a46822b7941498571a473417142'],
     }),
     ('cobs', '1.3-3', {
-        'checksums': ['6b1e760cf8dec6b6e63f042cdc3e5e633de5f982e8bc743a891932f6d9f91bdf'],
+        'checksums': [('6b1e760cf8dec6b6e63f042cdc3e5e633de5f982e8bc743a891932f6d9f91bdf',
+                       'f3fca282c9a258cc5e4976780f4907aca1051796524d6861fc15204ab22ab7d2')],
     }),
     ('resample', '0.4', {
         'checksums': ['f0d5f735e1b812612720845d79167a19f713a438fd10a6a3206e667045fd93e5'],

--- a/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-foss-2018b.eb
@@ -1,7 +1,7 @@
 name = 'R'
 version = '3.5.1'
 
-homepage = 'http://www.r-project.org/'
+homepage = 'https://www.r-project.org/'
 description = """R is a free software environment for statistical computing and graphics."""
 
 toolchain = {'name': 'foss', 'version': '2018b'}
@@ -59,9 +59,9 @@ easybuild_version = '3.5.0'
 
 exts_default_options = {
     'source_urls': [
-        'http://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
-        'http://cran.r-project.org/src/contrib/',  # current version of packages
-        'http://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
     ],
     'source_tmpl': '%(name)s_%(version)s.tar.gz',
 }
@@ -806,8 +806,8 @@ exts_list = [
     ('ROCR', '1.0-7', {
         'checksums': ['e7ef710f847e441a48b20fdc781dbc1377f5a060a5ee635234053f7a2a435ec9'],
     }),
-    ('later', '0.7.3', {
-        'checksums': ['5c57148c255ee5da61cb748550b73bad7094f4e045b99b362473be5e3dbc4212'],
+    ('later', '0.7.4', {
+        'checksums': ['c4d49aa91f5154ef54ea0498b17f230b8bf99da62541b64417e0c8971261bf88'],
     }),
     ('promises', '1.0.1', {
         'checksums': ['c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558'],
@@ -1919,17 +1919,8 @@ exts_list = [
     ('SDMTools', '1.1-221', {
         'checksums': ['a6da297a670f756ee964ffd99c3b212c55c297d385583fd0e767435dd5cd4ccd'],
     }),
-    ('later', '0.7.4', {
-        'checksums': ['c4d49aa91f5154ef54ea0498b17f230b8bf99da62541b64417e0c8971261bf88'],
-    }),
-    ('promises', '1.0.1', {
-        'checksums': ['c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558'],
-    }),
     ('ggridges', '0.5.0', {
         'checksums': ['124bc84044e56728fa965682f8232fc868f2af7d3eb7276f6b0df53be8d2dbfe'],
-    }),
-    ('bibtex', '0.4.2', {
-        'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
     }),
     ('gbRd', '0.4-11', {
         'checksums': ['0251f6dd6ca987a74acc4765838b858f1edb08b71dbad9e563669b58783ea91b'],
@@ -2041,9 +2032,6 @@ exts_list = [
     }),
     ('aggregation', '1.0.1', {
         'checksums': ['86f88a02479ddc8506bafb154117ebc3b1a4a44fa308e0193c8c315109302f49'],
-    }),
-    ('NMF', '0.21.0', {
-        'checksums': ['3b30c81c66066fab4a63c5611a0313418b840d8b63414db31ef0e932872d02e3'],
     }),
     ('ComICS', '1.0.4', {
         'checksums': ['0af7901215876f95f309d7da6e633c38e4d7faf04112dd6fd343bc15fc593a2f'],

--- a/easybuild/easyconfigs/r/R/R-3.5.1-intel-2018b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-intel-2018b.eb
@@ -768,7 +768,8 @@ exts_list = [
         'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
     }),
     ('pkgmaker', '0.27', {
-        'checksums': ['17a289d8f596ba5637b07077b3bff22411a2c2263c0b7de59fe848666555ec6a'],
+        'checksums': [('17a289d8f596ba5637b07077b3bff22411a2c2263c0b7de59fe848666555ec6a',
+                       'e5eb9058e68702c15e8dc6fee6ede41cdbe8e3914d190a5a1113079db26fb003')],
     }),
     ('rngtools', '1.3.1', {
         'checksums': ['763fc493cb821a4d3e514c0dc876d602a692c528e1d67f295dde70c77009e224'],
@@ -1233,7 +1234,8 @@ exts_list = [
         'checksums': ['8e259c2b12446197d1152b83a81bab84ccb5a5b77021a9b5645dd4c63c804bd1'],
     }),
     ('doRNG', '1.7.1', {
-        'checksums': ['27533d54464889d1c21301594137fc0f536574e3a413d61d7df9463ab12a67e9'],
+        'checksums': [('27533d54464889d1c21301594137fc0f536574e3a413d61d7df9463ab12a67e9',
+                       'bda8143e2b5554fb39fdea81af6482f8938160fdbf5c45014f3a5de40aacf4c4')],
     }),
     ('nleqslv', '3.3.2', {
         'checksums': ['f54956cf67f9970bb3c6803684c84a27ac78165055745e444efc45cfecb63fed'],
@@ -2139,7 +2141,8 @@ exts_list = [
         'checksums': ['76cee2393757390ad91d3db3e5aeb2c2d34c0a46822b7941498571a473417142'],
     }),
     ('cobs', '1.3-3', {
-        'checksums': ['6b1e760cf8dec6b6e63f042cdc3e5e633de5f982e8bc743a891932f6d9f91bdf'],
+        'checksums': [('6b1e760cf8dec6b6e63f042cdc3e5e633de5f982e8bc743a891932f6d9f91bdf',
+                       'f3fca282c9a258cc5e4976780f4907aca1051796524d6861fc15204ab22ab7d2')],
     }),
     ('resample', '0.4', {
         'checksums': ['f0d5f735e1b812612720845d79167a19f713a438fd10a6a3206e667045fd93e5'],

--- a/easybuild/easyconfigs/r/R/R-3.5.1-intel-2018b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.1-intel-2018b.eb
@@ -1,7 +1,7 @@
 name = 'R'
 version = '3.5.1'
 
-homepage = 'http://www.r-project.org/'
+homepage = 'https://www.r-project.org/'
 description = """R is a free software environment for statistical computing and graphics."""
 
 toolchain = {'name': 'intel', 'version': '2018b'}
@@ -59,9 +59,9 @@ easybuild_version = '3.5.0'
 
 exts_default_options = {
     'source_urls': [
-        'http://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
-        'http://cran.r-project.org/src/contrib/',  # current version of packages
-        'http://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
     ],
     'source_tmpl': '%(name)s_%(version)s.tar.gz',
 }
@@ -806,8 +806,8 @@ exts_list = [
     ('ROCR', '1.0-7', {
         'checksums': ['e7ef710f847e441a48b20fdc781dbc1377f5a060a5ee635234053f7a2a435ec9'],
     }),
-    ('later', '0.7.3', {
-        'checksums': ['5c57148c255ee5da61cb748550b73bad7094f4e045b99b362473be5e3dbc4212'],
+    ('later', '0.7.4', {
+        'checksums': ['c4d49aa91f5154ef54ea0498b17f230b8bf99da62541b64417e0c8971261bf88'],
     }),
     ('promises', '1.0.1', {
         'checksums': ['c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558'],
@@ -1947,17 +1947,8 @@ exts_list = [
     ('SDMTools', '1.1-221', {
         'checksums': ['a6da297a670f756ee964ffd99c3b212c55c297d385583fd0e767435dd5cd4ccd'],
     }),
-    ('later', '0.7.4', {
-        'checksums': ['c4d49aa91f5154ef54ea0498b17f230b8bf99da62541b64417e0c8971261bf88'],
-    }),
-    ('promises', '1.0.1', {
-        'checksums': ['c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558'],
-    }),
     ('ggridges', '0.5.0', {
         'checksums': ['124bc84044e56728fa965682f8232fc868f2af7d3eb7276f6b0df53be8d2dbfe'],
-    }),
-    ('bibtex', '0.4.2', {
-        'checksums': ['1f06ab3660c940405230ad16ff6e4ba38d4418a59cd9b16d78a4349f8b488372'],
     }),
     ('gbRd', '0.4-11', {
         'checksums': ['0251f6dd6ca987a74acc4765838b858f1edb08b71dbad9e563669b58783ea91b'],
@@ -2069,9 +2060,6 @@ exts_list = [
     }),
     ('aggregation', '1.0.1', {
         'checksums': ['86f88a02479ddc8506bafb154117ebc3b1a4a44fa308e0193c8c315109302f49'],
-    }),
-    ('NMF', '0.21.0', {
-        'checksums': ['3b30c81c66066fab4a63c5611a0313418b840d8b63414db31ef0e932872d02e3'],
     }),
     ('ComICS', '1.0.4', {
         'checksums': ['0af7901215876f95f309d7da6e633c38e4d7faf04112dd6fd343bc15fc593a2f'],

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -663,6 +663,26 @@ class EasyConfigTest(TestCase):
 
         self.assertFalse(failing_checks, '\n'.join(failing_checks))
 
+    def check_R_packages(self, changed_ecs):
+        """Several checks for easyconfigs that install (bundles of) R packages."""
+        failing_checks = []
+
+        for ec in changed_ecs:
+            ec_fn = os.path.basename(ec.path)
+            exts_defaultclass = ec.get('exts_defaultclass')
+            if exts_defaultclass == 'RPackage' or ec.name == 'R':
+                seen_exts = set()
+                for ext in ec['exts_list']:
+                    if isinstance(ext, (tuple, list)):
+                        ext_name = ext[0]
+                    else:
+                        ext_name = ext
+                    if ext_name in seen_exts:
+                        failing_checks.append('%s was added multiple times to exts_list in %s' % (ext_name, ec_fn))
+                    else:
+                        seen_exts.add(ext_name)
+        self.assertFalse(failing_checks, '\n'.join(failing_checks))
+
     def check_sanity_check_paths(self, changed_ecs):
         """Make sure a custom sanity_check_paths value is specified for easyconfigs that use a generic easyblock."""
 
@@ -738,8 +758,8 @@ class EasyConfigTest(TestCase):
 
                 if https_url_works:
                     failing_checks.append("Found http:// URL in %s, should be https:// : %s" % (ec_fn, http_url))
-
-        self.assertFalse(failing_checks, '\n'.join(failing_checks))
+        if failing_checks:
+            self.fail('\n'.join(failing_checks))
 
     def test_changed_files_pull_request(self):
         """Specific checks only done for the (easyconfig) files that were changed in a pull request."""
@@ -794,9 +814,9 @@ class EasyConfigTest(TestCase):
                 changed_ecs_filenames = get_eb_files_from_diff(diff_filter='M')
                 added_ecs_filenames = get_eb_files_from_diff(diff_filter='A')
                 if changed_ecs_filenames:
-                    print("\nList of changed easyconfig files in this PR: %s" % '\n'.join(changed_ecs_filenames))
+                    print("\nList of changed easyconfig files in this PR:\n\t%s" % '\n\t'.join(changed_ecs_filenames))
                 if added_ecs_filenames:
-                    print("\nList of added easyconfig files in this PR: %s" % '\n'.join(added_ecs_filenames))
+                    print("\nList of added easyconfig files in this PR:\n\t%s" % '\n\t'.join(added_ecs_filenames))
 
                 change_dir(cwd)
 
@@ -827,6 +847,7 @@ class EasyConfigTest(TestCase):
                 # run checks on changed easyconfigs
                 self.check_sha256_checksums(changed_ecs)
                 self.check_python_packages(changed_ecs, added_ecs_filenames)
+                self.check_R_packages(changed_ecs)
                 self.check_sanity_check_paths(changed_ecs)
                 self.check_https(changed_ecs)
 


### PR DESCRIPTION
A user reported a failure when building with: `eb --package R-3.5.1-foss-2018b.eb --skip --force --ignore-checksum --debug --info`

```
== 2021-01-28 18:36:09,232 run.py:222 INFO running cmd:  R CMD INSTALL /tmp/centos/R/3.5.1/foss-2018b/later/later   --library=/mnt/eb/apps/R/3.5.1-foss-2018b/lib64/R/library --no-clean-on-error
== 2021-01-28 18:36:10,920 build_log.py:169 ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:124 in __init__): cmd " R CMD INSTALL /tmp/centos/R/3.5.1/foss-2018b/later/later   --library=/mnt/eb/apps/R/3.5.1-foss-2018b/lib64/R/library --no-clean-on-error " exited with exit code 1 and output:
* installing *source* package later ...
[...]
C11-style threads.h support not detected. Using tinycthread library.
[...]
/mnt/eb/apps/binutils/2.30-GCCcore-7.3.0/bin/ld.gold: error: ./tinycthread/tinycthread.o: multiple definition of 'mtx_init'
/mnt/eb/apps/binutils/2.30-GCCcore-7.3.0/bin/ld.gold: tinycthread.o: previous definition here
[...]
/mnt/eb/apps/binutils/2.30-GCCcore-7.3.0/bin/ld.gold: error: ./tinycthread/tinycthread.o: multiple definition of 'tss_set'
/mnt/eb/apps/binutils/2.30-GCCcore-7.3.0/bin/ld.gold: tinycthread.o: previous definition here
collect2: error: ld returned 1 exit status
make: *** [later.so] Error 1
ERROR: compilation failed for package later
 (at easybuild/tools/run.py:533 in parse_cmd_output)
== 2021-01-28 18:36:10,921 filetools.py:1684 INFO Removing lock /mnt/eb/apps/.locks/_mnt_eb_apps_R_3.5.1-foss-2018b.lock...
== 2021-01-28 18:36:10,922 filetools.py:330 INFO Path /mnt/eb/apps/.locks/_mnt_eb_apps_R_3.5.1-foss-2018b.lock successfully removed.
== 2021-01-28 18:36:10,923 filetools.py:1688 INFO Lock removed: /mnt/eb/apps/.locks/_mnt_eb_apps_R_3.5.1-foss-2018b.lock
== 2021-01-28 18:36:10,923 easyblock.py:3340 WARNING build failed (first 300 chars): cmd " R CMD INSTALL /tmp/centos/R/3.5.1/foss-2018b/later/later   --library=/mnt/eb/apps/R/3.5.1-foss-2018b/lib64/R/library --no-clean-on-error " exited with exit code 1 and output:
```

Reason seems to be duplicated packages in the R ECs.

Removed the older versions and added a test case to detect this