### PR TITLE
{astro}[intelcuda/2020b] astropy v4.2.1 w/ Python 3.8.6

### DIFF
--- a/easybuild/easyconfigs/a/astropy/astropy-4.2.1-intelcuda-2020b.eb
+++ b/easybuild/easyconfigs/a/astropy/astropy-4.2.1-intelcuda-2020b.eb
@@ -1,0 +1,41 @@
+easyblock = 'PythonBundle'
+
+name = 'astropy'
+version = '4.2.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://www.astropy.org/'
+description = """The Astropy Project is a community effort to develop 
+a single core package for Astronomy in Python and foster interoperability 
+between Python astronomy packages."""
+
+toolchain = {'name': 'intelcuda', 'version': '2020b'}
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('SciPy-bundle', '2020.11'),
+]
+
+use_pip = True
+
+sanity_pip_check = True
+
+exts_list = [
+    ('pyerfa', '1.7.3', {
+        'modulename': 'erfa',
+        'checksums': ['6cf3a645d63e0c575a357797903eac5d2c6591d7cdb89217c8c4d39777cf18cb'],
+    }),
+    ('extension-helpers', '0.1', {
+        'checksums': ['ac8a6fe91c6d98986a51a9f08ca0c7945f8fd70d95b662ced4040ae5eb973882'],
+    }),
+    (name, version, {
+        'checksums': ['ed483e472241153daec45f4b0c318c2c63d9f47305b78e6e63d32fc388c18427'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/astropy'],
+}
+
+moduleclass = 'astro'

--- a/easybuild/easyconfigs/a/astropy/astropy-4.2.1-intelcuda-2020b.eb
+++ b/easybuild/easyconfigs/a/astropy/astropy-4.2.1-intelcuda-2020b.eb
@@ -2,7 +2,6 @@ easyblock = 'PythonBundle'
 
 name = 'astropy'
 version = '4.2.1'
-versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://www.astropy.org/'
 description = """The Astropy Project is a community effort to develop 


### PR DESCRIPTION
Adding astropy-4.2.1 into intel-cuda-2020b. Astropy documentation adds dependency on ERFA so adding it and replacing deprecated astropy-helpers with extension-helpers.