### PR TITLE
fix build of TensorFlow 2.5+ on aarch64

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.0-foss-2020b.eb
@@ -161,6 +161,7 @@ exts_list = [
             'TensorFlow-2.5.0-fix-alias-violation-in-absl.patch',
             'TensorFlow-2.5.0_fix-alignment-in-matmul-test.patch',
             'TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch',
+            'TensorFlow-2.5.3_fix-aarch64-build.patch',
         ],
         'checksums': [
             '233875ea27fc357f6b714b2a0de5f6ff124b50c1ee9b3b41f9e726e9e677b86c',  # v2.5.0.tar.gz
@@ -181,6 +182,8 @@ exts_list = [
             '6a4d6cbf45a622b8a2c3ea0b1c0171f01f595684d9c57d415bb39b1b27e1180f',
             # TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch
             '5edea55ce87d5adb14f6ed6996f308879e268b8cec760cf11288e3a56179a029',
+            {'TensorFlow-2.5.3_fix-aarch64-build.patch':
+             '9bfd9a3586bb04c131c4d07a40b0ef5c2e7f474dc986449fc68817d927af0c6d'},
         ],
         'test_script': 'TensorFlow-2.x_mnist-test.py',
         'test_tag_filters_cpu': '-gpu,-tpu,-no_cuda_on_cpu_tap,-no_pip,-no_oss,-oss_serial,-benchmark-test,-v1only',

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.0-foss-2020b.eb
@@ -180,7 +180,7 @@ exts_list = [
             # TensorFlow-2.5.0_fix-alignment-in-matmul-test.patch
             '6a4d6cbf45a622b8a2c3ea0b1c0171f01f595684d9c57d415bb39b1b27e1180f',
             # TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch
-            '6abfadc0f67ff3b510d70430843201cb46d7bd65db045ec9b482af70e0c8c0c8',
+            '5edea55ce87d5adb14f6ed6996f308879e268b8cec760cf11288e3a56179a029',
         ],
         'test_script': 'TensorFlow-2.x_mnist-test.py',
         'test_tag_filters_cpu': '-gpu,-tpu,-no_cuda_on_cpu_tap,-no_pip,-no_oss,-oss_serial,-benchmark-test,-v1only',

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.0-fosscuda-2019b-Python-3.7.4.eb
@@ -185,7 +185,7 @@ exts_list = [
             # TensorFlow-2.5.0_fix-alignment-in-matmul-test.patch
             '6a4d6cbf45a622b8a2c3ea0b1c0171f01f595684d9c57d415bb39b1b27e1180f',
             # TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch
-            '6abfadc0f67ff3b510d70430843201cb46d7bd65db045ec9b482af70e0c8c0c8',
+            '5edea55ce87d5adb14f6ed6996f308879e268b8cec760cf11288e3a56179a029',
             # TensorFlow-2.5.0_fix-CUDA10-build.patch
             'f6b44c82855bd2892ca67b528076acdaa75d8b9158aa25d84c808d1ce4d89256',
             # TensorFlow-2.5.0_fix-cub-cuda-dep.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.0-fosscuda-2019b-Python-3.7.4.eb
@@ -163,6 +163,7 @@ exts_list = [
             'TensorFlow-2.5.0_fix-cub-cuda-dep.patch',
             'TensorFlow-2.5.0_remove-duplicate-gpu-tests.patch',
             'TensorFlow-2.5.0-fix-alias-violation-in-absl.patch',
+            'TensorFlow-2.5.3_fix-aarch64-build.patch',
         ],
         'checksums': [
             '233875ea27fc357f6b714b2a0de5f6ff124b50c1ee9b3b41f9e726e9e677b86c',  # v2.5.0.tar.gz
@@ -194,6 +195,8 @@ exts_list = [
             'b940d438e036faac24453bff2cf1834c5e1359e87e84d1f1999fa7a30b278fec',
             # TensorFlow-2.5.0-fix-alias-violation-in-absl.patch
             '12454fda3330fb45cd380377e283f04488b40e0b8ae7378e786ddf731a581f75',
+            {'TensorFlow-2.5.3_fix-aarch64-build.patch':
+             '9bfd9a3586bb04c131c4d07a40b0ef5c2e7f474dc986449fc68817d927af0c6d'},
         ],
         'test_script': 'TensorFlow-2.x_mnist-test.py',
         'test_tag_filters_cpu': '-gpu,-tpu,-no_cuda_on_cpu_tap,-no_pip,-no_oss,-oss_serial,-benchmark-test,-v1only',

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.0-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.0-fosscuda-2020b.eb
@@ -189,7 +189,7 @@ exts_list = [
             # TensorFlow-2.5.0_fix-alignment-in-matmul-test.patch
             '6a4d6cbf45a622b8a2c3ea0b1c0171f01f595684d9c57d415bb39b1b27e1180f',
             # TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch
-            '6abfadc0f67ff3b510d70430843201cb46d7bd65db045ec9b482af70e0c8c0c8',
+            '5edea55ce87d5adb14f6ed6996f308879e268b8cec760cf11288e3a56179a029',
             # TensorFlow-2.5.0_fix-crash-on-shutdown.patch
             '578c7493221ebd3dc25ca43d63a72cbb28fdf4112b1e2baa7390f25781bd78fd',
             # TensorFlow-2.5.0_remove-duplicate-gpu-tests.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.0-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.0-fosscuda-2020b.eb
@@ -167,6 +167,7 @@ exts_list = [
             'TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch',
             'TensorFlow-2.5.0_fix-crash-on-shutdown.patch',
             'TensorFlow-2.5.0_remove-duplicate-gpu-tests.patch',
+            'TensorFlow-2.5.3_fix-aarch64-build.patch',
         ],
         'checksums': [
             '233875ea27fc357f6b714b2a0de5f6ff124b50c1ee9b3b41f9e726e9e677b86c',  # v2.5.0.tar.gz
@@ -194,6 +195,8 @@ exts_list = [
             '578c7493221ebd3dc25ca43d63a72cbb28fdf4112b1e2baa7390f25781bd78fd',
             # TensorFlow-2.5.0_remove-duplicate-gpu-tests.patch
             'b940d438e036faac24453bff2cf1834c5e1359e87e84d1f1999fa7a30b278fec',
+            {'TensorFlow-2.5.3_fix-aarch64-build.patch':
+             '9bfd9a3586bb04c131c4d07a40b0ef5c2e7f474dc986449fc68817d927af0c6d'},
         ],
         'test_script': 'TensorFlow-2.x_mnist-test.py',
         'test_tag_filters_cpu': '-gpu,-tpu,-no_cuda_on_cpu_tap,-no_pip,-no_oss,-oss_serial,-benchmark-test,-v1only',

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch
@@ -1,37 +1,42 @@
-The comment is not true, the function actually takes the arguments as it should
-Hence just redefine the function
+Fix compile error on ARM:
+> ./tensorflow/lite/kernels/internal/optimized/depthwiseconv_3x3_filter_common.h:132:58: error: cannot convert 'int32x2_t' to 'int8x8_t'
 
-Author: Alexander Grund (TU Dresden)
+From https://github.com/tensorflow/tensorflow/pull/53782
+
+From 4463f25d1622d162f870ff685da20f2c6df5bc6a Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Sat, 15 Jan 2022 21:06:27 +0100
+Subject: [PATCH] Fix casting in vdotq_four_lane_s32() in TFLite
+
+When building with GCC and dotprod ARM extension enabled,
+vreinterpret_s32_s8() casts int8x8_t to int32x2_t. However, third
+argument of vdotq_lane_s32() expects parameter of type int8x8_t.
+---
+ .../optimized/depthwiseconv_3x3_filter_common.h        | 10 ++++------
+ 1 file changed, 4 insertions(+), 6 deletions(-)
 
 diff --git a/tensorflow/lite/kernels/internal/optimized/depthwiseconv_3x3_filter_common.h b/tensorflow/lite/kernels/internal/optimized/depthwiseconv_3x3_filter_common.h
-index 916edd561ff..9c8025dac49 100644
+index 916edd561ff32..c519a81bc864d 100644
 --- a/tensorflow/lite/kernels/internal/optimized/depthwiseconv_3x3_filter_common.h
 +++ b/tensorflow/lite/kernels/internal/optimized/depthwiseconv_3x3_filter_common.h
-@@ -122,26 +122,7 @@ inline int32x4_t vpaddq_s32(int32x4_t a, int32x4_t b) {
- #endif  // !__aarch64__
- 
- #ifdef __ARM_FEATURE_DOTPROD
--// The vdotq_lane_s32 takes int8x8t for the rhs parameter, whereas the actual
--// instruction selects from between 4 32-bit (4x8-bit packed) sub-registers, an
--// unusual interpretation of "lane".
--inline int32x4_t vdotq_four_lane_s32(int32x4_t acc, int8x16_t lhs,
--                                     int8x16_t rhs, const int lane) {
--  switch (lane) {
--    case 0:
+@@ -129,16 +129,14 @@ inline int32x4_t vdotq_four_lane_s32(int32x4_t acc, int8x16_t lhs,
+                                      int8x16_t rhs, const int lane) {
+   switch (lane) {
+     case 0:
 -      return vdotq_lane_s32(acc, lhs, vreinterpret_s32_s8(vget_low_s8(rhs)), 0);
--    case 1:
++      return vdotq_lane_s32(acc, lhs, vget_low_s8(rhs), 0);
+     case 1:
 -      return vdotq_lane_s32(acc, lhs, vreinterpret_s32_s8(vget_low_s8(rhs)), 1);
--    case 2:
++      return vdotq_lane_s32(acc, lhs, vget_low_s8(rhs), 1);
+     case 2:
 -      return vdotq_lane_s32(acc, lhs, vreinterpret_s32_s8(vget_high_s8(rhs)),
 -                            0);
--    case 3:
--    default:
++      return vdotq_lane_s32(acc, lhs, vget_high_s8(rhs), 0);
+     case 3:
+     default:
 -      return vdotq_lane_s32(acc, lhs, vreinterpret_s32_s8(vget_high_s8(rhs)),
 -                            1);
--  }
--}
--
-+#define vdotq_four_lane_s32 vdotq_lane_s32
- #else
++      return vdotq_lane_s32(acc, lhs, vget_high_s8(rhs), 1);
+   }
+ }
  
- inline int32x4_t vdotq_s32(int32x4_t acc, int8x16_t lhs, int8x16_t rhs) {

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.3-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.3-foss-2021a-CUDA-11.3.1.eb
@@ -194,7 +194,7 @@ exts_list = [
             # TensorFlow-2.5.0_fix-alignment-in-matmul-test.patch
             '6a4d6cbf45a622b8a2c3ea0b1c0171f01f595684d9c57d415bb39b1b27e1180f',
             # TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch
-            '6abfadc0f67ff3b510d70430843201cb46d7bd65db045ec9b482af70e0c8c0c8',
+            '5edea55ce87d5adb14f6ed6996f308879e268b8cec760cf11288e3a56179a029',
             # TensorFlow-2.5.0_fix-crash-on-shutdown.patch
             '578c7493221ebd3dc25ca43d63a72cbb28fdf4112b1e2baa7390f25781bd78fd',
             # TensorFlow-2.5.0_remove-duplicate-gpu-tests.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.3-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.3-foss-2021a-CUDA-11.3.1.eb
@@ -171,6 +171,7 @@ exts_list = [
             'TensorFlow-2.5.0_fix-compatibility-with-protobuf-3.17.patch',
             'TensorFlow-2.5.0_fix-compatibility-with-CUDA-11.3.patch',
             'TensorFlow-2.5.0_fix_numpy_1.20_compatibility.patch',
+            'TensorFlow-2.5.3_fix-aarch64-build.patch',
             'TensorFlow-2.5.3_relax-required-versions.patch',
         ],
         'checksums': [
@@ -205,6 +206,8 @@ exts_list = [
             'e82db520e5e22f97c0dde2166f0d1a29e7ea828c2b4dfbc79dccc0d4cde5d95d',
             # TensorFlow-2.5.0_fix_numpy_1.20_compatibility.patch
             '4c32aba417e6ecb2642d5828b4ac618f1e4395f6c217cd621fa08a74433faa55',
+            {'TensorFlow-2.5.3_fix-aarch64-build.patch':
+             '9bfd9a3586bb04c131c4d07a40b0ef5c2e7f474dc986449fc68817d927af0c6d'},
             # TensorFlow-2.5.3_relax-required-versions.patch
             'e108c3877cf4a0cadc179290ec2098683367688bbbbc7d6fa9a321eb7020443c',
         ],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.3-foss-2021a.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.3-foss-2021a.eb
@@ -165,6 +165,7 @@ exts_list = [
             'TensorFlow-2.5.0_fix-compatibility-with-protobuf-3.17.patch',
             'TensorFlow-2.5.0_fix-compatibility-with-CUDA-11.3.patch',
             'TensorFlow-2.5.0_fix_numpy_1.20_compatibility.patch',
+            'TensorFlow-2.5.3_fix-aarch64-build.patch',
             'TensorFlow-2.5.3_relax-required-versions.patch',
         ],
         'checksums': [
@@ -196,6 +197,8 @@ exts_list = [
             'e82db520e5e22f97c0dde2166f0d1a29e7ea828c2b4dfbc79dccc0d4cde5d95d',
             # TensorFlow-2.5.0_fix_numpy_1.20_compatibility.patch
             '4c32aba417e6ecb2642d5828b4ac618f1e4395f6c217cd621fa08a74433faa55',
+            {'TensorFlow-2.5.3_fix-aarch64-build.patch':
+             '9bfd9a3586bb04c131c4d07a40b0ef5c2e7f474dc986449fc68817d927af0c6d'},
             # TensorFlow-2.5.3_relax-required-versions.patch
             'e108c3877cf4a0cadc179290ec2098683367688bbbbc7d6fa9a321eb7020443c',
         ],

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.3-foss-2021a.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.3-foss-2021a.eb
@@ -187,7 +187,7 @@ exts_list = [
             # TensorFlow-2.5.0_fix-alignment-in-matmul-test.patch
             '6a4d6cbf45a622b8a2c3ea0b1c0171f01f595684d9c57d415bb39b1b27e1180f',
             # TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch
-            '6abfadc0f67ff3b510d70430843201cb46d7bd65db045ec9b482af70e0c8c0c8',
+            '5edea55ce87d5adb14f6ed6996f308879e268b8cec760cf11288e3a56179a029',
             # TensorFlow-2.5.0_fix-crash-on-shutdown.patch
             '578c7493221ebd3dc25ca43d63a72cbb28fdf4112b1e2baa7390f25781bd78fd',
             # TensorFlow-2.5.0_fix-compatibility-with-protobuf-3.17.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.3_fix-aarch64-build.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.5.3_fix-aarch64-build.patch
@@ -1,0 +1,24 @@
+Without this tf_to_kernel fails to link on AARCH64
+
+Picked from https://github.com/tensorflow/tensorflow/commit/4933ada8c2b4b523acc94baea2609f0cce70a083
+
+Author: Alexander Grund (TU Dresden)
+
+diff --git a/tensorflow/core/platform/default/build_config.bzl b/tensorflow/core/platform/default/build_config.bzl
+index d0dadd12108..bf6c631fdf6 100644
+--- a/tensorflow/core/platform/default/build_config.bzl
++++ b/tensorflow/core/platform/default/build_config.bzl
+@@ -795,9 +795,10 @@ def tf_google_mobile_srcs_only_runtime():
+     return []
+ 
+ def if_llvm_aarch64_available(then, otherwise = []):
+-    # TODO(b/...): The TF XLA build fails when adding a dependency on
+-    # @llvm/llvm-project/llvm:aarch64_target.
+-    return otherwise
++    return select({
++        "//tensorflow:linux_aarch64": then,
++        "//conditions:default": otherwise,
++    })
+ 
+ def if_llvm_system_z_available(then, otherwise = []):
+     return select({

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.6.0-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.6.0-foss-2021a-CUDA-11.3.1.eb
@@ -184,7 +184,7 @@ exts_list = [
             # TensorFlow-2.5.0-fix-alias-violation-in-absl.patch
             '12454fda3330fb45cd380377e283f04488b40e0b8ae7378e786ddf731a581f75',
             # TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch
-            '6abfadc0f67ff3b510d70430843201cb46d7bd65db045ec9b482af70e0c8c0c8',
+            '5edea55ce87d5adb14f6ed6996f308879e268b8cec760cf11288e3a56179a029',
             # TensorFlow-2.5.0_fix-crash-on-shutdown.patch
             '578c7493221ebd3dc25ca43d63a72cbb28fdf4112b1e2baa7390f25781bd78fd',
             # TensorFlow-2.5.0_fix_numpy_1.20_compatibility.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.6.0-foss-2021a.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.6.0-foss-2021a.eb
@@ -177,7 +177,7 @@ exts_list = [
             # TensorFlow-2.5.0-fix-alias-violation-in-absl.patch
             '12454fda3330fb45cd380377e283f04488b40e0b8ae7378e786ddf731a581f75',
             # TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch
-            '6abfadc0f67ff3b510d70430843201cb46d7bd65db045ec9b482af70e0c8c0c8',
+            '5edea55ce87d5adb14f6ed6996f308879e268b8cec760cf11288e3a56179a029',
             # TensorFlow-2.5.0_fix-crash-on-shutdown.patch
             '578c7493221ebd3dc25ca43d63a72cbb28fdf4112b1e2baa7390f25781bd78fd',
             # TensorFlow-2.5.0_fix_numpy_1.20_compatibility.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.7.1-foss-2021b-CUDA-11.4.1.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.7.1-foss-2021b-CUDA-11.4.1.eb
@@ -223,7 +223,7 @@ exts_list = [
             # TensorFlow-2.5.0-fix-alias-violation-in-absl.patch
             '12454fda3330fb45cd380377e283f04488b40e0b8ae7378e786ddf731a581f75',
             # TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch
-            '6abfadc0f67ff3b510d70430843201cb46d7bd65db045ec9b482af70e0c8c0c8',
+            '5edea55ce87d5adb14f6ed6996f308879e268b8cec760cf11288e3a56179a029',
             # TensorFlow-2.5.0_fix-crash-on-shutdown.patch
             '578c7493221ebd3dc25ca43d63a72cbb28fdf4112b1e2baa7390f25781bd78fd',
             # TensorFlow-2.7.1_fix_protobuf_error_message.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.7.1-foss-2021b.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.7.1-foss-2021b.eb
@@ -219,7 +219,7 @@ exts_list = [
             # TensorFlow-2.5.0-fix-alias-violation-in-absl.patch
             '12454fda3330fb45cd380377e283f04488b40e0b8ae7378e786ddf731a581f75',
             # TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch
-            '6abfadc0f67ff3b510d70430843201cb46d7bd65db045ec9b482af70e0c8c0c8',
+            '5edea55ce87d5adb14f6ed6996f308879e268b8cec760cf11288e3a56179a029',
             # TensorFlow-2.5.0_fix-crash-on-shutdown.patch
             '578c7493221ebd3dc25ca43d63a72cbb28fdf4112b1e2baa7390f25781bd78fd',
             # TensorFlow-2.7.1_fix_protobuf_error_message.patch

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.8.4-foss-2021b.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.8.4-foss-2021b.eb
@@ -195,7 +195,7 @@ exts_list = [
             {'TensorFlow-2.5.0-fix-alias-violation-in-absl.patch':
              '12454fda3330fb45cd380377e283f04488b40e0b8ae7378e786ddf731a581f75'},
             {'TensorFlow-2.5.0_fix-arm-vector-intrinsics.patch':
-             '6abfadc0f67ff3b510d70430843201cb46d7bd65db045ec9b482af70e0c8c0c8'},
+             '5edea55ce87d5adb14f6ed6996f308879e268b8cec760cf11288e3a56179a029'},
             {'TensorFlow-2.5.0_fix-crash-on-shutdown.patch':
              '578c7493221ebd3dc25ca43d63a72cbb28fdf4112b1e2baa7390f25781bd78fd'},
             {'TensorFlow-2.7.1_remove-duplicate-gpu-tests.patch':


### PR DESCRIPTION
The patch is actually wrong and may yield wrong results. Use the upstream patch from TF 2.10

I misunderstood the comment when creating the original patch which I noticed when checking the patches for TF 2.11 where the issue was fixed in the TensorFlow repo.

@boegel Can you test this on your ARM machine and include this for the next release please?