### PR TITLE
add additional extensions to Python 3.10.8 (required for scipy test suite)

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.10.8-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.10.8-GCCcore-12.2.0.eb
@@ -138,6 +138,8 @@ exts_list = [
         'checksums': ['d8daccb14dc0eae1b6b6eb3ecef79675bd37b4065369f79c35393dd5c55652c7'],
     }),
     ('cryptography', '38.0.3', {
+        # avoid that cargo uses $HOME/.cargo, which can lead to build failures if home directory is NFS mounted,
+        # see https://github.com/rust-lang/cargo/issues/6652
         'preinstallopts': "export CARGO_HOME=%(builddir)s/cargo && ",
         'checksums': ['bfbe6ee19615b07a98b1d2287d6a6073f734735b49ee45b11324d85efc4d5cbd'],
     }),
@@ -383,19 +385,19 @@ exts_list = [
         'checksums': ['9e77e941042ad3a4cc305dcdf2b2dec1aec2fbe3dd9015d2698ad02b173006d1'],
     }),
     ('pastel', '0.2.1', {
-        'source_tmpl': '%(name)s-%(version)s-py2.py3-none-any.whl',
+        'source_tmpl': SOURCE_WHL,
         'checksums': ['4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364'],
     }),
     ('crashtest', '0.3.1', {
-        'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
+        'source_tmpl': SOURCE_PY3_WHL,
         'checksums': ['300f4b0825f57688b47b6d70c6a31de33512eb2fa1ac614f780939aa0cf91680'],
     }),
     ('clikit', '0.6.2', {
-        'source_tmpl': '%(name)s-%(version)s-py2.py3-none-any.whl',
+        'source_tmpl': SOURCE_WHL,
         'checksums': ['71268e074e68082306e23d7369a7b99f824a0ef926e55ba2665e911f7208489e'],
     }),
     ('jeepney', '0.8.0', {
-        'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
+        'source_tmpl': SOURCE_PY3_WHL,
         'checksums': ['c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755'],
     }),
     ('SecretStorage', '3.3.3', {
@@ -413,7 +415,7 @@ exts_list = [
         'checksums': ['2ba3d56441ba0637f5f9c096068f67010ac0453f9d0b626de2aa3019353b6431'],
     }),
     ('tomlkit', '0.11.6', {
-        'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
+        'source_tmpl': SOURCE_PY3_WHL,
         'checksums': ['07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b'],
     }),
     ('shellingham', '1.5.0', {
@@ -429,7 +431,7 @@ exts_list = [
         'checksums': ['a84da4318dd86f870a9447a8c98340aa06216bfc6f2b7bdc4b8766984ae1867c'],
     }),
     ('ptyprocess', '0.7.0', {
-        'source_tmpl': '%(name)s-%(version)s-py2.py3-none-any.whl',
+        'source_tmpl': SOURCE_WHL,
         'checksums': ['4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35'],
     }),
     ('pexpect', '4.8.0', {
@@ -451,7 +453,7 @@ exts_list = [
         'checksums': ['b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f'],
     }),
     ('cleo', '1.0.0a5', {
-        'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
+        'source_tmpl': SOURCE_PY3_WHL,
         'checksums': ['ff53056589300976e960f75afb792dfbfc9c78dcbb5a448e207a17b643826360'],
     }),
     ('cachy', '0.3.0', {

--- a/easybuild/easyconfigs/p/Python/Python-3.10.8-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.10.8-GCCcore-12.2.0.eb
@@ -138,8 +138,6 @@ exts_list = [
         'checksums': ['d8daccb14dc0eae1b6b6eb3ecef79675bd37b4065369f79c35393dd5c55652c7'],
     }),
     ('cryptography', '38.0.3', {
-        # avoid that cargo uses $HOME/.cargo, which can lead to build failures if home directory is NFS mounted,
-        # see https://github.com/rust-lang/cargo/issues/6652
         'preinstallopts': "export CARGO_HOME=%(builddir)s/cargo && ",
         'checksums': ['bfbe6ee19615b07a98b1d2287d6a6073f734735b49ee45b11324d85efc4d5cbd'],
     }),
@@ -385,19 +383,19 @@ exts_list = [
         'checksums': ['9e77e941042ad3a4cc305dcdf2b2dec1aec2fbe3dd9015d2698ad02b173006d1'],
     }),
     ('pastel', '0.2.1', {
-        'source_tmpl': SOURCE_WHL,
+        'source_tmpl': '%(name)s-%(version)s-py2.py3-none-any.whl',
         'checksums': ['4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364'],
     }),
     ('crashtest', '0.3.1', {
-        'source_tmpl': SOURCE_PY3_WHL,
+        'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
         'checksums': ['300f4b0825f57688b47b6d70c6a31de33512eb2fa1ac614f780939aa0cf91680'],
     }),
     ('clikit', '0.6.2', {
-        'source_tmpl': SOURCE_WHL,
+        'source_tmpl': '%(name)s-%(version)s-py2.py3-none-any.whl',
         'checksums': ['71268e074e68082306e23d7369a7b99f824a0ef926e55ba2665e911f7208489e'],
     }),
     ('jeepney', '0.8.0', {
-        'source_tmpl': SOURCE_PY3_WHL,
+        'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
         'checksums': ['c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755'],
     }),
     ('SecretStorage', '3.3.3', {
@@ -415,7 +413,7 @@ exts_list = [
         'checksums': ['2ba3d56441ba0637f5f9c096068f67010ac0453f9d0b626de2aa3019353b6431'],
     }),
     ('tomlkit', '0.11.6', {
-        'source_tmpl': SOURCE_PY3_WHL,
+        'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
         'checksums': ['07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b'],
     }),
     ('shellingham', '1.5.0', {
@@ -431,7 +429,7 @@ exts_list = [
         'checksums': ['a84da4318dd86f870a9447a8c98340aa06216bfc6f2b7bdc4b8766984ae1867c'],
     }),
     ('ptyprocess', '0.7.0', {
-        'source_tmpl': SOURCE_WHL,
+        'source_tmpl': '%(name)s-%(version)s-py2.py3-none-any.whl',
         'checksums': ['4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35'],
     }),
     ('pexpect', '4.8.0', {
@@ -453,7 +451,7 @@ exts_list = [
         'checksums': ['b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f'],
     }),
     ('cleo', '1.0.0a5', {
-        'source_tmpl': SOURCE_PY3_WHL,
+        'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
         'checksums': ['ff53056589300976e960f75afb792dfbfc9c78dcbb5a448e207a17b643826360'],
     }),
     ('cachy', '0.3.0', {
@@ -494,16 +492,33 @@ exts_list = [
         'source_tmpl': 'simplegeneric-%(version)s.zip',
         'checksums': ['dc972e06094b9af5b855b3df4a646395e43d1c9d0d39ed345b7393560d0b9173'],
     }),
-    ('pooch', '1.6.0'),
-    ('doit', '0.36.0'),
-    ('cloudpickle', '2.2.0'),
-    ('pydevtool', '0.3.0'),
-    ('rich', '13.1.0'),
-    ('rich-click', '1.6.0'),
-    ('commonmark', '0.9.1'),
-    ('execnet', '1.9.0'),
+    ('pooch', '1.6.0', {
+        'checksums': ['57d20ec4b10dd694d2b05bb64bc6b109c6e85a6c1405794ce87ed8b341ab3f44'],
+    }),
+    ('doit', '0.36.0', {
+        'checksums': ['71d07ccc9514cb22fe59d98999577665eaab57e16f644d04336ae0b4bae234bc'],
+    }),
+    ('cloudpickle', '2.2.0', {
+        'checksums': ['3f4219469c55453cfe4737e564b67c2a149109dabf7f242478948b895f61106f'],
+    }),
+    ('pydevtool', '0.3.0', {
+        'checksums': ['25e3ba4f3d33ccac33ee2b9775995848d49e9b318b7a146477fb5d52f786fc8a'],
+    }),
+    ('rich', '13.1.0', {
+        'checksums': ['81c73a30b144bbcdedc13f4ea0b6ffd7fdc3b0d3cc259a9402309c8e4aee1964'],
+    }),
+    ('rich-click', '1.6.0', {
+        'checksums': ['33799c31f8817101f2eb8fe90e95d2c2acd428a567ee64358ca487f963f75e9c'],
+    }),
+    ('commonmark', '0.9.1', {
+        'checksums': ['452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60'],
+    }),
+    ('execnet', '1.9.0', {
+        'checksums': ['8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5'],
+    }),
     ('pytest-xdist', '3.1.0', {
         'modulename': 'xdist',
+        'checksums': ['40fdb8f3544921c5dfcd486ac080ce22870e71d82ced6d2e78fa97c2addd480c'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Python/Python-3.10.8-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.10.8-GCCcore-12.2.0.eb
@@ -494,6 +494,17 @@ exts_list = [
         'source_tmpl': 'simplegeneric-%(version)s.zip',
         'checksums': ['dc972e06094b9af5b855b3df4a646395e43d1c9d0d39ed345b7393560d0b9173'],
     }),
+    ('pooch', '1.6.0'),
+    ('doit', '0.36.0'),
+    ('cloudpickle', '2.2.0'),
+    ('pydevtool', '0.3.0'),
+    ('rich', '13.1.0'),
+    ('rich-click', '1.6.0'),
+    ('commonmark', '0.9.1'),
+    ('execnet', '1.9.0'),
+    ('pytest-xdist', '3.1.0', {
+        'modulename': 'xdist',
+    }),
 ]
 
 moduleclass = 'lang'


### PR DESCRIPTION
adds the following extensions (used to run `scipy` test suite):

- pooch
- doit
- cloudpickle
- pydevtool
- rich
- rich-click
- commonmark
- execnet
- pytest-xdist

(created using `eb --new-pr`)
