### PR TITLE
fix software name for Snippy to snippy

### DIFF
--- a/easybuild/easyconfigs/s/snippy/snippy-4.6.0-GCC-9.3.0-Java-13-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/snippy/snippy-4.6.0-GCC-9.3.0-Java-13-Python-3.8.2.eb
@@ -2,7 +2,7 @@
 
 easyblock = 'CmdCp'
 
-name = 'Snippy'
+name = 'snippy'
 version = '4.6.0'
 local_pyversuffix = '-Python-%(pyver)s'
 local_javaversuffix = '-Java-%(javaver)s'
@@ -16,7 +16,7 @@ description = """Snippy finds SNPs between a haploid reference genome and your N
 toolchain = {'name': 'GCC', 'version': '9.3.0'}
 
 github_account = 'tseemann'
-source_urls = [GITHUB_LOWER_SOURCE]
+source_urls = [GITHUB_SOURCE]
 sources = ['v%(version)s.tar.gz']
 checksums = ['7264e3819e249387effd3eba170ff49404b1cf7347dfa25944866f5aeb6b11c3']
 


### PR DESCRIPTION
The `Snippy` easyconfig was added in #12893, but we already had `snippy` (cfr. #13475 and #8635)