### PR TITLE
only check sanity_check_components and sanity_check_all_components when Bundle easyblock is used in test_pr_sanity_check_paths

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1024,18 +1024,20 @@ class EasyConfigTest(TestCase):
         failing_checks = []
 
         for ec in self.changed_ecs:
-
             easyblock = ec.get('easyblock')
-
-            bundle_sanity_check_components = ec['sanity_check_components'] or ec['sanity_check_all_components']
-
             if is_generic_easyblock(easyblock) and not ec.get('sanity_check_paths'):
+
+                sanity_check_ok = False
+
                 if easyblock in whitelist or (easyblock == 'Bundle' and ec['name'] in bundles_whitelist):
-                    pass
+                    sanity_check_ok = True
+
                 # also allow bundles that enable per-component sanity checks
-                elif easyblock == 'Bundle' and bundle_sanity_check_components:
-                    pass
-                else:
+                elif easyblock == 'Bundle':
+                    if ec['sanity_check_components'] or ec['sanity_check_all_components']:
+                        sanity_check_ok = True
+
+                if not sanity_check_ok:
                     ec_fn = os.path.basename(ec.path)
                     failing_checks.append("No custom sanity_check_paths found in %s" % ec_fn)
 


### PR DESCRIPTION
fix for failing easyconfig tests, introduced in #14591:

```
ERROR: test_pr_sanity_check_paths (test.easyconfigs.easyconfigs.EasyConfigTest)
Make sure a custom sanity_check_paths value is specified for easyconfigs that use a generic easyblock.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/easyconfigs/easyconfigs.py", line 1030, in test_pr_sanity_check_paths
    bundle_sanity_check_components = ec['sanity_check_components'] or ec['sanity_check_all_components']
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/easybuild/framework/easyconfig/easyconfig.py", line 125, in new_ec_method
    return ec_method(self, key, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/easybuild/framework/easyconfig/easyconfig.py", line 1751, in __getitem__
    raise EasyBuildError("Use of unknown easyconfig parameter '%s' when getting parameter value", key)
EasyBuildError: "Use of unknown easyconfig parameter 'sanity_check_components' when getting parameter value"
```