### PR TITLE
adding easyconfigs: hmmcopy_utils-5911bf69f1-foss-2022a.eb

### DIFF
--- a/easybuild/easyconfigs/h/hmmcopy_utils/hmmcopy_utils-5911bf69f1-foss-2022a.eb
+++ b/easybuild/easyconfigs/h/hmmcopy_utils/hmmcopy_utils-5911bf69f1-foss-2022a.eb
@@ -1,0 +1,45 @@
+easyblock = 'CMakeMake'
+
+name = 'hmmcopy_utils'
+version = '5911bf69f1'
+
+homepage = 'https://github.com/shahcompbio/hmmcopy_utils/'
+description = """Varios tools to generate readcounts and
+ mappability stats for bioconductor package HMMCopy."""
+
+toolchain = {'name': 'foss', 'version': '2022a'}
+
+source_urls = ['https://github.com/shahcompbio/hmmcopy_utils/archive/']
+sources = ['5911bf69f11d8d185f7054098d39799d2c6894cc.zip']
+checksums = ['3972b41fbea12a5e78363a6919d8dc36b10c52f8edace1b505f5baed60000205']
+
+builddependencies = [
+    ('CMake', '3.23.1'),
+    ('pkg-config', '0.29.2')
+]
+
+dependencies = [
+    ('zlib', '1.2.12'),
+    ('bzip2', '1.0.8'),
+]
+
+skipsteps = ['install']
+buildopts =  ' && make && mkdir -p %(installdir)s && '
+buildopts += ' cp -r %(builddir)s/easybuild_obj/* %(installdir)s/'
+
+separate_build_dir = True
+
+local_files_to_copy = [('%(builddir)s/easybuild_obj/bin','bin'),
+    ('%(builddir)s/easybuild_obj/lib','bin'),
+    ('%(builddir)s/easybuild_obj/src','bin'),
+    ('%(builddir)s/easybuild_obj/util','.')
+]
+
+sanity_check_paths = {
+    'files': ['bin/readCounter', 
+        'bin/gcCounter',
+        'bin/mapCounter'],
+    'dirs': ['bin'],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
Hi easybuilders! 

I want to easybuild an complete install for IchorCNA as I installed via easybuild with a more sensible install.

Main changes with your install of IchorCNA:
- [ ] depends on hmmcopy_utils(this pr) for readcounter and mapcounter

other pr(s)
- depends on R3.6.3 because that is the last R version it was maintained for
- adding in runichorCNA.R for commandline use
- fixing legency artifacts in commits because this is an easybuild file from foss-2018a ported to foss-2022a 

What are the maintainers thoughts about this?