### PR TITLE
Revert "add Compress::Raw::Zlib to Perl v5.32.0"

### DIFF
--- a/easybuild/easyconfigs/p/Perl/Perl-5.32.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.32.0-GCCcore-10.2.0.eb
@@ -1796,11 +1796,6 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/I/IN/INGY/'],
         'checksums': ['510a7de2d011b0db80b0874e8c0f7390010991000ae135cff7474df1e6d51e3a'],
     }),
-    ('Compress::Raw::Zlib', '2.101', {
-        'source_tmpl': 'Compress-Raw-Zlib-%(version)s.tar.gz',
-        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PM/PMQS'],
-        'checksums': ['9d1b9515e8277c1b007e33fad1fd0f18717d56bf647e3794d61289c45b1aabb2'],
-    }),
 ]
 
 moduleclass = 'lang'


### PR DESCRIPTION
Reverts easybuilders/easybuild-easyconfigs#12627

This extension is already included in `perl-5.32.0.tar.gz`, the base distribution of Perl. Adding it as an extension is incompatible with `--skip` as the module in the base distribution will have precedence over the extension and it will not be installed, regardless of its version.