### PR TITLE
{mpi,perf,toolchain}[GCC/11.3.0] MPICH v4.0.2, gmpich v2022.05, OSU-Micro-Benchmarks v5.9

### DIFF
--- a/easybuild/easyconfigs/g/gmpich/gmpich-2022.05.eb
+++ b/easybuild/easyconfigs/g/gmpich/gmpich-2022.05.eb
@@ -1,0 +1,20 @@
+easyblock = 'Toolchain'
+
+name = 'gmpich'
+version = '2022.05'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain,
+ including MPICH for MPI support."""
+
+toolchain = SYSTEM
+
+local_gccver = '11.3.0'
+
+# compiler toolchain dependencies
+dependencies = [
+    ('GCC', local_gccver),  # includes both GCC and binutils
+    ('MPICH', '4.0.2', '', ('GCC', local_gccver)),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/m/MPICH/MPICH-4.0.2-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/m/MPICH/MPICH-4.0.2-GCC-11.3.0.eb
@@ -1,0 +1,28 @@
+name = 'MPICH'
+version = '4.0.2'
+
+homepage = 'https://www.mpich.org/'
+description = """MPICH is a high-performance and widely portable implementation
+of the Message Passing Interface (MPI) standard (MPI-1, MPI-2 and MPI-3)."""
+
+toolchain = {'name': 'GCC', 'version': '11.3.0'}
+
+source_urls = ['https://www.mpich.org/static/tarballs/%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['5a42f1a889d4a2d996c26e48cbf9c595cbf4316c6814f7c181e3320d21dedd42']
+
+builddependencies = [
+    ('Perl', '5.34.1'),
+    ('Python', '3.10.4', '-bare'),
+    ('json-c', '0.16'),
+]
+
+dependencies = [
+    ('UCX', '1.12.1'),
+    ('hwloc', '2.7.1'),
+]
+
+configopts = 'FFLAGS="$FFLAGS -fallow-argument-mismatch" FCFLAGS="$FCFLAGS -fallow-argument-mismatch"'
+configopts += ' --with-devices=ch4:ucx --with-ucx=$EBROOTUCX'
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OSU-Micro-Benchmarks/OSU-Micro-Benchmarks-5.9-gmpich-2022.05.eb
+++ b/easybuild/easyconfigs/o/OSU-Micro-Benchmarks/OSU-Micro-Benchmarks-5.9-gmpich-2022.05.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'OSU-Micro-Benchmarks'
+version = '5.9'
+
+homepage = 'https://mvapich.cse.ohio-state.edu/benchmarks/'
+description = """OSU Micro-Benchmarks"""
+
+toolchain = {'name': 'gmpich', 'version': '2022.05'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://mvapich.cse.ohio-state.edu/download/mvapich/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['d619740a1c2cc7c02a9763931546b320d0fa4093c415ff3873c2958e121c0609']
+
+local_benchmark_dirs = [
+    'libexec/osu-micro-benchmarks/mpi/%s' % x for x in ['collective', 'one-sided', 'pt2pt', 'startup']
+]
+modextrapaths = {'PATH': local_benchmark_dirs}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': local_benchmark_dirs,
+}
+
+moduleclass = 'perf'


### PR DESCRIPTION
requires:
- [x] #15554 

(created using `eb --new-pr`)
