### PR TITLE
Remove pkg-config use from SeqLib configure patch

### DIFF
--- a/easybuild/easyconfigs/s/SeqLib/SeqLib-1.2.0-GCC-10.2.0.eb
+++ b/easybuild/easyconfigs/s/SeqLib/SeqLib-1.2.0-GCC-10.2.0.eb
@@ -21,7 +21,7 @@ checksums = [
     '6892bdb5cae88d8d8acbbfadd351cfa00004bc7c0fd1ae912dc1ff1ccfd61a70',  # 1.2.0.tar.gz
     # SeqLib-1.2.0_avoid-bwa-fml-namespace-conflict.patch
     '9be9229bcf34db8e4bd1fd49614bb55d84c12df263ca7174980f7f4b1bd63da9',
-    '8a90edf72f95a52c61e4aed62a9a951bbd56f7c668dec326f2d3836f76b0f71d',  # SeqLib-1.2.0_use-external-deps.patch
+    '413f0ad8e0963d8922205d31e0c361cfa98a10f93e7d3e0506e0bed539ec70eb',  # SeqLib-1.2.0_use-external-deps.patch
 ]
 
 builddependencies = [('Autotools', '20200321')]

--- a/easybuild/easyconfigs/s/SeqLib/SeqLib-1.2.0-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/s/SeqLib/SeqLib-1.2.0-GCC-11.2.0.eb
@@ -21,7 +21,7 @@ checksums = [
     '6892bdb5cae88d8d8acbbfadd351cfa00004bc7c0fd1ae912dc1ff1ccfd61a70',  # 1.2.0.tar.gz
     # SeqLib-1.2.0_avoid-bwa-fml-namespace-conflict.patch
     '9be9229bcf34db8e4bd1fd49614bb55d84c12df263ca7174980f7f4b1bd63da9',
-    '8a90edf72f95a52c61e4aed62a9a951bbd56f7c668dec326f2d3836f76b0f71d',  # SeqLib-1.2.0_use-external-deps.patch
+    '413f0ad8e0963d8922205d31e0c361cfa98a10f93e7d3e0506e0bed539ec70eb',  # SeqLib-1.2.0_use-external-deps.patch
 ]
 
 builddependencies = [('Autotools', '20210726')]

--- a/easybuild/easyconfigs/s/SeqLib/SeqLib-1.2.0-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/s/SeqLib/SeqLib-1.2.0-GCC-9.3.0.eb
@@ -21,7 +21,7 @@ checksums = [
     '6892bdb5cae88d8d8acbbfadd351cfa00004bc7c0fd1ae912dc1ff1ccfd61a70',  # 1.2.0.tar.gz
     # SeqLib-1.2.0_avoid-bwa-fml-namespace-conflict.patch
     '9be9229bcf34db8e4bd1fd49614bb55d84c12df263ca7174980f7f4b1bd63da9',
-    '8a90edf72f95a52c61e4aed62a9a951bbd56f7c668dec326f2d3836f76b0f71d',  # SeqLib-1.2.0_use-external-deps.patch
+    '413f0ad8e0963d8922205d31e0c361cfa98a10f93e7d3e0506e0bed539ec70eb',  # SeqLib-1.2.0_use-external-deps.patch
 ]
 
 builddependencies = [('Autotools', '20180311')]

--- a/easybuild/easyconfigs/s/SeqLib/SeqLib-1.2.0_use-external-deps.patch
+++ b/easybuild/easyconfigs/s/SeqLib/SeqLib-1.2.0_use-external-deps.patch
@@ -47,15 +47,6 @@ diff -Nru SeqLib-1.2.0/configure.ac SeqLib-1.2.0b/configure.ac
  
  # Check for headers
  AC_LANG([C++])
-@@ -32,6 +38,8 @@
-     fail_on_warning="-Werror"
- fi
- 
-+PKG_CHECK_MODULES[[hts], [htslib]]
-+
- # Set compiler flags.
- AC_SUBST(AM_CXXFLAGS, "-g $fail_on_warning -std=c++11 -Wno-unknown-pragmas")
- AC_SUBST(CXXFLAGS, "$CXXFLAGS")
 diff -Nru SeqLib-1.2.0/Makefile.am SeqLib-1.2.0b/Makefile.am
 --- SeqLib-1.2.0/Makefile.am	2021-05-10 16:49:50.000000000 +0100
 +++ SeqLib-1.2.0b/Makefile.am	2021-05-12 17:22:39.000000000 +0100


### PR DESCRIPTION
There was a syntax error in the autoconf macro, which causes an
error if pkg-config is available, and if not available simply
causes configure to issue a warning and ignore it.

Since the result is not used anyway, we can remove it.