### PR TITLE
{perf}[gompi/2022a, gompi/2022b, iimpi/2022a, iimpi/2022b] IMB v2021.3

### DIFF
--- a/easybuild/easyconfigs/i/IMB/IMB-2021.3-gompi-2022a.eb
+++ b/easybuild/easyconfigs/i/IMB/IMB-2021.3-gompi-2022a.eb
@@ -1,0 +1,31 @@
+easyblock = 'MakeCp'
+
+name = 'IMB'
+version = '2021.3'
+
+homepage = 'https://software.intel.com/en-us/articles/intel-mpi-benchmarks'
+description = """The Intel MPI Benchmarks perform a set of MPI performance measurements for point-to-point and
+ global communication operations for a range of message sizes"""
+
+docurls = ['https://software.intel.com/en-us/imb-user-guide']
+
+toolchain = {'name': 'gompi', 'version': '2022a'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/intel/mpi-benchmarks/archive/']
+sources = ['IMB-v%(version)s.tar.gz']
+checksums = ['9b58a4a7eef7c0c877513152340948402fd87cb06270d2d81308dc2ef740f4c7']
+
+buildopts = 'all CC="$MPICC"'
+
+parallel = 1
+
+files_to_copy = [(['IMB-*'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/IMB-EXT', 'bin/IMB-IO', 'bin/IMB-MPI1', 'bin/IMB-MT',
+              'bin/IMB-NBC', 'bin/IMB-P2P', 'bin/IMB-RMA'],
+    'dirs': [],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/i/IMB/IMB-2021.3-gompi-2022b.eb
+++ b/easybuild/easyconfigs/i/IMB/IMB-2021.3-gompi-2022b.eb
@@ -1,0 +1,31 @@
+easyblock = 'MakeCp'
+
+name = 'IMB'
+version = '2021.3'
+
+homepage = 'https://software.intel.com/en-us/articles/intel-mpi-benchmarks'
+description = """The Intel MPI Benchmarks perform a set of MPI performance measurements for point-to-point and
+ global communication operations for a range of message sizes"""
+
+docurls = ['https://software.intel.com/en-us/imb-user-guide']
+
+toolchain = {'name': 'gompi', 'version': '2022b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/intel/mpi-benchmarks/archive/']
+sources = ['IMB-v%(version)s.tar.gz']
+checksums = ['9b58a4a7eef7c0c877513152340948402fd87cb06270d2d81308dc2ef740f4c7']
+
+buildopts = 'all CC="$MPICC"'
+
+parallel = 1
+
+files_to_copy = [(['IMB-*'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/IMB-EXT', 'bin/IMB-IO', 'bin/IMB-MPI1', 'bin/IMB-MT',
+              'bin/IMB-NBC', 'bin/IMB-P2P', 'bin/IMB-RMA'],
+    'dirs': [],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/i/IMB/IMB-2021.3-iimpi-2022a.eb
+++ b/easybuild/easyconfigs/i/IMB/IMB-2021.3-iimpi-2022a.eb
@@ -1,0 +1,31 @@
+easyblock = 'MakeCp'
+
+name = 'IMB'
+version = '2021.3'
+
+homepage = 'https://software.intel.com/en-us/articles/intel-mpi-benchmarks'
+description = """The Intel MPI Benchmarks perform a set of MPI performance measurements for point-to-point and
+ global communication operations for a range of message sizes"""
+
+docurls = ['https://software.intel.com/en-us/imb-user-guide']
+
+toolchain = {'name': 'iimpi', 'version': '2022a'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/intel/mpi-benchmarks/archive/']
+sources = ['IMB-v%(version)s.tar.gz']
+checksums = ['9b58a4a7eef7c0c877513152340948402fd87cb06270d2d81308dc2ef740f4c7']
+
+buildopts = 'all CC="$MPICC"'
+
+parallel = 1
+
+files_to_copy = [(['IMB-*'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/IMB-EXT', 'bin/IMB-IO', 'bin/IMB-MPI1', 'bin/IMB-MT',
+              'bin/IMB-NBC', 'bin/IMB-P2P', 'bin/IMB-RMA'],
+    'dirs': [],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/i/IMB/IMB-2021.3-iimpi-2022b.eb
+++ b/easybuild/easyconfigs/i/IMB/IMB-2021.3-iimpi-2022b.eb
@@ -1,0 +1,31 @@
+easyblock = 'MakeCp'
+
+name = 'IMB'
+version = '2021.3'
+
+homepage = 'https://software.intel.com/en-us/articles/intel-mpi-benchmarks'
+description = """The Intel MPI Benchmarks perform a set of MPI performance measurements for point-to-point and
+ global communication operations for a range of message sizes"""
+
+docurls = ['https://software.intel.com/en-us/imb-user-guide']
+
+toolchain = {'name': 'iimpi', 'version': '2022b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/intel/mpi-benchmarks/archive/']
+sources = ['IMB-v%(version)s.tar.gz']
+checksums = ['9b58a4a7eef7c0c877513152340948402fd87cb06270d2d81308dc2ef740f4c7']
+
+buildopts = 'all CC="$MPICC"'
+
+parallel = 1
+
+files_to_copy = [(['IMB-*'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/IMB-EXT', 'bin/IMB-IO', 'bin/IMB-MPI1', 'bin/IMB-MT',
+              'bin/IMB-NBC', 'bin/IMB-P2P', 'bin/IMB-RMA'],
+    'dirs': [],
+}
+
+moduleclass = 'perf'


### PR DESCRIPTION
 Easy configurations for Intel MPI Benchmarks on 2022a and 2022b toolchains

Replacing #17276, which is a mess.