### PR TITLE
{vis}[intelcuda/2020b] OpenCV v4.5.1-contrib

### DIFF
--- a/easybuild/easyconfigs/o/OpenCV/OpenCV-4.5.1-icc_FindLibsPerf.cmake.patch
+++ b/easybuild/easyconfigs/o/OpenCV/OpenCV-4.5.1-icc_FindLibsPerf.cmake.patch
@@ -1,0 +1,16 @@
+IPP linker workaround for Intel compiler on Linux
+Reported: https://github.com/opencv/opencv/pull/19681
+Fixed: https://github.com/opencv/opencv/commit/6465e393b697cfdba1d38c155e245598ab302f33
+Likely not needed for OpenCV version > 4.5.2
+An alternative is to use -DOPENCV_FORCE_IPP_EXCLUDE_LIBS=ON 
+--- opencv-4.5.1/cmake/OpenCVFindLibsPerf.cmake
++++ opencv-4.5.1/cmake/OpenCVFindLibsPerf.cmake
+@@ -29,7 +29,7 @@ if(WITH_IPP)
+     if(OPENCV_FORCE_IPP_EXCLUDE_LIBS
+         OR (HAVE_IPP_ICV
+             AND UNIX AND NOT ANDROID AND NOT APPLE
+-            AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
++            AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|Intel"
+         )
+         AND NOT OPENCV_SKIP_IPP_EXCLUDE_LIBS
+     )

