### PR TITLE
patch files for QT5-5.17.7-GCCcore-12.20.0.eb for SIGSTKSZ in glibc 2.34

### DIFF
--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.15.7-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.15.7-GCCcore-12.2.0.eb
@@ -29,8 +29,10 @@ checksums = [
     {'Qt5-5.13.1_fix-avx2.patch': '6f46005f056bf9e6ff3e5d012a874d18ee03b33e685941f2979c970be91a9dbc'},
     {'Qt5-5.13.1_fix-qmake-libdir.patch': '511ca9c0599ceb1989f73d8ceea9199c041512d3a26ee8c5fd870ead2c10cb63'},
     {'Qt5-5.14.1_fix-OF-Gentoo.patch': '0b9defb7ce75314d85bebe07e143db7f7de316fec64c17cbd13f7eec5d2d1afa'},
-    {'Qt5-5.15.2_fix-qtwebengine-abseil-cpp-glibc-2.34.patch': 'f39506495b70cc0968fb7a5f4c9028b0f0a180c552906ff4e58e0bcae83cf187'},
-    {'Qt5-5.15.2_fix-qtwebengine-breakpad-glibc-2.34.patch': '74590de2b9e32f2c88123cb096c4f5c3001b00710aad096a4d16444a8e9eb991'},
+    {'Qt5-5.15.2_fix-qtwebengine-abseil-cpp-glibc-2.34.patch':
+     'f39506495b70cc0968fb7a5f4c9028b0f0a180c552906ff4e58e0bcae83cf187'},
+    {'Qt5-5.15.2_fix-qtwebengine-breakpad-glibc-2.34.patch':
+     '74590de2b9e32f2c88123cb096c4f5c3001b00710aad096a4d16444a8e9eb991'},
     {'Qt5-5.15.7_GCC-12.patch': '9a5bde91b223a3e2e90d3d6bec107af69a1a0f18d789593738a953080473fa68'},
 ]
 

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.15.7-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.15.7-GCCcore-12.2.0.eb
@@ -20,6 +20,8 @@ patches = [
     'Qt5-5.13.1_fix-avx2.patch',
     'Qt5-5.13.1_fix-qmake-libdir.patch',
     'Qt5-5.14.1_fix-OF-Gentoo.patch',
+    'Qt5-5.15.2_fix-qtwebengine-abseil-cpp-glibc-2.34.patch',
+    'Qt5-5.15.2_fix-qtwebengine-breakpad-glibc-2.34.patch',
     'Qt5-5.15.7_GCC-12.patch',
 ]
 checksums = [
@@ -27,6 +29,8 @@ checksums = [
     {'Qt5-5.13.1_fix-avx2.patch': '6f46005f056bf9e6ff3e5d012a874d18ee03b33e685941f2979c970be91a9dbc'},
     {'Qt5-5.13.1_fix-qmake-libdir.patch': '511ca9c0599ceb1989f73d8ceea9199c041512d3a26ee8c5fd870ead2c10cb63'},
     {'Qt5-5.14.1_fix-OF-Gentoo.patch': '0b9defb7ce75314d85bebe07e143db7f7de316fec64c17cbd13f7eec5d2d1afa'},
+    {'Qt5-5.15.2_fix-qtwebengine-abseil-cpp-glibc-2.34.patch': 'f39506495b70cc0968fb7a5f4c9028b0f0a180c552906ff4e58e0bcae83cf187'},
+    {'Qt5-5.15.2_fix-qtwebengine-breakpad-glibc-2.34.patch': '74590de2b9e32f2c88123cb096c4f5c3001b00710aad096a4d16444a8e9eb991'},
     {'Qt5-5.15.7_GCC-12.patch': '9a5bde91b223a3e2e90d3d6bec107af69a1a0f18d789593738a953080473fa68'},
 ]
 


### PR DESCRIPTION
requires PR 18007, already merged into develop.