### PR TITLE
Add CI test checking if the Python default source_urls are used and Fix CI check where use_pip=False was ignored

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -629,7 +629,7 @@ class EasyConfigTest(TestCase):
 
                 download_dep_fail = ec.get('download_dep_fail')
                 exts_download_dep_fail = ec.get('exts_download_dep_fail')
-                use_pip = ec.get('use_pip') or exts_default_options.get('use_pip')
+                use_pip = ec.get('use_pip', default=exts_default_options.get('use_pip'))
 
             # download_dep_fail should be set when using PythonPackage
             if easyblock == 'PythonPackage':

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -629,14 +629,17 @@ class EasyConfigTest(TestCase):
 
                 download_dep_fail = ec.get('download_dep_fail')
                 exts_download_dep_fail = ec.get('exts_download_dep_fail')
-                use_pip = ec.get('use_pip', default=exts_default_options.get('use_pip'))
+                use_pip = ec.get('use_pip')
+                if use_pip is None:
+                    use_pip = exts_default_options.get('use_pip')
 
             # download_dep_fail should be set when using PythonPackage
             if easyblock == 'PythonPackage':
                 if download_dep_fail is None:
                     failing_checks.append("'download_dep_fail' should be set in %s" % ec_fn)
                 if ec.get('source_urls', resolve=False) == python_default_urls:
-                    failing_checks.append("'source_urls' can be omitted when using the default value in %s" % ec_fn)
+                    failing_checks.append("'source_urls' should not be defined when using the default value "
+                                          "in %s" % ec_fn)
 
             # use_pip should be set when using PythonPackage or PythonBundle (except for whitelisted easyconfigs)
             if easyblock in ['PythonBundle', 'PythonPackage']:
@@ -649,8 +652,8 @@ class EasyConfigTest(TestCase):
                     fail = "'*download_dep_fail' should not be set in %s since PythonBundle easyblock is used" % ec_fn
                     failing_checks.append(fail)
                 if exts_default_options.get('source_urls') == python_default_urls:
-                    failing_checks.append("'source_urls' can be omitted in exts_default_options when using the default"
-                                          " value in %s" % ec_fn)
+                    failing_checks.append("'source_urls' should not be defined in exts_default_options when using "
+                                          "the default value in %s" % ec_fn)
 
             elif exts_defaultclass == 'PythonPackage':
                 # bundle of Python packages should use PythonBundle

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -40,10 +40,11 @@ import easybuild.main as eb_main
 import easybuild.tools.options as eboptions
 from easybuild.base import fancylogger
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.easyblocks.generic.pythonpackage import PythonPackage
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig.default import DEFAULT_CONFIG
 from easybuild.framework.easyconfig.format.format import DEPENDENCY_PARAMETERS
-from easybuild.framework.easyconfig.easyconfig import get_easyblock_class, letter_dir_for
+from easybuild.framework.easyconfig.easyconfig import disable_templating, get_easyblock_class, letter_dir_for
 from easybuild.framework.easyconfig.easyconfig import resolve_template
 from easybuild.framework.easyconfig.parser import EasyConfigParser, fetch_parameters_from_easyconfig
 from easybuild.framework.easyconfig.tools import check_sha256_checksums, dep_graph, get_paths_for, process_easyconfig
@@ -616,21 +617,26 @@ class EasyConfigTest(TestCase):
 
         failing_checks = []
 
+        python_default_urls = PythonPackage.extra_options()['source_urls'][0]
+
         for ec in changed_ecs:
 
-            ec_fn = os.path.basename(ec.path)
-            easyblock = ec.get('easyblock')
-            exts_defaultclass = ec.get('exts_defaultclass')
-            exts_default_options = ec.get('exts_default_options', {})
+            with disable_templating(ec):
+                ec_fn = os.path.basename(ec.path)
+                easyblock = ec.get('easyblock')
+                exts_defaultclass = ec.get('exts_defaultclass')
+                exts_default_options = ec.get('exts_default_options', {})
 
-            download_dep_fail = ec.get('download_dep_fail')
-            exts_download_dep_fail = ec.get('exts_download_dep_fail')
-            use_pip = ec.get('use_pip') or exts_default_options.get('use_pip')
+                download_dep_fail = ec.get('download_dep_fail')
+                exts_download_dep_fail = ec.get('exts_download_dep_fail')
+                use_pip = ec.get('use_pip') or exts_default_options.get('use_pip')
 
             # download_dep_fail should be set when using PythonPackage
             if easyblock == 'PythonPackage':
                 if download_dep_fail is None:
                     failing_checks.append("'download_dep_fail' should be set in %s" % ec_fn)
+                if ec.get('source_urls', resolve=False) == python_default_urls:
+                    failing_checks.append("'source_urls' can be omitted when using the default value in %s" % ec_fn)
 
             # use_pip should be set when using PythonPackage or PythonBundle (except for whitelisted easyconfigs)
             if easyblock in ['PythonBundle', 'PythonPackage']:
@@ -642,6 +648,9 @@ class EasyConfigTest(TestCase):
                 if download_dep_fail or exts_download_dep_fail:
                     fail = "'*download_dep_fail' should not be set in %s since PythonBundle easyblock is used" % ec_fn
                     failing_checks.append(fail)
+                if exts_default_options.get('source_urls') == python_default_urls:
+                    failing_checks.append("'source_urls' can be omitted in exts_default_options when using the default"
+                                          " value in %s" % ec_fn)
 
             elif exts_defaultclass == 'PythonPackage':
                 # bundle of Python packages should use PythonBundle
@@ -687,7 +696,8 @@ class EasyConfigTest(TestCase):
                     if not any(re.match(regex, ec_fn) for regex in whitelist_pip_check):
                         failing_checks.append("sanity_pip_check should be enabled in %s" % ec_fn)
 
-        self.assertFalse(failing_checks, '\n'.join(failing_checks))
+        if failing_checks:
+            self.fail('\n'.join(failing_checks))
 
     def check_R_packages(self, changed_ecs):
         """Several checks for easyconfigs that install (bundles of) R packages."""


### PR DESCRIPTION
This is for #12451, #12452, #12453 to avoid reintroducing that

The 2nd commit fixes the failure seen in #12453: https://github.com/easybuilders/easybuild-easyconfigs/runs/2174370525