### PR TITLE
Ensure Bazel 3.7.2 respects $TMPDIR

### DIFF
--- a/easybuild/easyconfigs/b/Bazel/Bazel-3.7.2-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-3.7.2-GCCcore-10.3.0.eb
@@ -12,14 +12,13 @@ sources = ['%(namelower)s-%(version)s-dist.zip']
 patches = [
     '%(name)s-3.4.1-fix-grpc-protoc.patch',
     '%(name)s-%(version_major_minor)s.1_fix-protobuf-env.patch',
+    '%(name)s-3.7.2_respect-tmpdir.patch',
 ]
 checksums = [
-    # bazel-3.7.2-dist.zip
-    'de255bb42163a915312df9f4b86e5b874b46d9e8d4b72604b5123c3a845ed9b1',
-    # Bazel-3.4.1-fix-grpc-protoc.patch
-    'f87ad8ad6922fd9c974381ea22b7b0e6502ccad5e532145f179b80d5599e24ac',
-    # Bazel-3.7.1_fix-protobuf-env.patch
-    '8706ecc99b658e0a96c38dc2c23e44da35059b85f308602aac76a6d6680376e7',
+    'de255bb42163a915312df9f4b86e5b874b46d9e8d4b72604b5123c3a845ed9b1',  # bazel-3.7.2-dist.zip
+    'f87ad8ad6922fd9c974381ea22b7b0e6502ccad5e532145f179b80d5599e24ac',  # Bazel-3.4.1-fix-grpc-protoc.patch
+    '8706ecc99b658e0a96c38dc2c23e44da35059b85f308602aac76a6d6680376e7',  # Bazel-3.7.1_fix-protobuf-env.patch
+    '47e8b47f63ffb82996550b3b7607c841efbb328827dbb767697480562f7bef45',  # Bazel-3.7.2_respect-tmpdir.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/b/Bazel/Bazel-3.7.2_respect-tmpdir.patch
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-3.7.2_respect-tmpdir.patch
@@ -1,0 +1,14 @@
+Author: Jasper Grimm <jasper.grimm@york.ac.uk>
+Replace hardcoded /tmp to ensure build respects $TMPDIR
+diff -Nru bazel-3.7.2.orig/src/main/java/com/google/devtools/build/lib/BUILD bazel-3.7.2/src/main/java/com/google/devtools/build/lib/BUILD
+--- bazel-3.7.2.orig/src/main/java/com/google/devtools/build/lib/BUILD	1980-01-01 00:00:00.000000000 +0000
++++ bazel-3.7.2/src/main/java/com/google/devtools/build/lib/BUILD	2022-03-22 11:02:18.000000000 +0000
+@@ -499,7 +499,7 @@
+     outs = ["command-line-reference.html"],
+     cmd = (
+         "cat $(location //site:command-line-reference-prefix.html) > $@ && " +
+-        "TMP=`mktemp -d /tmp/tmp.XXXXXXXXXX` && " +
++        "TMP=$$(mktemp -d $${TMPDIR:-/tmp}/tmp.XXXXXXXXXX) && " +
+         # TODO(#11179): Remove when the stub template fix is released.
+         "export JARBIN=$(JAVABASE)/bin/jar && " +
+         "$(location //src/main/java/com/google/devtools/build/lib/bazel:BazelServer) " +


### PR DESCRIPTION
Haven't checked older versions; I assume that most versions will probably be affected

(created using `eb --new-pr`)
