### PR TITLE
add dependency on libnsl for ANIcalculator

### DIFF
--- a/easybuild/easyconfigs/a/ANIcalculator/ANIcalculator-1.0-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/a/ANIcalculator/ANIcalculator-1.0-GCCcore-10.3.0.eb
@@ -1,4 +1,3 @@
-# This installation only works for Linux distributions that provide libnsl.so.1 as part of the (g)libc package.
 easyblock = 'MakeCp'
 
 name = 'ANIcalculator'
@@ -21,6 +20,7 @@ builddependencies = [('binutils', '2.36.1')]
 
 dependencies = [
     ('Perl', '5.32.1'),
+    ('libnsl', '1.3.0'),
 ]
 
 skipsteps = ['build']

--- a/easybuild/easyconfigs/a/ANIcalculator/ANIcalculator-1.0-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/a/ANIcalculator/ANIcalculator-1.0-GCCcore-10.3.0.eb
@@ -16,8 +16,6 @@ source_urls = ['https://ani.jgi.doe.gov/download_files/']
 sources = ['%(name)s_v%(version_major)s.tgz']
 checksums = ['236596a9a204cbcad162fc66be3506b2530b1f48f4f84d9647ccec3ca7483a43']
 
-builddependencies = [('binutils', '2.36.1')]
-
 dependencies = [
     ('Perl', '5.32.1'),
     ('libnsl', '1.3.0'),

--- a/easybuild/easyconfigs/l/libnsl/libnsl-1.3.0-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/libnsl/libnsl-1.3.0-GCCcore-10.3.0.eb
@@ -10,6 +10,7 @@ toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
 
 source_urls = ['https://github.com/thkukuk/%(name)s/releases/download/v%(version)s/']
 sources = [SOURCE_TAR_XZ]
+checksums = ['eac3062957fa302c62eff4aed718a07bacbf9ceb0a058289f12a19bfdda3c8e2']
 
 builddependencies = [
     ('binutils', '2.36.1'),

--- a/easybuild/easyconfigs/l/libnsl/libnsl-1.3.0-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/libnsl/libnsl-1.3.0-GCCcore-10.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libnsl'
 version = '1.3.0'
 
-homepage = 'https://www.linuxfromscratch.org/blfs/view/svn/basicnet/libnsl.html'
+homepage = 'https://github.com/thkukuk/libnsl'
 description = """The libnsl package contains the public client interface for NIS(YP)."""
 
 toolchain = {'name': 'GCCcore', 'version': '10.3.0'}

--- a/easybuild/easyconfigs/l/libnsl/libnsl-1.3.0-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/libnsl/libnsl-1.3.0-GCCcore-10.3.0.eb
@@ -1,0 +1,32 @@
+easyblock = 'ConfigureMake'
+
+name = 'libnsl'
+version = '1.3.0'
+
+homepage = 'https://www.linuxfromscratch.org/blfs/view/svn/basicnet/libnsl.html'
+description = """The libnsl package contains the public client interface for NIS(YP)."""
+
+toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
+
+source_urls = ['https://github.com/thkukuk/%(name)s/releases/download/v%(version)s/']
+sources = [SOURCE_TAR_XZ]
+
+builddependencies = [
+    ('binutils', '2.36.1'),
+]
+
+dependencies = [
+    ('libtirpc', '1.3.2'),
+]
+
+# Provide a symlink for libnsl.so.1, which used to be part of glibc.
+# This new version of libnsl should be backwards compatible.
+postinstallcmds = ['ln -s libnsl.so %(installdir)s/lib/libnsl.so.1']
+
+sanity_check_paths = {
+    'files': ['include/rpcsvc/nis.h', 'include/rpcsvc/yp.h', 'lib/libnsl.a',
+              'lib/libnsl.%s' % SHLIB_EXT, 'lib/libnsl.%s.1' % SHLIB_EXT],
+    'dirs': ['include']
+}
+
+moduleclass = 'devel'

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1194,7 +1194,7 @@ def template_easyconfig_test(self, spec):
     # make sure binutils is included as a (build) dep if toolchain is GCCcore
     if ec['toolchain']['name'] == 'GCCcore':
         # with 'Tarball' easyblock: only unpacking, no building; Eigen is also just a tarball
-        requires_binutils = ec['easyblock'] not in ['Tarball'] and ec['name'] not in ['Eigen']
+        requires_binutils = ec['easyblock'] not in ['Tarball'] and ec['name'] not in ['ANIcalculator', 'Eigen']
 
         # let's also exclude the very special case where the system GCC is used as GCCcore, and only apply this
         # exception to the dependencies of binutils (since we should eventually build a new binutils with GCCcore)


### PR DESCRIPTION
This adds an easyconfig for `{devel}[GCCcore/10.3.0] libnsl`, and adds a dependency on that easyconfig to `ANIcalculator`. This should solve the issue that it doesn't work on newer Linux distros (e.g. EL8) due to a missing `libnsl.so.1` (which used to be part of older `glibc` versions). Note that `libnsl` creates a symlink `libnsl.so.1 -> libnsl.so.2`; it should be backwards compatible.

I've also removed the "fake" build dependency on `binutils`, which only was there to pass the CI tests. Instead, I've now added an exception in the test suite that allows `ANIcalculator` to not have a requirement on `binutils`, as it only installs some binaries.