### PR TITLE
{data}[intel/2020b] update PnetCDF with newer intel 2020b toolchain

### DIFF
--- a/easybuild/easyconfigs/p/PnetCDF/PnetCDF-1.12.1-iimpi-2020b.eb
+++ b/easybuild/easyconfigs/p/PnetCDF/PnetCDF-1.12.1-iimpi-2020b.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'PnetCDF'
+version = "1.12.1"
+
+homepage = 'https://trac.mcs.anl.gov/projects/parallel-netcdf'
+description = "Parallel netCDF: A Parallel I/O Library for NetCDF File Access"
+
+toolchain = {'name': 'iimpi', 'version': '2020b'}
+
+source_urls = ['https://parallel-netcdf.github.io/Release/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['56f5afaa0ddc256791c405719b6436a83b92dcd5be37fe860dea103aee8250a2']
+
+builddependencies = [
+    ('Autotools', '20200321'),
+]
+
+preconfigopts = "autoreconf -f -i && "
+
+configopts = ['', '--enable-shared']
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['ncmpidiff', 'ncmpidump', 'ncmpigen', 'ncoffsets',
+                                     'ncvalidator', 'pnetcdf-config', 'pnetcdf_version']] +
+             ['lib/lib%(namelower)s.a', 'lib/lib%%(namelower)s.%s' % SHLIB_EXT],
+    'dirs': ['include'],
+}
+
+modextrapaths = {
+    'PNETCDF': '',
+}
+
+moduleclass = 'data'


### PR DESCRIPTION
Update to newer intel toolchain. Very easy. Needed for CESM-deps update to same toolchain. 