### PR TITLE
fix check for default source_urls value for easyconfigs using PythonPackage or PythonBundle

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -633,11 +633,16 @@ class EasyConfigTest(TestCase):
                 if use_pip is None:
                     use_pip = exts_default_options.get('use_pip')
 
+            # only easyconfig parameters as they are defined in the easyconfig file,
+            # does *not* include other easyconfig parameters with their default value!
+            pure_ec = ec.parser.get_config_dict()
+
             # download_dep_fail should be set when using PythonPackage
             if easyblock == 'PythonPackage':
                 if download_dep_fail is None:
                     failing_checks.append("'download_dep_fail' should be set in %s" % ec_fn)
-                if ec.get('source_urls', resolve=False) == python_default_urls:
+
+                if pure_ec.get('source_urls') == python_default_urls:
                     failing_checks.append("'source_urls' should not be defined when using the default value "
                                           "in %s" % ec_fn)
 
@@ -651,7 +656,7 @@ class EasyConfigTest(TestCase):
                 if download_dep_fail or exts_download_dep_fail:
                     fail = "'*download_dep_fail' should not be set in %s since PythonBundle easyblock is used" % ec_fn
                     failing_checks.append(fail)
-                if exts_default_options.get('source_urls') == python_default_urls:
+                if pure_ec.get('exts_default_options', {}).get('source_urls') == python_default_urls:
                     failing_checks.append("'source_urls' should not be defined in exts_default_options when using "
                                           "the default value in %s" % ec_fn)
 


### PR DESCRIPTION
Fix for check that was added in #12456 by @Flamefire

Via the `EasyConfig` instance, you always get the default value for easyconfig parameters that are not defined in the easyconfig file.

If you only grab the *defined* easyconfig parameters via the parser instance though, you can check whether an easyconfig parameter was defined exactly like the default value:

```python
>>> from easybuild.tools.options import set_up_configuration
>>> set_up_configuration()

>>> from easybuild.framework.easyconfig.tools import process_easyconfig
>>> ec = process_easyconfig('easybuild/easyconfigs/p/pybedtools/pybedtools-0.8.2-iccifort-2020.4.304.eb')[0]['ec']

>>> ec.get('source_urls', resolve=False)
['https://pypi.python.org/packages/source/%(nameletter)s/%(name)s']
>>> pure_ec = ec.parser.get_config_dict()
>>> pure_ec.get('source_urls')
>>> pure_ec.get('exts_default_options')
>>> pure_ec.get('exts_default_options', {})
{}
```