### PR TITLE
use actions/setup-python@v2 in CI workflows, also test with Python 3.8-3.10

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python: [2.7, 3.6, 3.7, 3.8, 3.9, 3.10]
+        python: [2.7, 3.6, 3.7, 3.8, 3.9, '3.10']
         modules_tool: [Lmod-6.6.3, Lmod-7.8.22, Lmod-8.1.14]
         module_syntax: [Lua, Tcl]
         # exclude some configurations: only test Tcl module syntax with Lmod 7.x and Python 2.7 & 3.6
@@ -20,7 +20,7 @@ jobs:
             module_syntax: Tcl
           - python: 3.9
             module_syntax: Tcl
-          - python: 3.10
+          - python: '3.10'
             module_syntax: Tcl
       fail-fast: false
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,18 +5,22 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.6, 3.7]
+        python: [2.7, 3.6, 3.7, 3.8, 3.9, 3.10]
         modules_tool: [Lmod-6.6.3, Lmod-7.8.22, Lmod-8.1.14]
         module_syntax: [Lua, Tcl]
-        # exclude some configurations: only test Tcl module syntax with Lmod 7.x and Python 2.7 & 3.5
+        # exclude some configurations: only test Tcl module syntax with Lmod 7.x and Python 2.7 & 3.6
         exclude:
           - modules_tool: Lmod-6.6.3
             module_syntax: Tcl
           - modules_tool: Lmod-8.1.14
             module_syntax: Tcl
-          - python: 3.6
-            module_syntax: Tcl
           - python: 3.7
+            module_syntax: Tcl
+          - python: 3.8
+            module_syntax: Tcl
+          - python: 3.9
+            module_syntax: Tcl
+          - python: 3.10
             module_syntax: Tcl
       fail-fast: false
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python: [2.7, 3.6, 3.7, 3.8, 3.9, '3.10']
+        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
         modules_tool: [Lmod-6.6.3, Lmod-7.8.22, Lmod-8.1.14]
         module_syntax: [Lua, Tcl]
         # exclude some configurations: only test Tcl module syntax with Lmod 7.x and Python 2.7 & 3.6
@@ -13,6 +13,8 @@ jobs:
           - modules_tool: Lmod-6.6.3
             module_syntax: Tcl
           - modules_tool: Lmod-8.1.14
+            module_syntax: Tcl
+          - python: 3.5
             module_syntax: Tcl
           - python: 3.7
             module_syntax: Tcl
@@ -36,7 +38,7 @@ jobs:
         key: eb-sourcepath
 
     - name: set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.python}}
         architecture: x64


### PR DESCRIPTION
Running tests with Python 3.5 is broken using `setup-python@v1`, has been end-of-life for quite a long time now

```
Run actions/setup-python@v1
Error: Version 3.5 with arch x64 not found
Available versions:

2.7.18 (x64)
3.10.2 (x64)
3.6.15 (x64)
3.7.12 (x64)
3.8.12 (x64)
3.9.10 (x64)
```