### PR TITLE
fix installation with setuptools>=61 by explicitly declaring there are no Python packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ versions, etc.).""",
         "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Build Tools",
     ],
+    packages=[],
     platforms="Linux",
     requires=[
         "easybuild_framework(>=%s.0)" % MAJ_VER,


### PR DESCRIPTION
fixes [#790](https://github.com/easybuilders/easybuild/issues/790)

Tested with:
```
$ python3 -m venv
$ source venv/bin/activate
$ cd easybuild-framework/
$ pip install .
$ cd ../easybuild-easyblocks/
$ pip install .
$ cd ../easybuild-easyconfigs/
$ pip install .
```

And `$ eb --search pytorch` shows expected output.


Two tests with:
* updating setuptools to latest (61.2.0)
* using EB installed Python 3.9.5, which has 56.0.0
* using OS Python 3.6.8 which has 39.2.0