### PR TITLE
fix sanity check for libxml2 shared library

### DIFF
--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.10.3-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.10.3-GCCcore-12.2.0.eb
@@ -27,5 +27,6 @@ dependencies = [
 sanity_check_paths = {
     'files': ['lib/libxml2.%s' % SHLIB_EXT],
     'dirs': ['lib'],
+}
 
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.10.3-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.10.3-GCCcore-12.2.0.eb
@@ -24,4 +24,8 @@ dependencies = [
     ('zlib', '1.2.12'),
 ]
 
+sanity_check_paths = {
+    'files': ['lib/libxml2.%s' % SHLIB_EXT],
+    'dirs': ['lib'],
+
 moduleclass = 'lib'


### PR DESCRIPTION
- builtin sanity check searches for libxml2.a
- on our CentOS7 system no *.a  libraries were created