### PR TITLE
{numlib}[GCC/11.3.0] FFTW v3.3.10

### DIFF
--- a/easybuild/easyconfigs/f/FFTW.serial/FFTW.serial-3.3.10-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/f/FFTW.serial/FFTW.serial-3.3.10-GCC-11.3.0.eb
@@ -1,0 +1,18 @@
+easyblock = 'EB_FFTW'
+name = 'FFTW.serial'
+version = '3.3.10'
+
+homepage = 'https://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+in one or more dimensions, of arbitrary input size, and of both real and complex data."""
+
+toolchain = {'name': 'GCC', 'version': '11.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [homepage]
+sources = ['fftw-%(version)s.tar.gz']
+checksums = ['56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467']
+
+runtest = 'check'
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.10-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.10-GCC-11.3.0.eb
@@ -1,5 +1,4 @@
-easyblock = 'EB_FFTW'
-name = 'FFTW.serial'
+name = 'FFTW'
 version = '3.3.10'
 
 homepage = 'https://www.fftw.org'
@@ -10,7 +9,7 @@ toolchain = {'name': 'GCC', 'version': '11.3.0'}
 toolchainopts = {'pic': True}
 
 source_urls = [homepage]
-sources = ['fftw-%(version)s.tar.gz']
+sources = [SOURCELOWER_TAR_GZ]
 checksums = ['56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467']
 
 runtest = 'check'


### PR DESCRIPTION
using --new-pr but manually adjusted

Note that since FFTW puts MPI functionality in separate libraries (such as `libfftw3f_mpi.so.3.5.8`) the concerns raised by @Micket in https://github.com/easybuilders/easybuild/issues/649#issuecomment-692744500 that apply to HDF5 and netCDF don't apply for FFTW (or Boost).