### PR TITLE
Stop tests changing the EasyBuild easyconfigs

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -890,8 +890,6 @@ def template_easyconfig_test(self, spec):
     prev_single_tests_ok = single_tests_ok
     single_tests_ok = False
 
-    ec_fn = os.path.basename(spec)
-
     # parse easyconfig
     ecs = process_easyconfig(spec)
     if len(ecs) == 1:
@@ -935,6 +933,7 @@ def template_easyconfig_test(self, spec):
 
     # make sure that deprecated 'dummy' toolchain is no longer used, should use 'system' toolchain instead
     # but give recent EasyBuild easyconfigs special treatment to avoid breaking "eb --install-latest-eb-release"
+    ec_fn = os.path.basename(spec)
     if not (ec_fn == 'EasyBuild-3.9.4.eb' or ec_fn.startswith('EasyBuild-4.')):
         error_msg_tmpl = "%s should use 'system' toolchain rather than deprecated 'dummy' toolchain"
         self.assertFalse(ec['toolchain']['name'] == 'dummy', error_msg_tmpl % os.path.basename(spec))

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -890,15 +890,7 @@ def template_easyconfig_test(self, spec):
     prev_single_tests_ok = single_tests_ok
     single_tests_ok = False
 
-    # give recent EasyBuild easyconfigs special treatment
-    # replace use deprecated dummy toolchain, required to avoid breaking "eb --install-latest-eb-release",
-    # with SYSTEM toolchain constant
     ec_fn = os.path.basename(spec)
-    if ec_fn == 'EasyBuild-3.9.4.eb' or ec_fn.startswith('EasyBuild-4.'):
-        ectxt = read_file(spec)
-        regex = re.compile('^toolchain = .*dummy.*', re.M)
-        ectxt = regex.sub('toolchain = SYSTEM', ectxt)
-        write_file(spec, ectxt)
 
     # parse easyconfig
     ecs = process_easyconfig(spec)
@@ -942,8 +934,10 @@ def template_easyconfig_test(self, spec):
     self.assertTrue(ec['version'], app.version)
 
     # make sure that deprecated 'dummy' toolchain is no longer used, should use 'system' toolchain instead
-    error_msg_tmpl = "%s should use 'system' toolchain rather than deprecated 'dummy' toolchain"
-    self.assertFalse(ec['toolchain']['name'] == 'dummy', error_msg_tmpl % os.path.basename(spec))
+    # but give recent EasyBuild easyconfigs special treatment to avoid breaking "eb --install-latest-eb-release"
+    if not (ec_fn == 'EasyBuild-3.9.4.eb' or ec_fn.startswith('EasyBuild-4.')):
+        error_msg_tmpl = "%s should use 'system' toolchain rather than deprecated 'dummy' toolchain"
+        self.assertFalse(ec['toolchain']['name'] == 'dummy', error_msg_tmpl % os.path.basename(spec))
 
     # make sure that $root is not used, since it is not compatible with module files in Lua syntax
     res = re.findall(r'.*\$root.*', ec.rawtxt, re.M)

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -49,7 +49,7 @@ from easybuild.framework.easyconfig.parser import EasyConfigParser, fetch_parame
 from easybuild.framework.easyconfig.tools import check_sha256_checksums, dep_graph, get_paths_for, process_easyconfig
 from easybuild.tools import config
 from easybuild.tools.config import GENERAL_CLASS, build_option
-from easybuild.tools.filetools import change_dir, is_generic_easyblock, read_file, remove_file
+from easybuild.tools.filetools import change_dir, is_generic_easyblock, remove_file
 from easybuild.tools.filetools import verify_checksum, write_file
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.modules import modules_tool


### PR DESCRIPTION
When the tests are run they changes the EasyBuild easyconfigs, to replace
```
toolchain = {'name': 'dummy', 'version': 'dummy'}
```
with
```
toolchain = SYSTEM
```

This changes the tests to just not do the check for the `dummy` toolchain on the EasyBuild easyconfigs.