### PR TITLE
move most recent BLIS and libFLAME easyconfigs from GCC to GCCcore

### DIFF
--- a/easybuild/easyconfigs/b/BLIS/BLIS-0.8.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/b/BLIS/BLIS-0.8.0-GCCcore-10.2.0.eb
@@ -7,13 +7,14 @@ homepage = 'https://github.com/flame/blis/'
 description = """BLIS is a portable software framework for instantiating high-performance
 BLAS-like dense linear algebra libraries."""
 
-toolchain = {'name': 'GCC', 'version': '10.2.0'}
+toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
 source_urls = ['https://github.com/flame/blis/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = ['5e05868c4a6cf5032a7492f8861653e939a8f907a4fa524bbb6e14394e170a3d']
 
 builddependencies = [
+    ('binutils', '2.35'),
     ('Python', '3.8.6'),
     ('Perl', '5.32.0'),
 ]

--- a/easybuild/easyconfigs/b/BLIS/BLIS-0.8.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/b/BLIS/BLIS-0.8.0-GCCcore-9.3.0.eb
@@ -7,13 +7,14 @@ homepage = 'https://github.com/flame/blis/'
 description = """BLIS is a portable software framework for instantiating high-performance
 BLAS-like dense linear algebra libraries."""
 
-toolchain = {'name': 'GCC', 'version': '9.3.0'}
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
 source_urls = ['https://github.com/flame/blis/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = ['5e05868c4a6cf5032a7492f8861653e939a8f907a4fa524bbb6e14394e170a3d']
 
 builddependencies = [
+    ('binutils', '2.34'),
     ('Python', '3.8.2'),
     ('Perl', '5.30.2'),
 ]

--- a/easybuild/easyconfigs/b/BLIS/BLIS-2.2-GCCcore-9.3.0-amd.eb
+++ b/easybuild/easyconfigs/b/BLIS/BLIS-2.2-GCCcore-9.3.0-amd.eb
@@ -8,7 +8,7 @@ homepage = 'https://developer.amd.com/amd-cpu-libraries/blas-library/'
 description = """AMD's fork of BLIS. BLIS is a portable software framework for instantiating high-performance
 BLAS-like dense linear algebra libraries."""
 
-toolchain = {'name': 'GCC', 'version': '9.3.0'}
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
 source_urls = ['https://github.com/amd/blis/archive/']
 sources = ['%(version)s.tar.gz']
@@ -19,7 +19,11 @@ checksums = [
     'e879bd79e4438f7e6905461af1d483d27d14945eb9e75509b22c7584b8ba93c4',
 ]
 
-builddependencies = [('Python', '3.8.2')]
+builddependencies = [
+    ('binutils', '2.34'),
+    ('Python', '3.8.2'),
+    ('Perl', '5.30.2'),
+]
 
 # Build Serial and multithreaded library
 configopts = ['--enable-cblas --enable-shared CC="$CC" auto',

--- a/easybuild/easyconfigs/g/gobff/gobff-2020.06-amd.eb
+++ b/easybuild/easyconfigs/g/gobff/gobff-2020.06-amd.eb
@@ -12,7 +12,8 @@ toolchain = SYSTEM
 local_comp_name = 'GCC'
 local_comp_version = '9.3.0'
 local_comp = (local_comp_name, local_comp_version)
-local_blisver = '2.2'
+
+local_gcccore = ('GCCcore', local_comp_version)
 
 # toolchain used to build  dependencies
 local_comp_mpi_tc_name = 'gompi'
@@ -23,8 +24,8 @@ local_comp_mpi_tc = (local_comp_mpi_tc_name, local_comp_mpi_tc_ver)
 dependencies = [
     local_comp,
     ('OpenMPI', '4.0.3', '', local_comp),  # part of gompi toolchain
-    ('BLIS', local_blisver, '-amd', local_comp),
-    ('libFLAME', local_blisver, '-amd', local_comp),
+    ('BLIS', '2.2', '-amd', local_gcccore),
+    ('libFLAME', '2.2', '-amd', local_gcccore),
     ('ScaLAPACK', '2.2', '-amd', local_comp_mpi_tc),
     ('FFTW', '3.3.8', '-amd', local_comp_mpi_tc),
 ]

--- a/easybuild/easyconfigs/g/gobff/gobff-2020.11.eb
+++ b/easybuild/easyconfigs/g/gobff/gobff-2020.11.eb
@@ -11,8 +11,8 @@ toolchain = SYSTEM
 local_comp_name = 'GCC'
 local_comp_version = '9.3.0'
 local_comp = (local_comp_name, local_comp_version)
-local_blisver = '0.8.0'
-local_libflamever = '5.2.0'
+
+local_gcccore = ('GCCcore', local_comp_version)
 
 # toolchain used to build  dependencies
 local_comp_mpi_tc_name = 'gompi'
@@ -23,8 +23,8 @@ local_comp_mpi_tc = (local_comp_mpi_tc_name, local_comp_mpi_tc_ver)
 dependencies = [
     local_comp,
     ('OpenMPI', '4.0.3', '', local_comp),  # part of gompi toolchain
-    ('BLIS', local_blisver, '', local_comp),
-    ('libFLAME', local_libflamever, '', local_comp),
+    ('BLIS', '0.8.0', '', local_gcccore),
+    ('libFLAME', '5.2.0', '', local_gcccore),
     ('ScaLAPACK', '2.1.0', '-bf', local_comp_mpi_tc),
     ('FFTW', '3.3.8', '', local_comp_mpi_tc),
 ]

--- a/easybuild/easyconfigs/g/gobff/gobff-2020b.eb
+++ b/easybuild/easyconfigs/g/gobff/gobff-2020b.eb
@@ -11,8 +11,8 @@ toolchain = SYSTEM
 local_comp_name = 'GCC'
 local_comp_version = '10.2.0'
 local_comp = (local_comp_name, local_comp_version)
-local_blisver = '0.8.0'
-local_libflamever = '5.2.0'
+
+local_gcccore = ('GCCcore', local_comp_version)
 
 # toolchain used to build  dependencies
 local_comp_mpi_tc_name = 'gompi'
@@ -22,8 +22,8 @@ local_comp_mpi_tc = (local_comp_mpi_tc_name, version)
 dependencies = [
     local_comp,
     ('OpenMPI', '4.0.5', '', local_comp),  # part of gompi toolchain
-    ('BLIS', local_blisver, '', local_comp),
-    ('libFLAME', local_libflamever, '', local_comp),
+    ('BLIS', '0.8.0', '', local_gcccore),
+    ('libFLAME', '5.2.0', '', local_gcccore),
     ('ScaLAPACK', '2.1.0', '-bf', local_comp_mpi_tc),
     ('FFTW', '3.3.8', '', local_comp_mpi_tc),
 ]

--- a/easybuild/easyconfigs/l/libFLAME/libFLAME-2.2-GCCcore-9.3.0-amd.eb
+++ b/easybuild/easyconfigs/l/libFLAME/libFLAME-2.2-GCCcore-9.3.0-amd.eb
@@ -8,7 +8,7 @@ homepage = 'https://developer.amd.com/amd-cpu-libraries/blas-library/#libflame'
 description = """AMD fork of libFLAME. libFLAME is a portable library for dense matrix computations,
 providing much of the functionality present in LAPACK."""
 
-toolchain = {'name': 'GCC', 'version': '9.3.0'}
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/amd/libflame/archive/']

--- a/easybuild/easyconfigs/l/libFLAME/libFLAME-5.2.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/l/libFLAME/libFLAME-5.2.0-GCCcore-10.2.0.eb
@@ -7,7 +7,7 @@ homepage = 'https://developer.amd.com/amd-cpu-libraries/blas-library/#libflame'
 description = """libFLAME is a portable library for dense matrix computations,
 providing much of the functionality present in LAPACK."""
 
-toolchain = {'name': 'GCC', 'version': '10.2.0'}
+toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/flame/libflame/archive/']

--- a/easybuild/easyconfigs/l/libFLAME/libFLAME-5.2.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/l/libFLAME/libFLAME-5.2.0-GCCcore-9.3.0.eb
@@ -7,7 +7,7 @@ homepage = 'https://developer.amd.com/amd-cpu-libraries/blas-library/#libflame'
 description = """libFLAME is a portable library for dense matrix computations,
 providing much of the functionality present in LAPACK."""
 
-toolchain = {'name': 'GCC', 'version': '9.3.0'}
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/flame/libflame/archive/']


### PR DESCRIPTION
Building BLIS with Intel compilers is problematic (see https://github.com/flame/blis/issues/371), and doesn't make much sense either (no performance benefit in case of BLIS), so let's move these to `GCCcore`...

For the easyconfigs using `GCC/10.2.0` that's not a problem, since they're only in `develop` currently.

requires ~~#12166~~