### PR TITLE
rename CUDAcore to CUDA for v11.3.1 and v11.4.1 after merging foss/fosscuda, to ensure that get_software_root('CUDA') used in easyblocks works

### DIFF
--- a/easybuild/easyconfigs/c/CUDA/CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-11.3.1.eb
@@ -1,8 +1,6 @@
-easyblock = 'EB_CUDA'
-
-name = 'CUDAcore'
-version = '11.4.1'
-local_nv_version = '470.57.02'
+name = 'CUDA'
+version = '11.3.1'
+local_nv_version = '465.19.01'
 
 homepage = 'https://developer.nvidia.com/cuda-toolkit'
 description = """CUDA (formerly Compute Unified Device Architecture) is a parallel
@@ -17,11 +15,11 @@ sources = ['cuda_%%(version)s_%s_linux%%(cudaarch)s.run' % local_nv_version]
 checksums = [
     {
         'cuda_%%(version)s_%s_linux.run' % local_nv_version:
-            'dd6c339a719989d2518f5d54eeac1ed707d0673f8664ba0c4d4b2af7c3ba0005',
+            'ad93ea98efced35855c58d3a0fc326377c60917cb3e8c017d3e6d88819bf2934',
         'cuda_%%(version)s_%s_linux_ppc64le.run' % local_nv_version:
-            'dd92ca04f76ad938da3480e2901c0e52dbff6028ada63c09071ed9e3055dc361',
+            '220f2c10a21500d62b03c6848c1659ebb3a8e10dc0915ab87b86b397058407c5',
         'cuda_%%(version)s_%s_linux_sbsa.run' % local_nv_version:
-            'i8efa725a41dfd3c0c0f453c2dd535d149154102bf2b791718859417b4f84f922',
+            '39990d3da88b21289ac20850bc183f0b66275f32e1f562b551c05843bf506e4c'
     }
 ]
 

--- a/easybuild/easyconfigs/c/CUDA/CUDA-11.4.1.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-11.4.1.eb
@@ -1,8 +1,6 @@
-easyblock = 'EB_CUDA'
-
-name = 'CUDAcore'
-version = '11.3.1'
-local_nv_version = '465.19.01'
+name = 'CUDA'
+version = '11.4.1'
+local_nv_version = '470.57.02'
 
 homepage = 'https://developer.nvidia.com/cuda-toolkit'
 description = """CUDA (formerly Compute Unified Device Architecture) is a parallel
@@ -17,11 +15,11 @@ sources = ['cuda_%%(version)s_%s_linux%%(cudaarch)s.run' % local_nv_version]
 checksums = [
     {
         'cuda_%%(version)s_%s_linux.run' % local_nv_version:
-            'ad93ea98efced35855c58d3a0fc326377c60917cb3e8c017d3e6d88819bf2934',
+            'dd6c339a719989d2518f5d54eeac1ed707d0673f8664ba0c4d4b2af7c3ba0005',
         'cuda_%%(version)s_%s_linux_ppc64le.run' % local_nv_version:
-            '220f2c10a21500d62b03c6848c1659ebb3a8e10dc0915ab87b86b397058407c5',
+            'dd92ca04f76ad938da3480e2901c0e52dbff6028ada63c09071ed9e3055dc361',
         'cuda_%%(version)s_%s_linux_sbsa.run' % local_nv_version:
-            '39990d3da88b21289ac20850bc183f0b66275f32e1f562b551c05843bf506e4c'
+            'i8efa725a41dfd3c0c0f453c2dd535d149154102bf2b791718859417b4f84f922',
     }
 ]
 

--- a/easybuild/easyconfigs/c/ctffind/ctffind-4.1.14-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/c/ctffind/ctffind-4.1.14-foss-2021a-CUDA-11.3.1.eb
@@ -35,7 +35,7 @@ dependencies = [
     ('LibTIFF', '4.2.0'),
     ('GSL', '2.7'),
     ('wxWidgets', '3.1.5'),
-    ('CUDAcore', '11.3.1', '', True),
+    ('CUDA', '11.3.1', '', True),
 ]
 
 configopts = '--enable-openmp '

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.2.1.32-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.2.1.32-CUDA-11.3.1.eb
@@ -27,7 +27,7 @@ checksums = [
     }
 ]
 
-dependencies = [('CUDAcore', local_cuda_version)]
+dependencies = [('CUDA', local_cuda_version)]
 
 sanity_check_paths = {
     'files': ['include/cudnn.h', 'lib64/libcudnn_static.a'],

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.2.2.26-CUDA-11.4.1.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.2.2.26-CUDA-11.4.1.eb
@@ -27,7 +27,7 @@ checksums = [
     }
 ]
 
