### PR TITLE
{phys}[foss/2020b] BerkeleyGW v3.0.1

### DIFF
--- a/easybuild/easyconfigs/b/BerkeleyGW/BerkeleyGW-3.0.1-foss-2020b.eb
+++ b/easybuild/easyconfigs/b/BerkeleyGW/BerkeleyGW-3.0.1-foss-2020b.eb
@@ -1,0 +1,34 @@
+name = 'BerkeleyGW'
+version = '3.0.1'
+
+homepage = 'https://www.berkeleygw.org'
+description = """The BerkeleyGW Package is a set of computer codes that calculates the quasiparticle
+ properties and the optical responses of a large variety of materials from bulk periodic crystals to
+ nanostructures such as slabs, wires and molecules."""
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['https://berkeley.box.com/shared/static/']
+sources = [{'download_filename': 'm1dgnhiemo47lhxczrn6si71bwxoxor8.gz', 'filename': SOURCE_TAR_GZ}]
+patches = [
+    'BerkeleyGW-3.0.1_tests.patch',
+    'BerkeleyGW-3.0.1_makefile.patch',
+    'BerkeleyGW-3.0.1_version.patch',
+]
+checksums = [
+    '7d8c2cc1ee679afb48efbdd676689d4d537226b50e13a049dbcb052aaaf3654f',  # BerkeleyGW-3.0.1.tar.gz
+    'f66ff15e2b99de5e808f78a552985fda3181f35c25817de4ac7df4d8f7fddf5a',  # BerkeleyGW-3.0.1_tests.patch
+    '56d90dc4e43db379441b6a1802e24f1f1356cd4aca4eb6d8b673f6c7926a7406',  # BerkeleyGW-3.0.1_makefile.patch
+    '414a4f23e430a2c02bab7bad18bcaf9b62129fa9dd1c2f87bd4bbc9fcb3bdded',  # BerkeleyGW-3.0.1_version.patch
+]
+
+dependencies = [
+    ('ELPA', '2020.11.001'),
+    ('Python', '3.8.6'),
+    ('h5py', '3.1.0'),
+]
+
+runtest = True
+
+moduleclass = 'phys'


### PR DESCRIPTION
There is no existing 2020b EasyConfig for BerkeleyGW.