### PR TITLE
Update GroopM-0.3.4-foss-2016b-Python-2.7.12.eb

### DIFF
--- a/easybuild/easyconfigs/g/GroopM/GroopM-0.3.4-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/g/GroopM/GroopM-0.3.4-foss-2016b-Python-2.7.12.eb
@@ -32,7 +32,7 @@ dependencies = [
     ('matplotlib', '1.5.2', versionsuffix),
     ('Pysam', '0.10.0', versionsuffix),
     ('PyTables', '3.3.0', versionsuffix),
-    ('PIL', '1.1.7', versionsuffix),
+    ('Pillow', '3.4.2', versionsuffix),
     ('BamM', '1.7.3', versionsuffix),
     ('GTK+', '2.24.31'),
 ]


### PR DESCRIPTION
PIL is no longer downloadable; it has been superseded by Pillow.