### PR TITLE
remove superflous -DCMAKE_BUILD_TYPE=Release, use of 'build_type = Release', or enabling separate_build_dir from easyconfigs using CMakeMake easyblock

### DIFF
--- a/easybuild/easyconfigs/a/ANTs/ANTs-2.2.0-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/a/ANTs/ANTs-2.2.0-foss-2016b-Python-2.7.12.eb
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 configopts = '-DUSE_SYSTEM_ITK=ON '
-configopts += '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF'
+configopts += '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF '
 configopts += '-DUSE_VTK=ON -DUSE_SYSTEM_VTK=ON -DITK_DIR=$EBROOTITK/lib/cmake/ITK-%s' % local_itkshortver
 
 skipsteps = ['install']

--- a/easybuild/easyconfigs/a/ANTs/ANTs-2.2.0-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/a/ANTs/ANTs-2.2.0-foss-2016b-Python-2.7.12.eb
@@ -24,7 +24,7 @@ dependencies = [
     ('VTK', '6.3.0', versionsuffix),
 ]
 
-configopts = '-DCMAKE_BUILD_TYPE=Release -DUSE_SYSTEM_ITK=ON '
+configopts = '-DUSE_SYSTEM_ITK=ON '
 configopts += '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF'
 configopts += '-DUSE_VTK=ON -DUSE_SYSTEM_VTK=ON -DITK_DIR=$EBROOTITK/lib/cmake/ITK-%s' % local_itkshortver
 

