### PR TITLE
consistently use 'Grace' software name + sync homepage/source_urls + fix easyconfig for Grace v5.1.25 with foss/2021a

### DIFF
--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2016a.eb
@@ -3,11 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'Grace'
 version = '5.1.25'
 
-homepage = 'http://freecode.com/projects/grace'
+homepage = 'https://plasma-gate.weizmann.ac.il/Grace/'
 description = """Grace is a WYSIWYG 2D plotting tool for X Windows System and Motif."""
 
-source_urls = ['ftp://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
+source_urls = ['https://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
 sources = [SOURCE_TAR_GZ]
+checksums = ['751ab9917ed0f6232073c193aba74046037e185d73b77bab0f5af3e3ff1da2ac']
 
 toolchain = {'name': 'foss', 'version': '2016a'}
 

--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2016a.eb
@@ -7,7 +7,7 @@ homepage = 'https://plasma-gate.weizmann.ac.il/Grace/'
 description = """Grace is a WYSIWYG 2D plotting tool for X Windows System and Motif."""
 
 source_urls = ['https://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
-sources = [SOURCE_TAR_GZ]
+sources = [SOURCELOWER_TAR_GZ]
 checksums = ['751ab9917ed0f6232073c193aba74046037e185d73b77bab0f5af3e3ff1da2ac']
 
 toolchain = {'name': 'foss', 'version': '2016a'}

--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2016a.eb
@@ -1,6 +1,6 @@
 easyblock = 'ConfigureMake'
 
-name = 'grace'
+name = 'Grace'
 version = '5.1.25'
 
 homepage = 'http://freecode.com/projects/grace'
@@ -9,7 +9,7 @@ description = """Grace is a WYSIWYG 2D plotting tool for X Windows System and Mo
 source_urls = ['ftp://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
 sources = [SOURCE_TAR_GZ]
 
-toolchain = {'name': 'intel', 'version': '2016a'}
+toolchain = {'name': 'foss', 'version': '2016a'}
 
 dependencies = [
     ('motif', '2.3.5'),

--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2017b-5build1.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2017b-5build1.eb
@@ -4,12 +4,12 @@ name = 'Grace'
 version = '5.1.25'
 versionsuffix = '-5build1'
 
-homepage = 'http://plasma-gate.weizmann.ac.il/Grace/'
+homepage = 'https://plasma-gate.weizmann.ac.il/Grace/'
 description = """Grace is a WYSIWYG tool to make two-dimensional plots of numerical data."""
 
 toolchain = {'name': 'foss', 'version': '2017b'}
 
-source_urls = ['ftp://plasma-gate.weizmann.ac.il/pub/grace/src/grace5/']
+source_urls = ['https://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
 sources = [SOURCELOWER_TAR_GZ]
 patches = ['%(name)s-%(version)s%(versionsuffix)s.patch']
 checksums = [
@@ -23,7 +23,6 @@ dependencies = [
     ('libpng', '1.6.32'),
     ('zlib', '1.2.11'),
     ('libjpeg-turbo', '1.5.2'),
-    ('FFTW', '3.3.6'),
     ('netCDF', '4.5.0'),
 ]
 

--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2018a-5build1.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2018a-5build1.eb
@@ -4,12 +4,12 @@ name = 'Grace'
 version = '5.1.25'
 versionsuffix = '-5build1'
 
-homepage = 'http://plasma-gate.weizmann.ac.il/Grace/'
+homepage = 'https://plasma-gate.weizmann.ac.il/Grace/'
 description = """Grace is a WYSIWYG tool to make two-dimensional plots of numerical data."""
 
 toolchain = {'name': 'foss', 'version': '2018a'}
 
-source_urls = ['ftp://plasma-gate.weizmann.ac.il/pub/grace/src/grace5/']
+source_urls = ['https://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
 sources = [SOURCELOWER_TAR_GZ]
 patches = ['%(name)s-%(version)s%(versionsuffix)s.patch']
 checksums = [
@@ -23,7 +23,6 @@ dependencies = [
     ('libpng', '1.6.34'),
     ('zlib', '1.2.11'),
     ('libjpeg-turbo', '1.5.3'),
-    ('FFTW', '3.3.7'),
     ('netCDF', '4.6.0'),
 ]
 

--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2019a-5build1.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2019a-5build1.eb
@@ -4,12 +4,12 @@ name = 'Grace'
 version = '5.1.25'
 versionsuffix = '-5build1'
 
-homepage = 'http://plasma-gate.weizmann.ac.il/Grace/'
+homepage = 'https://plasma-gate.weizmann.ac.il/Grace/'
 description = """Grace is a WYSIWYG tool to make two-dimensional plots of numerical data."""
 
 toolchain = {'name': 'foss', 'version': '2019a'}
 
-source_urls = ['ftp://plasma-gate.weizmann.ac.il/pub/grace/src/grace5/']
+source_urls = ['https://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
 sources = [SOURCELOWER_TAR_GZ]
 patches = ['%(name)s-%(version)s%(versionsuffix)s.patch']
 checksums = [
@@ -23,7 +23,6 @@ dependencies = [
     ('libpng', '1.6.36'),
     ('zlib', '1.2.11'),
     ('libjpeg-turbo', '2.0.2'),
-    ('FFTW', '3.3.8'),
     ('netCDF', '4.6.2'),
 ]
 

--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2019b-5build1.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2019b-5build1.eb
@@ -9,7 +9,7 @@ description = """Grace is a WYSIWYG tool to make two-dimensional plots of numeri
 
 toolchain = {'name': 'foss', 'version': '2019b'}
 
-source_urls = ['ftp://plasma-gate.weizmann.ac.il/pub/grace/src/grace5/']
+source_urls = ['https://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
 sources = [SOURCELOWER_TAR_GZ]
 patches = ['%(name)s-%(version)s%(versionsuffix)s.patch']
 checksums = [
@@ -20,7 +20,6 @@ checksums = [
 dependencies = [
     ('motif', '2.3.8'),
     ('zlib', '1.2.11'),
-    ('FFTW', '3.3.8'),
     ('netCDF', '4.7.1'),
 ]
 

--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2021a.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2021a.eb
@@ -3,28 +3,32 @@ easyblock = 'ConfigureMake'
 name = 'Grace'
 version = '5.1.25'
 
-homepage = 'http://freecode.com/projects/grace'
-description = """Grace is a WYSIWYG 2D plotting tool for X Windows System and Motif."""
-
-source_urls = ['https://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
-sources = [SOURCE_TAR_GZ]
-checksums = ['751ab9917ed0f6232073c193aba74046037e185d73b77bab0f5af3e3ff1da2ac']
+homepage = 'https://plasma-gate.weizmann.ac.il/Grace/'
+description = """Grace is a WYSIWYG tool to make two-dimensional plots of numerical data."""
 
 toolchain = {'name': 'foss', 'version': '2021a'}
 
+source_urls = ['https://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['751ab9917ed0f6232073c193aba74046037e185d73b77bab0f5af3e3ff1da2ac']
+
 dependencies = [
     ('motif', '2.3.8'),
+    ('zlib', '1.2.11'),
     ('netCDF', '4.8.0'),
 ]
 
 runtest = 'tests'
 
-# we also need to run make links right before or after make install.
-installopts = 'links'
+postinstallcmds = ['mv %(installdir)s/grace/* %(installdir)s && rmdir %(installdir)s/grace']
 
 sanity_check_paths = {
-    'files': ['bin/xmgrace'],
-    'dirs': [],
+    'files': ['lib/libgrace_np.a', 'bin/convcal', 'bin/fdf2fit', 'bin/grconvert', 'bin/xmgrace'],
+    'dirs': ['include', 'fonts', 'templates'],
+}
+
+modextravars = {
+    'GRACE_HOME': '%(installdir)s',
 }
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2021a.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2021a.eb
@@ -1,6 +1,6 @@
 easyblock = 'ConfigureMake'
 
-name = 'grace'
+name = 'Grace'
 version = '5.1.25'
 
 homepage = 'http://freecode.com/projects/grace'

--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-intel-2016a.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-intel-2016a.eb
@@ -7,7 +7,7 @@ homepage = 'https://plasma-gate.weizmann.ac.il/Grace/'
 description = """Grace is a WYSIWYG 2D plotting tool for X Windows System and Motif."""
 
 source_urls = ['https://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
-sources = [SOURCE_TAR_GZ]
+sources = [SOURCELOWER_TAR_GZ]
 checksums = ['751ab9917ed0f6232073c193aba74046037e185d73b77bab0f5af3e3ff1da2ac']
 
 toolchain = {'name': 'intel', 'version': '2016a'}

--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-intel-2016a.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-intel-2016a.eb
@@ -3,11 +3,12 @@ easyblock = 'ConfigureMake'
 name = 'Grace'
 version = '5.1.25'
 
-homepage = 'http://freecode.com/projects/grace'
+homepage = 'https://plasma-gate.weizmann.ac.il/Grace/'
 description = """Grace is a WYSIWYG 2D plotting tool for X Windows System and Motif."""
 
-source_urls = ['ftp://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
+source_urls = ['https://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
 sources = [SOURCE_TAR_GZ]
+checksums = ['751ab9917ed0f6232073c193aba74046037e185d73b77bab0f5af3e3ff1da2ac']
 
 toolchain = {'name': 'intel', 'version': '2016a'}
 

--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-intel-2016a.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-intel-2016a.eb
@@ -1,6 +1,6 @@
 easyblock = 'ConfigureMake'
 
-name = 'grace'
+name = 'Grace'
 version = '5.1.25'
 
 homepage = 'http://freecode.com/projects/grace'
@@ -9,7 +9,7 @@ description = """Grace is a WYSIWYG 2D plotting tool for X Windows System and Mo
 source_urls = ['ftp://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
 sources = [SOURCE_TAR_GZ]
 
-toolchain = {'name': 'foss', 'version': '2016a'}
+toolchain = {'name': 'intel', 'version': '2016a'}
 
 dependencies = [
     ('motif', '2.3.5'),

--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-intel-2017b-5build1.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-intel-2017b-5build1.eb
@@ -4,12 +4,12 @@ name = 'Grace'
 version = '5.1.25'
 versionsuffix = '-5build1'
 
-homepage = 'http://plasma-gate.weizmann.ac.il/Grace/'
+homepage = 'https://plasma-gate.weizmann.ac.il/Grace/'
 description = """Grace is a WYSIWYG tool to make two-dimensional plots of numerical data."""
 
 toolchain = {'name': 'intel', 'version': '2017b'}
 
-source_urls = ['ftp://plasma-gate.weizmann.ac.il/pub/grace/src/grace5/']
+source_urls = ['https://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
 sources = [SOURCELOWER_TAR_GZ]
 patches = ['%(name)s-%(version)s%(versionsuffix)s.patch']
 checksums = [

--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-intel-2019a-5build1.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-intel-2019a-5build1.eb
@@ -4,7 +4,7 @@ name = 'Grace'
 version = '5.1.25'
 versionsuffix = '-5build1'
 
-homepage = 'http://plasma-gate.weizmann.ac.il/Grace/'
+homepage = 'https://plasma-gate.weizmann.ac.il/Grace/'
 description = """Grace is a WYSIWYG tool to make two-dimensional plots of numerical data."""
 
 toolchain = {'name': 'intel', 'version': '2019a'}


### PR DESCRIPTION
cleaning up after merging https://github.com/easybuilders/easybuild-easyconfigs/pull/14445 before noticing the different grace/Grace easyconfigs

WIP because we may want to additionally change the contents to make easyconfigs more uniform across toolchains

also related to https://github.com/easybuilders/easybuild-easyconfigs/pull/14468 and https://github.com/easybuilders/easybuild-easyconfigs/pull/12717