### PR TITLE
Create PyTables-3.5.2-foss-2020b-Python-2.7.18.eb

### DIFF
--- a/easybuild/easyconfigs/p/PyTables/PyTables-3.5.2-foss-2020b-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/p/PyTables/PyTables-3.5.2-foss-2020b-Python-2.7.18.eb
@@ -1,0 +1,50 @@
+easyblock = 'PythonPackage'
+
+name = 'PyTables'
+version = '3.5.2'
+# This is the last version to support Python 2.7.
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://www.pytables.org'
+description = """PyTables is a package for managing hierarchical datasets and designed to efficiently and easily cope
+ with extremely large amounts of data. PyTables is built on top of the HDF5 library, using the Python language and the
+ NumPy package. It features an object-oriented interface that, combined with C extensions for the performance-critical
+ parts of the code (generated using Cython), makes it a fast, yet extremely easy to use tool for interactively browse,
+ process and search very large amounts of data. One important feature of PyTables is that it optimizes memory and disk
+ resources so that data takes much less space (specially if on-flight compression is used) than other solutions such as
+ relational or object oriented databases."""
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/PyTables/PyTables/archive/']
+sources = ['v%(version)s.tar.gz']
+patches = ['%(name)s-%(version)s-fix-libs.patch']
+checksums = [
+    'e4fc6f1194f02a8b10ff923e77364fb70710592f620d7de35f4d4e064dc70e91',  # v3.5.2.tar.gz
+    '8df2a6379a9e4a941cb939ed1257a7d6105792d9c5e9dd0abd4bba3ece767c3a',  # PyTables-3.5.2-fix-libs.patch
+]
+
+dependencies = [
+    ('Python', '2.7.18'),
+    ('SciPy-bundle', '2020.11', versionsuffix),  # provides numexpr.
+    ('HDF5', '1.10.7'),
+    ('LZO', '2.10'),
+    ('Blosc', '1.21.0'),
+]
+
+use_pip = True
+download_dep_fail = True
+sanity_pip_check = True
+
+local_bins = ['pt2to3', 'ptdump', 'ptrepack']
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in local_bins],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+options = {'modulename': 'tables'}
+
+sanity_check_commands = ['%s --help' % x for x in local_bins]
+
+moduleclass = 'data'


### PR DESCRIPTION
New version for foss 2020b + Python 2.7.18.