### PR TITLE
stick to 'manta' software name, to be consistent with existing easyconfigs

### DIFF
--- a/easybuild/easyconfigs/m/manta/manta-1.6.0-GCC-10.2.0-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/m/manta/manta-1.6.0-GCC-10.2.0-Python-2.7.18.eb
@@ -3,7 +3,7 @@
 ##
 easyblock = 'CMakeMake'
 
-name = 'Manta'
+name = 'manta'
 version = '1.6.0'
 versionsuffix = '-Python-%(pyver)s'
 


### PR DESCRIPTION
I renamed `manta` to `Manta` in #12359 before merging it, but I overlooked the existing `manta` easyconfigs, so it's better to stick to `manta` (since it's not very clear that `Manta` should be preferred)...