### PR TITLE
use proper source tarball instead of cloning GitHub repository for wxWidgets v3.2.1

### DIFF
--- a/easybuild/easyconfigs/w/wxWidgets/wxWidgets-3.2.1-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/w/wxWidgets/wxWidgets-3.2.1-GCC-11.3.0.eb
@@ -14,7 +14,8 @@ uses the platform's native API rather than emulating the GUI."""
 toolchain = {'name': 'GCC', 'version': '11.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://github.com/wxWidgets/wxWidgets/archive']
+github_account = 'wxWidgets'
+source_urls = [GITHUB_RELEASE]
 sources = [SOURCE_TAR_BZ2]
 checksums = ['c229976bb413eb88e45cb5dfb68b27890d450149c09b331abd751e7ae0f5fa66']
 

--- a/easybuild/easyconfigs/w/wxWidgets/wxWidgets-3.2.1-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/w/wxWidgets/wxWidgets-3.2.1-GCC-11.3.0.eb
@@ -14,17 +14,9 @@ uses the platform's native API rather than emulating the GUI."""
 toolchain = {'name': 'GCC', 'version': '11.3.0'}
 toolchainopts = {'pic': True}
 
-# wxWidgets now contain three submodules: catch, nanosvg and pcre
-sources = [{
-    'git_config': {
-        'url': 'https://github.com/wxWidgets/',
-        'repo_name': 'wxWidgets',
-        'tag': 'v%(version)s',
-        'recursive': True,
-    },
-    'filename': SOURCE_TAR_GZ,
-}]
-checksums = [None]
+source_urls = ['https://github.com/wxWidgets/wxWidgets/archive']
+sources = [SOURCE_TAR_BZ2]
+checksums = ['c229976bb413eb88e45cb5dfb68b27890d450149c09b331abd751e7ae0f5fa66']
 
 builddependencies = [
     ('gettext', '0.21'),


### PR DESCRIPTION
Replace git checkout with a tarball download (see PR #16292)