### PR TITLE
add patch to fix broken (hanging) Mash binaries

### DIFF
--- a/easybuild/easyconfigs/m/Mash/Mash-2.0-foss-2018a.eb
+++ b/easybuild/easyconfigs/m/Mash/Mash-2.0-foss-2018a.eb
@@ -10,6 +10,10 @@ toolchain = {'name': 'foss', 'version': '2018a'}
 
 source_urls = ['https://github.com/marbl/Mash/archive/']
 sources = ['v%(version)s.tar.gz']
+patches = [
+    'Mash-2.1_fix-hardcoding.patch',
+    'Mash-2.1_disable-memcpy-wrap.patch',
+]
 checksums = ['7bea8cd3c266640bbd97f2e1c9d0168892915c1c14f7d03a9751bf7a3709dd01']
 
 builddependencies = [('Autotools', '20170619')]

--- a/easybuild/easyconfigs/m/Mash/Mash-2.0-foss-2018a.eb
+++ b/easybuild/easyconfigs/m/Mash/Mash-2.0-foss-2018a.eb
@@ -14,7 +14,11 @@ patches = [
     'Mash-2.1_fix-hardcoding.patch',
     'Mash-2.1_disable-memcpy-wrap.patch',
 ]
-checksums = ['7bea8cd3c266640bbd97f2e1c9d0168892915c1c14f7d03a9751bf7a3709dd01']
+checksums = [
+    '7bea8cd3c266640bbd97f2e1c9d0168892915c1c14f7d03a9751bf7a3709dd01',  # v2.0.tar.gz
+    'dc40511b25dab25e3fe88d4911ccf7bd793e60ba8f4b77a64488412d14796299',  # Mash-2.1_fix-hardcoding.patch
+    '40990cf3d192b533736374bc67a54dbd839d90b0310a0a66f994891da1f85b6e',  # Mash-2.1_disable-memcpy-wrap.patch
+]
 
 builddependencies = [('Autotools', '20170619')]
 dependencies = [

--- a/easybuild/easyconfigs/m/Mash/Mash-2.0-foss-2018a.eb
+++ b/easybuild/easyconfigs/m/Mash/Mash-2.0-foss-2018a.eb
@@ -27,4 +27,6 @@ sanity_check_paths = {
     'dirs': ['include/mash'],
 }
 
+sanity_check_commands = ['mash --version']
+
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/Mash/Mash-2.1-foss-2018b.eb
+++ b/easybuild/easyconfigs/m/Mash/Mash-2.1-foss-2018b.eb
@@ -36,4 +36,6 @@ sanity_check_paths = {
     'dirs': ['include/mash'],
 }
 
+sanity_check_commands = ['mash --version']
+
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/Mash/Mash-2.2-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/m/Mash/Mash-2.2-GCC-9.3.0.eb
@@ -17,7 +17,7 @@ toolchainopts = {'cstd': 'c++17'}
 source_urls = ['https://github.com/marbl/Mash/archive/']
 sources = ['v%(version)s.tar.gz']
 patches = [
-    'Mash-2.2_fix-hardcoding.patch',
+    'Mash-%(version)s_fix-hardcoding.patch',
     'Mash-2.1_disable-memcpy-wrap.patch',
 ]
 checksums = [

--- a/easybuild/easyconfigs/m/Mash/Mash-2.2-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/m/Mash/Mash-2.2-GCC-9.3.0.eb
@@ -16,6 +16,10 @@ toolchainopts = {'cstd': 'c++17'}
 
 source_urls = ['https://github.com/marbl/Mash/archive/']
 sources = ['v%(version)s.tar.gz']
+patches = [
+    'Mash-2.2_fix-hardcoding.patch',
+    'Mash-2.1_disable-memcpy-wrap.patch',
+]
 checksums = ['7ad006dbf0d6ffc3e164713ba955aab4cd24eaf85c864ac905f48cd8ba332691']
 
 builddependencies = [('Autotools', '20180311')]

--- a/easybuild/easyconfigs/m/Mash/Mash-2.2-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/m/Mash/Mash-2.2-GCC-9.3.0.eb
@@ -20,7 +20,11 @@ patches = [
     'Mash-2.2_fix-hardcoding.patch',
     'Mash-2.1_disable-memcpy-wrap.patch',
 ]
-checksums = ['7ad006dbf0d6ffc3e164713ba955aab4cd24eaf85c864ac905f48cd8ba332691']
+checksums = [
+    '7ad006dbf0d6ffc3e164713ba955aab4cd24eaf85c864ac905f48cd8ba332691',  # v2.2.tar.gz
+    '0c7315af727a06f408ab3ca69da0860fc671aa870b448a41a509b1e6d7027db5',  # Mash-2.2_fix-hardcoding.patch
+    '40990cf3d192b533736374bc67a54dbd839d90b0310a0a66f994891da1f85b6e',  # Mash-2.1_disable-memcpy-wrap.patch
+]
 
 builddependencies = [('Autotools', '20180311')]
 dependencies = [

--- a/easybuild/easyconfigs/m/Mash/Mash-2.2-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/m/Mash/Mash-2.2-GCC-9.3.0.eb
@@ -41,4 +41,6 @@ sanity_check_paths = {
     'dirs': ['include/mash'],
 }
 
+sanity_check_commands = ['mash --version']
+
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/Mash/Mash-2.2_fix-hardcoding.patch
+++ b/easybuild/easyconfigs/m/Mash/Mash-2.2_fix-hardcoding.patch
@@ -1,0 +1,20 @@
+don't hardcode -std=c++14, since -std=c++17 is required when building on top of CapnProto 0.8.0
+--- Mash-2.2/configure.ac.orig	2021-12-07 10:56:35.099497741 +0100
++++ Mash-2.2/configure.ac	2021-12-07 10:57:09.343306342 +0100
+@@ -33,7 +33,7 @@
+ 	AC_MSG_ERROR([Cap'n Proto compiler (capnp) not found.])
+ fi
+ 
+-CPPFLAGS="-I$with_capnp/include -std=c++14"
++CPPFLAGS="-I$with_capnp/include $CXXFLAGS"
+ 
+ AC_CHECK_HEADER(capnp/common.h, [result=1], [result=0])
+ 
+--- Mash-2.2/Makefile.in.orig	2021-12-07 10:57:13.619282453 +0100
++++ Mash-2.2/Makefile.in	2021-12-07 10:57:36.623153939 +0100
+@@ -1,4 +1,4 @@
+-CXXFLAGS += -O3 -std=c++14 -Isrc -I@capnp@/include -I@mathinc@
++CXXFLAGS += -Isrc -I@capnp@/include -I@mathinc@
+ CPPFLAGS += @amcppflags@
+ 
+ UNAME_S=$(shell uname -s)

--- a/easybuild/easyconfigs/m/Mash/Mash-2.3-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/m/Mash/Mash-2.3-GCC-10.3.0.eb
@@ -16,6 +16,10 @@ toolchainopts = {'cstd': 'c++17'}
 
 source_urls = ['https://github.com/marbl/Mash/archive/']
 sources = ['v%(version)s.tar.gz']
+patches = [
+    'Mash-2.2_fix-hardcoding.patch',
+    'Mash-2.1_disable-memcpy-wrap.patch',
+]
 checksums = ['f96cf7305e010012c3debed966ac83ceecac0351dbbfeaa6cd7ad7f068d87fe1']
 
 builddependencies = [('Autotools', '20210128')]

--- a/easybuild/easyconfigs/m/Mash/Mash-2.3-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/m/Mash/Mash-2.3-GCC-10.3.0.eb
@@ -20,7 +20,11 @@ patches = [
     'Mash-2.2_fix-hardcoding.patch',
     'Mash-2.1_disable-memcpy-wrap.patch',
 ]
-checksums = ['f96cf7305e010012c3debed966ac83ceecac0351dbbfeaa6cd7ad7f068d87fe1']
+checksums = [
+    'f96cf7305e010012c3debed966ac83ceecac0351dbbfeaa6cd7ad7f068d87fe1',  # v2.3.tar.gz
+    '0c7315af727a06f408ab3ca69da0860fc671aa870b448a41a509b1e6d7027db5',  # Mash-2.2_fix-hardcoding.patch
+    '40990cf3d192b533736374bc67a54dbd839d90b0310a0a66f994891da1f85b6e',  # Mash-2.1_disable-memcpy-wrap.patch
+]
 
 builddependencies = [('Autotools', '20210128')]
 dependencies = [

--- a/easybuild/easyconfigs/m/Mash/Mash-2.3-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/m/Mash/Mash-2.3-GCC-10.3.0.eb
@@ -41,4 +41,6 @@ sanity_check_paths = {
     'dirs': ['include/mash'],
 }
 
+sanity_check_commands = ['mash --version']
+
 moduleclass = 'bio'


### PR DESCRIPTION
Fixes #14509 by reintroducing (an updated version of) the patches that were already used for version 2.1. I've also added sanity check commands for all Mash easyconfigs, as this would have spotted the issue.