### PR TITLE
{vis}[GCCcore/11.3.0] cairo v1.17.4, GObject-Introspection v1.72.0, GLib v2.72.1, ... w/ Python 3.10.4

### DIFF
--- a/easybuild/easyconfigs/c/cairo/cairo-1.17.4-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/c/cairo/cairo-1.17.4-GCCcore-11.3.0.eb
@@ -1,0 +1,49 @@
+easyblock = 'ConfigureMake'
+
+name = 'cairo'
+version = '1.17.4'
+
+homepage = 'https://cairographics.org'
+description = """Cairo is a 2D graphics library with support for multiple output devices.
+ Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers,
+ PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = [
+    'https://cairographics.org/releases/',
+    'https://cairographics.org/snapshots/'
+]
+sources = [SOURCE_TAR_XZ]
+checksums = ['74b24c1ed436bbe87499179a3b27c43f4143b8676d8ad237a6fa787401959705']
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('pkgconf', '1.8.0'),
+]
+dependencies = [
+    ('bzip2', '1.0.8'),
+    ('zlib', '1.2.12'),
+    ('libpng', '1.6.37'),
+    ('freetype', '2.12.1'),
+    ('pixman', '0.40.0'),
+    ('expat', '2.4.8'),
+    ('GLib', '2.72.1'),
+    ('X11', '20220504'),
+]
+
+# disable symbol lookup, which requires -lbfd, to avoid link issues with (non-PIC) libiberty.a provided by GCC
+configopts = "--enable-symbol-lookup=no --enable-gobject=yes --enable-svg=yes --enable-tee=yes --enable-xlib-xcb "
+
+sanity_check_paths = {
+    'files': ['bin/cairo-trace', 'lib/cairo/libcairo-trace.%s' % SHLIB_EXT, 'lib/cairo/libcairo-trace.a',
+              'lib/libcairo.a', 'lib/libcairo-gobject.a', 'lib/libcairo-script-interpreter.a',
+              'lib/libcairo.%s' % SHLIB_EXT, 'lib/libcairo-gobject.%s' % SHLIB_EXT,
+              'lib/libcairo-script-interpreter.%s' % SHLIB_EXT] +
+             ['include/cairo/cairo%s.h' % x for x in ['', '-deprecated', '-features', '-ft', '-gobject', '-pdf', '-ps',
+                                                      '-script', '-script-interpreter', '-svg', '-version', '-xcb',
+                                                      '-xlib', '-xlib-xrender']],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GLib/GLib-2.72.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.72.1-GCCcore-11.3.0.eb
@@ -1,0 +1,52 @@
+easyblock = 'MesonNinja'
+
+name = 'GLib'
+version = '2.72.1'
+
+homepage = 'https://www.gtk.org/'
+description = """GLib is one of the base libraries of the GTK+ project"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['c07e57147b254cef92ce80a0378dc0c02a4358e7de4702e9f403069781095fe2']
+
+builddependencies = [
+    # Python is required for building against GLib, at least when
+    # gdbus-codegen or one of the other python scripts are used.
+    # Since Meson 0.50 and later are Python >=3.5 only we can't build
+    # Python specific versions of GLib that uses Python 2.x
+    # thus Python should not be a runtime dependency for GLib.
+    # Packages that use GLib should either have an explicit
+    # (build)dependency on Python or it will use the system version
+    # EasyBuild itself uses.
+    ('Python', '3.10.4', '-bare'),
+    ('Meson', '0.62.1'),
+    ('Ninja', '1.10.2'),
+    ('binutils', '2.38'),
+    ('pkgconf', '1.8.0'),
+]
+
+dependencies = [
+    ('libffi', '3.4.2'),
+    ('gettext', '0.21'),
+    ('libxml2', '2.9.13'),
+    ('PCRE', '8.45'),
+    ('util-linux', '2.38'),
+]
+
+# avoid using hardcoded path to Python binary in build step
+preconfigopts = "export PYTHON=python && "
+
+configopts = "--buildtype=release --default-library=both "
+
+fix_python_shebang_for = ['bin/*']
+
+sanity_check_paths = {
+    'files': ['lib/libglib-%(version_major)s.0.a', 'lib/libglib-%%(version_major)s.0.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'include'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GLib/GLib-2.72.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.72.1-GCCcore-11.3.0.eb
@@ -22,7 +22,7 @@ builddependencies = [
     # Packages that use GLib should either have an explicit
     # (build)dependency on Python or it will use the system version
     # EasyBuild itself uses.
-    ('Python', '3.10.4', '-bare'),
+    ('Python', '3.10.4'),
     ('Meson', '0.62.1'),
     ('Ninja', '1.10.2'),
     ('binutils', '2.38'),

--- a/easybuild/easyconfigs/g/GObject-Introspection/GObject-Introspection-1.72.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/g/GObject-Introspection/GObject-Introspection-1.72.0-GCCcore-11.3.0.eb
@@ -1,0 +1,44 @@
+easyblock = 'MesonNinja'
+
+name = 'GObject-Introspection'
+version = '1.72.0'
+
+homepage = 'https://gi.readthedocs.io/en/latest/'
+description = """GObject introspection is a middleware layer between C libraries
+ (using GObject) and language bindings. The C library can be scanned at
+ compile time and generate a metadata file, in addition to the actual
+ native C library. Then at runtime, language bindings can read this
+ metadata and automatically provide bindings to call into the C library."""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['02fe8e590861d88f83060dd39cda5ccaa60b2da1d21d0f95499301b186beaabc']
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('pkgconf', '1.8.0'),
+    ('Meson', '0.62.1'),
+    ('Ninja', '1.10.2'),
+    ('flex', '2.6.4'),
+    ('Bison', '3.8.2'),
+    ('cairo', '1.17.4'),
+]
+
+dependencies = [
+    ('Python', '3.10.4'),
+    ('GLib', '2.72.1'),
+    ('libffi', '3.4.2'),
+    ('util-linux', '2.38'),
+]
+
+preconfigopts = "env GI_SCANNER_DISABLE_CACHE=true "
+
+sanity_check_paths = {
+    'files': ['bin/g-ir-%s' % x for x in ['annotation-tool', 'compiler', 'generate', 'scanner']] +
+             ['lib/libgirepository-1.0.' + SHLIB_EXT],
+    'dirs': ['include', 'share']
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/pixman/pixman-0.40.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/p/pixman/pixman-0.40.0-GCCcore-11.3.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'pixman'
+version = '0.40.0'
+
+homepage = 'http://www.pixman.org/'
+description = """
+ Pixman is a low-level software library for pixel manipulation, providing
+ features such as image compositing and trapezoid rasterization. Important
+ users of pixman are the cairo graphics library and the X server.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = ['https://cairographics.org/releases/']
+sources = [SOURCE_TAR_GZ]
+checksums = ['6d200dec3740d9ec4ec8d1180e25779c00bc749f94278c8b9021f5534db223fc']
+
+builddependencies = [
+    ('binutils', '2.38'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/libpixman-1.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
depends on:

- [x] #15437 

(created using `eb --new-pr`)
