### PR TITLE
{phys}TRIQS-dcore3-3.0.0-foss-2020b

### DIFF
--- a/easybuild/easyconfigs/c/Clang-Python-bindings/Clang-Python-bindings-11.0.1-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/c/Clang-Python-bindings/Clang-Python-bindings-11.0.1-GCCcore-10.2.0.eb
@@ -1,0 +1,31 @@
+easyblock = 'Tarball'
+
+name = 'Clang-Python-bindings'
+version = '11.0.1'
+
+homepage = 'https://clang.llvm.org'
+description = """Python bindings for libclang"""
+
+toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+
+source_urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-%(version)s/"]
+sources = ['clang-%(version)s.src.tar.xz']
+checksums = ['73f572c2eefc5a155e01bcd84815751d722a4d3925f53c144acfb93eeb274b4d']
+
+dependencies = [
+    ('Clang', version),
+    ('Python', '3.8.6')
+]
+
+start_dir = 'bindings/python'
+
+sanity_check_paths = {
+    'files': ['clang/cindex.py'],
+    'dirs': ['clang']
+}
+
+sanity_check_commands = ["python -c 'import clang'"]
+
+modextrapaths = {'PYTHONPATH': ''}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/c/cppy/cppy-1.1.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/c/cppy/cppy-1.1.0-GCCcore-10.2.0.eb
@@ -12,6 +12,8 @@ methods for performing common object operations."""
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
+builddependencies = [('binutils', '2.35')]
+
 dependencies = [
     ('Python', '3.8.6'),
 ]

--- a/easybuild/easyconfigs/c/cppy/cppy-1.1.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/c/cppy/cppy-1.1.0-GCCcore-10.2.0.eb
@@ -1,0 +1,27 @@
+easyblock = 'PythonPackage'
+
+name = 'cppy'
+version = '1.1.0'
+
+homepage = "https://github.com/nucleic/cppy"
+description = """A small C++ header library which makes it easier to write
+Python extension modules. The primary feature is a PyObject smart pointer
+which automatically handles reference counting and provides convenience
+methods for performing common object operations."""
+
+
+toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+
+dependencies = [
+    ('Python', '3.8.6'),
+]
+
+source_urls = ['https://github.com/nucleic/cppy/archive/refs/tags/']
+sources = ['%(version)s.tar.gz']
+checksums = ['40a9672df1ec2d7f0b54f70e574101f42131c0f5e47980769f68085e728a4934']
+
+download_dep_fail = True
+sanity_pip_check = True
+use_pip = True
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-3.4.2-foss-2020b.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-3.4.2-foss-2020b.eb
@@ -1,0 +1,64 @@
+easyblock = 'PythonBundle'
+
+name = 'matplotlib'
+version = '3.4.2'
+
+homepage = 'https://matplotlib.org'
+description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
+ hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
+ and ipython shell, web application servers, and six graphical user interface toolkits."""
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+
+builddependencies = [
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('SciPy-bundle', '2020.11'),
+    ('libpng', '1.6.37'),
+    ('freetype', '2.10.3'),
+    ('Tkinter', '%(pyver)s'),
+    ('Pillow', '8.0.1'),
+    ('Qhull', '2020.2'),
+    ('cppy', '1.1.0')
+]
+
+use_pip = True
+sanity_pip_check = True
+
+# avoid that matplotlib downloads and builds its own copies of freetype and qhull
+_fix_setup = "sed -e 's/#system_freetype = False/system_freetype = True/g' "
+_fix_setup += "-e 's/#system_qhull = False/system_qhull = True/g' setup.cfg.template >setup.cfg && "
+
+_include_path = "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && "
+
+exts_list = [
+    ('Cycler', '0.10.0', {
+        'modulename': 'cycler',
+        'source_tmpl': 'cycler-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/C/Cycler'],
+        'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
+    }),
+    ('kiwisolver', '1.3.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/k/kiwisolver'],
+        'checksums': ['950a199911a8d94683a6b10321f9345d5a3a8433ec58b217ace979e18f16e248'],
+    }),
+    (name, version, {
+        'preinstallopts': _fix_setup + _include_path,
+        'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
+        'checksums': ['d8d994cefdff9aaba45166eb3de4f5211adb4accac85cbf97137e98f26ea0219'],
+    }),
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("Agg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
+
+# use non-interactive plotting backend as default
+# see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
+modextravars = {'MPLBACKEND': 'Agg'}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/n/NFFT/NFFT-3.5.2-foss-2020b.eb
+++ b/easybuild/easyconfigs/n/NFFT/NFFT-3.5.2-foss-2020b.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'NFFT'
+version = '3.5.2'
+
+homepage = 'https://www-user.tu-chemnitz.de/~potts/nfft/'
+description = """The NFFT (nonequispaced fast Fourier transform or nonuniform fast Fourier transform) is a C subroutine
+ library for computing the nonequispaced discrete Fourier transform (NDFT) and its generalisations in one or more
+ dimensions, of arbitrary input size, and of complex data."""
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+
+source_urls = ['https://github.com/NFFT/nfft/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['c68b22de2b914328d5d9fd33778defc66b226c72ef4c103956bbf36bbcd18e45']
+
+dependencies = [('FFTW', '3.3.8')]
+
+builddependencies = [('Autotools', '20200321')]
+
+configure_cmd_prefix = './bootstrap.sh ; '
+
+sanity_check_paths = {
+    'files': ['include/nfft3.h', 'include/nfft3mp.h', 'lib/libnfft3.a', 'lib/libnfft3.%s' % SHLIB_EXT],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/TRIQS-cthyb/TRIQS-cthyb-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TRIQS-cthyb/TRIQS-cthyb-3.0.0-foss-2020b.eb
@@ -29,7 +29,7 @@ sources = [
     {
         'filename': 'release-1.10.0.tar.gz',
         'source_urls': ['https://github.com/google/googletest/archive/refs/tags/'],
-        'extract_cmd': "tar -C cthyb-%(version)s/deps -zxf %s && " \
+        'extract_cmd': "tar -C cthyb-%(version)s/deps -zxf %s && "
                        "mv cthyb-%(version)s/deps/googletest-release-1.10.0 cthyb-%(version)s/deps/GTest",
     }
 ]

--- a/easybuild/easyconfigs/t/TRIQS-cthyb/TRIQS-cthyb-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TRIQS-cthyb/TRIQS-cthyb-3.0.0-foss-2020b.eb
@@ -1,0 +1,72 @@
+easyblock = 'CMakeMake'
+
+name = 'TRIQS-cthyb'
+version = '3.0.0'
+
+homepage = 'https://triqs.github.io/cthyb/'
+description = """
+ TRIQS (Toolbox for Research on Interacting Quantum Systems) is a
+ scientific project providing a set of C++ and Python libraries to
+ develop new tools for the study of interacting quantum systems.
+
+ cthyb = continuous-time hybridisation-expansion quantum Monte Carlo
+
+ The TRIQS-based hybridization-expansion solver allows to solve the
+ generic problem of a quantum impurity embedded in a conduction bath
+ for an arbitrary local interaction vertex. The “impurity” can be any
+ set of orbitals, on one or several atoms.
+"""
+
+docurls = ['https://triqs.github.io/cthyb/%(version_major_minor)s.x/']
+software_license = 'LicenseGPLv3'
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['https://github.com/TRIQS/cthyb/releases/download/%(version)s/']
+sources = [
+    'cthyb-%(version)s.tar.gz',
+    {
+        'filename': 'release-1.10.0.tar.gz',
+        'source_urls': ['https://github.com/google/googletest/archive/refs/tags/'],
+        'extract_cmd': "tar -C cthyb-%(version)s/deps -zxf %s && mv cthyb-%(version)s/deps/googletest-release-1.10.0 cthyb-%(version)s/deps/GTest",
+    }
+ ]
+checksums = [
+    '64970bfc73f5be819a87044411b4cc9e1f7996d122158c5c011046b7e1aec4e5',
+    '9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb'
+]
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('TRIQS', '3.0.0'),
+    ('NFFT', '3.5.2')
+]
+
+builddependencies = [
+    ('CMake', '3.18.4')
+]
+
+separate_build_dir = True
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['lib/libtriqs_cthyb_c.a'],
+    'dirs': ['include', 'include/triqs_cthyb', 'lib',
+             'lib/python%(pyshortver)s/site-packages', 'share'],
+}
+
+sanity_check_commands = ["python -c 'import triqs_cthyb'"]
+
+modextrapaths = {
+    'CPLUS_INCLUDE_PATH': 'include',
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
+    'CMAKE_PREFIX_PATH': 'lib/cmake/triqs_cthyb',
+}
+modextravars = {
+    'TRIQS_CTHYB_ROOT': '%(installdir)s',
+    'TRIQS_CTHYB_VERSION': '%(version)s',
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/t/TRIQS-cthyb/TRIQS-cthyb-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TRIQS-cthyb/TRIQS-cthyb-3.0.0-foss-2020b.eb
@@ -29,9 +29,10 @@ sources = [
     {
         'filename': 'release-1.10.0.tar.gz',
         'source_urls': ['https://github.com/google/googletest/archive/refs/tags/'],
-        'extract_cmd': "tar -C cthyb-%(version)s/deps -zxf %s && mv cthyb-%(version)s/deps/googletest-release-1.10.0 cthyb-%(version)s/deps/GTest",
+        'extract_cmd': "tar -C cthyb-%(version)s/deps -zxf %s && " \
+                       "mv cthyb-%(version)s/deps/googletest-release-1.10.0 cthyb-%(version)s/deps/GTest",
     }
- ]
+]
 checksums = [
     '64970bfc73f5be819a87044411b4cc9e1f7996d122158c5c011046b7e1aec4e5',
     '9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb'

--- a/easybuild/easyconfigs/t/TRIQS-dcore3/TRIQS-dcore3-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TRIQS-dcore3/TRIQS-dcore3-3.0.0-foss-2020b.eb
@@ -1,0 +1,64 @@
+easyblock = 'PythonPackage'
+
+name = 'TRIQS-dcore3'
+version = '3.0.0'
+
+homepage = 'https://issp-center-dev.github.io/DCore/master/about.html'
+description = """
+DCore is aimed at model calculations and ab-initio calculations by the dynamical mean-field theory (DMFT).
+This package consists of programs with text-based and hdf5-based interface.
+These programs enable users to perform DMFT calculations and analyze results without writing computer code.
+"""
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+
+sources = [{
+    'source_urls': ['https://github.com/issp-center-dev/DCore/archive/refs/tags'],
+    'download_filename': 'v%(version)s.tar.gz',
+    'filename': 'DCore-%(version)s.tar.gz',
+}]
+checksums = ['60f2694c52191ac5f99e5d7412b0b77582b255dcfe5a69b3f3f99065f6908ab4']
+
+options = {
+    'modulename': 'dcore',  # Used for sanity check
+}
+
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+builddependencies = [('CMake', '3.18.4')]
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('SciPy-bundle', '2020.11'), # numpy and scipy
+    ('matplotlib', '3.4.2'),
+    ('h5py', '3.1.0'),
+    ('TRIQS-dft_tools', '3.0.0'),
+    ('TRIQS-cthyb', '3.0.0'),
+    ('TRIQS-hubbardI', '3.0.0')
+]
+
+sanity_check_paths = {
+    'files': [
+        'bin/dcore_pre',
+        'bin/dcore',
+        'bin/dcore_post'
+    ],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/dcore'],
+}
+
+
+sanity_check_commands = [
+    # Tests require the package to be installed, so doing it pre-
+    # install via runtest is not working.  They also need running
+    # before cleanup, so tests (testcases) is also not appropriate.
+    "pytest %(builddir)s/DCore-%(version)s/tests/non-mpi/*/*.py",
+    "python -c 'from dcore.dcore_check import dcore_check'",
+    "dcore_pre --help",
+    "dcore --help",
+    "dcore_post --help"
+]
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/t/TRIQS-dcore3/TRIQS-dcore3-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TRIQS-dcore3/TRIQS-dcore3-3.0.0-foss-2020b.eb
@@ -32,7 +32,7 @@ builddependencies = [('CMake', '3.18.4')]
 
 dependencies = [
     ('Python', '3.8.6'),
-    ('SciPy-bundle', '2020.11'), # numpy and scipy
+    ('SciPy-bundle', '2020.11'),  # numpy and scipy
     ('matplotlib', '3.4.2'),
     ('h5py', '3.1.0'),
     ('TRIQS-dft_tools', '3.0.0'),

--- a/easybuild/easyconfigs/t/TRIQS-dft_tools/TRIQS-dft_tools-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TRIQS-dft_tools/TRIQS-dft_tools-3.0.0-foss-2020b.eb
@@ -31,7 +31,7 @@ sources = [
     {
         'filename': 'release-1.10.0.tar.gz',
         'source_urls': ['https://github.com/google/googletest/archive/refs/tags/'],
-        'extract_cmd': "tar -C dft_tools-%(version)s/deps -zxf %s && " \
+        'extract_cmd': "tar -C dft_tools-%(version)s/deps -zxf %s && "
                        "mv dft_tools-%(version)s/deps/googletest-release-1.10.0 dft_tools-%(version)s/deps/GTest",
     },
 ]

--- a/easybuild/easyconfigs/t/TRIQS-dft_tools/TRIQS-dft_tools-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TRIQS-dft_tools/TRIQS-dft_tools-3.0.0-foss-2020b.eb
@@ -31,7 +31,8 @@ sources = [
     {
         'filename': 'release-1.10.0.tar.gz',
         'source_urls': ['https://github.com/google/googletest/archive/refs/tags/'],
-        'extract_cmd': "tar -C dft_tools-%(version)s/deps -zxf %s && mv dft_tools-%(version)s/deps/googletest-release-1.10.0 dft_tools-%(version)s/deps/GTest",
+        'extract_cmd': "tar -C dft_tools-%(version)s/deps -zxf %s && " \
+                       "mv dft_tools-%(version)s/deps/googletest-release-1.10.0 dft_tools-%(version)s/deps/GTest",
     },
 ]
 checksums = [

--- a/easybuild/easyconfigs/t/TRIQS-dft_tools/TRIQS-dft_tools-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TRIQS-dft_tools/TRIQS-dft_tools-3.0.0-foss-2020b.eb
@@ -1,0 +1,73 @@
+easyblock = 'CMakeMake'
+
+name = 'TRIQS-dft_tools'
+version = '3.0.0'
+
+homepage = 'https://triqs.github.io/dft_tools/'
+description = """
+ TRIQS (Toolbox for Research on Interacting Quantum Systems) is a
+ scientific project providing a set of C++ and Python libraries to
+ develop new tools for the study of interacting quantum systems.
+
+ This TRIQS-based-based application is aimed at ab-initio calculations
+ for correlated materials, combining realistic DFT band-structure calculation 
+ with the dynamical mean-field theory. Together with the necessary tools to
+ perform the DMFT self-consistency loop for realistic multi-band problems,
+ the package provides a full-fledged charge self-consistent interface to the
+ Wien2K package. In addition, if Wien2k is not available, it provides a generic
+ interface for one-shot DFT+DMFT calculations, where only the single-particle
+ Hamiltonian in orbital space has to be provided.
+"""
+
+docurls = ['https://triqs.github.io/dft_tools/%(version_major_minor)s.x/']
+software_license = 'LicenseGPLv3'
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['https://github.com/TRIQS/dft_tools/releases/download/%(version)s/']
+sources = [
+    'dft_tools-%(version)s.tar.gz',
+    {
+        'filename': 'release-1.10.0.tar.gz',
+        'source_urls': ['https://github.com/google/googletest/archive/refs/tags/'],
+        'extract_cmd': "tar -C dft_tools-%(version)s/deps -zxf %s && mv dft_tools-%(version)s/deps/googletest-release-1.10.0 dft_tools-%(version)s/deps/GTest",
+    },
+]
+checksums = [
+    '646d1d2dca5cf6ad90e18d0706124f701aa94ec39c5236d8fcf36dc5c628a3f6',
+    '9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb'
+]
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('TRIQS', '3.0.0'),
+]
+
+builddependencies = [
+    ('CMake', '3.18.4')
+]
+
+separate_build_dir = True
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['bin/dmftproj', 'lib/libtriqs_dft_tools_c.a'],
+    'dirs': ['include/triqs_dft_tools', 'bin', 'lib', 'share',
+             'lib/python%(pyshortver)s/site-packages/triqs_dft_tools'],
+}
+
+sanity_check_commands = ["python -c 'import triqs_dft_tools'"]
+
+modextrapaths = {
+    'CPLUS_INCLUDE_PATH': 'include',
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
+    'CMAKE_PREFIX_PATH': 'lib/cmake/triqs_dft_tools',
+}
+modextravars = {
+    'TRIQS_DFT_TOOLS_ROOT': '%(installdir)s',
+    'TRIQS_DFT_TOOLS_VERSION': '%(version)s',
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/t/TRIQS-hubbardI/TRIQS-hubbardI-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TRIQS-hubbardI/TRIQS-hubbardI-3.0.0-foss-2020b.eb
@@ -31,7 +31,7 @@ sources = [
     {
         'filename': 'release-1.10.0.tar.gz',
         'source_urls': ['https://github.com/google/googletest/archive/refs/tags/'],
-        'extract_cmd': "tar -C hubbardI-%(version)s/deps -zxf %s && " \
+        'extract_cmd': "tar -C hubbardI-%(version)s/deps -zxf %s && "
                        "mv hubbardI-%(version)s/deps/googletest-release-1.10.0 hubbardI-%(version)s/deps/GTest",
     }
 ]

--- a/easybuild/easyconfigs/t/TRIQS-hubbardI/TRIQS-hubbardI-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TRIQS-hubbardI/TRIQS-hubbardI-3.0.0-foss-2020b.eb
@@ -31,9 +31,10 @@ sources = [
     {
         'filename': 'release-1.10.0.tar.gz',
         'source_urls': ['https://github.com/google/googletest/archive/refs/tags/'],
-        'extract_cmd': "tar -C hubbardI-%(version)s/deps -zxf %s && mv hubbardI-%(version)s/deps/googletest-release-1.10.0 hubbardI-%(version)s/deps/GTest",
+        'extract_cmd': "tar -C hubbardI-%(version)s/deps -zxf %s && " \
+                       "mv hubbardI-%(version)s/deps/googletest-release-1.10.0 hubbardI-%(version)s/deps/GTest",
     }
- ]
+]
 checksums = [
     '165d48a1f56f0658e6858262298c71b3353a7eec0ef8032a44444fde44cbf9e1',
     '9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb'

--- a/easybuild/easyconfigs/t/TRIQS-hubbardI/TRIQS-hubbardI-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TRIQS-hubbardI/TRIQS-hubbardI-3.0.0-foss-2020b.eb
@@ -1,0 +1,72 @@
+easyblock = 'CMakeMake'
+
+name = 'TRIQS-hubbardI'
+version = '3.0.0'
+
+homepage = 'https://triqs.github.io/hubbardI/'
+description = """
+ TRIQS (Toolbox for Research on Interacting Quantum Systems) is a
+ scientific project providing a set of C++ and Python libraries to
+ develop new tools for the study of interacting quantum systems.
+
+ hubbardI = A Hubbard-I solver based on triqs atom_diag
+
+ This application implements the Hubbard-I solver in pytriqs using
+ the lightweight diagonalization routine which come with
+ triqs/atom_diag.
+"""
+
+docurls = ['https://triqs.github.io/hubbardI/%(version_major_minor)s.x/']
+software_license = 'LicenseGPLv3'
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+sources = [
+    {
+        'filename': 'hubbardI-%(version)s.tar.gz',
+        'download_filename': '%(version)s.tar.gz',
+        'source_urls': ['https://github.com/TRIQS/hubbardI/archive/refs/tags/']
+    },
+    {
+        'filename': 'release-1.10.0.tar.gz',
+        'source_urls': ['https://github.com/google/googletest/archive/refs/tags/'],
+        'extract_cmd': "tar -C hubbardI-%(version)s/deps -zxf %s && mv hubbardI-%(version)s/deps/googletest-release-1.10.0 hubbardI-%(version)s/deps/GTest",
+    }
+ ]
+checksums = [
+    '165d48a1f56f0658e6858262298c71b3353a7eec0ef8032a44444fde44cbf9e1',
+    '9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb'
+]
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('TRIQS', '3.0.0'),
+    ('NFFT', '3.5.2')
+]
+
+builddependencies = [
+    ('CMake', '3.18.4')
+]
+
+separate_build_dir = True
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib', 'lib/python%(pyshortver)s/site-packages', 'share'],
+}
+
+sanity_check_commands = ["python -c 'import triqs_hubbardI'"]
+
+modextrapaths = {
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
+    'CMAKE_PREFIX_PATH': 'lib/cmake/triqs_hubbardI',
+}
+modextravars = {
+    'TRIQS_HUBBARDI_ROOT': '%(installdir)s',
+    'TRIQS_HUBBARDI_VERSION': '%(version)s',
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/t/TRIQS/TRIQS-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TRIQS/TRIQS-3.0.0-foss-2020b.eb
@@ -1,0 +1,116 @@
+easyblock = 'CMakeMake'
+
+name = 'TRIQS'
+version = '3.0.0'
+
+homepage = 'https://triqs.github.io/triqs'
+description = """
+ TRIQS (Toolbox for Research on Interacting Quantum Systems) is a
+ scientific project providing a set of C++ and Python libraries to
+ develop new tools for the study of interacting quantum systems.
+"""
+
+docurls = ['https://triqs.github.io/triqs/%(version_major_minor)s.x/']
+software_license = 'LicenseGPLv3'
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['https://github.com/TRIQS/triqs/releases/download/%(version)s/']
+sources = [
+    'triqs-%(version)s.tar.gz',
+    {
+        'filename': 'ccp2py-2.0.0.tar.gz',
+        'download_filename': '2.0.0.tar.gz',
+        'source_urls': ['https://github.com/TRIQS/cpp2py/archive/refs/tags/'],
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && mv triqs-%(version)s/deps/cpp2py-2.0.0 triqs-%(version)s/deps/Cpp2Py",
+    },
+    {
+        'filename': 'release-1.10.0.tar.gz',
+        'source_urls': ['https://github.com/google/googletest/archive/refs/tags/'],
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && mv triqs-%(version)s/deps/googletest-release-1.10.0 triqs-%(version)s/deps/GTest",
+    },
+    {
+        'filename': 'itertools-1.0.0.tar.gz',
+        'download_filename': '1.0.0.tar.gz',
+        'source_urls': ['https://github.com/TRIQS/itertools/archive/refs/tags/'],
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && mv triqs-%(version)s/deps/itertools-1.0.0 triqs-%(version)s/deps/itertools",
+    },
+    {
+        'filename': 'mpi-1.0.0.tar.gz',
+        'download_filename': '1.0.0.tar.gz',
+        'source_urls': ['https://github.com/TRIQS/mpi/archive/refs/tags/'],
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && mv triqs-%(version)s/deps/mpi-1.0.0 triqs-%(version)s/deps/mpi",
+    },
+    {
+        'filename': 'h5-1.0.0.tar.gz',
+        'download_filename': '1.0.0.tar.gz',
+        'source_urls': ['https://github.com/TRIQS/h5/archive/refs/tags/'],
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && mv triqs-%(version)s/deps/h5-1.0.0 triqs-%(version)s/deps/h5",
+    }
+]
+
+# Backport of https://github.com/TRIQS/triqs/commit/57b33abd050ef1b5ecc85aff42616398d2e8792e:
+# > Increase tolerance in test_delta_infty
+# > This fixes a test failure that occurs when compiling with GCC 10.
+# (In 3.0.x branch but not yet in a release)
+patches = ['test-3.0.0-tail_issues-gcc10.patch']
+
+checksums = [
+    '21239fb42ba73f84a77b63abce84c0d2b9162277233d5839aaf39e22e1be8128', # triqs-3.0.0-tar.gz
+    'df67dc69ef3a57c615f39ea14b63bb00309adfaf6130e64cf84b2df1553696f6', # ccp2py-2.0.0.tar.gz
+    '9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb', # release-1.10.0.tar.gz
+    'd3a1acd63be10b78a19a0e3047b9ea96cef64f8a8222882167a9617e06e5d498', # itertools-1.0.0.tar.gz
+    '64772763904984d62c6365ee14d01ff6360a3fc7943a864f2470673ea8aaf673', # mpi-1.0.0.tar.gz
+    'a0ed14b286b5b2119fb391b9126d236a728a4244bd4245c2b3564b88a2e50ed3', # h5-1.0.0.tar.gz
+    'e4368fbbe595776461ad83764aeffbb005082143913e54ab60f6fc2d94fef5ff'  # test-3.0.0-tail_issues-gcc10.patch
+]
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('SciPy-bundle', '2020.11'),
+    ('Boost', '1.74.0'),
+    ('Clang', '11.0.1'),
+    ('Clang-Python-bindings', '11.0.1'),
+    ('GMP', '6.2.0'),
+    ('HDF5', '1.10.7'),
+    ('Mako', '1.1.3')
+]
+
+builddependencies = [
+    ('CMake', '3.18.4')
+]
+
+separate_build_dir = True
+
+# Remove installation directory before building. This fixes problems with
+# failing builds in the presence of preexisting installation.
+preconfigopts = "rm -rf %(installdir)s && "
+
+configopts = "-DBuild_Deps=Always"
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['lib/libtriqs.%s' % SHLIB_EXT],
+    'dirs': ['include/triqs', 'include/itertools', 'include/mpi', 'include/cpp2py',
+             'lib/python%(pyshortver)s/site-packages', 'share'],
+}
+
+sanity_check_commands = [
+    "triqs++ --help",
+    "c++2py --help",
+    "python -c 'import triqs'"
+]
+
+modextrapaths = {
+    'CPLUS_INCLUDE_PATH': 'include',
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
+    'CMAKE_PREFIX_PATH': ['lib/cmake/triqs', 'lib/cmake/cpp2py']
+}
+modextravars = {
+    'TRIQS_ROOT': '%(installdir)s',
+    'TRIQS_VERSION': '%(version)s'
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/t/TRIQS/TRIQS-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TRIQS/TRIQS-3.0.0-foss-2020b.eb
@@ -23,30 +23,35 @@ sources = [
         'filename': 'ccp2py-2.0.0.tar.gz',
         'download_filename': '2.0.0.tar.gz',
         'source_urls': ['https://github.com/TRIQS/cpp2py/archive/refs/tags/'],
-        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && mv triqs-%(version)s/deps/cpp2py-2.0.0 triqs-%(version)s/deps/Cpp2Py",
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && " \
+                       "mv triqs-%(version)s/deps/cpp2py-2.0.0 triqs-%(version)s/deps/Cpp2Py",
     },
     {
         'filename': 'release-1.10.0.tar.gz',
         'source_urls': ['https://github.com/google/googletest/archive/refs/tags/'],
-        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && mv triqs-%(version)s/deps/googletest-release-1.10.0 triqs-%(version)s/deps/GTest",
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && " \
+                       "mv triqs-%(version)s/deps/googletest-release-1.10.0 triqs-%(version)s/deps/GTest",
     },
     {
         'filename': 'itertools-1.0.0.tar.gz',
         'download_filename': '1.0.0.tar.gz',
         'source_urls': ['https://github.com/TRIQS/itertools/archive/refs/tags/'],
-        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && mv triqs-%(version)s/deps/itertools-1.0.0 triqs-%(version)s/deps/itertools",
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && " \
+                       "mv triqs-%(version)s/deps/itertools-1.0.0 triqs-%(version)s/deps/itertools",
     },
     {
         'filename': 'mpi-1.0.0.tar.gz',
         'download_filename': '1.0.0.tar.gz',
         'source_urls': ['https://github.com/TRIQS/mpi/archive/refs/tags/'],
-        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && mv triqs-%(version)s/deps/mpi-1.0.0 triqs-%(version)s/deps/mpi",
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && " \
+                       "mv triqs-%(version)s/deps/mpi-1.0.0 triqs-%(version)s/deps/mpi",
     },
     {
         'filename': 'h5-1.0.0.tar.gz',
         'download_filename': '1.0.0.tar.gz',
         'source_urls': ['https://github.com/TRIQS/h5/archive/refs/tags/'],
-        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && mv triqs-%(version)s/deps/h5-1.0.0 triqs-%(version)s/deps/h5",
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && " \
+                       "mv triqs-%(version)s/deps/h5-1.0.0 triqs-%(version)s/deps/h5",
     }
 ]
 
