### PR TITLE
{lib}[foss/2020b] edep-sim v3.0.0

### DIFF
--- a/easybuild/easyconfigs/e/edep-sim/edep-sim-3.0.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/e/edep-sim/edep-sim-3.0.0-foss-2020b.eb
@@ -1,0 +1,34 @@
+# Author: Steven Baum (TAMU HPRC)
+# License:  GPLv2
+easyblock = 'CMakeMake'
+
+name = 'edep-sim'
+version = '3.0.0'
+local_root_version = '6.24.06'
+local_python_suffix = '-Python-3.8.6'
+
+homepage = 'https://github.com/ClarkMcGrew/edep-sim'
+description = """The energy deposition simulation is a wrapper around the GEANT4 particle propagation
+ simulation and is intended as a tool to simulate all of the particle propagation and geometry related issues."""
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+
+source_urls = ['https://github.com/ClarkMcGrew/edep-sim/archive/refs/tags/']
+sources = ['%(version)s.tar.gz']
+
+dependencies = [
+    ('binutils', '2.35'),
+    ('CMake', '3.20.1'),
+    ('Xerces-C++', '3.2.3'),
+    ('CLHEP', '2.4.4.0'),
+    ('Geant4', '10.7.1'),
+    ('Python', '3.8.6'),
+    ('ROOT', local_root_version, local_python_suffix),
+]
+
+sanity_check_paths = {
+    'files': ['include/EDepSim/TG4Event.h', 'lib/libedepsim.so'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
This is an easyconfig for a wrapper around Geant4 called edep-sim.  It is new to EB. A user request for compiling this with foss/2020b and some backpropagated prerequisites forced also the creation of a new ROOT/6.24.06-foss-2020b-Python-3.8.6 version, a modified Geant4/10.7.1-GCC-10.2.0 version, and another new to EB package called vdt/0.4.4-GCC-10.2.0.  I assume that all three require additional pull requests.