### PR TITLE
{lib}[GCC/11.2.0] nanodbc 2.14.0

### DIFF
--- a/easybuild/easyconfigs/n/nanodbc/nanodbc-2.14.0-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/n/nanodbc/nanodbc-2.14.0-GCC-11.2.0.eb
@@ -13,6 +13,8 @@ source_urls = ['https://github.com/%(name)s/%(name)s/archive/refs/tags/']
 sources = ['v%(version)s.tar.gz']
 checksums = ['56228372042b689beccd96b0ac3476643ea85b3f57b3f23fb11ca4314e68b9a5']
 
+osdependencies = [('unixODBC-devel', 'unixodbc-dev')]
+
 builddependencies = [
     ('CMake', '3.22.1'),
     ('Boost', '1.77.0'),


### PR DESCRIPTION
Added easyconfig for nanondbc, a small C++ wrapper for the native C ODBC API.