### PR TITLE
Add easyconfigs: dlb

### DIFF
--- a/easybuild/easyconfigs/d/dlb/dlb-3.2-gompi-2022a.eb
+++ b/easybuild/easyconfigs/d/dlb/dlb-3.2-gompi-2022a.eb
@@ -14,13 +14,13 @@ homepage = 'https://pm.bsc.es/dlb/'
 docurls = ['https://pm.bsc.es/ftp/dlb/doc/user-guide/']
 
 toolchain = {'name': 'gompi', 'version': '2022a'}
-builddependencies = [('Python', '3.10.4', '', ('GCCcore', '11.3.0-bare'))]
+builddependencies = [('Python', '3.10.4', '-bare')]
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['https://pm.bsc.es/ftp/dlb/releases']
 
 checksums = ['b1c65ce3179b5275cfdf0bf921c0565a4a3ebcfdab72d7cef014957c17136c7e']
 
-moduleclass = 'lib'
-
 configopts = '--with-mpi'
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/d/dlb/dlb-3.2-gompi-2022a.eb
+++ b/easybuild/easyconfigs/d/dlb/dlb-3.2-gompi-2022a.eb
@@ -23,4 +23,13 @@ checksums = ['b1c65ce3179b5275cfdf0bf921c0565a4a3ebcfdab72d7cef014957c17136c7e']
 
 configopts = '--with-mpi'
 
+sanity_check_paths = {
+    'files': [
+        'bin/dlb',
+        'lib/libdlb.a', 'lib/libdlb.%s' % SHLIB_EXT,
+        'lib64/libdlb.%s' % SHLIB_EXT
+    ],
+    'dirs': ['include'],
+}
+
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/d/dlb/dlb-3.2-gompi-2022a.eb
+++ b/easybuild/easyconfigs/d/dlb/dlb-3.2-gompi-2022a.eb
@@ -1,0 +1,26 @@
+# vim: set syntax=python:
+easyblock = 'ConfigureMake'
+
+name = 'dlb'
+version = '3.2'
+
+description = """
+DLB is a dynamic library designed to speed up HPC hybrid applications (i.e.,
+two levels of parallelism) by improving the load balance of the outer level of
+parallelism (e.g., MPI) by dynamically redistributing the computational
+resources at the inner level of parallelism (e.g., OpenMP). at run time.
+"""
+homepage = 'https://pm.bsc.es/dlb/'
+docurls = ['https://pm.bsc.es/ftp/dlb/doc/user-guide/']
+
+toolchain = {'name': 'gompi', 'version': '2022a'}
+builddependencies = [('Python', '3.10.4', '', ('GCCcore', '11.3.0-bare'))]
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://pm.bsc.es/ftp/dlb/releases']
+
+checksums = ['b1c65ce3179b5275cfdf0bf921c0565a4a3ebcfdab72d7cef014957c17136c7e']
+
+moduleclass = 'lib'
+
+configopts = '--with-mpi'

--- a/easybuild/easyconfigs/d/dlb/dlb-3.2-iimpi-2022a.eb
+++ b/easybuild/easyconfigs/d/dlb/dlb-3.2-iimpi-2022a.eb
@@ -1,0 +1,26 @@
+# vim: set syntax=python:
+easyblock = 'ConfigureMake'
+
+name = 'dlb'
+version = '3.2'
+
+description = """
+DLB is a dynamic library designed to speed up HPC hybrid applications (i.e.,
+two levels of parallelism) by improving the load balance of the outer level of
+parallelism (e.g., MPI) by dynamically redistributing the computational
+resources at the inner level of parallelism (e.g., OpenMP). at run time.
+"""
+homepage = 'https://pm.bsc.es/dlb/'
+docurls = ['https://pm.bsc.es/ftp/dlb/doc/user-guide/']
+
+toolchain = {'name': 'iimpi', 'version': '2022a'}
+builddependencies = [('Python', '3.10.4', '', ('GCCcore', '11.3.0-bare'))]
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://pm.bsc.es/ftp/dlb/releases']
+
+checksums = ['b1c65ce3179b5275cfdf0bf921c0565a4a3ebcfdab72d7cef014957c17136c7e']
+
+moduleclass = 'lib'
+
+configopts = '--with-mpi'

--- a/easybuild/easyconfigs/d/dlb/dlb-3.2-iimpi-2022a.eb
+++ b/easybuild/easyconfigs/d/dlb/dlb-3.2-iimpi-2022a.eb
@@ -14,13 +14,13 @@ homepage = 'https://pm.bsc.es/dlb/'
 docurls = ['https://pm.bsc.es/ftp/dlb/doc/user-guide/']
 
 toolchain = {'name': 'iimpi', 'version': '2022a'}
-builddependencies = [('Python', '3.10.4', '', ('GCCcore', '11.3.0-bare'))]
+builddependencies = [('Python', '3.10.4', '-bare')]
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['https://pm.bsc.es/ftp/dlb/releases']
 
 checksums = ['b1c65ce3179b5275cfdf0bf921c0565a4a3ebcfdab72d7cef014957c17136c7e']
 
-moduleclass = 'lib'
-
 configopts = '--with-mpi'
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/d/dlb/dlb-3.2-iimpi-2022a.eb
+++ b/easybuild/easyconfigs/d/dlb/dlb-3.2-iimpi-2022a.eb
@@ -23,4 +23,13 @@ checksums = ['b1c65ce3179b5275cfdf0bf921c0565a4a3ebcfdab72d7cef014957c17136c7e']
 
 configopts = '--with-mpi'
 
+sanity_check_paths = {
+    'files': [
+        'bin/dlb',
+        'lib/libdlb.a', 'lib/libdlb.%s' % SHLIB_EXT,
+        'lib64/libdlb.%s' % SHLIB_EXT
+    ],
+    'dirs': ['include'],
+}
+
 moduleclass = 'lib'


### PR DESCRIPTION
Add dlb easyconfigs.

DLB is a dynamic library designed to speed up HPC hybrid applications
(i.e., two levels of parallelism) by improving the load balance of the
outer level of parallelism (e.g., MPI) by dynamically redistributing the
computational resources at the inner level of parallelism (e.g., OpenMP).
at run time.
More info at https://pm.bsc.es/dlb.
