### PR TITLE
add alternative checksums for class, nnet, spatial extensions in R v4.2.0 easyconfig

### DIFF
--- a/easybuild/easyconfigs/r/R/R-4.2.0-foss-2021b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.2.0-foss-2021b.eb
@@ -539,7 +539,8 @@ exts_list = [
         'checksums': ['eff3a92756ca34cdc1661fa36d2bf7fc8e9f4132d2f1ef9ed0105c83594618bf'],
     }),
     ('class', '7.3-20', {
-        'checksums': ['e65b046bc72b312ff0c5dc7feba4fa3e9bc63387274d44911493782b85f65483'],
+        'checksums': [('e65b046bc72b312ff0c5dc7feba4fa3e9bc63387274d44911493782b85f65483',
+                       '93956d7b66ece2261e8846a1703e28a838c2621e366016f792ad48741f230205')],
     }),
     ('proxy', '0.4-26', {
         'checksums': ['676bad821343974e0297a0566c4bf0cf0ea890104906a745b87d3b5989c81a4d'],
@@ -548,7 +549,8 @@ exts_list = [
         'checksums': ['9bf9a15e7ce0b9b1a57ce3048d29cbea7f2a5bb2e91271b1b6aaafe07c852226'],
     }),
     ('nnet', '7.3-17', {
-        'checksums': ['ee750bb8164aa058edf93823af987ab2c7ec64128dce2abeaae1b7d3661e9a67'],
+        'checksums': [('ee750bb8164aa058edf93823af987ab2c7ec64128dce2abeaae1b7d3661e9a67',
+                       'd86871d54e4a331cd5e00da28a2f42a56d8976084578ed2fcdb3a7ad25d4dfaa')],
     }),
     ('minqa', '1.2.4', {
         'checksums': ['cfa193a4a9c55cb08f3faf4ab09c11b70412523767f19894e4eafc6e94cccd0c'],
@@ -845,7 +847,8 @@ exts_list = [
         'checksums': ['a81710357de2dcdaf00d9fa30a29cde0dd83616edc358452fd6105ea88f34218'],
     }),
     ('spatial', '7.3-15', {
-        'checksums': ['e5613be94d6f5c1f54813dadc96e4a86b3417dea28106cc90cb24dfd6c3c8cef'],
+        'checksums': [('e5613be94d6f5c1f54813dadc96e4a86b3417dea28106cc90cb24dfd6c3c8cef',
+                       'de1dafbccfde599ae24c5a78dbbc2df746d17f4c97d7b1c282a03ddff2f23ecf')],
     }),
     ('VGAM', '1.1-6', {
         'checksums': ['446a61bac5dd4794e05d20c2f3901eec54afac52c6e23ce2787c5575170dd417'],


### PR DESCRIPTION
As usual, only actual change in the "new" source tarballs is the publication date in the `DESCRIPTION` file:

```diff
$ diff -ru class.old class
diff -ru class.old/DESCRIPTION class/DESCRIPTION
--- class.old/DESCRIPTION       2022-01-13 09:05:10.000000000 +0100
+++ class/DESCRIPTION   2022-01-16 11:24:56.000000000 +0100
@@ -19,4 +19,4 @@
   William Venables [cph]
 Maintainer: Brian Ripley <ripley@stats.ox.ac.uk>
 Repository: CRAN
-Date/Publication: 2022-01-13 08:05:10 UTC
+Date/Publication: 2022-01-16 10:24:56 UTC
diff -ru class.old/MD5 class/MD5
--- class.old/MD5       2022-01-13 09:05:10.000000000 +0100
+++ class/MD5   2022-01-16 11:24:56.000000000 +0100
@@ -1,4 +1,4 @@
-c85caea72c963aee6dfa23c3c0309fc0 *DESCRIPTION
+e965faf1b6a7e86497d8047c9c255042 *DESCRIPTION
 a0e96c11b4d12e246a178ca1e77f7f7e *LICENCE.note
 a92febb02a17971969afc1e4e4067279 *NAMESPACE
 44e5755ae2d5d1f1b8509879577c17a5 *R/SOM.R
```
```diff
$ diff -ru nnet.old nnet
diff -ru nnet.old/DESCRIPTION nnet/DESCRIPTION
--- nnet.old/DESCRIPTION        2022-01-13 09:05:12.000000000 +0100
+++ nnet/DESCRIPTION    2022-01-16 11:25:14.000000000 +0100
@@ -19,4 +19,4 @@
   William Venables [cph]
 Maintainer: Brian Ripley <ripley@stats.ox.ac.uk>
 Repository: CRAN
-Date/Publication: 2022-01-13 08:05:12 UTC
+Date/Publication: 2022-01-16 10:25:14 UTC
diff -ru nnet.old/MD5 nnet/MD5
--- nnet.old/MD5        2022-01-13 09:05:12.000000000 +0100
+++ nnet/MD5    2022-01-16 11:25:14.000000000 +0100
@@ -1,4 +1,4 @@
-b3526e04aaa301b81f8effe5d622818b *DESCRIPTION
+25755a34686d1e700c6882e1152a781e *DESCRIPTION
 96ca8858604cc2dad175578a3481a5de *LICENCE.note
 3108fb45014de53cb6a33bdac2bc71b3 *NAMESPACE
 bddd60ee2fc196f68a625aae7a08aa56 *R/multinom.R
```
```diff
$ diff -ru spatial.old spatial
diff -ru spatial.old/DESCRIPTION spatial/DESCRIPTION
--- spatial.old/DESCRIPTION     2022-01-13 09:05:14.000000000 +0100
+++ spatial/DESCRIPTION 2022-01-16 11:25:16.000000000 +0100
@@ -21,4 +21,4 @@
   William Venables [cph]
 Maintainer: Brian Ripley <ripley@stats.ox.ac.uk>
 Repository: CRAN
-Date/Publication: 2022-01-13 08:05:14 UTC
+Date/Publication: 2022-01-16 10:25:16 UTC
diff -ru spatial.old/MD5 spatial/MD5
--- spatial.old/MD5     2022-01-13 09:05:14.000000000 +0100
+++ spatial/MD5 2022-01-16 11:25:16.000000000 +0100
@@ -1,4 +1,4 @@
-1ec4417e55ee0381307621dbd6833460 *DESCRIPTION
+d61177896fc8037fd9bf7c8ad1948a3d *DESCRIPTION
 9d3ab186ed88fca8f9806d8bb4a4fd56 *LICENCE.note
 9669a5ba859da001694e764789a4ce73 *NAMESPACE
 e917fff38af0195c39197a553712ebd5 *R/kr.R
```