### PR TITLE
Replacing AOCC broken link

### DIFF
--- a/easybuild/easyconfigs/a/AOCC/AOCC-4.0.0-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/a/AOCC/AOCC-4.0.0-GCCcore-12.2.0.eb
@@ -8,7 +8,7 @@ description = "AMD Optimized C/C++ & Fortran compilers (AOCC) based on LLVM 13.0
 # already specified as the toolchain.
 toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 
-source_urls = ['http://developer.amd.com/wordpress/media/files/']
+source_urls = ['https://download.amd.com/developer/eula/aocc-compiler/']
 sources = ['aocc-compiler-%(version)s.tar']
 checksums = ['2729ec524cbc927618e479994330eeb72df5947e90cfcc49434009eee29bf7d4']
 


### PR DESCRIPTION
It seems the current link does not work and has been replaced.

`== 2023-04-25 09:38:03,924 filetools.py:842 WARNING IOError occurred while trying to download http://developer.amd.com/wordpress/media/files/aocc-compiler-4.0.0.tar to /gxfs/apps/easybuild/sources/a/AOCC/aocc-compiler-4.0.0.tar: The read operation timed out`

'https://download.amd.com/developer/eula/aocc-compiler/' works well. The file and checksum are the same.