### PR TITLE
Fix for installing it from GPU-less nodes

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch-Geometric/PyTorch-Geometric-2.0.1-fosscuda-2020b-PyTorch-1.9.0.eb
+++ b/easybuild/easyconfigs/p/PyTorch-Geometric/PyTorch-Geometric-2.0.1-fosscuda-2020b-PyTorch-1.9.0.eb
@@ -54,6 +54,13 @@ exts_list = [
     }),
 ]
 
+preinstallopts = 'export TORCH_CUDA_ARCH_LIST="%(cuda_cc_semicolon_sep)s" ; '
+preinstallopts += 'export WITH_METIS=1; '
+preinstallopts += 'export FORCE_CUDA=1; '
+preinstallopts += 'export CUDA_HOME=$EBROOTCUDA; '
+preinstallopts += 'export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH; '
+preinstallopts += 'export PATH=$CUDA_HOME/bin:$PATH; '
+
 sanity_pip_check = True
 
 moduleclass = 'lib'


### PR DESCRIPTION
The current PyTorch-Geometric will not install any gpu support if the compilation node does not have a GPU. torch-sparse automatically detects a gpu, so it works on nodes with a gpu present, but you end up with this issue if you don't have gpus there: https://github.com/pyg-team/pytorch_geometric/issues/2429

This is a fix for it.