### PR TITLE
Correctly set execute permissions for ANIcalculator binaries

### DIFF
--- a/easybuild/easyconfigs/a/ANIcalculator/ANIcalculator-1.0-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/a/ANIcalculator/ANIcalculator-1.0-GCCcore-10.3.0.eb
@@ -29,8 +29,11 @@ skipsteps = ['build']
 # Instead of copying this, we use the version from the Perl module.
 files_to_copy = [(['ANIcalculator', 'nsimscan'], 'bin'), 'README.txt']
 
-# Remove the execute permissions on the README.txt, which it has by default.
-postinstallcmds = ['chmod -x %(installdir)s/README.txt']
+# Fix permissions on binaries and README.txt,
+postinstallcmds = [
+    'chmod a+x %(installdir)s/bin/*',
+    'chmod -x %(installdir)s/README.txt',
+]
 
 sanity_check_paths = {
     'files': ['README.txt', 'bin/ANIcalculator', 'bin/nsimscan'],


### PR DESCRIPTION
I just found that the permissions were not set correctly for the installed binaries (other users were not able to run them):
```
-rwxr-xr--. 1 boegelbot boegelbot  12M  7 aug  2014 ANIcalculator
-rwxr-xr--. 1 boegelbot boegelbot 451K  7 aug  2014 nsimscan
```
This PR fixes it by doing a `chmod a+x` on `bin/*`.