### PR TITLE
{data}[foss/2018b,foss/2019b] fix configure options for ROOT v6.14.06 and v6.20.04

### DIFF
--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.14.06-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.14.06-foss-2018b-Python-2.7.15.eb
@@ -39,11 +39,14 @@ dependencies = [
     ('libpng', '1.6.34'),
 ]
 
+# NOTE: Ensure that each configopts string begins with a blank
 # disable some components
-configopts = "-Dxrootd=OFF -Dmysql=OFF -Dkrb5=OFF -Dodbc=OFF -Doracle=OFF -Dpgsql=OFF -Dqt=OFF"
+configopts = " -Dxrootd=OFF -Dmysql=OFF -Dkrb5=OFF -Dodbc=OFF -Doracle=OFF -Dpgsql=OFF -Dqt=OFF"
 
 # make sure some components are enabled
 configopts += " -Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON -Droofit=ON"
+
+# Add component-specific settings based on dependencies
 configopts += " -Dfftw3=ON -Dgsl_shared=ON -DOpenGL_GL_PREFERENCE=GLVND"
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.14.06-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.14.06-foss-2018b-Python-2.7.15.eb
@@ -40,9 +40,10 @@ dependencies = [
 ]
 
 # disable some components
-configopts = "-Dxrootd=OFF -Dmysql=OFF -Dkrb5=OFF -Dodbc=OFF -Doracle=OFF -Dpgsql=OFF -Dqt=OFF "
+configopts = "-Dxrootd=OFF -Dmysql=OFF -Dkrb5=OFF -Dodbc=OFF -Doracle=OFF -Dpgsql=OFF -Dqt=OFF"
 
 # make sure some components are enabled
-configopts += "-Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON -Droofit=ON "
+configopts += " -Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON -Droofit=ON"
+configopts += " -Dfftw3=ON -Dgsl_shared=ON -DOpenGL_GL_PREFERENCE=GLVND"
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.14.06-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.14.06-foss-2018b-Python-3.6.6.eb
@@ -44,10 +44,9 @@ dependencies = [
 configopts = " -Dxrootd=OFF -Dmysql=OFF -Dkrb5=OFF -Dodbc=OFF -Doracle=OFF -Dpgsql=OFF -Dqt=OFF"
 
 # make sure some components are enabled
-configopts += " -Dpython=ON -Dpython3=ON -Dpcre=ON -Dzlib=ON"
 configopts += " -Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON -Droofit=ON "
 
 # Add component-specific settings based on dependencies
-configopts += ' -Dfftw3=ON -Dgsl=ON -DOpenGL_GL_PREFERENCE=GLVND'
+configopts += ' -Dfftw3=ON -Dgsl_shared=ON -DOpenGL_GL_PREFERENCE=GLVND'
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.14.06-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.14.06-foss-2018b-Python-3.6.6.eb
@@ -44,9 +44,9 @@ dependencies = [
 configopts = " -Dxrootd=OFF -Dmysql=OFF -Dkrb5=OFF -Dodbc=OFF -Doracle=OFF -Dpgsql=OFF -Dqt=OFF"
 
 # make sure some components are enabled
-configopts += " -Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON -Droofit=ON "
+configopts += " -Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON -Droofit=ON"
 
 # Add component-specific settings based on dependencies
-configopts += ' -Dfftw3=ON -Dgsl_shared=ON -DOpenGL_GL_PREFERENCE=GLVND'
+configopts += " -Dfftw3=ON -Dgsl_shared=ON -DOpenGL_GL_PREFERENCE=GLVND"
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.20.04-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.20.04-foss-2019b-Python-3.7.4.eb
@@ -43,13 +43,12 @@ dependencies = [
 
 # NOTE: Ensure that each configopts string begins with a blank
 # disable some components
-configopts = " -Dxrootd=OFF -Dmysql=OFF -Dkrb5=OFF -Dodbc=OFF -Doracle=OFF -Dpgsql=OFF -Dqt=OFF"
+configopts = " -Dxrootd=OFF -Dmysql=OFF -Dodbc=OFF -Doracle=OFF -Dpgsql=OFF"
 
 # make sure some components are enabled
-configopts += " -Dpython=ON -Dpython3=ON -Dpcre=ON -Dzlib=ON"
-configopts += " -Dunuran=ON -Dexplicitlink=ON -Dminuit2=ON -Droofit=ON "
+configopts += " -Dpyroot=ON -Dunuran=ON -Dminuit2=ON -Droofit=ON"
 
 # Add component-specific settings based on dependencies
-configopts += ' -Dfftw3=ON -Dgsl=ON -DOpenGL_GL_PREFERENCE=GLVND'
+configopts += ' -Dfftw3=ON -Dgsl_shared=ON -DOpenGL_GL_PREFERENCE=GLVND'
 
 moduleclass = 'data'


### PR DESCRIPTION
Refers to issue #12830 

Options
`-Dpython=ON -Dpython3=ON -Dpcre=ON -Dzlib=ON -Dgsl=ON`
Were removed for 6.14.06, they no longer have any function. Those features are now mandatory. In addition, the builtins are disabled by default, which is correct since easybuild provides the external dependency for them. I suppose if you wanted, you could explicitly disable the builtins to keep a record in the file. 

Option
`-Dgsl_shared=ON`
Was added for 6.14.06, but as far as I can tell, it does nothing. 

Option
`-Dexplicitlink=ON`
Was removed for 6.20.04, it no longer has any function. That feature is now mandatory. 

Option
`-Dpyroot=ON`
Was added for 6.20.04, but its default value is ON so this definition actually does nothing. 