### PR TITLE
add patch for recent GCCcore versions to fix compability with CUDA 11

### DIFF
--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-10.2.0.eb
@@ -32,6 +32,7 @@ sources = [
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
     'GCCcore-9.3.0_gmp-c99.patch',
+    'GCCcore-9.3.0_nvptx_sm_35_default.patch',
     'GCCcore-10.2.0_fix-has-include-Fortran.patch',
     'GCCcore-10.2.0_fix-ice-on-arm.patch',
     'GCCcore-10.2.0_fix-vec-builtins-conversion-on-ppc.patch',
@@ -46,6 +47,7 @@ checksums = [
     'a25b6f7761bb61c0d8e2a183bcf51fbaaeeac26868dcfc015e3b16a33fe11705',  # nvptx-tools-20180301.tar.gz
     '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68',  # GCCcore-6.2.0-fix-find-isl.patch
     '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e',  # GCCcore-9.3.0_gmp-c99.patch
+    '8d8b9834a570b5789d47296311953b6307d4427957a73e102de43cca7a6fa108',  # GCCcore-9.3.0_nvptx_sm_35_default.patch
     'f94fa117f3401b28fda0741f3f45439c09dc956d1ed27f9a3ebe40c0e7e404b6',  # GCCcore-10.2.0_fix-has-include-Fortran.patch
     '44edbf1cddb2d7037f9606b6995d9ef20ff664b810a3e3ef383420a4366ed278',  # GCCcore-10.2.0_fix-ice-on-arm.patch
     # GCCcore-10.2.0_fix-vec-builtins-conversion-on-ppc.patch

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-10.3.0.eb
@@ -32,6 +32,7 @@ sources = [
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
     'GCCcore-9.3.0_gmp-c99.patch',
+    'GCCcore-9.3.0_nvptx_sm_35_default.patch',
 ]
 checksums = [
     '8fcf994811ad4e5c7ac908e8cf62af2c1982319e5551f62ae72016064dacdf16',  # gcc-10.3.0.tar.gz
@@ -43,6 +44,7 @@ checksums = [
     '466abe1cef9cf294318ecb3c221593356f7a9e1674be987d576bc70d833d84a2',  # nvptx-tools-20210115.tar.gz
     '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68',  # GCCcore-6.2.0-fix-find-isl.patch
     '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e',  # GCCcore-9.3.0_gmp-c99.patch
+    '8d8b9834a570b5789d47296311953b6307d4427957a73e102de43cca7a6fa108',  # GCCcore-9.3.0_nvptx_sm_35_default.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-9.3.0.eb
@@ -34,6 +34,7 @@ patches = [
     'GCCcore-8.3.0_fix-xsmin-ppc.patch',
     'GCCcore-%(version)s_gmp-c99.patch',
     'GCCcore-%(version)s_vect_broadcasts_masmintel.patch',
+    'GCCcore-%(version)s_nvptx_sm_35_default.patch',
 ]
 checksums = [
     '5258a9b6afe9463c2e56b9e8355b1a4bee125ca828b8078f910303bc2ef91fa6',  # gcc-9.3.0.tar.gz
@@ -47,6 +48,7 @@ checksums = [
     'bea1bce8f50ea6d51b038309eb61dec00a8681fb653d211c539be80f184609a3',  # GCCcore-8.3.0_fix-xsmin-ppc.patch
     '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e',  # GCCcore-9.3.0_gmp-c99.patch
     'a32ac9c7d999a8b91bf93dba6a9d81b6ff58b3c89c425ff76090cbc90076685c',  # GCCcore-9.3.0_vect_broadcasts_masmintel.patch
+    '8d8b9834a570b5789d47296311953b6307d4427957a73e102de43cca7a6fa108',  # GCCcore-9.3.0_nvptx_sm_35_default.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-9.3.0_nvptx_sm_35_default.patch
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-9.3.0_nvptx_sm_35_default.patch
@@ -1,0 +1,67 @@
+From 383400a6078d75bbfa1216c9af2c37f7e88740c9 Mon Sep 17 00:00:00 2001
+From: Tom de Vries <tdevries@suse.de>
+Date: Fri, 9 Oct 2020 11:36:10 +0200
+Subject: [PATCH] [nvptx] Set -misa=sm_35 by default
+
+The nvptx-as assembler verifies the ptx code using ptxas, if there's any
+in the PATH.
+
+The default in the nvptx port for -misa=sm_xx is sm_30, but the ptxas of the
+latest cuda release (11.1) no longer supports sm_30.
+
+Consequently we cannot build gcc against that release (although we should
+still be able to build without any cuda release).
+
+Fix this by setting -misa=sm_35 by default.
+
+Tested check-gcc on nvptx.
+
+Tested libgomp on x86_64-linux with nvpx accelerator.
+
+Both build again cuda 9.1.
+
+gcc/ChangeLog:
+
+2020-10-09  Tom de Vries  <tdevries@suse.de>
+
+	PR target/97348
+	* config/nvptx/nvptx.h (ASM_SPEC): Also pass -m to nvptx-as if
+	default is used.
+	* config/nvptx/nvptx.opt (misa): Init with PTX_ISA_SM35.
+---
+ gcc/config/nvptx/nvptx.h   | 5 ++++-
+ gcc/config/nvptx/nvptx.opt | 3 ++-
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/gcc/config/nvptx/nvptx.h b/gcc/config/nvptx/nvptx.h
+index 6ebcc760771..17fe157058c 100644
+--- a/gcc/config/nvptx/nvptx.h
++++ b/gcc/config/nvptx/nvptx.h
+@@ -29,7 +29,10 @@
+ 
+ #define STARTFILE_SPEC "%{mmainkernel:crt0.o}"
+ 
+-#define ASM_SPEC "%{misa=*:-m %*}"
++/* Default needs to be in sync with default for misa in nvptx.opt.
++   We add a default here to work around a hard-coded sm_30 default in
++   nvptx-as.  */
++#define ASM_SPEC "%{misa=*:-m %*; :-m sm_35}"
+ 
+ #define TARGET_CPU_CPP_BUILTINS()		\
+   do						\
+diff --git a/gcc/config/nvptx/nvptx.opt b/gcc/config/nvptx/nvptx.opt
+index 75c3d54864e..d6910a96cf0 100644
+--- a/gcc/config/nvptx/nvptx.opt
++++ b/gcc/config/nvptx/nvptx.opt
+@@ -59,6 +59,7 @@ Enum(ptx_isa) String(sm_30) Value(PTX_ISA_SM30)
+ EnumValue
+ Enum(ptx_isa) String(sm_35) Value(PTX_ISA_SM35)
+ 
++; Default needs to be in sync with default in ASM_SPEC in nvptx.h.
+ misa=
+-Target RejectNegative ToLower Joined Enum(ptx_isa) Var(ptx_isa_option) Init(PTX_ISA_SM30)
++Target RejectNegative ToLower Joined Enum(ptx_isa) Var(ptx_isa_option) Init(PTX_ISA_SM35)
+ Specify the version of the ptx ISA to use.
+-- 
+2.27.0
+


### PR DESCRIPTION
This adds a patch included in GCC 11.1.0 setting -misa=sm_35 by default
for compatibility with CUDA 11 which no longer supports the previous
default sm_30.

Fixes #12518