### PR TITLE
install subtree support for git 2.38.1

### DIFF
--- a/easybuild/easyconfigs/g/git/git-2.38.1-GCCcore-12.2.0-nodocs.eb
+++ b/easybuild/easyconfigs/g/git/git-2.38.1-GCCcore-12.2.0-nodocs.eb
@@ -39,6 +39,8 @@ preconfigopts = 'make configure && '
 # will not append -lpthread to LDFLAGS, but Makefile ignores LIBS.
 configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
 
+postinstallcmds = ['cd contrib/subtree; make install']
+
 sanity_check_paths = {
     'files': ['bin/git'],
     'dirs': ['libexec/git-core', 'share'],


### PR DESCRIPTION
Git subtree is part of git since 1.7, and is default on OS git - we shouldn't have less functionality