### PR TITLE
remove PYPI_SOURCE source URL from easyconfigs using GCC(core) 9.3.0 or 10.2.0 as toolchain

### DIFF
--- a/easybuild/easyconfigs/a/archspec/archspec-0.1.0-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/a/archspec/archspec-0.1.0-GCCcore-9.3.0-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = "A library for detecting, labeling, and reasoning about microarchi
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = ['archspec-%(version)s-py2.py3-none-any.whl']
 checksums = ['12f2029f63ffbc560e43f7d1f366a45ff46c7bd0751653227f8015f83f121119']
 

--- a/easybuild/easyconfigs/a/awscli/awscli-1.18.89-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/a/awscli/awscli-1.18.89-GCCcore-9.3.0-Python-3.8.2.eb
@@ -20,8 +20,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('colorama', '0.4.3', {
         'checksums': ['e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1'],

--- a/easybuild/easyconfigs/a/awscli/awscli-2.0.55-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/a/awscli/awscli-2.0.55-GCCcore-9.3.0-Python-3.8.2.eb
@@ -20,8 +20,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('jmespath', '0.10.0', {
         'checksums': ['b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9'],

--- a/easybuild/easyconfigs/b/BeautifulSoup/BeautifulSoup-4.9.1-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/b/BeautifulSoup/BeautifulSoup-4.9.1-GCCcore-9.3.0-Python-3.8.2.eb
@@ -20,8 +20,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('soupsieve', '2.0.1', {
         'checksums': ['a59dc181727e95d25f781f0eb4fd1825ff45590ec8ff49eadfd7f1a537cc0232'],

--- a/easybuild/easyconfigs/c/cdsapi/cdsapi-0.3.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/cdsapi/cdsapi-0.3.0-GCCcore-9.3.0.eb
@@ -8,7 +8,6 @@ description = "Climate Data Store API"
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['1f89293459d9b6560426261d8e9fd1e32d8dcaf6f47342b174835bafc0dd06a1']
 

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-2.10-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-2.10-GCCcore-9.3.0-Python-3.8.2.eb
@@ -26,8 +26,6 @@ dependencies = [('Python', '3.8.2')]
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('xopen', '0.8.4', {
         'checksums': ['dcd8f5ef5da5564f514a990573a48a0c347ee1fdbb9b6374d31592819868f7ba'],

--- a/easybuild/easyconfigs/d/DFA/DFA-0.3.4-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/d/DFA/DFA-0.3.4-GCCcore-9.3.0-Python-3.8.2.eb
@@ -23,7 +23,6 @@ use_pip = True
 sanity_pip_check = True
 
 exts_default_options = {
-    'source_urls': [PYPI_SOURCE],
     'sources': [SOURCELOWER_TAR_GZ],
 }
 

--- a/easybuild/easyconfigs/d/DendroPy/DendroPy-4.4.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/d/DendroPy/DendroPy-4.4.0-GCCcore-9.3.0.eb
@@ -19,7 +19,6 @@ reading, writing, simulation, processing and manipulation of phylogenetic trees
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['f0a0e2ce78b3ed213d6c1791332d57778b7f63d602430c1548a5d822acf2799c']
 

--- a/easybuild/easyconfigs/d/DendroPy/DendroPy-4.5.2-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/d/DendroPy/DendroPy-4.5.2-GCCcore-10.2.0.eb
@@ -19,7 +19,6 @@ reading, writing, simulation, processing and manipulation of phylogenetic trees
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['3e5d2522170058ebc8d1ee63a7f2d25b915e34957dc02693ebfdc15f347a0101']
 

--- a/easybuild/easyconfigs/d/dm-tree/dm-tree-0.1.5-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/d/dm-tree/dm-tree-0.1.5-GCCcore-10.2.0.eb
@@ -10,7 +10,6 @@ allows to apply a function to each "leaf" preserving the overall structure."""
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['a951d2239111dfcc468071bc8ff792c7b1e3192cab5a3c94d33a8b2bda3127fa']
 

--- a/easybuild/easyconfigs/e/edlib/edlib-1.3.8.post1-GCC-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/e/edlib/edlib-1.3.8.post1-GCC-9.3.0-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = "Lightweight, super fast library for sequence alignment using edit
 
 toolchain = {'name': 'GCC', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['81bc688e8fc69d657a6b5067e104a0924b0217b7ab54547155278935d09346e0']
 

--- a/easybuild/easyconfigs/f/Flask/Flask-1.1.2-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/f/Flask/Flask-1.1.2-GCCcore-10.2.0.eb
@@ -21,8 +21,6 @@ builddependencies = [('binutils', '2.35')]
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_LOWER_SOURCE]}
-
 exts_list = [
     ('itsdangerous', '1.1.0', {
         'checksums': ['321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19'],

--- a/easybuild/easyconfigs/f/Flask/Flask-1.1.2-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/f/Flask/Flask-1.1.2-GCCcore-9.3.0-Python-3.8.2.eb
@@ -22,8 +22,6 @@ builddependencies = [('binutils', '2.34')]
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_LOWER_SOURCE]}
-
 exts_list = [
     ('itsdangerous', '1.1.0', {
         'checksums': ['321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19'],

--- a/easybuild/easyconfigs/g/GitPython/GitPython-3.1.9-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/g/GitPython/GitPython-3.1.9-GCCcore-9.3.0-Python-3.8.2.eb
@@ -19,8 +19,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('smmap', '3.0.4', {
         'checksums': ['9c98bbd1f9786d22f14b3d4126894d56befb835ec90cef151af566c7e19b5d24'],

--- a/easybuild/easyconfigs/g/gmpy2/gmpy2-2.1.0b5-GCC-10.2.0.eb
+++ b/easybuild/easyconfigs/g/gmpy2/gmpy2-2.1.0b5-GCC-10.2.0.eb
@@ -8,7 +8,6 @@ description = "GMP/MPIR, MPFR, and MPC interface to Python 2.6+ and 3.x"
 
 toolchain = {'name': 'GCC', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['8951bcfc61c0f40102b92a4777daf9eb85445b537c4d09086deb0e097190bef0']
 

--- a/easybuild/easyconfigs/g/gmpy2/gmpy2-2.1.0b5-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/g/gmpy2/gmpy2-2.1.0b5-GCC-9.3.0.eb
@@ -8,7 +8,6 @@ description = "GMP/MPIR, MPFR, and MPC interface to Python 2.6+ and 3.x"
 
 toolchain = {'name': 'GCC', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['8951bcfc61c0f40102b92a4777daf9eb85445b537c4d09086deb0e097190bef0']
 

--- a/easybuild/easyconfigs/h/hypothesis/hypothesis-5.41.2-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/h/hypothesis/hypothesis-5.41.2-GCCcore-10.2.0.eb
@@ -11,7 +11,6 @@ description = """Hypothesis is an advanced testing library for Python. It lets y
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['f8c281355aaba1da696e40f1488c2bb47c42660424f5750daea45a85e2d047b3']
 

--- a/easybuild/easyconfigs/h/hypothesis/hypothesis-5.41.5-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/h/hypothesis/hypothesis-5.41.5-GCCcore-10.2.0.eb
@@ -10,7 +10,6 @@ description = """Hypothesis is an advanced testing library for Python. It lets y
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['a74e127a865fde12b853cc00f5f52a3a1601d2a1c311b3ffc8de92a4c06778f7']
 

--- a/easybuild/easyconfigs/h/hypothesis/hypothesis-5.6.0-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/h/hypothesis/hypothesis-5.6.0-GCCcore-9.3.0-Python-3.8.2.eb
@@ -12,7 +12,6 @@ description = """Hypothesis is an advanced testing library for Python. It lets y
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['22fb60bd0c6eb7849121a7df263a91da23b4e8506d3ba9e92ac696d2720ac0f5']
 

--- a/easybuild/easyconfigs/i/IPython/IPython-7.18.1-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.18.1-GCCcore-10.2.0.eb
@@ -22,8 +22,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('ipython_genutils', '0.2.0', {
         'checksums': ['eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8'],

--- a/easybuild/easyconfigs/j/JupyterHub/JupyterHub-1.1.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/j/JupyterHub/JupyterHub-1.1.0-GCCcore-10.2.0.eb
@@ -24,8 +24,6 @@ osdependencies = [OS_PKG_OPENSSL_DEV]
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('certipy', '0.1.3', {
         'checksums': ['695704b7716b033375c9a1324d0d30f27110a28895c40151a90ec07ff1032859'],

--- a/easybuild/easyconfigs/j/JupyterLab/JupyterLab-2.2.8-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/j/JupyterLab/JupyterLab-2.2.8-GCCcore-10.2.0.eb
@@ -21,8 +21,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('json5', '0.9.5', {
         'checksums': ['703cfee540790576b56a92e1c6aaa6c4b0d98971dc358ead83812aa4d06bdb96'],

--- a/easybuild/easyconfigs/k/Kaleido/Kaleido-0.1.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/k/Kaleido/Kaleido-0.1.0-GCCcore-10.2.0.eb
@@ -8,7 +8,6 @@ description = "Fast static image export for web-based visualization libraries wi
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = ['kaleido-%(version)s-py2.py3-none-manylinux1_%(arch)s.whl']
 checksums = ['8d0403b1eb21080e09d6d728c1ea7170fd4763c415fe89dfea6edf35ec36f8e7']
 

--- a/easybuild/easyconfigs/l/lxml/lxml-4.6.2-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/l/lxml/lxml-4.6.2-GCCcore-10.2.0.eb
@@ -8,7 +8,6 @@ description = """The lxml XML toolkit is a Pythonic binding for the C libraries 
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['cd11c7e8d21af997ee8079037fff88f16fda188a9776eb4b81c7e4c9c0a7d7fc']
 

--- a/easybuild/easyconfigs/m/Mako/Mako-1.1.2-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/m/Mako/Mako-1.1.2-GCCcore-9.3.0.eb
@@ -8,7 +8,6 @@ description = """A super-fast templating language that borrows the best ideas fr
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['3139c5d64aa5d175dbafb95027057128b5fbd05a40c53999f3905ceb53366d9d']
 

--- a/easybuild/easyconfigs/m/Mako/Mako-1.1.3-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/m/Mako/Mako-1.1.3-GCCcore-10.2.0.eb
@@ -8,7 +8,6 @@ description = """A super-fast templating language that borrows the best ideas fr
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['8195c8c1400ceb53496064314c6736719c6f25e7479cd24c77be3d9361cddc27']
 

--- a/easybuild/easyconfigs/m/Meson/Meson-0.53.2-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/m/Meson/Meson-0.53.2-GCCcore-9.3.0-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = "Meson is a cross-platform build system designed to be both as fas
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['3e8f830f33184397c2eb0b651ec502adb63decb28978bdc84b3558d71284c21f']
 

--- a/easybuild/easyconfigs/m/Meson/Meson-0.55.1-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/m/Meson/Meson-0.55.1-GCCcore-9.3.0-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = "Meson is a cross-platform build system designed to be both as fas
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['3b5741f884e04928bdfa1947467ff06afa6c98e623c25cef75adf71ca39ce080']
 

--- a/easybuild/easyconfigs/m/Meson/Meson-0.55.3-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/m/Meson/Meson-0.55.3-GCCcore-10.2.0.eb
@@ -8,7 +8,6 @@ description = "Meson is a cross-platform build system designed to be both as fas
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['6bed2a25a128bbabe97cf40f63165ebe800e4fcb46db8ab7ef5c2b5789f092a5']
 

--- a/easybuild/easyconfigs/m/mpmath/mpmath-1.1.0-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/m/mpmath/mpmath-1.1.0-GCCcore-9.3.0-Python-3.8.2.eb
@@ -10,7 +10,7 @@ name = 'mpmath'
 version = '1.1.0'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'http://mpmath.org/'
+homepage = 'https://mpmath.org/'
 description = """mpmath can be used as an arbitrary-precision substitute for Python's float/complex
  types and math/cmath modules, but also does much more advanced mathematics. Almost any calculation
  can be performed just as well at 10-digit or 1000-digit precision, with either real or complex

--- a/easybuild/easyconfigs/m/mpmath/mpmath-1.1.0-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/m/mpmath/mpmath-1.1.0-GCCcore-9.3.0-Python-3.8.2.eb
@@ -19,7 +19,6 @@ description = """mpmath can be used as an arbitrary-precision substitute for Pyt
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['fc17abe05fbab3382b61a123c398508183406fa132e0223874578e20946499f6']
 

--- a/easybuild/easyconfigs/p/Pillow/Pillow-7.0.0-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/Pillow/Pillow-7.0.0-GCCcore-9.3.0-Python-3.8.2.eb
@@ -10,7 +10,6 @@ description = """Pillow is the 'friendly PIL fork' by Alex Clark and Contributor
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['4d9ed9a64095e031435af120d3c910148067087541131e82b3e8db302f4c8946']
 

--- a/easybuild/easyconfigs/p/Pillow/Pillow-8.0.1-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/p/Pillow/Pillow-8.0.1-GCCcore-10.2.0.eb
@@ -9,7 +9,6 @@ description = """Pillow is the 'friendly PIL fork' by Alex Clark and Contributor
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['11c5c6e9b02c9dac08af04f093eb5a2f84857df70a7d4a6a6ad461aca803fb9e']
 

--- a/easybuild/easyconfigs/p/PyCairo/PyCairo-1.18.2-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/p/PyCairo/PyCairo-1.18.2-GCCcore-9.3.0.eb
@@ -8,7 +8,6 @@ description = """Python bindings for the cairo library"""
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['dcb853fd020729516e8828ad364084e752327d4cff8505d20b13504b32b16531']
 

--- a/easybuild/easyconfigs/p/PyClone/PyClone-2020.9b2-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/p/PyClone/PyClone-2020.9b2-GCCcore-10.2.0.eb
@@ -22,7 +22,6 @@ dependencies = [
 ]
 
 exts_default_options = {
-    'source_urls': [PYPI_SOURCE],
     'use_pip': True
 }
 

--- a/easybuild/easyconfigs/p/PyOpenGL/PyOpenGL-3.1.5-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/p/PyOpenGL/PyOpenGL-3.1.5-GCCcore-10.2.0.eb
@@ -19,7 +19,6 @@ description = """PyOpenGL is the most common cross platform Python binding to Op
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['4107ba0d0390da5766a08c242cf0cf3404c377ed293c5f6d701e457c57ba3424']
 

--- a/easybuild/easyconfigs/p/PySAT/PySAT-0.1.6.dev11-GCC-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/PySAT/PySAT-0.1.6.dev11-GCC-9.3.0-Python-3.8.2.eb
@@ -21,11 +21,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {
-    'source_urls': [PYPI_SOURCE],
-    'sources': [SOURCE_TAR_GZ],
-}
-
 exts_list = [
     ('pypblib', '0.0.4', {
         'checksums': ['71dd930bf177ca38d6eeb473702d05df07e11f20382db0c766465297eaf49062'],

--- a/easybuild/easyconfigs/p/PyYAML/PyYAML-5.3-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/p/PyYAML/PyYAML-5.3-GCCcore-9.3.0.eb
@@ -8,7 +8,6 @@ description = """PyYAML is a YAML parser and emitter for the Python programming 
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['e9f45bd5b92c7974e59bcd2dcc8631a6b6cc380a904725fce7bc08872e691615']
 

--- a/easybuild/easyconfigs/p/PyYAML/PyYAML-5.3.1-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/p/PyYAML/PyYAML-5.3.1-GCCcore-10.2.0.eb
@@ -8,7 +8,6 @@ description = """PyYAML is a YAML parser and emitter for the Python programming 
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d']
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.18-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.18-GCCcore-10.2.0.eb
@@ -31,6 +31,7 @@ osdependencies = [OS_PKG_OPENSSL_DEV]
 exts_default_options = {
     'download_dep_fail': True,
     'sanity_pip_check': True,
+    'source_urls': [PYPI_SOURCE],
     'use_pip': True,
 }
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.18-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.18-GCCcore-10.2.0.eb
@@ -31,7 +31,6 @@ osdependencies = [OS_PKG_OPENSSL_DEV]
 exts_default_options = {
     'download_dep_fail': True,
     'sanity_pip_check': True,
-    'source_urls': [PYPI_SOURCE],
     'use_pip': True,
 }
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.18-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.18-GCCcore-9.3.0.eb
@@ -31,6 +31,7 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 exts_default_options = {
     'download_dep_fail': True,
     'sanity_pip_check': True,
+    'source_urls': [PYPI_SOURCE],
     'use_pip': True,
 }
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.18-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.18-GCCcore-9.3.0.eb
@@ -31,7 +31,6 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 exts_default_options = {
     'download_dep_fail': True,
     'sanity_pip_check': True,
-    'source_urls': [PYPI_SOURCE],
     'use_pip': True,
 }
 

--- a/easybuild/easyconfigs/p/Python/Python-3.8.2-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.8.2-GCCcore-9.3.0.eb
@@ -42,6 +42,7 @@ installopts = " && ln -s %(installdir)s/bin/pip3 %(installdir)s/bin/pip"
 exts_default_options = {
     'download_dep_fail': True,
     'sanity_pip_check': True,
+    'source_urls': [PYPI_SOURCE],
     'use_pip': True,
 }
 

--- a/easybuild/easyconfigs/p/Python/Python-3.8.2-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.8.2-GCCcore-9.3.0.eb
@@ -42,7 +42,6 @@ installopts = " && ln -s %(installdir)s/bin/pip3 %(installdir)s/bin/pip"
 exts_default_options = {
     'download_dep_fail': True,
     'sanity_pip_check': True,
-    'source_urls': [PYPI_SOURCE],
     'use_pip': True,
 }
 

--- a/easybuild/easyconfigs/p/Python/Python-3.8.6-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.8.6-GCCcore-10.2.0.eb
@@ -41,7 +41,6 @@ installopts = " && ln -s %(installdir)s/bin/pip3 %(installdir)s/bin/pip"
 exts_default_options = {
     'download_dep_fail': True,
     'sanity_pip_check': True,
-    'source_urls': [PYPI_SOURCE],
     'use_pip': True,
 }
 

--- a/easybuild/easyconfigs/p/Python/Python-3.8.6-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.8.6-GCCcore-10.2.0.eb
@@ -41,6 +41,7 @@ installopts = " && ln -s %(installdir)s/bin/pip3 %(installdir)s/bin/pip"
 exts_default_options = {
     'download_dep_fail': True,
     'sanity_pip_check': True,
+    'source_urls': [PYPI_SOURCE],
     'use_pip': True,
 }
 

--- a/easybuild/easyconfigs/p/pkgconfig/pkgconfig-1.5.1-GCCcore-10.2.0-python.eb
+++ b/easybuild/easyconfigs/p/pkgconfig/pkgconfig-1.5.1-GCCcore-10.2.0-python.eb
@@ -9,7 +9,6 @@ description = """pkgconfig is a Python module to interface with the pkg-config c
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['97bfe3d981bab675d5ea3ef259045d7919c93897db7d3b59d4e8593cba8d354f']
 

--- a/easybuild/easyconfigs/p/pkgconfig/pkgconfig-1.5.1-GCCcore-10.2.0-python.eb
+++ b/easybuild/easyconfigs/p/pkgconfig/pkgconfig-1.5.1-GCCcore-10.2.0-python.eb
@@ -9,6 +9,7 @@ description = """pkgconfig is a Python module to interface with the pkg-config c
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['97bfe3d981bab675d5ea3ef259045d7919c93897db7d3b59d4e8593cba8d354f']
 

--- a/easybuild/easyconfigs/p/plotly.py/plotly.py-4.14.3-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/p/plotly.py/plotly.py-4.14.3-GCCcore-10.2.0.eb
@@ -16,8 +16,6 @@ dependencies = [('Python', '3.8.6')]
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('retrying', '1.3.3', {
         'checksums': ['08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b'],

--- a/easybuild/easyconfigs/p/plotly.py/plotly.py-4.8.1-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/p/plotly.py/plotly.py-4.8.1-GCCcore-9.3.0.eb
@@ -12,8 +12,6 @@ multi_deps = {'Python': ['3.8.2', '2.7.18']}
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('retrying', '1.3.3', {
         'checksums': ['08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b'],

--- a/easybuild/easyconfigs/p/poetry/poetry-1.0.9-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/poetry/poetry-1.0.9-GCCcore-9.3.0-Python-3.8.2.eb
@@ -20,8 +20,6 @@ dependencies = [
 
 use_pip = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 # The order of extensions is significant!
 # some dependencies can't be installed via 'pip .' - using 'use_pip: False' in those cases
 exts_list = [

--- a/easybuild/easyconfigs/p/psycopg2/psycopg2-2.8.6-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/psycopg2/psycopg2-2.8.6-GCCcore-9.3.0-Python-3.8.2.eb
@@ -12,7 +12,6 @@ description = "Psycopg is the most popular PostgreSQL adapter for the Python pro
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['fb23f6c71107c37fd667cb4ea363ddeb936b348bbd6449278eb92c189699f543']
 

--- a/easybuild/easyconfigs/p/py-aiger/py-aiger-6.1.1-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/py-aiger/py-aiger-6.1.1-GCCcore-9.3.0-Python-3.8.2.eb
@@ -25,11 +25,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {
-    'source_urls': [PYPI_SOURCE],
-    'sources': [SOURCE_TAR_GZ],
-}
-
 exts_list = [
     ('bidict', '0.18.4', {
         'checksums': ['b60e16233ecb8d533afa072ad387ca0315700c6596a7ed4d576ada3418768324'],

--- a/easybuild/easyconfigs/p/pydot/pydot-1.4.1-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/p/pydot/pydot-1.4.1-GCCcore-9.3.0.eb
@@ -8,7 +8,6 @@ description = "Python interface to Graphviz's Dot language."
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['d49c9d4dd1913beec2a997f831543c8cbd53e535b1a739e921642fe416235f01']
 

--- a/easybuild/easyconfigs/p/pyproj/pyproj-2.6.1.post1-GCCcore-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/pyproj/pyproj-2.6.1.post1-GCCcore-9.3.0-Python-3.8.2.eb
@@ -9,7 +9,6 @@ description = "Python interface to PROJ4 library for cartographic transformation
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['4f5b02b4abbd41610397c635b275a8ee4a2b5bc72a75572b98ac6ae7befa471e']
 

--- a/easybuild/easyconfigs/p/pytest-xdist/pytest-xdist-2.1.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/p/pytest-xdist/pytest-xdist-2.1.0-GCCcore-10.2.0.eb
@@ -38,8 +38,6 @@ dependencies = [
 use_pip = True
 sanity_pip_check = True
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 exts_list = [
     ('apipkg', '1.5', {
         'checksums': ['37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6'],

--- a/easybuild/easyconfigs/q/QtPy/QtPy-1.9.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/q/QtPy/QtPy-1.9.0-GCCcore-10.2.0.eb
@@ -9,7 +9,6 @@ It provides support for PyQt5, PyQt4, PySide2 and PySide."""
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['2db72c44b55d0fe1407be8fba35c838ad0d6d3bb81f23007886dc1fc0f459c8d']
 

--- a/easybuild/easyconfigs/q/Qtconsole/Qtconsole-5.0.2-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/q/Qtconsole/Qtconsole-5.0.2-GCCcore-10.2.0.eb
@@ -11,7 +11,6 @@ such as inline figures, proper multiline editing with syntax highlighting, graph
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['404994edfe33c201d6bd0c4bd501b00c16125071573c938533224992bea0b30f']
 

--- a/easybuild/easyconfigs/r/RDFlib/RDFlib-5.0.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/r/RDFlib/RDFlib-5.0.0-GCCcore-10.2.0.eb
@@ -13,8 +13,6 @@ builddependencies = [('binutils', '2.35')]
 
 dependencies = [('Python', '3.8.6')]
 
-exts_default_options = {'source_urls': [PYPI_SOURCE]}
-
 use_pip = True
 
 exts_list = [

--- a/easybuild/easyconfigs/s/Shapely/Shapely-1.7.1-GCC-9.3.0-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/Shapely/Shapely-1.7.1-GCC-9.3.0-Python-3.8.2.eb
@@ -10,7 +10,6 @@ It is based on the widely deployed GEOS (the engine of PostGIS) and JTS (from wh
 
 toolchain = {'name': 'GCC', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['1641724c1055459a7e2b8bbe47ba25bdc89554582e62aec23cb3f3ca25f9b129']
 

--- a/easybuild/easyconfigs/t/tqdm/tqdm-4.47.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/t/tqdm/tqdm-4.47.0-GCCcore-9.3.0.eb
@@ -8,7 +8,6 @@ description = """A fast, extensible progress bar for Python and CLI"""
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['63ef7a6d3eb39f80d6b36e4867566b3d8e5f1fe3d6cb50c5e9ede2b3198ba7b7']
 

--- a/easybuild/easyconfigs/t/tqdm/tqdm-4.56.2-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/t/tqdm/tqdm-4.56.2-GCCcore-10.2.0.eb
@@ -8,7 +8,6 @@ description = """A fast, extensible progress bar for Python and CLI"""
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['11d544652edbdfc9cc41aa4c8a5c166513e279f3f2d9f1a9e1c89935b51de6ff']
 

--- a/easybuild/easyconfigs/t/typing-extensions/typing-extensions-3.7.4.3-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/t/typing-extensions/typing-extensions-3.7.4.3-GCCcore-10.2.0.eb
@@ -8,7 +8,6 @@ description = 'Typing Extensions – Backported and Experimental Type Hints for 
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = ['typing_extensions-%(version)s.tar.gz']
 checksums = ['99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c']
 

--- a/easybuild/easyconfigs/y/YACS/YACS-0.1.8-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/y/YACS/YACS-0.1.8-GCCcore-10.2.0.eb
@@ -13,7 +13,6 @@ of a convolutional neural network."""
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [PYPI_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['efc4c732942b3103bea904ee89af98bcd27d01f0ac12d8d4d369f1e7a2914384']
 


### PR DESCRIPTION
This is no longer required as it became the default with easybuilders/easybuild-easyblocks#2364

Tests should (and mine were) be done with e.g. `eb --from-pr 12453 --rebuild --fetch --force-download --sourcepath=/dev/shm/sources --upload-test-report` to only test the download and of course with latest develop easyblocks