### PR TITLE
Create gmpich-2021.06.eb

### DIFF
--- a/easybuild/easyconfigs/g/gmpich/gmpich-2021.06.eb
+++ b/easybuild/easyconfigs/g/gmpich/gmpich-2021.06.eb
@@ -1,0 +1,20 @@
+easyblock = "Toolchain"
+
+name = 'gmpich'
+version = '2021.06'
+
+homepage = '(none)'
+description = """gcc and GFortran based compiler toolchain,
+ including MPICH for MPI support."""
+
+toolchain = SYSTEM
+
+local_comp = ('GCC', '10.2.0')
+
+# compiler toolchain dependencies
+dependencies = [
+    local_comp,
+    ('MPICH', '3.3.2', '', local_comp),
+]
+
+moduleclass = 'toolchain'


### PR DESCRIPTION
Build updated for GCC 10.2.0 and MPICH 3.3.2.