### PR TITLE
Add TensorFlow-2.8.4-foss-2021b-CUDA-11.4.1.eb and fix TensorFlow-2.8.4-foss-2021b.eb

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.8.4-foss-2021b-CUDA-11.4.1.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.8.4-foss-2021b-CUDA-11.4.1.eb
@@ -2,6 +2,7 @@ easyblock = 'PythonBundle'
 
 name = 'TensorFlow'
 version = '2.8.4'
+versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://www.tensorflow.org/'
 description = "An open-source software library for Machine Intelligence"
@@ -19,6 +20,9 @@ builddependencies = [
     ('LLVM', '12.0.1'),  # for debugging with llvm-symbolizer, to be removed
 ]
 dependencies = [
+    ('CUDA', '11.4.1', '', SYSTEM),
+    ('cuDNN', '8.2.2.26', versionsuffix, SYSTEM),
+    ('NCCL', '2.10.3', versionsuffix),
     ('Python', '3.9.6'),
     ('h5py', '3.6.0'),
     ('cURL', '7.78.0'),

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.8.4_exclude-xnnpack-on-ppc.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.8.4_exclude-xnnpack-on-ppc.patch
@@ -1,0 +1,18 @@
+XNNPACK is not supported on PowerPC so disable it by default.
+See https://github.com/tensorflow/tensorflow/issues/58768
+
+Author: Alexander Grund (TU Dresden)
+
+diff --git a/tensorflow/lite/BUILD b/tensorflow/lite/BUILD
+index 198f949b341..d15dcf9a80d 100644
+--- a/tensorflow/lite/BUILD
++++ b/tensorflow/lite/BUILD
+@@ -709,6 +709,8 @@ cc_library(
+     deps = select({
+         "//tensorflow:macos": [],
+         "//tensorflow:fuchsia": [],
++        # XNNPACK is not supported on PPC
++        "//tensorflow:linux_ppc64le": [],
+         "//conditions:default": [":tflite_with_xnnpack_enabled"],
+     }),
+ )

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.8.4_fix-PPC-JIT.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.8.4_fix-PPC-JIT.patch
@@ -1,0 +1,58 @@
+diff --git a/third_party/cpuinfo/cpuinfo.BUILD b/third_party/cpuinfo/cpuinfo.BUILD
+index eb2937d20ef..dfea408db94 100644
+--- a/third_party/cpuinfo/cpuinfo.BUILD
++++ b/third_party/cpuinfo/cpuinfo.BUILD
+@@ -109,6 +109,7 @@ cc_library(
+         ":linux_mips64": COMMON_SRCS + LINUX_SRCS,
+         ":linux_riscv64": COMMON_SRCS + LINUX_SRCS,
+         ":linux_s390x": COMMON_SRCS + LINUX_SRCS,
++        ":linux_ppc64le": COMMON_SRCS + LINUX_SRCS,
+         ":macos_x86_64": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
+         ":macos_arm64": COMMON_SRCS + MACH_SRCS + MACH_ARM_SRCS,
+         ":windows_x86_64": COMMON_SRCS + X86_SRCS + WINDOWS_X86_SRCS,
+@@ -232,6 +233,11 @@ config_setting(
+     values = {"cpu": "s390x"},
+ )
+ 
++config_setting(
++    name = "linux_ppc64le",
++    values = {"cpu": "ppc"},
++)
++
+ config_setting(
+     name = "macos_x86_64",
+     values = {
+diff --git a/third_party/llvm/macos_build_fix.patch b/third_party/llvm/macos_build_fix.patch
+index 4dba8676ea5..af31f0c1d9e 100644
+--- a/third_party/llvm/macos_build_fix.patch
++++ b/third_party/llvm/macos_build_fix.patch
+@@ -42,5 +42,29 @@ index ff64df694048..c9c35b01711c 100644
+      "@bazel_tools//src/conditions:linux_aarch64": native_arch_defines("AArch64", "aarch64-unknown-linux-gnu"),
+      "//conditions:default": native_arch_defines("X86", "x86_64-unknown-linux-gnu"),
+  }) + [
++
++
++From b250c34bbd415b2a8c3e0532e98591ab1780cda6 Mon Sep 17 00:00:00 2001
++From: Nishidha Panpaliya <npanpa23@in.ibm.com>
++Date: Mon, 21 Mar 2022 09:51:36 -0400
++Subject: [PATCH] Fix for ppc64le
++
++---
++ utils/bazel/llvm-project-overlay/llvm/config.bzl | 1 +
++ 1 file changed, 1 insertion(+)
++
++diff --git a/utils/bazel/llvm-project-overlay/llvm/config.bzl b/utils/bazel/llvm-project-overlay/llvm/config.bzl
++index 772714f38941..9ed63e8d44a3 100644
++--- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
+++++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
++@@ -86,6 +86,7 @@ llvm_config_defines = os_defines + select({
++     "//llvm:macos_arm64": native_arch_defines("AArch64", "arm64-apple-darwin"),
++     "@bazel_tools//src/conditions:darwin": native_arch_defines("X86", "x86_64-unknown-darwin"),
++     "@bazel_tools//src/conditions:linux_aarch64": native_arch_defines("AArch64", "aarch64-unknown-linux-gnu"),
+++    "@bazel_tools//src/conditions:linux_ppc64le": native_arch_defines("PowerPC", "powerpc64le-unknown-linux-gnu"),
++     "//conditions:default": native_arch_defines("X86", "x86_64-unknown-linux-gnu"),
++ }) + [
++     # These shouldn't be needed by the C++11 standard, but are for some
++
+ -- 
+ 2.30.1 (Apple Git-130)

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.8.4_resolve-gcc-symlinks.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.8.4_resolve-gcc-symlinks.patch
@@ -1,0 +1,28 @@
+Fix for "undeclared inclusion(s) in rule" errors when the installation directory
+for GCC is hosted in a path that is a symlink to another path.
+
+From https://github.com/tensorflow/tensorflow/pull/56360
+
+From b3a8fdbcb79e723f8d62f86bddcfdfb73fe76291 Mon Sep 17 00:00:00 2001
+From: Jinzhe Zeng <jinzhe.zeng@rutgers.edu>
+Date: Sat, 4 Jun 2022 19:06:58 -0400
+Subject: [PATCH] resolve gcc_host_compiler_path in a symlink directory
+
+Resolves a missing dependency declarations error, when gcc_host_compiler_path is in a symlink directory resolving to other directories.
+---
+ configure.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.py b/configure.py
+index bf338bdda2297..77af09a22a05d 100644
+--- a/configure.py
++++ b/configure.py
+@@ -619,7 +619,7 @@ def prompt_loop_or_load_from_env(environ_cp,
+                          'Assuming to be a scripting mistake.' %
+                          (var_name, n_ask_attempts))
+ 
+-  if resolve_symlinks and os.path.islink(val):
++  if resolve_symlinks:
+     val = os.path.realpath(val)
+   environ_cp[var_name] = val
+   return val


### PR DESCRIPTION
This adds the new TF 2.8.4 EC with CUDA support and some changes for the non-CUDA version:

- Add missing `astor` package (SYSTEM_LIB, i.e. will be downloaded when missing which we want to avoid)
- Add the profile plugin for tensorboard as we did in previous ECs
- Reorder sources, patches, checksums so they are next to each other for easier manual verification
- Replace `TensorFlow-2.1.0_fix-cuda-build.patch` by the upstream patch from https://github.com/tensorflow/tensorflow/pull/56360 so we can drop it in the future
- Fix build on PPC (that was some major work)

- [x] the CUDA build requires the updated easyblock from https://github.com/easybuilders/easybuild-easyblocks/pull/2854 to work due to changes in TensorFlow and Bazel.

Once this is merged we can finish TF 2.9 in #16620 and #16008 as they suffer from the same issues as the ones fixed here.