### PR TITLE
WIP: {math} libcerf-Fortran-2.3: GCC/12.2.0, intel-compilers/2022.2.1

### DIFF
--- a/easybuild/easyconfigs/l/libcerf-Fortran/libcerf-Fortran-2.3-GCC-12.2.0.eb
+++ b/easybuild/easyconfigs/l/libcerf-Fortran/libcerf-Fortran-2.3-GCC-12.2.0.eb
@@ -1,0 +1,35 @@
+easyblock = 'ConfigureMake'
+
+name = 'libcerf-Fortran'
+version = '2.3'
+
+homepage = 'https://jugit.fz-juelich.de/mlz/libcerf'
+description = """
+ libcerf is a self-contained numeric library that provides an efficient and
+ accurate implementation of complex error functions, along with Dawson,
+ Faddeeva, and Voigt functions.
+"""
+
+toolchain = {'name': 'GCC', 'version': '12.2.0'}
+toolchainopts = {'pic': True}
+
+#patches = ["libcerf-Fortran-Makefile.patch"]
+source_urls = ['https://jugit.fz-juelich.de/mlz/libcerf/-/archive/v%(version)s/']
+sources = ['%s-v%%(version)s.tar.gz' % (name.split('-')[0])]
+checksums = ['cceefee46e84ce88d075103390b4f9d04c34e4bc3b96d733292c36836d4f7065']
+
+builddependencies = [
+    ('libcerf', version),
+]
+
+skipsteps = ['configure']
+start_dir = 'fortran/ccerflib_f95_interface'
+build_cmd = '$FC $FFLAGS -c use_libcerf_mod.f90 && $FC -shared use_libcerf_mod.o -o libcerf-Fortran.so && ar rc use_libcerf_mod.a use_libcerf_mod.o && echo ""'
+install_cmd = "mkdir -p %(installdir)s/{include,lib} && cp %(name)s.so use_libcerf_mod.o use_libcerf_mod.a %(installdir)s/lib && cp use_libcerf.mod %(installdir)s/include"
+
+sanity_check_paths = {
+    'files': ['include/use_libcerf.mod', 'lib/libcerf-Fortran.so', 'lib/use_libcerf_mod.a'],
+    'dirs': ['include']
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/l/libcerf-Fortran/libcerf-Fortran-2.3-intel-compilers-2022.2.1.eb
+++ b/easybuild/easyconfigs/l/libcerf-Fortran/libcerf-Fortran-2.3-intel-compilers-2022.2.1.eb
@@ -1,0 +1,35 @@
+easyblock = 'ConfigureMake'
+
+name = 'libcerf-Fortran'
+version = '2.3'
+
+homepage = 'https://jugit.fz-juelich.de/mlz/libcerf'
+description = """
+ libcerf is a self-contained numeric library that provides an efficient and
+ accurate implementation of complex error functions, along with Dawson,
+ Faddeeva, and Voigt functions.
+"""
+
+toolchain = {'name': 'intel-compilers', 'version': '2022.2.1'}
+toolchainopts = {'pic': True}
+
+#patches = ["libcerf-Fortran-Makefile.patch"]
+source_urls = ['https://jugit.fz-juelich.de/mlz/libcerf/-/archive/v%(version)s/']
+sources = ['libcerf-v%(version)s.tar.gz']
+checksums = ['cceefee46e84ce88d075103390b4f9d04c34e4bc3b96d733292c36836d4f7065']
+
+builddependencies = [
+    ('libcerf', version),
+]
+
+skipsteps = ['configure']
+start_dir = 'fortran/ccerflib_f95_interface'
+build_cmd = '$FC $FFLAGS -c use_libcerf_mod.f90 && $FC -shared use_libcerf_mod.o -o libcerf-Fortran.so && ar rc use_libcerf_mod.a use_libcerf_mod.o && echo ""'
+install_cmd = "mkdir -p %(installdir)s/{include,lib} && cp %(name)s.so use_libcerf_mod.o use_libcerf_mod.a %(installdir)s/lib && cp use_libcerf.mod %(installdir)s/include"
+
+sanity_check_paths = {
+    'files': ['include/use_libcerf.mod', 'lib/libcerf-Fortran.so', 'lib/use_libcerf_mod.a'],
+    'dirs': ['include']
+}
+
+moduleclass = 'math'


### PR DESCRIPTION
Pretty sure this is still a bit of a mess. Requires further testing.
Not sure what the best naming scheme is for the .a/.so files is (the documentation refers only to building `.mod` and `.o` files, but this seems a bit little).

Was contemplating adding a Makefile with a patch, not sure if that's better than just putting the $FC commands in like this.

See also: https://github.com/easybuilders/easybuild-easyconfigs/issues/17701