### PR TITLE
fix set-alias statements for MaxQuant v2.0.3.0

### DIFF
--- a/easybuild/easyconfigs/m/MaxQuant/MaxQuant-2.0.3.0-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/m/MaxQuant/MaxQuant-2.0.3.0-GCCcore-11.2.0.eb
@@ -26,8 +26,8 @@ sanity_check_commands = [
     ("mono $EBROOTMAXQUANT/bin/MaxQuantCmd.exe --help 2>&1 | grep -q USAGE", '')]
 
 modaliases = {
-    'maxquantcmd': 'mono $EBROOTMAXQUANT/bin/%(name)sCmd.exe',
-    'maxquantgui': 'mono $EBROOTMAXQUANT/bin/%(name)sGui.exe',
+    'maxquantcmd': 'mono %(installdir)s/bin/%(name)sCmd.exe',
+    'maxquantgui': 'mono %(installdir)s/bin/%(name)sGui.exe',
 }
 
 modloadmsg = """


### PR DESCRIPTION
Amends ``$EBROOTMAXQUANT`` to ``%(installdir)s`` as this variable would be undefined (as a TCL variable).