### PR TITLE
add check to make sure that source step is not being skipped

### DIFF
--- a/easybuild/easyconfigs/f/fastqz/fastqz-1.5-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/f/fastqz/fastqz-1.5-GCC-4.8.2.eb
@@ -11,6 +11,7 @@ easyblock = 'CmdCp'
 
 name = 'fastqz'
 version = '1.5'
+local_minver = ''.join(version.split('.'))
 
 homepage = 'http://mattmahoney.net/dc/fastqz/'
 description = """fastqz is a compressor for FASTQ files. FASTQ is the output of DNA sequencing machines.
@@ -18,16 +19,19 @@ description = """fastqz is a compressor for FASTQ files. FASTQ is the output of 
  FASTQ and SAM Format Sequencing Data. (mirror) PLoS ONE 8(3): e59190. doi:10.1371/journal.pone.0059190"""
 
 toolchain = {'name': 'GCC', 'version': '4.8.2'}
-toolchainopts = {'opt': True, 'optarch': True}
+toolchainopts = {'opt': True}
 
-local_minver = ''.join(version.split('.'))
-sources = ['fastqz%s.cpp' % local_minver, 'fapack.cpp']
 source_urls = [homepage]
-checksums = ['0a55cd15605ddf32c31dac5af8c0f442', '490efab4389637da5566cf5173b1d274']
+sources = [
+    {'filename': 'fastqz%s.cpp' % local_minver, 'extract_cmd': "cp %s ."},
+    {'filename': 'fapack.cpp', 'extract_cmd': "cp %s ."},
+]
+checksums = [
+    '67ead53084fe96bad337e66f4447070c113b71726f7e5e586bec0ade4a5b85dd',  # fastqz15.cpp
+    'cedfb0f3641f7c47333a0a66deff1da1356509fda80a60b1777759c95090b1da',  # fapack.cpp
+]
 
 dependencies = [('ZPAQ', '7.00')]
-
-skipsteps = ['source']
 
 cmds_map = [
     ('fastqz%s.cpp' % local_minver, '$CXX $CFLAGS -lpthread %%(source)s $EBROOTZPAQ/include/libzpaq.cpp -o %(name)s'),

--- a/easybuild/easyconfigs/g/Genome_Profiler/Genome_Profiler-2.1-foss-2016b-Perl-5.24.0.eb
+++ b/easybuild/easyconfigs/g/Genome_Profiler/Genome_Profiler-2.1-foss-2016b-Perl-5.24.0.eb
@@ -16,15 +16,12 @@ description = """Genome Profiler (GeP) is a program to perform whole-genome mult
 toolchain = {'name': 'foss', 'version': '2016b'}
 
 source_urls = ['https://sourceforge.net/projects/genomeprofiler/files/Genome_Profiler_%(version)s/']
-sources = [{'download_filename': 'GeP.pl', 'filename': 'GeP-%(version)s.pl'}]
+sources = [{'download_filename': 'GeP.pl', 'filename': 'GeP-%(version)s.pl', 'extract_cmd': "cp %s ."}]
 checksums = ['212624965f84316663499751b117608e30b2074675c0e8d38aa8c5f8f6a86a99']
 
 dependencies = [
     ('Perl', '5.24.0'),
 ]
-
-# skip uncompress because this is plain .pl file
-skipsteps = ['source']
 
 cmds_map = [("GeP.*\.pl", "cp %(source)s GeP.pl")]
 

--- a/easybuild/easyconfigs/s/STREAM/STREAM-5.10-GCC-7.3.0-2.30.eb
+++ b/easybuild/easyconfigs/s/STREAM/STREAM-5.10-GCC-7.3.0-2.30.eb
@@ -11,10 +11,8 @@ toolchain = {'name': 'GCC', 'version': '7.3.0-2.30'}
 toolchainopts = {'openmp': True}
 
 source_urls = ['https://www.cs.virginia.edu/stream/FTP/Code/']
-sources = [{'download_filename': '%(namelower)s.c', 'filename': 'stream-%(version)s.c'}]
+sources = [{'download_filename': '%(namelower)s.c', 'filename': 'stream-%(version)s.c', 'extract_cmd': "cp %s ."}]
 checksums = ['a52bae5e175bea3f7832112af9c085adab47117f7d2ce219165379849231692b']
-
-skipsteps = ['source']
 
 # 10 million array elements (1000 runs): requires ~224MB of memory
 local_cmds = "$CC $CFLAGS %(source)s -mcmodel=large -DSTREAM_ARRAY_SIZE=10000000 -DNTIMES=1000 -o stream_1Kx10M; "

--- a/easybuild/easyconfigs/s/STREAM/STREAM-5.10-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/s/STREAM/STREAM-5.10-GCC-8.2.0-2.31.1.eb
@@ -11,10 +11,8 @@ toolchain = {'name': 'GCC', 'version': '8.2.0-2.31.1'}
 toolchainopts = {'openmp': True}
 
 source_urls = ['https://www.cs.virginia.edu/stream/FTP/Code/']
-sources = [{'download_filename': '%(namelower)s.c', 'filename': 'stream-%(version)s.c'}]
+sources = [{'download_filename': '%(namelower)s.c', 'filename': 'stream-%(version)s.c', 'extract_cmd': "cp %s ."}]
 checksums = ['a52bae5e175bea3f7832112af9c085adab47117f7d2ce219165379849231692b']
