### PR TITLE
{tools/vis}[GCCcore/11.3.0] Ghostscript v9.56.1, GTK2 v2.24.33

### DIFF
--- a/easybuild/easyconfigs/g/GTK2/GTK2-2.24.33-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/g/GTK2/GTK2-2.24.33-GCCcore-11.3.0.eb
@@ -1,0 +1,35 @@
+easyblock = 'ConfigureMake'
+
+name = 'GTK2'
+version = '2.24.33'
+
+homepage = 'https://developer.gnome.org/gtk+/stable/'
+description = """
+ The GTK+ 2 package contains libraries used for creating graphical user interfaces for applications.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = ['https://ftp.gnome.org/pub/GNOME/sources/gtk+/%(version_major_minor)s']
+sources = ['gtk+-%(version)s.tar.xz']
+checksums = ['ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da']
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('pkgconf', '1.8.0'),
+    ('GObject-Introspection', '1.72.0'),
+]
+dependencies = [
+    ('ATK', '2.38.0'),
+    ('Gdk-Pixbuf', '2.42.8'),
+    ('Pango', '1.50.7'),
+]
+
+configopts = "--disable-silent-rules --disable-glibtest --enable-introspection=yes --disable-visibility "
+
+sanity_check_paths = {
+    'files': ['bin/gtk-update-icon-cache', 'lib/libgtk-x11-2.0.%s' % SHLIB_EXT],
+    'dirs': ['include/gtk-2.0'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GTK2/GTK2-2.24.33-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/g/GTK2/GTK2-2.24.33-GCCcore-11.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'GTK2'
 version = '2.24.33'
 
-homepage = 'https://developer.gnome.org/gtk+/stable/'
+homepage = 'https://www.gtk.org'
 description = """
  The GTK+ 2 package contains libraries used for creating graphical user interfaces for applications.
 """

--- a/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.56.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.56.1-GCCcore-11.3.0.eb
@@ -30,6 +30,7 @@ dependencies = [
     ('GLib', '2.72.1'),
     ('cairo', '1.17.4'),
     ('LibTIFF', '4.3.0'),
+    ('GTK2', '2.24.33'),
 ]
 
 # Do not use local copies of zlib, jpeg, freetype, and png


### PR DESCRIPTION
Currently, Ghostscript refers to GTK2 installed on OS level, I think it's better to include GTK2 as a dependency.