### PR TITLE
fix recent taxator-tk easyconfigs by adding (back) -DBoost_NO_BOOST_CMAKE=ON configure option

### DIFF
--- a/easybuild/easyconfigs/t/taxator-tk/taxator-tk-1.3.3-GCC-10.2.0.eb
+++ b/easybuild/easyconfigs/t/taxator-tk/taxator-tk-1.3.3-GCC-10.2.0.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('Boost', '1.74.0'),
 ]
 
-separate_build_dir = True
+configopts = "-DBoost_NO_BOOST_CMAKE=ON"
 
 buildopts = "&& mkdir -p %(installdir)s/bin"
 buildopts += " && cp -a {alignments-filter,binner,taxator,taxknife,unittest_ncbitaxonomy} %(installdir)s/bin/"

--- a/easybuild/easyconfigs/t/taxator-tk/taxator-tk-1.3.3-gompi-2019a.eb
+++ b/easybuild/easyconfigs/t/taxator-tk/taxator-tk-1.3.3-gompi-2019a.eb
@@ -22,7 +22,7 @@ dependencies = [
     ('Boost', '1.70.0'),
 ]
 
-separate_build_dir = True
+configopts = "-DBoost_NO_BOOST_CMAKE=ON"
 
 buildopts = "&& mkdir -p %(installdir)s/bin"
 buildopts += " && cp -a {alignments-filter,binner,taxator,taxknife,unittest_ncbitaxonomy} %(installdir)s/bin/"


### PR DESCRIPTION
This is required because of the changes made in 

Without it, these two `taxator-tk` easyconfigs fail at configure time with:

```
CMake Warning (dev) at /software/Boost/1.74.0-GCC-10.2.0/lib64/cmake/Boost-1.74.0/BoostConfig.cmake:240 (if):
  Policy CMP0057 is not set: Support new IN_LIST if() operator.  Run "cmake
  --help-policy CMP0057" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  IN_LIST will be interpreted as an operator when the policy is set to NEW.
  Since the policy is not set the OLD behavior will be used.
Call Stack (most recent call first):
  cmake-modules/FindBoost.cmake:206 (find_package)
  CMakeLists.txt:16 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at /software/Boost/1.74.0-GCC-10.2.0/lib64/cmake/Boost-1.74.0/BoostConfig.cmake:240 (if):
  if given arguments:

    "ALL" "IN_LIST" "Boost_FIND_COMPONENTS"

  Unknown arguments specified
Call Stack (most recent call first):
  cmake-modules/FindBoost.cmake:206 (find_package)
  CMakeLists.txt:16 (find_package)
```

With it, we get this back and the installation works fine:

```
-- Boost version: 1.74.0
-- Found the following Boost libraries:
--   program_options
--   system
--   filesystem
--   thread
-- Configuring done
```

Interestingly enough, `taxator-tk-1.3.3-foss-2018b.eb` still works fine, `-DBoost_NO_BOOST_CMAKE=ON` is not needed there, which suggests a bug in recent versions of Boost and/or CMake...