### PR TITLE
github_account in public repo?

### DIFF
--- a/easybuild/easyconfigs/t/tensorboardX/tensorboardX-2.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/tensorboardX/tensorboardX-2.0-foss-2019b-Python-3.7.4.eb
@@ -9,7 +9,6 @@ description = "Tensorboard for PyTorch."
 
 toolchain = {'name': 'foss', 'version': '2019b'}
 
-github_account = 'lanpa'
 source_urls = [GITHUB_SOURCE]
 sources = ['v%(version)s.tar.gz']
 checksums = ['fb63f8b1491c5070352d771f3c5a9ad12cdfed6c469bf6c5518e3d7d8f6bd494']


### PR DESCRIPTION
Should this be there at all? There is a 

`github_account = 'lanpa'` on the easyconfig