### PR TITLE
don't use v2.1.0rc1 release candidate of gmpy2, stick to proper release v2.1.2

### DIFF
--- a/easybuild/easyconfigs/g/gmpy2/gmpy2-2.1.2-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/g/gmpy2/gmpy2-2.1.2-GCC-11.2.0.eb
@@ -1,7 +1,7 @@
 easyblock = 'PythonPackage'
 
 name = 'gmpy2'
-version = '2.1.0rc1'
+version = '2.1.2'
 
 homepage = 'https://github.com/aleaxit/gmpy'
 description = "GMP/MPIR, MPFR, and MPC interface to Python 2.6+ and 3.x"
@@ -9,7 +9,7 @@ description = "GMP/MPIR, MPFR, and MPC interface to Python 2.6+ and 3.x"
 toolchain = {'name': 'GCC', 'version': '11.2.0'}
 
 sources = [SOURCE_TAR_GZ]
-checksums = ['86cb6d8e5837560c32c706d48d6ed25676be6b3c79e6aa5d245965b9e99231b9']
+checksums = ['da75140bca128ece795895477e53b43773e3748aa90ba6170eae7ca2c74b82d1']
 
 dependencies = [
     ('Python', '3.9.6'),

--- a/easybuild/easyconfigs/p/PPanGGOLiN/PPanGGOLiN-1.1.136-foss-2021b.eb
+++ b/easybuild/easyconfigs/p/PPanGGOLiN/PPanGGOLiN-1.1.136-foss-2021b.eb
@@ -28,7 +28,7 @@ dependencies = [
     ('networkx', '2.6.3'),
     ('SciPy-bundle', '2021.10'),
     ('plotly.py', '5.4.0'),
-    ('gmpy2', '2.1.0rc1'),
+    ('gmpy2', '2.1.2'),
     ('MAFFT', '7.490', '-with-extensions'),
     ('rpy2', '3.4.5'),
 ]


### PR DESCRIPTION
Using a release candidate rather than a proper release is something we should avoid, since it's a recipe for trouble (cfr. problems with `sympy` tests on top of `gmpy2` v2.1.0rc1 in #14376).