### PR TITLE
add elfutils as build dependency for Clang 11.0.1 built with gcccuda toolchain

### DIFF
--- a/easybuild/easyconfigs/c/Clang/Clang-11.0.1-gcccuda-2020b.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-11.0.1-gcccuda-2020b.eb
@@ -57,6 +57,7 @@ dependencies = [
 builddependencies = [
     ('CMake', '3.18.4'),
     ('Python', '3.8.6'),
+    ('elfutils', '0.183'),
 ]
 
 assertions = True


### PR DESCRIPTION
If `elfutils` is missing during build, CUDA offloading support is not enabled as one would expect with the `gcccuda` toolchain.

This fixes #13006 