### PR TITLE
Create GeneMark-ET-4.65-GCCcore-10.2.0.eb

### DIFF
--- a/easybuild/easyconfigs/g/GeneMark-ET/GeneMark-ET-4.65-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/g/GeneMark-ET/GeneMark-ET-4.65-GCCcore-10.2.0.eb
@@ -1,0 +1,26 @@
+easyblock = 'Tarball'
+
+name = 'GeneMark-ET'
+version = '4.65'
+
+homepage = 'http://exon.gatech.edu/GeneMark'
+description = "Eukaryotic gene prediction suite with automatic training"
+
+toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+
+# download via http://exon.gatech.edu/GeneMark/license_download.cgi
+sources = ['gmes_linux_64.tar.gz']
+checksums = ['62ea2dfa1954ab25edcc118dbeaeacf15924274fb9ed47bc54716cfd15ad04fe']
+
+dependencies = [('Perl', '5.32.0')]
+
+fix_perl_shebang_for = ['*.pl']
+
+sanity_check_paths = {
+    'files': ['gmes.cfg', 'gmes_petap.pl'],
+    'dirs': ['lib'],
+}
+
+modextrapaths = {'PATH': ''}
+
+moduleclass = 'bio'


### PR DESCRIPTION
Updated for latest versions of GeneMark, GCCcore and Perl5.