### PR TITLE
fix grconvert build for Grace/5.1.25 with foss/2021a by adding libtirpc dependency + related patch

### DIFF
--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2021a.eb
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-foss-2021a.eb
@@ -10,12 +10,17 @@ toolchain = {'name': 'foss', 'version': '2021a'}
 
 source_urls = ['https://plasma-gate.weizmann.ac.il/pub/grace/src/stable']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['751ab9917ed0f6232073c193aba74046037e185d73b77bab0f5af3e3ff1da2ac']
+patches = ['Grace-5.1.25-tirpc-dependency.patch']
+checksums = [
+    '751ab9917ed0f6232073c193aba74046037e185d73b77bab0f5af3e3ff1da2ac',  # grace-5.1.25.tar.gz
+    '093af4ddf344300aa31561c97e2765ed3fab609b70a5d199ac64a60dbd9e0c34',  # Grace-5.1.25-tirpc-dependency.patch
+]
 
 dependencies = [
     ('motif', '2.3.8'),
     ('zlib', '1.2.11'),
     ('netCDF', '4.8.0'),
+    ('libtirpc', '1.3.2'),
 ]
 
 runtest = 'tests'

--- a/easybuild/easyconfigs/g/Grace/Grace-5.1.25-tirpc-dependency.patch
+++ b/easybuild/easyconfigs/g/Grace/Grace-5.1.25-tirpc-dependency.patch
@@ -1,0 +1,32 @@
+grconvert has a dependency on XDR from a RPC library and will be omitted
+from the build if not present.
+
+On RedHat-like distros this is commonly missing and as such we add
+libtirpc as a drop-in replacement for the OS packages that no longer
+exist.
+
+Author: Lars Viklund (HPC2N)
+diff -ru grace-5.1.25.orig/ac-tools/configure.in grace-5.1.25/ac-tools/configure.in
+--- grace-5.1.25.orig/ac-tools/configure.in	2014-08-16 23:56:08.000000000 +0200
++++ grace-5.1.25/ac-tools/configure.in	2022-03-11 19:51:21.025110130 +0100
+@@ -515,7 +515,7 @@
+ fi
+ 
+ dnl **** Check for XDR
+-AC_SEARCH_LIBS(xdrstdio_create, nsl rpc xdr rpclib, XDR_LIB=$mdw_cv_lib_xdrstdio_create, XDR_LIB="NONE")
++AC_SEARCH_LIBS(xdrstdio_create, nsl rpc xdr rpclib tirpc, XDR_LIB=$mdw_cv_lib_xdrstdio_create, XDR_LIB="NONE")
+ 
+ if test "${XDR_LIB}" = "NONE"; then
+   XDR_LIB=
+diff -ru grace-5.1.25.orig/configure grace-5.1.25/configure
+--- grace-5.1.25.orig/configure	2015-02-14 23:59:46.000000000 +0100
++++ grace-5.1.25/configure	2022-03-11 19:50:45.678153923 +0100
+@@ -8000,7 +8000,7 @@
+   return 0;
+ }
+ _ACEOF
+-for ac_lib in '' nsl rpc xdr rpclib; do
++for ac_lib in '' nsl rpc xdr rpclib tirpc; do
+   if test -z "$ac_lib"; then
+     ac_res="none required"
+   else


### PR DESCRIPTION
The `grconvert` tool has a hard dependency on a RPC library providing XDR functionality.
This is typically not present under the expected library names on RedHat-like distros so we add a dependency on `libtirpc` to satisfy the requirement.

We expect the `grconvert` to be present during sanity check so this is otherwise a hard build breakage.

(created using `eb --new-pr`)
