### PR TITLE
Fix GitHub download link in libpsl-0.21.1-GCCcore-11.2.0.eb

### DIFF
--- a/easybuild/easyconfigs/l/libpsl/libpsl-0.21.1-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/l/libpsl/libpsl-0.21.1-GCCcore-11.2.0.eb
@@ -8,7 +8,7 @@ description = "C library for the Public Suffix List"
 
 toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
 
-source_urls = ['https://github.com/rockdaboot/libpsl/archive']
+source_urls = ['https://github.com/rockdaboot/libpsl/releases/download/%(version)s']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['ac6ce1e1fbd4d0254c4ddb9d37f1fa99dec83619c1253328155206b896210d4c']
 


### PR DESCRIPTION
The existing download link in this doesn't work anymore. This file was added by #16087.