### PR TITLE
add additional valid checksum for lhs 1.1.1 extension in recent R 4.0.x and 4.1.0 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R/R-4.0.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.3-foss-2020b.eb
@@ -1493,7 +1493,8 @@ exts_list = [
         'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
     }),
     ('lhs', '1.1.1', {
-        'checksums': ['00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2'],
+        'checksums': [('903e9f2adde87f6f9ad41dd52ff83d28a645dba69934c7535142cb48f10090dc',
+                       '00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2')],
     }),
     ('tensorA', '0.36.1', {
         'checksums': ['c7ffe12b99867675b5e9c9f31798f9521f14305c9d9f9485b171bcbd8697d09c'],

--- a/easybuild/easyconfigs/r/R/R-4.0.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.3-foss-2020b.eb
@@ -1493,7 +1493,7 @@ exts_list = [
         'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
     }),
     ('lhs', '1.1.1', {
-        'checksums': ['903e9f2adde87f6f9ad41dd52ff83d28a645dba69934c7535142cb48f10090dc'],
+        'checksums': ['00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2'],
     }),
     ('tensorA', '0.36.1', {
         'checksums': ['c7ffe12b99867675b5e9c9f31798f9521f14305c9d9f9485b171bcbd8697d09c'],

--- a/easybuild/easyconfigs/r/R/R-4.0.3-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.3-fosscuda-2020b.eb
@@ -1502,7 +1502,8 @@ exts_list = [
         'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
     }),
     ('lhs', '1.1.1', {
-        'checksums': ['00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2'],
+        'checksums': [('903e9f2adde87f6f9ad41dd52ff83d28a645dba69934c7535142cb48f10090dc',
+                       '00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2')],
     }),
     ('tensorA', '0.36.1', {
         'checksums': ['c7ffe12b99867675b5e9c9f31798f9521f14305c9d9f9485b171bcbd8697d09c'],

--- a/easybuild/easyconfigs/r/R/R-4.0.3-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.3-fosscuda-2020b.eb
@@ -1502,7 +1502,7 @@ exts_list = [
         'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
     }),
     ('lhs', '1.1.1', {
-        'checksums': ['903e9f2adde87f6f9ad41dd52ff83d28a645dba69934c7535142cb48f10090dc'],
+        'checksums': ['00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2'],
     }),
     ('tensorA', '0.36.1', {
         'checksums': ['c7ffe12b99867675b5e9c9f31798f9521f14305c9d9f9485b171bcbd8697d09c'],

--- a/easybuild/easyconfigs/r/R/R-4.0.4-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.4-foss-2020b.eb
@@ -1521,7 +1521,8 @@ exts_list = [
         'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
     }),
     ('lhs', '1.1.1', {
-        'checksums': ['00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2'],
+        'checksums': [('903e9f2adde87f6f9ad41dd52ff83d28a645dba69934c7535142cb48f10090dc',
+                       '00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2')],
     }),
     ('tensorA', '0.36.2', {
         'checksums': ['8e8947566bd3b65a54de4269df1abaa3d49cf5bfd2a963c3274a524c8a819ca7'],

--- a/easybuild/easyconfigs/r/R/R-4.0.4-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.4-foss-2020b.eb
@@ -1521,7 +1521,7 @@ exts_list = [
         'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
     }),
     ('lhs', '1.1.1', {
-        'checksums': ['903e9f2adde87f6f9ad41dd52ff83d28a645dba69934c7535142cb48f10090dc'],
+        'checksums': ['00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2'],
     }),
     ('tensorA', '0.36.2', {
         'checksums': ['8e8947566bd3b65a54de4269df1abaa3d49cf5bfd2a963c3274a524c8a819ca7'],

--- a/easybuild/easyconfigs/r/R/R-4.0.4-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.4-fosscuda-2020b.eb
@@ -1525,7 +1525,8 @@ exts_list = [
         'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
     }),
     ('lhs', '1.1.1', {
-        'checksums': ['00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2'],
+        'checksums': [('903e9f2adde87f6f9ad41dd52ff83d28a645dba69934c7535142cb48f10090dc',
+                       '00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2')],
     }),
     ('tensorA', '0.36.2', {
         'checksums': ['8e8947566bd3b65a54de4269df1abaa3d49cf5bfd2a963c3274a524c8a819ca7'],

--- a/easybuild/easyconfigs/r/R/R-4.0.4-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.4-fosscuda-2020b.eb
@@ -1525,7 +1525,7 @@ exts_list = [
         'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
     }),
     ('lhs', '1.1.1', {
-        'checksums': ['903e9f2adde87f6f9ad41dd52ff83d28a645dba69934c7535142cb48f10090dc'],
+        'checksums': ['00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2'],
     }),
     ('tensorA', '0.36.2', {
         'checksums': ['8e8947566bd3b65a54de4269df1abaa3d49cf5bfd2a963c3274a524c8a819ca7'],

--- a/easybuild/easyconfigs/r/R/R-4.0.5-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.5-foss-2020b.eb
@@ -1533,7 +1533,7 @@ exts_list = [
         'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
     }),
     ('lhs', '1.1.1', {
-        'checksums': ['903e9f2adde87f6f9ad41dd52ff83d28a645dba69934c7535142cb48f10090dc'],
+        'checksums': ['00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2'],
     }),
     ('tensorA', '0.36.2', {
         'checksums': ['8e8947566bd3b65a54de4269df1abaa3d49cf5bfd2a963c3274a524c8a819ca7'],

--- a/easybuild/easyconfigs/r/R/R-4.0.5-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.5-foss-2020b.eb
@@ -1533,7 +1533,8 @@ exts_list = [
         'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
     }),
     ('lhs', '1.1.1', {
-        'checksums': ['00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2'],
+        'checksums': [('903e9f2adde87f6f9ad41dd52ff83d28a645dba69934c7535142cb48f10090dc',
+                       '00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2')],
     }),
     ('tensorA', '0.36.2', {
         'checksums': ['8e8947566bd3b65a54de4269df1abaa3d49cf5bfd2a963c3274a524c8a819ca7'],

--- a/easybuild/easyconfigs/r/R/R-4.0.5-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.5-fosscuda-2020b.eb
@@ -1543,7 +1543,7 @@ exts_list = [
         'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
     }),
     ('lhs', '1.1.1', {
-        'checksums': ['903e9f2adde87f6f9ad41dd52ff83d28a645dba69934c7535142cb48f10090dc'],
+        'checksums': ['00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2'],
     }),
     ('tensorA', '0.36.2', {
         'checksums': ['8e8947566bd3b65a54de4269df1abaa3d49cf5bfd2a963c3274a524c8a819ca7'],

--- a/easybuild/easyconfigs/r/R/R-4.0.5-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.5-fosscuda-2020b.eb
@@ -1543,7 +1543,8 @@ exts_list = [
         'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
     }),
     ('lhs', '1.1.1', {
-        'checksums': ['00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2'],
+        'checksums': [('903e9f2adde87f6f9ad41dd52ff83d28a645dba69934c7535142cb48f10090dc',
+                       '00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2')],
     }),
     ('tensorA', '0.36.2', {
         'checksums': ['8e8947566bd3b65a54de4269df1abaa3d49cf5bfd2a963c3274a524c8a819ca7'],

--- a/easybuild/easyconfigs/r/R/R-4.1.0-foss-2021a.eb
+++ b/easybuild/easyconfigs/r/R/R-4.1.0-foss-2021a.eb
@@ -1549,7 +1549,7 @@ exts_list = [
         'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
     }),
     ('lhs', '1.1.1', {
-        'checksums': ['903e9f2adde87f6f9ad41dd52ff83d28a645dba69934c7535142cb48f10090dc'],
+        'checksums': ['00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2'],
     }),
     ('tensorA', '0.36.2', {
         'checksums': ['8e8947566bd3b65a54de4269df1abaa3d49cf5bfd2a963c3274a524c8a819ca7'],

--- a/easybuild/easyconfigs/r/R/R-4.1.0-foss-2021a.eb
+++ b/easybuild/easyconfigs/r/R/R-4.1.0-foss-2021a.eb
@@ -1549,7 +1549,8 @@ exts_list = [
         'checksums': ['0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59'],
     }),
     ('lhs', '1.1.1', {
-        'checksums': ['00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2'],
+        'checksums': [('903e9f2adde87f6f9ad41dd52ff83d28a645dba69934c7535142cb48f10090dc',
+                       '00278a65b18c86799301d27c55e3d32c6c307aed745ea69c9b96bbb1d0a352c2')],
     }),
     ('tensorA', '0.36.2', {
         'checksums': ['8e8947566bd3b65a54de4269df1abaa3d49cf5bfd2a963c3274a524c8a819ca7'],


### PR DESCRIPTION
When trying to build R 4.1.0 I found that the checksum for the lhs v1.1.1 extension was wrong.
I corrected with the right checksum (build tested and working) for all its occurences.
Don't know what happened, maybe they repackaged/replaced the source at some point...