### PR TITLE
move cxxopts, termcolor and ELFIO header only libraries to SYSTEM toolchain

### DIFF
--- a/easybuild/easyconfigs/c/cxxopts/cxxopts-3.0.0.eb
+++ b/easybuild/easyconfigs/c/cxxopts/cxxopts-3.0.0.eb
@@ -9,17 +9,14 @@ version = '3.0.0'
 homepage = 'https://github.com/jarro2783/cxxopts'
 description = """cxxopts is a lightweight C++ command line option parser"""
 
-toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
+toolchain = SYSTEM
 
 github_account = 'jarro2783'
 source_urls = [GITHUB_SOURCE]
 sources = ['v%(version)s.tar.gz']
 checksums = ['36f41fa2a46b3c1466613b63f3fa73dc24d912bc90d667147f1e43215a8c6d00']
 
-builddependencies = [
-    ('binutils', '2.36.1'),
-    ('CMake', '3.20.1'),
-]
+builddependencies = [('CMake', '3.18.4')]
 
 sanity_check_paths = {
     'files': ["include/cxxopts.hpp"],

--- a/easybuild/easyconfigs/e/ELFIO/ELFIO-3.9.eb
+++ b/easybuild/easyconfigs/e/ELFIO/ELFIO-3.9.eb
@@ -10,17 +10,14 @@ homepage = 'http://elfio.sourceforge.net'
 description = """ELFIO is a header-only C++ library intended
  for reading and generating files in the ELF binary format."""
 
-toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
+toolchain = SYSTEM
 
 github_account = 'serge1'
 source_urls = [GITHUB_SOURCE]
 sources = ['Release_%(version)s.tar.gz']
 checksums = ['bf93538afe916b333aef1d03e44c9b80dace61f4d097e581ae332cd2d4fa178e']
 
-builddependencies = [
-    ('binutils', '2.36.1'),
-    ('CMake', '3.20.1'),
-]
+builddependencies = [('CMake', '3.18.4')]
 
 sanity_check_paths = {
     'files': ["include/%(namelower)s/%(namelower)s.hpp"],

--- a/easybuild/easyconfigs/t/termcolor/termcolor-2.0.0.eb
+++ b/easybuild/easyconfigs/t/termcolor/termcolor-2.0.0.eb
@@ -10,17 +10,14 @@ homepage = 'https://termcolor.readthedocs.io/'
 description = """Termcolor is a header-only C++ library for printing colored
  messages to the terminal."""
 
-toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
+toolchain = SYSTEM
 
 github_account = 'ikalnytskyi'
 source_urls = [GITHUB_SOURCE]
 sources = ['v%(version)s.tar.gz']
 checksums = ['4a73a77053822ca1ed6d4a2af416d31028ec992fb0ffa794af95bd6216bb6a20']
 
-builddependencies = [
-    ('binutils', '2.36.1'),
-    ('CMake', '3.20.1'),
-]
+builddependencies = [('CMake', '3.18.4')]
 
 sanity_check_paths = {
     'files': ['include/%(name)s/%(name)s.hpp'],


### PR DESCRIPTION
follow up from #14487, #14488, #14489, cc @robert-mijakovic 