### PR TITLE
Update LAMMPS 23Jun2022 for latest bugfix sources

### DIFF
--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-23Jun2022-foss-2021a-kokkos.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-23Jun2022-foss-2021a-kokkos.eb
@@ -20,9 +20,9 @@ toolchainopts = {'openmp': True, 'usempi': True}
 # 'https://github.com/lammps/lammps/archive/'
 source_urls = [GITHUB_LOWER_SOURCE]
 sources = [
-    'stable_%(version)s.tar.gz',
+    'stable_%(version)s_update1.tar.gz',
 ]
-checksums = ['d27ede095c9f00cd13a26f967a723d07cf8f4df65c700ed73573577bc173d5ce']
+checksums = ['58e3b2b984f8935bb0db5631e143be2826c45ffd48844f7c394f36624a3e17a2']
 
 builddependencies = [
     ('CMake', '3.20.1'),

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-23Jun2022-foss-2021b-kokkos.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-23Jun2022-foss-2021b-kokkos.eb
@@ -19,8 +19,8 @@ toolchainopts = {'openmp': True, 'usempi': True}
 
 # 'https://github.com/lammps/lammps/archive/'
 source_urls = [GITHUB_LOWER_SOURCE]
-sources = ['stable_%(version)s.tar.gz']
-checksums = ['d27ede095c9f00cd13a26f967a723d07cf8f4df65c700ed73573577bc173d5ce']
+sources = ['stable_%(version)s_update1.tar.gz']
+checksums = ['58e3b2b984f8935bb0db5631e143be2826c45ffd48844f7c394f36624a3e17a2']
 
 builddependencies = [
     ('CMake', '3.22.1'),


### PR DESCRIPTION
We haven't made a release yet and the first update for the latest stable version of LAMMPS has landed, so makes sense to update the sources