### PR TITLE
Skip sanity check test in IPython-7.18.1-GCCcore-10.2.0.eb

### DIFF
--- a/easybuild/easyconfigs/i/IPython/IPython-7.18.1-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.18.1-GCCcore-10.2.0.eb
@@ -141,7 +141,7 @@ sanity_check_paths = {
 sanity_check_commands = [
     "ipython -h",
     "jupyter notebook --help",
-    "iptest",
+    "NOSE_EXCLUDE='system_interrupt' iptest",
 ]
 
 sanity_pip_check = True


### PR DESCRIPTION
skipping test_system_interrupt, generally failing (https://github.com/ipython/ipython/issues/12164)