### PR TITLE
{chem}Dalton-2020.0-foss-2020b

### DIFF
--- a/easybuild/easyconfigs/d/Dalton/Dalton-2020.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/d/Dalton/Dalton-2020.0-foss-2020b.eb
@@ -23,6 +23,8 @@ sources = [{
     },
 }]
 
+checksums = ['a939dfbf869ef90ea064fa3d00cc1937dd145438947ecf5556f964b38299b34a']
+
 builddependencies = [('CMake', '3.18.4'), ('Python', '3.8.6')]
 
 configure_cmd = 'python ../dalton/setup --prefix="%(installdir)s" .'

--- a/easybuild/easyconfigs/d/Dalton/Dalton-2020.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/d/Dalton/Dalton-2020.0-foss-2020b.eb
@@ -43,4 +43,9 @@ sanity_check_paths = {
     'dirs': ['dalton/basis'],
 }
 
+modextrapaths = {
+    'PATH': 'dalton',
+    'CMAKE_PREFIX_PATH': 'dalton/tools',
+}
+
 moduleclass = 'chem'


### PR DESCRIPTION
Bump of Dalton from 2016 to 2020.0 and build for foss-2020b (only other version in easybuild is for intel-2017b).

Dalton's new (python) configure command seems to fix the issues that needed a lot of patches in 2016.

N.B. This eb takes between 3 and 4.5 hours to build on my cluster (on each of 44-core Skylake, 60-core Zen and 120-core Zen2 nodes).  Most of that time is spent running the test suite.  One test fails on Zen2 due to upstream bug - https://gitlab.com/dalton/dalton/-/issues/183