### PR TITLE
stop running easyconfig unit tests with Python 2.7

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [3.6, '3.11']
+        python: [3.6]
         modules_tool: [Lmod-7.8.22, Lmod-8.6.8]
         module_syntax: [Lua, Tcl]
         # exclude some configurations: only test Tcl module syntax with Lmod 8.x and Python 3.6
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [3.6, '3.11']
+        python: [3.6]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [2.7, 3.6]
+        python: [3.6, '3.11']
         modules_tool: [Lmod-7.8.22, Lmod-8.6.8]
         module_syntax: [Lua, Tcl]
-        # exclude some configurations: only test Tcl module syntax with Lmod 8.x and Python 2.7 & 3.6
+        # exclude some configurations: only test Tcl module syntax with Lmod 8.x and Python 3.6
         exclude:
           - modules_tool: Lmod-7.8.22
             module_syntax: Tcl
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [2.7, 3.6, 3.7]
+        python: [3.6, '3.11']
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -34,7 +34,7 @@ jobs:
         key: eb-sourcepath
 
     - name: set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{matrix.python}}
         architecture: x64
@@ -164,7 +164,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{matrix.python}}
 


### PR DESCRIPTION
Fix for problem with `actions/setup-python`:
```
Error: Version 2.7 with arch x64 not found
```

Python 2.7 is no longer available in GitHub Actions, see https://github.com/actions/runner-images/issues/7401 and https://github.com/actions/setup-python/issues/672

edit: I was enabling running the tests with Python 3.11 as a replacement, but that re-introduces the problem that was fixed in https://github.com/easybuilders/easybuild-easyconfigs/pull/10326, because the `prune = 0` in `setup.cfg` doesn't seem to work anymore (see also https://github.com/pypa/setuptools/issues/1807)