### PR TITLE
Have GROMACS log files indicate EasyBuild was used

### DIFF
--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2021.3-foss-2021a.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2021.3-foss-2021a.eb
@@ -11,6 +11,7 @@
 # * Ake Sandgren <ake.sandgren@hpc2n.umu.se>
 # * J. Sassmannshausen <Crick HPC team>
 # * Dugan Witherick <dugan.witherick@warwick.ac.uk>
+# * Mark Abraham <mark.j.abraham@gmail.com>
 # License::   MIT/GPL
 
 name = 'GROMACS'
@@ -53,6 +54,10 @@ checksums = [
     # GROMACS-2020.5_fix_threads_gpu_Gmxapitests.patch
     '89fbb7e2754de45573632c74f53563bb979df9758c949238a35865391d6b53fb',
 ]
+
+# Ensure that the GROMACS log files report how the code was patched
+# during the build, so that any problems are easier to diagnose.
+configopts = '-DGMX_VERSION_STRING_OF_FORK=EasyBuild'
 
 builddependencies = [
     ('CMake', '3.20.1'),


### PR DESCRIPTION
Knowing that EasyBuild has patched the code and organized the build is potentially valuable information for GROMACS users and developers troubleshooting their runs.