### PR TITLE
libffi 3.4.2 - disable-exec-static-tramp

### DIFF
--- a/easybuild/easyconfigs/l/libffi/libffi-3.4.2-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/l/libffi/libffi-3.4.2-GCCcore-11.2.0.eb
@@ -19,6 +19,8 @@ builddependencies = [
     ('binutils', '2.37'),
 ]
 
+configopts = '--disable-exec-static-tramp '
+
 sanity_check_paths = {
     'files': ['lib/libffi.a', 'lib/libffi.%s' % SHLIB_EXT],
     'dirs': ['include', 'share'],


### PR DESCRIPTION
Some projects like gobject-introspection use ffi_closure_alloc() as a way to allocate executable memory.
The new exec static tramp in libffi 3.4 interferes with it and therefor must be disabled - or it can result in segfaults.
https://github.com/libffi/libffi/pull/647

This is currently the only solution like it is also done in conda:
https://github.com/conda-forge/libffi-feedstock/pull/39

"Interesting" is this comment: https://github.com/libffi/libffi/pull/647#issuecomment-869184620
`we can do the 3.4 release and distros can initially build with --disable-exec-static-tramp`