### PR TITLE
Xtb python

### DIFF
--- a/easybuild/easyconfigs/x/xtb-python/xtb-python-20.2-intel-2021b-Python-3.9.6.eb
+++ b/easybuild/easyconfigs/x/xtb-python/xtb-python-20.2-intel-2021b-Python-3.9.6.eb
@@ -1,0 +1,49 @@
+easyblock = 'MesonNinja'
+
+name = 'xtb-python'
+version = '20.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://xtb-python.readthedocs.io'
+description = """ Python API for the extended tight binding program xtb """
+
+toolchain = {'name': 'intel', 'version': '2021b'}
+
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
+checksums = ['37d0f6239c3fa536caeb3638a2ffb4f4070cb3cc2ca314be4504905f96c4aaf1']
+
+github_account = 'grimme-lab'
+builddependencies = [
+    ('Meson', '0.58.2'),
+    ('Ninja', '1.10.2'),
+]
+
+dependencies = [
+    ('Python', '3.9.6'),
+    ('xtb', '6.4.1'),
+    ('SciPy-bundle', '2021.10')
+]
+
+configopts = "--default-library=shared "
+configopts += "-Dla_backend=mkl "
+configopts += "--buildtype=release "
+
+# Tests can be performed after installation if ASE and QCSchema are
+# installed, i.e. pytest --pyargs xtb, some ASE and QCSchema tests
+# may fail but they can be ignored, see
+# https://github.com/grimme-lab/xtb-python/issues/71
+
+local_shared_lib_file = 'lib/_libxtb.cpython-%(pymajver)s%(pyminver)s-%(arch)s' + '-linux-gnu.%s' % SHLIB_EXT
+sanity_check_paths = {
+    'files': [local_shared_lib_file],
+    'dirs': ['lib'],
+}
+
+sanity_check_commands = [('python', '-c "import xtb.interface"')]
+
+postinstallcmds = ['cp -r %(builddir)s/%(namelower)s-%(version_major_minor)s %(installdir)s', 'cp %(installdir)s/' + local_shared_lib_file + ' %(installdir)s/%(namelower)s-%(version_major_minor)s/xtb/']
+
+modextrapaths = {'PYTHONPATH': '%(namelower)s-%(version_major_minor)s'}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/x/xtb/xtb-6.4.1-intel-2021b.eb
+++ b/easybuild/easyconfigs/x/xtb/xtb-6.4.1-intel-2021b.eb
@@ -1,0 +1,42 @@
+easyblock = 'MesonNinja'
+
+name = 'xtb'
+version = '6.4.1'
+
+homepage = 'https://xtb-docs.readthedocs.io'
+description = """ xtb - An extended tight-binding semi-empirical program package. """
+
+toolchain = {'name': 'intel', 'version': '2021b'}
+
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
+checksums = ['cd7b6ec9b7963012ce71220a70773641f0d9e06e0691750a25b83e823510d1d7']
+
+github_account = 'grimme-lab'
+builddependencies = [
+    ('Meson', '0.58.2'),
+    ('Ninja', '1.10.2'),
+    ('pkg-config', '0.29.2')
+]
+
+configopts = "--buildtype=release "
+configopts += "-Dla_backend='mkl-rt' "
+configopts += "--optimization 2 "
+configopts += "--warnlevel 0 "
+# Next option is because: https://github.com/grimme-lab/xtb/issues/402
+configopts += "-Dfortran_link_args=-qopenmp "
+
+runtest = 'meson'
+testopts = 'test -C %(builddir)s/easybuild_obj -t 60'  # Ensure test don't timeout
+
+sanity_check_paths = {
+    'files': ['bin/xtb', 'include/xtb/xtb.h'] + ['lib/libxtb.%s' % e for e in ('a', SHLIB_EXT)],
+    'dirs': ['share'],
+}
+
+modextravars = {
+    'XTBHOME': '%(installdir)s',
+    'XTBPATH': '%(installdir)s/share/xtb',
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/x/xtb/xtb-6.4.1-intel-2021b.eb
+++ b/easybuild/easyconfigs/x/xtb/xtb-6.4.1-intel-2021b.eb
@@ -21,10 +21,6 @@ builddependencies = [
 
 configopts = "--buildtype=release "
 configopts += "-Dla_backend='mkl-rt' "
-configopts += "--optimization 2 "
-configopts += "--warnlevel 0 "
-# Next option is because: https://github.com/grimme-lab/xtb/issues/402
-configopts += "-Dfortran_link_args=-qopenmp "
 
 runtest = 'meson'
 testopts = 'test -C %(builddir)s/easybuild_obj -t 60'  # Ensure test don't timeout


### PR DESCRIPTION
This adds an easyconfig file for xtb-python and an update for xtb in order to use the same intel toolchain.

The post install commands look a bit messy, the reason is that xtb-python needs to be compiled with Meson-Ninja but is imported like a Python package. There could be better ways of doing this.