### PR TITLE
in-place update for cryoDRGN to v0.3.5 with foss/2021a to fix compatibility issue with PyTorch v1.10

### DIFF
--- a/easybuild/easyconfigs/c/cryoDRGN/cryoDRGN-0.3.5-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/c/cryoDRGN/cryoDRGN-0.3.5-foss-2021a-CUDA-11.3.1.eb
@@ -1,7 +1,7 @@
 easyblock = 'PythonBundle'
 
 name = 'cryoDRGN'
-version = '0.3.4'
+version = '0.3.5'
 versionsuffix = '-CUDA-11.3.1'
 
 homepage = 'https://cb.csail.mit.edu/cb/cryodrgn/'
@@ -51,7 +51,7 @@ exts_list = [
         ],
         'source_urls': ['https://github.com/zhonge/cryodrgn/archive'],
         'sources': ['%(version)s.tar.gz'],
-        'checksums': ['5be9709a2bd19a4ab7c80acd82eef5bfbcdf02b4dd8dcb61113636fa5d44d0c5'],
+        'checksums': ['93f0c939376154bcd5c677406251a6aff794e5d62299a01cdecae1c4947d38e4'],
     }),
 ]
 
@@ -60,7 +60,7 @@ fix_python_shebang_for = ['bin/*.py']
 local_scripts = [
     'add_psize', 'filter_mrcs', 'filter_pkl', 'filter_star', 'flip_hand', 'fsc', 'invert_contrast', 'kmeans',
     'phase_flip', 'plotfsc', 'plot_loss', 'plot_z1', 'plot_z2', 'plot_z_pca', 'run_umap', 'translate_stack', 'tsne',
-    'view_header', 'view_stack', 'write_starfile'
+    'view_header', 'view_stack',
 ]
 
 sanity_check_paths = {


### PR DESCRIPTION
cfr. https://github.com/zhonge/cryodrgn/issues/81, which is fixed with https://github.com/zhonge/cryodrgn/commit/80aa37612a5eda018f0553a23a26c8ad38fd2459, which is included in cryoDRGN v0.3.5