### PR TITLE
{bio}[foss/2017a] MrBayes v3.2.6

### DIFF
--- a/easybuild/easyconfigs/m/MrBayes/MrBayes-3.2.6-foss-2017a.eb
+++ b/easybuild/easyconfigs/m/MrBayes/MrBayes-3.2.6-foss-2017a.eb
@@ -1,0 +1,23 @@
+name = 'MrBayes'
+version = '3.2.6'
+
+homepage = 'http://mrbayes.csit.fsu.edu'
+description = "MrBayes is a program for the Bayesian estimation of phylogeny."
+
+toolchain = {'name': 'foss', 'version': '2017a'}
+toolchainopts = {'usempi': True}
+
+github_account = 'NBISweden'
+source_urls = [ 'https://github.com/%(github_account)s/%(name)s/releases/download/v%(version)s' ]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('beagle-lib', '2.1.2'),
+    ('libreadline', '6.3'),
+]
+
+builddependencies = [
+    ('Autotools', '20150215'),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/MrBayes/MrBayes-3.2.6-foss-2017a.eb
+++ b/easybuild/easyconfigs/m/MrBayes/MrBayes-3.2.6-foss-2017a.eb
@@ -8,7 +8,7 @@ toolchain = {'name': 'foss', 'version': '2017a'}
 toolchainopts = {'usempi': True}
 
 github_account = 'NBISweden'
-source_urls = [ 'https://github.com/%(github_account)s/%(name)s/releases/download/v%(version)s' ]
+source_urls = ['https://github.com/%(github_account)s/%(name)s/releases/download/v%(version)s']
 sources = [SOURCELOWER_TAR_GZ]
 
 dependencies = [

--- a/easybuild/easyconfigs/m/MrBayes/MrBayes-3.2.6-foss-2017a.eb
+++ b/easybuild/easyconfigs/m/MrBayes/MrBayes-3.2.6-foss-2017a.eb
@@ -10,6 +10,7 @@ toolchainopts = {'usempi': True}
 github_account = 'NBISweden'
 source_urls = ['https://github.com/%(github_account)s/%(name)s/releases/download/v%(version)s']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['f8fea43b5cb5e24a203a2bb233bfe9f6e7f77af48332f8df20085467cc61496d']
 
 dependencies = [
     ('beagle-lib', '2.1.2'),


### PR DESCRIPTION
1.  Now using 2017a FOSS toolchain, to avoid libibverbs failures with 2016a.  
2.  Download location updated from SourceForge to GitHub.