### PR TITLE
add GCCcore-[1-9][0-9].x to test_dep_versions_per_toolchain_generation

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -575,7 +575,7 @@ class EasyConfigTest(TestCase):
 
         # restrict to checking dependencies of easyconfigs using common toolchains (start with 2018a)
         # and GCCcore subtoolchain for common toolchains, starting with GCCcore 7.x
-        for pattern in ['201[89][ab]', '20[2-9][0-9][ab]', r'GCCcore-([7-9]|1[0-9])\.[0-9]']:
+        for pattern in ['201[89][ab]', '20[2-9][0-9][ab]', r'GCCcore-([7-9]|[1-9][0-9])\.[0-9]']:
             all_deps = {}
             regex = re.compile(r'^.*-(?P<tc_gen>%s).*\.eb$' % pattern)
 


### PR DESCRIPTION
Improves https://github.com/easybuilders/easybuild-easyconfigs/pull/13243

This PR adds `GCCcore-[1-9][0-9]` to `test_dep_versions_per_toolchain_generation`.