### PR TITLE
{data}[GCCcore/11.3.0] SoX w/ GCCcore/11.3.0 + additional format support

### DIFF
--- a/easybuild/easyconfigs/s/SoX/SoX-14.4.2-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/s/SoX/SoX-14.4.2-GCC-11.3.0.eb
@@ -1,0 +1,34 @@
+# Institution: IT4Innovations National Supercomputing Center, Czech Republic
+# Author: Jakub Kropacek
+# License: GPLv3
+# Year: 2022
+
+easyblock = 'ConfigureMake'
+
+name = 'SoX'
+version = '14.4.2'
+
+homepage = 'http://sox.sourceforge.net/'
+docurls = 'http://sox.sourceforge.net/Docs/Documentation'
+description = """Sound eXchange, the Swiss Army knife of audio manipulation"""
+
+toolchain = {'name': 'GCC', 'version': '11.3.0'}
+
+source_urls = ['https://sourceforge.net/projects/sox/files/sox/%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['b45f598643ffbd8e363ff24d61166ccec4836fea6d3888881b8df53e3bb55f6c']
+
+dependencies = [
+    ('FLAC', '1.3.4'),
+    ('LAME', '3.100'),
+    ('libvorbis', '1.3.7'),
+    ('FFmpeg', '5.0.1'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/play', 'bin/rec', 'bin/sox', 'bin/soxi', 'include/sox.h',
+              'lib/libsox.la', 'lib/libsox.a', 'lib/pkgconfig/sox.pc', 'lib/libsox.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'include', 'lib', 'lib/pkgconfig', 'share/man'],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/s/SoX/SoX-14.4.2-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/s/SoX/SoX-14.4.2-GCCcore-11.3.0.eb
@@ -33,4 +33,6 @@ sanity_check_paths = {
     'dirs': ['bin', 'include', 'lib', 'lib/pkgconfig', 'share/man'],
 }
 
+sanity_check_commands = ['sox --help']
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/SoX/SoX-14.4.2-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/s/SoX/SoX-14.4.2-GCCcore-11.3.0.eb
@@ -14,7 +14,7 @@ description = """Sound eXchange, the Swiss Army knife of audio manipulation"""
 
 toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 
-source_urls = ['https://sourceforge.net/projects/sox/files/sox/%(version)s']
+source_urls = [SOURCEFORGE_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['b45f598643ffbd8e363ff24d61166ccec4836fea6d3888881b8df53e3bb55f6c']
 

--- a/easybuild/easyconfigs/s/SoX/SoX-14.4.2-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/s/SoX/SoX-14.4.2-GCCcore-11.3.0.eb
@@ -12,11 +12,13 @@ homepage = 'http://sox.sourceforge.net/'
 docurls = 'http://sox.sourceforge.net/Docs/Documentation'
 description = """Sound eXchange, the Swiss Army knife of audio manipulation"""
 
-toolchain = {'name': 'GCC', 'version': '11.3.0'}
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 
 source_urls = ['https://sourceforge.net/projects/sox/files/sox/%(version)s']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['b45f598643ffbd8e363ff24d61166ccec4836fea6d3888881b8df53e3bb55f6c']
+
+builddependencies = [('binutils', '2.38')]
 
 dependencies = [
     ('FLAC', '1.3.4'),


### PR DESCRIPTION
Hi.
Since the existing SoX is built on GCC/8.3.0, I decided to upgrade it and add support for other sound file types after receiving a request for SoX some time ago.

Edit:
To be absolutely clear, here are the changes in supported file formats
```
 OPTIONAL FILE FORMATS
 amrnb......................no
 amrwb......................no
-flac.......................no
+flac.......................yes
 gsm........................yes (in-tree)
 lpc10......................yes (in-tree)
-mp2/mp3....................no
+mp2/mp3....................yes
  id3tag....................no
- lame......................no
+ lame......................yes
+ lame id3tag...............yes
+ dlopen lame...............no
  mad.......................no
  twolame...................no
-oggvorbis..................no
+oggvorbis..................yes
 opus.......................no
 sndfile....................no
 wavpack....................no
```