### PR TITLE
Add OpenSSL (os) dependency to DCMTK easyconfigs

### DIFF
--- a/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.3-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.3-GCCcore-7.3.0.eb
@@ -29,6 +29,8 @@ dependencies = [
     ('libiconv', '1.15'),
 ]
 
+osdependencies = [OS_PKG_OPENSSL_DEV]
+
 sanity_check_paths = {
     'files': ['bin/dcmdump', 'bin/dcmj2pnm'],
     'dirs': ['lib'],

--- a/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.3-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.3-GCCcore-7.3.0.eb
@@ -27,9 +27,8 @@ dependencies = [
     ('libpng', '1.6.34'),
     ('libxml2', '2.9.8'),
     ('libiconv', '1.15'),
+    ('OpenSSL', '1.1', '', True),
 ]
-
-osdependencies = [OS_PKG_OPENSSL_DEV]
 
 sanity_check_paths = {
     'files': ['bin/dcmdump', 'bin/dcmj2pnm'],

--- a/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.5-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.5-GCCcore-8.2.0.eb
@@ -27,9 +27,8 @@ dependencies = [
     ('libpng', '1.6.36'),
     ('libxml2', '2.9.8'),
     ('libiconv', '1.16'),
+    ('OpenSSL', '1.1', '', True),
 ]
-
-osdependencies = [OS_PKG_OPENSSL_DEV]
 
 sanity_check_paths = {
     'files': ['bin/dcmdump', 'bin/dcmj2pnm'],

--- a/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.5-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.5-GCCcore-8.2.0.eb
@@ -29,6 +29,8 @@ dependencies = [
     ('libiconv', '1.16'),
 ]
 
+osdependencies = [OS_PKG_OPENSSL_DEV]
+
 sanity_check_paths = {
     'files': ['bin/dcmdump', 'bin/dcmj2pnm'],
     'dirs': ['lib'],

--- a/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.5-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.5-GCCcore-8.3.0.eb
@@ -29,6 +29,8 @@ dependencies = [
     ('libiconv', '1.16'),
 ]
 
+osdependencies = [OS_PKG_OPENSSL_DEV]
+
 sanity_check_paths = {
     'files': ['bin/dcmdump', 'bin/dcmj2pnm'],
     'dirs': ['lib'],

--- a/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.5-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.5-GCCcore-8.3.0.eb
@@ -27,9 +27,8 @@ dependencies = [
     ('libpng', '1.6.37'),
     ('libxml2', '2.9.9'),
     ('libiconv', '1.16'),
+    ('OpenSSL', '1.1', '', True),
 ]
-
-osdependencies = [OS_PKG_OPENSSL_DEV]
 
 sanity_check_paths = {
     'files': ['bin/dcmdump', 'bin/dcmj2pnm'],

--- a/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.6-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/d/DCMTK/DCMTK-3.6.6-GCCcore-10.3.0.eb
@@ -27,6 +27,7 @@ dependencies = [
     ('libpng', '1.6.37'),
     ('libxml2', '2.9.10'),
     ('libiconv', '1.16'),
+    ('OpenSSL', '1.1', '', True),
 ]
 
 sanity_check_paths = {


### PR DESCRIPTION
Fixes #14455 by adding OS dependencies on OpenSSL for the older DCMTK versions, and an explicit dependency on OpenSSL for the newest DCMTK.