### PR TITLE
fix software name for xTB to xtb

### DIFF
--- a/easybuild/easyconfigs/x/xtb/xtb-6.4.1-intel-2021a.eb
+++ b/easybuild/easyconfigs/x/xtb/xtb-6.4.1-intel-2021a.eb
@@ -2,7 +2,7 @@
 
 easyblock = 'MesonNinja'
 
-name = 'xTB'
+name = 'xtb'
 version = '6.4.1'
 
 homepage = 'https://xtb-docs.readthedocs.io'


### PR DESCRIPTION
Easyconfig for `xTB` was added in #13649, but we already have easyconfigs under the `xtb` name, cfr. #9878 and #9993