### PR TITLE
replace PIL with Pillow for GroopM 0.3.4 with foss/2016b

### DIFF
--- a/easybuild/easyconfigs/g/GroopM/GroopM-0.3.4-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/g/GroopM/GroopM-0.3.4-foss-2016b-Python-2.7.12.eb
@@ -32,13 +32,14 @@ dependencies = [
     ('matplotlib', '1.5.2', versionsuffix),
     ('Pysam', '0.10.0', versionsuffix),
     ('PyTables', '3.3.0', versionsuffix),
-    ('PIL', '1.1.7', versionsuffix),
+    ('Pillow', '3.4.2', versionsuffix),
     ('BamM', '1.7.3', versionsuffix),
     ('GTK+', '2.24.31'),
 ]
 
 download_dep_fail = True
 use_pip = True
+sanity_pip_check = False
 
 sanity_check_paths = {
     'files': ["bin/groopm"],


### PR DESCRIPTION
Source for module 'PIL' is no longer downloadable; it has been superseded by 'Pillow'.