### PR TITLE
make the testsuite print error and still return a non-zero exitcode

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -121,7 +121,8 @@ jobs:
           eb --show-system-info
 
           # run test suite
-          python -O -m test.easyconfigs.suite
+          # if tests failed, print error message that is picked up by boegelbot to determine end of test output
+          python -O -m test.easyconfigs.suite || (echo "ERROR: Not all tests were successful" && exit 1)
 
           unset PYTHONPATH
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -121,8 +121,7 @@ jobs:
           eb --show-system-info
 
           # run test suite
-          # if tests failed, print error message that is picked up by boegelbot to determine end of test output
-          python -O -m test.easyconfigs.suite || echo "ERROR: Not all tests were successful"
+          python -O -m test.easyconfigs.suite
 
           unset PYTHONPATH
 


### PR DESCRIPTION
see https://github.com/easybuilders/easybuild-easyconfigs/pull/13767#discussion_r691452271

If the tests fail then the `|| echo "ERROR: Not all tests were successful"` means that the non-zero exit code is taken since the `echo` succeeds.