### PR TITLE
Fix wrong variable name in BirdNET patch

### DIFF
--- a/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214-fosscuda-2019b-Python-3.7.4.eb
@@ -32,7 +32,7 @@ patches = ['BirdNET-20201214_add-model-path-envvar.patch']
 checksums = [
     '3a7a5f562bfdd55138603847d206125328f02a25df5e86278d2fb35242bb1c1d',  # BirdNET-20201214.tar.gz
     '7db0b2fe57da002aff62fe1aecf56b16065c2b699dcbee1d8d7e07a42719b3fe',  # BirdNET_Soundscape_Model.pkl
-    'e27409a304e7b2a3d27b6db575c25db9bf6c6be478468f3ffdc33898f20c6ea5',  # BirdNET-20201214_add-model-path-envvar.patch
+    'd7587d82a4c21df58c589b9044df720752abab7efcb2769a671f75feb9661337',  # BirdNET-20201214_add-model-path-envvar.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214_add-model-path-envvar.patch
+++ b/easybuild/easyconfigs/b/BirdNET/BirdNET-20201214_add-model-path-envvar.patch
@@ -1,6 +1,9 @@
 The location to a model snapshot file is hardcoded in the analyze.py script.
 This patch allows users to override the default location to that file by setting $BIRDNET_MODEL.
 
+The same is done for two locations to metadata files in config.py;
+they can now be overridden by using $EBIRD_SPECIES_CODES and $EBIRD_MDATA.
+
 Author: Bob Dröge (University of Groningen)
 
 --- analyze.py	2021-04-20 15:16:25.000000000 +0200
@@ -30,7 +33,7 @@ Author: Bob Dröge (University of Groningen)
 -EBIRD_MDATA = 'metadata/eBird_grid_data_weekly.gz'
 +default_metadata_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'metadata')
 +EBIRD_SPECIES_CODES = os.getenv('EBIRD_SPECIES_CODES', os.path.join(default_metadata_dir, 'eBird_taxonomy_codes_2018.json'))
-+EBIRD_MDATA = os.getenv('EBIRD_SPECIES_CODES', os.path.join(default_metadata_dir, 'eBird_grid_data_weekly.gz'))
++EBIRD_MDATA = os.getenv('EBIRD_MDATA', os.path.join(default_metadata_dir, 'eBird_grid_data_weekly.gz'))
  USE_EBIRD_CHECKLIST = True
  EBIRD_THRESHOLD = 0.02
  DEPLOYMENT_LOCATION = (-1, -1)


### PR DESCRIPTION
Found one more issue after #12685 and #12712 were merged: the name of one of the environment variables that is being checked is wrong (too much copy-pasting...). This should fix that, and also adds a comment about the purpose of the 2nd part of the patch.