### PR TITLE
make excluded tests for PyTorch 1.12.1 consistent + also exclude flaky test_optim rather than adding patch to try and fix it

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021a-CUDA-11.3.1.eb
@@ -122,6 +122,15 @@ excluded_tests = {
     '': [
         # This test seems to take too long on NVIDIA Ampere at least.
         'distributed/test_distributed_spawn',
+        # Produces a single test failure on some systems
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
+        'distributed/fsdp/test_fsdp_core',
+        # failing on broadwell
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
+        'test_native_mha',
+        # flaky test which fails on some systems,
+        # see https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
+        'distributed/elastic/multiprocessing/api_test',
         # Fails on A10s: https://github.com/pytorch/pytorch/issues/63079
         # Fails intermittently: https://github.com/pytorch/pytorch/issues/98414
         'test_optim',

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021a-CUDA-11.3.1.eb
@@ -122,6 +122,9 @@ excluded_tests = {
     '': [
         # This test seems to take too long on NVIDIA Ampere at least.
         'distributed/test_distributed_spawn',
+        # Fails on A10s: https://github.com/pytorch/pytorch/issues/63079
+        # Fails intermittently: https://github.com/pytorch/pytorch/issues/98414
+        'test_optim',
     ]
 }
 

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021a.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021a.eb
@@ -111,6 +111,9 @@ excluded_tests = {
     '': [
         # This test seems to take too long on NVIDIA Ampere at least.
         'distributed/test_distributed_spawn',
+        # Fails on A10s: https://github.com/pytorch/pytorch/issues/63079
+        # Fails intermittently: https://github.com/pytorch/pytorch/issues/98414
+        'test_optim',
     ]
 }
 

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021a.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021a.eb
@@ -111,6 +111,15 @@ excluded_tests = {
     '': [
         # This test seems to take too long on NVIDIA Ampere at least.
         'distributed/test_distributed_spawn',
+        # Produces a single test failure on some systems
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
+        'distributed/fsdp/test_fsdp_core',
+        # failing on broadwell
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
+        'test_native_mha',
+        # flaky test which fails on some systems,
+        # see https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
+        'distributed/elastic/multiprocessing/api_test',
         # Fails on A10s: https://github.com/pytorch/pytorch/issues/63079
         # Fails intermittently: https://github.com/pytorch/pytorch/issues/98414
         'test_optim',

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021b-CUDA-11.5.2.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021b-CUDA-11.5.2.eb
@@ -146,7 +146,10 @@ excluded_tests = {
         'distributed/fsdp/test_fsdp_core',
         # failing on broadwell
         # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
-        'test_native_mha'
+        'test_native_mha',
+        # Fails on A10s: https://github.com/pytorch/pytorch/issues/63079
+        # Fails intermittently: https://github.com/pytorch/pytorch/issues/98414
+        'test_optim',
     ]
 }
 

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021b-CUDA-11.5.2.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021b-CUDA-11.5.2.eb
@@ -147,6 +147,9 @@ excluded_tests = {
         # failing on broadwell
         # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
         'test_native_mha',
+        # flaky test which fails on some systems,
+        # see https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
+        'distributed/elastic/multiprocessing/api_test',
         # Fails on A10s: https://github.com/pytorch/pytorch/issues/63079
         # Fails intermittently: https://github.com/pytorch/pytorch/issues/98414
         'test_optim',

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021b.eb
@@ -122,6 +122,9 @@ excluded_tests = {
     '': [
         # This test seems to take too long on NVIDIA Ampere at least.
         'distributed/test_distributed_spawn',
+        # Produces a single test failure on some systems
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
+        'distributed/fsdp/test_fsdp_core',
         # failing on broadwell
         # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
         'test_native_mha',

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021b.eb
@@ -128,6 +128,9 @@ excluded_tests = {
         # flaky test which fails on some systems,
         # see https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
         'distributed/elastic/multiprocessing/api_test',
+        # Fails on A10s: https://github.com/pytorch/pytorch/issues/63079
+        # Fails intermittently: https://github.com/pytorch/pytorch/issues/98414
+        'test_optim',
     ]
 }
 

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2021b.eb
@@ -41,7 +41,6 @@ patches = [
     'PyTorch-1.12.1_skip-ao-sparsity-test-without-fbgemm.patch',
     'PyTorch-1.12.1_skip-failing-grad-test.patch',
     'PyTorch-1.12.1_skip-test_round_robin.patch',
-    'PyTorch-1.12.1_use-predefined-data-in-test-optim.patch',
 ]
 checksums = [
     '031c71073db73da732b5d01710220564ce6dd88d812ba053f0cc94296401eccb',  # pytorch-v1.12.1.tar.gz
@@ -93,8 +92,6 @@ checksums = [
     '1c89e7e67287fe6b9a95480a4178d3653b94d0ab2fe68edf227606c8ae548fdc',  # PyTorch-1.12.1_skip-failing-grad-test.patch
     # PyTorch-1.12.1_skip-test_round_robin.patch
     '63d4849b78605aa088fdff695637d9473ea60dee603a3ff7f788690d70c55349',
-    # PyTorch-1.12.1_use-predefined-data-in-test-optim.patch
-    'a55f5465f5324cddae44416d67ef7506acb3513df7c4efb47db2f19eaa169054',
 ]
 
 osdependencies = [OS_PKG_IBVERBS_DEV]

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a-CUDA-11.7.0.eb
@@ -140,6 +140,9 @@ excluded_tests = {
         # Those 2 abort on some machines. Skip for now
         'distributed/fsdp/test_fsdp_input',
         'distributed/fsdp/test_fsdp_mixed_precision',
+        # Fails on A10s: https://github.com/pytorch/pytorch/issues/63079
+        # Fails intermittently: https://github.com/pytorch/pytorch/issues/98414
+        'test_optim',
     ]
 }
 

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a-CUDA-11.7.0.eb
@@ -140,6 +140,15 @@ excluded_tests = {
         # Those 2 abort on some machines. Skip for now
         'distributed/fsdp/test_fsdp_input',
         'distributed/fsdp/test_fsdp_mixed_precision',
+        # Produces a single test failure on some systems
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
+        'distributed/fsdp/test_fsdp_core',
+        # failing on broadwell
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
+        'test_native_mha',
+        # flaky test which fails on some systems,
+        # see https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
+        'distributed/elastic/multiprocessing/api_test',
         # Fails on A10s: https://github.com/pytorch/pytorch/issues/63079
         # Fails intermittently: https://github.com/pytorch/pytorch/issues/98414
         'test_optim',

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a-CUDA-11.7.0.eb
@@ -44,7 +44,6 @@ patches = [
     'PyTorch-1.12.1_skip-ao-sparsity-test-without-fbgemm.patch',
     'PyTorch-1.12.1_skip-failing-grad-test.patch',
     'PyTorch-1.12.1_skip-test_round_robin.patch',
-    'PyTorch-1.12.1_use-predefined-data-in-test-optim.patch',
 ]
 checksums = [
     '031c71073db73da732b5d01710220564ce6dd88d812ba053f0cc94296401eccb',  # pytorch-v1.12.1.tar.gz
@@ -100,8 +99,6 @@ checksums = [
     '1c89e7e67287fe6b9a95480a4178d3653b94d0ab2fe68edf227606c8ae548fdc',  # PyTorch-1.12.1_skip-failing-grad-test.patch
     # PyTorch-1.12.1_skip-test_round_robin.patch
     '63d4849b78605aa088fdff695637d9473ea60dee603a3ff7f788690d70c55349',
-    # PyTorch-1.12.1_use-predefined-data-in-test-optim.patch
-    'a55f5465f5324cddae44416d67ef7506acb3513df7c4efb47db2f19eaa169054',
 ]
 
 osdependencies = [OS_PKG_IBVERBS_DEV]

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a.eb
@@ -123,6 +123,9 @@ excluded_tests = {
         'distributed/test_distributed_spawn',
         # Broken on CUDA 11.6/11.7: https://github.com/pytorch/pytorch/issues/75375
         'distributions/test_constraints',
+        # Fails on A10s: https://github.com/pytorch/pytorch/issues/63079
+        # Fails intermittently: https://github.com/pytorch/pytorch/issues/98414
+        'test_optim',
     ]
 }
 

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a.eb
@@ -41,7 +41,6 @@ patches = [
     'PyTorch-1.12.1_skip-ao-sparsity-test-without-fbgemm.patch',
     'PyTorch-1.12.1_skip-failing-grad-test.patch',
     'PyTorch-1.12.1_skip-test_round_robin_create_destroy.patch',
-    'PyTorch-1.12.1_use-predefined-data-in-test-optim.patch',
 ]
 checksums = [
     '031c71073db73da732b5d01710220564ce6dd88d812ba053f0cc94296401eccb',  # pytorch-v1.12.1.tar.gz
@@ -93,8 +92,6 @@ checksums = [
     '1c89e7e67287fe6b9a95480a4178d3653b94d0ab2fe68edf227606c8ae548fdc',  # PyTorch-1.12.1_skip-failing-grad-test.patch
     # PyTorch-1.12.1_skip-test_round_robin_create_destroy.patch
     '1435fcac3234edc865479199673b902eb67f6a2bd046af7d731141f03594666d',
-    # PyTorch-1.12.1_use-predefined-data-in-test-optim.patch
-    'a55f5465f5324cddae44416d67ef7506acb3513df7c4efb47db2f19eaa169054',
 ]
 
 osdependencies = [OS_PKG_IBVERBS_DEV]

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a.eb
@@ -123,6 +123,15 @@ excluded_tests = {
         'distributed/test_distributed_spawn',
         # Broken on CUDA 11.6/11.7: https://github.com/pytorch/pytorch/issues/75375
         'distributions/test_constraints',
+        # Produces a single test failure on some systems
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
+        'distributed/fsdp/test_fsdp_core',
+        # failing on broadwell
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
+        'test_native_mha',
+        # flaky test which fails on some systems,
+        # see https://github.com/easybuilders/easybuild-easyconfigs/issues/17615
+        'distributed/elastic/multiprocessing/api_test',
         # Fails on A10s: https://github.com/pytorch/pytorch/issues/63079
         # Fails intermittently: https://github.com/pytorch/pytorch/issues/98414
         'test_optim',


### PR DESCRIPTION
Based on the failures in  #17732 and #17733 I think we should revert this. It looks to be a case of fixing one flaky test and making other tests less reliable. :(

We'll also add `test_optim` to excluded tests, which it has been for 1.9.0 to 1.12.0.

I've also made sure all 1.12.1 easyconfigs skip the tests metnioned in #17615.