### PR TITLE
update homepage and source urls of DFT-D3

### DIFF
--- a/easybuild/easyconfigs/d/DFT-D3/DFT-D3-3.2.0-GCC-8.3.0.eb
+++ b/easybuild/easyconfigs/d/DFT-D3/DFT-D3-3.2.0-GCC-8.3.0.eb
@@ -3,13 +3,13 @@ easyblock = 'MakeCp'
 name = 'DFT-D3'
 version = '3.2.0'
 
-homepage = 'http://www.thch.uni-bonn.de/tc/index.php?section=downloads&subsection=DFT-D3&lang=english'
+homepage = 'https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3'
 description = """DFT-D3 implements a dispersion correction for density functionals,
 Hartree-Fock and semi-empirical quantum chemical methods."""
 
 toolchain = {'name': 'GCC', 'version': '8.3.0'}
 
-source_urls = ['https://www.chemie.uni-bonn.de/pctc/mulliken-center/software/dft-d3']
+source_urls = ['https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3']
 # Note that the DFT-D3 tarball is named as "dftd3.tgz" with no version
 # numbering. Also, the authors are prone (alas) to stealth upgrades, so that two
 # tarballs with the same version number can have different checksums. For this

--- a/easybuild/easyconfigs/d/DFT-D3/DFT-D3-3.2.0-iccifort-2020.4.304.eb
+++ b/easybuild/easyconfigs/d/DFT-D3/DFT-D3-3.2.0-iccifort-2020.4.304.eb
@@ -3,13 +3,13 @@ easyblock = 'MakeCp'
 name = 'DFT-D3'
 version = '3.2.0'
 
-homepage = 'http://www.thch.uni-bonn.de/tc/index.php?section=downloads&subsection=DFT-D3&lang=english'
+homepage = 'https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3'
 description = """DFT-D3 implements a dispersion correction for density functionals, Hartree-Fock and semi-empirical
  quantum chemical methods."""
 
 toolchain = {'name': 'iccifort', 'version': '2020.4.304'}
 
-source_urls = ['https://www.chemie.uni-bonn.de/pctc/mulliken-center/software/dft-d3']
+source_urls = ['https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3']
 sources = [{'download_filename': 'dftd3.tgz', 'filename': SOURCELOWER_TGZ}]
 checksums = ['d97cf9758f61aa81fd85425448fbf4a6e8ce07c12e9236739831a3af32880f59']
 

--- a/easybuild/easyconfigs/d/DFT-D3/DFT-D3-3.2.0-intel-2019a.eb
+++ b/easybuild/easyconfigs/d/DFT-D3/DFT-D3-3.2.0-intel-2019a.eb
@@ -3,13 +3,13 @@ easyblock = 'MakeCp'
 name = 'DFT-D3'
 version = '3.2.0'
 
-homepage = 'http://www.thch.uni-bonn.de/tc/index.php?section=downloads&subsection=DFT-D3&lang=english'
+homepage = 'https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3'
 description = """DFT-D3 implements a dispersion correction for density functionals, Hartree-Fock and semi-empirical
  quantum chemical methods."""
 
 toolchain = {'name': 'intel', 'version': '2019a'}
 
-source_urls = ['https://www.chemie.uni-bonn.de/pctc/mulliken-center/software/dft-d3']
+source_urls = ['https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3']
 # Note that the DFT-D3 tarball is named as "dftd3.tgz" with no version
 # numbering. Also, the authors are prone (alas) to stealth upgrades, so that two
 # tarballs with the same version number can have different checksums. For this

--- a/easybuild/easyconfigs/d/DFT-D3/DFT-D3-3.2.0-intel-compilers-2021.2.0.eb
+++ b/easybuild/easyconfigs/d/DFT-D3/DFT-D3-3.2.0-intel-compilers-2021.2.0.eb
@@ -3,13 +3,13 @@ easyblock = 'MakeCp'
 name = 'DFT-D3'
 version = '3.2.0'
 
-homepage = 'http://www.thch.uni-bonn.de/tc/index.php?section=downloads&subsection=DFT-D3&lang=english'
+homepage = 'https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3'
 description = """DFT-D3 implements a dispersion correction for density functionals, Hartree-Fock and semi-empirical
  quantum chemical methods."""
 
 toolchain = {'name': 'intel-compilers', 'version': '2021.2.0'}
 
-source_urls = ['https://www.chemie.uni-bonn.de/pctc/mulliken-center/software/dft-d3']
+source_urls = ['https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3']
 # Note that the DFT-D3 tarball is named as "dftd3.tgz" with no version
 # numbering. Also, the authors are prone (alas) to stealth upgrades, so that two
 # tarballs with the same version number can have different checksums. For this


### PR DESCRIPTION
Both the homepage and source urls of the `DFT-D3` easyconfigs didn't work for me, and it looks like they have been moved. This PR changes them for all existing easyconfigs.