### PR TITLE
WIP: add amd toolchains

### DIFF
--- a/easybuild/easyconfigs/a/AOCC/AOCC-3.2.0.eb
+++ b/easybuild/easyconfigs/a/AOCC/AOCC-3.2.0.eb
@@ -1,0 +1,26 @@
+name = 'AOCC'
+version = '3.2.0'
+
+homepage = 'https://developer.amd.com/amd-aocc/'
+description = "AMD Optimized C/C++ & Fortran compilers (AOCC) based on LLVM 13.0"
+
+# Clang also depends on libstdc++ during runtime, but this dependency is
+# already specified as the toolchain.
+toolchain = SYSTEM
+
+source_urls = ['http://developer.amd.com/wordpress/media/files/']
+sources = ['aocc-compiler-%(version)s.tar']
+checksums = ['8493525b3df77f48ee16f3395a68ad4c42e18233a44b4d9282b25dbb95b113ec']
+
+clangversion = '13.0.0'
+
+local_gccver = '11.3.0'
+dependencies = [
+    ('GCCcore', local_gccver),
+    ('binutils', '2.38', '', ('GCCcore', local_gccver)),
+    ('ncurses', '6.3', '', ('GCCcore', local_gccver)),
+    ('zlib', '1.2.12', '', ('GCCcore', local_gccver)),
+    ('libxml2', '2.9.13', '', ('GCCcore', local_gccver)),
+]
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/a/amd/amd-2022a.eb
+++ b/easybuild/easyconfigs/a/amd/amd-2022a.eb
@@ -1,0 +1,37 @@
+easyblock = 'Toolchain'
+
+name = 'amd'
+version = '2022a'
+
+homepage = 'None'
+description = """AMD Optimizing C Compiler (AOCC) based compiler toolchain, including
+ OpenMPI for MPI support and AOCL libraries."""
+
+toolchain = SYSTEM
+
+local_aoccver = '3.2.0'
+local_aoclver = '3.2'
+
+# toolchains used to build foss dependencies
+local_compiler_tc = ('AOCC', local_aoccver)
+local_comp_mpi_tc = ('aompi', version)
+
+# we need AOCC and OpenMPI as explicit dependencies instead of aompi toolchain
+# because of toolchain preparation functions
+dependencies = [
+    ('AOCC', local_aoccver),
+    ('OpenMPI', '4.1.4', '', local_compiler_tc),
+    ('BLIS', local_aoclver, '-amd', local_compiler_tc),
+    ('libFLAME', local_aoclver, '-amd', (local_compiler_tc)),
+    ('FFTW', '3.3.10', '-amd', local_comp_mpi_tc),
+    ('ScaLAPACK', local_aoclver, '-amd', local_comp_mpi_tc),
+    # TODO add more AOCL libs
+    # https://developer.amd.com/wp-content/resources/57404_User_Guide_AMD_AOCL_v3.2_GA.pdf
+    # ('AOCL-RNG', local_aoclver, ...)
+    # ('AOCL-SecureRNG', local_aoclver, ...)
+    # ('AOCL-Sparse', local_aoclver, ...)
+    # ('AOCL-LibMem', local_aoclver, ...)
+    # ('AOCL-Cryptography', local_aoclver, ...)
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/a/aompi/aompi-2022a.eb
+++ b/easybuild/easyconfigs/a/aompi/aompi-2022a.eb
@@ -1,0 +1,19 @@
+easyblock = 'Toolchain'
+
+name = 'aompi'
+version = '2022a'
+
+homepage = '(none)'
+description = """AOCC based compiler toolchain, including OpenMPI for MPI support."""
+
+toolchain = SYSTEM
+
+local_aoccver = '3.2.0'
+
+# compiler toolchain dependencies
+dependencies = [
+    ('AOCC', local_aoccver),  # includes both AOCC and binutils
+    ('OpenMPI', '4.1.4', '', ('AOCC', local_aoccver)),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/b/BLIS/BLIS-3.2-AOCC-3.2.0-amd.eb
+++ b/easybuild/easyconfigs/b/BLIS/BLIS-3.2-AOCC-3.2.0-amd.eb
@@ -1,0 +1,47 @@
+easyblock = 'ConfigureMake'
+
+name = 'BLIS'
+version = '3.2'
+versionsuffix = '-amd'
+
+homepage = 'https://developer.amd.com/amd-cpu-libraries/blas-library/'
+description = """AMD's fork of BLIS. BLIS is a portable software framework for instantiating high-performance
+BLAS-like dense linear algebra libraries."""
+
+toolchain = {'name': 'AOCC', 'version': '3.2.0'}
+
+source_urls = ['https://github.com/amd/blis/archive/']
+sources = ['%(version)s.tar.gz']
+patches = [
+    '%(name)s-0.8.1_enable_ppc_autodetect.patch',
+    '%(name)s-0.8.1_fix_dgemm-fpe-signalling-on-broadwell.patch',
+]
+checksums = [
+    '5a400ee4fc324e224e12f73cc37b915a00f92b400443b15ce3350278ad46fff6',  # 3.2.tar.gz
+    'b8a3d564a8d4f205e70241765ddfd28331c3c12355ef9c44172c9a0cab9f0111',  # BLIS-0.8.1_enable_ppc_autodetect.patch
+    # BLIS-0.8.1_fix_dgemm-fpe-signalling-on-broadwell.patch
+    '345fa39933e9d1442d2eb1e4ed9129df3fe4aefecf4d104e5d4f25b3bca24d0d',
+]
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('Python', '3.10.4'),
+    ('Perl', '5.34.1'),
+]
+
+# Build Serial and multithreaded library
+configopts = ['--enable-cblas --enable-shared CC="$CC" auto',
+              '--enable-cblas --enable-threading=openmp --enable-shared CC="$CC" auto']
+
+runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['include/blis/cblas.h', 'include/blis/blis.h',
+              'lib/libblis.a', 'lib/libblis.%s' % SHLIB_EXT,
+              'lib/libblis-mt.a', 'lib/libblis-mt.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+modextrapaths = {'CPATH': 'include/blis'}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.10-aompi-2022a-amd.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.10-aompi-2022a-amd.eb
@@ -1,0 +1,25 @@
+name = 'FFTW'
+version = '3.3.10'
+local_amd_fftw_ver = '3.2'
+versionsuffix = '-amd'
+
+homepage = 'https://developer.amd.com/amd-aocl/fftw/'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+in one or more dimensions, of arbitrary input size, and of both real and complex data.
+AMD FFTW includes selective kernels and routines optimized for the AMD EPYC™ processor family."""
+
+toolchain = {'name': 'aompi', 'version': '2022a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/amd/amd-fftw/archive/']
+sources = [{
+    'download_filename': '%s.tar.gz' % local_amd_fftw_ver,
+    'filename': 'amd-fftw-%s.tar.gz' % local_amd_fftw_ver,
+}]
+checksums = ['31cab17a93e03b5b606e88dd6116a1055b8f49542d7d0890dbfcca057087b8d0']
+
+configopts = '--enable-amd-opt'
+
+runtest = 'check'
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/l/libFLAME/libFLAME-3.2-AOCC-3.2.0-amd.eb
+++ b/easybuild/easyconfigs/l/libFLAME/libFLAME-3.2-AOCC-3.2.0-amd.eb
@@ -1,0 +1,60 @@
+easyblock = 'ConfigureMake'
+
+name = 'libFLAME'
+version = '3.2'
+versionsuffix = '-amd'
+
+homepage = 'https://developer.amd.com/amd-cpu-libraries/blas-library/#libflame'
+description = """AMD fork of libFLAME. libFLAME is a portable library for dense matrix computations,
+providing much of the functionality present in LAPACK."""
+
+toolchain = {'name': 'AOCC', 'version': '3.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/amd/libflame/archive/']
+sources = ['%(version)s.tar.gz']
+patches = ['libFLAME-3.2-AOCC_ignore_lwp.patch']
+checksums = [
+    '6b5337fb668b82d0ed0a4ab4b5af4e2f72e4cedbeeb4a8b6eb9a3ef057fb749a',  # 3.2.tar.gz
+    '7e5927ee08d0620d78f73293c4c0e154a51a4d3346573e9a047614a0bd431772',  # libFLAME-3.2-AOCC_ignore_lwp.patch
+]
+
+# '--enable-max-arg-list-hack --enable-dynamic-build' requires 'file' function from GNU Make 4.x
+builddependencies = [
+    ('binutils', '2.38'),
+    ('Python', '3.10.4'),
+    ('make', '4.3'),  # needed on Cent OS 7  where make 3 is installed
+]
+
+dependencies = [('BLIS', version, versionsuffix)]
+
+# Use unset FLIBS to let configure pick up LDFLAGS
+preconfigopts = 'unset FLIBS && '
+preconfigopts += 'LIBS="-lblis-mt $LIBS" '
+preconfigopts += 'LDFLAGS="$LDFLAGS -L$EBROOTBLIS/lib -fopenmp -lalm -lpthread" '
+preconfigopts += 'CFLAGS="$CFLAGS -I$EBROOTBLIS/include/blis" '
+
+
+configopts = '--enable-max-arg-list-hack '
+configopts += '--enable-lapack2flame '
+configopts += '--enable-external-lapack-interfaces '
+configopts += '--enable-cblas-interfaces '
+configopts += '--enable-dynamic-build '
+configopts += '--enable-multithreading=openmp '
+configopts += '--enable-amd-aocc-flags '
+
+# libFLAME C++ Template API tests
+# runtest = 'checkcpp LIBBLAS=$EBROOTBLIS/lib/libblis.a'
+
+# sanity_check_commands = [
+#     'cd %(builddir)s/%(namelower)s-%(version)s/test '
+#     '&& make LIBBLAS=$EBROOTBLIS/lib/libblis-mt.so LDFLAGS="-fopenmp -lm -lpthread" '
+#     '&& ./test_libfame.x'
+# ]
+
+sanity_check_paths = {
+    'files': ['include/FLAME.h', 'lib/libflame.a', 'lib/libflame.%s' % SHLIB_EXT],
+    'dirs': ['lib'],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/l/libFLAME/libFLAME-3.2-AOCC_ignore_lwp.patch
+++ b/easybuild/easyconfigs/l/libFLAME/libFLAME-3.2-AOCC_ignore_lwp.patch
@@ -1,0 +1,19 @@
+Do not try to interpret -lwp as linker flag.
+Inspired by https://lists.gnu.org/r/bug-autoconf/2020-07/msg00091.html
+This would be fixed in recent autoconf versions but we cannot use them as
+./configure contains amd modifiations
+
+Author: Christoph Siegert (Leipzig University, christoph.siegert@uni-leipzig.de)
+
+diff --git a/configure b/configure
+index a9ab9824..1a312e5d 100755
+--- a/configure
++++ b/configure
+@@ -4677,6 +4677,7 @@ fi
+ 	  ac_cv_f77_libs="$ac_cv_f77_libs $ac_arg"
+ 	  ;;
+ 	  # Ignore everything else.
++    -target-feature) ${2+shift};; # Defend against 'flang -target-feature -lwp'.
+   esac
+ done
+ # restore positional arguments

--- a/easybuild/easyconfigs/m/make/make-4.3-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/m/make/make-4.3-GCCcore-11.3.0.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'make'
+version = '4.3'
+
+homepage = 'https://www.gnu.org/software/make/make.html'
+description = "GNU version of make utility"
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['e05fdde47c5f7ca45cb697e973894ff4f5d79e13b750ed57d7b66d8defc78e19']
+
+builddependencies = [('binutils', '2.38')]
+
+postinstallcmds = ["cd %(installdir)s/bin && ln -s make gmake"]
+
+sanity_check_paths = {
+    'files': ['bin/gmake', 'bin/make'],
+    'dirs': []
+}
+
+sanity_check_commands = [
+    "gmake --help",
+    "make --help",
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.4-AOCC-3.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.4-AOCC-3.2.0.eb
@@ -1,0 +1,50 @@
+name = 'OpenMPI'
+version = '4.1.4'
+
+homepage = 'https://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-3 implementation."""
+
+toolchain = {'name': 'AOCC', 'version': '3.2.0'}
+
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+sources = [SOURCELOWER_TAR_BZ2]
+patches = [
+    'OpenMPI-4.1.1_build-with-internal-cuda-header.patch',
+    'OpenMPI-4.1.1_opal-datatype-cuda-performance.patch',
+]
+checksums = [
+    '92912e175fd1234368c8730c03f4996fe5942e7479bb1d10059405e7f2b3930d',  # openmpi-4.1.4.tar.bz2
+    # OpenMPI-4.1.1_build-with-internal-cuda-header.patch
+    '63eac52736bdf7644c480362440a7f1f0ae7c7cae47b7565f5635c41793f8c83',
+    # OpenMPI-4.1.1_opal-datatype-cuda-performance.patch
+    'b767c7166cf0b32906132d58de5439c735193c9fd09ec3c5c11db8d5fa68750e',
+]
+
+builddependencies = [
+    ('pkgconf', '1.8.0'),
+    ('Perl', '5.34.1'),
+    ('Autotools', '20220317'),
+]
+
+dependencies = [
+    ('zlib', '1.2.12'),
+    ('hwloc', '2.7.1'),
+    ('libevent', '2.1.12'),
+    ('UCX', '1.12.1'),
+    ('libfabric', '1.15.1'),
+    ('PMIx', '4.1.2'),
+    ('UCC', '1.0.0'),
+]
+
+preconfigopts = './autogen.pl --force && '
+
+# CUDA related patches and custom configure option can be removed if CUDA support isn't wanted.
+configopts = '--with-cuda=internal '
+
+# disable MPI1 compatibility for now, see what breaks...
+# configopts += '--enable-mpi1-compatibility '
+
+# to enable SLURM integration (site-specific)
+# configopts += '--with-slurm --with-pmi=/usr/include/slurm --with-pmi-libdir=/usr'
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-3.2-aompi-2022a-amd.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-3.2-aompi-2022a-amd.eb
@@ -1,0 +1,41 @@
+name = 'ScaLAPACK'
+version = '3.2'
+versionsuffix = '-amd'
+
+homepage = 'https://www.netlib.org/scalapack/'
+description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
+ redesigned for distributed memory MIMD parallel computers."""
+
+toolchain = {'name': 'aompi', 'version': '2022a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/amd/aocl-scalapack/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['9e00979bb1be39d627bdacb01774bc043029840d542fafc934d16fec3e3b0892']
+
+builddependencies = [
+    ('CMake', '3.23.1'),
+]
+
+dependencies = [
+    ('BLIS', version, versionsuffix),
+    ('libFLAME', version, versionsuffix),
+]
+
+# Config Opts based on AOCL User Guide:
+# https://developer.amd.com/wp-content/resources/57404_User_Guide_AMD_AOCL_v3.2_GA.pdf
+
+configopts = '-DBUILD_SHARED_LIBS=ON '
+configopts += '-DBLAS_LIBRARIES="-fopenmp $EBROOTBLIS/lib/libblis-mt.%s" ' % SHLIB_EXT
+configopts += '-DLAPACK_LIBRARIES="$EBROOTLIBFLAME/lib/libflame.%s" ' % SHLIB_EXT
+configopts += '-DCMAKE_C_COMPILER=mpicc '
+configopts += '-DCMAKE_Fortran_COMPILER=mpif90 '
+configopts += '-DCMAKE_Fortran_FLAGS="-lpthread -fopenmp $DCMAKE_Fortran_FLAGS" '
+configopts += '-DUSE_OPTIMIZED_LAPACK_BLAS=OFF '
+
+sanity_check_paths = {
+    'files': ['lib/libscalapack.%s' % SHLIB_EXT, 'lib64/libscalapack.%s' % SHLIB_EXT],
+    'dirs': ["lib", "lib64"],
+}
+
+moduleclass = 'numlib'


### PR DESCRIPTION
depends on 
- https://github.com/easybuilders/easybuild-framework/pull/4058
- https://github.com/easybuilders/easybuild-easyblocks/pull/2774

Adds easyconfigs for toolchains in https://github.com/easybuilders/easybuild-framework/pull/4058 with AOCC 3.2.0 and AOCL 3.2. GCC and OpenMPI versions are the same as in 2022a toolchains.

TODO:
- should `AOCC` have a `versionsuffix` for `GCCcore`?
- decide on which versioning to use. FFTW is using the upstream versioning 3.10. Everything else got the AOCL version (3.2)
- should we add the non-foss AOCL libraries to the `amd` toolchain (see comments in `amd-2022a.eb`)
- is there a way to get rid of the Rust dependency introduced by Python? 