### PR TITLE
Intel compilers are -need to be- requested explicitly

### DIFF
--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-22.0-intel-2021a.eb
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-22.0-intel-2021a.eb
@@ -21,6 +21,9 @@ dependencies = [
 ]
 
 configopts = '-DMKL_FLAG=sequential '
+configopts += '-DCMAKE_Fortran_COMPILER=mpiifort '
+configopts += '-DCMAKE_C_COMPILER=mpiicc '
+configopts += '-DCMAKE_CXX_COMPILER=mpiicpc '
 configopts += '-DENABLE_MPI=True '
 configopts += '-DENABLE_EXATENSOR=off '
 configopts += '-DENABLE_PCMSOLVER=off '


### PR DESCRIPTION
Explicit mention of intel compilers (mpiifort, mpiicc, mpiicpc) in intel compilation is mandatory to get them correctly. If not explicitly declared, foss compilers (mpif90, mpicc, mpicxx) are used instead.