### PR TITLE
Require sanity_pip_check for all Python package/bundles

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -693,11 +693,10 @@ class EasyConfigTest(TestCase):
                     failing_checks.append(msg)
 
             # require that running of "pip check" during sanity check is enabled via sanity_pip_check
-            if use_pip and easyblock in ['PythonBundle', 'PythonPackage']:
+            if easyblock in ['PythonBundle', 'PythonPackage']:
                 sanity_pip_check = ec.get('sanity_pip_check') or exts_default_options.get('sanity_pip_check')
-                if not sanity_pip_check and not any(re.match(regex, ec_fn) for regex in whitelist_pip):
-                    if not any(re.match(regex, ec_fn) for regex in whitelist_pip_check):
-                        failing_checks.append("sanity_pip_check should be enabled in %s" % ec_fn)
+                if not sanity_pip_check and not any(re.match(regex, ec_fn) for regex in whitelist_pip_check):
+                    failing_checks.append("sanity_pip_check should be enabled in %s" % ec_fn)
 
         if failing_checks:
             self.fail('\n'.join(failing_checks))


### PR DESCRIPTION
From https://github.com/easybuilders/easybuild-easyconfigs/pull/12456#issuecomment-805852017

IMO it should always be required as this could/does(?) catch the recent issue where installation via setup.py resulted in a version of 0.0.0

@boegel 
> I'm not sure it makes sense to run pip check when pip was not used to install the package...
>
> How would running pip check catch the problem with 0.0.0 versions? That would require enhancements in the generic PythonPackage PR first?

`pip` also sees packages installed by `setup.py` and that might introduce conflicts as well which would make later installations that use this software fail.

It may catch the 0.0.0 versions indirectly: When another package requires a specific version of this software but that is 0.0.0 `pip check` will fail

A proper check is in https://github.com/easybuilders/easybuild-easyblocks/pull/2367