### PR TITLE
fix incorrect version for GMAP-GSNAP 2021-12-17 (was 2021-21-17)

### DIFF
--- a/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2021-12-17-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2021-12-17-GCC-11.2.0.eb
@@ -9,7 +9,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'GMAP-GSNAP'
-version = '2021-21-17'
+version = '2021-12-17'
 
 homepage = 'http://research-pub.gene.com/gmap/'
 description = """GMAP: A Genomic Mapping and Alignment Program for mRNA and EST Sequences

--- a/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2021-12-17-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2021-12-17-GCC-11.2.0.eb
@@ -26,7 +26,7 @@ checksums = ['9e8368bc997d79292f84a3553bc1a09c1d5ea5337d252dadc0f6ed85b4bb6dae']
 dependencies = [
     ('bzip2', '1.0.8'),
     ('zlib', '1.2.11'),
-    ('Perl','5.34.0'),
+    ('Perl', '5.34.0'),
 ]
 
 # GSNAP uses MAX_STACK_READLENGTH to control the use of stack or heap memory depending on the read length

--- a/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2021-12-17-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/g/GMAP-GSNAP/GMAP-GSNAP-2021-12-17-GCC-11.2.0.eb
@@ -26,6 +26,7 @@ checksums = ['9e8368bc997d79292f84a3553bc1a09c1d5ea5337d252dadc0f6ed85b4bb6dae']
 dependencies = [
     ('bzip2', '1.0.8'),
     ('zlib', '1.2.11'),
+    ('Perl','5.34.0'),
 ]
 
 # GSNAP uses MAX_STACK_READLENGTH to control the use of stack or heap memory depending on the read length

--- a/easybuild/easyconfigs/r/rnaQUAST/rnaQUAST-2.2.2-foss-2021b.eb
+++ b/easybuild/easyconfigs/r/rnaQUAST/rnaQUAST-2.2.2-foss-2021b.eb
@@ -16,7 +16,7 @@ checksums = ['941aeb9a296aa0135f8973c0cffa76e05d7451cc698f0f56c23c5627ae163c8f']
 
 dependencies = [
     ('Python', '3.9.6'),
-    ('GMAP-GSNAP', '2021-21-17'),
+    ('GMAP-GSNAP', '2021-12-17'),
     ('Biopython', '1.79'),
     ('matplotlib', '3.4.3'),
     ('BLAST+', '2.12.0'),


### PR DESCRIPTION
The original tarfile was named gmap-gsnap-2021-21-17.tar.gz but has later been corrected for the typo. Also adjust the  version in rnaQUAST-2.2.2-foss-2021b.eb which is the only place it is used.