### PR TITLE
dump easyconfig before initializing easyblock in order to compare it with original easyconfig

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1040,6 +1040,16 @@ def template_easyconfig_test(self, spec):
     error_msg = "%s relies on automagic fallback to ConfigureMake, should use easyblock = 'ConfigureMake' instead" % fn
     self.assertTrue(easyblock or app_class is not ConfigureMake, error_msg)
 
+    # dump the easyconfig file;
+    # this should be done before creating the easyblock instance (done below via app_class),
+    # because some easyblocks (like PythonBundle) modify easyconfig parameters at initialisation
+    handle, test_ecfile = tempfile.mkstemp()
+    os.close(handle)
+
+    ec.dump(test_ecfile)
+    dumped_ec = EasyConfigParser(test_ecfile).get_config_dict()
+    os.remove(test_ecfile)
+
     app = app_class(ec)
 
     # more sanity checks
@@ -1168,14 +1178,6 @@ def template_easyconfig_test(self, spec):
     app.close_log()
     os.remove(app.logfile)
 
-    # dump the easyconfig file
-    handle, test_ecfile = tempfile.mkstemp()
-    os.close(handle)
-
-    ec.dump(test_ecfile)
-    dumped_ec = EasyConfigParser(test_ecfile).get_config_dict()
-    os.remove(test_ecfile)
-
     # inject dummy values for templates that are only known at a later stage
     dummy_template_values = {
         'builddir': '/dummy/builddir',
@@ -1238,7 +1240,8 @@ def template_easyconfig_test(self, spec):
             error_msg = "%s value '%s' should start with '%s'" % (key, dumped_val, orig_val)
             self.assertTrue(dumped_val.startswith(orig_val), error_msg)
         else:
-            self.assertEqual(orig_val, dumped_val)
+            error_msg = "%s value should be equal in original and dumped easyconfig: '%s' vs '%s'"
+            self.assertEqual(orig_val, dumped_val, error_msg % (key, orig_val, dumped_val))
 
     # test passed, so set back to True
     single_tests_ok = True and prev_single_tests_ok
@@ -1265,7 +1268,7 @@ def suite():
             if spec.endswith('.eb') and spec != 'TEMPLATE.eb':
                 cnt += 1
                 innertest = make_inner_test(os.path.join(subpath, spec))
-                innertest.__doc__ = "Test for parsing of easyconfig %s" % spec
+                innertest.__doc__ = "Test for easyconfig %s" % spec
                 # double underscore so parsing tests are run first
                 innertest.__name__ = "test__parse_easyconfig_%s" % spec
                 setattr(EasyConfigTest, innertest.__name__, innertest)


### PR DESCRIPTION
This change is required because of the fix to `get_config_dict` in https://github.com/easybuilders/easybuild-framework/pull/3692 .

The result of the fix is that `ec.parser.get_config_dict()` now accurately reflects the original easyconfig file, whereas before the fix the value of mutable easyconfig parameters could have been tweaked by the easyblock constructor (like `PythonBundle` does for `exts_default_options`).

The easyconfig file that is dumped via `ec.dump()` will still include the modified easyconfig parameter though, and hence the comparison between the original easyconfig file and the dumped easyconfig file failed for easyconfigs that use an easyblock like `PythonBundle` that fiddles with easyconfig parameters at initialization.

Note that the behavior of `dump()` wasn't affected by the change in https://github.com/easybuilders/easybuild-framework/pull/3692, but we're now (accurately) comparing the parsed dumped easyconfig with the actual original easyconfig parameter as defined in the easyconfig file.

The fix here is to just dump the easyconfig file before the easyblock instance is created, so any tweaks done by the easyblock constructor to parameter values don't affect the value comparison for easyconfig parameters we want to do in the tests...