### PR TITLE
libwpe 1.13.3: add patch to avoid build issues on CentOS 7

### DIFF
--- a/easybuild/easyconfigs/l/libwpe/libwpe-1.13.3-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/l/libwpe/libwpe-1.13.3-GCCcore-11.2.0.eb
@@ -6,10 +6,10 @@ name = 'libwpe'
 version = '1.13.3'
 
 homepage = 'https://webkit.org/wpe'
-description = """WPE is the reference WebKit port for embedded and 
-low-consumption computer devices. It has been designed from the 
-ground-up with performance, small footprint, accelerated content 
-rendering, and simplicity of deployment in mind, bringing the 
+description = """WPE is the reference WebKit port for embedded and
+low-consumption computer devices. It has been designed from the
+ground-up with performance, small footprint, accelerated content
+rendering, and simplicity of deployment in mind, bringing the
 excellence of the WebKit engine to countless platforms and target devices."""
 
 toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
@@ -17,9 +17,11 @@ toolchainopts = {'pic': True}
 
 source_urls = ['https://wpewebkit.org/releases']
 sources = ['%(name)s-%(version)s.tar.xz']
-
+patches = ['%(name)s-1.13.3_include-string-before-poison.patch']
 checksums = [
-    '05f871922f6ca750c5689a38a346c3fba130417d3490dd52362b4fe22f334e96',  # libwpe-1.13.3.tar.xz
+    {'libwpe-1.13.3.tar.xz': '05f871922f6ca750c5689a38a346c3fba130417d3490dd52362b4fe22f334e96'},
+    {'libwpe-1.13.3_include-string-before-poison.patch':
+     '2d21ed6b2dafa758126cda162e450ab2b3a3c0b622e375ff443523ba32fc5812'},
 ]
 
 builddependencies = [
@@ -32,8 +34,6 @@ builddependencies = [
 dependencies = [
     ('glew', '2.2.0', '-egl'),
 ]
-
-parallel = 2
 
 sanity_check_paths = {
     'files': ['lib/libwpe-1.0.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/l/libwpe/libwpe-1.13.3_include-string-before-poison.patch
+++ b/easybuild/easyconfigs/l/libwpe/libwpe-1.13.3_include-string-before-poison.patch
@@ -1,0 +1,13 @@
+Author: Jasper Grimm <jasper.grimm@york.ac.uk>
+Description: Include string.h before poisoning {c,m}alloc
+diff -ruN libwpe-1.13.3/src/alloc-private.h libwpe-1.13.3.p1/src/alloc-private.h
+--- libwpe-1.13.3/src/alloc-private.h	2022-08-11 12:59:47.000000000 +0100
++++ libwpe-1.13.3.p1/src/alloc-private.h	2022-12-22 12:01:51.000000000 +0000
+@@ -27,6 +27,7 @@
+ #ifndef wpe_alloc_private_h
+ #define wpe_alloc_private_h
+ 
++#include <string.h>
+ #include <stdlib.h>
+ 
+ #if defined(__has_attribute) && __has_attribute(noreturn)


### PR DESCRIPTION
also removed the `parallel = 2` restriction, since it builds fine with more cores.

(created using `eb --new-pr`)
