### PR TITLE
{phys}[foss/2021a,foss/2021b,intel/2021a,intel/2021b] libGridXC v0.9.6 

### DIFF
--- a/easybuild/easyconfigs/l/libGridXC/libGridXC-0.9.6-gompi-2021a.eb
+++ b/easybuild/easyconfigs/l/libGridXC/libGridXC-0.9.6-gompi-2021a.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'libGridXC'
+version = '0.9.6'
+
+homepage = 'https://gitlab.com/siesta-project/libraries/libgridxc'
+description = """A library to compute the exchange and correlation energy
+ and potential in spherical (i.e. atoms) or periodic systems."""
+
+toolchain = {'name': 'gompi', 'version': '2021a'}
+toolchainopts = {'usempi': True, 'opt': True}
+
+source_urls = ['https://gitlab.com/siesta-project/libraries/libgridxc/uploads/e6e4ec1e3ec648a45b3613e724c7be04']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['ee513eeb08b631e2efaaea62e73d85b6fbf204da85963be785915802e5497463']
+
+local_common_configopts = "--enable-static --enable-shared --enable-multiconfig --with-libxc"
+
+configopts = [
+    local_common_configopts + " --without-mpi",
+    local_common_configopts + " CC=$MPICC FC=$MPIFC CXX=$MPICXX --with-mpi",
+]
+
+dependencies = [('libxc', '4.3.4')]
+
+sanity_check_paths = {
+    'files':
+        ['include/gridxc_dp%s/gridxc.mod' % x for x in ['', '_mpi']] +
+        [('lib/libgridxc_dp.a', 'lib64/libgridxc_dp.a')] +
+        [('lib/libgridxc_dp_mpi.a', 'lib64/libgridxc_dp_mpi.a')],
+    'dirs': [],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/l/libGridXC/libGridXC-0.9.6-gompi-2021b.eb
+++ b/easybuild/easyconfigs/l/libGridXC/libGridXC-0.9.6-gompi-2021b.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'libGridXC'
+version = '0.9.6'
+
+homepage = 'https://gitlab.com/siesta-project/libraries/libgridxc'
+description = """A library to compute the exchange and correlation energy
+ and potential in spherical (i.e. atoms) or periodic systems."""
+
+toolchain = {'name': 'gompi', 'version': '2021b'}
+toolchainopts = {'usempi': True, 'opt': True}
+
+source_urls = ['https://gitlab.com/siesta-project/libraries/libgridxc/uploads/e6e4ec1e3ec648a45b3613e724c7be04']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['ee513eeb08b631e2efaaea62e73d85b6fbf204da85963be785915802e5497463']
+
+local_common_configopts = "--enable-static --enable-shared --enable-multiconfig --with-libxc"
+
+configopts = [
+    local_common_configopts + " --without-mpi",
+    local_common_configopts + " CC=$MPICC FC=$MPIFC CXX=$MPICXX --with-mpi",
+]
+
+dependencies = [('libxc', '4.3.4')]
+
+sanity_check_paths = {
+    'files':
+        ['include/gridxc_dp%s/gridxc.mod' % x for x in ['', '_mpi']] +
+        [('lib/libgridxc_dp.a', 'lib64/libgridxc_dp.a')] +
+        [('lib/libgridxc_dp_mpi.a', 'lib64/libgridxc_dp_mpi.a')],
+    'dirs': [],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/l/libGridXC/libGridXC-0.9.6-iimpi-2021a.eb
+++ b/easybuild/easyconfigs/l/libGridXC/libGridXC-0.9.6-iimpi-2021a.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'libGridXC'
+version = '0.9.6'
+
+homepage = 'https://gitlab.com/siesta-project/libraries/libgridxc'
+description = """A library to compute the exchange and correlation energy
+ and potential in spherical (i.e. atoms) or periodic systems."""
+
+toolchain = {'name': 'iimpi', 'version': '2021a'}
+toolchainopts = {'usempi': True, 'opt': True}
+
+source_urls = ['https://gitlab.com/siesta-project/libraries/libgridxc/uploads/e6e4ec1e3ec648a45b3613e724c7be04']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['ee513eeb08b631e2efaaea62e73d85b6fbf204da85963be785915802e5497463']
+
+local_common_configopts = "--enable-static --enable-shared --enable-multiconfig --with-libxc"
+
+configopts = [
+    local_common_configopts + " --without-mpi",
+    local_common_configopts + " CC=$MPICC FC=$MPIFC CXX=$MPICXX --with-mpi",
+]
+
+dependencies = [('libxc', '4.3.4')]
+
+sanity_check_paths = {
+    'files':
+        ['include/gridxc_dp%s/gridxc.mod' % x for x in ['', '_mpi']] +
+        [('lib/libgridxc_dp.a', 'lib64/libgridxc_dp.a')] +
+        [('lib/libgridxc_dp_mpi.a', 'lib64/libgridxc_dp_mpi.a')],
+    'dirs': [],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/l/libGridXC/libGridXC-0.9.6-iimpi-2021b.eb
+++ b/easybuild/easyconfigs/l/libGridXC/libGridXC-0.9.6-iimpi-2021b.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'libGridXC'
+version = '0.9.6'
+
+homepage = 'https://gitlab.com/siesta-project/libraries/libgridxc'
+description = """A library to compute the exchange and correlation energy
+ and potential in spherical (i.e. atoms) or periodic systems."""
+
+toolchain = {'name': 'iimpi', 'version': '2021b'}
+toolchainopts = {'usempi': True, 'opt': True}
+
+source_urls = ['https://gitlab.com/siesta-project/libraries/libgridxc/uploads/e6e4ec1e3ec648a45b3613e724c7be04']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['ee513eeb08b631e2efaaea62e73d85b6fbf204da85963be785915802e5497463']
+
+local_common_configopts = "--enable-static --enable-shared --enable-multiconfig --with-libxc"
+
+configopts = [
+    local_common_configopts + " --without-mpi",
+    local_common_configopts + " CC=$MPICC FC=$MPIFC CXX=$MPICXX --with-mpi",
+]
+
+dependencies = [('libxc', '4.3.4')]
+
+sanity_check_paths = {
+    'files':
+        ['include/gridxc_dp%s/gridxc.mod' % x for x in ['', '_mpi']] +
+        [('lib/libgridxc_dp.a', 'lib64/libgridxc_dp.a')] +
+        [('lib/libgridxc_dp_mpi.a', 'lib64/libgridxc_dp_mpi.a')],
+    'dirs': [],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/l/libxc/libxc-4.3.4-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.3.4-GCC-11.2.0.eb
@@ -1,0 +1,55 @@
+easyblock = 'CMakeMake'
+
+name = 'libxc'
+version = '4.3.4'
+
+homepage = 'https://www.tddft.org/programs/libxc'
+description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
+ The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
+
+toolchain = {'name': 'GCC', 'version': '11.2.0'}
+
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
+sources = [SOURCE_TAR_GZ]
+patches = [
+    'libxc-%(version)s_lm-fix.patch',
+    'libxc-%(version)s_fix-CMakeLists.patch',
+    'libxc-%(version)s_fix-timeout.patch',
+]
+checksums = [
+    'a8ee37ddc5079339854bd313272856c9d41a27802472ee9ae44b58ee9a298337',  # libxc-4.3.4.tar.gz
+    'f2cae17533d3527e11cfec958a7f253872f7c5fcd104c3cffc02382be0ccfb9c',  # libxc-4.3.4_lm-fix.patch
+    '5a5e7d69729326e0d44e60b554ba6d8650a28958ec54b27a98757dc78a040946',  # libxc-4.3.4_fix-CMakeLists.patch
+    'd44d4a35ae22542c3086e57638e0e2b6b1ad8e98d0898036972a0248cf8778e8',  # libxc-4.3.4_fix-timeout.patch
+]
+
+builddependencies = [
+    ('CMake', '3.21.1'),
+    ('Perl', '5.34.0'),
+]
+
+separate_build_dir = True
+
+parallel = 1
+
+local_common_configopts = "-DENABLE_FORTRAN=ON -DENABLE_FORTRAN03=ON -DENABLE_XHOST=OFF"
+
+# perform iterative build to get both static and shared libraries
+configopts = [
+    local_common_configopts + ' -DBUILD_SHARED_LIBS=OFF',
+    local_common_configopts + ' -DBUILD_SHARED_LIBS=ON',
+]
+
+# make sure that built libraries (libxc*.so*) in build directory are picked when running tests
+# this is required when RPATH linking is used
+pretestopts = "export LD_LIBRARY_PATH=%(builddir)s/easybuild_obj:$LD_LIBRARY_PATH && "
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['bin/xc-info', 'bin/xc-threshold'] +
+             ['lib/libxc%s.%s' % (x, y) for x in ['', 'f03', 'f90'] for y in ['a', SHLIB_EXT]],
+    'dirs': ['include', 'lib/pkgconfig', 'share/cmake/Libxc'],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/libxc/libxc-4.3.4-intel-compilers-2021.4.0.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.3.4-intel-compilers-2021.4.0.eb
@@ -1,0 +1,61 @@
+easyblock = 'CMakeMake'
+
+name = 'libxc'
+version = '4.3.4'
+
+homepage = 'https://www.tddft.org/programs/libxc'
+description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
+ The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
+
+toolchain = {'name': 'intel-compilers', 'version': '2021.4.0'}
+
+source_urls = ['https://www.tddft.org/programs/libxc/down.php?file=%(version)s/']
+sources = [SOURCE_TAR_GZ]
+patches = [
+    'libxc-%(version)s_rename-F03.patch',
+    'libxc-%(version)s_lm-fix.patch',
+    'libxc-%(version)s_fix-CMakeLists.patch',
+    'libxc-%(version)s_fix-timeout.patch',
+]
+checksums = [
+    'a8ee37ddc5079339854bd313272856c9d41a27802472ee9ae44b58ee9a298337',  # libxc-4.3.4.tar.gz
+    'e494be3ca2026998f2dd7c6b03a4e662f204fd3d963271e588f9f0d5739e76b5',  # libxc-4.3.4_rename-F03.patch
+    'f2cae17533d3527e11cfec958a7f253872f7c5fcd104c3cffc02382be0ccfb9c',  # libxc-4.3.4_lm-fix.patch
+    '5a5e7d69729326e0d44e60b554ba6d8650a28958ec54b27a98757dc78a040946',  # libxc-4.3.4_fix-CMakeLists.patch
+    'd44d4a35ae22542c3086e57638e0e2b6b1ad8e98d0898036972a0248cf8778e8',  # libxc-4.3.4_fix-timeout.patch
+]
+
+builddependencies = [
+    ('CMake', '3.21.1'),
+    ('Perl', '5.34.0'),
+]
+
+separate_build_dir = True
+
+# rename *.F03 source file since Intel Fortran compiler doesn't like that extension
+# also requires patch file to rename file in CMakeLists.txt and src/Makefile.in
+preconfigopts = "mv ../libxc-%(version)s/src/libxc_master.F03 ../libxc-%(version)s/src/libxc_master_F03.F90 && "
+
+local_common_configopts = "-DENABLE_FORTRAN=ON -DENABLE_FORTRAN03=ON -DENABLE_XHOST=OFF"
+
+# perform iterative build to get both static and shared libraries
+configopts = [
+    local_common_configopts + ' -DBUILD_SHARED_LIBS=OFF',
+    local_common_configopts + ' -DBUILD_SHARED_LIBS=ON',
+]
+
+parallel = 1
+
+# make sure that built libraries (libxc*.so*) in build directory are picked when running tests
+# this is required when RPATH linking is used
+pretestopts = "export LD_LIBRARY_PATH=%(builddir)s/easybuild_obj:$LD_LIBRARY_PATH && "
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['bin/xc-info', 'bin/xc-threshold'] +
+             ['lib/libxc%s.%s' % (x, y) for x in ['', 'f03', 'f90'] for y in ['a', SHLIB_EXT]],
+    'dirs': ['include', 'lib/pkgconfig', 'share/cmake/Libxc'],
+}
+
+moduleclass = 'chem'

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -446,10 +446,12 @@ class EasyConfigTest(TestCase):
             # Libint 1.1.6 is required by older CP2K versions
             'Libint': [(r'1\.1\.6', [r'CP2K-[3-6]'])],
             # libxc 2.x or 3.x is required by ABINIT, AtomPAW, CP2K, GPAW, horton, PySCF, WIEN2k
+            # libxc 4.x is required by libGridXC
             # (Qiskit depends on PySCF), Elk 7.x requires libxc >= 5
             'libxc': [
                 (r'[23]\.', [r'ABINIT-', r'AtomPAW-', r'CP2K-', r'GPAW-', r'horton-',
                              r'PySCF-', r'Qiskit-', r'WIEN2k-']),
+                (r'4\.', [r'libGridXC-']),
                 (r'5\.', [r'Elk-']),
             ],
             # some software depends on numba, which typically requires an older LLVM;


### PR DESCRIPTION
This PR also adds Libxc v4.3.4 for `GCC/11.2.0` and `intel-compilers/2021.4.0`, as libGridXC is currently not compatible with Libxc v5.x.