### PR TITLE
remove PYPI_SOURCE source URL from easyconfigs using 2020b toolchain

### DIFF
--- a/easybuild/easyconfigs/a/ASAP3/ASAP3-3.12.2-foss-2020b-ASE-3.21.1.eb
+++ b/easybuild/easyconfigs/a/ASAP3/ASAP3-3.12.2-foss-2020b-ASE-3.21.1.eb
@@ -12,7 +12,6 @@ dynamics within the Campos Atomic Simulation Environment (ASE)."""
 toolchain = {'name': 'foss', 'version': '2020b'}
 toolchainopts = {'pic': True, 'usempi': True, 'openmp': False}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['b6c03c790ba4c9f0d231659078c26ce8193fa21314bf2fe4adaa7899d5cd9dbe']
 

--- a/easybuild/easyconfigs/a/ASAP3/ASAP3-3.12.2-intel-2020b-ASE-3.21.1.eb
+++ b/easybuild/easyconfigs/a/ASAP3/ASAP3-3.12.2-intel-2020b-ASE-3.21.1.eb
@@ -12,7 +12,6 @@ dynamics within the Campos Atomic Simulation Environment (ASE)."""
 toolchain = {'name': 'intel', 'version': '2020b'}
 toolchainopts = {'pic': True, 'usempi': True, 'openmp': False}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['b6c03c790ba4c9f0d231659078c26ce8193fa21314bf2fe4adaa7899d5cd9dbe']
 

