### PR TITLE
in easyconfig tests, check version of dependencies named Python, not if dependencies with certain versions are named Python

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -775,8 +775,8 @@ class EasyConfigTest(TestCase):
                 'R-keras-2.1.6-foss-2018a-R-3.4.4.eb',
             ]
             whitelisted = any(re.match(regex, ec_fn) for regex in whitelist_python_suffix)
-            has_python_dep = any(dep['name'] == 'Python' for dep in ec['dependencies']
-                                 if LooseVersion(dep['version']) < LooseVersion('3.8.6'))
+            has_python_dep = any(LooseVersion(dep['version']) < LooseVersion('3.8.6')
+                                 for dep in ec['dependencies'] if dep['name'] == 'Python')
             if has_python_dep and ec.name != 'Tkinter' and not whitelisted:
                 if not re.search(r'-Python-[23]\.[0-9]+\.[0-9]+', ec['versionsuffix']):
                     msg = "'-Python-%%(pyver)s' should be included in versionsuffix in %s" % ec_fn
@@ -787,8 +787,8 @@ class EasyConfigTest(TestCase):
                     else:
                         print('\nNote: Failed non-critical check: ' + msg)
             else:
-                has_recent_python3_dep = any(dep['name'] == 'Python' for dep in ec['dependencies']
-                                             if LooseVersion(dep['version']) >= LooseVersion('3.8.6'))
+                has_recent_python3_dep = any(LooseVersion(dep['version']) >= LooseVersion('3.8.6')
+                                             for dep in ec['dependencies'] if dep['name'] == 'Python')
                 if has_recent_python3_dep and re.search(r'-Python-3\.[0-9]+\.[0-9]+', ec['versionsuffix']):
                     msg = "'-Python-%%(pyver)s' should no longer be included in versionsuffix in %s" % ec_fn
                     failing_checks.append(msg)


### PR DESCRIPTION
I think this is what was intended?

This showed up when testing https://github.com/easybuilders/easybuild-easyconfigs/pull/12863, which has an external module dependency with no version information, but I suppose `test_changed_files_pull_request` should also filter out external modules, like `process_all_easyconfigs` does?