### PR TITLE
update CI workflows to use Ubuntu 20.04 (since Ubuntu 18.04 is deprecated)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,7 +2,7 @@ name: Static Analysis
 on: [push, pull_request]
 jobs:
   python-linting:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,7 +2,7 @@ name: easyconfigs unit tests
 on: [push, pull_request]
 jobs:
   test-suite:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python: [2.7, 3.6]
@@ -148,7 +148,7 @@ jobs:
           eb --prefix /tmp/$USER/$GITHUB_SHA --sourcepath /tmp/sources M4-1.4.18.eb
 
   test-sdist:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python: [2.7, 3.6, 3.7]


### PR DESCRIPTION
see also https://github.com/actions/runner-images/issues/6002