### PR TITLE
{chem}[foss/2022b,intel/2022b,intel/2022b 64bits] DIRAC v23.0

### DIFF
--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-foss-2022b.eb
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-foss-2022b.eb
@@ -1,0 +1,41 @@
+easyblock = 'CMakeMake'
+
+name = 'DIRAC'
+version = '23.0'
+
+homepage = 'http://www.diracprogram.org'
+description = "DIRAC: Program for Atomic and Molecular Direct Iterative Relativistic All-electron Calculations"
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://zenodo.org/record/7670749/files/']
+sources = ['DIRAC-%(version)s-Source.tar.gz']
+checksums = ['a0a6b6318b3cd2e3c6042221de720bb1e87eb758999e2108a48dedb9c564e1f8']
+
+builddependencies = [('CMake', '3.24.3')]
+
+dependencies = [
+    ('Python', '3.10.8'),
+    ('HDF5', '1.14.0')
+]
+
+configopts = '-DMKL_FLAG=off '
+configopts += '-DMATH_LIBS="$LIBLAPACK" '
+configopts += '-DENABLE_MPI=True '
+configopts += '-DENABLE_EXATENSOR=off '
+configopts += '-DENABLE_PCMSOLVER=off '
+
+pretestopts = 'export DIRAC_TMPDIR=%(builddir)s/scratch && '
+pretestopts += 'export DIRAC_MPI_COMMAND="%(mpi_cmd_prefix)s " && '
+
+runtest = 'test ARGS="-R pam_test" '
+
+sanity_check_paths = {
+    'files': ['bin/pam-dirac', 'share/dirac/dirac.x'],
+    'dirs': ['share/dirac/basis'],
+}
+
+sanity_check_commands = ["pam-dirac --help"]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-foss-2022b.eb
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-foss-2022b.eb
@@ -10,7 +10,7 @@ toolchain = {'name': 'foss', 'version': '2022b'}
 toolchainopts = {'usempi': True}
 
 source_urls = ['https://zenodo.org/record/7670749/files/']
-sources = ['DIRAC-%(version)s-Source.tar.gz']
+sources = ['DIRAC-%(version)s-Source.tgz']
 checksums = ['a0a6b6318b3cd2e3c6042221de720bb1e87eb758999e2108a48dedb9c564e1f8']
 
 builddependencies = [('CMake', '3.24.3')]

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-intel-2022b-int64.eb
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-intel-2022b-int64.eb
@@ -1,0 +1,42 @@
+easyblock = 'CMakeMake'
+
+name = 'DIRAC'
+version = '23.0'
+versionsuffix = '-int64'
+
+homepage = 'http://www.diracprogram.org'
+description = "DIRAC: Program for Atomic and Molecular Direct Iterative Relativistic All-electron Calculations"
+
+toolchain = {'name': 'intel', 'version': '2022b'}
+toolchainopts = {'usempi': True, 'i8': True}
+
+source_urls = ['https://zenodo.org/record/7670749/files/']
+sources = ['DIRAC-%(version)s-Source.tar.gz']
+checksums = ['a0a6b6318b3cd2e3c6042221de720bb1e87eb758999e2108a48dedb9c564e1f8']
+
+builddependencies = [('CMake', '3.24.3')]
+
+dependencies = [
+    ('Python', '3.10.8'),
+    ('HDF5', '1.14.0')
+]
+
+configopts = '-DMKL_FLAG=sequential '
+configopts += '-DENABLE_MPI=True '
+configopts += '-DENABLE_64BIT_INTEGERS=True '
+configopts += '-DENABLE_EXATENSOR=off '
+configopts += '-DENABLE_PCMSOLVER=off '
+
+pretestopts = 'export DIRAC_TMPDIR=%(builddir)s/scratch && '
+pretestopts += 'export DIRAC_MPI_COMMAND="%(mpi_cmd_prefix)s " && '
+
+runtest = 'test ARGS="-R symmetry_scf_energy" '
+
+sanity_check_paths = {
+    'files': ['bin/pam-dirac', 'share/dirac/dirac.x'],
+    'dirs': ['share/dirac/basis'],
+}
+
+sanity_check_commands = ["pam-dirac --help"]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-intel-2022b-int64.eb
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-intel-2022b-int64.eb
@@ -11,7 +11,7 @@ toolchain = {'name': 'intel', 'version': '2022b'}
 toolchainopts = {'usempi': True, 'i8': True}
 
 source_urls = ['https://zenodo.org/record/7670749/files/']
