### PR TITLE
Allow multiple ECs with same name if they differ by CUDA version

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -444,7 +444,7 @@ class EasyConfigTest(TestCase):
 
         # for some dependencies, we allow exceptions for software that depends on a particular version,
         # as long as that's indicated by the versionsuffix
-        versionsuffix_deps = ['ASE', 'Boost', 'CUDAcore', 'Java', 'Lua',
+        versionsuffix_deps = ['ASE', 'Boost', 'CUDA', 'CUDAcore', 'Java', 'Lua',
                               'PLUMED', 'PyTorch', 'R', 'TensorFlow']
         if dep in versionsuffix_deps and len(dep_vars) > 1:
 


### PR DESCRIPTION
Add `CUDA` to `versionsuffix_deps` next to `CUDAcore` as newer toolchains don't use `CUDAcore`.

Tested locally on top of #17272 : Before `test_dep_versions_per_toolchain_generation` fails, after this PR it succeeds.