### PR TITLE
remove PYPI_SOURCE source URL from easyconfigs using 2020a toolchain

### DIFF
--- a/easybuild/easyconfigs/a/ASE/ASE-3.19.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.19.0-foss-2020a-Python-3.8.2.eb
@@ -19,8 +19,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('MarkupSafe', '1.1.1', {
         'checksums': ['29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b'],

--- a/easybuild/easyconfigs/a/ASE/ASE-3.19.0-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.19.0-intel-2020a-Python-3.8.2.eb
@@ -22,8 +22,6 @@ sanity_pip_check = True
 # required because we're building Python packages (MarkupSafe) using Intel compilers on top of Python built with GCC.
 check_ldshared = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('MarkupSafe', '1.1.1', {
         'checksums': ['29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b'],

--- a/easybuild/easyconfigs/a/ASE/ASE-3.20.1-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.20.1-intel-2020a-Python-3.8.2.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('MarkupSafe', '1.1.1', {
         'checksums': ['29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b'],

--- a/easybuild/easyconfigs/b/BioServices/BioServices-1.7.9-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/b/BioServices/BioServices-1.7.9-foss-2020a-Python-3.8.2.eb
@@ -23,10 +23,6 @@ dependencies = [
 sanity_pip_check = True
 use_pip = True
 
-exts_default_options = {
-    'source_urls': [PYPI_SOURCE],
-}
-
 exts_list = [
     ('colorlog', '4.4.0', {
         'checksums': ['0272c537469ab1e63b9915535874d15b671963c9325db0c4891a2aeff97ce3d1'],

--- a/easybuild/easyconfigs/b/Bottleneck/Bottleneck-1.3.2-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/b/Bottleneck/Bottleneck-1.3.2-foss-2020a-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = "Fast NumPy array functions written in C"
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['20179f0b66359792ea283b69aa16366419132f3b6cf3adadc0c48e2e8118e573']
 

--- a/easybuild/easyconfigs/b/basemap/basemap-1.2.2-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/b/basemap/basemap-1.2.2-foss-2020a-Python-3.8.2.eb
@@ -19,8 +19,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('pyshp', '2.1.3', {
         'modulename': 'shapefile',

--- a/easybuild/easyconfigs/b/bcolz/bcolz-1.2.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/b/bcolz/bcolz-1.2.1-foss-2020a-Python-3.8.2.eb
@@ -12,7 +12,6 @@ description = """bcolz provides columnar, chunked data containers that can be co
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 patches = [
     '%(name)s-%(version)s_fix-deprecation.patch',

--- a/easybuild/easyconfigs/b/bokeh/bokeh-2.0.2-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/b/bokeh/bokeh-2.0.2-foss-2020a-Python-3.8.2.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('tornado', '6.0.4', {
         'checksums': ['0fe2d45ba43b00a41cd73f8be321a44936dc1aba233dee979f17a042b83eb6dc'],

--- a/easybuild/easyconfigs/b/bokeh/bokeh-2.0.2-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/b/bokeh/bokeh-2.0.2-intel-2020a-Python-3.8.2.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('tornado', '6.0.4', {
         'checksums': ['0fe2d45ba43b00a41cd73f8be321a44936dc1aba233dee979f17a042b83eb6dc'],

--- a/easybuild/easyconfigs/b/bx-python/bx-python-0.8.9-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/b/bx-python/bx-python-0.8.9-foss-2020a-Python-3.8.2.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('python-lzo', '1.12', {
         'modulename': 'lzo',

--- a/easybuild/easyconfigs/c/Cartopy/Cartopy-0.18.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/c/Cartopy/Cartopy-0.18.0-foss-2020a-Python-3.8.2.eb
@@ -27,8 +27,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('OWSLib', '0.20.0', {
         'checksums': ['334988857b260c8cdf1f6698d07eab61839c51acb52ee10eed1275439200a40e'],

--- a/easybuild/easyconfigs/c/carputils/carputils-20200915-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/c/carputils/carputils-20200915-foss-2020a-Python-3.8.2.eb
@@ -22,8 +22,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('doxypypy', '0.8.8.6', {
         'checksums': ['627571455c537eb91d6998d95b32efc3c53562b2dbadafcb17e49593e0dae01b'],

--- a/easybuild/easyconfigs/c/causallift/causallift-1.0.6-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/c/causallift/causallift-1.0.6-foss-2020a-Python-3.8.2.eb
@@ -21,8 +21,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('easydict', '1.9', {
         'checksums': ['3f3f0dab07c299f0f4df032db1f388d985bb57fa4c5be30acd25c5f9a516883b'],

--- a/easybuild/easyconfigs/c/causalml/causalml-0.8.0-20200909-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/c/causalml/causalml-0.8.0-20200909-foss-2020a-Python-3.8.2.eb
@@ -28,8 +28,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('slicer', '0.0.4', {
         'checksums': ['21d53aac4e78c93fd83c0fd2f8f9d8a2195ac079dffdc0da81cd749da0f2f355'],

--- a/easybuild/easyconfigs/c/cclib/cclib-1.6.3-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/c/cclib/cclib-1.6.3-foss-2020a-Python-3.8.2.eb
@@ -21,8 +21,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('periodictable', '1.5.2', {
         'checksums': ['1fea8abf0c20453550630ca682a75f0148f65b6d21fdcce7cf0c0e98631fa0d3'],

--- a/easybuild/easyconfigs/c/cclib/cclib-1.6.3-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/c/cclib/cclib-1.6.3-intel-2020a-Python-3.8.2.eb
@@ -21,8 +21,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('periodictable', '1.5.2', {
         'checksums': ['1fea8abf0c20453550630ca682a75f0148f65b6d21fdcce7cf0c0e98631fa0d3'],

--- a/easybuild/easyconfigs/c/chewBBACA/chewBBACA-2.5.5-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/c/chewBBACA/chewBBACA-2.5.5-intel-2020a-Python-3.8.2.eb
@@ -28,7 +28,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
 exts_list = [
     ('isodate', '0.6.0', {
         'checksums': ['2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8'],

--- a/easybuild/easyconfigs/d/dask/dask-2.18.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/d/dask/dask-2.18.1-foss-2020a-Python-3.8.2.eb
@@ -19,8 +19,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('fsspec', '0.7.4', {
         'checksums': ['7075fde6d617cd3a97eac633d230d868121a188a46d16a0dcb484eea0cf2b955'],

--- a/easybuild/easyconfigs/d/dask/dask-2.18.1-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/d/dask/dask-2.18.1-intel-2020a-Python-3.8.2.eb
@@ -19,8 +19,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('fsspec', '0.7.4', {
         'checksums': ['7075fde6d617cd3a97eac633d230d868121a188a46d16a0dcb484eea0cf2b955'],

--- a/easybuild/easyconfigs/d/deepTools/deepTools-3.3.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/d/deepTools/deepTools-3.3.1-foss-2020a-Python-3.8.2.eb
@@ -17,8 +17,6 @@ dependencies = [
     ('plotly.py', '4.8.1'),
 ]
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 use_pip = True
 
 exts_list = [

--- a/easybuild/easyconfigs/d/dicom2nifti/dicom2nifti-2.2.12-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/d/dicom2nifti/dicom2nifti-2.2.12-foss-2020a-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = "Python library for converting dicom files to nifti"
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['6ba845b723326882a1da900fc27848f3c1456ddc6e50b698c92f8c96b3894db8']
 

--- a/easybuild/easyconfigs/f/Fiona/Fiona-1.8.16-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/f/Fiona/Fiona-1.8.16-foss-2020a-Python-3.8.2.eb
@@ -21,8 +21,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('cligj', '0.5.0', {
         'checksums': ['6c7d52d529a78712491974f975c33473f430c0f7beb18c0d7a402a743dcb460a'],

--- a/easybuild/easyconfigs/g/geocube/geocube-0.0.14-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/g/geocube/geocube-0.0.14-foss-2020a-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = "Tool to convert geopandas vector data into rasterized xarray data
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['6e3819fdf5f6bec45296c3eb3e852b89e42569a6119de9feb01e3e9816e59c1a']
 

--- a/easybuild/easyconfigs/g/geopandas/geopandas-0.8.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/g/geopandas/geopandas-0.8.1-foss-2020a-Python-3.8.2.eb
@@ -25,8 +25,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('descartes', '1.1.0', {
         'checksums': ['135a502146af5ed6ff359975e2ebc5fa4b71b5432c355c2cafdc6dea1337035b'],

--- a/easybuild/easyconfigs/h/h5py/h5py-2.10.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.10.0-foss-2020a-Python-3.8.2.eb
@@ -12,7 +12,6 @@ description = """HDF5 for Python (h5py) is a general-purpose Python interface to
 toolchain = {'name': 'foss', 'version': '2020a'}
 toolchainopts = {'usempi': True}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 patches = ['h5py-%(version)s_avoid-mpi-init.patch']
 checksums = [

--- a/easybuild/easyconfigs/h/h5py/h5py-2.10.0-fosscuda-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.10.0-fosscuda-2020a-Python-3.8.2.eb
@@ -12,7 +12,6 @@ description = """HDF5 for Python (h5py) is a general-purpose Python interface to
 toolchain = {'name': 'fosscuda', 'version': '2020a'}
 toolchainopts = {'usempi': True}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 patches = ['h5py-%(version)s_avoid-mpi-init.patch']
 checksums = [

--- a/easybuild/easyconfigs/h/h5py/h5py-2.10.0-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.10.0-intel-2020a-Python-3.8.2.eb
@@ -12,7 +12,6 @@ description = """HDF5 for Python (h5py) is a general-purpose Python interface to
 toolchain = {'name': 'intel', 'version': '2020a'}
 toolchainopts = {'usempi': True}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 patches = ['h5py-%(version)s_avoid-mpi-init.patch']
 checksums = [

--- a/easybuild/easyconfigs/h/h5py/h5py-2.10.0-intelcuda-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.10.0-intelcuda-2020a-Python-3.8.2.eb
@@ -12,7 +12,6 @@ description = """HDF5 for Python (h5py) is a general-purpose Python interface to
 toolchain = {'name': 'intelcuda', 'version': '2020a'}
 toolchainopts = {'usempi': True}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 patches = ['h5py-%(version)s_avoid-mpi-init.patch']
 checksums = [

--- a/easybuild/easyconfigs/i/ILAMB/ILAMB-2.5-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/i/ILAMB/ILAMB-2.5-foss-2020a-Python-3.8.2.eb
@@ -25,8 +25,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('antlr4-python3-runtime', '4.7.2', {
         'modulename': 'antlr4',

--- a/easybuild/easyconfigs/i/IPython/IPython-7.13.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.13.0-foss-2020a-Python-3.8.2.eb
@@ -23,8 +23,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('ipython_genutils', '0.2.0', {
         'checksums': ['eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8'],

--- a/easybuild/easyconfigs/i/IPython/IPython-7.13.0-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.13.0-intel-2020a-Python-3.8.2.eb
@@ -24,8 +24,6 @@ dependencies = [
 use_pip = True
 check_ldshared = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('ipython_genutils', '0.2.0', {
         'checksums': ['eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8'],

--- a/easybuild/easyconfigs/i/IPython/IPython-7.15.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.15.0-foss-2020a-Python-3.8.2.eb
@@ -23,8 +23,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('ipython_genutils', '0.2.0', {
         'checksums': ['eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8'],

--- a/easybuild/easyconfigs/i/IPython/IPython-7.15.0-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.15.0-intel-2020a-Python-3.8.2.eb
@@ -23,8 +23,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('ipython_genutils', '0.2.0', {
         'checksums': ['eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8'],

--- a/easybuild/easyconfigs/k/Keras/Keras-2.3.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/k/Keras/Keras-2.3.1-foss-2020a-Python-3.8.2.eb
@@ -20,8 +20,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('Keras_Applications', '1.0.8', {
         'checksums': ['5579f9a12bcde9748f4a12233925a59b93b73ae6947409ff34aa2ba258189fe5'],

--- a/easybuild/easyconfigs/k/kedro/kedro-0.16.5-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/k/kedro/kedro-0.16.5-foss-2020a-Python-3.8.2.eb
@@ -19,8 +19,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('anyconfig', '0.9.7', {
         'checksums': ['4d6016ae6eecc5e502bc7e99ae0639c5710c5c67bde5f21b06b9eaafd9ce0e7e'],

--- a/easybuild/easyconfigs/l/LMfit/LMfit-1.0.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/l/LMfit/LMfit-1.0.1-foss-2020a-Python-3.8.2.eb
@@ -18,8 +18,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('asteval', '0.9.21', {
         'checksums': ['ee14ba2211cda1c76114e3e7b552cdd57e940309203d5f4106e6d6f2c2346a2e'],

--- a/easybuild/easyconfigs/l/leidenalg/leidenalg-0.8.2-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/l/leidenalg/leidenalg-0.8.2-foss-2020a-Python-3.8.2.eb
@@ -24,7 +24,6 @@ dependencies = [
 use_pip = False
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
 exts_list = [
     # Test-only dependency
     ('ddt', '1.4.1', {

--- a/easybuild/easyconfigs/m/MDTraj/MDTraj-1.9.4-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/m/MDTraj/MDTraj-1.9.4-foss-2020a-Python-3.8.2.eb
@@ -6,7 +6,7 @@ name = 'MDTraj'
 version = '1.9.4'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://mdtraj.org'
+homepage = 'https://mdtraj.org'
 description = "Read, write and analyze MD trajectories with only a few lines of Python code."
 
 toolchain = {'name': 'foss', 'version': '2020a'}
@@ -19,8 +19,6 @@ dependencies = [
 ]
 
 use_pip = True
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('astor', '0.8.1', {
         'checksums': ['6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e'],

--- a/easybuild/easyconfigs/m/MDTraj/MDTraj-1.9.4-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/m/MDTraj/MDTraj-1.9.4-intel-2020a-Python-3.8.2.eb
@@ -6,7 +6,7 @@ name = 'MDTraj'
 version = '1.9.4'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://mdtraj.org'
+homepage = 'https://mdtraj.org'
 description = "Read, write and analyze MD trajectories with only a few lines of Python code."
 
 toolchain = {'name': 'intel', 'version': '2020a'}
@@ -19,8 +19,6 @@ dependencies = [
 ]
 
 use_pip = True
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('astor', '0.8.1', {
         'checksums': ['6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e'],

--- a/easybuild/easyconfigs/m/MLxtend/MLxtend-0.17.3-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/m/MLxtend/MLxtend-0.17.3-foss-2020a-Python-3.8.2.eb
@@ -18,7 +18,6 @@ dependencies = [
     ('SciPy-bundle', '2020.03', versionsuffix),
 ]
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['66d10059630a84c394cd8d82bca62c3da77b9fe6566f03656f2b52e353b8fe06']
 

--- a/easybuild/easyconfigs/m/Metagenome-Atlas/Metagenome-Atlas-2.4.3-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/m/Metagenome-Atlas/Metagenome-Atlas-2.4.3-intel-2020a-Python-3.8.2.eb
@@ -24,8 +24,6 @@ dependencies = [
     ('IPython', '7.15.0', versionsuffix),
 ]
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 use_pip = True
 
 exts_list = [

--- a/easybuild/easyconfigs/m/MultiQC/MultiQC-1.9-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/m/MultiQC/MultiQC-1.9-foss-2020a-Python-3.8.2.eb
@@ -32,8 +32,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('simplejson', '3.17.0', {
         'checksums': ['2b4b2b738b3b99819a17feaf118265d0753d5536049ea570b3c43b51c4701e81'],

--- a/easybuild/easyconfigs/m/MultiQC/MultiQC-1.9-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/m/MultiQC/MultiQC-1.9-intel-2020a-Python-3.8.2.eb
@@ -32,8 +32,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('simplejson', '3.17.0', {
         'checksums': ['2b4b2b738b3b99819a17feaf118265d0753d5536049ea570b3c43b51c4701e81'],

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.5-foss-2020a-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.5-foss-2020a-Python-2.7.18.eb
@@ -26,8 +26,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('Cycler', '0.10.0', {
         'modulename': 'cycler',

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.5-intel-2020a-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.5-intel-2020a-Python-2.7.18.eb
@@ -26,8 +26,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('Cycler', '0.10.0', {
         'modulename': 'cycler',

--- a/easybuild/easyconfigs/n/NLTK/NLTK-3.5-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/NLTK/NLTK-3.5-foss-2020a-Python-3.8.2.eb
@@ -18,8 +18,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_LOWER_SOURCE]}
-
 exts_list = [
     ('regex', '2020.7.14', {
         'checksums': ['3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb'],

--- a/easybuild/easyconfigs/n/NLTK/NLTK-3.5-fosscuda-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/NLTK/NLTK-3.5-fosscuda-2020a-Python-3.8.2.eb
@@ -18,8 +18,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_LOWER_SOURCE]}
-
 exts_list = [
     ('regex', '2020.7.14', {
         'checksums': ['3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb'],

--- a/easybuild/easyconfigs/n/NanopolishComp/NanopolishComp-0.6.11-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/NanopolishComp/NanopolishComp-0.6.11-foss-2020a-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = "NanopolishComp is a Python3 package for downstream analyses of Na
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['753eed9ed93d12b15b693c43382c73379064d86eeef651611fa27abe7f8a44b3']
 

--- a/easybuild/easyconfigs/n/NiBabel/NiBabel-3.2.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/NiBabel/NiBabel-3.2.0-foss-2020a-Python-3.8.2.eb
@@ -21,8 +21,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('bz2file', '0.98', {
         'checksums': ['64c1f811e31556ba9931953c8ec7b397488726c63e09a4c67004f43bdd28da88'],

--- a/easybuild/easyconfigs/n/Nilearn/Nilearn-0.7.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/Nilearn/Nilearn-0.7.0-foss-2020a-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = """Nilearn is a Python module for fast and easy statistical learni
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['e7c9df82a31319366f02919794e0ec4eacbae1fb24c41c826070c2a3acf117e6']
 

--- a/easybuild/easyconfigs/n/nanocompore/nanocompore-1.0.0rc3-2-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/nanocompore/nanocompore-1.0.0rc3-2-intel-2020a-Python-3.8.2.eb
@@ -24,8 +24,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 # poetry has unnecessarily restrictive dependencies
 local_nanocompore_preinstallopts = """sed -i'' 's/\^/>=/g' pyproject.toml && """
 local_nanocompore_preinstallopts += """sed -i'' 's/~/>=/g' pyproject.toml && """

--- a/easybuild/easyconfigs/n/neptune-client/neptune-client-0.4.129-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/neptune-client/neptune-client-0.4.129-foss-2020a-Python-3.8.2.eb
@@ -21,8 +21,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('jsonref', '0.2', {
         'checksums': ['f3c45b121cf6257eafabdc3a8008763aed1cd7da06dbabc59a9e4d2a5e4e6697'],

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.5.3-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.5.3-foss-2020a-Python-3.8.2.eb
@@ -22,8 +22,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('cftime', '1.2.0', {
         'checksums': ['ff0a175edda260357ff7d24a32bbe0a8c72eafd5f6a404ce487127f9d01836db'],

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.5.3-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.5.3-foss-2020a-Python-3.8.2.eb
@@ -10,8 +10,6 @@ description = """Python/numpy interface to netCDF."""
 toolchain = {'name': 'foss', 'version': '2020a'}
 toolchainopts = {'usempi': True}
 
-source_urls = ['https://github.com/Unidata/netcdf4-python/archive/']
-
 dependencies = [
     ('Python', '3.8.2'),
     ('SciPy-bundle', '2020.03', versionsuffix),  # for numpy

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.5.3-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.5.3-intel-2020a-Python-3.8.2.eb
@@ -22,8 +22,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('cftime', '1.2.0', {
         'checksums': ['ff0a175edda260357ff7d24a32bbe0a8c72eafd5f6a404ce487127f9d01836db'],

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.5.3-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.5.3-intel-2020a-Python-3.8.2.eb
@@ -10,8 +10,6 @@ description = """Python/numpy interface to netCDF."""
 toolchain = {'name': 'intel', 'version': '2020a'}
 toolchainopts = {'usempi': True}
 
-source_urls = ['https://github.com/Unidata/netcdf4-python/archive/']
-
 dependencies = [
     ('Python', '3.8.2'),
     ('SciPy-bundle', '2020.03', versionsuffix),  # for numpy

--- a/easybuild/easyconfigs/n/networkx/networkx-2.4-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/networkx/networkx-2.4-foss-2020a-Python-3.8.2.eb
@@ -10,7 +10,6 @@ and study of the structure, dynamics, and functions of complex networks."""
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['f8f4ff0b6f96e4f9b16af6b84622597b5334bf9cae8cf9b2e42e7985d5c95c64']
 

--- a/easybuild/easyconfigs/n/networkx/networkx-2.4-fosscuda-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/networkx/networkx-2.4-fosscuda-2020a-Python-3.8.2.eb
@@ -10,7 +10,6 @@ and study of the structure, dynamics, and functions of complex networks."""
 
 toolchain = {'name': 'fosscuda', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['f8f4ff0b6f96e4f9b16af6b84622597b5334bf9cae8cf9b2e42e7985d5c95c64']
 

--- a/easybuild/easyconfigs/n/networkx/networkx-2.4-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/networkx/networkx-2.4-intel-2020a-Python-3.8.2.eb
@@ -10,7 +10,6 @@ and study of the structure, dynamics, and functions of complex networks."""
 
 toolchain = {'name': 'intel', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['f8f4ff0b6f96e4f9b16af6b84622597b5334bf9cae8cf9b2e42e7985d5c95c64']
 

--- a/easybuild/easyconfigs/n/nglview/nglview-2.7.7-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/nglview/nglview-2.7.7-intel-2020a-Python-3.8.2.eb
@@ -17,8 +17,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('widgetsnbextension', '3.5.1', {
         'checksums': ['079f87d87270bce047512400efd70238820751a11d2d8cb137a5a5bdbaf255c7'],

--- a/easybuild/easyconfigs/n/numba/numba-0.50.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.50.0-foss-2020a-Python-3.8.2.eb
@@ -23,8 +23,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('llvmlite', '0.33.0', {
         'patches': ['llvmlite-0.31.0_fix-ffi-Makefile.patch'],

--- a/easybuild/easyconfigs/n/numba/numba-0.50.0-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.50.0-intel-2020a-Python-3.8.2.eb
@@ -26,8 +26,6 @@ check_ldshared = True
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('llvmlite', '0.33.0', {
         'patches': ['llvmlite-0.31.0_fix-ffi-Makefile.patch'],

--- a/easybuild/easyconfigs/n/numba/numba-0.52.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.52.0-foss-2020a-Python-3.8.2.eb
@@ -23,8 +23,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('llvmlite', '0.35.0', {
         'patches': ['llvmlite-0.31.0_fix-ffi-Makefile.patch'],

--- a/easybuild/easyconfigs/o/Open-Data-Cube-Core/Open-Data-Cube-Core-1.8.3-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/o/Open-Data-Cube-Core/Open-Data-Cube-Core-1.8.3-foss-2020a-Python-3.8.2.eb
@@ -25,8 +25,6 @@ dependencies = [
     ('xarray', '0.16.1', versionsuffix),
 ]
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('cachetools', '4.1.1', {
         'checksums': ['bbaa39c3dede00175df2dc2b03d0cf18dd2d32a7de7beb68072d13043c9edb20'],

--- a/easybuild/easyconfigs/o/OpenForceField/OpenForceField-0.7.0-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/o/OpenForceField/OpenForceField-0.7.0-intel-2020a-Python-3.8.2.eb
@@ -26,8 +26,6 @@ dependencies = [
 ]
 
 use_pip = True
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('bson', '0.5.10', {
         'checksums': ['d6511b2ab051139a9123c184de1a04227262173ad593429d21e443d6462d6590'],

--- a/easybuild/easyconfigs/o/OpenForceField/OpenForceField-0.7.0-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/o/OpenForceField/OpenForceField-0.7.0-intel-2020a-Python-3.8.2.eb
@@ -40,7 +40,8 @@ exts_list = [
     (name, version, {
         'source_tmpl': '%(version)s.tar.gz',
         'source_urls': ['https://github.com/openforcefield/openforcefield/archive/'],
-        'checksums': ['a87642d1e4dd2192602a2b4fccb6c7764cb43df51a4fd845c2c3cd2a3220389d'],
+        'checksums': [('a87642d1e4dd2192602a2b4fccb6c7764cb43df51a4fd845c2c3cd2a3220389d',
+                       'c66d9cdf80fb2049ec7dc94394d515f87ca93963ad6db4e5e47a2515ef4d6928')],
     }),
 ]
 

--- a/easybuild/easyconfigs/o/OpenMMTools/OpenMMTools-0.20.0-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/o/OpenMMTools/OpenMMTools-0.20.0-intel-2020a-Python-3.8.2.eb
@@ -26,8 +26,6 @@ dependencies = [
 ]
 
 use_pip = True
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('ipython_genutils', '0.2.0', {
         'checksums': ['eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8'],

--- a/easybuild/easyconfigs/p/PIPITS/PIPITS-2.7-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/PIPITS/PIPITS-2.7-foss-2020a-Python-3.8.2.eb
@@ -24,8 +24,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('biom-format', '2.1.8-1', {
         'modulename': 'biom',

--- a/easybuild/easyconfigs/p/ParmEd/ParmEd-3.2.0-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/ParmEd/ParmEd-3.2.0-intel-2020a-Python-3.8.2.eb
@@ -10,7 +10,6 @@ description = """ParmEd is a general tool for aiding in investigations of biomol
 
 toolchain = {'name': 'intel', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['0c178994af736b16df3c8eaa9c54a0ac98425129c8f0228563acc094e7c6f40f']
 

--- a/easybuild/easyconfigs/p/PyGEOS/PyGEOS-0.8-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/PyGEOS/PyGEOS-0.8-foss-2020a-Python-3.8.2.eb
@@ -12,7 +12,6 @@ description = """PyGEOS is a C/Python library with vectorized geometry functions
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['45b7e1aaa5fc9ff53565ef089fb75c53c419ace8cee18385ec1d7c1515c17cbc']
 

--- a/easybuild/easyconfigs/p/pandas/pandas-1.1.2-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/pandas/pandas-1.1.2-foss-2020a-Python-3.8.2.eb
@@ -10,7 +10,6 @@ description = """pandas is an open source, BSD-licensed library providing high-p
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['b64ffd87a2cfd31b40acd4b92cb72ea9a52a48165aec4c140e78fd69c45d1444']
 

--- a/easybuild/easyconfigs/p/phonemizer/phonemizer-2.2.1-gompi-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/phonemizer/phonemizer-2.2.1-gompi-2020a-Python-3.8.2.eb
@@ -22,8 +22,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('regex', '2020.7.14', {
         'checksums': ['3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb'],

--- a/easybuild/easyconfigs/p/phonopy/phonopy-2.7.1-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/phonopy/phonopy-2.7.1-intel-2020a-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = """Phonopy is an open source package of phonon calculations based 
 
 toolchain = {'name': 'intel', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['482c6ff29c058d091ac885e561e28ba3e516ea9e91c44a951cad11f3ae19856c']
 

--- a/easybuild/easyconfigs/p/plantcv/plantcv-3.8.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/plantcv/plantcv-3.8.0-foss-2020a-Python-3.8.2.eb
@@ -26,8 +26,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('palettable', '3.3.0', {
         'checksums': ['72feca71cf7d79830cd6d9181b02edf227b867d503bec953cf9fa91bf44896bd'],

--- a/easybuild/easyconfigs/p/py-aiger-bdd/py-aiger-bdd-3.0.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/py-aiger-bdd/py-aiger-bdd-3.0.0-foss-2020a-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = "Aiger to BDD bridge."
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['f91ac998ce1d2e352f522ff69937ee55ed69a20d649dcc8abcfd7cd63c955844']
 

--- a/easybuild/easyconfigs/p/pySCENIC/pySCENIC-0.10.3-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/pySCENIC/pySCENIC-0.10.3-foss-2020a-Python-3.8.2.eb
@@ -26,8 +26,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('cytoolz', '0.10.1', {
         'checksums': ['82f5bba81d73a5a6b06f2a3553ff9003d865952fcb32e1df192378dd944d8a5c'],

--- a/easybuild/easyconfigs/p/pySCENIC/pySCENIC-0.10.3-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/pySCENIC/pySCENIC-0.10.3-intel-2020a-Python-3.8.2.eb
@@ -26,8 +26,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('cytoolz', '0.10.1', {
         'checksums': ['82f5bba81d73a5a6b06f2a3553ff9003d865952fcb32e1df192378dd944d8a5c'],

--- a/easybuild/easyconfigs/p/pycocotools/pycocotools-2.0.2-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/pycocotools/pycocotools-2.0.2-foss-2020a-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = "Official APIs for the MS-COCO dataset"
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['24717a12799b4471c2e54aa210d642e6cd4028826a1d49fcc2b0e3497e041f1a']
 

--- a/easybuild/easyconfigs/p/pycocotools/pycocotools-2.0.2-fosscuda-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/pycocotools/pycocotools-2.0.2-fosscuda-2020a-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = "Official APIs for the MS-COCO dataset"
 
 toolchain = {'name': 'fosscuda', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['24717a12799b4471c2e54aa210d642e6cd4028826a1d49fcc2b0e3497e041f1a']
 

--- a/easybuild/easyconfigs/p/pylift/pylift-0.1.5-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/pylift/pylift-0.1.5-foss-2020a-Python-3.8.2.eb
@@ -10,7 +10,6 @@ description = """ pylift is an uplift library that provides, primarily:
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['bf855996abfd65125cde40b378393766c379694a4b814cdecb1cadd743392730']
 

--- a/easybuild/easyconfigs/p/pyobjcryst/pyobjcryst-2.1.0.post2-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/pyobjcryst/pyobjcryst-2.1.0.post2-intel-2020a-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = "Python bindings to ObjCryst++, the Object-Oriented Crystallograph
 
 toolchain = {'name': 'intel', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['2ee797cf4d0ba90a7d144110b0f3295ee7fa73462c648297100bfd5eb467bb6d']
 

--- a/easybuild/easyconfigs/p/python-igraph/python-igraph-0.8.0-foss-2020a.eb
+++ b/easybuild/easyconfigs/p/python-igraph/python-igraph-0.8.0-foss-2020a.eb
@@ -23,7 +23,6 @@ dependencies = [
 use_pip = False
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
 exts_list = [
     ('texttable', '1.6.3', {
         'checksums': ['ce0faf21aa77d806bbff22b107cc22cce68dc9438f97a2df32c93e9afa4ce436'],

--- a/easybuild/easyconfigs/q/qcat/qcat-1.1.0-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/q/qcat/qcat-1.1.0-intel-2020a-Python-3.8.2.eb
@@ -12,7 +12,6 @@ description = "qcat is a Python command-line tool for demultiplexing Oxford Nano
 
 toolchain = {'name': 'intel', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['56f225321a48eef43e2b83a33cbbb47bf1b1edcd569f3db4d088a1bc0199e20a']
 

--- a/easybuild/easyconfigs/r/rasterio/rasterio-1.1.7-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/r/rasterio/rasterio-1.1.7-foss-2020a-Python-3.8.2.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('affine', '2.3.0', {
         'checksums': ['2e045def1aa29e613c42e801a7e10e0b9bacfed1a7c6af0cadf8843530a15102'],

--- a/easybuild/easyconfigs/r/rasterstats/rasterstats-0.15.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/r/rasterstats/rasterstats-0.15.0-foss-2020a-Python-3.8.2.eb
@@ -19,8 +19,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('affine', '2.3.0', {
         'checksums': ['2e045def1aa29e613c42e801a7e10e0b9bacfed1a7c6af0cadf8843530a15102'],

--- a/easybuild/easyconfigs/r/rioxarray/rioxarray-0.1.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/r/rioxarray/rioxarray-0.1.1-foss-2020a-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = "geospatial xarray extension powered by rasterio"
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['635bf755beaae9414f5a19cc6dd5bde7a04dfbf38b7a02d152754653f79e4330']
 

--- a/easybuild/easyconfigs/s/SICER2/SICER2-1.0.3-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/SICER2/SICER2-1.0.3-foss-2020a-Python-3.8.2.eb
@@ -16,7 +16,6 @@ dependencies = [
     ('BEDTools', '2.29.2'),
 ]
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['003e0f46fb45717fa6b1c94b2c21416161f5b3a4896fbb335cf2024daf2560dd']
 

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.03-foss-2020a-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.03-foss-2020a-Python-2.7.18.eb
@@ -16,8 +16,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 # order is important!
 exts_list = [
     ('numpy', '1.16.6', {

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.03-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.03-foss-2020a-Python-3.8.2.eb
@@ -17,8 +17,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 # order is important!
 exts_list = [
     ('numpy', '1.18.3', {

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.03-fosscuda-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.03-fosscuda-2020a-Python-3.8.2.eb
@@ -17,8 +17,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 # order is important!
 exts_list = [
     ('numpy', '1.18.3', {

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.03-intel-2020a-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.03-intel-2020a-Python-2.7.18.eb
@@ -16,8 +16,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 # order is important!
 exts_list = [
     ('numpy', '1.16.6', {

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.03-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.03-intel-2020a-Python-3.8.2.eb
@@ -17,8 +17,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 # order is important!
 exts_list = [
     ('numpy', '1.18.3', {

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.03-intelcuda-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.03-intelcuda-2020a-Python-3.8.2.eb
@@ -17,8 +17,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 # order is important!
 exts_list = [
     ('numpy', '1.18.3', {

--- a/easybuild/easyconfigs/s/Seaborn/Seaborn-0.10.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/Seaborn/Seaborn-0.10.1-foss-2020a-Python-3.8.2.eb
@@ -14,7 +14,6 @@ description = """ Seaborn is a Python visualization library based on matplotlib.
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['2d1a0c9d6bd1bc3cadb0364b8f06540f51322a670cf8438d0fde1c1c7317adc0']
 

--- a/easybuild/easyconfigs/s/Seaborn/Seaborn-0.10.1-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/Seaborn/Seaborn-0.10.1-intel-2020a-Python-3.8.2.eb
@@ -14,7 +14,6 @@ description = """ Seaborn is a Python visualization library based on matplotlib.
 
 toolchain = {'name': 'intel', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['2d1a0c9d6bd1bc3cadb0364b8f06540f51322a670cf8438d0fde1c1c7317adc0']
 

--- a/easybuild/easyconfigs/s/SimPEG/SimPEG-0.14.1-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/SimPEG/SimPEG-0.14.1-intel-2020a-Python-3.8.2.eb
@@ -22,8 +22,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('pyMKL', '0.0.3', {
         'modulename': '%(name)s',

--- a/easybuild/easyconfigs/s/Spyder/Spyder-4.1.5-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/Spyder/Spyder-4.1.5-foss-2020a-Python-3.8.2.eb
@@ -31,7 +31,6 @@ local_spyder_preinstallopts = (
     """sed -i "s/'pyqtwebengine.*,//g" setup.py && """
 )
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
 exts_list = [
     ('astroid', '2.4.2', {
         'checksums': ['2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703'],

--- a/easybuild/easyconfigs/s/scikit-allel/scikit-allel-1.2.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/scikit-allel/scikit-allel-1.2.1-foss-2020a-Python-3.8.2.eb
@@ -23,8 +23,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('pytoml', '0.1.21', {
         'checksums': ['8eecf7c8d0adcff3b375b09fe403407aa9b645c499e5ab8cac670ac4a35f61e7'],

--- a/easybuild/easyconfigs/s/scikit-bio/scikit-bio-0.5.6-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/scikit-bio/scikit-bio-0.5.6-foss-2020a-Python-3.8.2.eb
@@ -20,8 +20,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('msgpack', '1.0.0', {
         'checksums': ['9534d5cc480d4aff720233411a1f765be90885750b07df772380b34c10ecb5c0'],

--- a/easybuild/easyconfigs/s/scikit-build/scikit-build-0.10.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/scikit-build/scikit-build-0.10.0-foss-2020a-Python-3.8.2.eb
@@ -10,7 +10,6 @@ for CPython C/C++/Fortran/Cython extensions."""
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['7342017cc82dd6178e3b19377389b8a8d1f8b429d9cdb315cfb1094e34a0f526']
 

--- a/easybuild/easyconfigs/s/scikit-build/scikit-build-0.10.0-fosscuda-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/scikit-build/scikit-build-0.10.0-fosscuda-2020a-Python-3.8.2.eb
@@ -10,7 +10,6 @@ for CPython C/C++/Fortran/Cython extensions."""
 
 toolchain = {'name': 'fosscuda', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['7342017cc82dd6178e3b19377389b8a8d1f8b429d9cdb315cfb1094e34a0f526']
 

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.17.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.17.1-foss-2020a-Python-3.8.2.eb
@@ -19,8 +19,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('networkx', '2.4', {
         'checksums': ['f8f4ff0b6f96e4f9b16af6b84622597b5334bf9cae8cf9b2e42e7985d5c95c64'],

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.1-foss-2020a-Python-3.8.2.eb
@@ -19,8 +19,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('pytoml', '0.1.21', {
         'checksums': ['8eecf7c8d0adcff3b375b09fe403407aa9b645c499e5ab8cac670ac4a35f61e7'],

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.1-fosscuda-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.1-fosscuda-2020a-Python-3.8.2.eb
@@ -19,8 +19,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('pytoml', '0.1.21', {
         'checksums': ['8eecf7c8d0adcff3b375b09fe403407aa9b645c499e5ab8cac670ac4a35f61e7'],

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.1-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.1-intel-2020a-Python-3.8.2.eb
@@ -19,8 +19,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('pytoml', '0.1.21', {
         'checksums': ['8eecf7c8d0adcff3b375b09fe403407aa9b645c499e5ab8cac670ac4a35f61e7'],

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.1-intelcuda-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.23.1-intelcuda-2020a-Python-3.8.2.eb
@@ -19,8 +19,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('pytoml', '0.1.21', {
         'checksums': ['8eecf7c8d0adcff3b375b09fe403407aa9b645c499e5ab8cac670ac4a35f61e7'],

--- a/easybuild/easyconfigs/s/scikit-optimize/scikit-optimize-0.8.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/scikit-optimize/scikit-optimize-0.8.1-foss-2020a-Python-3.8.2.eb
@@ -10,7 +10,6 @@ description = """Scikit-Optimize, or skopt, is a simple and efficient library to
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['ed5c47818959c91490120b89240527cf5ef36dc3e350dc79e5dbc22edc4ee186']
 

--- a/easybuild/easyconfigs/s/snakemake/snakemake-5.26.1-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/snakemake/snakemake-5.26.1-intel-2020a-Python-3.8.2.eb
@@ -16,8 +16,6 @@ dependencies = [
     ('GitPython', '3.1.9', versionsuffix),
 ]
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 use_pip = True
 sanity_pip_check = True
 

--- a/easybuild/easyconfigs/s/statsmodels/statsmodels-0.11.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/statsmodels/statsmodels-0.11.1-foss-2020a-Python-3.8.2.eb
@@ -18,8 +18,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('patsy', '0.5.1', {
         'checksums': ['f115cec4201e1465cd58b9866b0b0e7b941caafec129869057405bfe5b5e3991'],

--- a/easybuild/easyconfigs/s/statsmodels/statsmodels-0.11.1-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/statsmodels/statsmodels-0.11.1-intel-2020a-Python-3.8.2.eb
@@ -18,8 +18,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('patsy', '0.5.1', {
         'checksums': ['f115cec4201e1465cd58b9866b0b0e7b941caafec129869057405bfe5b5e3991'],

--- a/easybuild/easyconfigs/s/sympy/sympy-1.6.2-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/sympy/sympy-1.6.2-foss-2020a-Python-3.8.2.eb
@@ -12,7 +12,6 @@ description = """SymPy is a Python library for symbolic mathematics. It aims to
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 patches = ['%(name)s-%(version)s_allpython.patch']
 checksums = [

--- a/easybuild/easyconfigs/t/TEtranscripts/TEtranscripts-2.2.0-foss-2020a.eb
+++ b/easybuild/easyconfigs/t/TEtranscripts/TEtranscripts-2.2.0-foss-2020a.eb
@@ -21,7 +21,6 @@ use_pip = True
 
 exts_list = [
     ('argparse', '1.4.0', {
-        'source_urls': [PYPI_SOURCE],
         'checksums': ['62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4'],
     }),
     (name, version, {

--- a/easybuild/easyconfigs/t/Teneto/Teneto-0.5.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/t/Teneto/Teneto-0.5.1-foss-2020a-Python-3.8.2.eb
@@ -23,8 +23,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('templateflow', '0.7.1', {
         'patches': ['templateflow-0.7.1_fix_egg_version.patch'],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.3.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.3.1-foss-2020a-Python-3.8.2.eb
@@ -41,7 +41,6 @@ dependencies = [
 ]
 
 exts_default_options = {
-    'source_urls': [PYPI_SOURCE],
     'sanity_pip_check': True,
 }
 use_pip = True

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.3.1-fosscuda-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.3.1-fosscuda-2020a-Python-3.8.2.eb
@@ -43,7 +43,6 @@ dependencies = [
 ]
 
 exts_default_options = {
-    'source_urls': [PYPI_SOURCE],
     'sanity_pip_check': True,
 }
 use_pip = True

--- a/easybuild/easyconfigs/t/Theano/Theano-1.0.4-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/t/Theano/Theano-1.0.4-foss-2020a-Python-3.8.2.eb
@@ -10,7 +10,6 @@ and evaluate mathematical expressions involving multi-dimensional arrays efficie
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['35c9bbef56b61ffa299265a42a4e8f8cb5a07b2997dabaef0f8830b397086913']
 

--- a/easybuild/easyconfigs/t/Transformers/Transformers-4.2.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/t/Transformers/Transformers-4.2.1-foss-2020a-Python-3.8.2.eb
@@ -18,8 +18,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('regex', '2020.4.4', {
         'checksums': ['295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142'],

--- a/easybuild/easyconfigs/t/tqdm/tqdm-4.51.0-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/t/tqdm/tqdm-4.51.0-intel-2020a-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = """Instantly make your loops show a smart progress meter."""
 
 toolchain = {'name': 'intel', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['ef54779f1c09f346b2b5a8e5c61f96fbcb639929e640e59f8cf810794f406432']
 

--- a/easybuild/easyconfigs/v/velocyto/velocyto-0.17.17-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/v/velocyto/velocyto-0.17.17-intel-2020a-Python-3.8.2.eb
@@ -22,8 +22,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('numpy_groupies', '0.9.13', {
         'checksums': ['7b17b291322353f07c51598512d077e3731da0a048cfa8f738f3460d1ef0658d'],

--- a/easybuild/easyconfigs/x/XGBoost/XGBoost-1.2.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/x/XGBoost/XGBoost-1.2.0-foss-2020a-Python-3.8.2.eb
@@ -10,7 +10,6 @@ description = """XGBoost is an optimized distributed gradient boosting library d
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['e5f4abcd5df6767293f31b7c58d67ea38b2689641a95b2cd8ca8935295097a36']
 

--- a/easybuild/easyconfigs/x/xarray/xarray-0.16.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/x/xarray/xarray-0.16.1-foss-2020a-Python-3.8.2.eb
@@ -11,7 +11,6 @@ description = """xarray (formerly xray) is an open source project and Python pac
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['5e1af056ff834bf62ca57da917159328fab21b1f8c25284f92083016bb2d92a5']
 

--- a/easybuild/easyconfigs/x/xarray/xarray-0.16.1-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/x/xarray/xarray-0.16.1-intel-2020a-Python-3.8.2.eb
@@ -11,7 +11,6 @@ description = """xarray (formerly xray) is an open source project and Python pac
 
 toolchain = {'name': 'intel', 'version': '2020a'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['5e1af056ff834bf62ca57da917159328fab21b1f8c25284f92083016bb2d92a5']
 

--- a/easybuild/easyconfigs/y/YANK/YANK-0.25.2-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/y/YANK/YANK-0.25.2-intel-2020a-Python-3.8.2.eb
@@ -29,8 +29,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('docopt', '0.6.2', {
         'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],

--- a/easybuild/easyconfigs/z/zarr/zarr-2.4.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/z/zarr/zarr-2.4.0-foss-2020a-Python-3.8.2.eb
@@ -17,8 +17,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('asciitree', '0.3.3', {
         'checksums': ['4aa4b9b649f85e3fcb343363d97564aa1fb62e249677f2e18a96765145cc0f6e'],


### PR DESCRIPTION
This is no longer required as it became the default with easybuilders/easybuild-easyblocks#2364

Tests should (and mine were) be done with e.g. `eb --from-pr 12452 --rebuild --fetch --force-download --sourcepath=/dev/shm/sources --upload-test-report` to only test the download and of course with latest develop easyblocks