### PR TITLE
{phys}[foss/2020b,intel/2020b] PSolver v1.8.3

### DIFF
--- a/easybuild/easyconfigs/f/futile/futile-1.8.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/f/futile/futile-1.8.3-foss-2020b.eb
@@ -1,0 +1,37 @@
+easyblock = 'ConfigureMake'
+
+name = 'futile'
+version = '1.8.3'
+
+homepage = 'https://launchpad.net/futile'
+description = """
+ The FUTILE project (Fortran Utilities for the Treatment of Innermost Level of Executables) is a set of modules 
+ and wrapper that encapsulate the most common low-level operations of a Fortran code.
+ """
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+toolchainopts = {'usempi': True}
+
+sources = ['bigdft-suite-%(version)s.tar.gz']
+source_urls = ['https://launchpad.net/bigdft/%(version_major_minor)s/%(version)s/+download/']
+checksums = ['7ecb968a16e9cba35966f9f4d8acc454']
+
+unpack_options = " spred-suite/futile-%(version_major_minor)s.tar.gz --strip 1 && "
+unpack_options += "tar xzf futile-%(version_major_minor)s.tar.gz --transform='s,%(version_major_minor)s,%(version)s,'"
+start_dir = "futile-%(version)s"
+
+configopts = 'CC=$MPICC FC=$MPIFC FCFLAGS="$FCLAGS -fallow-argument-mismatch" '
+configopts += '--enable-mpi '
+configopts += '--with-ext-linalg="-L$SCALAPACK_LIB_DIR $LIBSCALAPACK '
+configopts += '-L$BLACS_LIB_DIR $LIBBLACS -L$LAPACK_LIB_DIR $LIBLAPACK -L$BLAS_LIB_DIR $LIBBLAS" '
+configopts += '--with-yaml-path=$EBROOTLIBYAML '
+
+dependencies = [('libyaml', '0.2.5')]
+
+sanity_check_paths = {
+    'files': ['include/futile.mod', 'include/futile.h', 'bin/futilevars.sh'] +
+             [('lib/libfutile-1.a', 'lib64/libfutile-1.a')],
+    'dirs': []
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/f/futile/futile-1.8.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/f/futile/futile-1.8.3-foss-2020b.eb
@@ -12,9 +12,9 @@ description = """
 toolchain = {'name': 'foss', 'version': '2020b'}
 toolchainopts = {'usempi': True}
 
-sources = ['bigdft-suite-%(version)s.tar.gz']
 source_urls = ['https://launchpad.net/bigdft/%(version_major_minor)s/%(version)s/+download/']
-checksums = ['7ecb968a16e9cba35966f9f4d8acc454']
+sources = ['bigdft-suite-%(version)s.tar.gz']
+checksums = ['39aeae8bd62ad5d82ed20a47006aa478d93b3751ae7929027088c2e6b8439388']
 
 unpack_options = " spred-suite/futile-%(version_major_minor)s.tar.gz --strip 1 && "
 unpack_options += "tar xzf futile-%(version_major_minor)s.tar.gz --transform='s,%(version_major_minor)s,%(version)s,'"

--- a/easybuild/easyconfigs/f/futile/futile-1.8.3-intel-2020b.eb
+++ b/easybuild/easyconfigs/f/futile/futile-1.8.3-intel-2020b.eb
@@ -1,0 +1,41 @@
+easyblock = 'ConfigureMake'
+
+name = 'futile'
+version = '1.8.3'
+
+homepage = 'https://launchpad.net/futile'
+description = """
+ The FUTILE project (Fortran Utilities for the Treatment of Innermost Level of Executables) is a set of modules 
+ and wrapper that encapsulate the most common low-level operations of a Fortran code.
+ """
+
+toolchain = {'name': 'intel', 'version': '2020b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://launchpad.net/bigdft/%(version_major_minor)s/%(version)s/+download/']
+sources = ['bigdft-suite-%(version)s.tar.gz']
+patches = ['futile_intel_bug.patch']
+checksums = [
+    '39aeae8bd62ad5d82ed20a47006aa478d93b3751ae7929027088c2e6b8439388',  # bigdft-suite-1.8.3.tar.gz
+    '9efc3f94cdb6131b00715afcdeb16c7ed016b8fc69a2c95f4449088bf79f84ba',  # futile_intel_bug.patch
+]
+
+unpack_options = " spred-suite/futile-%(version_major_minor)s.tar.gz --strip 1 && "
+unpack_options += "tar xzf futile-%(version_major_minor)s.tar.gz --transform='s,%(version_major_minor)s,%(version)s,'"
+start_dir = "futile-%(version)s"
+
+configopts = 'CC=$MPICC FC=$MPIFC '
+configopts += '--enable-mpi '
+configopts += '--with-ext-linalg="-L$SCALAPACK_LIB_DIR $LIBSCALAPACK '
+configopts += '-L$BLACS_LIB_DIR $LIBBLACS -L$LAPACK_LIB_DIR $LIBLAPACK -L$BLAS_LIB_DIR $LIBBLAS" '
+configopts += '--with-yaml-path=$EBROOTLIBYAML '
+
+dependencies = [('libyaml', '0.2.5')]
+
+sanity_check_paths = {
+    'files': ['include/futile.mod', 'include/futile.h', 'bin/futilevars.sh'] +
+             [('lib/libfutile-1.a', 'lib64/libfutile-1.a')],
+    'dirs': []
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/f/futile/futile-1.8.3-intel-2020b.eb
+++ b/easybuild/easyconfigs/f/futile/futile-1.8.3-intel-2020b.eb
@@ -17,7 +17,7 @@ sources = ['bigdft-suite-%(version)s.tar.gz']
 patches = ['futile_intel_bug.patch']
 checksums = [
     '39aeae8bd62ad5d82ed20a47006aa478d93b3751ae7929027088c2e6b8439388',  # bigdft-suite-1.8.3.tar.gz
-    '9efc3f94cdb6131b00715afcdeb16c7ed016b8fc69a2c95f4449088bf79f84ba',  # futile_intel_bug.patch
+    'e3681e6dda9364a1be4fba937423b8ac1774c3ebfd1ff04211482df25a188e95',  # futile_intel_bug.patch
 ]
 
 unpack_options = " spred-suite/futile-%(version_major_minor)s.tar.gz --strip 1 && "

--- a/easybuild/easyconfigs/f/futile/futile_intel_bug.patch
+++ b/easybuild/easyconfigs/f/futile/futile_intel_bug.patch
@@ -1,0 +1,47 @@
+diff -rup futile-1.8.3.orig/flib/fpython.f90 futile-1.8.3/flib/fpython.f90
+--- futile-1.8.3.orig/flib/fpython.f90	2019-08-29 17:04:28.319733800 +0200
++++ futile-1.8.3/flib/fpython.f90	2019-08-29 17:04:34.895795372 +0200
+@@ -1,6 +1,7 @@
+ module f_python
+   use f_precisions, only: f_address
+-
++  use dictionaries
++  
+   implicit none
+ 
+   !> Equivalent type than the numpy one, to be able
+@@ -24,7 +25,7 @@ module f_python
+ 
+   interface
+      subroutine f_python_initialize(iproc, nproc, igroup, ngroup)
+-       use dictionaries
++       import
+        implicit none
+        integer, intent(in) :: iproc, nproc, igroup, ngroup
+      end subroutine f_python_initialize
+@@ -32,14 +33,14 @@ module f_python
+ 
+   interface
+      subroutine f_python_finalize()
+-       use dictionaries
++       import
+        implicit none
+      end subroutine f_python_finalize
+   end interface
+ 
+   interface
+      subroutine f_python_execute_dict(dict, status)
+-       use dictionaries
++       import
+        implicit none
+        type(dictionary), pointer :: dict
+        integer, intent(out) :: status
+@@ -48,7 +49,7 @@ module f_python
+ 
+   interface
+      subroutine f_python_execute(script, status)
+-       use dictionaries
++       import
+        implicit none
+        character(len = *), intent(in) :: script
+        integer, intent(out) :: status

--- a/easybuild/easyconfigs/f/futile/futile_intel_bug.patch
+++ b/easybuild/easyconfigs/f/futile/futile_intel_bug.patch
@@ -1,3 +1,6 @@
+Patch to fix compilation with the Intel compiler. It replaces some 'use'
+statements with 'import' in several interfaces.
+author: Micael Oliveira (Max Planck Institute for the Structure and Dynamics of Matter)
 diff -rup futile-1.8.3.orig/flib/fpython.f90 futile-1.8.3/flib/fpython.f90
 --- futile-1.8.3.orig/flib/fpython.f90	2019-08-29 17:04:28.319733800 +0200
 +++ futile-1.8.3/flib/fpython.f90	2019-08-29 17:04:34.895795372 +0200

--- a/easybuild/easyconfigs/p/PSolver/PSolver-1.8.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/p/PSolver/PSolver-1.8.3-foss-2020b.eb
@@ -11,9 +11,9 @@ description = """
 toolchain = {'name': 'foss', 'version': '2020b'}
 toolchainopts = {'usempi': True, 'opt': True}
 
-sources = ['bigdft-suite-%(version)s.tar.gz']
 source_urls = ['https://launchpad.net/bigdft/%(version_major_minor)s/%(version)s/+download/']
-checksums = ['7ecb968a16e9cba35966f9f4d8acc454']
+sources = ['bigdft-suite-%(version)s.tar.gz']
+checksums = ['39aeae8bd62ad5d82ed20a47006aa478d93b3751ae7929027088c2e6b8439388']
 
 local_cddir = ' cd psolver-%(version_major_minor)s && '
 preconfigopts = 'tar xzf psolver-%(version_major_minor)s.tar.gz &&' + local_cddir

--- a/easybuild/easyconfigs/p/PSolver/PSolver-1.8.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/p/PSolver/PSolver-1.8.3-foss-2020b.eb
@@ -1,0 +1,38 @@
+easyblock = 'ConfigureMake'
+
+name = 'PSolver'
+version = '1.8.3'
+
+homepage = 'http://bigdft.org/devel-doc/d1/d81/group__PSOLVER.html'
+description = """
+ Interpolating scaling function Poisson Solver Library
+ """
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+toolchainopts = {'usempi': True, 'opt': True}
+
+sources = ['bigdft-suite-%(version)s.tar.gz']
+source_urls = ['https://launchpad.net/bigdft/%(version_major_minor)s/%(version)s/+download/']
+checksums = ['7ecb968a16e9cba35966f9f4d8acc454']
+
+local_cddir = ' cd psolver-%(version_major_minor)s && '
+preconfigopts = 'tar xzf psolver-%(version_major_minor)s.tar.gz &&' + local_cddir
+configopts = 'CC=$MPICC FC=$MPIFC FCFLAGS="$FCFLAGS -fallow-argument-mismatch -I$EBROOTFUTILE/include" '
+configopts += ' --with-ext-linalg="-L$BLACS_LIB_DIR $LIBBLACS -L$SCALAPACK_LIB_DIR $LIBSCALAPACK"'\
+              '" -L$BLAS_LIB_DIR $LIBBLAS -L$LAPACK_LIB_DIR $LIBLAPACK" '
+configopts += ' --with-mpi3 '
+prebuildopts = local_cddir
+preinstallopts = local_cddir
+
+dependencies = [
+    ('libyaml', '0.2.5'),
+    ('futile', '1.8.3')
+]
+
+sanity_check_paths = {
+    'files': ['include/poisson_solver.mod'] +
+             [('lib/libPSolver-1.a', 'lib64/libPSolver-1.a')],
+    'dirs': []
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/p/PSolver/PSolver-1.8.3-intel-2020b.eb
+++ b/easybuild/easyconfigs/p/PSolver/PSolver-1.8.3-intel-2020b.eb
@@ -1,0 +1,38 @@
+easyblock = 'ConfigureMake'
+
+name = 'PSolver'
+version = '1.8.3'
+
+homepage = 'http://bigdft.org/devel-doc/d1/d81/group__PSOLVER.html'
+description = """
+ Interpolating scaling function Poisson Solver Library
+ """
+
+toolchain = {'name': 'intel', 'version': '2020b'}
+toolchainopts = {'usempi': True, 'opt': True}
+
+sources = ['bigdft-suite-%(version)s.tar.gz']
+source_urls = ['https://launchpad.net/bigdft/%(version_major_minor)s/%(version)s/+download/']
+checksums = ['7ecb968a16e9cba35966f9f4d8acc454']
+
+local_cddir = ' cd psolver-%(version_major_minor)s && '
+preconfigopts = 'tar xzf psolver-%(version_major_minor)s.tar.gz &&' + local_cddir
+configopts = 'CC=$MPICC FC=$MPIFC FCFLAGS="$FCFLAGS -I$EBROOTFUTILE/include" '
+configopts += ' --with-ext-linalg="-L$BLACS_LIB_DIR $LIBBLACS -L$SCALAPACK_LIB_DIR $LIBSCALAPACK"'\
+              '" -L$BLAS_LIB_DIR $LIBBLAS -L$LAPACK_LIB_DIR $LIBLAPACK" '
+configopts += ' --with-mpi3 '
+prebuildopts = local_cddir
+preinstallopts = local_cddir
+
+dependencies = [
+    ('libyaml', '0.2.5'),
+    ('futile', '1.8.3')
+]
+
+sanity_check_paths = {
+    'files': ['include/poisson_solver.mod'] +
+             [('lib/libPSolver-1.a', 'lib64/libPSolver-1.a')],
+    'dirs': []
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/p/PSolver/PSolver-1.8.3-intel-2020b.eb
+++ b/easybuild/easyconfigs/p/PSolver/PSolver-1.8.3-intel-2020b.eb
@@ -11,9 +11,9 @@ description = """
 toolchain = {'name': 'intel', 'version': '2020b'}
 toolchainopts = {'usempi': True, 'opt': True}
 
-sources = ['bigdft-suite-%(version)s.tar.gz']
 source_urls = ['https://launchpad.net/bigdft/%(version_major_minor)s/%(version)s/+download/']
-checksums = ['7ecb968a16e9cba35966f9f4d8acc454']
+sources = ['bigdft-suite-%(version)s.tar.gz']
+checksums = ['39aeae8bd62ad5d82ed20a47006aa478d93b3751ae7929027088c2e6b8439388']
 
 local_cddir = ' cd psolver-%(version_major_minor)s && '
 preconfigopts = 'tar xzf psolver-%(version_major_minor)s.tar.gz &&' + local_cddir


### PR DESCRIPTION
This version has a new dependency on the futile library, so we also include futile-1.8.3-foss-2020b and futile-1.8.3-foss-2020b.