### PR TITLE
add Autotools build dependency to R 4.2.0 w/ foss 2021b

### DIFF
--- a/easybuild/easyconfigs/r/R/R-4.2.0-foss-2021b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.2.0-foss-2021b.eb
@@ -18,6 +18,7 @@ checksums = [
 builddependencies = [
     ('pkg-config', '0.29.2'),
     ('Xvfb', '1.20.13'),
+    ('Autotools', '20210726'),
 ]
 dependencies = [
     ('X11', '20210802'),


### PR DESCRIPTION
fixes the same issue I also saw in 4.2.1: https://github.com/easybuilders/easybuild-easyconfigs/pull/15767#issuecomment-1175049808

(created using `eb --new-pr`)
