### PR TITLE
{devel}[GCC/11.2.0] Autotools v20200321

### DIFF
--- a/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-GCCcore-11.2.0.eb
@@ -1,0 +1,41 @@
+easyblock = 'ConfigureMake'
+
+name = 'Autoconf'
+version = '2.69'
+
+homepage = 'https://www.gnu.org/software/autoconf/'
+
+description = """
+ Autoconf is an extensible package of M4 macros that produce shell scripts
+ to automatically configure software source code packages. These scripts can
+ adapt the packages to many kinds of UNIX-like systems without manual user
+ intervention. Autoconf creates a configuration script for a package from a
+ template file that lists the operating system features that the package can
+ use, in the form of M4 macro calls.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969']
+
+builddependencies = [
+    ('binutils', '2.37'),
+    # non-standard Perl modules are required,
+    # see https://github.com/easybuilders/easybuild-easyconfigs/issues/1822
+    ('Perl', '5.34.0'),
+]
+
+dependencies = [
+    ('M4', '1.4.19'),
+]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x
+              for x in ["autoconf", "autoheader", "autom4te", "autoreconf",
+                        "autoscan", "autoupdate", "ifnames"]],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Automake/Automake-1.16.2-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.16.2-GCCcore-11.2.0.eb
@@ -1,0 +1,44 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'Automake'
+version = '1.16.2'
+
+homepage = 'https://www.gnu.org/software/automake/automake.html'
+
+description = "Automake: GNU Standards-compliant Makefile generator"
+
+toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['b2f361094b410b4acbf4efba7337bdb786335ca09eb2518635a09fb7319ca5c1']
+
+builddependencies = [
+    ('binutils', '2.37'),
+    # non-standard Perl modules are required,
+    # see https://github.com/easybuilders/easybuild-easyconfigs/issues/1822
+    ('Perl', '5.34.0'),
+]
+
+dependencies = [
+    ('Autoconf', '2.69'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/automake', 'bin/aclocal'],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Autotools/Autotools-20200321-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/a/Autotools/Autotools-20200321-GCCcore-11.2.0.eb
@@ -14,7 +14,7 @@ toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
 
 dependencies = [
     ('Autoconf', '2.69'),    # 20120424
-    ('Automake', '1.16.4'),  # 20200321
+    ('Automake', '1.16.2'),  # 20200321
     ('libtool', '2.4.6'),    # 20150215
 ]
 

--- a/easybuild/easyconfigs/a/Autotools/Autotools-20200321-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/a/Autotools/Autotools-20200321-GCCcore-11.2.0.eb
@@ -1,0 +1,24 @@
+easyblock = 'Bundle'
+
+name = 'Autotools'
+version = '20200321'  # date of the most recent change
+
+homepage = 'https://autotools.io'
+
+description = """
+ This bundle collect the standard GNU build tools: Autoconf, Automake
+ and libtool
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
+
+dependencies = [
+    ('Autoconf', '2.69'),    # 20120424
+    ('Automake', '1.16.4'),  # 20200321
+    ('libtool', '2.4.6'),    # 20150215
+]
+
+# Pure bundle -- no need to specify 'binutils' used when building GCCcore
+# toolchain as build dependency
+
+moduleclass = 'devel'


### PR DESCRIPTION
In some rare cases, autotools downgrade seems a solution. For example: https://karobben.github.io/2020/07/28/Bioinfor/Trinity/#Errors