### PR TITLE
add checksums for PyTorch 1.9.0

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.9.0-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.9.0-fosscuda-2020b.eb
@@ -40,41 +40,28 @@ patches = [
     'PyTorch-1.9.0_skip-nccl-error-tests.patch',
 ]
 checksums = [
-    None,  # can't add proper SHA256 checksum, because source tarball is created locally after recursive 'git clone'
-    # PyTorch-1.6.0_fix-test-dataloader-fixed-affinity.patch
-    'a4208a46cd2098744daaba96cebb96cd91166f8fc616924315e05974bad80c67',
-    'b899aa94d9e60f11ee75a706563312ccefa9cf432756c470caa8e623991c8f18',  # PyTorch-1.7.0_avoid-nan-in-test-torch.patch
-    '622cb1eaeadc06e13128a862d9946bcc1f1edd3d02b259c56a9aecc4d5406b8a',  # PyTorch-1.7.0_disable-dev-shm-test.patch
-    # PyTorch-1.7.1_correctly-pass-jit_opt_level.patch
-    'd4d967d47f8a6172fcbf57f0a61835482968850967c4fdb01108b720696a988d',
-    # PyTorch-1.7.1_fix-alias-violation-in-bitwise-ops.patch
-    'e92f054f1297df83ace901e7af38222787b709ee29580f5f2b89a300ca03666b',
-    '89ac7a8e9e7df2e64cf8404fe3a279f5e9b759fee41c9de3aaff9c22f385c2c6',  # PyTorch-1.8.1_dont-use-gpu-ccc-in-test.patch
-    'eca718ce0ecc61b57659808179cc660919b3c25b5dce326f51c1cc5a5bfb9829',  # PyTorch-1.8.1_fix-arange-on-VSX.patch
-    # PyTorch-1.8.1_fix-faulty-asserts-and-skip-test.patch
-    '1601eacd336e01176bdbdbc5a2207743dc2999b535a738a8e36b3da3e8a2f3b6',
-    # PyTorch-1.8.1_increase-distributed-test-timeout.patch
-    '7a6e512274f0b8673f4f207a5bc53387d88be7e79833f42d20365668b2118071',
-    # PyTorch-1.8.1_skip_dist_autograd_sync_streams.patch
-    '7940e571f41c350d3b634e98b1658a7001c96fdb1b1920835b8f5484ce389d09',
-    # PyTorch-1.9.0_avoid-failures-in-test_unary_ufuncs.patch
-    'f600e6831f8a03af007845687d1e0f65b2394ca89a9dab5178e2cdc9bd384d43',
-    # PyTorch-1.9.0_fix-min-amount-of-devices-for-test.patch
-    'edb180d6967c507c147400a64422ff4499bcd5519f9be8d332890c317359dbad',
-    '8e8b417782e2f3004462c32338e12685e7296d15207f3e3087dcb8015e648f98',  # PyTorch-1.9.0_fix-testnn-on-A100.patch
-    # PyTorch-1.9.0_fix-use-after-destruct-in-cudaipctypes.patch
-    '67960bf9140baf004b07e29f7c2b338e7bc4e4e4f2c931768be44f58526e605f',
-    '1ed5e125f7922ea577d43053a6652aedc21cc036157e101c0e3b9aee9029d3b0',  # PyTorch-1.9.0_fix-kineto-crash.patch
-    'a4733b6b16a0db4ee5f85f2b103abc29bd711cfc5253f8dd8494d2b0c1509516',  # PyTorch-1.9.0_fix-vsx-vector-functions.patch
-    # PyTorch-1.9.0_increase-test-cuda-tolerance.patch
-    '73de855ab1ed38043c7fb2a983927786b83d7547aefed926f19e554e2214838a',
-    # PyTorch-1.9.0_increase-tolerance-for-distributed-tests.patch
-    '725922f0000d51c03f726a34b249db8f53eee7e5c67417774a5113de954f5a5c',
-    # PyTorch-1.9.0_limit-world-size-for-zero-redundancy-opt-test.patch
-    'ff573660913ce055e24cfd194ce747ba5685091c631cfd443eae2a99d56b57ea',
-    # PyTorch-1.9.0_skip-lstm-serialization-test.patch
-    '0fc14e29bd7530bcc09f4212df3c846072b1313216da86b827e102b85d695f49',
-    '9634fb34fedff4589b9175a4e4c3f278b60d4dcbc7b36b0f19604748d32074f0',  # PyTorch-1.9.skip-nccl-error-tests.patch
+    'a082118e3bb0658b25fae8bb04bf496c4fcd845c760acd93f6bff15c2ffadcc8', # PyTorch-1.9.0.tar.gz
+    'a4208a46cd2098744daaba96cebb96cd91166f8fc616924315e05974bad80c67', # PyTorch-1.6.0_fix-test-dataloader-fixed-affinity.patch
+    'b899aa94d9e60f11ee75a706563312ccefa9cf432756c470caa8e623991c8f18', # PyTorch-1.7.0_avoid-nan-in-test-torch.patch
+    '622cb1eaeadc06e13128a862d9946bcc1f1edd3d02b259c56a9aecc4d5406b8a', # PyTorch-1.7.0_disable-dev-shm-test.patch
+    'd4d967d47f8a6172fcbf57f0a61835482968850967c4fdb01108b720696a988d', # PyTorch-1.7.1_correctly-pass-jit_opt_level.patch
+    'e92f054f1297df83ace901e7af38222787b709ee29580f5f2b89a300ca03666b', # PyTorch-1.7.1_fix-alias-violation-in-bitwise-ops.patch
+    '89ac7a8e9e7df2e64cf8404fe3a279f5e9b759fee41c9de3aaff9c22f385c2c6', # PyTorch-1.8.1_dont-use-gpu-ccc-in-test.patch
+    'eca718ce0ecc61b57659808179cc660919b3c25b5dce326f51c1cc5a5bfb9829', # PyTorch-1.8.1_fix-arange-on-VSX.patch
+    '1601eacd336e01176bdbdbc5a2207743dc2999b535a738a8e36b3da3e8a2f3b6', # PyTorch-1.8.1_fix-faulty-asserts-and-skip-test.patch
+    '7a6e512274f0b8673f4f207a5bc53387d88be7e79833f42d20365668b2118071', # PyTorch-1.8.1_increase-distributed-test-timeout.patch
+    '7940e571f41c350d3b634e98b1658a7001c96fdb1b1920835b8f5484ce389d09', # PyTorch-1.8.1_skip_dist_autograd_sync_streams.patch
+    'f600e6831f8a03af007845687d1e0f65b2394ca89a9dab5178e2cdc9bd384d43', # PyTorch-1.9.0_avoid-failures-in-test_unary_ufuncs.patch
+    'edb180d6967c507c147400a64422ff4499bcd5519f9be8d332890c317359dbad', # PyTorch-1.9.0_fix-min-amount-of-devices-for-test.patch
+    '8e8b417782e2f3004462c32338e12685e7296d15207f3e3087dcb8015e648f98', # PyTorch-1.9.0_fix-testnn-on-A100.patch
+    '67960bf9140baf004b07e29f7c2b338e7bc4e4e4f2c931768be44f58526e605f', # PyTorch-1.9.0_fix-use-after-destruct-in-cudaipctypes.patch
+    '1ed5e125f7922ea577d43053a6652aedc21cc036157e101c0e3b9aee9029d3b0', # PyTorch-1.9.0_fix-kineto-crash.patch
+    'a4733b6b16a0db4ee5f85f2b103abc29bd711cfc5253f8dd8494d2b0c1509516', # PyTorch-1.9.0_fix-vsx-vector-functions.patch
+    '73de855ab1ed38043c7fb2a983927786b83d7547aefed926f19e554e2214838a', # PyTorch-1.9.0_increase-test-cuda-tolerance.patch
+    '725922f0000d51c03f726a34b249db8f53eee7e5c67417774a5113de954f5a5c', # PyTorch-1.9.0_increase-tolerance-for-distributed-tests.patch
+    'ff573660913ce055e24cfd194ce747ba5685091c631cfd443eae2a99d56b57ea', # PyTorch-1.9.0_limit-world-size-for-zero-redundancy-opt-test.patch
+    '0fc14e29bd7530bcc09f4212df3c846072b1313216da86b827e102b85d695f49', # PyTorch-1.9.0_skip-lstm-serialization-test.patch
+    '9634fb34fedff4589b9175a4e4c3f278b60d4dcbc7b36b0f19604748d32074f0', # PyTorch-1.9.0_skip-nccl-error-tests.patch
 ]
 
 osdependencies = [OS_PKG_IBVERBS_DEV]


### PR DESCRIPTION
Downloaded the patch files from this repo, plus the upstream PyTorch-1.9.0.tar.gz and sha256sum them all.