### PR TITLE
{math}[foss/2020b] numpy v1.13.0 w/ Python 2.7.18

### DIFF
--- a/easybuild/easyconfigs/n/numpy/numpy-1.13.0-foss-2020b-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/n/numpy/numpy-1.13.0-foss-2020b-Python-2.7.18.eb
@@ -1,0 +1,28 @@
+name = 'numpy'
+version = '1.13.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.numpy.org'
+description = """NumPy is the fundamental package for scientific computing with Python. It contains among other things:
+ a powerful N-dimensional array object, sophisticated (broadcasting) functions, tools for integrating C/C++ and Fortran
+ code, useful linear algebra, Fourier transform, and random number capabilities. Besides its obvious scientific uses,
+ NumPy can also be used as an efficient multi-dimensional container of generic data. Arbitrary data-types can be
+ defined. This allows NumPy to seamlessly and speedily integrate with a wide variety of databases."""
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+
+sources = [SOURCE_ZIP]
+checksums = [
+    'dcff367b725586830ff0e20b805c7654c876c2d4585c0834a6049502b9d6cf7e',  # numpy-1.13.0.zip
+    'f212296ed289eb1b4e3f703997499dee8a2cdd0af78b55e017477487b6377ca4',  # numpy-1.12.0-mkl.patch
+]
+
+patches = [
+    'numpy-1.12.0-mkl.patch',
+]
+
+dependencies = [
+    ('Python', '2.7.18'),
+]
+
+moduleclass = 'math'


### PR DESCRIPTION
New version for foss 2020b + Python 2.7.18.  This is a prerequisite for a new easyconfig BamM-1.7.3-foss-2020b-Python-2.7.18.eb.