### PR TITLE
bump nbconvert extension in recent IPython easyconfigs to version 6.4.0

### DIFF
--- a/easybuild/easyconfigs/i/IPython/IPython-7.25.0-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.25.0-GCCcore-10.3.0.eb
@@ -90,8 +90,8 @@ exts_list = [
     ('nbclient', '0.5.3', {
         'checksums': ['db17271330c68c8c88d46d72349e24c147bb6f34ec82d8481a8f025c4d26589c'],
     }),
-    ('nbconvert', '6.1.0', {
-        'checksums': ['d22a8ff202644d31db254d24d52c3a96c82156623fcd7c7f987bba2612303ec9'],
+    ('nbconvert', '6.4.0', {
+        'checksums': ['5412ec774c6db4fccecb8c4ba07ec5d37d6dcf5762593cb3d6ecbbeb562ebbe5'],
     }),
     ('tornado', '6.1', {
         'checksums': ['33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791'],

--- a/easybuild/easyconfigs/i/IPython/IPython-7.26.0-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.26.0-GCCcore-11.2.0.eb
@@ -90,8 +90,8 @@ exts_list = [
     ('nbclient', '0.5.3', {
         'checksums': ['db17271330c68c8c88d46d72349e24c147bb6f34ec82d8481a8f025c4d26589c'],
     }),
-    ('nbconvert', '6.1.0', {
-        'checksums': ['d22a8ff202644d31db254d24d52c3a96c82156623fcd7c7f987bba2612303ec9'],
+    ('nbconvert', '6.4.0', {
+        'checksums': ['5412ec774c6db4fccecb8c4ba07ec5d37d6dcf5762593cb3d6ecbbeb562ebbe5'],
     }),
     ('tornado', '6.1', {
         'checksums': ['33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791'],


### PR DESCRIPTION
Bump of nbconvert to version 6.4.0. The previous version of nbconvert that was in `IPython-7.25.0-GCCcore-10.3.0.eb` (nbconvert 6.1.0), could cause permission denied errors when run in a shared environment. See https://github.com/jupyter/nbconvert/issues/1430 . This was fixed in PR https://github.com/jupyter/nbconvert/pull/1646 . Since many EasyBuild users work in shared environments, I think this is a relevant fix to have included.

(created using `eb --new-pr`)
