### PR TITLE
{vis}[foss/2021b] PyOpenCL v2021.2.13 w/ Python 3.9.6

### DIFF
--- a/easybuild/easyconfigs/p/PyOpenCL/PyOpenCL-2021.2.13-foss-2021b.eb
+++ b/easybuild/easyconfigs/p/PyOpenCL/PyOpenCL-2021.2.13-foss-2021b.eb
@@ -1,0 +1,33 @@
+easyblock = 'PythonBundle'
+
+name = 'PyOpenCL'
+version = '2021.2.13'
+
+homepage = "https://mathema.tician.de/software/pyopencl/"
+description = """PyOpenCL lets you access GPUs and other massively parallel compute devices from Python."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+dependencies = [
+    ('Python', '3.9.6'),
+    ('SciPy-bundle', '2021.10'),
+    ('pocl', '1.8'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('appdirs', '1.4.4', {
+        'checksums': ['7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41'],
+    }),
+    ('pytools', '2021.2.9', {
+        'checksums': ['db6cf83c9ba0a165d545029e2301621486d1e9ef295684072e5cd75316a13755'],
+    }),
+    ('pyopencl', version, {
+        'preinstallopts': "./configure.py --cl-pretend-version=1.2 && ",
+        'checksums': ['8b969c3a9d4153adc6b0915301ffdf626a3784b869a964645de100ae60de7b06'],
+    }),
+]
+
+moduleclass = 'vis'


### PR DESCRIPTION
All easyconfigs are `vis` so I am keeping it.