### PR TITLE
add m4 as build dependency for CCL

### DIFF
--- a/easybuild/easyconfigs/c/CCL/CCL-1.12-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/CCL/CCL-1.12-GCCcore-9.3.0.eb
@@ -16,6 +16,7 @@ checksums = ['84a95aaf1d1abafba586e9ff079343b04fe374b98b38ed24d830f1fb7ed4ab34']
 
 builddependencies = [
     ('binutils', '2.34'),
+    ('M4', '1.4.18'),
 ]
 
 local_ccl_bin = 'lx86cl64'


### PR DESCRIPTION
without m4 I get` /bin/sh: 1: m4: not found`  and the build fails a bit later with /../pmcl-kernel.c:1555: undefined reference to `spjump_start'

see also https://shammerism.hatenadiary.com/entry/20160114/p1