### PR TITLE
eliminate benign libcuda warning when OpenMPI is configured with --with-cuda=internal

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-GCC-10.3.0.eb
@@ -27,7 +27,7 @@ checksums = [
     # OpenMPI-4.1.0-1-pml-ucx-datatype-memleak.patch
     'a94a74b174ce783328abfd3656ff5196b89ef4c819fe4c8b8a0f1277123e76ea',
     # OpenMPI-4.1.1_build-with-internal-cuda-header.patch
-    '1ceb82b19f62da2525357debaae694d7751b6352adae7ffa55c71e19a4d7101c',
+    '63eac52736bdf7644c480362440a7f1f0ae7c7cae47b7565f5635c41793f8c83',
     # OpenMPI-4.1.1_opal-datatype-cuda-performance.patch
     'b767c7166cf0b32906132d58de5439c735193c9fd09ec3c5c11db8d5fa68750e',
 ]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-GCC-11.2.0.eb
@@ -28,7 +28,7 @@ checksums = [
     # OpenMPI-4.1.0-1-pml-ucx-datatype-memleak.patch
     'a94a74b174ce783328abfd3656ff5196b89ef4c819fe4c8b8a0f1277123e76ea',
     # OpenMPI-4.1.1_build-with-internal-cuda-header.patch
-    '1ceb82b19f62da2525357debaae694d7751b6352adae7ffa55c71e19a4d7101c',
+    '63eac52736bdf7644c480362440a7f1f0ae7c7cae47b7565f5635c41793f8c83',
     # OpenMPI-4.1.1_opal-datatype-cuda-performance.patch
     'b767c7166cf0b32906132d58de5439c735193c9fd09ec3c5c11db8d5fa68750e',
 ]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1_build-with-internal-cuda-header.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1_build-with-internal-cuda-header.patch
@@ -1,25 +1,29 @@
 Allow building Open MPI with --with-cuda=internal, by providing an
-internal minimal cuda.h header file. This eliminate the CUDA
+internal minimal cuda.h header file. This eliminates the CUDA
 (build)dependency; as long as the runtime CUDA version is 8.0+,
 libcuda.so will be dlopen'ed and used successfully.
 
+This then also sets the default value of opal_warn_on_missing_libcuda to false
+as missing libcuda is then a common situation.
 Author: Bart Oldeman <bart.oldeman@calculquebec.ca>
 --- openmpi-4.1.3.orig/config/opal_check_cuda.m4	2022-03-31 16:04:13.000000000 +0000
-+++ openmpi-4.1.3/config/opal_check_cuda.m4	2022-05-04 17:37:57.576260311 +0000
-@@ -45,6 +45,12 @@
++++ openmpi-4.1.3/config/opal_check_cuda.m4	2022-06-01 23:30:09.255003842 +0000
+@@ -45,6 +45,14 @@
  # macro as that would error out after not finding it in the first directory.
  # Note that anywhere CUDA aware code is in the Open MPI repository requires
  # us to make use of AC_REQUIRE to ensure this check has been done.
 +opal_check_cuda_internal=""
