### PR TITLE
CP2K v2023.1-foss2022a-CUDA (for v2023 compatible cp2k easyblock) 

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-2023.1-cuda-foss-2022a.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-2023.1-cuda-foss-2022a.eb
@@ -1,0 +1,45 @@
+##
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+# Modified by: O. Baris Malcioglu <mbaris@metu.edu.tr>
+##
+name = 'CP2K'
+version = '2023.1'
+versionsuffix = 'CUDA' 
+
+homepage = 'https://www.cp2k.org/'
+description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
+ simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
+ methods such as e.g. density functional theory (DFT) using a mixed Gaussian and plane waves approach (GPW), and
+ classical pair and many-body potentials. """
+
+toolchain = {'name': 'foss', 'version': '2022a'}
+toolchainopts = {'pic': True, 'openmp': True}
+
+source_urls = ['https://github.com/cp2k/cp2k/releases/download/v%(version)s/']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['dff343b4a80c3a79363b805429bdb3320d3e1db48e0ff7d20a3dfd1c946a51ce']
+
+dependencies = [
+    ('Libint', '2.7.2', '-lmax-6-cp2k'),
+    ('libxc', '5.2.3'),
+    ('libxsmm', '1.17'),
+    ('FFTW', '3.3.10'),
+    ('PLUMED', '2.8.1'),
+    ('CUDA/11.7.0',EXTERNAL_MODULE),
+    ('math/ELPA/2022.05.001-foss-2022a-CUDA-11.7.0',EXTERNAL_MODULE),
+]
+
+builddependencies = [
+    ('flex', '2.6.4'),
+    ('Bison', '3.8.2'),
+]
+
+type = 'psmp'
+v2023 = True
+gpuver = 'A100'
+
+# regression test reports handful of failures,
+# we're assuming those are OK to ignore...
+ignore_regtest_fails = True
+parallel = 1
+moduleclass = 'chem'


### PR DESCRIPTION
Will produce a working executable for the v2023.1 release of CP2K (with GPU) when combined with the proposed cp2k easyblock. Please see the pull request for cp2k easyblock for details. 

I am a newbie to easybuild. Please check carefully. 