### PR TITLE
install subtree support for git 2.36.0

### DIFF
--- a/easybuild/easyconfigs/g/git/git-2.36.0-GCCcore-11.3.0-nodocs.eb
+++ b/easybuild/easyconfigs/g/git/git-2.36.0-GCCcore-11.3.0-nodocs.eb
@@ -39,6 +39,8 @@ preconfigopts = 'make configure && '
 # will not append -lpthread to LDFLAGS, but Makefile ignores LIBS.
 configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
 
+postinstallcmds = ['cd contrib/subtree; make install']
+
 sanity_check_paths = {
     'files': ['bin/git'],
     'dirs': ['libexec/git-core', 'share'],


### PR DESCRIPTION
Git subtree is part of git since 1.7, and it gets installed by default on the OS package of git.