### PR TITLE
add patch to fix memory leak in OpenMPI that heavily affects CP2K, SIESTA, QuantumESPRESSO, VASP, ...

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-6-pml-ucx-datatype-memleak.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-6-pml-ucx-datatype-memleak.patch
@@ -1,0 +1,66 @@
+From f5c391288b766a96cb5c5d0b7164e9cf8795921f Mon Sep 17 00:00:00 2001
+From: Sergey Oblomov <sergeyo@nvidia.com>
+Date: Thu, 15 Jul 2021 19:24:40 +0300
+Subject: [PATCH] PML/UCX/DATATYPE: fixed memory leak
+
+- fixed memory leak in datatype processin
+
+Signed-off-by: Sergey Oblomov <sergeyo@nvidia.com>
+(cherry picked from commit 4145b9f)
+---
+ ompi/mca/pml/ucx/pml_ucx_datatype.c | 28 +++++++++++++++++-----------
+ 1 file changed, 17 insertions(+), 11 deletions(-)
+
+diff --git a/ompi/mca/pml/ucx/pml_ucx_datatype.c b/ompi/mca/pml/ucx/pml_ucx_datatype.c
+index 5b1b8ccbed3..7277aef64bc 100644
+--- a/ompi/mca/pml/ucx/pml_ucx_datatype.c
++++ b/ompi/mca/pml/ucx/pml_ucx_datatype.c
+@@ -212,14 +212,23 @@ ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype)
+         ompi_datatype_type_size(datatype, &size);
+         PML_UCX_ASSERT(size > 0);
+         ucp_datatype = ucp_dt_make_contig(size);
+-        goto out;
+-    }
+-
+-    status = ucp_dt_create_generic(&pml_ucx_generic_datatype_ops,
+-                                   datatype, &ucp_datatype);
+-    if (status != UCS_OK) {
+-        PML_UCX_ERROR("Failed to create UCX datatype for %s", datatype->name);
+-        ompi_mpi_abort(&ompi_mpi_comm_world.comm, 1);
++        PML_UCX_VERBOSE(7, "created contig UCX datatype 0x%"PRIx64,
++                        ucp_datatype)
++    } else {
++        status = ucp_dt_create_generic(&pml_ucx_generic_datatype_ops,
++                                       datatype, &ucp_datatype);
++        if (status != UCS_OK) {
++            int err = MPI_ERR_INTERN;
++            PML_UCX_ERROR("Failed to create UCX datatype for %s",
++                          datatype->name);
++            /* TODO: this error should return to the caller and invoke an error
++             * handler from the MPI API call.
++             * For now, it is fatal. */
++            ompi_mpi_errors_are_fatal_comm_handler(NULL, &err,
++                                                   "Failed to allocate "
++                                                   "datatype structure");
++        }
++        PML_UCX_VERBOSE(7, "created generic UCX datatype 0x%"PRIx64, ucp_datatype)
+     }
+ 
+     /* Add custom attribute, to clean up UCX resources when OMPI datatype is
+@@ -238,8 +247,6 @@ ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype)
+             ompi_mpi_abort(&ompi_mpi_comm_world.comm, 1);
+         }
+     }
+-out:
+-    PML_UCX_VERBOSE(7, "created generic UCX datatype 0x%"PRIx64, ucp_datatype)
+ 
+ #ifdef HAVE_UCP_REQUEST_PARAM_T
+     UCS_STATIC_ASSERT(sizeof(datatype->pml_data) >= sizeof(pml_ucx_datatype_t*));
+@@ -249,7 +256,6 @@ ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype)
+ #else
+     datatype->pml_data = ucp_datatype;
+ #endif
+-
+     return ucp_datatype;
+ }
+ 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-GCC-10.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-GCC-10.2.0.eb
@@ -11,12 +11,15 @@ sources = [SOURCELOWER_TAR_GZ]
 patches = [
     'OpenMPI-4.0.1_remove-pmix-check-in-pmi-switch.patch',
     'OpenMPI-4.x_fix_pmix_discovery.patch',
+    'OpenMPI-4.0.5-6-pml-ucx-datatype-memleak.patch',
 ]
 checksums = [
     '572e777441fd47d7f06f1b8a166e7f44b8ea01b8b2e79d1e299d509725d1bd05',  # openmpi-4.0.5.tar.gz
     # OpenMPI-4.0.1_remove-pmix-check-in-pmi-switch.patch
     'a5737061eb9006e862f30019776adf092d800f681272be7f1575e74b4bfa20fb',
     '547641fff884c917237d158b0b13bdf387977cf0dddfd7e49e78d5f759a6a31b',  # OpenMPI-4.x_fix_pmix_discovery.patch
+    # OpenMPI-4.0.5-6-pml-ucx-datatype-memleak.patch
+    '7d8695f0d23453c82638ad33b18e41690274d5c7784291213e98335b42c54578',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-GCC-9.3.0.eb
@@ -11,12 +11,15 @@ sources = [SOURCELOWER_TAR_GZ]
 patches = [
     'OpenMPI-4.0.1_remove-pmix-check-in-pmi-switch.patch',
     'OpenMPI-4.x_fix_pmix_discovery.patch',
+    'OpenMPI-4.0.5-6-pml-ucx-datatype-memleak.patch',
 ]
 checksums = [
     '572e777441fd47d7f06f1b8a166e7f44b8ea01b8b2e79d1e299d509725d1bd05',  # openmpi-4.0.5.tar.gz
     # OpenMPI-4.0.1_remove-pmix-check-in-pmi-switch.patch
     'a5737061eb9006e862f30019776adf092d800f681272be7f1575e74b4bfa20fb',
     '547641fff884c917237d158b0b13bdf387977cf0dddfd7e49e78d5f759a6a31b',  # OpenMPI-4.x_fix_pmix_discovery.patch
+    # OpenMPI-4.0.5-6-pml-ucx-datatype-memleak.patch
+    '7d8695f0d23453c82638ad33b18e41690274d5c7784291213e98335b42c54578',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-NVHPC-21.2-CUDA-11.2.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-NVHPC-21.2-CUDA-11.2.1.eb
@@ -13,12 +13,15 @@ sources = [SOURCELOWER_TAR_GZ]
 patches = [
     'OpenMPI-4.0.1_remove-pmix-check-in-pmi-switch.patch',
     'OpenMPI-4.x_fix_pmix_discovery.patch',
+    'OpenMPI-4.0.5-6-pml-ucx-datatype-memleak.patch',
 ]
 checksums = [
     '572e777441fd47d7f06f1b8a166e7f44b8ea01b8b2e79d1e299d509725d1bd05',  # openmpi-4.0.5.tar.gz
     # OpenMPI-4.0.1_remove-pmix-check-in-pmi-switch.patch
     'a5737061eb9006e862f30019776adf092d800f681272be7f1575e74b4bfa20fb',
     '547641fff884c917237d158b0b13bdf387977cf0dddfd7e49e78d5f759a6a31b',  # OpenMPI-4.x_fix_pmix_discovery.patch
+    # OpenMPI-4.0.5-6-pml-ucx-datatype-memleak.patch
+    '7d8695f0d23453c82638ad33b18e41690274d5c7784291213e98335b42c54578',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-gcccuda-2020b.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-gcccuda-2020b.eb
@@ -11,12 +11,15 @@ sources = [SOURCELOWER_TAR_GZ]
 patches = [
     'OpenMPI-4.0.1_remove-pmix-check-in-pmi-switch.patch',
     'OpenMPI-4.x_fix_pmix_discovery.patch',
+    'OpenMPI-4.0.5-6-pml-ucx-datatype-memleak.patch',
 ]
 checksums = [
     '572e777441fd47d7f06f1b8a166e7f44b8ea01b8b2e79d1e299d509725d1bd05',  # openmpi-4.0.5.tar.gz
     # OpenMPI-4.0.1_remove-pmix-check-in-pmi-switch.patch
     'a5737061eb9006e862f30019776adf092d800f681272be7f1575e74b4bfa20fb',
     '547641fff884c917237d158b0b13bdf387977cf0dddfd7e49e78d5f759a6a31b',  # OpenMPI-4.x_fix_pmix_discovery.patch
+    # OpenMPI-4.0.5-6-pml-ucx-datatype-memleak.patch
+    '7d8695f0d23453c82638ad33b18e41690274d5c7784291213e98335b42c54578',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-iccifort-2020.4.304.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-iccifort-2020.4.304.eb
@@ -11,12 +11,15 @@ sources = [SOURCELOWER_TAR_GZ]
 patches = [
     'OpenMPI-4.0.1_remove-pmix-check-in-pmi-switch.patch',
     'OpenMPI-4.x_fix_pmix_discovery.patch',
+    'OpenMPI-4.0.5-6-pml-ucx-datatype-memleak.patch',
 ]
 checksums = [
     '572e777441fd47d7f06f1b8a166e7f44b8ea01b8b2e79d1e299d509725d1bd05',  # openmpi-4.0.5.tar.gz
     # OpenMPI-4.0.1_remove-pmix-check-in-pmi-switch.patch
     'a5737061eb9006e862f30019776adf092d800f681272be7f1575e74b4bfa20fb',
     '547641fff884c917237d158b0b13bdf387977cf0dddfd7e49e78d5f759a6a31b',  # OpenMPI-4.x_fix_pmix_discovery.patch
+    # OpenMPI-4.0.5-6-pml-ucx-datatype-memleak.patch
+    '7d8695f0d23453c82638ad33b18e41690274d5c7784291213e98335b42c54578',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.6-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.6-GCC-10.3.0.eb
@@ -8,11 +8,16 @@ toolchain = {'name': 'GCC', 'version': '10.3.0'}
 
 source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-patches = ['OpenMPI-4.0.6_remove-pmix-check-in-pmi-switch.patch']
+patches = [
+    'OpenMPI-4.0.6_remove-pmix-check-in-pmi-switch.patch',
+    'OpenMPI-4.0.5-6-pml-ucx-datatype-memleak.patch',
+]
 checksums = [
     '8f2d159d2d846979b1380e9552f56e4365f5ec71d54a05077ddb244719d70fc3',  # openmpi-4.0.6.tar.gz
     # OpenMPI-4.0.6_remove-pmix-check-in-pmi-switch.patch
     '8acee6c9b2b4bf12873a39b85a58ca669de78e90d26186e52f221bb4853abc4d',
+    # OpenMPI-4.0.5-6-pml-ucx-datatype-memleak.patch
+    '7d8695f0d23453c82638ad33b18e41690274d5c7784291213e98335b42c54578',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.0-1-pml-ucx-datatype-memleak.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.0-1-pml-ucx-datatype-memleak.patch
@@ -1,0 +1,58 @@
+From 080e54b07d5976407daf8c607a5d2b80ee40684d Mon Sep 17 00:00:00 2001
+From: Sergey Oblomov <sergeyo@nvidia.com>
+Date: Mon, 19 Apr 2021 16:50:46 +0300
+Subject: [PATCH] PML/UCX/DATATYPE: fixed memory leak
+
+- fixed memory leak in datatype processing
+
+Signed-off-by: Sergey Oblomov <sergeyo@nvidia.com>
+(cherry picked from commit 4145b9f00b9a9c2e5326044b765ee3d1b743ccbf)
+---
+ ompi/mca/pml/ucx/pml_ucx_datatype.c | 27 +++++++++++++++++----------
+ 1 file changed, 17 insertions(+), 10 deletions(-)
+
+diff --git a/ompi/mca/pml/ucx/pml_ucx_datatype.c b/ompi/mca/pml/ucx/pml_ucx_datatype.c
+index 5b1b8ccbed3..8b55e773e7a 100644
+--- a/ompi/mca/pml/ucx/pml_ucx_datatype.c
++++ b/ompi/mca/pml/ucx/pml_ucx_datatype.c
+@@ -212,14 +212,23 @@ ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype)
+         ompi_datatype_type_size(datatype, &size);
+         PML_UCX_ASSERT(size > 0);
+         ucp_datatype = ucp_dt_make_contig(size);
+-        goto out;
+-    }
+-
+-    status = ucp_dt_create_generic(&pml_ucx_generic_datatype_ops,
+-                                   datatype, &ucp_datatype);
+-    if (status != UCS_OK) {
+-        PML_UCX_ERROR("Failed to create UCX datatype for %s", datatype->name);
+-        ompi_mpi_abort(&ompi_mpi_comm_world.comm, 1);
++        PML_UCX_VERBOSE(7, "created contig UCX datatype 0x%"PRIx64,
++                        ucp_datatype)
++    } else {
++        status = ucp_dt_create_generic(&pml_ucx_generic_datatype_ops,
++                                       datatype, &ucp_datatype);
++        if (status != UCS_OK) {
++            int err = MPI_ERR_INTERN;
++            PML_UCX_ERROR("Failed to create UCX datatype for %s",
++                          datatype->name);
++            /* TODO: this error should return to the caller and invoke an error
++             * handler from the MPI API call.
++             * For now, it is fatal. */
++            ompi_mpi_errors_are_fatal_comm_handler(NULL, &err,
++                                                   "Failed to allocate "
++                                                   "datatype structure");
++        }
++        PML_UCX_VERBOSE(7, "created generic UCX datatype 0x%"PRIx64, ucp_datatype)
+     }
+ 
+     /* Add custom attribute, to clean up UCX resources when OMPI datatype is
+@@ -238,8 +247,6 @@ ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype)
+             ompi_mpi_abort(&ompi_mpi_comm_world.comm, 1);
+         }
+     }
+-out:
+-    PML_UCX_VERBOSE(7, "created generic UCX datatype 0x%"PRIx64, ucp_datatype)
+ 
+ #ifdef HAVE_UCP_REQUEST_PARAM_T
+     UCS_STATIC_ASSERT(sizeof(datatype->pml_data) >= sizeof(pml_ucx_datatype_t*));

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.0-GCC-10.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.0-GCC-10.2.0.eb
@@ -12,6 +12,7 @@ patches = [
     'OpenMPI-4.1.1_fix-bufferoverflow-in-common_ofi.patch',
     'OpenMPI-4.0.1_remove-pmix-check-in-pmi-switch.patch',
     'OpenMPI-4.x_fix_pmix_discovery.patch',
+    'OpenMPI-4.1.0-1-pml-ucx-datatype-memleak.patch',
 ]
 checksums = [
     '228467c3dd15339d9b26cf26a291af3ee7c770699c5e8a1b3ad786f9ae78140a',  # openmpi-4.1.0.tar.gz
@@ -20,6 +21,8 @@ checksums = [
     # OpenMPI-4.0.1_remove-pmix-check-in-pmi-switch.patch
     'a5737061eb9006e862f30019776adf092d800f681272be7f1575e74b4bfa20fb',
     '547641fff884c917237d158b0b13bdf387977cf0dddfd7e49e78d5f759a6a31b',  # OpenMPI-4.x_fix_pmix_discovery.patch
+    # OpenMPI-4.1.0-1-pml-ucx-datatype-memleak.patch
+    'a94a74b174ce783328abfd3656ff5196b89ef4c819fe4c8b8a0f1277123e76ea',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-GCC-10.3.0.eb
@@ -13,7 +13,7 @@ source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/
 sources = [SOURCELOWER_TAR_BZ2]
 patches = [
     'OpenMPI-4.1.1_fix-bufferoverflow-in-common_ofi.patch',
-    'OpenMPI-4.0.6_remove-pmix-check-in-pmi-switch.patch'
+    'OpenMPI-4.0.6_remove-pmix-check-in-pmi-switch.patch',
     'OpenMPI-4.1.0-1-pml-ucx-datatype-memleak.patch',
 ]
 checksums = [

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-GCC-10.3.0.eb
@@ -14,6 +14,7 @@ sources = [SOURCELOWER_TAR_BZ2]
 patches = [
     'OpenMPI-4.1.1_fix-bufferoverflow-in-common_ofi.patch',
     'OpenMPI-4.0.6_remove-pmix-check-in-pmi-switch.patch'
+    'OpenMPI-4.1.0-1-pml-ucx-datatype-memleak.patch',
 ]
 checksums = [
     'e24f7a778bd11a71ad0c14587a7f5b00e68a71aa5623e2157bafee3d44c07cda',  # openmpi-4.1.1.tar.bz2
@@ -21,6 +22,8 @@ checksums = [
     'a189d834506f3d7c31eda6aa184598a3631ea24a94bc551d5ed1f053772ca49e',
     # OpenMPI-4.0.6_remove-pmix-check-in-pmi-switch.patch
     '8acee6c9b2b4bf12873a39b85a58ca669de78e90d26186e52f221bb4853abc4d',
+    # OpenMPI-4.1.0-1-pml-ucx-datatype-memleak.patch
+    'a94a74b174ce783328abfd3656ff5196b89ef4c819fe4c8b8a0f1277123e76ea',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-GCC-11.2.0.eb
@@ -13,6 +13,7 @@ patches = [
     'OpenMPI-4.0.6_remove-pmix-check-in-pmi-switch.patch',
     'OpenMPI-4.1.1_opal-pmix-package-rank.patch',
     'OpenMPI-4.1.1_pmix3x-protection.patch',
+    'OpenMPI-4.1.0-1-pml-ucx-datatype-memleak.patch',
 ]
 checksums = [
     'e24f7a778bd11a71ad0c14587a7f5b00e68a71aa5623e2157bafee3d44c07cda',  # openmpi-4.1.1.tar.bz2
@@ -22,6 +23,8 @@ checksums = [
     '8acee6c9b2b4bf12873a39b85a58ca669de78e90d26186e52f221bb4853abc4d',
     '04353672cf7be031e5306c94068d7012d99e6cd94b69d93230797ffcd7f31903',  # OpenMPI-4.1.1_opal-pmix-package-rank.patch
     '384ef9f1fa803b0d71dae2ec0748d0f20295992437532afedf21478bda164ff8',  # OpenMPI-4.1.1_pmix3x-protection.patch
+    # OpenMPI-4.1.0-1-pml-ucx-datatype-memleak.patch
+    'a94a74b174ce783328abfd3656ff5196b89ef4c819fe4c8b8a0f1277123e76ea',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-intel-compilers-2021.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-intel-compilers-2021.2.0.eb
@@ -13,7 +13,7 @@ source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/
 sources = [SOURCELOWER_TAR_BZ2]
 patches = [
     'OpenMPI-4.1.1_fix-bufferoverflow-in-common_ofi.patch',
-    'OpenMPI-4.0.6_remove-pmix-check-in-pmi-switch.patch'
+    'OpenMPI-4.0.6_remove-pmix-check-in-pmi-switch.patch',
     'OpenMPI-4.1.0-1-pml-ucx-datatype-memleak.patch',
 ]
 checksums = [

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-intel-compilers-2021.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-intel-compilers-2021.2.0.eb
@@ -14,6 +14,7 @@ sources = [SOURCELOWER_TAR_BZ2]
 patches = [
     'OpenMPI-4.1.1_fix-bufferoverflow-in-common_ofi.patch',
     'OpenMPI-4.0.6_remove-pmix-check-in-pmi-switch.patch'
+    'OpenMPI-4.1.0-1-pml-ucx-datatype-memleak.patch',
 ]
 checksums = [
     'e24f7a778bd11a71ad0c14587a7f5b00e68a71aa5623e2157bafee3d44c07cda',  # openmpi-4.1.1.tar.bz2
@@ -21,6 +22,8 @@ checksums = [
     'a189d834506f3d7c31eda6aa184598a3631ea24a94bc551d5ed1f053772ca49e',
     # OpenMPI-4.0.6_remove-pmix-check-in-pmi-switch.patch
     '8acee6c9b2b4bf12873a39b85a58ca669de78e90d26186e52f221bb4853abc4d',
+    # OpenMPI-4.1.0-1-pml-ucx-datatype-memleak.patch
+    'a94a74b174ce783328abfd3656ff5196b89ef4c819fe4c8b8a0f1277123e76ea',
 ]
 
 builddependencies = [


### PR DESCRIPTION
There is a memory leak in `OpenMPI` `4.0.5`, `4.0.6`, `4.1.0`, and `4.1.1` which heavily affects `CP2K`, `SIESTA`, `QuantumESPRESSO`, `VASP`, and probably other programs as well. A constant (quick) memory increase happens mainly in the case of Molecular Dynamics (MD) simulations, some (huge) matrix diagonalization, finite field, numerical (first and second) derivations, and probably many others as well. 

The problem is solved in `OpenMPI` `4.0.7` and `4.1.2`. Version `4.0.3` is not affected. The patches were taken from https://github.com/open-mpi/ompi/pull/8828