### PR TITLE
{lib}[gompi/2022a,iimpi/2022a] dlb v3.3.1

### DIFF
--- a/easybuild/easyconfigs/d/dlb/dlb-3.3.1-gompi-2022a.eb
+++ b/easybuild/easyconfigs/d/dlb/dlb-3.3.1-gompi-2022a.eb
@@ -1,0 +1,35 @@
+# vim: set syntax=python:
+easyblock = 'ConfigureMake'
+
+name = 'dlb'
+version = '3.3.1'
+
+description = """
+DLB is a dynamic library designed to speed up HPC hybrid applications (i.e.,
+two levels of parallelism) by improving the load balance of the outer level of
+parallelism (e.g., MPI) by dynamically redistributing the computational
+resources at the inner level of parallelism (e.g., OpenMP). at run time.
+"""
+homepage = 'https://pm.bsc.es/dlb/'
+docurls = ['https://pm.bsc.es/ftp/dlb/doc/user-guide/']
+
+toolchain = {'name': 'gompi', 'version': '2022a'}
+builddependencies = [('Python', '3.10.4', '-bare')]
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://pm.bsc.es/ftp/dlb/releases']
+
+checksums = ['1b245acad80b03eb83e815fd59dcfc598cfddd899de4504cf6a9572fe5359f40']
+
+configopts = '--with-mpi'
+
+sanity_check_paths = {
+    'files': [
+        'bin/dlb',
+        'lib/libdlb.a', 'lib/libdlb.%s' % SHLIB_EXT,
+        'lib64/libdlb.%s' % SHLIB_EXT
+    ],
+    'dirs': ['include'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/d/dlb/dlb-3.3.1-iimpi-2022a.eb
+++ b/easybuild/easyconfigs/d/dlb/dlb-3.3.1-iimpi-2022a.eb
@@ -1,0 +1,35 @@
+# vim: set syntax=python:
+easyblock = 'ConfigureMake'
+
+name = 'dlb'
+version = '3.3.1'
+
+description = """
+DLB is a dynamic library designed to speed up HPC hybrid applications (i.e.,
+two levels of parallelism) by improving the load balance of the outer level of
+parallelism (e.g., MPI) by dynamically redistributing the computational
+resources at the inner level of parallelism (e.g., OpenMP). at run time.
+"""
+homepage = 'https://pm.bsc.es/dlb/'
+docurls = ['https://pm.bsc.es/ftp/dlb/doc/user-guide/']
+
+toolchain = {'name': 'iimpi', 'version': '2022a'}
+builddependencies = [('Python', '3.10.4', '-bare')]
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://pm.bsc.es/ftp/dlb/releases']
+
+checksums = ['1b245acad80b03eb83e815fd59dcfc598cfddd899de4504cf6a9572fe5359f40']
+
+configopts = '--with-mpi'
+
+sanity_check_paths = {
+    'files': [
+        'bin/dlb',
+        'lib/libdlb.a', 'lib/libdlb.%s' % SHLIB_EXT,
+        'lib64/libdlb.%s' % SHLIB_EXT
+    ],
+    'dirs': ['include'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
Add version 3.3 for gompi and iimpi toolchains