### PR TITLE
downgrade to setuptools 63.4.3 in Python 3.10.8 easyconfig

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.10.8-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.10.8-GCCcore-12.2.0.eb
@@ -47,8 +47,8 @@ exts_list = [
     ('wheel', '0.38.4', {
         'checksums': ['965f5259b566725405b05e7cf774052044b1ed30119b5d586b2703aafe8719ac'],
     }),
-    ('setuptools', '65.5.1', {
-        'checksums': ['e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f'],
+    ('setuptools', '63.4.3', {
+        'checksums': ['521c833d1e5e1ef0869940e7f486a83de7773b9f029010ad0c2fe35453a9dad9'],
     }),
     ('pip', '22.3.1', {
         'checksums': ['65fd48317359f3af8e593943e6ae1506b66325085ea64b706a998c6e83eeaf38'],


### PR DESCRIPTION
setuptools >= 64.0 has some breaking changes (see [setuptools history](https://setuptools.pypa.io/en/latest/history.html#v64-0-0)) that are likely to cause trouble with various Python packages which are not aware of that yet, or which need time to resolve the problems that pop up because of that.

When installing `numpy` on top of setuptools 65.5.1, we hit this for example:
```
    File "/software/Python/3.10.8-GCCcore-12.2.0/lib/python3.10/site-packages/setuptools/_distutils/cmd.py", line 105, in __getattr__
      raise AttributeError(attr)
  AttributeError: fcompiler. Did you mean: 'compiler'?
  error: subprocess-exited-with-error
```

(see also https://github.com/numpy/numpy/issues/22157)