### PR TITLE
Create RIblast-1.2.0-GCCcore-11.3.0.eb

### DIFF
--- a/easybuild/easyconfigs/r/RIblast/RIblast-1.2.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/r/RIblast/RIblast-1.2.0-GCCcore-11.3.0.eb
@@ -1,0 +1,26 @@
+easyblock = 'MakeCp'
+
+name = 'RIblast'
+version = '1.2.0'
+
+homepage = 'https://github.com/fukunagatsu/RIblast/'
+
+description = """RIblast is ultrafast RNA-RNA interaction prediction software based on seed-and-extension algorithm for comprehensive lncRNA interactome analysis."""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = ['https://github.com/fukunagatsu/RIblast/archive/refs/tags']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [('binutils', '2.38')]
+
+files_to_copy = [
+    (['RIblast'], 'bin'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/RIblast'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
Older software, but works with new toolchain.