### PR TITLE
Fix RPATH issue in hipSYCL

### DIFF
--- a/easybuild/easyconfigs/h/hipSYCL/hipSYCL-0.9.1-gcccuda-2020b.eb
+++ b/easybuild/easyconfigs/h/hipSYCL/hipSYCL-0.9.1-gcccuda-2020b.eb
@@ -29,6 +29,7 @@ configopts += '-DLLVM_DIR=$EBROOTCLANG '
 configopts += '-DCLANG_EXECUTABLE_PATH=$EBROOTCLANG/bin/clang++ '
 configopts += '-DWITH_CPU_BACKEND=ON '
 configopts += '-DWITH_CUDA_BACKEND=ON '
+configopts += '-DWITH_INSTALL_RPATH_USE_LINK_PATH=OFF '
 
 sanity_check_paths = {
     'files': ['bin/syclcc-clang', 'include/sycl/sycl.hpp',


### PR DESCRIPTION
For whatever reason, [this](https://github.com/easybuilders/easybuild-easyblocks/pull/2561) change in the `cuda.py` easyblock triggered an error in the `hipSYCL` build.

_Before_ this easyblock change the `hipSYCL` CMake installation reports
```
-- Set runtime path of "/cluster/software/hipSYCL/0.9.1-gcccuda-2020b/lib/hipSYCL/librt-backend-cuda.so" to ""
```
which allows it to pick up the correct runtime CUDA library, i.e. the `CUDAcore` "stub" library when building on a machine without a CUDA driver, but a proper CUDA lib when running on a CUDA machine. _After_ said easyblock change the `hipSYCL` installation instead reports
```
-- Set runtime path of "/cluster/software/hipSYCL/0.9.1-gcccuda-2020b/lib/hipSYCL/librt-backend-cuda.so" to "/cluster/software/CUDAcore/11.1.1/lib64/stubs"
```
which fixes the runtime path to the stub library, even if a proper CUDA lib is present on the machine.

The proposed change will again set the runtime path to empty `""` so that the expected behavior is retained. Not sure if the original correct behavior was a result of "two wrongs make a right", but at least the `-DWITH_INSTALL_RPATH_USE_LINK_PATH=OFF` options seems appropriate here.