### PR TITLE
use 'main' rather than 'master' branch in test suite configuration

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -57,7 +57,7 @@ jobs:
           cd $HOME
           # first determine which branch of easybuild-framework repo to install
           BRANCH=develop
-          if [ "x$GITHUB_BASE_REF" = 'xmaster' ]; then BRANCH=master; fi
+          if [ "x$GITHUB_BASE_REF" = 'xmain' ]; then BRANCH=main; fi
           if [ "x$GITHUB_BASE_REF" = 'x4.x' ]; then BRANCH=4.x; fi
           echo "Using easybuild-framework branch $BRANCH (\$GITHUB_BASE_REF $GITHUB_BASE_REF)"
 
@@ -90,7 +90,7 @@ jobs:
         EASYBUILD_MODULE_SYNTAX: ${{matrix.module_syntax}}
       run: |
           # pull in target so we can diff against it to obtain list of touched files
-          if [ "x$GITHUB_BASE_REF" != 'xmaster' ]; then git fetch -v origin ${GITHUB_BASE_REF}:${GITHUB_BASE_REF}; fi
+          if [ "x$GITHUB_BASE_REF" != 'xmain' ]; then git fetch -v origin ${GITHUB_BASE_REF}:${GITHUB_BASE_REF}; fi
 
           # initialize environment for modules tool
           if [ -f $HOME/moduleshome ]; then export MODULESHOME=$(cat $HOME/moduleshome); fi


### PR DESCRIPTION
We're making the necessary changes to rename the `master` branch to `main`.

Currently both are available (and they're identical), but we'll remove `master` as soon as we're done with making the necessary changes.

See also https://github.com/easybuilders/easybuild-framework/pull/3589