### PR TITLE
{vis}[GCCcore/10.2.0] matplotlib-inline v0.1.3

### DIFF
--- a/easybuild/easyconfigs/m/matplotlib-inline/matplotlib-inline-0.1.3-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/m/matplotlib-inline/matplotlib-inline-0.1.3-GCCcore-10.2.0.eb
@@ -1,0 +1,27 @@
+easyblock = 'PythonPackage'
+
+name = 'matplotlib-inline'
+version = '0.1.3'
+
+homepage = 'https://github.com/ipython/matplotlib-inline'
+description = """Matplotlib Inline Back-end for IPython and Jupyter."""
+
+toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a04bfba22e0d1395479f866853ec1ee28eea1485c1d69a6faf00dc3e24ff34ee']
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('IPython', '7.18.1'), # has traitlets
+]
+
+use_pip = True
+download_dep_fail = True
+sanity_pip_check = True
+
+# use matplotlib-inline backend as default
+# see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
+modextravars = {'MPLBACKEND': 'module://matplotlib_inline.backend_inline'}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib-inline/matplotlib-inline-0.1.3-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/m/matplotlib-inline/matplotlib-inline-0.1.3-GCCcore-10.2.0.eb
@@ -11,9 +11,11 @@ toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['a04bfba22e0d1395479f866853ec1ee28eea1485c1d69a6faf00dc3e24ff34ee']
 
+builddependencies = [('binutils', '2.35')]
+
 dependencies = [
     ('Python', '3.8.6'),
-    ('IPython', '7.18.1'),
+    ('IPython', '7.18.1'), # has traitlets
 ]
 
 use_pip = True

--- a/easybuild/easyconfigs/m/matplotlib-inline/matplotlib-inline-0.1.3-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/m/matplotlib-inline/matplotlib-inline-0.1.3-GCCcore-10.2.0.eb
@@ -15,7 +15,7 @@ builddependencies = [('binutils', '2.35')]
 
 dependencies = [
     ('Python', '3.8.6'),
-    ('IPython', '7.18.1'), # has traitlets
+    ('IPython', '7.18.1'),  # has traitlets
 ]
 
 use_pip = True

--- a/easybuild/easyconfigs/m/matplotlib-inline/matplotlib-inline-0.1.3-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/m/matplotlib-inline/matplotlib-inline-0.1.3-GCCcore-10.2.0.eb
@@ -22,8 +22,4 @@ use_pip = True
 download_dep_fail = True
 sanity_pip_check = True
 
-# use matplotlib-inline backend as default
-# see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
-modextravars = {'MPLBACKEND': 'module://matplotlib_inline.backend_inline'}
-
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib-inline/matplotlib-inline-0.1.3-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/m/matplotlib-inline/matplotlib-inline-0.1.3-GCCcore-10.2.0.eb
@@ -13,7 +13,7 @@ checksums = ['a04bfba22e0d1395479f866853ec1ee28eea1485c1d69a6faf00dc3e24ff34ee']
 
 dependencies = [
     ('Python', '3.8.6'),
-    ('IPython', '7.18.1'), # has traitlets
+    ('IPython', '7.18.1'),
 ]
 
 use_pip = True


### PR DESCRIPTION
Adding an easyconfig recipe for a new sw called matplotlib-inline providing a Matplotlib Inline Back-end for IPython and Jupyter.