### PR TITLE
netCDF:add patch fixing MPI_Info_f2c OpenMPI issue

### DIFF
--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.6.2-gompi-2019a.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.6.2-gompi-2019a.eb
@@ -1,7 +1,7 @@
 name = 'netCDF'
 version = '4.6.2'
 
-homepage = 'http://www.unidata.ucar.edu/software/netcdf/'
+homepage = 'https://www.unidata.ucar.edu/software/netcdf/'
 description = """NetCDF (network Common Data Form) is a set of software libraries 
  and machine-independent data formats that support the creation, access, and sharing of array-oriented 
  scientific data."""

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.6.2-gompi-2019a.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.6.2-gompi-2019a.eb
@@ -11,7 +11,12 @@ toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = ['https://github.com/Unidata/netcdf-c/archive/']
 sources = ['v%(version)s.tar.gz']
-checksums = ['673936c76ae0c496f6dde7e077f5be480afc1e300adb2c200bf56fbe22e5a82a']
+patches = ['netCDF-4.7.4-fix-mpi-info-f2c.patch']
+checksums = [
+    '673936c76ae0c496f6dde7e077f5be480afc1e300adb2c200bf56fbe22e5a82a',  # v4.6.2.tar.gz
+    '7ff8a922ca3be35fca261a94f725abde32807f17c196c475053a570f03eb7396',  # netCDF-4.7.4-fix-mpi-info-f2c.patch
+]
+
 
 builddependencies = [
     ('Autotools', '20180311'),

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.7.1-gompi-2019b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.7.1-gompi-2019b.eb
@@ -11,7 +11,11 @@ toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = ['https://github.com/Unidata/netcdf-c/archive/']
 sources = ['v%(version)s.tar.gz']
-checksums = ['583e6b89c57037293fc3878c9181bb89151da8c6015ecea404dd426fea219b2c']
+patches = ['netCDF-4.7.4-fix-mpi-info-f2c.patch']
+checksums = [
+    '583e6b89c57037293fc3878c9181bb89151da8c6015ecea404dd426fea219b2c',  # v4.7.1.tar.gz
+    '7ff8a922ca3be35fca261a94f725abde32807f17c196c475053a570f03eb7396',  # netCDF-4.7.4-fix-mpi-info-f2c.patch
+]
 
 builddependencies = [
     ('Autotools', '20180311'),

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.7.1-gompic-2019b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.7.1-gompic-2019b.eb
@@ -11,7 +11,11 @@ toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = ['https://github.com/Unidata/netcdf-c/archive/']
 sources = ['v%(version)s.tar.gz']
-checksums = ['583e6b89c57037293fc3878c9181bb89151da8c6015ecea404dd426fea219b2c']
+patches = ['netCDF-4.7.4-fix-mpi-info-f2c.patch']
+checksums = [
+    '583e6b89c57037293fc3878c9181bb89151da8c6015ecea404dd426fea219b2c',  # v4.7.1.tar.gz
+    '7ff8a922ca3be35fca261a94f725abde32807f17c196c475053a570f03eb7396',  # netCDF-4.7.4-fix-mpi-info-f2c.patch
+]
 
 builddependencies = [
     ('Autotools', '20180311'),

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.7.4-fix-mpi-info-f2c.patch
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.7.4-fix-mpi-info-f2c.patch
@@ -1,0 +1,35 @@
+From 0eb1f83fd16cbda8223bc5047953acba5645869b Mon Sep 17 00:00:00 2001
+From: Bart Oldeman <bart.oldeman@calculquebec.ca>
+Date: Thu, 4 Mar 2021 00:33:20 +0000
+Subject: [PATCH] Add HAVE_MPI_INFO_F2C to cmake config.h input file
+
+Without this define parallel netCDF-Fortran did not work
+correctly with Open MPI, for example
+examples/F90/simple_xy_par_wr.f90
+reported
+*** An error occurred in MPI_Info_dup
+*** reported by process [2543714305,2]
+*** on communicator MPI_COMM_WORLD
+*** MPI_ERR_INFO: invalid info object
+*** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
+***    and potentially your MPI job)
+
+Fixes Unidata/netcdf-fortran#109
+---
+ config.h.cmake.in | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/config.h.cmake.in b/config.h.cmake.in
+index 0b746e228..7ed01bf64 100644
+--- a/config.h.cmake.in
++++ b/config.h.cmake.in
+@@ -313,6 +313,9 @@ are set when opening a binary file on Windows. */
+ /* Define to 1 if you have the `MPI_Comm_f2c' function. */
+ #cmakedefine HAVE_MPI_COMM_F2C 1
+ 
++/* Define to 1 if you have the `MPI_Info_f2c' function. */
++#cmakedefine HAVE_MPI_INFO_F2C 1
++
+ /* Define to 1 if you have the `mremap' function. */
+ #cmakedefine HAVE_MREMAP 1
+ 

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.7.4-gompi-2020a.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.7.4-gompi-2020a.eb
@@ -11,7 +11,11 @@ toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = ['https://github.com/Unidata/netcdf-c/archive/']
 sources = ['v%(version)s.tar.gz']
-checksums = ['99930ad7b3c4c1a8e8831fb061cb02b2170fc8e5ccaeda733bd99c3b9d31666b']
+patches = ['netCDF-%(version)s-fix-mpi-info-f2c.patch']
+checksums = [
+    '99930ad7b3c4c1a8e8831fb061cb02b2170fc8e5ccaeda733bd99c3b9d31666b',  # v4.7.4.tar.gz
+    '7ff8a922ca3be35fca261a94f725abde32807f17c196c475053a570f03eb7396',  # netCDF-4.7.4-fix-mpi-info-f2c.patch
+]
 
 builddependencies = [
     ('Autotools', '20180311'),

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.7.4-gompi-2020b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.7.4-gompi-2020b.eb
@@ -11,10 +11,14 @@ toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = ['https://github.com/Unidata/netcdf-c/archive/']
 sources = ['v%(version)s.tar.gz']
-patches = ['netCDF-%(version)s_fix-ocdebug.patch']
+patches = [
+    'netCDF-%(version)s_fix-ocdebug.patch',
+    'netCDF-%(version)s-fix-mpi-info-f2c.patch',
+]
 checksums = [
     '99930ad7b3c4c1a8e8831fb061cb02b2170fc8e5ccaeda733bd99c3b9d31666b',  # v4.7.4.tar.gz
     '94c9883005f189a4551947e04191a68199cf4cdcada4b2d313115720fb4690e9',  # netCDF-4.7.4_fix-ocdebug.patch
+    '7ff8a922ca3be35fca261a94f725abde32807f17c196c475053a570f03eb7396',  # netCDF-4.7.4-fix-mpi-info-f2c.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.7.4-gompic-2020a.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.7.4-gompic-2020a.eb
@@ -11,7 +11,11 @@ toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = ['https://github.com/Unidata/netcdf-c/archive/']
 sources = ['v%(version)s.tar.gz']
-checksums = ['99930ad7b3c4c1a8e8831fb061cb02b2170fc8e5ccaeda733bd99c3b9d31666b']
+patches = ['netCDF-%(version)s-fix-mpi-info-f2c.patch']
+checksums = [
+    '99930ad7b3c4c1a8e8831fb061cb02b2170fc8e5ccaeda733bd99c3b9d31666b',  # v4.7.4.tar.gz
+    '7ff8a922ca3be35fca261a94f725abde32807f17c196c475053a570f03eb7396',  # netCDF-4.7.4-fix-mpi-info-f2c.patch
+]
 
 builddependencies = [
     ('Autotools', '20180311'),


### PR DESCRIPTION
This affects versions 4.6.2 to 4.7.4, see
https://github.com/Unidata/netcdf-c/pull/1957