### PR TITLE
add patch to fix hardcoded num_cores in DMCfun extension included with R 4.0.x

### DIFF
--- a/easybuild/easyconfigs/r/R/DMCfun-1.3.0_fix-parallel-detect.patch
+++ b/easybuild/easyconfigs/r/R/DMCfun-1.3.0_fix-parallel-detect.patch
@@ -10,7 +10,7 @@ diff -ru DMCfun.orig/MD5 DMCfun/MD5
  034299149a3219bf581d440b19d94fbb *R/RcppExports.R
  4e07b13ccaf91457dfc167540129c61f *R/dmcData.R
 -0bce9adf54182001c9eadbca3c6af0f8 *R/dmcFit.R
-+1f8c6ded3317c4efee6cdd8538907acc *R/dmcFit.R
++8f8759267c76167e07ac0f015edfbd45 *R/dmcFit.R
  655fea3d9c03b02d6f2539ec478ab9b0 *R/dmcSim.R
  f301185baf6007e9ade686f9964ecf23 *R/methods.R
  1b5964cab6608330647f601921f15a5c *R/plot.R
@@ -22,7 +22,7 @@ diff -ru DMCfun.orig/R/dmcFit.R DMCfun/R/dmcFit.R
        num_cores <- 2L
      } else {
 -      num_cores <- parallel::detectCores() / 2
-+      num_cores <- as.numeric(Sys.getenv("PBS_NP", parallel::detectCores() / 2))
++      num_cores <- as.numeric(Sys.getenv("SLURM_NTASKS", Sys.getenv("PBS_NP", parallel::detectCores() / 2))
      }
      
      # Older code (pre June 2020) used doSNOW progress bar 
@@ -31,7 +31,7 @@ diff -ru DMCfun.orig/R/dmcFit.R DMCfun/R/dmcFit.R
      num_cores <- 2L
    } else {
 -    num_cores <- parallel::detectCores() / 2
-+    num_cores <- as.numeric(Sys.getenv("PBS_NP", parallel::detectCores() / 2))
++    num_cores <- as.numeric(Sys.getenv("SLURM_NTASKS", Sys.getenv("PBS_NP", parallel::detectCores() / 2))
    }
    cl <- parallel::makeCluster(num_cores)
    invisible(parallel::clusterExport(cl = cl, varlist=c("dmcSim", "calculateCostValue")))

--- a/easybuild/easyconfigs/r/R/DMCfun-1.3.0_fix-parallel-detect.patch
+++ b/easybuild/easyconfigs/r/R/DMCfun-1.3.0_fix-parallel-detect.patch
@@ -10,7 +10,7 @@ diff -ru DMCfun.orig/MD5 DMCfun/MD5
  034299149a3219bf581d440b19d94fbb *R/RcppExports.R
  4e07b13ccaf91457dfc167540129c61f *R/dmcData.R
 -0bce9adf54182001c9eadbca3c6af0f8 *R/dmcFit.R
-+19cd38db9d88a63d920c21a68a01d85b *R/dmcFit.R
++d66108a6cddee34ca0dc1556b6b24f53 *R/dmcFit.R
  655fea3d9c03b02d6f2539ec478ab9b0 *R/dmcSim.R
  f301185baf6007e9ade686f9964ecf23 *R/methods.R
  1b5964cab6608330647f601921f15a5c *R/plot.R
@@ -22,7 +22,7 @@ diff -ru DMCfun.orig/R/dmcFit.R DMCfun/R/dmcFit.R
        num_cores <- 2L
      } else {
 -      num_cores <- parallel::detectCores() / 2
-+      num_cores <- as.numeric(Sys.getenv("SLURM_CPUS_ON_NODE", Sys.getenv("PBS_NUM_PPN", parallel::detectCores() / 2))
++      num_cores <- as.numeric(Sys.getenv("SLURM_CPUS_ON_NODE", Sys.getenv("PBS_NUM_PPN", parallel::detectCores() / 2)))
      }
      
      # Older code (pre June 2020) used doSNOW progress bar 
@@ -31,7 +31,7 @@ diff -ru DMCfun.orig/R/dmcFit.R DMCfun/R/dmcFit.R
      num_cores <- 2L
    } else {
 -    num_cores <- parallel::detectCores() / 2
-+    num_cores <- as.numeric(Sys.getenv("SLURM_CPUS_ON_NODE", Sys.getenv("PBS_NUM_PPN", parallel::detectCores() / 2))
++    num_cores <- as.numeric(Sys.getenv("SLURM_CPUS_ON_NODE", Sys.getenv("PBS_NUM_PPN", parallel::detectCores() / 2)))
    }
    cl <- parallel::makeCluster(num_cores)
    invisible(parallel::clusterExport(cl = cl, varlist=c("dmcSim", "calculateCostValue")))

--- a/easybuild/easyconfigs/r/R/DMCfun-1.3.0_fix-parallel-detect.patch
+++ b/easybuild/easyconfigs/r/R/DMCfun-1.3.0_fix-parallel-detect.patch
@@ -10,7 +10,7 @@ diff -ru DMCfun.orig/MD5 DMCfun/MD5
  034299149a3219bf581d440b19d94fbb *R/RcppExports.R
  4e07b13ccaf91457dfc167540129c61f *R/dmcData.R
 -0bce9adf54182001c9eadbca3c6af0f8 *R/dmcFit.R
-+8f8759267c76167e07ac0f015edfbd45 *R/dmcFit.R
++19cd38db9d88a63d920c21a68a01d85b *R/dmcFit.R
  655fea3d9c03b02d6f2539ec478ab9b0 *R/dmcSim.R
  f301185baf6007e9ade686f9964ecf23 *R/methods.R
  1b5964cab6608330647f601921f15a5c *R/plot.R
@@ -22,7 +22,7 @@ diff -ru DMCfun.orig/R/dmcFit.R DMCfun/R/dmcFit.R
        num_cores <- 2L
      } else {
 -      num_cores <- parallel::detectCores() / 2
-+      num_cores <- as.numeric(Sys.getenv("SLURM_NTASKS", Sys.getenv("PBS_NP", parallel::detectCores() / 2))
++      num_cores <- as.numeric(Sys.getenv("SLURM_CPUS_ON_NODE", Sys.getenv("PBS_NUM_PPN", parallel::detectCores() / 2))
      }
      
      # Older code (pre June 2020) used doSNOW progress bar 
@@ -31,7 +31,7 @@ diff -ru DMCfun.orig/R/dmcFit.R DMCfun/R/dmcFit.R
      num_cores <- 2L
    } else {
 -    num_cores <- parallel::detectCores() / 2
-+    num_cores <- as.numeric(Sys.getenv("SLURM_NTASKS", Sys.getenv("PBS_NP", parallel::detectCores() / 2))
++    num_cores <- as.numeric(Sys.getenv("SLURM_CPUS_ON_NODE", Sys.getenv("PBS_NUM_PPN", parallel::detectCores() / 2))
    }
    cl <- parallel::makeCluster(num_cores)
    invisible(parallel::clusterExport(cl = cl, varlist=c("dmcSim", "calculateCostValue")))

--- a/easybuild/easyconfigs/r/R/DMCfun-1.3.0_fix-parallel-detect.patch
+++ b/easybuild/easyconfigs/r/R/DMCfun-1.3.0_fix-parallel-detect.patch
@@ -1,0 +1,37 @@
+# parallal::detectCores() detects physical cores and not available cores. It is ususally problem in queue systems
+# like PBS or Slurm. This patch gives solution for that problem for PBS and with Slurm with PBS compatibility switched
+# on. For other queue systems, a different solutiom might needed.
+# April 13th 2021 by B. Hajgato (UGent)
+diff -ru DMCfun.orig/MD5 DMCfun/MD5
+--- DMCfun.orig/MD5	2021-01-10 18:50:10.000000000 +0100
++++ DMCfun/MD5	2021-04-13 09:31:31.242654188 +0200
+@@ -4,7 +4,7 @@
+ a835c7e49694b2c835c438362b16946f *R/DMCfun.R
+ 034299149a3219bf581d440b19d94fbb *R/RcppExports.R
+ 4e07b13ccaf91457dfc167540129c61f *R/dmcData.R
+-0bce9adf54182001c9eadbca3c6af0f8 *R/dmcFit.R
++1f8c6ded3317c4efee6cdd8538907acc *R/dmcFit.R
+ 655fea3d9c03b02d6f2539ec478ab9b0 *R/dmcSim.R
+ f301185baf6007e9ade686f9964ecf23 *R/methods.R
+ 1b5964cab6608330647f601921f15a5c *R/plot.R
+diff -ru DMCfun.orig/R/dmcFit.R DMCfun/R/dmcFit.R
+--- DMCfun.orig/R/dmcFit.R	2020-12-03 18:53:03.000000000 +0100
++++ DMCfun/R/dmcFit.R	2021-04-13 09:28:47.506520017 +0200
+@@ -159,7 +159,7 @@
+     if (nzchar(chk) && (chk == "true")) {
+       num_cores <- 2L
+     } else {
+-      num_cores <- parallel::detectCores() / 2
++      num_cores <- as.numeric(Sys.getenv("PBS_NP", parallel::detectCores() / 2))
+     }
+     
+     # Older code (pre June 2020) used doSNOW progress bar 
+@@ -297,7 +297,7 @@
+   if (nzchar(chk) && (chk == "true")) {
+     num_cores <- 2L
+   } else {
+-    num_cores <- parallel::detectCores() / 2
++    num_cores <- as.numeric(Sys.getenv("PBS_NP", parallel::detectCores() / 2))
+   }
+   cl <- parallel::makeCluster(num_cores)
+   invisible(parallel::clusterExport(cl = cl, varlist=c("dmcSim", "calculateCostValue")))

--- a/easybuild/easyconfigs/r/R/R-4.0.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.3-foss-2020b.eb
@@ -2805,7 +2805,7 @@ exts_list = [
         'checksums': [
             '2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7',  # DMCfun_1.3.0.tar.gz
             # DMCfun-1.3.0_fix-parallel-detect.patch
-            '96cccbe650dfab5619e3b6e782062ab72e9f1038ddf05b439dd097e1d8a59a79',
+            '67259a76722717f29577d7a25c822a4fb9c1b5ce45699d02aa53ab0ffa1d0b2a',
         ],
     }),
     ('miceadds', '3.11-6', {

--- a/easybuild/easyconfigs/r/R/R-4.0.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.3-foss-2020b.eb
@@ -2805,7 +2805,7 @@ exts_list = [
         'checksums': [
             '2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7',  # DMCfun_1.3.0.tar.gz
             # DMCfun-1.3.0_fix-parallel-detect.patch
-            '555a4746375ec3c27473d6549a785359db91340f5126db5609cf5c6bca97cdff',
+            '96cccbe650dfab5619e3b6e782062ab72e9f1038ddf05b439dd097e1d8a59a79',
         ],
     }),
 ]

--- a/easybuild/easyconfigs/r/R/R-4.0.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.3-foss-2020b.eb
@@ -2801,7 +2801,12 @@ exts_list = [
         'checksums': ['73b1ed560ffd74599517e8baa4c5b293aa062e9c8d50219a3a24b63e72fa7c00'],
     }),
     ('DMCfun', '1.3.0', {
-        'checksums': ['2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7'],
+        'patches': ['DMCfun-1.3.0_fix-parallel-detect.patch'],
+        'checksums': [
+            '2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7',  # DMCfun_1.3.0.tar.gz
+            # DMCfun-1.3.0_fix-parallel-detect.patch
+            '555a4746375ec3c27473d6549a785359db91340f5126db5609cf5c6bca97cdff',
+        ],
     }),
 ]
 