--- a/easybuild/easyconfigs/a/ASE/ASE-3.20.1-foss-2020b.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.20.1-foss-2020b.eb
@@ -24,8 +24,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('ase', version, {
         'checksums': ['72c81f21b6adb907595fce8d883c0231301cbd8e9f6e5ce8e98bab927054daca'],

--- a/easybuild/easyconfigs/a/ASE/ASE-3.20.1-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.20.1-fosscuda-2020b.eb
@@ -24,8 +24,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('ase', version, {
         'checksums': ['72c81f21b6adb907595fce8d883c0231301cbd8e9f6e5ce8e98bab927054daca'],

--- a/easybuild/easyconfigs/a/ASE/ASE-3.20.1-intel-2020b.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.20.1-intel-2020b.eb
@@ -28,8 +28,6 @@ sanity_pip_check = True
 # ase-ext) using Intel compilers on top of Python built with GCC.
 check_ldshared = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('ase', version, {
         'checksums': ['72c81f21b6adb907595fce8d883c0231301cbd8e9f6e5ce8e98bab927054daca'],

--- a/easybuild/easyconfigs/a/ASE/ASE-3.21.1-foss-2020b.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.21.1-foss-2020b.eb
@@ -24,8 +24,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('ase', version, {
         'checksums': ['78b01d88529d5f604e76bc64be102d48f058ca50faad72ac740d717545711c7b'],

--- a/easybuild/easyconfigs/a/ASE/ASE-3.21.1-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.21.1-fosscuda-2020b.eb
@@ -24,8 +24,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('ase', version, {
         'checksums': ['78b01d88529d5f604e76bc64be102d48f058ca50faad72ac740d717545711c7b'],

--- a/easybuild/easyconfigs/a/ASE/ASE-3.21.1-intel-2020b.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.21.1-intel-2020b.eb
@@ -28,8 +28,6 @@ sanity_pip_check = True
 # ase-ext) using Intel compilers on top of Python built with GCC.
 check_ldshared = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('ase', version, {
         'checksums': ['78b01d88529d5f604e76bc64be102d48f058ca50faad72ac740d717545711c7b'],

--- a/easybuild/easyconfigs/a/ArviZ/ArviZ-0.11.1-intel-2020b.eb
+++ b/easybuild/easyconfigs/a/ArviZ/ArviZ-0.11.1-intel-2020b.eb
@@ -8,7 +8,6 @@ description = "Exploratory analysis of Bayesian models with Python"
 
 toolchain = {'name': 'intel', 'version': '2020b'}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['bb0730ab62223a44ec99072b12f9e9f24521a36e6b7ba2624df9f9908eba1d82']
 

--- a/easybuild/easyconfigs/b/bokeh/bokeh-2.2.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/b/bokeh/bokeh-2.2.3-foss-2020b.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('tornado', '6.1', {
         'checksums': ['33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791'],

--- a/easybuild/easyconfigs/b/bokeh/bokeh-2.2.3-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/b/bokeh/bokeh-2.2.3-fosscuda-2020b.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('tornado', '6.1', {
         'checksums': ['33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791'],

--- a/easybuild/easyconfigs/b/bokeh/bokeh-2.2.3-intel-2020b.eb
+++ b/easybuild/easyconfigs/b/bokeh/bokeh-2.2.3-intel-2020b.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('tornado', '6.1', {
         'checksums': ['33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791'],

--- a/easybuild/easyconfigs/d/dask/dask-2021.2.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/d/dask/dask-2021.2.0-foss-2020b.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('fsspec', '0.8.7', {
         'checksums': ['4b11557a90ac637089b10afa4c77adf42080c0696f6f2771c41ce92d73c41432'],

--- a/easybuild/easyconfigs/d/dask/dask-2021.2.0-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/d/dask/dask-2021.2.0-fosscuda-2020b.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('fsspec', '0.8.7', {
         'checksums': ['4b11557a90ac637089b10afa4c77adf42080c0696f6f2771c41ce92d73c41432'],

--- a/easybuild/easyconfigs/d/dask/dask-2021.2.0-intel-2020b.eb
+++ b/easybuild/easyconfigs/d/dask/dask-2021.2.0-intel-2020b.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('fsspec', '0.8.7', {
         'checksums': ['4b11557a90ac637089b10afa4c77adf42080c0696f6f2771c41ce92d73c41432'],

--- a/easybuild/easyconfigs/f/FabIO/FabIO-0.11.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/f/FabIO/FabIO-0.11.0-foss-2020b.eb
@@ -11,7 +11,6 @@ for a total of 20 different file formats (like CBF, EDF, TIFF, ...) and offers a
 
 toolchain = {'name': 'foss', 'version': '2020b'}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['1d2fcf58006c82548a16004e607d4518613d49e4a2f02a3797703eee2b39c6d8']
 

--- a/easybuild/easyconfigs/g/GPAW/GPAW-20.10.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-20.10.0-foss-2020b.eb
@@ -11,7 +11,6 @@ description = """GPAW is a density-functional theory (DFT) Python code based on 
 toolchain = {'name': 'foss', 'version': '2020b'}
 toolchainopts = {'usempi': True, 'openmp': False}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 patches = [
     ('GPAW-20.1.0-Add-Easybuild-configuration-files.patch', 1),

--- a/easybuild/easyconfigs/g/GPAW/GPAW-20.10.0-intel-2020b.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-20.10.0-intel-2020b.eb
@@ -11,7 +11,6 @@ description = """GPAW is a density-functional theory (DFT) Python code based on 
 toolchain = {'name': 'intel', 'version': '2020b'}
 toolchainopts = {'usempi': True, 'openmp': False}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 patches = [
     ('GPAW-20.1.0-Add-Easybuild-configuration-files.patch', 1),

--- a/easybuild/easyconfigs/g/GPAW/GPAW-21.1.0-foss-2020b-ASE-3.21.1.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-21.1.0-foss-2020b-ASE-3.21.1.eb
@@ -13,7 +13,6 @@ description = """GPAW is a density-functional theory (DFT) Python code based on 
 toolchain = {'name': 'foss', 'version': '2020b'}
 toolchainopts = {'usempi': True, 'openmp': False}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 patches = [
     ('GPAW-20.1.0-Add-Easybuild-configuration-files.patch', 1),

--- a/easybuild/easyconfigs/g/GPAW/GPAW-21.1.0-intel-2020b-ASE-3.21.1.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-21.1.0-intel-2020b-ASE-3.21.1.eb
@@ -13,7 +13,6 @@ description = """GPAW is a density-functional theory (DFT) Python code based on 
 toolchain = {'name': 'intel', 'version': '2020b'}
 toolchainopts = {'usempi': True, 'openmp': False}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 patches = [
     ('GPAW-20.1.0-Add-Easybuild-configuration-files.patch', 1),

--- a/easybuild/easyconfigs/g/GPyTorch/GPyTorch-1.3.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/g/GPyTorch/GPyTorch-1.3.0-foss-2020b.eb
@@ -8,7 +8,6 @@ description = "GPyTorch is a Gaussian process library implemented using PyTorch.
 
 toolchain = {'name': 'foss', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['9bc7aea1dee188b69ff181e3406aabf6fedfa4446b834ed6adf68b94b6ebebd5']
 

--- a/easybuild/easyconfigs/g/gensim/gensim-3.8.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/g/gensim/gensim-3.8.3-foss-2020b.eb
@@ -16,8 +16,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('smart_open', '4.1.2', {
         'checksums': ['4bbb6233364fc1173cc0af6b7a56ed76fce32509514f1978a995a5835f3177f1'],

--- a/easybuild/easyconfigs/g/gensim/gensim-3.8.3-intel-2020b.eb
+++ b/easybuild/easyconfigs/g/gensim/gensim-3.8.3-intel-2020b.eb
@@ -16,8 +16,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('smart_open', '4.1.2', {
         'checksums': ['4bbb6233364fc1173cc0af6b7a56ed76fce32509514f1978a995a5835f3177f1'],

--- a/easybuild/easyconfigs/h/HTSeq/HTSeq-0.11.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/h/HTSeq/HTSeq-0.11.3-foss-2020b.eb
@@ -11,7 +11,6 @@ description = """HTSeq is a Python library to facilitate processing and analysis
 
 toolchain = {'name': 'foss', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 checksums = ['abd13b48021340fea783a9dff110534c19a306b54182501e1aa7b324d458b080']

--- a/easybuild/easyconfigs/h/Horovod/Horovod-0.21.1-fosscuda-2020b-TensorFlow-2.4.1.eb
+++ b/easybuild/easyconfigs/h/Horovod/Horovod-0.21.1-fosscuda-2020b-TensorFlow-2.4.1.eb
@@ -28,8 +28,6 @@ preinstallopts += 'HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITHOUT_PYTORCH=1 HOROVOD_W
 
 parallel = 1  # Bug in CMake causes a race condition on horovod_cuda_kernels_generated_cuda_kernels.cu.o.NVCC-depend
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('cloudpickle', '1.5.0', {
         'checksums': ['820c9245cebdec7257211cbe88745101d5d6a042bca11336d78ebd4897ddbc82'],

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-foss-2020b.eb
@@ -11,7 +11,6 @@ description = """HDF5 for Python (h5py) is a general-purpose Python interface to
 toolchain = {'name': 'foss', 'version': '2020b'}
 toolchainopts = {'usempi': True}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['1e2516f190652beedcb8c7acfa1c6fa92d99b42331cbef5e5c7ec2d65b0fc3c2']
 

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-fosscuda-2020b.eb
@@ -11,7 +11,6 @@ description = """HDF5 for Python (h5py) is a general-purpose Python interface to
 toolchain = {'name': 'fosscuda', 'version': '2020b'}
 toolchainopts = {'usempi': True}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['1e2516f190652beedcb8c7acfa1c6fa92d99b42331cbef5e5c7ec2d65b0fc3c2']
 

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intel-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intel-2020b.eb
@@ -11,7 +11,6 @@ description = """HDF5 for Python (h5py) is a general-purpose Python interface to
 toolchain = {'name': 'intel', 'version': '2020b'}
 toolchainopts = {'usempi': True}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['1e2516f190652beedcb8c7acfa1c6fa92d99b42331cbef5e5c7ec2d65b0fc3c2']
 

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intelcuda-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intelcuda-2020b.eb
@@ -11,7 +11,6 @@ description = """HDF5 for Python (h5py) is a general-purpose Python interface to
 toolchain = {'name': 'intelcuda', 'version': '2020b'}
 toolchainopts = {'usempi': True}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['1e2516f190652beedcb8c7acfa1c6fa92d99b42331cbef5e5c7ec2d65b0fc3c2']
 

--- a/easybuild/easyconfigs/i/imbalanced-learn/imbalanced-learn-0.7.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/i/imbalanced-learn/imbalanced-learn-0.7.0-foss-2020b.eb
@@ -9,7 +9,6 @@ description = """imbalanced-learn is a Python package offering a number of re-sa
 
 toolchain = {'name': 'foss', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['da59de0d1c0fa66f62054dd9a0a295a182563aa1abbb3bf9224a3678fcfe8fa4']
 

--- a/easybuild/easyconfigs/j/joypy/joypy-0.2.4-intel-2020b.eb
+++ b/easybuild/easyconfigs/j/joypy/joypy-0.2.4-intel-2020b.eb
@@ -11,7 +11,6 @@ description = "Joyplots in Python with matplotlib & pandas"
 
 toolchain = {'name': 'intel', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['55d268386a1d2d974aa90cbf6dcca3ad943d17075987dfb8c4a772852fbe79c7']
 

--- a/easybuild/easyconfigs/l/LncLOOM/LncLOOM-2.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/l/LncLOOM/LncLOOM-2.0-foss-2020b.eb
@@ -23,7 +23,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
 exts_list = [
     ('amply', '0.1.4', {
         'checksums': ['cb12dcb49d16b168c02be128a1527ecde50211e4bd94af76ff4e67707f5a2d38'],

--- a/easybuild/easyconfigs/m/MDTraj/MDTraj-1.9.5-foss-2020b.eb
+++ b/easybuild/easyconfigs/m/MDTraj/MDTraj-1.9.5-foss-2020b.eb
@@ -18,8 +18,6 @@ dependencies = [
 ]
 
 use_pip = True
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('astor', '0.8.1', {
         'checksums': ['6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e'],

--- a/easybuild/easyconfigs/m/MDTraj/MDTraj-1.9.5-intel-2020b.eb
+++ b/easybuild/easyconfigs/m/MDTraj/MDTraj-1.9.5-intel-2020b.eb
@@ -18,8 +18,6 @@ dependencies = [
 ]
 
 use_pip = True
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('astor', '0.8.1', {
         'checksums': ['6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e'],

--- a/easybuild/easyconfigs/m/Myokit/Myokit-1.32.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/m/Myokit/Myokit-1.32.0-foss-2020b.eb
@@ -9,7 +9,6 @@ cellular electrophysiology."""
 
 toolchain = {'name': 'foss', 'version': '2020b'}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['393ebc85413bd1b573909736caeadd9d7757f41cceb7bd29f3b30f5107237cba']
 

--- a/easybuild/easyconfigs/n/NanoComp/NanoComp-1.13.1-intel-2020b.eb
+++ b/easybuild/easyconfigs/n/NanoComp/NanoComp-1.13.1-intel-2020b.eb
@@ -11,7 +11,6 @@ description = "Comparing runs of Oxford Nanopore sequencing data and alignments"
 
 toolchain = {'name': 'intel', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['e8af09f3f9462b045e1c7abe8d4110ea4aaf10e4a1ba0152ad27c1331eb9e389']
 

--- a/easybuild/easyconfigs/n/NanoPlot/NanoPlot-1.33.0-intel-2020b.eb
+++ b/easybuild/easyconfigs/n/NanoPlot/NanoPlot-1.33.0-intel-2020b.eb
@@ -11,7 +11,6 @@ description = "Plotting suite for long read sequencing data and alignments"
 
 toolchain = {'name': 'intel', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['caf69a5789625e746814238cb4f0d510ed6768a094566e8f1dcaa77933c4d6fd']
 

--- a/easybuild/easyconfigs/n/nanoget/nanoget-1.15.0-intel-2020b.eb
+++ b/easybuild/easyconfigs/n/nanoget/nanoget-1.15.0-intel-2020b.eb
@@ -11,7 +11,6 @@ description = "Functions to extract information from Oxford Nanopore sequencing 
 
 toolchain = {'name': 'intel', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['f6993855d5f1aa1e9271c61e39184b22fccd6a90e634ca88d2684ff85c8c22e5']
 

--- a/easybuild/easyconfigs/n/nanomath/nanomath-1.2.0-intel-2020b.eb
+++ b/easybuild/easyconfigs/n/nanomath/nanomath-1.2.0-intel-2020b.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('Python-Deprecated', '1.1.0', {
         'modulename': 'deprecated',

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.5.5.1-intel-2020b.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.5.5.1-intel-2020b.eb
@@ -9,8 +9,6 @@ description = """Python/numpy interface to netCDF."""
 toolchain = {'name': 'intel', 'version': '2020b'}
 toolchainopts = {'usempi': True}
 
-source_urls = ['https://github.com/Unidata/netcdf4-python/archive/']
-
 dependencies = [
     ('Python', '3.8.6'),
     ('SciPy-bundle', '2020.11'),  # for numpy

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.5.5.1-intel-2020b.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.5.5.1-intel-2020b.eb
@@ -21,8 +21,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('cftime', '1.2.0', {
         'checksums': ['ff0a175edda260357ff7d24a32bbe0a8c72eafd5f6a404ce487127f9d01836db'],

--- a/easybuild/easyconfigs/n/networkx/networkx-2.5-foss-2020b.eb
+++ b/easybuild/easyconfigs/n/networkx/networkx-2.5-foss-2020b.eb
@@ -9,7 +9,6 @@ and study of the structure, dynamics, and functions of complex networks."""
 
 toolchain = {'name': 'foss', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['7978955423fbc9639c10498878be59caf99b44dc304c2286162fd24b458c1602']
 

--- a/easybuild/easyconfigs/n/networkx/networkx-2.5-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/n/networkx/networkx-2.5-fosscuda-2020b.eb
@@ -9,7 +9,6 @@ and study of the structure, dynamics, and functions of complex networks."""
 
 toolchain = {'name': 'fosscuda', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['7978955423fbc9639c10498878be59caf99b44dc304c2286162fd24b458c1602']
 

--- a/easybuild/easyconfigs/n/networkx/networkx-2.5-intel-2020b.eb
+++ b/easybuild/easyconfigs/n/networkx/networkx-2.5-intel-2020b.eb
@@ -9,7 +9,6 @@ and study of the structure, dynamics, and functions of complex networks."""
 
 toolchain = {'name': 'intel', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['7978955423fbc9639c10498878be59caf99b44dc304c2286162fd24b458c1602']
 

--- a/easybuild/easyconfigs/n/numba/numba-0.52.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.52.0-foss-2020b.eb
@@ -22,8 +22,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('llvmlite', '0.35.0', {
         'patches': ['llvmlite-0.31.0_fix-ffi-Makefile.patch'],

--- a/easybuild/easyconfigs/n/numba/numba-0.52.0-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.52.0-fosscuda-2020b.eb
@@ -22,8 +22,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('llvmlite', '0.35.0', {
         'patches': ['llvmlite-0.31.0_fix-ffi-Makefile.patch'],

--- a/easybuild/easyconfigs/p/PyAMG/PyAMG-4.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/p/PyAMG/PyAMG-4.0.0-foss-2020b.eb
@@ -8,7 +8,6 @@ description = """PyAMG is a library of Algebraic Multigrid (AMG) solvers with a 
 
 toolchain = {'name': 'foss', 'version': '2020b'}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['3ceb38ffd86e29774e759486f2961599c8ed847459c68727493cadeaf115a38a']
 

--- a/easybuild/easyconfigs/p/PyAMG/PyAMG-4.0.0-intel-2020b.eb
+++ b/easybuild/easyconfigs/p/PyAMG/PyAMG-4.0.0-intel-2020b.eb
@@ -8,7 +8,6 @@ description = """PyAMG is a library of Algebraic Multigrid (AMG) solvers with a 
 
 toolchain = {'name': 'intel', 'version': '2020b'}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['3ceb38ffd86e29774e759486f2961599c8ed847459c68727493cadeaf115a38a']
 

--- a/easybuild/easyconfigs/p/PyCUDA/PyCUDA-2020.1-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/p/PyCUDA/PyCUDA-2020.1-fosscuda-2020b.eb
@@ -24,7 +24,6 @@ use_pip = True
 
 exts_default_options = {
     'source_tmpl': SOURCELOWER_TAR_GZ,
-    'source_urls': [PYPI_SOURCE],
 }
 
 exts_list = [

--- a/easybuild/easyconfigs/p/PyMC3/PyMC3-3.11.1-intel-2020b.eb
+++ b/easybuild/easyconfigs/p/PyMC3/PyMC3-3.11.1-intel-2020b.eb
@@ -26,8 +26,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('typing_extensions', '3.7.4.3', {
         'checksums': ['99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c'],

--- a/easybuild/easyconfigs/p/PyOpenCL/PyOpenCL-2021.1.2-foss-2020b.eb
+++ b/easybuild/easyconfigs/p/PyOpenCL/PyOpenCL-2021.1.2-foss-2020b.eb
@@ -17,8 +17,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('appdirs', '1.4.4', {
         'checksums': ['7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41'],

--- a/easybuild/easyconfigs/p/PyOpenCL/PyOpenCL-2021.1.2-intel-2020b.eb
+++ b/easybuild/easyconfigs/p/PyOpenCL/PyOpenCL-2021.1.2-intel-2020b.eb
@@ -17,8 +17,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('appdirs', '1.4.4', {
         'checksums': ['7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41'],

--- a/easybuild/easyconfigs/p/PyStan/PyStan-2.19.1.1-intel-2020b.eb
+++ b/easybuild/easyconfigs/p/PyStan/PyStan-2.19.1.1-intel-2020b.eb
@@ -9,7 +9,6 @@ description = """Python interface to Stan, a package for Bayesian inference
 
 toolchain = {'name': 'intel', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['fa8bad8dbc0da22bbe6f36af56c9abbfcf10f92df8ce627d59a36bd8d25eb038']
 

--- a/easybuild/easyconfigs/p/PyTorch-Geometric/PyTorch-Geometric-1.6.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/p/PyTorch-Geometric/PyTorch-Geometric-1.6.3-foss-2020b.eb
@@ -20,8 +20,6 @@ dependencies = [
     ('ASE', '3.20.1'),
 ]
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 use_pip = True
 
 exts_list = [

--- a/easybuild/easyconfigs/p/PyTorch-Geometric/PyTorch-Geometric-1.6.3-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/p/PyTorch-Geometric/PyTorch-Geometric-1.6.3-fosscuda-2020b.eb
@@ -20,8 +20,6 @@ dependencies = [
     ('ASE', '3.20.1'),
 ]
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 use_pip = True
 
 exts_list = [

--- a/easybuild/easyconfigs/p/pauvre/pauvre-0.1924-intel-2020b.eb
+++ b/easybuild/easyconfigs/p/pauvre/pauvre-0.1924-intel-2020b.eb
@@ -11,7 +11,6 @@ description = "Tools for plotting Oxford Nanopore and other long-read data"
 
 toolchain = {'name': 'intel', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['0a5f4fab1cabf7a9dbe5ec0d21be1e2ab0fabc78c8a74453006b63677bcc038f']
 

--- a/easybuild/easyconfigs/p/pymatgen/pymatgen-2022.0.4-foss-2020b.eb
+++ b/easybuild/easyconfigs/p/pymatgen/pymatgen-2022.0.4-foss-2020b.eb
@@ -26,8 +26,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('numpy', '1.20.1', {
         'sources': ['numpy-%(version)s.zip'],

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.11-foss-2020b.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.11-foss-2020b.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 # order is important!
 exts_list = [
     ('numpy', '1.19.4', {

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.11-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.11-fosscuda-2020b.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 # order is important!
 exts_list = [
     ('numpy', '1.19.4', {

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.11-intel-2020b.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.11-intel-2020b.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 # order is important!
 exts_list = [
     ('numpy', '1.19.4', {

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.11-intelcuda-2020b.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.11-intelcuda-2020b.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 # order is important!
 exts_list = [
     ('numpy', '1.19.4', {

--- a/easybuild/easyconfigs/s/Seaborn/Seaborn-0.10.1-intel-2020b.eb
+++ b/easybuild/easyconfigs/s/Seaborn/Seaborn-0.10.1-intel-2020b.eb
@@ -13,7 +13,6 @@ description = """ Seaborn is a Python visualization library based on matplotlib.
 
 toolchain = {'name': 'intel', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['2d1a0c9d6bd1bc3cadb0364b8f06540f51322a670cf8438d0fde1c1c7317adc0']
 

--- a/easybuild/easyconfigs/s/Seaborn/Seaborn-0.11.1-intel-2020b.eb
+++ b/easybuild/easyconfigs/s/Seaborn/Seaborn-0.11.1-intel-2020b.eb
@@ -13,7 +13,6 @@ description = """ Seaborn is a Python visualization library based on matplotlib.
 
 toolchain = {'name': 'intel', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['44e78eaed937c5a87fc7a892c329a7cc091060b67ebd1d0d306b446a74ba01ad']
 

--- a/easybuild/easyconfigs/s/scikit-build/scikit-build-0.11.1-foss-2020b.eb
+++ b/easybuild/easyconfigs/s/scikit-build/scikit-build-0.11.1-foss-2020b.eb
@@ -16,11 +16,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {
-    'source_urls': [PYPI_SOURCE],
-    'sources': [SOURCE_TAR_GZ],
-}
-
 exts_list = [
     ('distro', '1.5.0', {
         'checksums': ['0e58756ae38fbd8fc3020d54badb8eae17c5b9dcbed388b17bb55b8a5928df92'],

--- a/easybuild/easyconfigs/s/scikit-build/scikit-build-0.11.1-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/s/scikit-build/scikit-build-0.11.1-fosscuda-2020b.eb
@@ -16,11 +16,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {
-    'source_urls': [PYPI_SOURCE],
-    'sources': [SOURCE_TAR_GZ],
-}
-
 exts_list = [
     ('distro', '1.5.0', {
         'checksums': ['0e58756ae38fbd8fc3020d54badb8eae17c5b9dcbed388b17bb55b8a5928df92'],

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.18.1-foss-2020b.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.18.1-foss-2020b.eb
@@ -19,8 +19,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('PyWavelets', '1.1.1', {
         'modulename': 'pywt',

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.18.1-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.18.1-fosscuda-2020b.eb
@@ -19,8 +19,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('PyWavelets', '1.1.1', {
         'modulename': 'pywt',

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.18.1-intel-2020b.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.18.1-intel-2020b.eb
@@ -19,8 +19,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('PyWavelets', '1.1.1', {
         'modulename': 'pywt',

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.2-foss-2020b.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.2-foss-2020b.eb
@@ -11,7 +11,6 @@ It strives to be simple and efficient, accessible to everybody, and reusable in 
 
 toolchain = {'name': 'foss', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['20766f515e6cd6f954554387dfae705d93c7b544ec0e6c6a5d8e006f6f7ef480']
 

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.2-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.2-fosscuda-2020b.eb
@@ -11,7 +11,6 @@ It strives to be simple and efficient, accessible to everybody, and reusable in 
 
 toolchain = {'name': 'fosscuda', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['20766f515e6cd6f954554387dfae705d93c7b544ec0e6c6a5d8e006f6f7ef480']
 

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.2-intel-2020b.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.2-intel-2020b.eb
@@ -11,7 +11,6 @@ It strives to be simple and efficient, accessible to everybody, and reusable in 
 
 toolchain = {'name': 'intel', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['20766f515e6cd6f954554387dfae705d93c7b544ec0e6c6a5d8e006f6f7ef480']
 

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.2-intelcuda-2020b.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.2-intelcuda-2020b.eb
@@ -11,7 +11,6 @@ It strives to be simple and efficient, accessible to everybody, and reusable in 
 
 toolchain = {'name': 'intelcuda', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['20766f515e6cd6f954554387dfae705d93c7b544ec0e6c6a5d8e006f6f7ef480']
 

--- a/easybuild/easyconfigs/s/silx/silx-0.14.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/s/silx/silx-0.14.0-foss-2020b.eb
@@ -25,8 +25,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('hdf5plugin', '2.3.1', {
         'checksums': ['2f6d886012c37bf7e8e002173dd6b16e6879b8e0e9f7d2f2ef9f79db97ed28d2'],

--- a/easybuild/easyconfigs/s/statsmodels/statsmodels-0.12.1-intel-2020b.eb
+++ b/easybuild/easyconfigs/s/statsmodels/statsmodels-0.12.1-intel-2020b.eb
@@ -17,8 +17,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('patsy', '0.5.1', {
         'checksums': ['f115cec4201e1465cd58b9866b0b0e7b941caafec129869057405bfe5b5e3991'],

--- a/easybuild/easyconfigs/s/sympy/sympy-1.7.1-foss-2020b.eb
+++ b/easybuild/easyconfigs/s/sympy/sympy-1.7.1-foss-2020b.eb
@@ -11,7 +11,6 @@ description = """SymPy is a Python library for symbolic mathematics. It aims to
 
 toolchain = {'name': 'foss', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['a3de9261e97535b83bb8607b0da2c7d03126650fafea2b2789657b229c246b2e']
 

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.4.1-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.4.1-foss-2020b.eb
@@ -44,7 +44,6 @@ dependencies = [
 ]
 
 exts_default_options = {
-    'source_urls': [PYPI_SOURCE],
     'sanity_pip_check': True,
 }
 use_pip = True

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.4.1-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.4.1-fosscuda-2020b.eb
@@ -46,7 +46,6 @@ dependencies = [
 ]
 
 exts_default_options = {
-    'source_urls': [PYPI_SOURCE],
     'sanity_pip_check': True,
 }
 use_pip = True

--- a/easybuild/easyconfigs/t/tensorflow-probability/tensorflow-probability-0.12.1-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/tensorflow-probability/tensorflow-probability-0.12.1-foss-2020b.eb
@@ -24,8 +24,6 @@ dependencies = [
     ('dm-tree', '0.1.5'),
 ]
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 use_pip = True
 
 exts_list = [

--- a/easybuild/easyconfigs/t/tensorflow-probability/tensorflow-probability-0.12.1-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/t/tensorflow-probability/tensorflow-probability-0.12.1-fosscuda-2020b.eb
@@ -24,8 +24,6 @@ dependencies = [
     ('dm-tree', '0.1.5'),
 ]
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 use_pip = True
 
 exts_list = [

--- a/easybuild/easyconfigs/x/xarray/xarray-0.16.2-intel-2020b.eb
+++ b/easybuild/easyconfigs/x/xarray/xarray-0.16.2-intel-2020b.eb
@@ -10,7 +10,6 @@ description = """xarray (formerly xray) is an open source project and Python pac
 
 toolchain = {'name': 'intel', 'version': '2020b'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['38e8439d6c91bcd5b7c0fca349daf8e0643ac68850c987262d53526e9d7d01e4']
 


### PR DESCRIPTION
This is no longer required as it became the default with https://github.com/easybuilders/easybuild-easyblocks/pull/2364

Tests should (and mine were) be done with e.g. `eb --from-pr 12451 --rebuild --fetch --force-download --sourcepath=/dev/shm/sources --upload-test-report` to only test the download and of course with latest develop easyblocks