### PR TITLE
{geo}[foss/2020a] WRF v4.1.3

### DIFF
--- a/easybuild/easyconfigs/w/WRF/WRF-4.1.3-foss-2020a-dmpar.eb
+++ b/easybuild/easyconfigs/w/WRF/WRF-4.1.3-foss-2020a-dmpar.eb
@@ -1,0 +1,43 @@
+name = 'WRF'
+version = '4.1.3'
+buildtype = "dmpar"
+versionsuffix = '-%s' % buildtype
+
+homepage = 'https://www.wrf-model.org'
+description = """The Weather Research and Forecasting (WRF) Model is a next-generation mesoscale
+ numerical weather prediction system designed to serve both operational forecasting and atmospheric
+ research needs."""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+toolchainopts = {'opt': False}  # don't use agressive optimization, stick to -O2
+
+source_urls = ['https://github.com/wrf-model/WRF/archive/']
+sources = ['v%(version)s.tar.gz']
+patches = [
+    'WRF_parallel_build_fix.patch',
+    'WRFv4_netCDF-Fortran_separate_path.patch',
+]
+checksums = [
+    'a020e83e8a7a927fb080075031630e2af592e9fa802293ad72caa7ee50d6968d',  # v4.1.3.tar.gz
+    'f93bb6dbb8b52d72f816e2f9a6815bffd536afeca8511552ec5abc4253a59346',  # WRF_parallel_build_fix.patch
+    'a431159180757a895c07fc193fe93bb69c4c9d25d31adcc7c2adfa7c1edb04ad',  # WRFv4_netCDF-Fortran_separate_path.patch
+]
+
+# csh is used by WRF install scripts
+builddependencies = [
+    ('Autotools', '20180311'),
+    ('tcsh', '6.22.02'),
+    ('time', '1.9'),
+    ('Perl', '5.30.2'),
+]
+
+dependencies = [
+    ('JasPer', '2.0.14'),
+    ('netCDF', '4.7.4'),
+    ('netCDF-Fortran', '4.5.2'),
+]
+
+# limit parallel build to 20
+maxparallel = 20
+
+moduleclass = 'geo'


### PR DESCRIPTION
some dependency tweaking; no significant changes

edit (by @boegel): original PR title: add WRF-4.1.3 to foss-2020a toolchain to be supported in EESSI 2021.6