### PR TITLE
update libxml2, libxslt sources to use gnome.org

### DIFF
--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.10-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.10-GCCcore-10.2.0.eb
@@ -11,12 +11,9 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f']
+source_urls = ['https://download.gnome.org/sources/libxml2/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['593b7b751dd18c2d6abcd0c4bcb29efc203d0b4373a6df98e3a455ea74ae2813']
 
 builddependencies = [('binutils', '2.35')]
 

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.10-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.10-GCCcore-10.3.0.eb
@@ -14,12 +14,9 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f']
+source_urls = ['https://download.gnome.org/sources/libxml2/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['593b7b751dd18c2d6abcd0c4bcb29efc203d0b4373a6df98e3a455ea74ae2813']
 
 builddependencies = [('binutils', '2.36.1')]
 

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.10-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.10-GCCcore-11.2.0.eb
@@ -11,12 +11,9 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f']
+source_urls = ['https://download.gnome.org/sources/libxml2/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['593b7b751dd18c2d6abcd0c4bcb29efc203d0b4373a6df98e3a455ea74ae2813']
 
 builddependencies = [('binutils', '2.37')]
 

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.10-GCCcore-9.2.0.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.10-GCCcore-9.2.0.eb
@@ -11,12 +11,9 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '9.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f']
+source_urls = ['https://download.gnome.org/sources/libxml2/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['593b7b751dd18c2d6abcd0c4bcb29efc203d0b4373a6df98e3a455ea74ae2813']
 
 builddependencies = [('binutils', '2.32')]
 

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.10-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.10-GCCcore-9.3.0.eb
@@ -11,12 +11,9 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f']
+source_urls = ['https://download.gnome.org/sources/libxml2/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['593b7b751dd18c2d6abcd0c4bcb29efc203d0b4373a6df98e3a455ea74ae2813']
 
 builddependencies = [('binutils', '2.34')]
 

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.8-GCCcore-7.2.0.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.8-GCCcore-7.2.0.eb
@@ -11,12 +11,9 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '7.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['0b74e51595654f958148759cfef0993114ddccccbb6f31aee018f3558e8e2732']
+source_urls = ['https://download.gnome.org/sources/libxml2/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['dcca21d624bbbe094fcc104e1f15f2eacfb65aecd0e38ed220aeca56b62c81e2']
 
 builddependencies = [('binutils', '2.29')]
 

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.8-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.8-GCCcore-7.3.0.eb
@@ -11,12 +11,9 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['0b74e51595654f958148759cfef0993114ddccccbb6f31aee018f3558e8e2732']
+source_urls = ['https://download.gnome.org/sources/libxml2/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['dcca21d624bbbe094fcc104e1f15f2eacfb65aecd0e38ed220aeca56b62c81e2']
 
 builddependencies = [('binutils', '2.30')]
 

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.8-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.8-GCCcore-8.2.0.eb
@@ -11,12 +11,9 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['0b74e51595654f958148759cfef0993114ddccccbb6f31aee018f3558e8e2732']
+source_urls = ['https://download.gnome.org/sources/libxml2/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['dcca21d624bbbe094fcc104e1f15f2eacfb65aecd0e38ed220aeca56b62c81e2']
 
 builddependencies = [('binutils', '2.31.1')]
 

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.9-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.9-GCCcore-8.3.0.eb
@@ -11,12 +11,9 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871']
+source_urls = ['https://download.gnome.org/sources/libxml2/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['58a5c05a2951f8b47656b676ce1017921a29f6b1419c45e3baed0d6435ba03f5']
 
 builddependencies = [('binutils', '2.32')]
 

--- a/easybuild/easyconfigs/l/libxslt/libxslt-1.1.32-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/l/libxslt/libxslt-1.1.32-GCCcore-7.3.0.eb
@@ -20,4 +20,9 @@ dependencies = [
     ('libxml2', '2.9.8'),
 ]
 
+sanity_check_paths = {
+    'files': ['bin/xsltproc', 'include/libxslt/xslt.h', 'lib/%%(name)s.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxslt/libxslt-1.1.32-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/l/libxslt/libxslt-1.1.32-GCCcore-7.3.0.eb
@@ -9,12 +9,9 @@ description = """Libxslt is the XSLT C library developed for the GNOME project
 
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['526ecd0abaf4a7789041622c3950c0e7f2c4c8835471515fd77eec684a355460']
+source_urls = ['https://download.gnome.org/sources/libxslt/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['b7da90eaa6b0dae9e9a3769e29a757342eef0edb9a7b431424814375414422af']
 
 builddependencies = [('binutils', '2.30')]
 

--- a/easybuild/easyconfigs/l/libxslt/libxslt-1.1.33-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/l/libxslt/libxslt-1.1.33-GCCcore-8.2.0.eb
@@ -9,12 +9,9 @@ description = """Libxslt is the XSLT C library developed for the GNOME project
 
 toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['8e36605144409df979cab43d835002f63988f3dc94d5d3537c12796db90e38c8']
+source_urls = ['https://download.gnome.org/sources/libxslt/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['3944d3a74b4ca6b40f59967e2a587abc6994f6935d697d9fa1b8edd722513e90']
 
 builddependencies = [('binutils', '2.31.1')]
 

--- a/easybuild/easyconfigs/l/libxslt/libxslt-1.1.33-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/l/libxslt/libxslt-1.1.33-GCCcore-8.2.0.eb
@@ -20,4 +20,9 @@ dependencies = [
     ('libxml2', '2.9.8'),
 ]
 
+sanity_check_paths = {
+    'files': ['bin/xsltproc', 'include/libxslt/xslt.h', 'lib/%%(name)s.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxslt/libxslt-1.1.34-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/l/libxslt/libxslt-1.1.34-GCCcore-10.2.0.eb
@@ -9,12 +9,9 @@ description = """Libxslt is the XSLT C library developed for the GNOME project
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f']
+source_urls = ['https://download.gnome.org/sources/libxslt/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['28c47db33ab4daefa6232f31ccb3c65260c825151ec86ec461355247f3f56824']
 
 builddependencies = [('binutils', '2.35')]
 

--- a/easybuild/easyconfigs/l/libxslt/libxslt-1.1.34-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/libxslt/libxslt-1.1.34-GCCcore-10.3.0.eb
@@ -9,12 +9,9 @@ description = """Libxslt is the XSLT C library developed for the GNOME project
 
 toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f']
+source_urls = ['https://download.gnome.org/sources/libxslt/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['28c47db33ab4daefa6232f31ccb3c65260c825151ec86ec461355247f3f56824']
 
 builddependencies = [('binutils', '2.36.1')]
 

--- a/easybuild/easyconfigs/l/libxslt/libxslt-1.1.34-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/l/libxslt/libxslt-1.1.34-GCCcore-11.2.0.eb
@@ -9,12 +9,9 @@ description = """Libxslt is the XSLT C library developed for the GNOME project
 
 toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f']
+source_urls = ['https://download.gnome.org/sources/libxslt/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['28c47db33ab4daefa6232f31ccb3c65260c825151ec86ec461355247f3f56824']
 
 builddependencies = [('binutils', '2.37')]
 

--- a/easybuild/easyconfigs/l/libxslt/libxslt-1.1.34-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/l/libxslt/libxslt-1.1.34-GCCcore-11.3.0.eb
@@ -9,12 +9,9 @@ description = """Libxslt is the XSLT C library developed for the GNOME project
 
 toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f']
+source_urls = ['https://download.gnome.org/sources/libxslt/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['28c47db33ab4daefa6232f31ccb3c65260c825151ec86ec461355247f3f56824']
 
 builddependencies = [('binutils', '2.38')]
 

--- a/easybuild/easyconfigs/l/libxslt/libxslt-1.1.34-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/libxslt/libxslt-1.1.34-GCCcore-8.3.0.eb
@@ -9,12 +9,9 @@ description = """Libxslt is the XSLT C library developed for the GNOME project
 
 toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f']
+source_urls = ['https://download.gnome.org/sources/libxslt/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['28c47db33ab4daefa6232f31ccb3c65260c825151ec86ec461355247f3f56824']
 
 builddependencies = [('binutils', '2.32')]
 

--- a/easybuild/easyconfigs/l/libxslt/libxslt-1.1.34-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/l/libxslt/libxslt-1.1.34-GCCcore-9.3.0.eb
@@ -9,12 +9,9 @@ description = """Libxslt is the XSLT C library developed for the GNOME project
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-source_urls = [
-    'http://xmlsoft.org/sources/',
-    'http://xmlsoft.org/sources/old/'
-]
-sources = [SOURCELOWER_TAR_GZ]
-checksums = ['98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f']
+source_urls = ['https://download.gnome.org/sources/libxslt/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['28c47db33ab4daefa6232f31ccb3c65260c825151ec86ec461355247f3f56824']
 
 builddependencies = [('binutils', '2.34')]
 


### PR DESCRIPTION
closes https://github.com/easybuilders/easybuild-easyconfigs/issues/16419
updates sources for all relatively recent easyconfigs (`GCCcore/7.3.0` and onwards)

(created using `eb --new-pr`)