++OPAL_WARN_ON_MISSING_LIBCUDA_DEFAULT=1
 +AS_IF([test "$with_cuda" = "internal"],
 +      [AC_MSG_RESULT([internal support requested])
 +       with_cuda="${OPAL_TOP_SRCDIR}/opal/mca/common/cuda/cuda"
 +       opal_check_cuda_internal=" (internal)"
++       OPAL_WARN_ON_MISSING_LIBCUDA_DEFAULT=0
 +      ])
  AS_IF([test "$with_cuda" = "no" || test "x$with_cuda" = "x"],
        [opal_check_cuda_happy="no"
         AC_MSG_RESULT([not set (--with-cuda=$with_cuda)])],
-@@ -124,7 +130,7 @@
+@@ -124,7 +132,7 @@
      CUDA_SUPPORT=0
  fi
  
@@ -28,6 +32,30 @@ Author: Bart Oldeman <bart.oldeman@calculquebec.ca>
  
  AM_CONDITIONAL([OPAL_cuda_support], [test "x$CUDA_SUPPORT" = "x1"])
  AC_DEFINE_UNQUOTED([OPAL_CUDA_SUPPORT],$CUDA_SUPPORT,
+@@ -144,6 +152,9 @@
+ AC_DEFINE_UNQUOTED([OPAL_CUDA_GDR_SUPPORT],$CUDA_VERSION_60_OR_GREATER,
+                    [Whether we have CUDA GDR support available])
+ 
++AM_CONDITIONAL([OPAL_warn_on_missing_libcuda_default], [test "x$OPAL_WARN_ON_MISSING_LIBCUDA_DEFAULT" = "x1"])
++AC_DEFINE_UNQUOTED([OPAL_WARN_ON_MISSING_LIBCUDA_DEFAULT],$OPAL_WARN_ON_MISSING_LIBCUDA_DEFAULT,
++                   [Whether to warn by default if libcuda is not available])
+ ])
+ 
+ dnl
+--- openmpi-4.1.3.orig/opal/runtime/opal_params.c	2022-03-31 16:04:13.000000000 +0000
++++ openmpi-4.1.3/opal/runtime/opal_params.c	2022-06-01 23:23:11.127963103 +0000
+@@ -246,7 +246,11 @@
+         return ret;
+     }
+ 
++#if OPAL_WARN_ON_MISSING_LIBCUDA_DEFAULT == 1
+     opal_warn_on_missing_libcuda = true;
++#else
++    opal_warn_on_missing_libcuda = false;
++#endif
+     ret = mca_base_var_register ("opal", "opal", NULL, "warn_on_missing_libcuda",
+                                  "Whether to print a message when CUDA support is enabled but libcuda is not found",
+                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
 --- openmpi-4.1.3.orig/opal/mca/common/cuda/cuda/cuda.h	1970-01-01 00:00:00.000000000 +0000
 +++ openmpi-4.1.3/opal/mca/common/cuda/cuda/cuda.h	2022-05-04 18:52:14.991300184 +0000
 @@ -0,0 +1,60 @@

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.4-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.4-GCC-11.3.0.eb
@@ -15,7 +15,7 @@ patches = [
 checksums = [
     '92912e175fd1234368c8730c03f4996fe5942e7479bb1d10059405e7f2b3930d',  # openmpi-4.1.4.tar.bz2
     # OpenMPI-4.1.1_build-with-internal-cuda-header.patch
-    '1ceb82b19f62da2525357debaae694d7751b6352adae7ffa55c71e19a4d7101c',
+    '63eac52736bdf7644c480362440a7f1f0ae7c7cae47b7565f5635c41793f8c83',
     # OpenMPI-4.1.1_opal-datatype-cuda-performance.patch
     'b767c7166cf0b32906132d58de5439c735193c9fd09ec3c5c11db8d5fa68750e',
 ]


### PR DESCRIPTION
If libcuda.so is not found then Open MPI will warn, but this is a
common situation if the base Open MPI tries to find libcuda.so even
on nodes without GPUs. Therefore disable this warning by default
if we use --with-cuda=internal in configure.

edit (by @boegel): just for reference, here's the warning that is produced without this enhanced patch:
```
The library attempted to open the following supporting CUDA libraries,
but each of them failed.  CUDA-aware support is disabled.
libcuda.so.1: cannot open shared object file: No such file or directory
libcuda.dylib: cannot open shared object file: No such file or directory
/usr/lib64/libcuda.so.1: cannot open shared object file: No such file or directory
/usr/lib64/libcuda.dylib: cannot open shared object file: No such file or directory
If you are not interested in CUDA-aware support, then run with
--mca opal_warn_on_missing_libcuda 0 to suppress this message.  If you are interested
in CUDA-aware support, then try setting LD_LIBRARY_PATH to the location
of libcuda.so.1 to get passed this issue.
```