### PR TITLE
don't include unversioned go-basic.odo and goslin_generic.odo files in GOATOOLS installation (renamed from goatools)

### DIFF
--- a/easybuild/easyconfigs/g/GOATOOLS/GOATOOLS-1.1.6-foss-2020b.eb
+++ b/easybuild/easyconfigs/g/GOATOOLS/GOATOOLS-1.1.6-foss-2020b.eb
@@ -10,19 +10,11 @@ description = "A Python library for Gene Ontology analyses"
 
 toolchain = {'name': 'foss', 'version': '2020b'}
 
-# extra downloaded files are needed acc. to docs: https://github.com/tanghaibao/goatools#installation
-sources = [
-    {'source_urls': ['https://github.com/tanghaibao/goatools/archive/'],
-     'filename': 'v%(version)s.tar.gz'},
-    {'source_urls': ['http://geneontology.org/ontology/'],
-     'filename': 'go-basic.obo', 'extract_cmd': 'cp %s %(builddir)s'},
-    {'source_urls': ['http://www.geneontology.org/ontology/subsets/'],
-     'filename': 'goslim_generic.obo', 'extract_cmd': 'cp %s %(builddir)s'}]
-checksums = [
-    '41222308c2bc34eefd3292326a61bc215bd32831b4b2652eff00b1b8e3fcf8c6',  # v1.1.6.tar.gz
-    '57bd37b4301a7a6be65da033c8e812698e62fd0f12a30e18cf9e3cfeed238702',  # go-basic.obo
-    '161ccdabf702faee796335939858772703f5e05a2ccb0400a4cab481f41136d9',  # goslim_generic.obo
-]
+source_urls = ['https://github.com/tanghaibao/goatools/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['41222308c2bc34eefd3292326a61bc215bd32831b4b2652eff00b1b8e3fcf8c6']
+
+builddependencies = [('cURL', '7.72.0')]
 
 dependencies = [
     ('Python', '3.8.6'),
@@ -31,40 +23,29 @@ dependencies = [
     ('statsmodels', '0.12.1'),
     ('pydot', '1.4.2'),
 ]
+
 download_dep_fail = True
+use_pip = True
 
 preinstallopts = "sed -i 's/==[0-9]*.[0-9]*.[0-9]*//g' requirements.txt && "
 # wget was here only to download some src files which we download via sources
 preinstallopts += "sed -i 's/wget//g' requirements.txt && "
 
-local_go_path = "%(installdir)s/bin/goafiles"
-
-
-local_data_dir = '%(builddir)s/%(name)s-%(version)s/data/*'
-# copy downloaded GOA files into dedicated folder for user and to bin/ for sanity_check
-postinstallcmds = ["mkdir %s" % local_go_path,
-                   "cp %%(builddir)s/go-basic.obo %s" % local_go_path,
-                   "cp %%(builddir)s/goslim_generic.obo %s" % local_go_path,
-                   "cp %(builddir)s/go-basic.obo %(installdir)s/bin/",
-                   "cp %(builddir)s/goslim_generic.obo %(installdir)s/bin/",
-                   "mkdir %%(installdir)s/bin/data && cp -r %s %%(installdir)s/bin/data" % local_data_dir]
-
-# making sure user knows about downloaded files
-modextravars = {'GOAFILES': local_go_path}
-modloadmsg = """\n GOATOOLS: Downloaded files from "geneontology.org" are accessible in a directory behind a variable \
-$GOAFILES.\n You need to have them in a directory from which you run goatools commands."""
-
-use_pip = True
+local_data_dir = '%(builddir)s/%(namelower)s-%(version)s/data/*'
+postinstallcmds = ["mkdir %%(installdir)s/data && cp -r %s %%(installdir)s/data" % local_data_dir]
 
 sanity_check_paths = {
     'files': ['bin/find_enrichment.py'],
-    'dirs': ['bin/data'],
+    'dirs': ['data'],
 }
 
-# example from https://github.com/tanghaibao/goatools#find-go-enrichment-of-genes-under-study
-local_cmd = "cd %(installdir)s/bin && find_enrichment.py --pval=0.05\
-    --indent data/study data/population data/association && cd -"
-sanity_check_commands = [local_cmd]
+# example test run, see https://github.com/tanghaibao/goatools/blob/master/run.sh
+sanity_check_commands = [
+    "cd %(builddir)s && curl -OL http://geneontology.org/ontology/go-basic.obo",
+    "cd %(builddir)s && curl -OL http://www.geneontology.org/ontology/subsets/goslim_generic.obo",
+    "cd %(builddir)s && cp -a %(installdir)s/data .",
+    "cd %(builddir)s && find_enrichment.py --pval=0.05 --indent data/study data/population data/association",
+]
 
 sanity_pip_check = True
 

--- a/easybuild/easyconfigs/g/GOATOOLS/GOATOOLS-1.1.6-foss-2020b.eb
+++ b/easybuild/easyconfigs/g/GOATOOLS/GOATOOLS-1.1.6-foss-2020b.eb
@@ -2,7 +2,7 @@
 # Author: Denis Kristak
 easyblock = 'PythonPackage'
 
-name = 'goatools'
+name = 'GOATOOLS'
 version = '1.1.6'
 
 homepage = 'https://github.com/tanghaibao/goatools'


### PR DESCRIPTION
follow-up for #13364

The original easyconfig is already broken because `go-basic.odo` was updated in place, and there's no versioned download available.

These files don't need to be part of the installation itself, they just need to be available in the current working directory, so and end user can download these easily themselves...