### PR TITLE
rename python graphviz to graphviz-python to avoid case-insensitiive name clash

### DIFF
--- a/easybuild/easyconfigs/g/graphviz-python/graphviz-python-0.5.1-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/g/graphviz-python/graphviz-python-0.5.1-foss-2016b-Python-2.7.12.eb
@@ -1,6 +1,6 @@
 easyblock = 'PythonPackage'
 
-name = 'graphviz'
+name = 'graphviz-python'
 version = '0.5.1'
 versionsuffix = '-Python-%(pyver)s'
 
@@ -9,11 +9,19 @@ description = """Simple Python interface for Graphviz"""
 
 toolchain = {'name': 'foss', 'version': '2016b'}
 
-sources = [SOURCE_ZIP]
+source_urls = ['https://pypi.python.org/packages/source/g/graphviz']
+sources = ['graphviz-%(version)s.zip']
+checksums = ['d8f8f369a5c109d3fc971bbc1860b6848515d210aee8f5019c460351dbb00a50']
 
 dependencies = [
     ('Python', '2.7.12'),
     ('Graphviz', '2.38.0'),
 ]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+options = {'modulename': 'graphviz'}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/graphviz-python/graphviz-python-0.5.1-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/g/graphviz-python/graphviz-python-0.5.1-intel-2016b-Python-2.7.12.eb
@@ -1,6 +1,6 @@
 easyblock = 'PythonPackage'
 
-name = 'graphviz'
+name = 'graphviz-python'
 version = '0.5.1'
 versionsuffix = '-Python-%(pyver)s'
 
@@ -9,11 +9,19 @@ description = """Simple Python interface for Graphviz"""
 
 toolchain = {'name': 'intel', 'version': '2016b'}
 
-sources = [SOURCE_ZIP]
+source_urls = ['https://pypi.python.org/packages/source/g/graphviz']
+sources = ['graphviz-%(version)s.zip']
+checksums = ['d8f8f369a5c109d3fc971bbc1860b6848515d210aee8f5019c460351dbb00a50']
 
 dependencies = [
     ('Python', '2.7.12'),
     ('Graphviz', '2.38.0'),
 ]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+options = {'modulename': 'graphviz'}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/graphviz-python/graphviz-python-0.5.1-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/g/graphviz-python/graphviz-python-0.5.1-intel-2016b-Python-3.5.2.eb
@@ -1,6 +1,6 @@
 easyblock = 'PythonPackage'
 
-name = 'graphviz'
+name = 'graphviz-python'
 version = '0.5.1'
 versionsuffix = '-Python-%(pyver)s'
 
@@ -9,11 +9,19 @@ description = """Simple Python interface for Graphviz"""
 
 toolchain = {'name': 'intel', 'version': '2016b'}
 
-sources = [SOURCE_ZIP]
+source_urls = ['https://pypi.python.org/packages/source/g/graphviz']
+sources = ['graphviz-%(version)s.zip']
+checksums = ['d8f8f369a5c109d3fc971bbc1860b6848515d210aee8f5019c460351dbb00a50']
 
 dependencies = [
     ('Python', '3.5.2'),
     ('Graphviz', '2.38.0'),
 ]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+options = {'modulename': 'graphviz'}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/graphviz-python/graphviz-python-0.8.2-intel-2018a-Python-3.6.4.eb
+++ b/easybuild/easyconfigs/g/graphviz-python/graphviz-python-0.8.2-intel-2018a-Python-3.6.4.eb
@@ -1,6 +1,6 @@
 easyblock = 'PythonPackage'
 
-name = 'graphviz'
+name = 'graphviz-python'
 version = '0.8.2'
 versionsuffix = '-Python-%(pyver)s'
 
@@ -9,12 +9,19 @@ description = """Simple Python interface for Graphviz"""
 
 toolchain = {'name': 'intel', 'version': '2018a'}
 
-sources = [SOURCE_ZIP]
+source_urls = ['https://pypi.python.org/packages/source/g/graphviz']
+sources = ['graphviz-%(version)s.zip']
 checksums = ['606741c028acc54b1a065b33045f8c89ee0927ea77273ec409ac988f2c3d1091']
 
 dependencies = [
     ('Python', '3.6.4'),
     ('Graphviz', '2.40.1'),
 ]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+options = {'modulename': 'graphviz'}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/MXNet/MXNet-0.9.3-foss-2016b-Python-2.7.12-R-3.3.3.eb
+++ b/easybuild/easyconfigs/m/MXNet/MXNet-0.9.3-foss-2016b-Python-2.7.12-R-3.3.3.eb
@@ -2,7 +2,7 @@ name = 'MXNet'
 version = '0.9.3'
 versionsuffix = '-Python-%(pyver)s-R-%(rver)s'
 
-homepage = 'http://mxnet.io/'
+homepage = 'https://mxnet.io/'
 description = """Flexible and Efficient Library for Deep Learning"""
 
 toolchain = {'name': 'foss', 'version': '2016b'}
@@ -30,7 +30,7 @@ checksums = [
 
 dependencies = [
     ('Python', '2.7.12'),
-    ('graphviz', '0.5.1', '-Python-%(pyver)s'),
+    ('graphviz-python', '0.5.1', '-Python-%(pyver)s'),
     ('OpenCV', '3.1.0'),
     ('R', '3.3.3', '-X11-20160819'),
 ]


### PR DESCRIPTION
for https://github.com/easybuilders/easybuild-easyconfigs/issues/11824

I'm unable to build easyconfigs from these toolchains.