### PR TITLE
add historical repo paths to install cmd for old versions of texlive

### DIFF
--- a/easybuild/easyconfigs/t/texlive/texlive-20200406-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20200406-GCCcore-8.3.0.eb
@@ -4,6 +4,7 @@ easyblock = 'Tarball'
 
 name = 'texlive'
 version = '20200406'
+local_version_year = version[:4]
 
 homepage = 'https://tug.org'
 description = """TeX is a typesetting language. Instead of visually formatting your text, you enter your manuscript
@@ -13,7 +14,10 @@ description = """TeX is a typesetting language. Instead of visually formatting y
 
 toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
 
-source_urls = ['ftp://tug.org/texlive/historic/2020/']
+source_urls = [
+    'ftp://tug.org/texlive/historic/%s/' % local_version_year,
+    'https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/%s/' % local_version_year,
+]
 sources = [
     {
         'download_filename': 'install-tl-unx.tar.gz',
@@ -41,6 +45,7 @@ postinstallcmds = [
     'echo "TEXMFSYSCONFIG %(installdir)s/texmf-config" >> %(installdir)s/texlive.profile && '
     'echo "TEXMFSYSVAR    %(installdir)s/texmf-var" >> %(installdir)s/texlive.profile && '
     '%(builddir)s/install-tl-%(version)s/install-tl -profile %(installdir)s/texlive.profile'
+    ' -repository ' + 'ftp://tug.org/historic/systems/texlive/%s/tlnet-final' % local_version_year
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/t/texlive/texlive-20200406-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20200406-GCCcore-8.3.0.eb
@@ -45,11 +45,11 @@ postinstallcmds = [
     'echo "TEXMFSYSCONFIG %(installdir)s/texmf-config" >> %(installdir)s/texlive.profile && '
     'echo "TEXMFSYSVAR    %(installdir)s/texmf-var" >> %(installdir)s/texlive.profile && '
     '%(builddir)s/install-tl-%(version)s/install-tl -profile %(installdir)s/texlive.profile'
-    ' -repository ' + 'ftp://tug.org/historic/systems/texlive/%s/tlnet-final' % local_version_year
+    ' -repository ' + 'https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/%s/tlnet-final' % local_version_year
 ]
 
 modextrapaths = {
-    'PATH': 'bin/x86_64-linux',
+    'PATH': 'bin/%(arch)s-linux',
     'INFOPATH': 'texmf-dist/doc/info',
     'MANPATH': 'texmf-dist/doc/man',
 }
@@ -58,8 +58,8 @@ modextravars = {
 }
 
 sanity_check_paths = {
-    'files': ['bin/x86_64-linux/tex', 'bin/x86_64-linux/latex'],
-    'dirs': ['bin/x86_64-linux', 'texmf-dist'],
+    'files': ['bin/%(arch)s-linux/tex', 'bin/%(arch)s-linux/latex'],
+    'dirs': ['bin/%(arch)s-linux', 'texmf-dist'],
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/texlive/texlive-20210324-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20210324-GCC-10.3.0.eb
@@ -4,6 +4,7 @@ easyblock = 'Tarball'
 
 name = 'texlive'
 version = '20210324'
+local_version_year = version[:4]
 
 homepage = 'https://tug.org'
 description = """TeX is a typesetting language. Instead of visually formatting your text, you enter your manuscript
@@ -14,8 +15,8 @@ description = """TeX is a typesetting language. Instead of visually formatting y
 toolchain = {'name': 'GCC', 'version': '10.3.0'}
 
 source_urls = [
-    'ftp://tug.org/texlive/historic/2021/',
-    'https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2021/',
+    'ftp://tug.org/texlive/historic/%s/' % local_version_year,
+    'https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/%s/' % local_version_year,
 ]
 sources = [
     {
@@ -44,6 +45,7 @@ postinstallcmds = [
     'echo "TEXMFSYSCONFIG %(installdir)s/texmf-config" >> %(installdir)s/texlive.profile && '
     'echo "TEXMFSYSVAR    %(installdir)s/texmf-var" >> %(installdir)s/texlive.profile && '
     '%(builddir)s/install-tl-%(version)s/install-tl -profile %(installdir)s/texlive.profile'
+    ' -repository ' + 'ftp://tug.org/historic/systems/texlive/%s/tlnet-final' % local_version_year
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/t/texlive/texlive-20210324-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20210324-GCC-10.3.0.eb
@@ -45,7 +45,7 @@ postinstallcmds = [
     'echo "TEXMFSYSCONFIG %(installdir)s/texmf-config" >> %(installdir)s/texlive.profile && '
     'echo "TEXMFSYSVAR    %(installdir)s/texmf-var" >> %(installdir)s/texlive.profile && '
     '%(builddir)s/install-tl-%(version)s/install-tl -profile %(installdir)s/texlive.profile'
-    ' -repository ' + 'ftp://tug.org/historic/systems/texlive/%s/tlnet-final' % local_version_year
+    ' -repository ' + 'https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/%s/tlnet-final' % local_version_year
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/t/texlive/texlive-20210324-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20210324-GCC-11.2.0.eb
@@ -4,6 +4,7 @@ easyblock = 'Tarball'
 
 name = 'texlive'
 version = '20210324'
+local_version_year = version[:4]
 
 homepage = 'https://tug.org'
 description = """TeX is a typesetting language. Instead of visually formatting your text, you enter your manuscript
@@ -14,8 +15,8 @@ description = """TeX is a typesetting language. Instead of visually formatting y
 toolchain = {'name': 'GCC', 'version': '11.2.0'}
 
 source_urls = [
-    'ftp://tug.org/texlive/historic/2021/',
-    'https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2021/',
+    'ftp://tug.org/texlive/historic/%s/' % local_version_year,
+    'https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/%s/' % local_version_year,
 ]
 sources = [
     {
@@ -44,6 +45,7 @@ postinstallcmds = [
     'echo "TEXMFSYSCONFIG %(installdir)s/texmf-config" >> %(installdir)s/texlive.profile && '
     'echo "TEXMFSYSVAR    %(installdir)s/texmf-var" >> %(installdir)s/texlive.profile && '
     '%(builddir)s/install-tl-%(version)s/install-tl -profile %(installdir)s/texlive.profile'
+    ' -repository ' + 'ftp://tug.org/historic/systems/texlive/%s/tlnet-final' % local_version_year
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/t/texlive/texlive-20210324-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20210324-GCC-11.2.0.eb
@@ -45,7 +45,7 @@ postinstallcmds = [
     'echo "TEXMFSYSCONFIG %(installdir)s/texmf-config" >> %(installdir)s/texlive.profile && '
     'echo "TEXMFSYSVAR    %(installdir)s/texmf-var" >> %(installdir)s/texlive.profile && '
     '%(builddir)s/install-tl-%(version)s/install-tl -profile %(installdir)s/texlive.profile'
-    ' -repository ' + 'ftp://tug.org/historic/systems/texlive/%s/tlnet-final' % local_version_year
+    ' -repository ' + 'https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/%s/tlnet-final' % local_version_year
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/t/texlive/texlive-20220321-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20220321-GCC-11.2.0.eb
@@ -15,8 +15,8 @@ description = """TeX is a typesetting language. Instead of visually formatting y
 toolchain = {'name': 'GCC', 'version': '11.2.0'}
 
 source_urls = [
-    'ftp://tug.org/texlive/historic/2022/',
-    'https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2022/',
+    'ftp://tug.org/texlive/historic/%s/' % local_version_year,
+    'https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/%s/' % local_version_year,
 ]
 sources = [
     {
@@ -45,7 +45,7 @@ postinstallcmds = [
     'echo "TEXMFSYSCONFIG %(installdir)s/texmf-config" >> %(installdir)s/texlive.profile && '
     'echo "TEXMFSYSVAR    %(installdir)s/texmf-var" >> %(installdir)s/texlive.profile && '
     '%(builddir)s/install-tl-%(version)s/install-tl -profile %(installdir)s/texlive.profile'
-    ' -repository ' + 'ftp://tug.org/historic/systems/texlive/%s/tlnet-final' % local_version_year
+    ' -repository ' + 'https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/%s/tlnet-final' % local_version_year
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/t/texlive/texlive-20220321-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20220321-GCC-11.2.0.eb
@@ -4,6 +4,7 @@ easyblock = 'Tarball'
 
 name = 'texlive'
 version = '20220321'
+local_version_year = version[:4]
 
 homepage = 'https://tug.org'
 description = """TeX is a typesetting language. Instead of visually formatting your text, you enter your manuscript
@@ -44,6 +45,7 @@ postinstallcmds = [
     'echo "TEXMFSYSCONFIG %(installdir)s/texmf-config" >> %(installdir)s/texlive.profile && '
     'echo "TEXMFSYSVAR    %(installdir)s/texmf-var" >> %(installdir)s/texlive.profile && '
     '%(builddir)s/install-tl-%(version)s/install-tl -profile %(installdir)s/texlive.profile'
+    ' -repository ' + 'ftp://tug.org/historic/systems/texlive/%s/tlnet-final' % local_version_year
 ]
 
 modextrapaths = {


### PR DESCRIPTION
* see discussion in https://github.com/easybuilders/easybuild-easyconfigs/issues/17871

tl;dr: the default `-repository` location for the install script points to the default mirror, which raises an error for version_year != 2023