--- a/easybuild/easyconfigs/a/ANTs/ANTs-2.3.0-foss-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/a/ANTs/ANTs-2.3.0-foss-2017b-Python-2.7.14.eb
@@ -24,8 +24,7 @@ dependencies = [
 
 separate_build_dir = True
 
-configopts = '-DCMAKE_BUILD_TYPE=Release '
-configopts += '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF '
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF '
 configopts += '-DUSE_VTK=ON -DUSE_SYSTEM_VTK=ON '
 configopts += '-DSuperBuild_ANTS_USE_GIT_PROTOCOL=OFF'
 

--- a/easybuild/easyconfigs/a/ANTs/ANTs-2.3.0-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/a/ANTs/ANTs-2.3.0-intel-2017b-Python-2.7.14.eb
@@ -24,8 +24,7 @@ dependencies = [
 
 separate_build_dir = True
 
-configopts = '-DCMAKE_BUILD_TYPE=Release '
-configopts += '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF '
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF '
 configopts += '-DUSE_VTK=ON -DUSE_SYSTEM_VTK=ON '
 configopts += '-DSuperBuild_ANTS_USE_GIT_PROTOCOL=OFF'
 

--- a/easybuild/easyconfigs/a/ANTs/ANTs-2.3.1-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/a/ANTs/ANTs-2.3.1-foss-2018b-Python-3.6.6.eb
@@ -28,8 +28,7 @@ dependencies = [
 
 separate_build_dir = True
 
-configopts = '-DCMAKE_BUILD_TYPE=Release '
-configopts += '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF '
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF '
 configopts += '-DUSE_VTK=ON -DUSE_SYSTEM_VTK=ON '
 configopts += '-DSuperBuild_ANTS_USE_GIT_PROTOCOL=OFF'
 

--- a/easybuild/easyconfigs/a/ANTs/ANTs-2.3.2-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/a/ANTs/ANTs-2.3.2-foss-2019b-Python-3.7.4.eb
@@ -33,8 +33,7 @@ dependencies = [
 
 separate_build_dir = True
 
-configopts = '-DCMAKE_BUILD_TYPE=Release '
-configopts += '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF '
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF '
 configopts += '-DUSE_VTK=ON -DUSE_SYSTEM_VTK=ON '
 configopts += '-DSuperBuild_ANTS_USE_GIT_PROTOCOL=OFF'
 

--- a/easybuild/easyconfigs/a/ANTs/ANTs-2.3.5-foss-2021a.eb
+++ b/easybuild/easyconfigs/a/ANTs/ANTs-2.3.5-foss-2021a.eb
@@ -21,10 +21,7 @@ dependencies = [
     ('VTK', '9.0.1'),
 ]
 
-separate_build_dir = True
-
-configopts = '-DCMAKE_BUILD_TYPE=Release '
-configopts += '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF '
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF '
 configopts += '-DUSE_VTK=ON -DUSE_SYSTEM_VTK=ON '
 configopts += '-DSuperBuild_ANTS_USE_GIT_PROTOCOL=OFF'
 

--- a/easybuild/easyconfigs/b/BUFRLIB/BUFRLIB-11.3.0.2-iccifort-2020.1.217.eb
+++ b/easybuild/easyconfigs/b/BUFRLIB/BUFRLIB-11.3.0.2-iccifort-2020.1.217.eb
@@ -14,7 +14,7 @@ sources = ['v%(version)s.tar.gz']
 checksums = ['1023eb590e2112d5bc213c568a212390fc65ff98732ac8d2ccdda5062e6bc8c6']
 
 builddependencies = [('CMake', '3.16.4')]
-configopts = " -DBUILD_STATIC_LIBS=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release "
+configopts = " -DBUILD_STATIC_LIBS=1 -DBUILD_SHARED_LIBS=1"
 
 sanity_check_paths = {
     'files': ['lib/libbufr.a', 'lib/libbufr.so'],

--- a/easybuild/easyconfigs/b/BreakDancer/BreakDancer-1.4.5-intel-2017a.eb
+++ b/easybuild/easyconfigs/b/BreakDancer/BreakDancer-1.4.5-intel-2017a.eb
@@ -12,12 +12,13 @@ toolchain = {'name': 'intel', 'version': '2017a'}
 source_urls = ['https://github.com/genome/breakdancer/archive/']
 sources = ['v%(version)s.tar.gz']
 patches = ['BreakDancer-%(version)s_fix-icpc-compilation.patch']
+checksums = [
+    '5d74f3a90f5c69026ebb4cf4cb9ccc51ec8dd49ac7a88595a1efabd5a73e92b6',  # v1.4.5.tar.gz
+    '3652cd5fcd02edb8d82a30c4e110ce6a63291608a9e2535525f90636c1840da4',  # BreakDancer-1.4.5_fix-icpc-compilation.patch
+]
 
 dependencies = [('zlib', '1.2.11')]
 builddependencies = [('CMake', '3.7.2')]
-
-separate_build_dir = True
-configopts = '-DCMAKE_BUILD_TYPE=release'
 
 parallel = 1
 

--- a/easybuild/easyconfigs/c/Calib/Calib-0.3.4-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/c/Calib/Calib-0.3.4-GCC-9.3.0.eb
@@ -42,7 +42,7 @@ buildopts = 'CXXFLAGS="$CXXFLAGS -pthread -Iclustering/ -lz" && '
 # building calib_cons requires SPOA, so build that first
 buildopts += "mv %(builddir)s/spoa-1.1.3 %(builddir)s/calib-%(version)s/consensus/spoa_v1.1.3 && "
 buildopts += "mkdir consensus/spoa_v1.1.3/build && cd consensus/spoa_v1.1.3/build && "
-buildopts += "cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON .. && make && "
+buildopts += "cmake -DCMAKE_VERBOSE_MAKEFILE=ON .. && make && "
 buildopts += "cd - && make -C consensus"
 
 files_to_copy = [(['calib', 'consensus/calib_cons'], 'bin')]

--- a/easybuild/easyconfigs/c/ConnectomeWorkbench/ConnectomeWorkbench-1.3.2-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/c/ConnectomeWorkbench/ConnectomeWorkbench-1.3.2-GCCcore-8.2.0.eb
@@ -30,7 +30,7 @@ dependencies = [
 
 start_dir = 'src'
 
-configopts = '-DCMAKE_BUILD_TYPE=Release -DWORKBENCH_MESA_DIR=${EBROOTMESA} '
+configopts = '-DWORKBENCH_MESA_DIR=${EBROOTMESA} '
 configopts += '-DWORKBENCH_USE_QT5=TRUE -Wno-dev '
 
 # It is necessary to deactivate the SIMD optimization in order to build

--- a/easybuild/easyconfigs/c/ConnectomeWorkbench/ConnectomeWorkbench-1.3.2-foss-2017b.eb
+++ b/easybuild/easyconfigs/c/ConnectomeWorkbench/ConnectomeWorkbench-1.3.2-foss-2017b.eb
@@ -28,7 +28,7 @@ dependencies = [
 
 start_dir = 'src'
 
-configopts = '-DCMAKE_BUILD_TYPE=Release -DWORKBENCH_MESA_DIR=${EBROOTMESA} '
+configopts = '-DWORKBENCH_MESA_DIR=${EBROOTMESA} '
 configopts += '-DWORKBENCH_USE_QT5=TRUE -Wno-dev '
 
 # It is necessary to deactivate the SIMD optimization in order to build

--- a/easybuild/easyconfigs/c/ConnectomeWorkbench/ConnectomeWorkbench-1.3.2-intel-2017b.eb
+++ b/easybuild/easyconfigs/c/ConnectomeWorkbench/ConnectomeWorkbench-1.3.2-intel-2017b.eb
@@ -28,7 +28,7 @@ dependencies = [
 
 start_dir = 'src'
 
-configopts = '-DCMAKE_BUILD_TYPE=Release -DWORKBENCH_MESA_DIR=${EBROOTMESA} '
+configopts = '-DWORKBENCH_MESA_DIR=${EBROOTMESA} '
 configopts += '-DWORKBENCH_USE_QT5=TRUE -Wno-dev '
 
 # It is necessary to deactivate the SIMD optimization in order to build

--- a/easybuild/easyconfigs/d/Dalton/Dalton-2016-intel-2017b-i8.eb
+++ b/easybuild/easyconfigs/d/Dalton/Dalton-2016-intel-2017b-i8.eb
@@ -46,8 +46,7 @@ builddependencies = [('CMake', '3.9.5')]
 
 separate_build_dir = True
 
-configopts = '-DCMAKE_BUILD_TYPE=RELEASE '
-configopts += '-DENABLE_MPI=ON '
+configopts = '-DENABLE_MPI=ON '
 configopts += '-DENABLE_OMP=ON '
 # Only enable for BLAS/LAPACK having 8 byte integers (basically MKL) adjust the configopts 'i8' option accordingly
 configopts += '-DENABLE_64BIT_INTEGERS=ON '

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.2.0.eb
@@ -17,10 +17,6 @@ builddependencies = [
     ('CMake', '3.13.3'),
 ]
 
-separate_build_dir = True
-
-build_type = 'Release'
-
 # Build static lib, static lib with -fPIC and shared lib
 configopts = [
     '',

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.4-GCCcore-8.3.0.eb
@@ -17,10 +17,6 @@ builddependencies = [
     ('CMake', '3.15.3'),
 ]
 
-separate_build_dir = True
-
-build_type = 'Release'
-
 # Build static lib, static lib with -fPIC and shared lib
 configopts = [
     '',

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.5-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.5-GCCcore-10.2.0.eb
@@ -17,10 +17,6 @@ builddependencies = [
     ('CMake', '3.18.4'),
 ]
 
-separate_build_dir = True
-
-build_type = 'Release'
-
 # Build static lib, static lib with -fPIC and shared lib
 configopts = [
     '',

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.5-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.5-GCCcore-10.3.0.eb
@@ -17,10 +17,6 @@ builddependencies = [
     ('CMake', '3.20.1'),
 ]
 
-separate_build_dir = True
-
-build_type = 'Release'
-
 # Build static lib, static lib with -fPIC and shared lib
 configopts = [
     '',

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.5-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.5-GCCcore-11.2.0.eb
@@ -17,10 +17,6 @@ builddependencies = [
     ('CMake', '3.21.1'),
 ]
 
-separate_build_dir = True
-
-build_type = 'Release'
-
 # Build static lib, static lib with -fPIC and shared lib
 configopts = [
     '',

--- a/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.5-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/d/double-conversion/double-conversion-3.1.5-GCCcore-9.3.0.eb
@@ -17,10 +17,6 @@ builddependencies = [
     ('CMake', '3.16.4'),
 ]
 
-separate_build_dir = True
-
-build_type = 'Release'
-
 # Build static lib, static lib with -fPIC and shared lib
 configopts = [
     '',

--- a/easybuild/easyconfigs/e/elastix/elastix-4.9.0-foss-2018a.eb
+++ b/easybuild/easyconfigs/e/elastix/elastix-4.9.0-foss-2018a.eb
@@ -19,10 +19,6 @@ dependencies = [
     ('ITK', '4.13.0', '-Python-2.7.14'),
 ]
 
-configopts = '-DCMAKE_BUILD_TYPE=Release '
-
-separate_build_dir = True
-
 sanity_check_paths = {
     'files': ['bin/elastix', 'bin/transformix'],
     'dirs': ['include', 'lib']

--- a/easybuild/easyconfigs/f/FLANN/FLANN-1.8.4-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/f/FLANN/FLANN-1.8.4-intel-2016a-Python-2.7.11.eb
@@ -12,6 +12,7 @@ toolchainopts = {'openmp': True}
 
 source_urls = ['http://www.cs.ubc.ca/research/flann/uploads/FLANN/']
 sources = ['flann-%(version)s-src.zip']
+checksums = ['dfbb9321b0d687626a644c70872a2c540b16200e7f4c7bd72f91ae032f445c08']
 
 builddependencies = [('CMake', '3.5.2')]
 dependencies = [
@@ -20,7 +21,7 @@ dependencies = [
 
 separate_build_dir = True
 
-configopts = "-DCMAKE_BUILD_TYPE=Release -DUSE_OPENMP=ON -DUSE_MPI=ON -DBUILD_PYTHON_BINDINGS=ON -DBUILD_C_BINDINGS=ON"
+configopts = "-DUSE_OPENMP=ON -DUSE_MPI=ON -DBUILD_PYTHON_BINDINGS=ON -DBUILD_C_BINDINGS=ON"
 
 modextrapaths = {'PYTHONPATH': ['share/flann/python']}
 

--- a/easybuild/easyconfigs/f/FLANN/FLANN-1.8.4-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/f/FLANN/FLANN-1.8.4-intel-2017b-Python-2.7.14.eb
@@ -23,7 +23,7 @@ dependencies = [('Python', '2.7.14')]
 
 separate_build_dir = True
 
-configopts = "-DCMAKE_BUILD_TYPE=Release -DUSE_OPENMP=ON -DUSE_MPI=ON -DBUILD_PYTHON_BINDINGS=ON -DBUILD_C_BINDINGS=ON"
+configopts = "-DUSE_OPENMP=ON -DUSE_MPI=ON -DBUILD_PYTHON_BINDINGS=ON -DBUILD_C_BINDINGS=ON"
 
 modextrapaths = {'PYTHONPATH': ['share/flann/python']}
 

--- a/easybuild/easyconfigs/h/HH-suite/HH-suite-3.0-beta.3-intel-2018a.eb
+++ b/easybuild/easyconfigs/h/HH-suite/HH-suite-3.0-beta.3-intel-2018a.eb
@@ -29,10 +29,6 @@ builddependencies = [('CMake', '3.10.2')]
 preconfigopts = 'cp -a ../ffindex_soedinglab-%s/* ' % local_ffindex_commit
 preconfigopts += '%(builddir)s/%(namelower)s-%(version)s/lib/ffindex && '
 
-configopts = '-DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" '
-
-separate_build_dir = True
-
 modextravars = {'HHLIB': '%(installdir)s'}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/h/HyPo/HyPo-1.0.3-GCC-8.3.0-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/h/HyPo/HyPo-1.0.3-GCC-8.3.0-Python-3.7.4.eb
@@ -28,7 +28,8 @@ preconfigopts = "rm -r %(builddir)s/hypo*/external/install/htslib/lib && "
 configopts = "-Doptimise_for_native=ON "
 
 # using 'Conda' as build type to make CMake honor the specified location for dependencies
-configopts += "-DCMAKE_BUILD_TYPE=Conda -DHTSLIB_INSTALL_DIR=$EBROOTHTSLIB -DSDSLLIB_INSTALL_DIR=$EBROOTSDSL"
+build_type = 'Conda'
+configopts += "-DHTSLIB_INSTALL_DIR=$EBROOTHTSLIB -DSDSLLIB_INSTALL_DIR=$EBROOTSDSL"
 
 sanity_check_paths = {
     'files': ['bin/hypo'],

--- a/easybuild/easyconfigs/k/Kratos/Kratos-6.0-foss-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/k/Kratos/Kratos-6.0-foss-2018a-Python-3.6.4.eb
@@ -27,7 +27,7 @@ dependencies = [
 separate_build_dir = True
 
 # see configure.sh script for default set of configuration options
-configopts = "-DCMAKE_BUILD_TYPE=Release -DKRATOS_INSTALL_PREFIX=%(installdir)s "
+configopts = "-DKRATOS_INSTALL_PREFIX=%(installdir)s "
 configopts += "-DBOOST_ROOT=$EBROOTBOOST -DBoost_NO_SYSTEM_PATHS=ON -DBoost_NO_BOOST_CMAKE=ON "
 configopts += "-DPYTHON_EXECUTABLE=$EBROOTPYTHON/bin/python -DINSTALL_EMBEDDED_PYTHON=ON -DINSTALL_PYTHON_FILES=ON "
 configopts += "-DMESHING_APPLICATION=ON -DEXTERNAL_SOLVERS_APPLICATION=ON -DSTRUCTURAL_MECHANICS_APPLICATION=ON "

--- a/easybuild/easyconfigs/k/Kratos/Kratos-6.0-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/k/Kratos/Kratos-6.0-intel-2018a-Python-3.6.4.eb
@@ -31,7 +31,7 @@ dependencies = [
 separate_build_dir = True
 
 # see configure.sh script for default set of configuration options
-configopts = "-DCMAKE_BUILD_TYPE=Release -DKRATOS_INSTALL_PREFIX=%(installdir)s "
+configopts = "-DKRATOS_INSTALL_PREFIX=%(installdir)s "
 configopts += "-DBOOST_ROOT=$EBROOTBOOST -DBoost_NO_SYSTEM_PATHS=ON -DBoost_NO_BOOST_CMAKE=ON "
 configopts += "-DPYTHON_EXECUTABLE=$EBROOTPYTHON/bin/python -DINSTALL_EMBEDDED_PYTHON=ON -DINSTALL_PYTHON_FILES=ON "
 configopts += "-DMESHING_APPLICATION=ON -DEXTERNAL_SOLVERS_APPLICATION=ON -DSTRUCTURAL_MECHANICS_APPLICATION=ON "

--- a/easybuild/easyconfigs/k/kim-api/kim-api-2.1.2-foss-2019a.eb
+++ b/easybuild/easyconfigs/k/kim-api/kim-api-2.1.2-foss-2019a.eb
@@ -29,8 +29,6 @@ sources = ['%(name)s-%(version)s.txz']
 checksums = ['16c7dd362cf95288b6288e1a76caf8baef652eb2cf8af500a5eb4767ba2fe80c']
 
 parallel = 1
-separate_build_dir = True
-configopts = '-DCMAKE_BUILD_TYPE=Release '
 
 modextravars = {
     'KIM_API_CMAKE_PREFIX_DIR': '%(installdir)s/lib64'

--- a/easybuild/easyconfigs/k/kim-api/kim-api-2.1.2-intel-2019a.eb
+++ b/easybuild/easyconfigs/k/kim-api/kim-api-2.1.2-intel-2019a.eb
@@ -29,9 +29,6 @@ sources = ['%(name)s-%(version)s.txz']
 checksums = ['16c7dd362cf95288b6288e1a76caf8baef652eb2cf8af500a5eb4767ba2fe80c']
 
 parallel = 1
-separate_build_dir = True
-configopts = '-DCMAKE_BUILD_TYPE=Release '
-
 modextravars = {
     'KIM_API_CMAKE_PREFIX_DIR': '%(installdir)s/lib64'
 }

--- a/easybuild/easyconfigs/k/kim-api/kim-api-2.1.3-foss-2019b.eb
+++ b/easybuild/easyconfigs/k/kim-api/kim-api-2.1.3-foss-2019b.eb
@@ -29,9 +29,6 @@ sources = ['%(name)s-%(version)s.txz']
 checksums = ['88a5416006c65a2940d82fad49de0885aead05bfa8b59f87d287db5516b9c467']
 
 parallel = 1
-separate_build_dir = True
-configopts = '-DCMAKE_BUILD_TYPE=Release '
-
 modextravars = {
     'KIM_API_CMAKE_PREFIX_DIR': '%(installdir)s/lib64'
 }

--- a/easybuild/easyconfigs/k/kim-api/kim-api-2.1.3-foss-2020a.eb
+++ b/easybuild/easyconfigs/k/kim-api/kim-api-2.1.3-foss-2020a.eb
@@ -29,8 +29,6 @@ dependencies = [
 ]
 
 parallel = 1
-separate_build_dir = True
-build_type = 'Release'
 
 modextravars = {
     'KIM_API_CMAKE_PREFIX_DIR': '%(installdir)s/lib64'

--- a/easybuild/easyconfigs/k/kim-api/kim-api-2.1.3-intel-2019b.eb
+++ b/easybuild/easyconfigs/k/kim-api/kim-api-2.1.3-intel-2019b.eb
@@ -29,9 +29,6 @@ sources = ['%(name)s-%(version)s.txz']
 checksums = ['88a5416006c65a2940d82fad49de0885aead05bfa8b59f87d287db5516b9c467']
 
 parallel = 1
-separate_build_dir = True
-configopts = '-DCMAKE_BUILD_TYPE=Release '
-
 modextravars = {
     'KIM_API_CMAKE_PREFIX_DIR': '%(installdir)s/lib64'
 }

--- a/easybuild/easyconfigs/k/kim-api/kim-api-2.1.3-intel-2020a.eb
+++ b/easybuild/easyconfigs/k/kim-api/kim-api-2.1.3-intel-2020a.eb
@@ -29,8 +29,6 @@ dependencies = [
 ]
 
 parallel = 1
-separate_build_dir = True
-build_type = 'Release'
 
 modextravars = {
     'KIM_API_CMAKE_PREFIX_DIR': '%(installdir)s/lib64'

--- a/easybuild/easyconfigs/k/kim-api/kim-api-2.2.1-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/k/kim-api/kim-api-2.2.1-GCCcore-10.2.0.eb
@@ -31,8 +31,6 @@ dependencies = [
 ]
 
 parallel = 1
-separate_build_dir = True
-build_type = 'Release'
 
 modextravars = {
     'KIM_API_CMAKE_PREFIX_DIR': '%(installdir)s/lib64'

--- a/easybuild/easyconfigs/k/kim-api/kim-api-2.2.1-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/k/kim-api/kim-api-2.2.1-GCCcore-10.3.0.eb
@@ -31,8 +31,6 @@ dependencies = [
 ]
 
 parallel = 1
-separate_build_dir = True
-build_type = 'Release'
 
 modextravars = {
     'KIM_API_CMAKE_PREFIX_DIR': '%(installdir)s/lib64'

--- a/easybuild/easyconfigs/l/libgpuarray/libgpuarray-0.7.6-fosscuda-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/l/libgpuarray/libgpuarray-0.7.6-fosscuda-2018b-Python-3.6.6.eb
@@ -15,7 +15,6 @@ checksums = ['887b6433a30282cb002117da89b05812c770fd9469f93950ff3866ddd02bfc64']
 
 builddependencies = [('CMake', '3.12.1')]
 
-configopts = '-DCMAKE_BUILD_TYPE=Release'
 
 dependencies = [
     ('Python', '3.6.6'),

--- a/easybuild/easyconfigs/l/libgpuarray/libgpuarray-0.7.6-fosscuda-2019a.eb
+++ b/easybuild/easyconfigs/l/libgpuarray/libgpuarray-0.7.6-fosscuda-2019a.eb
@@ -22,7 +22,6 @@ dependencies = [
     ('NCCL', '2.4.2'),
 ]
 
-configopts = '-DCMAKE_BUILD_TYPE=Release'
 
 exts_defaultclass = 'PythonPackage'
 exts_default_options = {

--- a/easybuild/easyconfigs/l/libgpuarray/libgpuarray-0.7.6-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/l/libgpuarray/libgpuarray-0.7.6-fosscuda-2019b-Python-3.7.4.eb
@@ -22,8 +22,6 @@ dependencies = [
     ('NCCL', '2.4.8'),
 ]
 
-build_type = 'Release'
-
 exts_defaultclass = 'PythonPackage'
 exts_default_options = {
     'download_dep_fail': True,

--- a/easybuild/easyconfigs/l/libgpuarray/libgpuarray-0.7.6-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/l/libgpuarray/libgpuarray-0.7.6-fosscuda-2020b.eb
@@ -23,8 +23,6 @@ dependencies = [
     ('NCCL', '2.8.3', '-CUDA-%(cudaver)s'),
 ]
 
-build_type = 'Release'
-
 exts_defaultclass = 'PythonPackage'
 exts_default_options = {
     'download_dep_fail': True,

--- a/easybuild/easyconfigs/m/MRCPP/MRCPP-1.3.6-foss-2020a.eb
+++ b/easybuild/easyconfigs/m/MRCPP/MRCPP-1.3.6-foss-2020a.eb
@@ -19,8 +19,6 @@ builddependencies = [
 ]
 
 configopts = "-DENABLE_MPI=True -DENABLE_OPENMP=True"
-separate_build_dir = True
-build_type = 'release'
 runtest = 'test'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/MRChem/MRChem-1.0.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/m/MRChem/MRChem-1.0.0-foss-2020a-Python-3.8.2.eb
@@ -28,8 +28,6 @@ dependencies = [
 ]
 
 configopts = "-DENABLE_MPI=True -DENABLE_OPENMP=True"
-separate_build_dir = True
-build_type = 'release'
 runtest = 'test'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/MariaDB/MariaDB-10.3.14-foss-2019a.eb
+++ b/easybuild/easyconfigs/m/MariaDB/MariaDB-10.3.14-foss-2019a.eb
@@ -37,8 +37,7 @@ dependencies = [
 
 separate_build_dir = True
 
-configopts = "-DCMAKE_BUILD_TYPE=Release "
-configopts += "-DCMAKE_SHARED_LINKER_FLAGS='-fuse-ld=bfd' "  # Linking fails with default gold linker
+configopts = "-DCMAKE_SHARED_LINKER_FLAGS='-fuse-ld=bfd' "  # Linking fails with default gold linker
 configopts += "-DMYSQL_MAINTAINER_MODE=OFF "  # disabled to not treat warnings as errors (-Werror)
 configopts += "-DWITH_PCRE=bundled "  # using an external PCRE is broken, see https://bugs.exim.org/show_bug.cgi?id=2173
 configopts += "-DWITH_ZLIB=system "

--- a/easybuild/easyconfigs/m/MariaDB/MariaDB-10.4.13-gompi-2019b.eb
+++ b/easybuild/easyconfigs/m/MariaDB/MariaDB-10.4.13-gompi-2019b.eb
@@ -37,8 +37,7 @@ dependencies = [
 
 separate_build_dir = True
 
-configopts = "-DCMAKE_BUILD_TYPE=Release "
-configopts += "-DCMAKE_SHARED_LINKER_FLAGS='-fuse-ld=bfd' "  # Linking fails with default gold linker
+configopts = "-DCMAKE_SHARED_LINKER_FLAGS='-fuse-ld=bfd' "  # Linking fails with default gold linker
 configopts += "-DMYSQL_MAINTAINER_MODE=OFF "  # disabled to not treat warnings as errors (-Werror)
 configopts += "-DWITH_PCRE=bundled "  # using an external PCRE is broken, see https://bugs.exim.org/show_bug.cgi?id=2173
 configopts += "-DWITH_ZLIB=system "

--- a/easybuild/easyconfigs/m/MariaDB/MariaDB-10.5.8-GCC-10.2.0.eb
+++ b/easybuild/easyconfigs/m/MariaDB/MariaDB-10.5.8-GCC-10.2.0.eb
@@ -47,8 +47,7 @@ dependencies = [
 local_pcre2_path = '%%(builddir)s/pcre2-%s.zip' % local_pcre2_ver
 preconfigopts = "sed -i 's@http://.*.zip@file://%s@g' ../mariadb-%%(version)s/cmake/pcre.cmake && " % local_pcre2_path
 
-configopts = "-DCMAKE_BUILD_TYPE=Release "
-configopts += "-DCMAKE_SHARED_LINKER_FLAGS='-fuse-ld=bfd' "  # Linking fails with default gold linker
+configopts = "-DCMAKE_SHARED_LINKER_FLAGS='-fuse-ld=bfd' "  # Linking fails with default gold linker
 configopts += "-DMYSQL_MAINTAINER_MODE=OFF "  # disabled to not treat warnings as errors (-Werror)
 configopts += "-DWITH_PCRE=bundled "  # using an external PCRE is broken, see https://bugs.exim.org/show_bug.cgi?id=2173
 configopts += "-DWITH_ZLIB=system "

--- a/easybuild/easyconfigs/m/MariaDB/MariaDB-10.6.4-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/m/MariaDB/MariaDB-10.6.4-GCC-10.3.0.eb
@@ -47,8 +47,7 @@ dependencies = [
 local_pcre2_path = '%%(builddir)s/pcre2-%s.zip' % local_pcre2_ver
 preconfigopts = "sed -i 's@http://.*.zip@file://%s@g' ../mariadb-%%(version)s/cmake/pcre.cmake && " % local_pcre2_path
 
-configopts = "-DCMAKE_BUILD_TYPE=Release "
-configopts += "-DCMAKE_SHARED_LINKER_FLAGS='-fuse-ld=bfd' "  # Linking fails with default gold linker
+configopts = "-DCMAKE_SHARED_LINKER_FLAGS='-fuse-ld=bfd' "  # Linking fails with default gold linker
 configopts += "-DMYSQL_MAINTAINER_MODE=OFF "  # disabled to not treat warnings as errors (-Werror)
 configopts += "-DWITH_PCRE=bundled "  # using an external PCRE is broken, see https://bugs.exim.org/show_bug.cgi?id=2173
 configopts += "-DWITH_ZLIB=system "

--- a/easybuild/easyconfigs/p/PCL/PCL-1.7.2-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/p/PCL/PCL-1.7.2-intel-2016a-Python-2.7.11.eb
@@ -13,6 +13,7 @@ toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/PointCloudLibrary/pcl/archive/']
 sources = [SOURCELOWER_TAR_GZ]
+checksums = ['479f84f2c658a6319b78271111251b4c2d6cf07643421b66bbc351d9bed0ae93']
 
 builddependencies = [('CMake', '3.5.2')]
 dependencies = [
@@ -22,8 +23,6 @@ dependencies = [
     ('VTK', '6.3.0', versionsuffix),
     ('Qhull', '2015.2'),
 ]
-
-configopts = '-DCMAKE_BUILD_TYPE=Release '
 
 sanity_check_paths = {
     'files': [],

--- a/easybuild/easyconfigs/p/PCL/PCL-1.8.1-intel-2017b-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/p/PCL/PCL-1.8.1-intel-2017b-Python-2.7.14.eb
@@ -28,8 +28,6 @@ dependencies = [
     ('Qhull', '2015.2'),
 ]
 
-configopts = '-DCMAKE_BUILD_TYPE=Release '
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['bin', 'include/pcl-%(version_major_minor)s/pcl', 'lib', 'share/pcl-%(version_major_minor)s'],

--- a/easybuild/easyconfigs/p/PCMSolver/PCMSolver-1.1.4-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/p/PCMSolver/PCMSolver-1.1.4-intel-2016a-Python-2.7.11.eb
@@ -10,8 +10,9 @@ description = """An API for the Polarizable Continuum Model."""
 toolchain = {'name': 'intel', 'version': '2016a'}
 toolchainopts = {'cstd': 'c99'}
 
-sources = ['v%(version)s.tar.gz']
 source_urls = ['https://github.com/PCMSolver/pcmsolver/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['e20d6e984cdb2795351714c2659c71d69fede9ebf159435fc7a0fdf897981ee9']
 
 dependencies = [
     ('Python', '2.7.11'),
@@ -24,7 +25,7 @@ builddependencies = [
     ('Eigen', '3.2.7'),
 ]
 
-configopts = '-DCMAKE_BUILD_TYPE=Release -DEIGEN3_ROOT=$EBROOTEIGEN'
+configopts = '-DEIGEN3_ROOT=$EBROOTEIGEN'
 configopts += ' -DCMAKE_CXX_FLAGS="$CXXFLAGS $LIBLAPACK_MT -DEIGEN_USE_MKL_ALL"'
 
 separate_build_dir = True

--- a/easybuild/easyconfigs/p/PCMSolver/PCMSolver-1.2.3-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/p/PCMSolver/PCMSolver-1.2.3-foss-2018b-Python-3.6.6.eb
@@ -27,7 +27,7 @@ builddependencies = [
     ('Eigen', '3.3.7', '', True),
 ]
 
-configopts = '-DCMAKE_BUILD_TYPE=Release -DEIGEN3_ROOT=$EBROOTEIGEN'
+configopts = '-DEIGEN3_ROOT=$EBROOTEIGEN'
 
 separate_build_dir = True
 

--- a/easybuild/easyconfigs/p/PCMSolver/PCMSolver-1.2.3-gompi-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/p/PCMSolver/PCMSolver-1.2.3-gompi-2019a-Python-3.7.2.eb
@@ -27,7 +27,7 @@ builddependencies = [
     ('Eigen', '3.3.7', '', True),
 ]
 
-configopts = '-DCMAKE_BUILD_TYPE=Release -DEIGEN3_ROOT=$EBROOTEIGEN'
+configopts = '-DEIGEN3_ROOT=$EBROOTEIGEN'
 
 separate_build_dir = True
 

--- a/easybuild/easyconfigs/p/PCMSolver/PCMSolver-20160205-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/p/PCMSolver/PCMSolver-20160205-intel-2016a-Python-2.7.11.eb
@@ -10,8 +10,9 @@ description = """An API for the Polarizable Continuum Model."""
 toolchain = {'name': 'intel', 'version': '2016a'}
 toolchainopts = {'cstd': 'c99'}
 
-sources = ['2473699d6c5db36525160e.tar.gz']
 source_urls = ['https://github.com/PCMSolver/pcmsolver/archive/']
+sources = ['2473699d6c5db36525160e.tar.gz']
+checksums = ['52219902e1cdc7a8f3725f7b72938c7722ecdaf5bfb3ca6fff7917979335eee2']
 
 dependencies = [
     ('Python', '2.7.11'),
@@ -24,7 +25,7 @@ builddependencies = [
     ('Eigen', '3.2.7'),
 ]
 
-configopts = "-DCMAKE_BUILD_TYPE=Release -DEIGEN3_ROOT=$EBROOTEIGEN "
+configopts = "-DEIGEN3_ROOT=$EBROOTEIGEN "
 configopts += '-DCMAKE_CXX_FLAGS="$LIBLAPACK_MT -DEIGEN_USE_MKL_ALL"'
 
 separate_build_dir = True

--- a/easybuild/easyconfigs/p/pizzly/pizzly-0.37.3-foss-2018b.eb
+++ b/easybuild/easyconfigs/p/pizzly/pizzly-0.37.3-foss-2018b.eb
@@ -23,7 +23,6 @@ builddependencies = [('CMake', '3.12.1')]
 
 dependencies = [('zlib', '1.2.11')]
 
-configopts = '-DCMAKE_BUILD_TYPE=Release'
 
 separate_build_dir = True
 

--- a/easybuild/easyconfigs/q/Qt5Webkit/Qt5Webkit-5.212.0-alpha3-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/q/Qt5Webkit/Qt5Webkit-5.212.0-alpha3-GCCcore-8.2.0.eb
@@ -39,7 +39,7 @@ dependencies = [
     ('libjpeg-turbo', '2.0.2'),
 ]
 
-configopts = "-G Ninja -DPORT=Qt -DCMAKE_BUILD_TYPE=Release -DUSE_LIBHYPHEN=OFF -DUSE_GSTREAMER=OFF "
+configopts = "-DPORT=Qt -DUSE_LIBHYPHEN=OFF -DUSE_GSTREAMER=OFF "
 
 sanity_check_paths = {
     'files': [

--- a/easybuild/easyconfigs/q/Qt5Webkit/Qt5Webkit-5.212.0-alpha4-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/q/Qt5Webkit/Qt5Webkit-5.212.0-alpha4-GCCcore-10.2.0.eb
@@ -43,7 +43,7 @@ dependencies = [
     ('libjpeg-turbo', '2.0.5'),
 ]
 
-configopts = "-G Ninja -DPORT=Qt -DCMAKE_BUILD_TYPE=Release -DUSE_LIBHYPHEN=OFF -DUSE_GSTREAMER=OFF "
+configopts = "-DPORT=Qt -DUSE_LIBHYPHEN=OFF -DUSE_GSTREAMER=OFF "
 
 sanity_check_paths = {
     'files': [

--- a/easybuild/easyconfigs/r/RAxML-NG/RAxML-NG-0.9.0-GCC-8.3.0.eb
+++ b/easybuild/easyconfigs/r/RAxML-NG/RAxML-NG-0.9.0-GCC-8.3.0.eb
@@ -63,10 +63,6 @@ builddependencies = [
 configopts = '-DUSE_MPI=OFF '
 configopts += '-DUSE_GMP=ON '
 
-build_type = 'Release'
-
-separate_build_dir = True
-
 # too much parallellism makes the build fail with:
 # No rule to make target 'localdeps/lib/libterraces.a';
 # see https://github.com/amkozlov/raxml-ng/issues/108

--- a/easybuild/easyconfigs/r/RAxML-NG/RAxML-NG-0.9.0-gompi-2019b.eb
+++ b/easybuild/easyconfigs/r/RAxML-NG/RAxML-NG-0.9.0-gompi-2019b.eb
@@ -63,10 +63,6 @@ builddependencies = [
 configopts = '-DUSE_MPI=ON '
 configopts += '-DUSE_GMP=ON '
 
-build_type = 'Release'
-
-separate_build_dir = True
-
 # too much parallellism makes the build fail with:
 # No rule to make target 'localdeps/lib/libterraces.a';
 # see https://github.com/amkozlov/raxml-ng/issues/108

--- a/easybuild/easyconfigs/r/RAxML-NG/RAxML-NG-1.0.1-gompi-2019b.eb
+++ b/easybuild/easyconfigs/r/RAxML-NG/RAxML-NG-1.0.1-gompi-2019b.eb
@@ -62,10 +62,6 @@ builddependencies = [
 configopts = '-DUSE_MPI=ON '
 configopts += '-DUSE_GMP=ON '
 
-build_type = 'Release'
-
-separate_build_dir = True
-
 # too much parallellism makes the build fail with:
 # No rule to make target 'localdeps/lib/libterraces.a';
 # see https://github.com/amkozlov/raxml-ng/issues/108

--- a/easybuild/easyconfigs/r/RAxML-NG/RAxML-NG-1.0.2-gompi-2020b.eb
+++ b/easybuild/easyconfigs/r/RAxML-NG/RAxML-NG-1.0.2-gompi-2020b.eb
@@ -62,10 +62,6 @@ builddependencies = [
 configopts = '-DUSE_MPI=ON '
 configopts += '-DUSE_GMP=ON '
 
-build_type = 'Release'
-
-separate_build_dir = True
-
 # too much parallellism makes the build fail with:
 # No rule to make target 'localdeps/lib/libterraces.a';
 # see https://github.com/amkozlov/raxml-ng/issues/108

--- a/easybuild/easyconfigs/s/strelka/strelka-2.9.10-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/s/strelka/strelka-2.9.10-foss-2018b-Python-2.7.15.eb
@@ -23,7 +23,7 @@ dependencies = [
     ('Python', '2.7.15'),
 ]
 
-configopts = "-DBOOST_ROOT=$EBROOTBOOST -DCMAKE_BUILD_TYPE=Release"
+configopts = "-DBOOST_ROOT=$EBROOTBOOST"
 
 separate_build_dir = True
 

--- a/easybuild/easyconfigs/s/strelka/strelka-2.9.10-intel-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/s/strelka/strelka-2.9.10-intel-2018b-Python-2.7.15.eb
@@ -25,7 +25,7 @@ dependencies = [
 
 separate_build_dir = True
 
-configopts = "-DBOOST_ROOT=$EBROOTBOOST -DCMAKE_BUILD_TYPE=Release"
+configopts = "-DBOOST_ROOT=$EBROOTBOOST"
 
 sanity_check_paths = {
     'files': ['bin/configureStrelkaGermlineWorkflow.py', 'libexec/strelka%(version_major)s'],

--- a/easybuild/easyconfigs/x/XCFun/XCFun-2.1.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/x/XCFun/XCFun-2.1.0-GCCcore-9.3.0.eb
@@ -17,9 +17,6 @@ builddependencies = [
     ('CMake', '3.16.4')
 ]
 
-separate_build_dir = True
-build_type = 'release'
-
 modextravars = {'XCFun_DIR': '%(installdir)s/share/cmake/XCFun/'}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/x/XCFun/XCFun-2.1.1-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/x/XCFun/XCFun-2.1.1-GCCcore-10.2.0.eb
@@ -17,9 +17,6 @@ builddependencies = [
     ('CMake', '3.18.4')
 ]
 
-separate_build_dir = True
-build_type = 'release'
-
 modextravars = {'XCFun_DIR': '%(installdir)s/share/cmake/XCFun/'}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/x/XCFun/XCFun-2.1.1-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/x/XCFun/XCFun-2.1.1-GCCcore-10.3.0.eb
@@ -17,9 +17,6 @@ builddependencies = [
     ('CMake', '3.20.1')
 ]
 
-separate_build_dir = True
-build_type = 'release'
-
 modextravars = {'XCFun_DIR': '%(installdir)s/share/cmake/XCFun/'}
 
 sanity_check_paths = {


### PR DESCRIPTION
This is the default for a few releases now and may lead to confusion or bugs.

Examples:
- `RELEASE` used instead of `Release` -> confusing
- `ON` used in 1 place -> bug

Bonus: CMakeMake reacts on toolchainopts.debug to set the build type correctly which works now after this change

Dependend on:

- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/13613
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/13614
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/13615
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/13616
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/13617
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/13619
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/13620
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/13621
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/13623
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/13624
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/13456
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/13434