-sources = ['DIRAC-%(version)s-Source.tar.gz']
+sources = ['DIRAC-%(version)s-Source.tgz']
 checksums = ['a0a6b6318b3cd2e3c6042221de720bb1e87eb758999e2108a48dedb9c564e1f8']
 
 builddependencies = [('CMake', '3.24.3')]

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-intel-2022b-int64.eb
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-intel-2022b-int64.eb
@@ -8,7 +8,7 @@ homepage = 'http://www.diracprogram.org'
 description = "DIRAC: Program for Atomic and Molecular Direct Iterative Relativistic All-electron Calculations"
 
 toolchain = {'name': 'intel', 'version': '2022b'}
-toolchainopts = {'usempi': True, 'i8': True}
+toolchainopts = {'usempi': True, 'i8': True, 'oneapi': False}
 
 source_urls = ['https://zenodo.org/record/7670749/files/']
 sources = ['DIRAC-%(version)s-Source.tgz']

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-intel-2022b.eb
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-intel-2022b.eb
@@ -1,0 +1,40 @@
+easyblock = 'CMakeMake'
+
+name = 'DIRAC'
+version = '23.0'
+
+homepage = 'http://www.diracprogram.org'
+description = "DIRAC: Program for Atomic and Molecular Direct Iterative Relativistic All-electron Calculations"
+
+toolchain = {'name': 'intel', 'version': '2022b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://zenodo.org/record/7670749/files/']
+sources = ['DIRAC-%(version)s-Source.tar.gz']
+checksums = ['a0a6b6318b3cd2e3c6042221de720bb1e87eb758999e2108a48dedb9c564e1f8']
+
+builddependencies = [('CMake', '3.24.3')]
+
+dependencies = [
+    ('Python', '3.10.8'),
+    ('HDF5', '1.14.0')
+]
+
+configopts = '-DMKL_FLAG=sequential '
+configopts += '-DENABLE_MPI=True '
+configopts += '-DENABLE_EXATENSOR=off '
+configopts += '-DENABLE_PCMSOLVER=off '
+
+pretestopts = 'export DIRAC_TMPDIR=%(builddir)s/scratch && '
+pretestopts += 'export DIRAC_MPI_COMMAND="%(mpi_cmd_prefix)s " && '
+
+runtest = 'test ARGS="-R pam_test" '
+
+sanity_check_paths = {
+    'files': ['bin/pam-dirac', 'share/dirac/dirac.x'],
+    'dirs': ['share/dirac/basis'],
+}
+
+sanity_check_commands = ["pam-dirac --help"]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-intel-2022b.eb
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-intel-2022b.eb
@@ -7,7 +7,7 @@ homepage = 'http://www.diracprogram.org'
 description = "DIRAC: Program for Atomic and Molecular Direct Iterative Relativistic All-electron Calculations"
 
 toolchain = {'name': 'intel', 'version': '2022b'}
-toolchainopts = {'usempi': True}
+toolchainopts = {'usempi': True, 'oneapi': False}
 
 source_urls = ['https://zenodo.org/record/7670749/files/']
 sources = ['DIRAC-%(version)s-Source.tgz']

--- a/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-intel-2022b.eb
+++ b/easybuild/easyconfigs/d/DIRAC/DIRAC-23.0-intel-2022b.eb
@@ -10,7 +10,7 @@ toolchain = {'name': 'intel', 'version': '2022b'}
 toolchainopts = {'usempi': True}
 
 source_urls = ['https://zenodo.org/record/7670749/files/']
-sources = ['DIRAC-%(version)s-Source.tar.gz']
+sources = ['DIRAC-%(version)s-Source.tgz']
 checksums = ['a0a6b6318b3cd2e3c6042221de720bb1e87eb758999e2108a48dedb9c564e1f8']
 
 builddependencies = [('CMake', '3.24.3')]


### PR DESCRIPTION
DIRAC code, release 23.0

Both, intel and foss compilations are given. In addition, a 64bits intel compilation is also provided.