### PR TITLE
add -Java versionsuffix for Hadoop easyconfig using GCCcore/10.2.0 toolchain, since it depends on Java 1.8

### DIFF
--- a/easybuild/easyconfigs/h/Hadoop/Hadoop-2.10.0-GCCcore-10.2.0-native-Java-1.8.eb
+++ b/easybuild/easyconfigs/h/Hadoop/Hadoop-2.10.0-GCCcore-10.2.0-native-Java-1.8.eb
@@ -1,6 +1,6 @@
 name = 'Hadoop'
 version = '2.10.0'
-versionsuffix = '-native'
+versionsuffix = '-native-Java-%(javaver)s'
 
 homepage = 'https://archive.cloudera.com/cdh5/cdh/5/'
 description = """Hadoop MapReduce by Cloudera"""


### PR DESCRIPTION
required to make enhanced easyconfig test suite pass, see #3655