### PR TITLE
Fix CUDA build of TensorFlow when using compiler symlinks

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.11.0-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.11.0-foss-2022a-CUDA-11.7.0.eb
@@ -159,6 +159,7 @@ exts_list = [
         'source_tmpl': 'v%(version)s.tar.gz',
         'source_urls': ['https://github.com/tensorflow/tensorflow/archive/'],
         'patches': [
+            'TensorFlow-2.1.0_fix-cuda-build.patch',
             '%(name)s-2.4.0_dont-use-var-lock.patch',
             '%(name)s-2.5.0-fix-alias-violation-in-absl.patch',
             '%(name)s-2.5.0_fix-crash-on-shutdown.patch',
@@ -173,6 +174,8 @@ exts_list = [
         ],
         'checksums': [
             {'v2.11.0.tar.gz': '99c732b92b1b37fc243a559e02f9aef5671771e272758aa4aec7f34dc92dac48'},
+            {'TensorFlow-2.1.0_fix-cuda-build.patch':
+             '78c20aeaa7784b8ceb46238a81e8c2461137d28e0b576deeba8357d23fbe1f5a'},
             {'TensorFlow-2.4.0_dont-use-var-lock.patch':
              'b14f2493fd2edf79abd1c4f2dde6c98a3e7d5cb9c25ab9386df874d5f072d6b5'},
             {'TensorFlow-2.5.0-fix-alias-violation-in-absl.patch':

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.8.4-foss-2021b-CUDA-11.4.1.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.8.4-foss-2021b-CUDA-11.4.1.eb
@@ -152,6 +152,7 @@ exts_list = [
         'source_tmpl': 'v%(version)s.tar.gz',
         'source_urls': ['https://github.com/tensorflow/tensorflow/archive/'],
         'patches': [
+            'TensorFlow-2.1.0_fix-cuda-build.patch',
             'TensorFlow-2.4.0_add-ldl.patch',
             'TensorFlow-2.4.0_dont-use-var-lock.patch',
             'TensorFlow-2.5.0_add-support-for-large-core-systems.patch',
@@ -168,6 +169,8 @@ exts_list = [
         ],
         'checksums': [
             {'v2.8.4.tar.gz': 'c08a222792bdbff9da299c7885561ee27b95d414d1111c426efac4ccdce92cde'},
+            {'TensorFlow-2.1.0_fix-cuda-build.patch':
+             '78c20aeaa7784b8ceb46238a81e8c2461137d28e0b576deeba8357d23fbe1f5a'},
             {'TensorFlow-2.4.0_add-ldl.patch': '917ee7282e782e48673596d8917c3207e60e0851bb9acf230a2a439b067af2e3'},
             {'TensorFlow-2.4.0_dont-use-var-lock.patch':
              'b14f2493fd2edf79abd1c4f2dde6c98a3e7d5cb9c25ab9386df874d5f072d6b5'},

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.9.1-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.9.1-foss-2022a-CUDA-11.7.0.eb
@@ -165,6 +165,7 @@ exts_list = [
         'source_tmpl': 'v%(version)s.tar.gz',
         'source_urls': ['https://github.com/tensorflow/tensorflow/archive/'],
         'patches': [
+            'TensorFlow-2.1.0_fix-cuda-build.patch',
             'TensorFlow-2.4.0_add-ldl.patch',
             'TensorFlow-2.4.0_dont-use-var-lock.patch',
             'TensorFlow-2.5.0_add-support-for-large-core-systems.patch',
@@ -185,6 +186,8 @@ exts_list = [
         ],
         'checksums': [
             {'v2.9.1.tar.gz': '6eaf86ead73e23988fe192da1db68f4d3828bcdd0f3a9dc195935e339c95dbdc'},
+            {'TensorFlow-2.1.0_fix-cuda-build.patch':
+             '78c20aeaa7784b8ceb46238a81e8c2461137d28e0b576deeba8357d23fbe1f5a'},
             {'TensorFlow-2.4.0_add-ldl.patch': '917ee7282e782e48673596d8917c3207e60e0851bb9acf230a2a439b067af2e3'},
             {'TensorFlow-2.4.0_dont-use-var-lock.patch':
              'b14f2493fd2edf79abd1c4f2dde6c98a3e7d5cb9c25ab9386df874d5f072d6b5'},


### PR DESCRIPTION
Add the TensorFlow-2.1.0_fix-cuda-build.patch to the TensorFlow-CUDA ECs to fix failure when compilers are on symlinked paths and e.g. ccache or rpath wrappers are used.

Fixes #17892

Followup to #17058

I don't think a full test build is required as we already have experience with that patch and it used to be in 2.8.4. I verified that it applies to a git checkout of 2.9.1 and 2.11.0 as `--stop=patch` doesn't work for extensions.