--- a/easybuild/easyconfigs/o/OpenCV/OpenCV-4.5.1-intelcuda-2020b-contrib.eb
+++ b/easybuild/easyconfigs/o/OpenCV/OpenCV-4.5.1-intelcuda-2020b-contrib.eb
@@ -55,13 +55,13 @@ dependencies = [
     ('libwebp', '1.1.0'),
     ('OpenEXR', '2.5.5'),
     ('JasPer', '2.0.24'),
-    ('Java', '11', '', True),
-    ('ant', '1.10.9', '-Java-%(javaver)s', True),
+    ('Java', '11', '', SYSTEM),
+    ('ant', '1.10.9', '-Java-%(javaver)s', SYSTEM),
     ('GLib', '2.66.1'),
     ('GTK+', '3.24.23'),
     ('HDF5', '1.10.7'),  # needed by hdf from contrib
     ('Eigen', '3.3.8'),
-    ('cuDNN', '8.0.4.30', '-CUDA-%(cudaver)s', True),
+    ('cuDNN', '8.0.4.30', '-CUDA-%(cudaver)s', SYSTEM),
 ]
 
 configopts = [

--- a/easybuild/easyconfigs/o/OpenCV/OpenCV-4.5.1-intelcuda-2020b-contrib.eb
+++ b/easybuild/easyconfigs/o/OpenCV/OpenCV-4.5.1-intelcuda-2020b-contrib.eb
@@ -61,7 +61,7 @@ dependencies = [
     ('GTK+', '3.24.23'),
     ('HDF5', '1.10.7'),  # needed by hdf from contrib
     ('Eigen', '3.3.8'),
-    ('cuDNN', '8.0.5.39', '-CUDA-%(cudaver)s', True),
+    ('cuDNN', '8.0.4.30', '-CUDA-%(cudaver)s', True),
 ]
 
 configopts = [

--- a/easybuild/easyconfigs/o/OpenCV/OpenCV-4.5.1-intelcuda-2020b-contrib.eb
+++ b/easybuild/easyconfigs/o/OpenCV/OpenCV-4.5.1-intelcuda-2020b-contrib.eb
@@ -1,0 +1,93 @@
+name = 'OpenCV'
+version = '4.5.1'
+versionsuffix = '-contrib'
+
+# the hash is version dependent! see 3rdparty/ippicv/ippicv.cmake
+local_ippicv_hash = 'a56b6ac6f030c312b2dce17430eef13aed9af274'
+
+homepage = 'https://opencv.org/'
+description = """OpenCV (Open Source Computer Vision Library) is an open source computer vision
+ and machine learning software library. OpenCV was built to provide
+ a common infrastructure for computer vision applications and to accelerate
+ the use of machine perception in the commercial products.
+ Includes extra modules for OpenCV from the contrib repository."""
+
+toolchain = {'name': 'intelcuda', 'version': '2020b'}
+
+# Tests issues with default toolchains options, in particular Core_SVD orthogonality test
+# failing for a singluar matrix, FP32 and intel CXX compiler with '-fp-model source' on Haswell.
+# Note: OpenCV is templetized, dependent software should use '-fp-model precise'
+toolchainopts = {'precise': True}
+
+sources = [
+    {'source_urls': ['https://github.com/opencv/opencv/archive/'],
+     'download_filename': '%(version)s.zip', 'filename': SOURCELOWER_ZIP},
+    {'source_urls': ['https://github.com/opencv/opencv_contrib/archive/'],
+     'download_filename': '%(version)s.zip', 'filename': '%(namelower)s_contrib-%(version)s.zip'},
+    {'source_urls': ['https://github.com/opencv/opencv_extra/archive/'],
+     'download_filename': '%(version)s.zip', 'filename': '%(namelower)s_extra-%(version)s.zip'},
+    {'source_urls': ['https://raw.githubusercontent.com/opencv/opencv_3rdparty/%s/ippicv' % local_ippicv_hash],
+     'filename': 'ippicv_2020_lnx_intel64_20191018_general.tgz', 'extract_cmd': "cp %s %(builddir)s"},
+]
+patches = [
+    'OpenCV-4.5.1-icc_FindLibsPerf.cmake.patch',
+]
+checksums = [
+    '5fbc26ee09e148a4d494b225d04217f7c913ca1a4d46115b70cca3565d7bbe05',  # opencv-4.5.1.zip
+    'fdbd851985fd79797a04e16bdd672aff698aee89086b944295c90265f3cfffda',  # opencv_contrib-4.5.1.zip
+    '1b2eb8567f0441e779bf22e8584a89be372e627626dee64b81938a137404d60d',  # opencv_extra-4.5.1.zip
+    '08627fa5660d52d59309a572dd7db5b9c8aea234cfa5aee0942a1dd903554246',  # ippicv_2020_lnx_intel64_20191018_general.tgz
+    '36f8e30cd7adb8163097c83730e8cde1131c237039a67ef9ea78d55f3bbdaaa8',  # OpenCV-4.5.1-icc_FindLibsPerf.cmake.patch
+]
+
+builddependencies = [
+    ('CMake', '3.18.4'),
+]
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('SciPy-bundle', '2020.11'),  # for numpy
+    ('zlib', '1.2.11'),
+    ('FFmpeg', '4.3.1'),
+    ('libjpeg-turbo', '2.0.5'),
+    ('libpng', '1.6.37'),
+    ('LibTIFF', '4.1.0'),
+    ('libwebp', '1.1.0'),
+    ('OpenEXR', '2.5.5'),
+    ('JasPer', '2.0.24'),
+    ('Java', '11', '', True),
+    ('ant', '1.10.9', '-Java-%(javaver)s', True),
+    ('GLib', '2.66.1'),
+    ('GTK+', '3.24.23'),
+    ('HDF5', '1.10.7'),  # needed by hdf from contrib
+    ('Eigen', '3.3.8'),
+    ('cuDNN', '8.0.5.39', '-CUDA-%(cudaver)s', True),
+]
+
+configopts = [
+    '-DOPENCV_EXTRA_MODULES_PATH=%(builddir)s/%(namelower)s_contrib-%(version)s/modules',
+]
+
+local_contrib_libs = [
+    'aruco', 'bgsegm', 'bioinspired', 'ccalib', 'datasets', 'dnn_objdetect', 'dnn_superres', 'dpm', 'face', 'freetype',
+    'fuzzy', 'hdf', 'hfs', 'img_hash', 'line_descriptor', 'optflow', 'phase_unwrapping', 'plot', 'quality', 'reg',
+    'rgbd', 'shape', 'stereo', 'structured_light', 'superres', 'surface_matching', 'text', 'tracking',
+    'videostab', 'xfeatures2d', 'ximgproc', 'xobjdetect', 'xphoto'
+]
+
+runtest = 'test'
+pretestopts = 'OPENCV_TEST_DATA_PATH=%(builddir)s/%(namelower)s_extra-%(version)s/testdata'
+testopts = 'ARGS="-R opencv_test_core"'
+
+enhance_sanity_check = True
+
+sanity_check_paths = {
+    'files': ['lib64/libopencv_%s.%s' % (l, SHLIB_EXT) for l in local_contrib_libs],
+    'dirs': [],
+}
+
+sanity_check_commands = [
+    'opencv_version',
+]
+
+moduleclass = 'vis'


### PR DESCRIPTION
 based on OpenCV-4.5.1-contrib easyconfig for fosscuda/2020b
- removed **saliency** from cotrib_libs as it does not build with ICC (see [CMakeLists.txt](https://github.com/opencv/opencv_contrib/blob/4fc6995375e384b8e25bd6c8693fa8dd2ed4bb0a/modules/saliency/CMakeLists.txt)) and sanity check fails
- added **Eigen** and **cuDNN** as dependencies
- issues with static libs included in IPP: backported fix from [OpenCV issue 19681](https://github.com/opencv/opencv/pull/19681) as **OpenCV-4.5.1-icc_FindLibsPerf.cmake.patch**. An alternative is to exclude the libraries with `-DOPENCV_FORCE_IPP_EXCLUDE_LIBS=ON`
- added at least a single test: **opencv_test_core**
- issues with **Core_SVD orthogonality test** - fixed by switching to OpenCV default: `-fp-model precise` in toolchainopts