### PR TITLE
don't define `$TEXMFHOME` in `texlive` easyconfigs + add a note for the load of the module

### DIFF
--- a/easybuild/easyconfigs/t/texlive/texlive-20200406-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20200406-GCCcore-8.3.0.eb
@@ -48,9 +48,10 @@ modextrapaths = {
     'INFOPATH': 'texmf-dist/doc/info',
     'MANPATH': 'texmf-dist/doc/man',
 }
-modextravars = {
-    'TEXMFHOME': '%(installdir)s/texmf-dist'
-}
+
+modloadmsg = "\n\nWARNING: This texlive module does not define a value for the environment variable $TEXMFHOME.\n"
+modloadmsg += "If you use a custom texmf directory (such as ~/texmf) you will need to manually set the\n"
+modloadmsg += "$TEXMFHOME to point to your custom directory.\n"
 
 sanity_check_paths = {
     'files': ['bin/x86_64-linux/tex', 'bin/x86_64-linux/latex'],

--- a/easybuild/easyconfigs/t/texlive/texlive-20210324-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20210324-GCC-11.2.0.eb
@@ -51,9 +51,10 @@ modextrapaths = {
     'INFOPATH': 'texmf-dist/doc/info',
     'MANPATH': 'texmf-dist/doc/man',
 }
-modextravars = {
-    'TEXMFHOME': '%(installdir)s/texmf-dist'
-}
+
+modloadmsg = "\n\nWARNING: This texlive module does not define a value for the environment variable $TEXMFHOME.\n"
+modloadmsg += "If you use a custom texmf directory (such as ~/texmf) you will need to manually set the\n"
+modloadmsg += "$TEXMFHOME to point to your custom directory.\n"
 
 sanity_check_paths = {
     'files': ['bin/%(arch)s-linux/tex', 'bin/%(arch)s-linux/latex'],


### PR DESCRIPTION
This is a suggestion for changes needed for https://github.com/easybuilders/easybuild-easyconfigs/issues/15014. 