### PR TITLE
Update to include artic-ncov2019-2021.06.24

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -474,8 +474,8 @@ class EasyConfigTest(TestCase):
                             'NGSpeciesID-0.1.1.1-']),
                 # medaka 1.4.3 (foss/2019b) depends on TensorFlow 2.2.2
                 ('2.2.2;', ['medaka-1.4.3-']),
-                # medaka 1.4.3 (foss/2020b) depends on TensorFlow 2.2.3
-                ('2.2.3;', ['medaka-1.4.3-']),
+                # medaka 1.4.3 (foss/2020b) and thus artic-ncov2019-2021.06.24 depend on TensorFlow 2.2.3
+                ('2.2.3;', ['medaka-1.4.3-', 'artic-ncov2019-2021.06.24artic-ncov2019-2021.06.24']),
             ],
             # medaka 1.1.*, 1.2.*, 1.4.* requires Pysam 0.16.0.1,
             # which is newer than what others use as dependency w.r.t. Pysam version in 2019b generation;

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -475,7 +475,7 @@ class EasyConfigTest(TestCase):
                 # medaka 1.4.3 (foss/2019b) depends on TensorFlow 2.2.2
                 ('2.2.2;', ['medaka-1.4.3-']),
                 # medaka 1.4.3 (foss/2020b) and thus artic-ncov2019-2021.06.24 depend on TensorFlow 2.2.3
-                ('2.2.3;', ['medaka-1.4.3-', 'artic-ncov2019-2021.06.24artic-ncov2019-2021.06.24']),
+                ('2.2.3;', ['medaka-1.4.3-', 'artic-ncov2019-2021.06.24-']),
             ],
             # medaka 1.1.*, 1.2.*, 1.4.* requires Pysam 0.16.0.1,
             # which is newer than what others use as dependency w.r.t. Pysam version in 2019b generation;


### PR DESCRIPTION
Added artic-ncov2019-2021.06.24 for TF version 2.2.3 as artic-ncov2019-2021.06.24 required medaka which itself required TF-2.2.3.