### PR TITLE
[foss/2022a] switch to Java v13 as dependency for R v4.2.1

### DIFF
--- a/easybuild/easyconfigs/r/R/R-4.2.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/r/R/R-4.2.1-foss-2022a.eb
@@ -31,7 +31,7 @@ dependencies = [
     ('libpng', '1.6.37'),  # for plotting in R
     ('libjpeg-turbo', '2.1.3'),  # for plottting in R
     ('LibTIFF', '4.3.0'),
-    ('Java', '11', '', True),
+    ('Java', '13', '', True),
     ('Tk', '8.6.12'),  # for tcltk
     ('cURL', '7.83.0'),  # for RCurl
     ('libxml2', '2.9.13'),  # for XML


### PR DESCRIPTION
We're using `Java/13` as dependency in `Bazel-5.1.1-GCCcore-11.3.0.eb`, while we're still using `Java/11` in `R-4.2.1-foss-2022a.eb`.
Under the assumption that this wasn't deliberate (@branfosj?), we should sync this up in the `2022a` generation of easyconfigs.