### PR TITLE
include output of failing code style check in message produced by failing easyconfigs style test

### DIFF
--- a/test/easyconfigs/styletests.py
+++ b/test/easyconfigs/styletests.py
@@ -29,9 +29,10 @@ Style tests for easyconfig files. Uses pep8.
 """
 
 import glob
-from unittest import TestCase, TestLoader, main, skipIf
+from unittest import TestLoader, main, skipIf
 
 from easybuild.base import fancylogger
+from easybuild.base.testing import TestCase
 from easybuild.framework.easyconfig.tools import get_paths_for
 from easybuild.framework.easyconfig.style import check_easyconfigs_style
 
@@ -52,9 +53,19 @@ class StyleTest(TestCase):
         specs = glob.glob('%s/*/*/*.eb' % easyconfigs_path)
         specs = sorted(specs)
 
+        self.mock_stderr(True)
+        self.mock_stdout(True)
         result = check_easyconfigs_style(specs)
+        stderr, stdout = self.get_stderr(), self.get_stdout()
+        self.mock_stderr(False)
+        self.mock_stdout(False)
 
-        self.assertEqual(result, 0, "Found code style errors (and/or warnings): %s" % result)
+        error_msg = '\n'.join([
+            "There shouldn't be any code style errors (and/or warnings), found %d:" % result,
+            stdout,
+            stderr,
+        ])
+        self.assertEqual(result, 0, error_msg)
 
 
 def suite(loader=None):


### PR DESCRIPTION
Example output of failing style checks without this change:

```
FAIL: test_style_conformance (test.easyconfigs.styletests.StyleTest)
Check the easyconfigs for style
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/easyconfigs/styletests.py", line 57, in test_style_conformance
    self.assertEqual(result, 0, "Found code style errors (and/or warnings): %s" % result)
AssertionError: Found code style errors (and/or warnings): 1

----------------------------------------------------------------------
```

with this change you at least get a clue of what's wrong (so you don't need to run `eb --check-style --from-pr` anymore...):

```
FAIL: test_style_conformance (test.easyconfigs.styletests.StyleTest)
Check the easyconfigs for style
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/easyconfigs/styletests.py", line 68, in test_style_conformance
    self.assertEqual(result, 0, error_msg)
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/easybuild/base/testing.py", line 116, in assertEqual
    raise AssertionError("%s:\nDIFF%s:\n%s" % (msg, limit, ''.join(diff[:self.ASSERT_MAX_DIFF])))
AssertionError: There shouldn't be any code style errors (and/or warnings), found 1:
/home/runner/work/easybuild-easyconfigs/easybuild-easyconfigs/easybuild/easyconfigs/n/numba/numba-0.54.1-foss-2021b.eb:31:121: E501 line too long (126 > 120 characters)

: 1 != 0:
DIFF:
- 1

----------------------------------------------------------------------
```