### PR TITLE
code cleanup + improvements for easyconfigs test suite

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,6 +21,8 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # Required for git merge-base to work
 
     - name: Cache source files in /tmp/sources
       id: cache-sources

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -141,7 +141,7 @@ class EasyConfigTest(TestCase):
                 os.environ['EB_SCRIPT_PATH'] = eb_path
 
         # initialize configuration (required for e.g. default modules_tool setting)
-        eb_go = eboptions.parse_options()
+        eb_go = eboptions.parse_options(args=[])  # Ignore cmdline args as those are meant for the unittest framework
         config.init(eb_go.options, eb_go.get_options_by_section('config'))
         build_options = {
             'check_osdeps': False,

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1123,7 +1123,6 @@ def template_easyconfig_test(self, spec):
     # make sure that OpenSSL wrapper is used rather than OS dependency,
     # for easyconfigs using a 2021a (sub)toolchain or more recent common toolchain version
     osdeps = ec['osdependencies']
-    print(spec, osdeps)
     if osdeps:
         # check whether any entry in osdependencies related to OpenSSL
         openssl_osdep = False

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1335,11 +1335,11 @@ def suite():
     # define new inner functions that can be added as class methods to InitTest
     easyconfigs_path = get_paths_for('easyconfigs')[0]
     cnt = 0
-    for (subpath, _, specs) in os.walk(easyconfigs_path, topdown=True):
+    for (subpath, dirs, specs) in os.walk(easyconfigs_path, topdown=True):
 
         # ignore archived easyconfigs
-        if '__archive__' in subpath:
-            continue
+        if '__archive__' in dirs:
+            dirs.remove('__archive__')
 
         for spec in specs:
             if spec.endswith('.eb') and spec != 'TEMPLATE.eb':

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1324,7 +1324,7 @@ def template_easyconfig_test(self, spec):
     single_tests_ok = True and prev_single_tests_ok
 
 
-def suite():
+def suite(loader=None):
     """Return all easyblock initialisation tests."""
     def make_inner_test(spec_path):
         def innertest(self):
@@ -1351,7 +1351,9 @@ def suite():
                 setattr(EasyConfigTest, innertest.__name__, innertest)
 
     print("Found %s easyconfigs..." % cnt)
-    return TestLoader().loadTestsFromTestCase(EasyConfigTest)
+    if not loader:
+        loader = TestLoader()
+    return loader.loadTestsFromTestCase(EasyConfigTest)
 
 
 if __name__ == '__main__':

--- a/test/easyconfigs/styletests.py
+++ b/test/easyconfigs/styletests.py
@@ -57,9 +57,11 @@ class StyleTest(TestCase):
         self.assertEqual(result, 0, "Found code style errors (and/or warnings): %s" % result)
 
 
-def suite():
+def suite(loader=None):
     """Return all style tests for easyconfigs."""
-    return TestLoader().loadTestsFromTestCase(StyleTest)
+    if not loader:
+        loader = TestLoader()
+    return loader.loadTestsFromTestCase(StyleTest)
 
 
 if __name__ == '__main__':

--- a/test/easyconfigs/suite.py
+++ b/test/easyconfigs/suite.py
@@ -32,9 +32,9 @@ Usage: "python -m easybuild.easyconfigs.test.suite.py" or "./easybuild/easyconfi
 """
 import os
 import shutil
-import sys
 import tempfile
 import unittest
+from unittest import main
 
 import easybuild.tools.build_log  # noqa initialize EasyBuild logging, so we can disable it
 import test.easyconfigs.easyconfigs as e
@@ -48,15 +48,22 @@ fancylogger.setLogLevelError()
 # make sure no deprecated behaviour is triggered
 # os.environ['EASYBUILD_DEPRECATED'] = '10000'
 
-os.environ['EASYBUILD_TMP_LOGDIR'] = tempfile.mkdtemp(prefix='easyconfigs_test_')
 
-# call suite() for each module and then run them all
-SUITE = unittest.TestSuite([x.suite() for x in [e, s]])
-res = unittest.TextTestRunner().run(SUITE)
+class EasyConfigsTestSuite(unittest.TestSuite):
+    def __init__(self, loader):
+        # call suite() for each module and then run them all
+        super(EasyConfigsTestSuite, self).__init__([x.suite(loader) for x in [e, s]])
 
-shutil.rmtree(os.environ['EASYBUILD_TMP_LOGDIR'])
-del os.environ['EASYBUILD_TMP_LOGDIR']
+    def run(self, *args, **kwargs):
+        os.environ['EASYBUILD_TMP_LOGDIR'] = tempfile.mkdtemp(prefix='easyconfigs_test_')
+        super(EasyConfigsTestSuite, self).run(*args, **kwargs)
+        shutil.rmtree(os.environ['EASYBUILD_TMP_LOGDIR'])
+        del os.environ['EASYBUILD_TMP_LOGDIR']
 
-if not res.wasSuccessful():
-    sys.stderr.write("ERROR: Not all tests were successful.\n")
-    sys.exit(2)
+
+def load_tests(loader, tests, pattern):
+    return EasyConfigsTestSuite(loader)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/easyconfigs/suite.py
+++ b/test/easyconfigs/suite.py
@@ -46,7 +46,7 @@ fancylogger.disableDefaultHandlers()
 fancylogger.setLogLevelError()
 
 # make sure no deprecated behaviour is triggered
-os.environ['EASYBUILD_DEPRECATED'] = '10000'
+# os.environ['EASYBUILD_DEPRECATED'] = '10000'
 
 os.environ['EASYBUILD_TMP_LOGDIR'] = tempfile.mkdtemp(prefix='easyconfigs_test_')
 


### PR DESCRIPTION
Major improvements to the test suite

- Remove a forgotten debug print
- Checkout full history on CI to avoid failure to get merge base
- Remove workaround to cleanup test TMPDIR in favor of class teardown method
- Process ECs on demand (preparation for next change, but also means for non-prs the ecs-in-pr-changed test is a no-op instead of parsing all ECs and never using them)
- Refactor the ECs-changed-in-PR test to run the subtests as separate test cases so failures in one of them don't abort the others
- Ignore cmdline args passed to the test suite, those are handled by unittest and should not be handled by easybuild. This allows to run subsets of tests like: `python test/easyconfigs/easyconfigs.py -v -k test_pr` to run all PR tests only
- Remove unused setting of `EASYBUILD_DEPRECATED` which, if in effect, would cause many failures due to deprecated ECs (using old versions) or even using LMod 6 (on CI) is already deprecated
- Honor setting of `EASYBUILD_TMP_LOGDIR`
- Allow filtering over all tests via: `python test/easyconfigs/suite.py -k foo` which includes the EC parsing tests. This removes the custom output of "ERROR: Not all tests were successful." but still has the output from unittest