--- a/easybuild/easyconfigs/r/R/R-4.0.3-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.3-fosscuda-2020b.eb
@@ -2815,7 +2815,7 @@ exts_list = [
         'checksums': [
             '2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7',  # DMCfun_1.3.0.tar.gz
             # DMCfun-1.3.0_fix-parallel-detect.patch
-            '555a4746375ec3c27473d6549a785359db91340f5126db5609cf5c6bca97cdff',
+            '96cccbe650dfab5619e3b6e782062ab72e9f1038ddf05b439dd097e1d8a59a79',
         ],
     }),
     # Specific packages for GPUs

--- a/easybuild/easyconfigs/r/R/R-4.0.3-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.3-fosscuda-2020b.eb
@@ -2815,7 +2815,7 @@ exts_list = [
         'checksums': [
             '2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7',  # DMCfun_1.3.0.tar.gz
             # DMCfun-1.3.0_fix-parallel-detect.patch
-            '96cccbe650dfab5619e3b6e782062ab72e9f1038ddf05b439dd097e1d8a59a79',
+            '67259a76722717f29577d7a25c822a4fb9c1b5ce45699d02aa53ab0ffa1d0b2a',
         ],
     }),
     ('miceadds', '3.11-6', {

--- a/easybuild/easyconfigs/r/R/R-4.0.3-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.3-fosscuda-2020b.eb
@@ -2811,7 +2811,12 @@ exts_list = [
         'checksums': ['73b1ed560ffd74599517e8baa4c5b293aa062e9c8d50219a3a24b63e72fa7c00'],
     }),
     ('DMCfun', '1.3.0', {
-        'checksums': ['2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7'],
+        'patches': ['DMCfun-1.3.0_fix-parallel-detect.patch'],
+        'checksums': [
+            '2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7',  # DMCfun_1.3.0.tar.gz
+            # DMCfun-1.3.0_fix-parallel-detect.patch
+            '555a4746375ec3c27473d6549a785359db91340f5126db5609cf5c6bca97cdff',
+        ],
     }),
     # Specific packages for GPUs
     ('OpenCL', '0.2-1', {

--- a/easybuild/easyconfigs/r/R/R-4.0.4-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.4-foss-2020b.eb
@@ -2840,7 +2840,7 @@ exts_list = [
         'checksums': [
             '2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7',  # DMCfun_1.3.0.tar.gz
             # DMCfun-1.3.0_fix-parallel-detect.patch
-            '96cccbe650dfab5619e3b6e782062ab72e9f1038ddf05b439dd097e1d8a59a79',
+            '67259a76722717f29577d7a25c822a4fb9c1b5ce45699d02aa53ab0ffa1d0b2a',
         ],
     }),
     ('miceadds', '3.11-6', {

--- a/easybuild/easyconfigs/r/R/R-4.0.4-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.4-foss-2020b.eb
@@ -2836,7 +2836,12 @@ exts_list = [
         'checksums': ['73b1ed560ffd74599517e8baa4c5b293aa062e9c8d50219a3a24b63e72fa7c00'],
     }),
     ('DMCfun', '1.3.0', {
-        'checksums': ['2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7'],
+        'patches': ['DMCfun-1.3.0_fix-parallel-detect.patch'],
+        'checksums': [
+            '2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7',  # DMCfun_1.3.0.tar.gz
+            # DMCfun-1.3.0_fix-parallel-detect.patch
+            '555a4746375ec3c27473d6549a785359db91340f5126db5609cf5c6bca97cdff',
+        ],
     }),
 ]
 

--- a/easybuild/easyconfigs/r/R/R-4.0.4-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.4-foss-2020b.eb
@@ -2840,7 +2840,7 @@ exts_list = [
         'checksums': [
             '2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7',  # DMCfun_1.3.0.tar.gz
             # DMCfun-1.3.0_fix-parallel-detect.patch
-            '555a4746375ec3c27473d6549a785359db91340f5126db5609cf5c6bca97cdff',
+            '96cccbe650dfab5619e3b6e782062ab72e9f1038ddf05b439dd097e1d8a59a79',
         ],
     }),
 ]