@@ -57,13 +62,13 @@ sources = [
 patches = ['test-3.0.0-tail_issues-gcc10.patch']
 
 checksums = [
-    '21239fb42ba73f84a77b63abce84c0d2b9162277233d5839aaf39e22e1be8128', # triqs-3.0.0-tar.gz
-    'df67dc69ef3a57c615f39ea14b63bb00309adfaf6130e64cf84b2df1553696f6', # ccp2py-2.0.0.tar.gz
-    '9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb', # release-1.10.0.tar.gz
-    'd3a1acd63be10b78a19a0e3047b9ea96cef64f8a8222882167a9617e06e5d498', # itertools-1.0.0.tar.gz
-    '64772763904984d62c6365ee14d01ff6360a3fc7943a864f2470673ea8aaf673', # mpi-1.0.0.tar.gz
-    'a0ed14b286b5b2119fb391b9126d236a728a4244bd4245c2b3564b88a2e50ed3', # h5-1.0.0.tar.gz
-    'e4368fbbe595776461ad83764aeffbb005082143913e54ab60f6fc2d94fef5ff'  # test-3.0.0-tail_issues-gcc10.patch
+    '21239fb42ba73f84a77b63abce84c0d2b9162277233d5839aaf39e22e1be8128',  # triqs-3.0.0-tar.gz
+    'df67dc69ef3a57c615f39ea14b63bb00309adfaf6130e64cf84b2df1553696f6',  # ccp2py-2.0.0.tar.gz
+    '9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb',  # release-1.10.0.tar.gz
+    'd3a1acd63be10b78a19a0e3047b9ea96cef64f8a8222882167a9617e06e5d498',  # itertools-1.0.0.tar.gz
+    '64772763904984d62c6365ee14d01ff6360a3fc7943a864f2470673ea8aaf673',  # mpi-1.0.0.tar.gz
+    'a0ed14b286b5b2119fb391b9126d236a728a4244bd4245c2b3564b88a2e50ed3',  # h5-1.0.0.tar.gz
+    'e4368fbbe595776461ad83764aeffbb005082143913e54ab60f6fc2d94fef5ff'   # test-3.0.0-tail_issues-gcc10.patch
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/t/TRIQS/TRIQS-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TRIQS/TRIQS-3.0.0-foss-2020b.eb
@@ -23,34 +23,34 @@ sources = [
         'filename': 'ccp2py-2.0.0.tar.gz',
         'download_filename': '2.0.0.tar.gz',
         'source_urls': ['https://github.com/TRIQS/cpp2py/archive/refs/tags/'],
-        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && " \
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && "
                        "mv triqs-%(version)s/deps/cpp2py-2.0.0 triqs-%(version)s/deps/Cpp2Py",
     },
     {
         'filename': 'release-1.10.0.tar.gz',
         'source_urls': ['https://github.com/google/googletest/archive/refs/tags/'],
-        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && " \
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && "
                        "mv triqs-%(version)s/deps/googletest-release-1.10.0 triqs-%(version)s/deps/GTest",
     },
     {
         'filename': 'itertools-1.0.0.tar.gz',
         'download_filename': '1.0.0.tar.gz',
         'source_urls': ['https://github.com/TRIQS/itertools/archive/refs/tags/'],
-        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && " \
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && "
                        "mv triqs-%(version)s/deps/itertools-1.0.0 triqs-%(version)s/deps/itertools",
     },
     {
         'filename': 'mpi-1.0.0.tar.gz',
         'download_filename': '1.0.0.tar.gz',
         'source_urls': ['https://github.com/TRIQS/mpi/archive/refs/tags/'],
-        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && " \
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && "
                        "mv triqs-%(version)s/deps/mpi-1.0.0 triqs-%(version)s/deps/mpi",
     },
     {
         'filename': 'h5-1.0.0.tar.gz',
         'download_filename': '1.0.0.tar.gz',
         'source_urls': ['https://github.com/TRIQS/h5/archive/refs/tags/'],
-        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && " \
+        'extract_cmd': "tar -C triqs-%(version)s/deps -zxf %s && "
                        "mv triqs-%(version)s/deps/h5-1.0.0 triqs-%(version)s/deps/h5",
     }
 ]

--- a/easybuild/easyconfigs/t/TRIQS/test-3.0.0-tail_issues-gcc10.patch
+++ b/easybuild/easyconfigs/t/TRIQS/test-3.0.0-tail_issues-gcc10.patch
@@ -1,0 +1,11 @@
+--- test/python/base/tail_issues.py	2021-08-17 15:05:28.378668396 +0000
++++ test/python/base/tail_issues.py	2021-08-17 15:05:50.846691101 +0000
+@@ -134,7 +134,7 @@
+         dt = make_gf_from_fourier(d, tau_mesh, tail)
+         max_im = np.max(np.abs(dt.data.imag))
+         # print "Imag Delta", max_im
+-        self.assertTrue(max_im < 1e-12)
++        self.assertTrue(max_im < 2e-12)
+ 
+         # Check Delta(iw) extracted through triqs.gf.tools.delta
+         D_exact = g.copy()


### PR DESCRIPTION
I hope this is the appropriate way to contribute a new easyconfig...

This pull includes multiple easyconfigs updated to 2020b (where no existing 2020b easyconfig existed) which TRIQS-dcore3 depends on.

In the process, this fixes some issues with the older easyconfig (closes #13415).

The way the multiple components of TRIQS depend on google test seems not to work with the existing module (see the discussion in issue #13415) as it looks for 'Gtest' which cmake failes to find even with 'googletest' given as a dependency.  Fixing this is going to require patching TRIQS's cmake files in each component's easyconfigs.

I am not sure how you test easyconfigs, but I also found their (TRIQS) test suites fail if run within a slurm job - doing `ssh localhost bash -l -c "'module load eb; eb -Tr TRIQS-dcore3-3.0.0-foss-2020b.eb'"` (for example) within a slurm job and the test suites of the other TRIQS componenets pass.  Upstream were very unhelpful about this - their suggests was "use anaconda to install instead".  The software, once built, appears to work fine within a slurm job - examples provided by upstream work without an issue.

It also failed to build against the matplotlib already in 2020b, hence the new 2020b easyconfig for 3.4.2 (backported from 2021a).

Not the tidiest, I imagine - the whole set of TRIQS software has been quite painful to get built - I just hope its good enough :)