### PR TITLE
fix sanity check error for OpenCV v4.5.1

### DIFF
--- a/easybuild/easyconfigs/o/OpenCV/OpenCV-4.5.1-foss-2020b-contrib.eb
+++ b/easybuild/easyconfigs/o/OpenCV/OpenCV-4.5.1-foss-2020b-contrib.eb
@@ -37,6 +37,8 @@ dependencies = [
     ('SciPy-bundle', '2020.11'),  # for numpy
     ('zlib', '1.2.11'),
     ('FFmpeg', '4.3.1'),
+    ('freetype', '2.10.3'),
+    ('HarfBuzz', '2.6.7'),
     ('libjpeg-turbo', '2.0.5'),
     ('libpng', '1.6.37'),
     ('LibTIFF', '4.1.0'),
@@ -50,7 +52,20 @@ dependencies = [
     ('HDF5', '1.10.7'),  # needed by hdf from contrib
 ]
 
-configopts = '-DOPENCV_EXTRA_MODULES_PATH=%(builddir)s/%(namelower)s_contrib-%(version)s/modules'
+# XXXX in configurations is a bug fix in OpenCV because ocv_check_modules is not able to recognize freetype and harfbuzz
+# ref: https://github.com/opencv/opencv/blob/6e8daaec0f46aaba9ea22e2afce47307b1dbff9f/cmake/OpenCVUtils.cmake#L861
+configopts = '-DOPENCV_EXTRA_MODULES_PATH=%(builddir)s/%(namelower)s_contrib-%(version)s/modules '
+configopts += '-DFREETYPE_FOUND=ON '
+configopts += '-DFREETYPE_INCLUDE_DIRS=$EBROOTFREETYPE/include/freetype2/ '
+configopts += '-DFREETYPE_LIBRARIES=$EBROOTFREETYPE/lib64/libfreetype.so '
+configopts += '-DFREETYPE_LINK_LIBRARIES=$EBROOTFREETYPE/lib64/libfreetype.so '
+configopts += '-DFREETYPE_LINK_LIBRARIES_XXXXX=ON '
+configopts += '-DHARFBUZZ_FOUND=ON '
+configopts += '-DHARFBUZZ_INCLUDE_DIRS=$EBROOTHARFBUZZ/include/harfbuzz '
+configopts += '-DHARFBUZZ_LIBRARIES=$EBROOTHARFBUZZ/lib64/libharfbuzz.so '
+configopts += '-DHARFBUZZ_LINK_LIBRARIES=$EBROOTHARFBUZZ/lib64/libharfbuzz.so '
+configopts += '-DHARFBUZZ_LINK_LIBRARIES_XXXXX=ON '
+configopts += '-DBUILD_opencv_python2=OFF '
 
 enhance_sanity_check = True
 

--- a/easybuild/easyconfigs/o/OpenCV/OpenCV-4.5.1-fosscuda-2020b-contrib.eb
+++ b/easybuild/easyconfigs/o/OpenCV/OpenCV-4.5.1-fosscuda-2020b-contrib.eb
@@ -37,6 +37,8 @@ dependencies = [
     ('SciPy-bundle', '2020.11'),  # for numpy
     ('zlib', '1.2.11'),
     ('FFmpeg', '4.3.1'),
+    ('freetype', '2.10.3'),
+    ('HarfBuzz', '2.6.7'),
     ('libjpeg-turbo', '2.0.5'),
     ('libpng', '1.6.37'),
     ('LibTIFF', '4.1.0'),
@@ -50,7 +52,20 @@ dependencies = [
     ('HDF5', '1.10.7'),  # needed by hdf from contrib
 ]
 
-configopts = '-DOPENCV_EXTRA_MODULES_PATH=%(builddir)s/%(namelower)s_contrib-%(version)s/modules'
+# XXXX in configurations is a bug fix in OpenCV because ocv_check_modules is not able to recognize freetype and harfbuzz
+# ref: https://github.com/opencv/opencv/blob/6e8daaec0f46aaba9ea22e2afce47307b1dbff9f/cmake/OpenCVUtils.cmake#L861
+configopts = '-DOPENCV_EXTRA_MODULES_PATH=%(builddir)s/%(namelower)s_contrib-%(version)s/modules '
+configopts += '-DFREETYPE_FOUND=ON '
+configopts += '-DFREETYPE_INCLUDE_DIRS=$EBROOTFREETYPE/include/freetype2/ '
+configopts += '-DFREETYPE_LIBRARIES=$EBROOTFREETYPE/lib64/libfreetype.so '
+configopts += '-DFREETYPE_LINK_LIBRARIES=$EBROOTFREETYPE/lib64/libfreetype.so '
+configopts += '-DFREETYPE_LINK_LIBRARIES_XXXXX=ON '
+configopts += '-DHARFBUZZ_FOUND=ON '
+configopts += '-DHARFBUZZ_INCLUDE_DIRS=$EBROOTHARFBUZZ/include/harfbuzz '
+configopts += '-DHARFBUZZ_LIBRARIES=$EBROOTHARFBUZZ/lib64/libharfbuzz.so '
+configopts += '-DHARFBUZZ_LINK_LIBRARIES=$EBROOTHARFBUZZ/lib64/libharfbuzz.so '
+configopts += '-DHARFBUZZ_LINK_LIBRARIES_XXXXX=ON '
+configopts += '-DBUILD_opencv_python2=OFF '
 
 enhance_sanity_check = True
 


### PR DESCRIPTION
fixes #12491 
Freetype and Harfbuzz are required to build freetype: https://github.com/opencv/opencv_contrib/tree/master/modules/freetype
=> Added those modules as dependencies

OpenCV contrib bug in ocv_check_modules prevents detection of Freetype and HarfBuzz, required to build freetype module, ref:
- https://github.com/opencv/opencv_contrib/issues/1497
- https://github.com/opencv/opencv_contrib/issues/2239

=> Applied configopts to "force detection" of the module as per described workaround in issue 2239.

Module requires Python 3:
=> Added configopt to disable Python2 compilation (removes error messages)