### PR TITLE
avoid downloading old numpy version during install for h5py

### DIFF
--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-foss-2020b.eb
@@ -26,6 +26,6 @@ use_pip = True
 sanity_pip_check = True
 download_dep_fail = True
 
-preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" '
+preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-foss-2020b.eb
@@ -26,6 +26,9 @@ use_pip = True
 sanity_pip_check = True
 download_dep_fail = True
 
+# h5py's setup.py will disable setup_requires if H5PY_SETUP_REQUIRES is set to 0
+# without this environment variable, pip will fetch the minimum version h5py supports during intall,
+# even though SciPy-bundle provides a newer version that satisfies h5py's install_requires dependency.
 preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-foss-2020b.eb
@@ -27,7 +27,7 @@ sanity_pip_check = True
 download_dep_fail = True
 
 # h5py's setup.py will disable setup_requires if H5PY_SETUP_REQUIRES is set to 0
-# without this environment variable, pip will fetch the minimum version h5py supports during intall,
+# without this environment variable, pip will fetch the minimum numpy version h5py supports during intall,
 # even though SciPy-bundle provides a newer version that satisfies h5py's install_requires dependency.
 preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
 

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-fosscuda-2020b.eb
@@ -26,6 +26,6 @@ use_pip = True
 sanity_pip_check = True
 download_dep_fail = True
 
-preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" '
+preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-fosscuda-2020b.eb
@@ -26,6 +26,9 @@ use_pip = True
 sanity_pip_check = True
 download_dep_fail = True
 
+# h5py's setup.py will disable setup_requires if H5PY_SETUP_REQUIRES is set to 0
+# without this environment variable, pip will fetch the minimum version h5py supports during intall,
+# even though SciPy-bundle provides a newer version that satisfies h5py's install_requires dependency.
 preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-fosscuda-2020b.eb
@@ -27,7 +27,7 @@ sanity_pip_check = True
 download_dep_fail = True
 
 # h5py's setup.py will disable setup_requires if H5PY_SETUP_REQUIRES is set to 0
-# without this environment variable, pip will fetch the minimum version h5py supports during intall,
+# without this environment variable, pip will fetch the minimum numpy version h5py supports during install,
 # even though SciPy-bundle provides a newer version that satisfies h5py's install_requires dependency.
 preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
 

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intel-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intel-2020b.eb
@@ -26,6 +26,6 @@ use_pip = True
 sanity_pip_check = True
 download_dep_fail = True
 
-preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" '
+preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intel-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intel-2020b.eb
@@ -26,6 +26,9 @@ use_pip = True
 sanity_pip_check = True
 download_dep_fail = True
 
+# h5py's setup.py will disable setup_requires if H5PY_SETUP_REQUIRES is set to 0
+# without this environment variable, pip will fetch the minimum version h5py supports during intall,
+# even though SciPy-bundle provides a newer version that satisfies h5py's install_requires dependency.
 preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intel-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intel-2020b.eb
@@ -27,7 +27,7 @@ sanity_pip_check = True
 download_dep_fail = True
 
 # h5py's setup.py will disable setup_requires if H5PY_SETUP_REQUIRES is set to 0
-# without this environment variable, pip will fetch the minimum version h5py supports during intall,
+# without this environment variable, pip will fetch the minimum numpy version h5py supports during install,
 # even though SciPy-bundle provides a newer version that satisfies h5py's install_requires dependency.
 preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
 

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intelcuda-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intelcuda-2020b.eb
@@ -26,6 +26,6 @@ use_pip = True
 sanity_pip_check = True
 download_dep_fail = True
 
-preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" '
+preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intelcuda-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intelcuda-2020b.eb
@@ -26,6 +26,9 @@ use_pip = True
 sanity_pip_check = True
 download_dep_fail = True
 
+# h5py's setup.py will disable setup_requires if H5PY_SETUP_REQUIRES is set to 0
+# without this environment variable, pip will fetch the minimum version h5py supports during intall,
+# even though SciPy-bundle provides a newer version that satisfies h5py's install_requires dependency.
 preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intelcuda-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.1.0-intelcuda-2020b.eb
@@ -27,7 +27,7 @@ sanity_pip_check = True
 download_dep_fail = True
 
 # h5py's setup.py will disable setup_requires if H5PY_SETUP_REQUIRES is set to 0
-# without this environment variable, pip will fetch the minimum version h5py supports during intall,
+# without this environment variable, pip will fetch the minimum numpy version h5py supports during install,
 # even though SciPy-bundle provides a newer version that satisfies h5py's install_requires dependency.
 preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
 

--- a/easybuild/easyconfigs/h/h5py/h5py-3.2.1-foss-2021a.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.2.1-foss-2021a.eb
@@ -26,6 +26,9 @@ use_pip = True
 sanity_pip_check = True
 download_dep_fail = True
 
-preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" '
+# h5py's setup.py will disable setup_requires if H5PY_SETUP_REQUIRES is set to 0
+# without this environment variable, pip will fetch the minimum version h5py supports during intall,
+# even though SciPy-bundle provides a newer version that satisfies h5py's install_requires dependency.
+preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-3.2.1-foss-2021a.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.2.1-foss-2021a.eb
@@ -27,7 +27,7 @@ sanity_pip_check = True
 download_dep_fail = True
 
 # h5py's setup.py will disable setup_requires if H5PY_SETUP_REQUIRES is set to 0
-# without this environment variable, pip will fetch the minimum version h5py supports during intall,
+# without this environment variable, pip will fetch the minimum numpy version h5py supports during install,
 # even though SciPy-bundle provides a newer version that satisfies h5py's install_requires dependency.
 preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
 


### PR DESCRIPTION
By default h5py's setup.py has a setup_requires for exactly the minimum supported version of numpy (older then the one in SciPy-bundle, in some cases) based on the python interpretor version, resulting in pip attempting to fetch it during the EasyBuild install phase.

As the dependency is already managed through easy_build, and h5py's install_requires is for any version newer than the minimum version, this change suppresses the setup_requires (using the mechanism provided by h2py for "downstream packagers - e.g. Linux distros").

Resolves #13424 