--- a/easybuild/easyconfigs/r/R/R-4.0.4-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.4-fosscuda-2020b.eb
@@ -2845,7 +2845,7 @@ exts_list = [
         'checksums': [
             '2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7',  # DMCfun_1.3.0.tar.gz
             # DMCfun-1.3.0_fix-parallel-detect.patch
-            '96cccbe650dfab5619e3b6e782062ab72e9f1038ddf05b439dd097e1d8a59a79',
+            '67259a76722717f29577d7a25c822a4fb9c1b5ce45699d02aa53ab0ffa1d0b2a',
         ],
     }),
     ('miceadds', '3.11-6', {

--- a/easybuild/easyconfigs/r/R/R-4.0.4-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.4-fosscuda-2020b.eb
@@ -2841,7 +2841,12 @@ exts_list = [
         'checksums': ['73b1ed560ffd74599517e8baa4c5b293aa062e9c8d50219a3a24b63e72fa7c00'],
     }),
     ('DMCfun', '1.3.0', {
-        'checksums': ['2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7'],
+        'patches': ['DMCfun-1.3.0_fix-parallel-detect.patch'],
+        'checksums': [
+            '2ca5e633c1af56d7f13a811a72e33853026ad4b6ca34290d017c8bb66443d2e7',  # DMCfun_1.3.0.tar.gz
+            # DMCfun-1.3.0_fix-parallel-detect.patch
+            '96cccbe650dfab5619e3b6e782062ab72e9f1038ddf05b439dd097e1d8a59a79',
+        ],
     }),
     ('miceadds', '3.11-6', {
         'checksums': ['121d03c812fbcf584a25585ac73f6c44f4b5d6cd21b05362ddd15395fb3909f6'],


### PR DESCRIPTION
fixes #12569
This only solves PBS cases so other queue systems might need different solution(s)