### PR TITLE
{bio}[GCCcore/11.2.0] snpEff v5.0e w/ Python 3.9.6

### DIFF
--- a/easybuild/easyconfigs/s/snpEff/snpEff-5.0e-GCCcore-11.2.0-Java-11.eb
+++ b/easybuild/easyconfigs/s/snpEff/snpEff-5.0e-GCCcore-11.2.0-Java-11.eb
@@ -1,0 +1,37 @@
+easyblock = 'Tarball'
+
+name = 'snpEff'
+version = '5.0e'
+versionsuffix = '-Java-%(javaver)s'
+
+homepage = 'https://pcingola.github.io/SnpEff/'
+description = """SnpEff is a variant annotation and effect prediction tool.
+ It annotates and predicts the effects of genetic variants (such as amino acid changes)."""
+
+toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
+
+source_urls = ['https://snpeff.blob.core.windows.net/versions/']
+sources = ['%%(name)s_v%s_core.zip' % version.replace('.', '_')]
+checksums = ['85d907b5dd9e9008a0cf245956e3c9077a31e45f21a1b580d9b98a53fd8dcb9d']
+
+dependencies = [
+    # ignore website claim that Java 12+ is required, nothing is compiled for
+    # anything newer than Java 11
+    ('Java', '11', '', True),
+    ('Python', '3.9.6'),
+    ('Perl', '5.34.0'),
+]
+
+fix_perl_shebang_for = ['scripts/*.pl']
+fix_python_shebang_for = ['scripts/*.py']
+
+sanity_check_paths = {
+    'files': ['%(name)s.jar', 'SnpSift.jar', 'scripts/%(name)s'],
+    'dirs': [],
+}
+
+sanity_check_commands = ["%(name)s -version"]
+
+modextrapaths = {'PATH': 'scripts'}
+
+moduleclass = 'bio'


### PR DESCRIPTION
Despite claims on the website that snpEff needs Java 12+, Java 11 is perfectly sufficient (and used in e.g. the debian package):

```
$ java -xf snpEff.jar
$ find . -type f -name "*.class" -exec file {} \; | grep -Eo "(version .*)" | sort | uniq
version 45.3
version 46.0 (Java 1.2)
version 48.0 (Java 1.4)
version 49.0 (Java 1.5)
version 50.0 (Java 1.6)
version 51.0 (Java 1.7)
version 52.0 (Java 1.8)
version 53.0
```

(created using `eb --new-pr`)
