### PR TITLE
Add binutils-2.35.2 for SYSTEM and GCCcore-10.2.0

### DIFF
--- a/easybuild/easyconfigs/b/binutils/binutils-2.35.2-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.35.2-GCCcore-10.2.0.eb
@@ -1,0 +1,35 @@
+name = 'binutils'
+version = '2.35.2'
+
+homepage = 'https://directory.fsf.org/project/binutils/'
+description = "binutils: GNU binary utilities"
+
+toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+patches = ['binutils-2.34-readd-avx512-vmovd.patch']
+checksums = [
+    'f484f61c81aa679df84d358d9818d5bf3e71fd227303f234f72b24420d98d3cd',  # binutils-2.35.2.tar.gz
+    '45ecf7f5d198dd446d1a2e2a4d46b2747eb6fb8f2bfa18d7d42769e710e85716',  # binutils-2.34-readd-avx512-vmovd.patch
+]
+
+builddependencies = [
+    ('flex', '2.6.4'),
+    ('Bison', '3.7.1'),
+    # use same binutils version that was used when building GCC toolchain, to 'bootstrap' this binutils
+    ('binutils', version, '', True)
+]
+
+dependencies = [
+    # zlib is a runtime dep to avoid that it gets embedded in libbfd.so,
+    # see https://github.com/easybuilders/easybuild-easyblocks/issues/1350
+    ('zlib', '1.2.11'),
+]
+
+# avoid build failure when makeinfo command is not available
+# see https://sourceware.org/bugzilla/show_bug.cgi?id=15345
+buildopts = 'MAKEINFO=true'
+installopts = buildopts
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/binutils/binutils-2.35.2.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.35.2.eb
@@ -1,0 +1,30 @@
+name = 'binutils'
+version = '2.35.2'
+
+homepage = 'https://directory.fsf.org/project/binutils/'
+
+description = "binutils: GNU binary utilities"
+
+toolchain = SYSTEM
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+patches = ['binutils-2.34-readd-avx512-vmovd.patch']
+checksums = [
+    'f484f61c81aa679df84d358d9818d5bf3e71fd227303f234f72b24420d98d3cd',  # binutils-2.35.2.tar.gz
+    '45ecf7f5d198dd446d1a2e2a4d46b2747eb6fb8f2bfa18d7d42769e710e85716',  # binutils-2.34-readd-avx512-vmovd.patch
+]
+
+builddependencies = [
+    ('flex', '2.6.4'),
+    ('Bison', '3.7.1'),
+    # zlib required, but being linked in statically, so not a runtime dep
+    ('zlib', '1.2.11'),
+]
+
+# avoid build failure when makeinfo command is not available
+# see https://sourceware.org/bugzilla/show_bug.cgi?id=15345
+buildopts = 'MAKEINFO=true'
+installopts = buildopts
+
+moduleclass = 'tools'

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -575,7 +575,7 @@ class EasyConfigTest(TestCase):
 
         # restrict to checking dependencies of easyconfigs using common toolchains (start with 2018a)
         # and GCCcore subtoolchain for common toolchains, starting with GCCcore 7.x
-        for pattern in ['201[89][ab]', '20[2-9][0-9][ab]', r'GCCcore-[7-9]\.[0-9]']:
+        for pattern in ['20(1[89]|[2-9][0-9])[ab]', r'GCCcore-([7-9]|[1-9][0-9])\.[0-9]']:
             all_deps = {}
             regex = re.compile(r'^.*-(?P<tc_gen>%s).*\.eb$' % pattern)
 

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -188,9 +188,16 @@ class EasyConfigTest(TestCase):
 
         # filter out binutils with empty versionsuffix which is used to build toolchain compiler
         if dep == 'binutils' and len(dep_vars) > 1:
-            empty_vsuff_vars = [v for v in dep_vars.keys() if v.endswith('versionsuffix: ')]
-            if len(empty_vsuff_vars) == 1:
-                dep_vars = dict((k, v) for (k, v) in dep_vars.items() if k != empty_vsuff_vars[0])
+            # binutils 2.35 was updated to 2.35.2, but some ECs were left at 2.35
+            # So treat both as 2.35.2
+            ver_2_35 = dep_vars.pop('version: 2.35; versionsuffix: ', None)
+            if ver_2_35:
+                dep_vars.setdefault('version: 2.35.2; versionsuffix: ', {}).update(ver_2_35)
+
+            if len(dep_vars) > 1:
+                empty_vsuff_vars = [v for v in dep_vars.keys() if v.endswith('versionsuffix: ')]
+                if len(empty_vsuff_vars) == 1:
+                    dep_vars = dict((k, v) for (k, v) in dep_vars.items() if k != empty_vsuff_vars[0])
 
         # multiple variants of HTSlib is OK as long as they are deps for a matching version of BCFtools;
         # same goes for WRF and WPS


### PR DESCRIPTION
The least controversial part of https://github.com/easybuilders/easybuild-easyconfigs/pull/12920

With this merged it would be possible to use it as a builddependency for ECs that fail due to the error fixed in 2.35.2