### PR TITLE
{tools}[GCCcore/10.2.0] Subversion 1.10.7

### DIFF
--- a/easybuild/easyconfigs/s/Subversion/Subversion-1.10.7-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/s/Subversion/Subversion-1.10.7-GCCcore-10.2.0.eb
@@ -15,6 +15,7 @@ source_urls = [
     'https://archive.apache.org/dist/%(namelower)s',
 ]
 sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['9c0b8f66ce8da896569b6177d0c72baad886516afefeec33609a24663e6a19da']
 
 builddependencies = [
     ('binutils', '2.35'),
@@ -42,4 +43,3 @@ sanity_check_paths = {
 }
 
 moduleclass = 'tools'
-

--- a/easybuild/easyconfigs/s/Subversion/Subversion-1.10.7-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/s/Subversion/Subversion-1.10.7-GCCcore-10.2.0.eb
@@ -1,0 +1,45 @@
+easyblock = 'ConfigureMake'
+
+name = 'Subversion'
+version = '1.10.7'
+
+homepage = 'https://subversion.apache.org/'
+description = " Subversion is an open source version control system."
+
+toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+
+source_urls = [
+    'https://apache.belnet.be/%(namelower)s',
+    'http://www.eu.apache.org/dist/%(namelower)s',
+    'http://www.us.apache.org/dist/%(namelower)s',
+    'https://archive.apache.org/dist/%(namelower)s',
+]
+sources = [SOURCELOWER_TAR_BZ2]
+
+builddependencies = [
+    ('binutils', '2.35'),
+    ('Autotools', '20200321'),
+]
+
+dependencies = [
+    ('APR', '1.7.0'),
+    ('APR-util', '1.6.1'),
+    ('SQLite', '3.33.0'),
+    ('zlib', '1.2.11'),
+    ('lz4', '1.9.2'),
+    ('utf8proc', '2.5.0'),
+    ('Serf', '1.3.9'),
+]
+
+preconfigopts = './autogen.sh && '
+
+configopts = "--with-apr=$EBROOTAPR/bin/apr-1-config --with-apr-util=$EBROOTAPRMINUTIL/bin/apu-1-config "
+configopts += "--with-zlib=$EBROOTZLIB --with-lz4=$EBROOTLZ4 --with-serf=$EBROOTSERF"
+
+sanity_check_paths = {
+    'files': ["bin/svn", "bin/svnversion"],
+    'dirs': [],
+}
+
+moduleclass = 'tools'
+


### PR DESCRIPTION
created ebfile for older version of Subversion 1.10.7 with newer toolchain GCCcore/10.2.0 because CESM is _still_ not compatible with recent versions of svn. Welcome to 2021. 