### PR TITLE
add patches for Qt5 5.15.5 to fix compilation failures in abseil and breakpad with glibc 2.34

### DIFF
--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.15.2_fix-qtwebengine-abseil-cpp-glibc-2.34.patch
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.15.2_fix-qtwebengine-abseil-cpp-glibc-2.34.patch
@@ -1,0 +1,75 @@
+Fix "no matching function" error.
+Patch taken from https://bugs.gentoo.org/811312
+
+From 78b1bcff4d9b977313e9ea15068168e1b11f5ba1 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Wed, 4 Aug 2021 19:08:03 +0200
+Subject: [PATCH] chromium: abseil-cpp: fix build with glibc-2.34
+
+* backport a fix from upstream abseil-cpp:
+  https://github.com/abseil/abseil-cpp/commit/a9831f1cbf93fb18dd951453635f488037454ce9
+
+  to fix:
+
+[97/24505] CXX obj/third_party/abseil-cpp/absl/debugging/failure_signal_handler/failure_signal_handler.o
+FAILED: obj/third_party/abseil-cpp/absl/debugging/failure_signal_handler/failure_signal_handler.o
+/OE/build/luneos-honister/webos-ports/tmp-glibc/work/core2-64-webos-linux/qtwebengine/5.15.4+gitAUTOINC+dd7f7a9166_555f348ae8-r0/recipe-sysroot-native/usr/bin/x86_64-webos-linux/x86_64-webos-linux-g++ -m64 -march=core2 -mtune=core2 -msse3 -mfpmath=sse -Wdate-time --sysroot=/OE/build/luneos-honister/webos-ports/tmp-glibc/work/core2-64-webos-linux/qtwebengine/5.15.4+gitAUTOINC+dd7f7a9166_555f348ae8-r0/recipe-sysroot -MMD -MF obj/third_party/abseil-cpp/absl/debugging/failure_signal_handler/failure_signal_handler.o.d -DUSE_UDEV -DUSE_AURA=1 -DUSE_NSS_CERTS=1 -DUSE_OZONE=1 -DOFFICIAL_BUILD -DTOOLKIT_QT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DNO_UNWIND_TABLES -DCR_SYSROOT_HASH=5f64b417e1018dcf8fcc81dc2714e0f264b9b911 -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DABSL_ALLOCATOR_NOTHROW=1 -Igen -I../../../../git/src/3rdparty/chromium -I../../../../git/src/3rdparty/chromium/third_party/abseil-cpp -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -pipe -pthread -m64 -O2 -fno-ident -fdata-sections -ffunction-sections -fno-omit-frame-pointer -g1 -fvisibility=hidden -Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wno-deprecated-declarations -fno-delete-null-pointer-checks -Wno-comments -Wno-packed-not-aligned -Wno-dangling-else -Wno-missing-field-initializers -Wno-unused-parameter -std=gnu++14 -fno-exceptions -fno-rtti --sysroot=../../../../recipe-sysroot -fvisibility-inlines-hidden -Wno-narrowing -Wno-class-memaccess -Wno-attributes -Wno-class-memaccess -Wno-subobject-linkage -Wno-invalid-offsetof -Wno-return-type -Wno-deprecated-copy -c ../../../../git/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc -o obj/third_party/abseil-cpp/absl/debugging/failure_signal_handler/failure_signal_handler.o
+../../../../git/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc: In function 'bool absl::SetupAlternateStackOnce()':
+../../../../git/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc:138:32: error: no matching function for call to 'max(long int, int)'
+  138 |   size_t stack_size = (std::max(SIGSTKSZ, 65536) + page_mask) & ~page_mask;
+      |                        ~~~~~~~~^~~~~~~~~~~~~~~~~
+In file included from ../../../../recipe-sysroot/usr/include/c++/11.2.0/algorithm:61,
+                 from ../../../../git/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc:35:
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algobase.h:254:5: note: candidate: 'template<class _Tp> constexpr const _Tp& std::max(const _Tp&, const _Tp&)'
+  254 |     max(const _Tp& __a, const _Tp& __b)
+      |     ^~~
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algobase.h:254:5: note:   template argument deduction/substitution failed:
+../../../../git/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc:138:32: note:   deduced conflicting types for parameter 'const _Tp' ('long int' and 'int')
+  138 |   size_t stack_size = (std::max(SIGSTKSZ, 65536) + page_mask) & ~page_mask;
+      |                        ~~~~~~~~^~~~~~~~~~~~~~~~~
+In file included from ../../../../recipe-sysroot/usr/include/c++/11.2.0/algorithm:61,
+                 from ../../../../git/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc:35:
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algobase.h:300:5: note: candidate: 'template<class _Tp, class _Compare> constexpr const _Tp& std::max(const _Tp&, const _Tp&, _Compare)'
+  300 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
+      |     ^~~
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algobase.h:300:5: note:   template argument deduction/substitution failed:
+../../../../git/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc:138:32: note:   deduced conflicting types for parameter 'const _Tp' ('long int' and 'int')
+  138 |   size_t stack_size = (std::max(SIGSTKSZ, 65536) + page_mask) & ~page_mask;
+      |                        ~~~~~~~~^~~~~~~~~~~~~~~~~
+In file included from ../../../../recipe-sysroot/usr/include/c++/11.2.0/algorithm:62,
+                 from ../../../../git/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc:35:
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algo.h:3461:5: note: candidate: 'template<class _Tp> constexpr _Tp std::max(std::initializer_list<_Tp>)'
+ 3461 |     max(initializer_list<_Tp> __l)
+      |     ^~~
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algo.h:3461:5: note:   template argument deduction/substitution failed:
+../../../../git/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc:138:32: note:   mismatched types 'std::initializer_list<_Tp>' and 'long int'
+  138 |   size_t stack_size = (std::max(SIGSTKSZ, 65536) + page_mask) & ~page_mask;
+      |                        ~~~~~~~~^~~~~~~~~~~~~~~~~
+In file included from ../../../../recipe-sysroot/usr/include/c++/11.2.0/algorithm:62,
+                 from ../../../../git/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc:35:
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algo.h:3467:5: note: candidate: 'template<class _Tp, class _Compare> constexpr _Tp std::max(std::initializer_list<_Tp>, _Compare)'
+ 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
+      |     ^~~
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algo.h:3467:5: note:   template argument deduction/substitution failed:
+../../../../git/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc:138:32: note:   mismatched types 'std::initializer_list<_Tp>' and 'long int'
+  138 |   size_t stack_size = (std::max(SIGSTKSZ, 65536) + page_mask) & ~page_mask;
+      |                        ~~~~~~~~^~~~~~~~~~~~~~~~~
+
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+ .../abseil-cpp/absl/debugging/failure_signal_handler.cc         | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc b/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
+index 5d13bdbbbd1..150a43f2660 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
+@@ -135,7 +135,7 @@ static bool SetupAlternateStackOnce() {
+ #else
+   const size_t page_mask = sysconf(_SC_PAGESIZE) - 1;
+ #endif
+-  size_t stack_size = (std::max(SIGSTKSZ, 65536) + page_mask) & ~page_mask;
++  size_t stack_size = (std::max<size_t>(SIGSTKSZ, 65536) + page_mask) & ~page_mask;
+ #if defined(ABSL_HAVE_ADDRESS_SANITIZER) || \
+     defined(ABSL_HAVE_MEMORY_SANITIZER) || defined(ABSL_HAVE_THREAD_SANITIZER)
+   // Account for sanitizer instrumentation requiring additional stack space.

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.15.2_fix-qtwebengine-breakpad-glibc-2.34.patch
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.15.2_fix-qtwebengine-breakpad-glibc-2.34.patch
@@ -1,0 +1,75 @@
+Fix "no matching function" error.
+Patch taken from https://bugs.gentoo.org/811312
+
+From a3bc792bdc116806a50e022d9102914c8daf6210 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Wed, 4 Aug 2021 19:11:06 +0200
+Subject: [PATCH] chromium: breakpad: fix build with glibc-2.34
+
+* fixes:
+[218/24061] CXX obj/third_party/breakpad/client/exception_handler.o
+FAILED: obj/third_party/breakpad/client/exception_handler.o
+/OE/build/luneos-honister/webos-ports/tmp-glibc/work/core2-64-webos-linux/qtwebengine/5.15.4+gitAUTOINC+dd7f7a9166_555f348ae8-r0/recipe-sysroot-native/usr/bin/x86_64-webos-linux/x86_64-webos-linux-g++ -m64 -march=core2 -mtune=core2 -msse3 -mfpmath=sse -Wdate-time --sysroot=/OE/build/luneos-honister/webos-ports/tmp-glibc/work/core2-64-webos-linux/qtwebengine/5.15.4+gitAUTOINC+dd7f7a9166_555f348ae8-r0/recipe-sysroot -MMD -MF obj/third_party/breakpad/client/exception_handler.o.d -DUSE_UDEV -DUSE_AURA=1 -DUSE_NSS_CERTS=1 -DUSE_OZONE=1 -DOFFICIAL_BUILD -DTOOLKIT_QT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DNO_UNWIND_TABLES -DCR_SYSROOT_HASH=5f64b417e1018dcf8fcc81dc2714e0f264b9b911 -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -I../../../../git/src/3rdparty/chromium/third_party/breakpad -I../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src -I../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client -I../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/third_party/linux/include -Igen -I../../../../git/src/3rdparty/chromium -I../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -pipe -pthread -m64 -O2 -fno-ident -fdata-sections -ffunction-sections -fno-omit-frame-pointer -g1 -fvisibility=hidden -Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wno-deprecated-declarations -fno-delete-null-pointer-checks -Wno-comments -Wno-packed-not-aligned -Wno-dangling-else -Wno-missing-field-initializers -Wno-unused-parameter -std=gnu++14 -fno-exceptions -fno-rtti --sysroot=../../../../recipe-sysroot -fvisibility-inlines-hidden -Wno-narrowing -Wno-class-memaccess -Wno-attributes -Wno-class-memaccess -Wno-subobject-linkage -Wno-invalid-offsetof -Wno-return-type -Wno-deprecated-copy -c ../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc -o obj/third_party/breakpad/client/exception_handler.o
+../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc: In function 'void google_breakpad::{anonymous}::InstallAlternateStackLocked()':
+../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc:141:49: error: no matching function for call to 'max(int, long int)'
+  141 |   static const unsigned kSigStackSize = std::max(16384, SIGSTKSZ);
+      |                                         ~~~~~~~~^~~~~~~~~~~~~~~~~
+In file included from ../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/char_traits.h:39,
+                 from ../../../../recipe-sysroot/usr/include/c++/11.2.0/string:40,
+                 from ../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.h:38,
+                 from ../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc:66:
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algobase.h:254:5: note: candidate: 'template<class _Tp> constexpr const _Tp& std::max(const _Tp&, const _Tp&)'
+  254 |     max(const _Tp& __a, const _Tp& __b)
+      |     ^~~
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algobase.h:254:5: note:   template argument deduction/substitution failed:
+../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc:141:49: note:   deduced conflicting types for parameter 'const _Tp' ('int' and 'long int')
+  141 |   static const unsigned kSigStackSize = std::max(16384, SIGSTKSZ);
+      |                                         ~~~~~~~~^~~~~~~~~~~~~~~~~
+In file included from ../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/char_traits.h:39,
+                 from ../../../../recipe-sysroot/usr/include/c++/11.2.0/string:40,
+                 from ../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.h:38,
+                 from ../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc:66:
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algobase.h:300:5: note: candidate: 'template<class _Tp, class _Compare> constexpr const _Tp& std::max(const _Tp&, const _Tp&, _Compare)'
+  300 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
+      |     ^~~
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algobase.h:300:5: note:   template argument deduction/substitution failed:
+../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc:141:49: note:   deduced conflicting types for parameter 'const _Tp' ('int' and 'long int')
+  141 |   static const unsigned kSigStackSize = std::max(16384, SIGSTKSZ);
+      |                                         ~~~~~~~~^~~~~~~~~~~~~~~~~
+In file included from ../../../../recipe-sysroot/usr/include/c++/11.2.0/algorithm:62,
+                 from ../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc:85:
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algo.h:3461:5: note: candidate: 'template<class _Tp> constexpr _Tp std::max(std::initializer_list<_Tp>)'
+ 3461 |     max(initializer_list<_Tp> __l)
+      |     ^~~
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algo.h:3461:5: note:   template argument deduction/substitution failed:
+../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc:141:49: note:   mismatched types 'std::initializer_list<_Tp>' and 'int'
+  141 |   static const unsigned kSigStackSize = std::max(16384, SIGSTKSZ);
+      |                                         ~~~~~~~~^~~~~~~~~~~~~~~~~
+In file included from ../../../../recipe-sysroot/usr/include/c++/11.2.0/algorithm:62,
+                 from ../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc:85:
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algo.h:3467:5: note: candidate: 'template<class _Tp, class _Compare> constexpr _Tp std::max(std::initializer_list<_Tp>, _Compare)'
+ 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
+      |     ^~~
+../../../../recipe-sysroot/usr/include/c++/11.2.0/bits/stl_algo.h:3467:5: note:   template argument deduction/substitution failed:
+../../../../git/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc:141:49: note:   mismatched types 'std::initializer_list<_Tp>' and 'int'
+  141 |   static const unsigned kSigStackSize = std::max(16384, SIGSTKSZ);
+      |                                         ~~~~~~~~^~~~~~~~~~~~~~~~~
+
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+ .../breakpad/src/client/linux/handler/exception_handler.cc      | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc b/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc
+index ca353c40997..2e43ba6fc04 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc
+@@ -138,7 +138,7 @@ void InstallAlternateStackLocked() {
+   // SIGSTKSZ may be too small to prevent the signal handlers from overrunning
+   // the alternative stack. Ensure that the size of the alternative stack is
+   // large enough.
+-  static const unsigned kSigStackSize = std::max(16384, SIGSTKSZ);
++  static const unsigned kSigStackSize = std::max<size_t>(16384, SIGSTKSZ);
+ 
+   // Only set an alternative stack if there isn't already one, or if the current
+   // one is too small.

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.15.5-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.15.5-GCCcore-11.3.0.eb
@@ -20,14 +20,21 @@ patches = [
     'Qt5-5.13.1_fix-avx2.patch',
     'Qt5-5.13.1_fix-qmake-libdir.patch',
     'Qt5-5.14.1_fix-OF-Gentoo.patch',
+    'Qt5-5.15.2_fix-qtwebengine-abseil-cpp-glibc-2.34.patch',
+    'Qt5-5.15.2_fix-qtwebengine-breakpad-glibc-2.34.patch',
     'Qt5-5.15.5_fix-qtwebegine-HarfBuzz-3.x.patch',
 ]
 checksums = [
-    '5a97827bdf9fd515f43bc7651defaf64fecb7a55e051c79b8f80510d0e990f06',  # qt-everywhere-opensource-src-5.15.5.tar.xz
-    '6f46005f056bf9e6ff3e5d012a874d18ee03b33e685941f2979c970be91a9dbc',  # Qt5-5.13.1_fix-avx2.patch
-    '511ca9c0599ceb1989f73d8ceea9199c041512d3a26ee8c5fd870ead2c10cb63',  # Qt5-5.13.1_fix-qmake-libdir.patch
-    '0b9defb7ce75314d85bebe07e143db7f7de316fec64c17cbd13f7eec5d2d1afa',  # Qt5-5.14.1_fix-OF-Gentoo.patch
-    '599cc94535dc276a5d97e002c81907c74ead9dc8d55f35567017fb7a491aaf01',  # Qt5-5.15.5_fix-qtwebegine-HarfBuzz-3.x.patch
+    {'qt-everywhere-opensource-src-5.15.5.tar.xz': '5a97827bdf9fd515f43bc7651defaf64fecb7a55e051c79b8f80510d0e990f06'},
+    {'Qt5-5.13.1_fix-avx2.patch': '6f46005f056bf9e6ff3e5d012a874d18ee03b33e685941f2979c970be91a9dbc'},
+    {'Qt5-5.13.1_fix-qmake-libdir.patch': '511ca9c0599ceb1989f73d8ceea9199c041512d3a26ee8c5fd870ead2c10cb63'},
+    {'Qt5-5.14.1_fix-OF-Gentoo.patch': '0b9defb7ce75314d85bebe07e143db7f7de316fec64c17cbd13f7eec5d2d1afa'},
+    {'Qt5-5.15.2_fix-qtwebengine-abseil-cpp-glibc-2.34.patch':
+     'f39506495b70cc0968fb7a5f4c9028b0f0a180c552906ff4e58e0bcae83cf187'},
+    {'Qt5-5.15.2_fix-qtwebengine-breakpad-glibc-2.34.patch':
+     '74590de2b9e32f2c88123cb096c4f5c3001b00710aad096a4d16444a8e9eb991'},
+    {'Qt5-5.15.5_fix-qtwebegine-HarfBuzz-3.x.patch':
+     '599cc94535dc276a5d97e002c81907c74ead9dc8d55f35567017fb7a491aaf01'},
 ]
 
 builddependencies = [


### PR DESCRIPTION
Fixes #17059 