### PR TITLE
fix postinstallcmds in shovill easyconfigs

### DIFF
--- a/easybuild/easyconfigs/s/shovill/shovill-0.9.0-foss-2018a-Python-2.7.14.eb
+++ b/easybuild/easyconfigs/s/shovill/shovill-0.9.0-foss-2018a-Python-2.7.14.eb
@@ -33,8 +33,8 @@ dependencies = [
 ]
 
 postinstallcmds = [
-    """echo exec java -jar \$EBROOTTRIMMOMATIC/trimmomatic-*.jar '"$@"' > %(installdir)s/bin/trimmomatic""",
-    """echo exec java -jar $EBROOTPILON/pilon-*.jar '"$@"' > %(installdir)s/bin/pilon""",
+    """echo 'exec java -jar "$EBROOTTRIMMOMATIC"/trimmomatic-*.jar "$@"' > %(installdir)s/bin/trimmomatic""",
+    """echo 'exec java -jar "$EBROOTPILON"/pilon-*.jar "$@"' > %(installdir)s/bin/pilon""",
     "chmod a+rx %(installdir)s/bin/trimmomatic %(installdir)s/bin/pilon",
 ]
 

--- a/easybuild/easyconfigs/s/shovill/shovill-1.0.4-foss-2018b-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/s/shovill/shovill-1.0.4-foss-2018b-Python-2.7.15.eb
@@ -34,8 +34,8 @@ dependencies = [
 ]
 
 postinstallcmds = [
-    """echo exec java -jar \$EBROOTTRIMMOMATIC/trimmomatic-*.jar '"$@"' > %(installdir)s/bin/trimmomatic""",
-    """echo exec java -jar $EBROOTPILON/pilon-*.jar '"$@"' > %(installdir)s/bin/pilon""",
+    """echo 'exec java -jar "$EBROOTTRIMMOMATIC"/trimmomatic-*.jar "$@"' > %(installdir)s/bin/trimmomatic""",
+    """echo 'exec java -jar "$EBROOTPILON"/pilon-*.jar "$@"' > %(installdir)s/bin/pilon""",
     "chmod a+rx %(installdir)s/bin/trimmomatic %(installdir)s/bin/pilon",
 ]
 

--- a/easybuild/easyconfigs/s/shovill/shovill-1.1.0-gompi-2021b.eb
+++ b/easybuild/easyconfigs/s/shovill/shovill-1.1.0-gompi-2021b.eb
@@ -33,8 +33,8 @@ dependencies = [
 ]
 
 postinstallcmds = [
-    """echo exec java -jar \$EBROOTTRIMMOMATIC/trimmomatic-*.jar '"$@"' > %(installdir)s/bin/trimmomatic""",
-    """echo exec java -jar $EBROOTPILON/pilon-*.jar '"$@"' > %(installdir)s/bin/pilon""",
+    """echo 'exec java -jar "$EBROOTTRIMMOMATIC"/trimmomatic-*.jar "$@"' > %(installdir)s/bin/trimmomatic""",
+    """echo 'exec java -jar "$EBROOTPILON"/pilon-*.jar "$@"' > %(installdir)s/bin/pilon""",
     "chmod a+rx %(installdir)s/bin/trimmomatic %(installdir)s/bin/pilon",
 ]
 


### PR DESCRIPTION
- Create the script containing the (unexpanded) $EBROOT* variables.
- Quote string to be echoed to make it easier to read and avoid the escaping

Extracted from #11149

```
$ cat software/shovill/1.1.0-gompi-2021b/bin/{pilon,trimmomatic}
exec java -jar "$EBROOTPILON"/pilon-*.jar "$@"
exec java -jar "$EBROOTTRIMMOMATIC"/trimmomatic-*.jar "$@"
```


@jfgrimm @boegel 