### PR TITLE
add path to Intel libraries to $LIBRARY_PATH for iccifort 2020.1.217

### DIFF
--- a/easybuild/easyconfigs/i/iccifort/iccifort-2020.1.217.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2020.1.217.eb
@@ -35,6 +35,8 @@ components = [
 
 dontcreateinstalldir = True
 
+modextrapaths  = {'LIBRARY_PATH': 'compilers_and_libraries_%(version)s/linux/compiler/lib/intel64_lin'}
+
 license_file = HOME + '/licenses/intel/license.lic'
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2020.1.217.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2020.1.217.eb
@@ -35,7 +35,7 @@ components = [
 
 dontcreateinstalldir = True
 
-modextrapaths  = {'LIBRARY_PATH': 'compilers_and_libraries_%(version)s/linux/compiler/lib/intel64_lin'}
+modextrapaths = {'LIBRARY_PATH': 'compilers_and_libraries_%(version)s/linux/compiler/lib/intel64_lin'}
 
 license_file = HOME + '/licenses/intel/license.lic'
 


### PR DESCRIPTION
When compiling HDF5 with Intel toolchain, it reports the following error in the "configure" stage:
```
configure: error: Fortran compiler requires either intrinsic functions SIZEOF or STORAGE_SIZE
```
This issue can be fixed by exposing the libraries available in ```compilers_and_libraries_%(version)s/linux/compiler/lib/intel64_lin```