### PR TITLE
rename hyperopt to Hyperopt, to be consistent with existing Hyperopt easyconfigs

### DIFF
--- a/easybuild/easyconfigs/c/cell2location/cell2location-0.05-alpha-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/c/cell2location/cell2location-0.05-alpha-fosscuda-2020b.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('Java', '11', '', SYSTEM),
     ('SciPy-bundle', '2020.11'),
     ('leidenalg', '0.8.3'),
-    ('hyperopt', '0.2.5'),
+    ('Hyperopt', '0.2.5'),
     ('CMake', '3.18.4'),
     ('dill', '0.3.3'),
     ('IPython', '7.18.1'),

--- a/easybuild/easyconfigs/h/Hyperopt/Hyperopt-0.2.4-intel-2019b-Python-3.7.4-Java-1.8.eb
+++ b/easybuild/easyconfigs/h/Hyperopt/Hyperopt-0.2.4-intel-2019b-Python-3.7.4-Java-1.8.eb
@@ -3,7 +3,7 @@
 
 easyblock = 'PythonBundle'
 
-name = 'hyperopt'
+name = 'Hyperopt'
 version = '0.2.4'
 local_python_versionsuffix = '-Python-%(pyver)s'
 local_java_versionsuffix = '-Java-%(javaver)s'
@@ -43,7 +43,7 @@ exts_list = [
     ('lightgbm', '2.3.1', {
         'checksums': ['bd1817be401e74c0d8b049e97ea2f35d2ce155cfa130119ce4195ea207bd6388'],
     }),
-    (name, version, {
+    ('hyperopt', version, {
         'use_pip_extras': 'SparkTrials,MongoTrials,ATPE',
         'checksums': ['6e72089a42eb70cf84b0567d4552a908adff7cfc5cf6b1c38add41adc775d9c6'],
     }),

--- a/easybuild/easyconfigs/h/Hyperopt/Hyperopt-0.2.5-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/h/Hyperopt/Hyperopt-0.2.5-fosscuda-2020b.eb
@@ -2,7 +2,7 @@
 
 easyblock = 'PythonBundle'
 
-name = 'hyperopt'
+name = 'Hyperopt'
 version = '0.2.5'
 
 homepage = 'https://github.com/hyperopt/hyperopt'
@@ -40,7 +40,7 @@ exts_list = [
     ('py4j', '0.10.9.2', {
         'checksums': ['624f97c363b8dd84822bc666b12fa7f7d97824632b2ff3d852cc491359ce7615'],
     }),
-    (name, version, {
+    ('hyperopt', version, {
         'use_pip_extras': 'SparkTrials,MongoTrials,ATPE',
         'checksums': ['bc6047d50f956ae64eebcb34b1fd40f186a93e214957f20e87af2f10195295cc'],
     }),


### PR DESCRIPTION
We have easyconfigs for Hyperopt with both names `Hyperopt` and `hyperopt`. Consolidate names on Hyperopt.