### PR TITLE
ignore missing binutils dependency for binaries in easyconfigs test suite

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1196,7 +1196,7 @@ def template_easyconfig_test(self, spec):
     # make sure binutils is included as a (build) dep if toolchain is GCCcore
     if ec['toolchain']['name'] == 'GCCcore':
         # with 'Tarball' easyblock: only unpacking, no building; Eigen is also just a tarball
-        requires_binutils = ec['easyblock'] not in ['Tarball'] and ec['name'] not in ['ANIcalculator', 'Eigen']
+        requires_binutils = ec['easyblock'] not in ['Tarball', 'Binary', 'PackedBinary'] and ec['name'] not in ['ANIcalculator', 'Eigen']
 
         # let's also exclude the very special case where the system GCC is used as GCCcore, and only apply this
         # exception to the dependencies of binutils (since we should eventually build a new binutils with GCCcore)

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1196,7 +1196,8 @@ def template_easyconfig_test(self, spec):
     # make sure binutils is included as a (build) dep if toolchain is GCCcore
     if ec['toolchain']['name'] == 'GCCcore':
         # with 'Tarball' easyblock: only unpacking, no building; Eigen is also just a tarball
-        requires_binutils = ec['easyblock'] not in ['Tarball', 'Binary', 'PackedBinary'] and ec['name'] not in ['ANIcalculator', 'Eigen']
+        requires_binutils = ec['easyblock'] not in ['Tarball', 'Binary', 'PackedBinary']
+        and ec['name'] not in ['ANIcalculator', 'Eigen']
 
         # let's also exclude the very special case where the system GCC is used as GCCcore, and only apply this
         # exception to the dependencies of binutils (since we should eventually build a new binutils with GCCcore)

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1196,8 +1196,8 @@ def template_easyconfig_test(self, spec):
     # make sure binutils is included as a (build) dep if toolchain is GCCcore
     if ec['toolchain']['name'] == 'GCCcore':
         # with 'Tarball' easyblock: only unpacking, no building; Eigen is also just a tarball
-        requires_binutils = ec['easyblock'] not in ['Tarball', 'Binary', 'PackedBinary']
-        and ec['name'] not in ['ANIcalculator', 'Eigen']
+        requires_binutils = ec['easyblock'] not in ['Tarball', 'Binary', 'PackedBinary'] and \
+                ec['name'] not in ['ANIcalculator', 'Eigen']
 
         # let's also exclude the very special case where the system GCC is used as GCCcore, and only apply this
         # exception to the dependencies of binutils (since we should eventually build a new binutils with GCCcore)


### PR DESCRIPTION
By default the testsuite checks for a binutils or GCC dependency, when
using the GCCcore toolchain to avoid accidentially using the system
binutils. However, this is not necessary for packages that do not need
to be build like binaries. This commit adds exceptions for the 'Binary'
and the 'PackedBinary' easyblock to the existing exception for the
'Tarball' easyblock.