### PR TITLE
HDF5 has a FORTRAN api so must be at compiler level

### DIFF
--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.5-GCC-8.3.0-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.5-GCC-8.3.0-serial.eb
@@ -7,16 +7,12 @@ description = """HDF5 is a data model, library, and file format for storing and 
  It supports an unlimited variety of datatypes, and is designed for flexible
  and efficient I/O and for high volume and complex data."""
 
-toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+toolchain = {'name': 'GCC', 'version': '8.3.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['6d4ce8bf902a97b050f6f491f4268634e252a63dadd6656a1a9be5b7b7726fa8']
-
-builddependencies = [
-    ('binutils', '2.32'),
-]
 
 dependencies = [
     ('zlib', '1.2.11'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.12.2-GCC-11.3.0-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.12.2-GCC-11.3.0-serial.eb
@@ -1,5 +1,6 @@
 name = 'HDF5'
-version = '1.13.1'
+# Note: Odd minor releases are only RCs and should not be used.
+version = '1.12.2'
 versionsuffix = '-serial'
 
 homepage = 'https://portal.hdfgroup.org/display/support'
@@ -7,16 +8,12 @@ description = """HDF5 is a data model, library, and file format for storing and 
  It supports an unlimited variety of datatypes, and is designed for flexible
  and efficient I/O and for high volume and complex data."""
 
-toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+toolchain = {'name': 'GCC', 'version': '11.3.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['051655873105112f7aeccd5f59ab21f35f7f4907f06921ae61aaf1ef1c71fd53']
-
-builddependencies = [
-    ('binutils', '2.38'),
-]
+checksums = ['2a89af03d56ce7502dcae18232c241281ad1773561ec00c0f0e8ee2463910f14']
 
 dependencies = [
     ('zlib', '1.2.12'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.13.1-GCC-11.3.0-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.13.1-GCC-11.3.0-serial.eb
@@ -1,6 +1,5 @@
 name = 'HDF5'
-# Note: Odd minor releases are only RCs and should not be used.
-version = '1.12.2'
+version = '1.13.1'
 versionsuffix = '-serial'
 
 homepage = 'https://portal.hdfgroup.org/display/support'
@@ -8,16 +7,12 @@ description = """HDF5 is a data model, library, and file format for storing and 
  It supports an unlimited variety of datatypes, and is designed for flexible
  and efficient I/O and for high volume and complex data."""
 
-toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+toolchain = {'name': 'GCC', 'version': '11.3.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['2a89af03d56ce7502dcae18232c241281ad1773561ec00c0f0e8ee2463910f14']
-
-builddependencies = [
-    ('binutils', '2.38'),
-]
+checksums = ['051655873105112f7aeccd5f59ab21f35f7f4907f06921ae61aaf1ef1c71fd53']
 
 dependencies = [
     ('zlib', '1.2.12'),


### PR DESCRIPTION
Fixes https://github.com/easybuilders/easybuild-easyconfigs/issues/17219

I've left the merged `v1.13.1` there as I can't be sure of the impact of removing it. The only easyconfig that depends on one of  these (in our releases) is `h5py-2.10.0-foss-2019b-serial-Python-3.7.4.eb` and since that uses the same compiler there is no material change.