### PR TITLE
add pcre dependency for interproscan

### DIFF
--- a/easybuild/easyconfigs/i/InterProScan/InterProScan-5.55-88.0-foss-2021a.eb
+++ b/easybuild/easyconfigs/i/InterProScan/InterProScan-5.55-88.0-foss-2021a.eb
@@ -27,6 +27,7 @@ dependencies = [
     ('Perl',    '5.32.1'),
     ('libgd',   '2.3.1'),
     ('Python',  '3.9.5'),
+    ('PCRE',    '8.44'),
 ]
 # NOTE some analyses done by InterProScan require extra tools not included in the interproscan
 # distribution because of license issues.


### PR DESCRIPTION
Got error message when running the `interproscan.sh` program
```
Error output from binary:
bin/prosite/pfsearchV3: error while loading shared libraries: libpcre.so: cannot open shared object file: No such file or directory
Error running prosite binary bin/prosite/pfsearchV3
```

Adding the dependency for PCRE should fix this problem.