### PR TITLE
{chem}[foss/2022a] Cantera v2.6.0 w/ Python 3.10.4

### DIFF
--- a/easybuild/easyconfigs/c/Cantera/Cantera-2.6.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/c/Cantera/Cantera-2.6.0-foss-2022a.eb
@@ -15,9 +15,13 @@ checksums = ['7273622ea76a53373cee820f939613b15eea3dd83db6e1b127c5ed043f77dc5b']
 
 dependencies = [
     ('Python', '3.10.4'),
-    ('SciPy-bundle', '2022.05'),
+    ('h5py', '3.7.0'),
+    ('pygraphviz', '1.10'),
+    ('JupyterLab', '3.5.0'),
+    ('matplotlib', '3.5.2'),
+    ('PyQt5', '5.15.5'),
     ('Boost', '1.79.0'),
-    ('SUNDIALS', '6.3.0'),
+    ('SUNDIALS', '6.5.1'),
     ('yaml-cpp', '0.7.0'),
     ('ruamel.yaml', '0.17.21'),
 ]

--- a/easybuild/easyconfigs/c/Cantera/Cantera-2.6.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/c/Cantera/Cantera-2.6.0-foss-2022a.eb
@@ -19,7 +19,6 @@ dependencies = [
     ('pygraphviz', '1.10'),
     ('JupyterLab', '3.5.0'),
     ('matplotlib', '3.5.2'),
-    ('PyQt5', '5.15.5'),
     ('Boost', '1.79.0'),
     ('SUNDIALS', '6.5.1'),
     ('yaml-cpp', '0.7.0'),


### PR DESCRIPTION
CVodes from SUNDIALS 6.3.0 was bugged, with 6.5.1 seems working fine

```
CanteraError thrown by CVodesIntegrator::integrate:
CVodes error encountered. Error code: -4
```

In https://github.com/LLNL/sundials/releases/tag/v6.5.0
was solved: Fixed an underflow bug during root finding in ARKODE, CVODE, CVODES, IDA and IDAS.
