### PR TITLE
fix BirdNET patch: don't use relative paths to files in installation directory

### DIFF
--- a/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214-fosscuda-2019b-Python-3.7.4.eb
@@ -32,7 +32,7 @@ patches = ['BirdNET-20201214_add-model-path-envvar.patch']
 checksums = [
     '3a7a5f562bfdd55138603847d206125328f02a25df5e86278d2fb35242bb1c1d',  # BirdNET-20201214.tar.gz
     '7db0b2fe57da002aff62fe1aecf56b16065c2b699dcbee1d8d7e07a42719b3fe',  # BirdNET_Soundscape_Model.pkl
-    'c4480ee26c3fe637097d66c08fc8dd7394e75f2d7f0f32c6c920d88dde1b7511',  # BirdNET-20201214_add-model-path-envvar.patch
+    '1d66624de3b9a16c33b9231af2972de7bcf4db613ae1f76597a8b0af4ca4e423',  # BirdNET-20201214_add-model-path-envvar.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214-fosscuda-2019b-Python-3.7.4.eb
@@ -32,7 +32,7 @@ patches = ['BirdNET-20201214_add-model-path-envvar.patch']
 checksums = [
     '3a7a5f562bfdd55138603847d206125328f02a25df5e86278d2fb35242bb1c1d',  # BirdNET-20201214.tar.gz
     '7db0b2fe57da002aff62fe1aecf56b16065c2b699dcbee1d8d7e07a42719b3fe',  # BirdNET_Soundscape_Model.pkl
-    '1d66624de3b9a16c33b9231af2972de7bcf4db613ae1f76597a8b0af4ca4e423',  # BirdNET-20201214_add-model-path-envvar.patch
+    'e27409a304e7b2a3d27b6db575c25db9bf6c6be478468f3ffdc33898f20c6ea5',  # BirdNET-20201214_add-model-path-envvar.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214-fosscuda-2019b-Python-3.7.4.eb
@@ -32,7 +32,7 @@ patches = ['BirdNET-20201214_add-model-path-envvar.patch']
 checksums = [
     '3a7a5f562bfdd55138603847d206125328f02a25df5e86278d2fb35242bb1c1d',  # BirdNET-20201214.tar.gz
     '7db0b2fe57da002aff62fe1aecf56b16065c2b699dcbee1d8d7e07a42719b3fe',  # BirdNET_Soundscape_Model.pkl
-    '5332335c2166b9bad502c47a9d14b31f9d264a8048632840dd3b82ec70dbed7b',  # BirdNET-20201214_add-model-path-envvar.patch
+    'c4480ee26c3fe637097d66c08fc8dd7394e75f2d7f0f32c6c920d88dde1b7511',  # BirdNET-20201214_add-model-path-envvar.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214_add-model-path-envvar.patch
+++ b/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214_add-model-path-envvar.patch
@@ -5,12 +5,13 @@ Author: Bob Dröge (University of Groningen)
 
 --- analyze.py	2021-04-20 15:16:25.000000000 +0200
 +++ analyze.py	2021-04-20 15:12:39.000000000 +0200
-@@ -35,7 +35,8 @@
+@@ -34,7 +34,9 @@
  def loadModel():
  
      # Load trained net
 -    snapshot = model.loadSnapshot('model/BirdNET_Soundscape_Model.pkl')
-+    model_path = os.getenv('BIRDNET_MODEL', 'model/BirdNET_Soundscape_Model.pkl')
++    default_model_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'model', 'BirdNET_Soundscape_Model.pkl')
++    model_path = os.getenv('BIRDNET_MODEL', default_model_path)
 +    snapshot = model.loadSnapshot(model_path)
  
      # Build simple model

--- a/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214_add-model-path-envvar.patch
+++ b/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214_add-model-path-envvar.patch
@@ -28,7 +28,7 @@ Author: Bob Dröge (University of Groningen)
  # for a location to be considered plausible.
 -EBIRD_SPECIES_CODES = 'metadata/eBird_taxonomy_codes_2018.json'
 -EBIRD_MDATA = 'metadata/eBird_grid_data_weekly.gz'
-+default_metadata_dir = os.path.abspath(os.path.dirname(__file__))
++default_metadata_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'metadata')
 +EBIRD_SPECIES_CODES = os.getenv('EBIRD_SPECIES_CODES', os.path.join(default_metadata_dir, 'eBird_taxonomy_codes_2018.json'))
 +EBIRD_MDATA = os.getenv('EBIRD_SPECIES_CODES', os.path.join(default_metadata_dir, 'eBird_grid_data_weekly.gz'))
  USE_EBIRD_CHECKLIST = True

--- a/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214_add-model-path-envvar.patch
+++ b/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214_add-model-path-envvar.patch
@@ -16,3 +16,22 @@ Author: Bob Dröge (University of Groningen)
  
      # Build simple model
      net = model.buildNet()
+
+--- config.py	2021-04-22 12:36:49.833750795 +0200
++++ config.py	2021-04-22 12:39:27.162404283 +0200
+@@ -1,9 +1,12 @@
++import os
++
+ # BirdNET uses eBird checklist frequency data to determine plausible species
+ # occurrences for a specific location (lat, lon) and one week. An EBIRD_THRESHOLD
+ # of 0.02 means that a species must occur on at least 2% of all checklists
+ # for a location to be considered plausible.
+-EBIRD_SPECIES_CODES = 'metadata/eBird_taxonomy_codes_2018.json'
+-EBIRD_MDATA = 'metadata/eBird_grid_data_weekly.gz'
++default_metadata_dir = os.path.abspath(os.path.dirname(__file__))
++EBIRD_SPECIES_CODES = os.getenv('EBIRD_SPECIES_CODES', os.path.join(default_metadata_dir, 'eBird_taxonomy_codes_2018.json'))
++EBIRD_MDATA = os.getenv('EBIRD_SPECIES_CODES', os.path.join(default_metadata_dir, 'eBird_grid_data_weekly.gz'))
+ USE_EBIRD_CHECKLIST = True
+ EBIRD_THRESHOLD = 0.02
+ DEPLOYMENT_LOCATION = (-1, -1)
+


### PR DESCRIPTION
The patch included with PR #12685 didn't seem to work correctly, as the main script (`analyze.py`) has some relative paths to files in a subdir of the installation. By calling the script for any location other than the installation dir, this leads to errors. This new patch fixes it by prepending the location by the path to the script that is being called.