### PR TITLE
pkg-config-0.29.2 easyconfig: "find /usr" should not descend into other filesystems

### DIFF
--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.2.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.2.eb
@@ -23,7 +23,7 @@ checksums = ['6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591']
 tar_config_opts = True
 
 # add pkgconfig directories in the system to list of default search paths
-preconfigopts = 'EB_SYS_PC_PATH=":$(find /usr -type d -name "pkgconfig" -printf %p: 2>/dev/null)";'
+preconfigopts = 'EB_SYS_PC_PATH=":$(find /usr -xdev -type d -name "pkgconfig" -printf %p: 2>/dev/null)";'
 configopts = '--with-pc-path="%(installdir)s/lib/pkgconfig:%(installdir)s/share/pkgconfig${EB_SYS_PC_PATH%:}"'
 
 configopts += " --with-internal-glib"


### PR DESCRIPTION
Closes #15312