### PR TITLE
[Julia-1.8.5] Prevent setting environment that breaks Julia

### DIFF
--- a/easybuild/easyconfigs/j/Julia/Julia-1.8.5-linux-x86_64.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.8.5-linux-x86_64.eb
@@ -35,12 +35,4 @@ _depot_paths = ':'.join([
     '~/.julia',
 ])
 
-modextravars = {
-    'JULIA_DEPOT_PATH': _depot_paths,
-    # 'set JULIA_HISTORY to user's DEPOT_PATH (~/.julia)
-    # by default it will point to the DEPOT_PATH (install dir) of the last module loaded
-    # https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_HISTORY
-    'JULIA_HISTORY': '~/.julia/logs/repl_history.jl',
-}
-
 moduleclass = 'lang'


### PR DESCRIPTION
Julia breaks if the depot path is set to an unwritable location. At the same time, setting ~ into environment variables typically forces a creation of actual directory named `~`, creating mild risk of fun `rm -fr` stories and impacting data of novice usrers.

Removing all environment fixes the problem and is generally safe (Julia will properly use a well-defaulted depot path).

cc @laurentheirendt @ekieffer (Thanks @ULHPC team for applying and quicktesting this fix).