### PR TITLE
fix installation of fmesher within R-INLA

### DIFF
--- a/easybuild/easyconfigs/r/R-INLA/R-INLA-21.05.02-foss-2020b-R-4.0.4.eb
+++ b/easybuild/easyconfigs/r/R-INLA/R-INLA-21.05.02-foss-2020b-R-4.0.4.eb
@@ -73,7 +73,7 @@ components = [
 
 local_bins = ['inla', 'fmesher']
 
-postinstallcmds = ['ln -s %%(installdir)s/bin/%s %%(installdir)s/INLA/bin/linux/64bit/%s' % (x,x) for x in local_bins]
+postinstallcmds = ['ln -s %%(installdir)s/bin/%s %%(installdir)s/INLA/bin/linux/64bit/%s' % (x, x) for x in local_bins]
 
 sanity_check_paths = {
     'files': ['%s/%s' % (p, x) for p in ['bin', 'INLA/bin/linux/64bit'] for x in local_bins] +

--- a/easybuild/easyconfigs/r/R-INLA/R-INLA-21.05.02-foss-2020b-R-4.0.4.eb
+++ b/easybuild/easyconfigs/r/R-INLA/R-INLA-21.05.02-foss-2020b-R-4.0.4.eb
@@ -54,7 +54,7 @@ components = [
     }),
     ('rinla', version, {
         'checksums': default_component_specs['checksums'] + [
-            'c88e22739d1238414d10a5473a99dbc8fa6ccf811f2e6dc7701e015025f62f07',
+            '368bef641bbb55fe198529ee350e603936efebfca7b16f54a6c60573ecef2e9d',
         ],
         'patches': ['R-INLA-%(version)s-foss-2020b-remove-hardcoding.patch'],
         'easyblock': 'RPackage',
@@ -71,19 +71,18 @@ components = [
     }),
 ]
 
-postinstallcmds = ['ln -s %(installdir)s/bin/inla %(installdir)s/INLA/bin/linux/64bit/inla']
+local_bins = ['inla', 'fmesher']
 
-modextrapaths = {'R_LIBS_SITE': ''}
+postinstallcmds = ['ln -s %%(installdir)s/bin/%s %%(installdir)s/INLA/bin/linux/64bit/%s' % (x,x) for x in local_bins]
 
 sanity_check_paths = {
-    'files': ['bin/fmesher', 'bin/inla', 'lib/libGMRFLib.a', 'lib/libGMRFLib-geo.a', 'lib/libtaucs.a'],
+    'files': ['%s/%s' % (p, x) for p in ['bin', 'INLA/bin/linux/64bit'] for x in local_bins] +
+             ['lib/libGMRFLib.a', 'lib/libGMRFLib-geo.a', 'lib/libtaucs.a'],
     'dirs': ['doc', 'include/GMRFLib'],
 }
 
-sanity_check_commands = [
-    "fmesher -h",
-    "inla -h",
-    "Rscript -e 'library(INLA)'",
-]
+sanity_check_commands = ["Rscript -e 'library(INLA)'"] + ["%s -h" % x for x in local_bins]
+
+modextrapaths = {'R_LIBS_SITE': ''}
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/r/R-INLA/R-INLA-21.05.02-foss-2020b-remove-hardcoding.patch
+++ b/easybuild/easyconfigs/r/R-INLA/R-INLA-21.05.02-foss-2020b-remove-hardcoding.patch
@@ -38,3 +38,34 @@
              vecLib = if (inla.os("mac")) TRUE else FALSE,
              vecLibPath = "", 
              pardiso.license = NULL,
+--- r-inla-Version_21.05.02/rinla/inst/bin/linux/64bit/fmesher.run.orig	2021-05-25 11:45:08.870229000 +0200
++++ r-inla-Version_21.05.02/rinla/inst/bin/linux/64bit/fmesher.run	2021-05-25 11:51:42.965833000 +0200
+@@ -4,17 +4,17 @@
+ prog=${tmp%%.run}
+ DIR=$(dirname "$cmd")
+ 
+-D=""
+-for d in {,/usr}/lib64 /usr/lib64/R/lib {,/usr}/lib/x86_64-linux-gnu {,/usr}/lib; do
+-    if [ -d "$d" ]; then
+-	if [ -z "$D" ]; then
+-	    D="$d"
+-	else
+-	    D="$D:$d"
+-	fi
+-    fi
+-done
+-export LD_LIBRARY_PATH="$DIR/first:$D:$DIR:$LD_LIBRARY_PATH"
++#D=""
++#for d in {,/usr}/lib64 /usr/lib64/R/lib {,/usr}/lib/x86_64-linux-gnu {,/usr}/lib; do
++#    if [ -d "$d" ]; then
++#	if [ -z "$D" ]; then
++#	    D="$d"
++#	else
++#	    D="$D:$d"
++#	fi
++#    fi
++#done
++#export LD_LIBRARY_PATH="$DIR/first:$D:$DIR:$LD_LIBRARY_PATH"
+ 
+ if [ "${INLA_DEBUG}XX" != "XX" ]; then
+     echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"


### PR DESCRIPTION
Changelog:

* add link to `bin/fmesher` into `INLA/bin/linux/64bit/`, in the same way that we already do for `bin/inla`
* patch out hardcoded paths from `fmesher.run`, in the same way that we already do for `inla.run`
* improve sanity checks