### PR TITLE
trim test configurations for easyconfigs test suite: only test with Python 2.7 + 3.6 and Lmod 7.x + 8.x

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,24 +5,12 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
-        modules_tool: [Lmod-6.6.3, Lmod-7.8.22, Lmod-8.1.14]
+        python: [2.7, 3.6]
+        modules_tool: [Lmod-7.8.22, Lmod-8.6.8]
         module_syntax: [Lua, Tcl]
-        # exclude some configurations: only test Tcl module syntax with Lmod 7.x and Python 2.7 & 3.6
+        # exclude some configurations: only test Tcl module syntax with Lmod 8.x and Python 2.7 & 3.6
         exclude:
-          - modules_tool: Lmod-6.6.3
-            module_syntax: Tcl
-          - modules_tool: Lmod-8.1.14
-            module_syntax: Tcl
-          - python: 3.5
-            module_syntax: Tcl
-          - python: 3.7
-            module_syntax: Tcl
-          - python: 3.8
-            module_syntax: Tcl
-          - python: 3.9
-            module_syntax: Tcl
-          - python: '3.10'
+          - modules_tool: Lmod-7.8.22
             module_syntax: Tcl
       fail-fast: false
     steps:


### PR DESCRIPTION
The changes in #14857 were a bit ambitious, testing with a wide range of Python 3.x versions quickly leads to a large backlog for easyconfig PRs...

Only testing with Python 2.7 + 3.6 (most popular Python 3.x version), and no longer testing with Lmod 6.x (deprecated for a while, see https://github.com/easybuilders/easybuild-framework/pull/3077) should be enough...