-
-skipsteps = ['source']
 
 # 10 million array elements (1000 runs): requires ~224MB of memory
 local_cmds = "$CC $CFLAGS %(source)s -mcmodel=large -DSTREAM_ARRAY_SIZE=10000000 -DNTIMES=1000 -o stream_1Kx10M; "

--- a/easybuild/easyconfigs/s/STREAM/STREAM-5.10-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/s/STREAM/STREAM-5.10-GCC-9.3.0.eb
@@ -11,10 +11,8 @@ toolchain = {'name': 'GCC', 'version': '9.3.0'}
 toolchainopts = {'openmp': True}
 
 source_urls = ['https://www.cs.virginia.edu/stream/FTP/Code/']
-sources = [{'download_filename': '%(namelower)s.c', 'filename': 'stream-%(version)s.c'}]
+sources = [{'download_filename': '%(namelower)s.c', 'filename': 'stream-%(version)s.c', 'extract_cmd': "cp %s ."}]
 checksums = ['a52bae5e175bea3f7832112af9c085adab47117f7d2ce219165379849231692b']
-
-skipsteps = ['source']
 
 # 10 million array elements (1000 runs): requires ~224MB of memory
 local_cmds = "$CC $CFLAGS %(source)s -mcmodel=large -DSTREAM_ARRAY_SIZE=10000000 -DNTIMES=1000 -o stream_1Kx10M; "

--- a/easybuild/easyconfigs/s/STREAM/STREAM-5.10-iccifort-2020.1.217.eb
+++ b/easybuild/easyconfigs/s/STREAM/STREAM-5.10-iccifort-2020.1.217.eb
@@ -11,10 +11,8 @@ toolchain = {'name': 'iccifort', 'version': '2020.1.217'}
 toolchainopts = {'openmp': True}
 
 source_urls = ['https://www.cs.virginia.edu/stream/FTP/Code/']
-sources = [{'download_filename': '%(namelower)s.c', 'filename': 'stream-%(version)s.c'}]
+sources = [{'download_filename': '%(namelower)s.c', 'filename': 'stream-%(version)s.c', 'extract_cmd': "cp %s ."}]
 checksums = ['a52bae5e175bea3f7832112af9c085adab47117f7d2ce219165379849231692b']
-
-skipsteps = ['source']
 
 # 10 million array elements (1000 runs): requires ~224MB of memory
 local_cmds = "$CC $CFLAGS %(source)s -mcmodel=large -DSTREAM_ARRAY_SIZE=10000000 -DNTIMES=1000 -o stream_1Kx10M; "

--- a/easybuild/easyconfigs/s/STREAM/STREAM-5.10-intel-2016b.eb
+++ b/easybuild/easyconfigs/s/STREAM/STREAM-5.10-intel-2016b.eb
@@ -11,10 +11,8 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 toolchainopts = {'openmp': True}
 
 source_urls = ['https://www.cs.virginia.edu/stream/FTP/Code/']
-sources = [{'download_filename': '%(namelower)s.c', 'filename': 'stream-%(version)s.c'}]
+sources = [{'download_filename': '%(namelower)s.c', 'filename': 'stream-%(version)s.c', 'extract_cmd': "cp %s ."}]
 checksums = ['a52bae5e175bea3f7832112af9c085adab47117f7d2ce219165379849231692b']
-
-skipsteps = ['source']
 
 # 10 million array elements (1000 runs): requires ~224MB of memory
 local_cmds = "$CC $CFLAGS %(source)s -mcmodel=large -DSTREAM_ARRAY_SIZE=10000000 -DNTIMES=1000 -o stream_1Kx10M; "

--- a/easybuild/easyconfigs/s/STREAM/STREAM-5.10-intel-2018b.eb
+++ b/easybuild/easyconfigs/s/STREAM/STREAM-5.10-intel-2018b.eb
@@ -11,10 +11,8 @@ toolchain = {'name': 'intel', 'version': '2018b'}
 toolchainopts = {'openmp': True}
 
 source_urls = ['https://www.cs.virginia.edu/stream/FTP/Code/']
-sources = [{'download_filename': '%(namelower)s.c', 'filename': 'stream-%(version)s.c'}]
+sources = [{'download_filename': '%(namelower)s.c', 'filename': 'stream-%(version)s.c', 'extract_cmd': "cp %s ."}]
 checksums = ['a52bae5e175bea3f7832112af9c085adab47117f7d2ce219165379849231692b']
-
-skipsteps = ['source']
 
 # 10 million array elements (1000 runs): requires ~224MB of memory
 local_cmds = "$CC $CFLAGS %(source)s -mcmodel=large -DSTREAM_ARRAY_SIZE=10000000 -DNTIMES=1000 -o stream_1Kx10M; "

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1120,6 +1120,11 @@ def template_easyconfig_test(self, spec):
             res = verify_checksum(patch_full, checksum)
             self.assertTrue(res, error_msg)
 
+    # make sure 'source' step is not being skipped,
+    # since that implies not verifying the checksum
+    error_msg = "'source' step should not be skipped in %s, since that implies not verifying checksums" % ec_fn
+    self.assertFalse(ec['checksums'] and ('source' in ec['skipsteps']), error_msg)
+
     for ext in ec['exts_list']:
         if isinstance(ext, (tuple, list)) and len(ext) == 3:
 


### PR DESCRIPTION
Skipping the `source` step implies not verifying checksums, so we shouldn't do that...

requires ~~#12794~~ (fixes for FastTree)
