### PR TITLE
{chem}[foss/2022a] MRChem v1.1.1 w/ Python-3.10.4

### DIFF
--- a/easybuild/easyconfigs/m/MRCPP/MRCPP-1.4.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/m/MRCPP/MRCPP-1.4.1-foss-2022a.eb
@@ -1,0 +1,31 @@
+easyblock = 'CMakeMake'
+
+name = 'MRCPP'
+version = '1.4.1'
+
+homepage = 'https://mrcpp.readthedocs.io'
+description = """MultiResolution Computation Program Package"""
+
+toolchain = {'name': 'foss', 'version': '2022a'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = ['https://github.com/MRChemSoft/mrcpp/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['f369d72cc37415e9a6bdc0692ec4f6c5cfcc22e34b9ce569470e656c45e5b86c']
+
+builddependencies = [
+    ('CMake', '3.23.1'),
+    ('Eigen', '3.4.0')
+]
+
+configopts = "-DENABLE_MPI=True -DENABLE_OPENMP=True"
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['lib/libmrcpp.%s' % SHLIB_EXT],
+    'dirs': ['include/MRCPP']
+}
+
+modextravars = {'MRCPP_DIR': '%(installdir)s/share/cmake/MRCPP/'}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MRChem/MRChem-1.1.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/m/MRChem/MRChem-1.1.1-foss-2022a.eb
@@ -1,0 +1,37 @@
+easyblock = 'CMakeMake'
+
+name = 'MRChem'
+version = '1.1.1'
+
+homepage = 'https://mrchem.readthedocs.io'
+description = """MRChem is a numerical real-space code for molecular electronic
+structure calculations within the self-consistent field (SCF) approximations of
+quantum chemistry: Hartree-Fock and Density Functional Theory."""
+
+toolchain = {'name': 'foss', 'version': '2022a'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = ['https://github.com/MRChemSoft/mrchem/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['9926778edf8bb49fd4cde513faf6a887800ecf1791d1a71c0edae228ba6da646']
+
+builddependencies = [
+    ('CMake', '3.23.1'),
+    ('Eigen', '3.4.0')
+]
+
+dependencies = [
+    ('MRCPP', '1.4.1'),
+    ('Python', '3.10.4'),
+    ('XCFun', '2.1.1')
+]
+
+configopts = "-DENABLE_MPI=True -DENABLE_OPENMP=True"
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['bin/mrchem', 'bin/mrchem.x'],
+    'dirs': ['lib'],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/x/XCFun/XCFun-2.1.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/x/XCFun/XCFun-2.1.1-GCCcore-11.3.0.eb
@@ -1,0 +1,27 @@
+easyblock = 'CMakeMake'
+
+name = 'XCFun'
+version = '2.1.1'
+
+homepage = 'https://xcfun.readthedocs.io'
+description = """Arbitrary order exchange-correlation functional library"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = ['https://github.com/dftlibs/xcfun/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['8b602df74c7be83d501532565deafd1b7881946d94789122f24c309a669298ab']
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('CMake', '3.23.1')
+]
+
+modextravars = {'XCFun_DIR': '%(installdir)s/share/cmake/XCFun/'}
+
+sanity_check_paths = {
+    'files': ['lib/libxcfun.%s' % SHLIB_EXT],
+    'dirs': ['include/XCFun']
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
Trivial version upgrade of MRChem with dependencies:
- `XCfun-2.1.1-GCCcore-11.3.0`
- `MRCPP-1.4.1-foss-2022a`
- `MRChem-1.1.1-foss-2022a`