### PR TITLE
{vis}[GCCcore/11.3.0] ATK v2.38.0, at-spi2-atk v2.38.0, at-spi2-core v2.44.1, ...

### DIFF
--- a/easybuild/easyconfigs/a/ATK/ATK-2.38.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/a/ATK/ATK-2.38.0-GCCcore-11.3.0.eb
@@ -1,0 +1,39 @@
+easyblock = 'MesonNinja'
+
+name = 'ATK'
+version = '2.38.0'
+
+homepage = 'https://developer.gnome.org/atk/'
+description = """
+ ATK provides the set of accessibility interfaces that are implemented by other
+ toolkits and applications. Using the ATK interfaces, accessibility tools have
+ full access to view and control running applications.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['ac4de2a4ef4bd5665052952fe169657e65e895c5057dffb3c2a810f6191a0c36']
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('Meson', '0.62.1'),
+    ('Ninja', '1.10.2'),
+    ('pkgconf', '1.8.0'),
+    ('GObject-Introspection', '1.72.0'),
+]
+
+dependencies = [
+    ('GLib', '2.72.1'),
+]
+
+configopts = "--buildtype=release --default-library=both "
+configopts += "-Dintrospection=true "
+
+sanity_check_paths = {
+    'files': ['lib/libatk-1.0.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/a/at-spi2-atk/at-spi2-atk-2.38.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-atk/at-spi2-atk-2.38.0-GCCcore-11.3.0.eb
@@ -1,0 +1,37 @@
+easyblock = 'MesonNinja'
+
+name = 'at-spi2-atk'
+version = '2.38.0'
+
+homepage = 'https://wiki.gnome.org/Accessibility'
+description = "AT-SPI 2 toolkit bridge"
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['cfa008a5af822b36ae6287f18182c40c91dd699c55faa38605881ed175ca464f']
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('Meson', '0.62.1'),
+    ('Ninja', '1.10.2'),
+    ('pkgconf', '1.8.0'),
+]
+
+dependencies = [
+    ('GLib', '2.72.1'),
+    ('DBus', '1.14.0'),
+    ('at-spi2-core', '2.44.1'),
+    ('libxml2', '2.9.13'),
+    ('ATK', '2.38.0'),
+]
+
+configopts = "--libdir lib "
+
+sanity_check_paths = {
+    'files': ['lib/libatk-bridge-2.0.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.44.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.44.1-GCCcore-11.3.0.eb
@@ -1,0 +1,39 @@
+easyblock = 'MesonNinja'
+
+name = 'at-spi2-core'
+version = '2.44.1'
+
+homepage = 'https://wiki.gnome.org/Accessibility'
+description = """
+ Assistive Technology Service Provider Interface.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['4beb23270ba6cf7caf20b597354d75194d89afb69d2efcf15f4271688ba6f746']
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('Meson', '0.62.1'),
+    ('Ninja', '1.10.2'),
+    ('GObject-Introspection', '1.72.0'),
+    ('gettext', '0.21'),
+    ('pkgconf', '1.8.0'),
+]
+
+dependencies = [
+    ('GLib', '2.72.1'),
+    ('DBus', '1.14.0'),
+    ('X11', '20220504'),
+]
+
+configopts = "--libdir lib "
+
+sanity_check_paths = {
+    'files': ['lib/libatspi.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/d/DBus/DBus-1.14.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/d/DBus/DBus-1.14.0-GCCcore-11.3.0.eb
@@ -1,0 +1,44 @@
+easyblock = 'ConfigureMake'
+
+name = 'DBus'
+version = '1.14.0'
+
+homepage = 'https://dbus.freedesktop.org/'
+
+description = """
+ D-Bus is a message bus system, a simple way for applications to talk
+ to one another.  In addition to interprocess communication, D-Bus helps
+ coordinate process lifecycle; it makes it simple and reliable to code
+ a "single instance" application or daemon, and to launch applications
+ and daemons on demand when their services are needed.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://dbus.freedesktop.org/releases/dbus']
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['ccd7cce37596e0a19558fd6648d1272ab43f011d80c8635aea8fd0bad58aebd4']
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('pkgconf', '1.8.0'),
+]
+
+dependencies = [
+    ('expat', '2.4.8'),
+]
+
+configopts = '--with-systemdsystemunitdir=no '
+# disable documentation
+configopts += '--disable-xml-docs --disable-doxygen-docs --disable-ducktype-docs'
+
+sanity_check_paths = {
+    'files': ['bin/dbus-%s' % x for x in
+              ['cleanup-sockets', 'daemon', 'launch', 'monitor',
+               'run-session', 'send', 'uuidgen']] +
+             ['lib/libdbus-1.%s' % x for x in ['a', SHLIB_EXT]],
+    'dirs': ['include', 'share'],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
depends on:

- [x] #15437
- [x] #15439 

(created using `eb --new-pr`)
