### PR TITLE
{math}[foss/2022.05] Hypre v2.24.0, METIS v5.1.0, MPFR v4.1.0, ... w/ Python 3.10.4

### DIFF
--- a/easybuild/easyconfigs/h/Hypre/Hypre-2.24.0-foss-2022.05.eb
+++ b/easybuild/easyconfigs/h/Hypre/Hypre-2.24.0-foss-2022.05.eb
@@ -1,0 +1,22 @@
+##
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+# Author:    Jasper Grimm (UoY)
+##
+name = 'Hypre'
+version = '2.24.0'
+
+homepage = 'https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods'
+description = """Hypre is a library for solving large, sparse linear systems of equations on massively
+ parallel computers. The problems of interest arise in the simulation codes being developed at LLNL
+ and elsewhere to study physical phenomena in the defense, environmental, energy, and biological sciences."""
+
+toolchain = {'name': 'foss', 'version': '2022.05'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/hypre-space/hypre/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['f480e61fc25bf533fc201fdf79ec440be79bb8117650627d1f25151e8be2fdb5']
+
+start_dir = 'src'
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/m/METIS/METIS-5.1.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/m/METIS/METIS-5.1.0-GCCcore-11.3.0.eb
@@ -1,0 +1,36 @@
+name = 'METIS'
+version = '5.1.0'
+
+homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/metis/overview'
+
+description = """
+ METIS is a set of serial programs for partitioning graphs, partitioning
+ finite element meshes, and producing fill reducing orderings for sparse
+ matrices. The algorithms implemented in METIS are based on the multilevel
+ recursive-bisection, multilevel k-way, and multi-constraint partitioning
+ schemes.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis',
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD',
+]
+sources = [SOURCELOWER_TAR_GZ]
+patches = ['%(name)s-%(version)s-use-doubles.patch']
+checksums = [
+    '76faebe03f6c963127dbb73c13eab58c9a3faeae48779f049066a21c087c5db2',  # metis-5.1.0.tar.gz
+    '7e38a3ec8f2b8e3d189239bade5b28c0dd1c564485050109164fa71a6a767c67',  # METIS-5.1.0-use-doubles.patch
+]
+
+# We use 32bit for indices and 64bit for content
+builddependencies = [
+    ('binutils', '2.38'),
+    ('CMake', '3.23.1'),
+]
+
+configopts = ['', 'shared=1']
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MPFR/MPFR-4.1.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/m/MPFR/MPFR-4.1.0-GCCcore-11.3.0.eb
@@ -1,0 +1,39 @@
+easyblock = 'ConfigureMake'
+
+name = 'MPFR'
+version = '4.1.0'
+
+homepage = 'https://www.mpfr.org'
+
+description = """
+ The MPFR library is a C library for multiple-precision floating-point
+ computations with correct rounding.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = ['https://www.mpfr.org/mpfr-%(version)s/']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['feced2d430dd5a97805fa289fed3fc8ff2b094c02d05287fd6133e7f1f0ec926']
+
+builddependencies = [
+    ('binutils', '2.38'),
+]
+
+dependencies = [
+    ('GMP', '6.2.1'),
+]
+
+runtest = 'check'
+
+# copy libmpfr.so* to <installdir>/lib to make sure that it  is picked up by tests
+# when EasyBuild is configured with --rpath, and clean up afterwards (let 'make install' do its job)
+pretestopts = "mkdir -p %%(installdir)s/lib && cp -a src/.libs/libmpfr.%s* %%(installdir)s/lib && " % SHLIB_EXT
+testopts = " && rm -r %(installdir)s/lib"
+
+sanity_check_paths = {
+    'files': ['lib/libmpfr.%s' % SHLIB_EXT, 'include/mpfr.h'],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MUMPS/MUMPS-5.5.0-foss-2022.05-metis.eb
+++ b/easybuild/easyconfigs/m/MUMPS/MUMPS-5.5.0-foss-2022.05-metis.eb
@@ -1,0 +1,35 @@
+name = 'MUMPS'
+version = '5.5.0'
+versionsuffix = '-metis'
+
+homepage = 'https://graal.ens-lyon.fr/MUMPS/'
+description = "A parallel sparse direct solver"
+
+toolchain = {'name': 'foss', 'version': '2022.05'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['http://mumps.enseeiht.fr/']
+sources = ['%(name)s_%(version)s.tar.gz']
+patches = [
+    '%(name)s-%(version)s_shared-pord.patch',    # builds the shared libs of PORD
+    '%(name)s-%(version)s_shared-mumps.patch',   # builds shared libs of MUMPS
+]
+checksums = [
+    'e54d17c5e42a36c40607a03279e0704d239d71d38503aab68ef3bfe0a9a79c13',  # MUMPS_5.5.0.tar.gz
+    'a21b5c84125dceaf015a54d6d1dea61cb0c93b24130ba5a7d5a2cdf83de5f197',  # MUMPS-5.5.0_shared-pord.patch
+    '7c597d2696dbe48c0a964e332af7e86b2c98daf643ba588d6bd5f2f4864ad015',  # MUMPS-5.5.0_shared-mumps.patch
+]
+
+dependencies = [
+    ('SCOTCH', '7.0.1'),
+    ('METIS', '5.1.0'),
+]
+
+parallel = 1
+
+# fix 'Type mismatch between actual argument' errors with GCC 10.x
+prebuildopts = 'export FFLAGS="$FFLAGS -fallow-argument-mismatch" && '
+
+buildopts = 'all SONAME_VERSION="%(version)s"'
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.17.1-foss-2022.05.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.17.1-foss-2022.05.eb
@@ -1,0 +1,51 @@
+##
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+# Author:    Jasper Grimm (UoY)
+##
+name = 'PETSc'
+version = '3.17.1'
+
+homepage = 'https://www.mcs.anl.gov/petsc'
+description = """PETSc, pronounced PET-see (the S is silent), is a suite of data structures and routines for the
+ scalable (parallel) solution of scientific applications modeled by partial differential equations."""
+
+toolchain = {'name': 'foss', 'version': '2022.05'}
+toolchainopts = {'openmp': True, 'usempi': True, 'pic': True}
+
+source_urls = [
+    'https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/',
+    'ftp://ftp.mcs.anl.gov/pub/petsc/release-snapshots/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'PETSc_ranlib-fix.patch',
+]
+checksums = [
+    'c504609d9f532327c20b6363d6a6c7647ebd3c98acfb382c28fcd3852300ddd1',  # petsc-3.17.1.tar.gz
+    '64cf9d5008d5e92117e65bdec5316d991b6a6b8c8ecf7ea46eb790a498266297',  # PETSc_ranlib-fix.patch
+]
+
+builddependencies = [('CMake', '3.23.1')]
+
+dependencies = [
+    ('Python', '3.10.4'),
+    ('SciPy-bundle', '2022.05'),
+    ('Boost', '1.79.0'),
+    ('METIS', '5.1.0'),
+    ('SCOTCH', '7.0.1'),
+    ('MUMPS', '5.5.0', '-metis'),
+    ('SuiteSparse', '5.12.0', '-METIS-5.1.0'),
+    ('Hypre', '2.24.0'),
+]
+
+# enabling --with-mpi4py seems to be totally broken, leads to make errors like:
+# No rule to make target 'mpi4py-build'
+configopts = '--LIBS="$LIBS -lrt" --with-mpi4py=0 '
+
+shared_libs = 1
+
+# only required when building PETSc in a SLURM job environment
+# configopts += '--with-batch=1 --known-mpi-shared-libraries=1 --known-64-bit-blas-indices=0 '
+# prebuildopts = "srun ./conftest-arch-linux2-c-opt && ./reconfigure-arch-linux2-c-opt.py && "
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/SCOTCH/SCOTCH-7.0.1-gompi-2022.05.eb
+++ b/easybuild/easyconfigs/s/SCOTCH/SCOTCH-7.0.1-gompi-2022.05.eb
@@ -16,6 +16,11 @@ source_urls = ['https://gitlab.inria.fr/scotch/scotch/-/archive/v%(version)s/']
 sources = ['%(namelower)s-v%(version)s.tar.gz']
 checksums = ['0618e9bc33c02172ea7351600fce4fccd32fe00b3359c4aabb5e415f17c06fed']
 
+builddependencies = [
+    ('flex', '2.6.4'),
+    ('Bison', '3.8.2'),
+]
+
 dependencies = [
     ('zlib', '1.2.12'),
 ]

--- a/easybuild/easyconfigs/s/SCOTCH/SCOTCH-7.0.1-gompi-2022.05.eb
+++ b/easybuild/easyconfigs/s/SCOTCH/SCOTCH-7.0.1-gompi-2022.05.eb
@@ -1,0 +1,23 @@
+##
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+# Author:    Jasper Grimm (UoY)
+##
+name = 'SCOTCH'
+version = '7.0.1'
+
+homepage = 'https://gitlab.inria.fr/scotch/scotch/'
+description = """Software package and libraries for sequential and parallel graph partitioning,
+static mapping, and sparse matrix block ordering, and sequential mesh and hypergraph partitioning."""
+
+toolchain = {'name': 'gompi', 'version': '2022.05'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://gitlab.inria.fr/scotch/scotch/-/archive/v%(version)s/']
+sources = ['%(namelower)s-v%(version)s.tar.gz']
+checksums = ['0618e9bc33c02172ea7351600fce4fccd32fe00b3359c4aabb5e415f17c06fed']
+
+dependencies = [
+    ('zlib', '1.2.12'),
+]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/s/SuiteSparse/SuiteSparse-5.12.0-foss-2022.05-METIS-5.1.0.eb
+++ b/easybuild/easyconfigs/s/SuiteSparse/SuiteSparse-5.12.0-foss-2022.05-METIS-5.1.0.eb
@@ -1,0 +1,29 @@
+name = 'SuiteSparse'
+version = '5.12.0'
+local_metis_ver = '5.1.0'
+versionsuffix = '-METIS-%s' % local_metis_ver
+
+homepage = 'https://faculty.cse.tamu.edu/davis/suitesparse.html'
+description = """SuiteSparse is a collection of libraries manipulate sparse matrices."""
+
+toolchain = {'name': 'foss', 'version': '2022.05'}
+toolchainopts = {'unroll': True, 'pic': True}
+
+source_urls = ['https://github.com/DrTimothyAldenDavis/SuiteSparse/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['5fb0064a3398111976f30c5908a8c0b40df44c6dd8f0cc4bfa7b9e45d8c647de']
+
+builddependencies = [
+    ('CMake', '3.23.1'),
+    ('M4', '1.4.19'),
+]
+
+dependencies = [
+    ('METIS', local_metis_ver),
+    ('MPFR', '4.1.0'),
+]
+
+# make sure that bin/demo can find libsuitesparseconfig.so.5 during build
+prebuildopts = "export LD_LIBRARY_PATH=%(builddir)s/SuiteSparse-%(version)s/lib:$LD_LIBRARY_PATH && "
+
+moduleclass = 'numlib'


### PR DESCRIPTION
requires:

- [x] #15561
- [x] #15563
- [x] #15572 

(created using `eb --new-pr`)
