### PR TITLE
{vis}[GCCcore/11.3.0] X11 v20220504

### DIFF
--- a/easybuild/easyconfigs/x/X11/X11-20220504-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20220504-GCCcore-11.3.0.eb
@@ -30,7 +30,7 @@ builddependencies = [
 
 dependencies = [
     ('bzip2', '1.0.8'),
-    ('fontconfig', '2.13.96'),
+    ('fontconfig', '2.14.0'),
     ('freetype', '2.12.1'),
     ('zlib', '1.2.12'),
     ('xorg-macros', '1.19.3'),

--- a/easybuild/easyconfigs/x/X11/X11-20220504-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20220504-GCCcore-11.3.0.eb
@@ -185,8 +185,10 @@ components = [
         'checksums': ['a322332716a384c94d3cbf98f2d8fe2ce63c2fe7e2b26664b6cea1d411723df8'],
     }),
     ('xkeyboard-config', '2.35.1', {  # 2022-02-08
+        'easyblock': 'MesonNinja',
         'sources': [SOURCE_TAR_XZ],
         'checksums': ['18ce50ff0c74ae6093062bce1aeab3d363913ea35162fe271f8a0ce399de85cc'],
+        'preconfigopts': '',
     }),
     ('printproto', '1.0.5', {  # 2011-01-06
         'checksums': ['e8b6f405fd865f0ea7a3a2908dfbf06622f57f2f91359ec65d13b955e49843fc'],

--- a/easybuild/easyconfigs/x/X11/X11-20220504-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20220504-GCCcore-11.3.0.eb
@@ -1,0 +1,210 @@
+easyblock = 'Bundle'
+
+name = 'X11'
+version = '20220504'
+
+homepage = 'https://www.x.org'
+description = "The X Window System (X11) is a windowing system for bitmap displays"
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = [
+    XORG_LIB_SOURCE,
+    XORG_PROTO_SOURCE,
+    'https://xcb.freedesktop.org/dist/',
+    'https://xkbcommon.org/download/',
+    XORG_DATA_SOURCE + '/xkeyboard-config',
+    XORG_DATA_SOURCE,
+]
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('Autotools', '20220317'),
+    ('Bison', '3.8.2'),
+    ('gettext', '0.21'),
+    ('pkgconf', '1.8.0'),
+    ('intltool', '0.51.0'),
+    ('Meson', '0.62.1'),
+    ('Ninja', '1.10.2'),
+]
+
+dependencies = [
+    ('bzip2', '1.0.8'),
+    ('fontconfig', '2.13.96'),
+    ('freetype', '2.12.1'),
+    ('zlib', '1.2.12'),
+    ('xorg-macros', '1.19.3'),
+    ('libpciaccess', '0.16'),
+]
+
+default_easyblock = 'ConfigureMake'
+
+default_component_specs = {
+    'sources': [SOURCE_TAR_GZ],
+    'start_dir': '%(name)s-%(version)s',
+}
+
+components = [
+    ('libpthread-stubs', '0.4', {  # 2017-03-14
+        'checksums': ['50d5686b79019ccea08bcbd7b02fe5a40634abcfd4146b6e75c6420cc170e9d9'],
+    }),
+    ('xorgproto', '2022.1', {  # 2022-04-21
+        'checksums': ['2a399e77d98fe53e9056726a1934b62cbaa6c41d7b1f41a354911b0925363343'],
+    }),
+    ('libXau', '1.0.9', {  # 2019-02-10
+        'checksums': ['1f123d8304b082ad63a9e89376400a3b1d4c29e67e3ea07b3f659cccca690eea'],
+    }),
+    ('libXdmcp', '1.1.3', {  # 2019-03-16
+        'checksums': ['2ef9653d32e09d1bf1b837d0e0311024979653fe755ad3aaada8db1aa6ea180c'],
+    }),
+    ('xcb-proto', '1.15', {  # 2022-05-03
+        'checksums': ['0e434af76af722ef9b2dc21066da1cd11e5dd85fc1996d66228d090f9ae9b217'],
+    }),
+    ('libxcb', '1.15', {  # 2022-05-03
+        'checksums': ['1cb65df8543a69ec0555ac696123ee386321dfac1964a3da39976c9a05ad724d'],
+    }),
+    ('xtrans', '1.4.0', {  # 2019-03-16
+        'checksums': ['48ed850ce772fef1b44ca23639b0a57e38884045ed2cbb18ab137ef33ec713f9'],
+    }),
+    ('libxkbcommon', '1.4.0', {  # 2022-02-04
+        'easyblock': 'MesonNinja',
+        'sources': [SOURCE_TAR_XZ],
+        'checksums': ['106cec5263f9100a7e79b5f7220f889bc78e7d7ffc55d2b6fdb1efefb8024031'],
+        'preconfigopts': '',
+        'configopts': '-Denable-wayland=false -Denable-docs=false ',
+    }),
+    ('libX11', '1.8', {  # 2022-04-29
+        'checksums': ['68e0a30c4248b9f41492891a4b49672c3b0c59e84c4868144f03eef01ebc5eea'],
+    }),
+    ('libXext', '1.3.4', {  # 2019-03-16
+        'checksums': ['8ef0789f282826661ff40a8eef22430378516ac580167da35cc948be9041aac1'],
+    }),
+    ('libFS', '1.0.8', {  # 2019-03-10
+        'checksums': ['e3da723257f4f4c0c629aec402e0a36fbec66a9418f70d24a159cb0470ec83d2'],
+    }),
+    ('libICE', '1.0.10', {  # 2019-07-14
+        'checksums': ['1116bc64c772fd127a0d0c0ffa2833479905e3d3d8197740b3abd5f292f22d2d'],
+    }),
+    ('libSM', '1.2.3', {  # 2018-10-10
+        'checksums': ['1e92408417cb6c6c477a8a6104291001a40b3bb56a4a60608fdd9cd2c5a0f320'],
+    }),
+    ('libXScrnSaver', '1.2.3', {  # 2018-07-05
+        'checksums': ['4f74e7e412144591d8e0616db27f433cfc9f45aae6669c6c4bb03e6bf9be809a'],
+    }),
+    ('libXt', '1.2.1', {  # 2021-01-24
+        'checksums': ['6da1bfa9dd0ed87430a5ce95b129485086394df308998ebe34d98e378e3dfb33'],
+    }),
+    ('libXmu', '1.1.3', {  # 2019-03-16
+        'checksums': ['5bd9d4ed1ceaac9ea023d86bf1c1632cd3b172dce4a193a72a94e1d9df87a62e'],
+    }),
+    ('libXpm', '3.5.13', {  # 2019-12-13
+        'checksums': ['e3dfb0fb8c1f127432f2a498c7856b37ce78a61e8da73f1aab165a73dd97ad00'],
+    }),
+    ('libXaw', '1.0.14', {  # 2021-03-27
+        'checksums': ['59cfed2712cc80bbfe62dd1aacf24f58d74a76dd08329a922077b134a8d8048f'],
+    }),
+    ('libXfixes', '6.0.0', {  # 2021-05-11
+        'checksums': ['82045da5625350838390c9440598b90d69c882c324ca92f73af9f0e992cb57c7'],
+    }),
+    ('libXcomposite', '0.4.5', {  # 2019-03-11
+        'checksums': ['581c7fc0f41a99af38b1c36b9be64bc13ef3f60091cd3f01105bbc7c01617d6c'],
+    }),
+    ('libXrender', '0.9.10', {  # 2016-10-04
+        'checksums': ['770527cce42500790433df84ec3521e8bf095dfe5079454a92236494ab296adf'],
+    }),
+    ('libXcursor', '1.2.1', {  # 2022-04-03
+        'checksums': ['77f96b9ad0a3c422cfa826afabaf1e02b9bfbfc8908c5fa1a45094faad074b98'],
+    }),
+    ('libXdamage', '1.1.5', {  # 2019-03-11
+        'checksums': ['630ec53abb8c2d6dac5cd9f06c1f73ffb4a3167f8118fdebd77afd639dbc2019'],
+    }),
+    ('libfontenc', '1.1.4', {  # 2019-02-20
+        'checksums': ['895ee0986b32fbfcda7f4f25ef6cbacfa760e1690bf59f02085ce0e7d1eebb41'],
+    }),
+    ('libXfont', '1.5.4', {  # 2017-11-28
+        'checksums': ['59be6eab53f7b0feb6b7933c11d67d076ae2c0fd8921229c703fc7a4e9a80d6e'],
+    }),
+    ('libXfont2', '2.0.5', {  # 2021-08-02
+        'checksums': ['d7544aa35ea67a87840ff0b1bd15130b102e473de3611b7d78604ba635fd6d94'],
+    }),
+    ('libXft', '2.3.4', {  # 2021-08-02
+        'checksums': ['1eca71bec9cb483165ce1ab94f5cd3036269f5268651df6a2d99c4a7ab644d79'],
+    }),
+    ('libXi', '1.8', {  # 2021-09-15
+        'checksums': ['c80fd200a1190e4406bb4cc6958839d9651638cb47fa546a595d4bebcd3b9e2d'],
+    }),
+    ('libXinerama', '1.1.4', {  # 2018-07-05
+        'checksums': ['64de45e18cc76b8e703cb09b3c9d28bd16e3d05d5cd99f2d630de2d62c3acc18'],
+    }),
+    ('libXrandr', '1.5.2', {  # 2019-03-16
+        'checksums': ['3f10813ab355e7a09f17e147d61b0ce090d898a5ea5b5519acd0ef68675dcf8e'],
+    }),
+    ('libXres', '1.2.1', {  # 2021-03-31
+        'checksums': ['918fb33c3897b389a1fbb51571c5c04c6b297058df286d8b48faa5af85e88bcc'],
+    }),
+    ('libXtst', '1.2.3', {  # 2016-10-04
+        'checksums': ['a0c83acce02d4923018c744662cb28eb0dbbc33b4adc027726879ccf68fbc2c2'],
+    }),
+    ('libXv', '1.0.11', {  # 2016-10-04
+        'checksums': ['c4112532889b210e21cf05f46f0f2f8354ff7e1b58061e12d7a76c95c0d47bb1'],
+    }),
+    ('libXvMC', '1.0.13', {  # 2022-03-22
+        'checksums': ['e630b4373af8c67a7c8f07ebe626a1269a613d262d1f737b57231a06f7c34b4e'],
+    }),
+    ('libXxf86dga', '1.1.5', {  # 2019-03-16
+        'checksums': ['715e2bf5caf6276f0858eb4b11a1aef1a26beeb40dce2942387339da395bef69'],
+    }),
+    ('libXxf86vm', '1.1.4', {  # 2015-02-24
+        'checksums': ['5108553c378a25688dcb57dca383664c36e293d60b1505815f67980ba9318a99'],
+    }),
+    ('libdmx', '1.1.4', {  # 2018-05-14
+        'checksums': ['4d05bd5b248c1f46729fa1536b7a5e4d692567327ad41564c36742fb327af925'],
+    }),
+    ('libxkbfile', '1.1.0', {  # 2019-03-16
+        'checksums': ['2a92adda3992aa7cbad758ef0b8dfeaedebb49338b772c64ddf369d78c1c51d3'],
+    }),
+    ('libxshmfence', '1.3', {  # 2018-02-26
+        'checksums': ['7eb3d46ad91bab444f121d475b11b39273142d090f7e9ac43e6a87f4ff5f902c'],
+    }),
+    ('xcb-util', '0.4.0', {  # 2014-10-15
+        'checksums': ['0ed0934e2ef4ddff53fcc70fc64fb16fe766cd41ee00330312e20a985fd927a7'],
+    }),
+    ('xcb-util-image', '0.4.0', {  # 2014-10-15
+        'checksums': ['cb2c86190cf6216260b7357a57d9100811bb6f78c24576a3a5bfef6ad3740a42'],
+    }),
+    ('xcb-util-keysyms', '0.4.0', {  # 2014-10-01
+        'checksums': ['0807cf078fbe38489a41d755095c58239e1b67299f14460dec2ec811e96caa96'],
+    }),
+    ('xcb-util-renderutil', '0.3.9', {  # 2014-06-13
+        'checksums': ['55eee797e3214fe39d0f3f4d9448cc53cffe06706d108824ea37bb79fcedcad5'],
+    }),
+    ('xcb-util-wm', '0.4.1', {  # 2014-02-19
+        'checksums': ['038b39c4bdc04a792d62d163ba7908f4bb3373057208c07110be73c1b04b8334'],
+    }),
+    ('xcb-util-cursor', '0.1.3', {  # 2016-05-12
+        'checksums': ['a322332716a384c94d3cbf98f2d8fe2ce63c2fe7e2b26664b6cea1d411723df8'],
+    }),
+    ('xkeyboard-config', '2.35.1', {  # 2022-02-08
+        'sources': [SOURCE_TAR_XZ],
+        'checksums': ['18ce50ff0c74ae6093062bce1aeab3d363913ea35162fe271f8a0ce399de85cc'],
+    }),
+    ('printproto', '1.0.5', {  # 2011-01-06
+        'checksums': ['e8b6f405fd865f0ea7a3a2908dfbf06622f57f2f91359ec65d13b955e49843fc'],
+    }),
+    ('libXp', '1.0.3', {  # 2015-02-21
+        'checksums': ['f6b8cc4ef05d3eafc9ef5fc72819dd412024b4ed60197c0d5914758125817e9c'],
+    }),
+    ('xbitmaps', '1.1.2', {  # 2018-03-10
+        'checksums': ['27e700e8ee02c43f7206f4eca8f1953ad15236cac95d7a0f08505c3f7d99c265'],
+    }),
+]
+
+preconfigopts = "if [ ! -f configure ]; then ./autogen.sh; fi && "
+
+sanity_check_paths = {
+    'files': ['include/X11/Xlib.h', 'include/X11/Xutil.h'],
+    'dirs': ['include/GL', 'include/X11', 'include/X11/extensions', 'lib/pkgconfig',
+             'share/pkgconfig', 'share/X11/xkb'],
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
depends on:

- [x] #15429 
- [x] #15430 

(created using `eb --new-pr`)
