### PR TITLE
add Doxygen build dependency to X11

### DIFF
--- a/easybuild/easyconfigs/x/X11/X11-20190717-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20190717-GCCcore-8.3.0.eb
@@ -31,6 +31,7 @@ builddependencies = [
     ('gettext', '0.20.1'),
     ('pkg-config', '0.29.2'),
     ('intltool', '0.51.0'),
+    ('Doxygen', '1.8.16'),
 ]
 
 default_easyblock = 'ConfigureMake'

--- a/easybuild/easyconfigs/x/X11/X11-20200222-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20200222-GCCcore-9.3.0.eb
@@ -26,6 +26,7 @@ builddependencies = [
     ('intltool', '0.51.0'),
     ('Meson', '0.55.1', '-Python-3.8.2'),
     ('Ninja', '1.10.0'),
+    ('Doxygen', '1.8.17'),
 ]
 dependencies = [
     ('bzip2', '1.0.8'),

--- a/easybuild/easyconfigs/x/X11/X11-20201008-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20201008-GCCcore-10.2.0.eb
@@ -26,6 +26,7 @@ builddependencies = [
     ('intltool', '0.51.0'),
     ('Meson', '0.55.3'),
     ('Ninja', '1.10.1'),
+    ('Doxygen', '1.8.20'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/x/X11/X11-20210518-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20210518-GCCcore-10.3.0.eb
@@ -26,6 +26,7 @@ builddependencies = [
     ('intltool', '0.51.0'),
     ('Meson', '0.58.0'),
     ('Ninja', '1.10.2'),
+    ('Doxygen', '1.9.1'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/x/X11/X11-20210802-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20210802-GCCcore-11.2.0.eb
@@ -26,6 +26,7 @@ builddependencies = [
     ('intltool', '0.51.0'),
     ('Meson', '0.58.2'),
     ('Ninja', '1.10.2'),
+    ('Doxygen', '1.9.1'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/x/X11/X11-20220504-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20220504-GCCcore-11.3.0.eb
@@ -26,6 +26,7 @@ builddependencies = [
     ('intltool', '0.51.0'),
     ('Meson', '0.62.1'),
     ('Ninja', '1.10.2'),
+    ('Doxygen', '1.9.4'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/x/X11/X11-20221110-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20221110-GCCcore-12.2.0.eb
@@ -26,6 +26,7 @@ builddependencies = [
     ('intltool', '0.51.0'),
     ('Meson', '0.64.0'),
     ('Ninja', '1.11.1'),
+    ('Doxygen', '1.9.5'),
 ]
 
 dependencies = [


### PR DESCRIPTION
adding `Doxygen` since finding it in the OS is causing build failures in `X11-20210802-GCCcore-11.2.0.eb` on our 22.04 Ubuntu systems

(created using `eb --new-pr`)