-dependencies = [('CUDAcore', local_cuda_version)]
+dependencies = [('CUDA', local_cuda_version)]
 
 sanity_check_paths = {
     'files': ['include/cudnn.h', 'lib64/libcudnn_static.a'],

--- a/easybuild/easyconfigs/m/magma/magma-2.6.1-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/m/magma/magma-2.6.1-foss-2021a-CUDA-11.3.1.eb
@@ -24,7 +24,7 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('CUDAcore', '11.3.1', '', True),
+    ('CUDA', '11.3.1', '', True),
 ]
 
 # default CUDA compute capabilities to use (override via --cuda-compute-capabilities)

--- a/easybuild/easyconfigs/n/NCCL/NCCL-2.10.3-GCCcore-10.3.0-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/n/NCCL/NCCL-2.10.3-GCCcore-10.3.0-CUDA-11.3.1.eb
@@ -16,7 +16,7 @@ checksums = ['55de166eb7dcab9ecef2629cdb5fb0c5ebec4fae03589c469ebe5dcb5716b3c5']
 builddependencies = [('binutils', '2.36.1')]
 
 dependencies = [
-    ('CUDAcore', '11.3.1', '', True),
+    ('CUDA', '11.3.1', '', True),
     ('UCX-CUDA', '1.10.0', versionsuffix),
 ]
 

--- a/easybuild/easyconfigs/n/NCCL/NCCL-2.10.3-GCCcore-11.2.0-CUDA-11.4.1.eb
+++ b/easybuild/easyconfigs/n/NCCL/NCCL-2.10.3-GCCcore-11.2.0-CUDA-11.4.1.eb
@@ -16,7 +16,7 @@ checksums = ['55de166eb7dcab9ecef2629cdb5fb0c5ebec4fae03589c469ebe5dcb5716b3c5']
 builddependencies = [('binutils', '2.37')]
 
 dependencies = [
-    ('CUDAcore', '11.4.1', '', True),
+    ('CUDA', '11.4.1', '', True),
     ('UCX-CUDA', '1.11.0', versionsuffix),
 ]
 

--- a/easybuild/easyconfigs/n/NCCL/NCCL-2.9.9-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/n/NCCL/NCCL-2.9.9-CUDA-11.3.1.eb
@@ -29,7 +29,7 @@ checksums = [
     }
 ]
 
-dependencies = [('CUDAcore', local_cuda_version)]
+dependencies = [('CUDA', local_cuda_version)]
 
 skipsteps = ['build']
 

--- a/easybuild/easyconfigs/o/OSU-Micro-Benchmarks/OSU-Micro-Benchmarks-5.7.1-gompi-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/o/OSU-Micro-Benchmarks/OSU-Micro-Benchmarks-5.7.1-gompi-2021a-CUDA-11.3.1.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TGZ]
 checksums = ['cb5ce4e2e68ed012d9952e96ef880a802058c87a1d840a2093b19bddc7faa165']
 
 dependencies = [
-    ('CUDAcore', '11.3.1', '', True),
+    ('CUDA', '11.3.1', '', True),
     ('UCX-CUDA', '1.10.0', versionsuffix),
 ]
 

--- a/easybuild/easyconfigs/u/UCX-CUDA/UCX-CUDA-1.10.0-GCCcore-10.3.0-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/u/UCX-CUDA/UCX-CUDA-1.10.0-GCCcore-10.3.0-CUDA-11.3.1.eb
@@ -35,7 +35,7 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.2.11'),
     ('UCX', version),
-    ('CUDAcore',  '11.3.1', '', True),
+    ('CUDA',  '11.3.1', '', True),
     ('GDRCopy', '2.2'),
 ]
 

--- a/easybuild/easyconfigs/u/UCX-CUDA/UCX-CUDA-1.11.0-GCCcore-11.2.0-CUDA-11.4.1.eb
+++ b/easybuild/easyconfigs/u/UCX-CUDA/UCX-CUDA-1.11.0-GCCcore-11.2.0-CUDA-11.4.1.eb
@@ -35,7 +35,7 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.2.11'),
     ('UCX', version),
-    ('CUDAcore',  '11.4.1', '', True),
+    ('CUDA',  '11.4.1', '', True),
     ('GDRCopy', '2.3'),
 ]
 


### PR DESCRIPTION
So, unfortunately, we have released some of these easyconfigs, but it is an important change we might still consider, as it would otherwise require some either ugly workarounds, or fixing a bunch of easyblocks.

Some of these only need to rebuild the module.

Possible alternative: Have CUDAcore also defined EBROOTCUDA 

Affected easyconfigs that have already been released:
cuDNN-8.2.1.32-CUDA-11.3.1.eb
NCCL-2.10.3-GCCcore-10.3.0-CUDA-11.3.1.eb
magma-2.6.1-foss-2021a-CUDA-11.3.1.eb
OSU-Micro-Benchmarks-5.7.1-gompi-2021a-CUDA-11.3.1.eb
edit this was wrong, it was actually just cuDNN was affected, yay

I.M.O., having to rebuild these is not a huge issue as we don't provide anything that depends on top of them. Might also get away with just a module-rebuild if it's not RPATH'ed