### PR TITLE
add sysroot patch to Rust 1.60.0 (GCCcore/11.3.0)

### DIFF
--- a/easybuild/easyconfigs/r/Rust/Rust-1.60.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/r/Rust/Rust-1.60.0-GCCcore-11.3.0.eb
@@ -11,7 +11,11 @@ toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 
 source_urls = ['https://static.rust-lang.org/dist/']
 sources = ['rustc-%(version)s-src.tar.gz']
-checksums = ['20ca826d1cf674daf8e22c4f8c4b9743af07973211c839b85839742314c838b7']
+patches = ['Rust-1.60_sysroot-fix-interpreter.patch']
+checksums = [
+    '20ca826d1cf674daf8e22c4f8c4b9743af07973211c839b85839742314c838b7',  # rustc-1.60.0-src.tar.gz
+    'b59ed4c2591fc9098277299be21dd6752654f6f193d8652b7d21cb0fa0dd8716',  # Rust-1.60_sysroot-fix-interpreter.patch
+]
 
 builddependencies = [
     ('binutils', '2.38'),


### PR DESCRIPTION
requires:
- [x] #15586

(created using `eb --new-pr`)
