### PR TITLE
use patch to make ncbi-vdb 2.11.2 compatible with HDF5 1.12.2

### DIFF
--- a/easybuild/easyconfigs/n/ncbi-vdb/ncbi-vdb-2.11.2-gompi-2021b.eb
+++ b/easybuild/easyconfigs/n/ncbi-vdb/ncbi-vdb-2.11.2-gompi-2021b.eb
@@ -15,6 +15,7 @@ sources = [{'download_filename': '%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ
 patches = [
     'ncbi-vdb-2.10.7_fix-LD_LIBRARY_PATH.patch',
     'ncbi-vdb-cstdlib.patch',
+    'ncbi-vdb-3.0.0_hdf5_api.patch',
 ]
 checksums = [
     '647efea2762d63dee6d3e462b1fed2ae6d0f2cf1adb0da583ac95f3ee073abdf',  # ncbi-vdb-2.11.2.tar.gz
@@ -31,7 +32,7 @@ builddependencies = [
 dependencies = [
     ('NGS', '2.11.2'),
     ('file', '5.41'),  # provides libmagic
-    ('HDF5', '1.10.8'),  # version 1.12.x has changes to API and is not compatible
+    ('HDF5', '1.12.1'),
     ('libxml2', '2.9.10'),
     ('bzip2', '1.0.8'),
 ]

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -509,11 +509,6 @@ class EasyConfigTest(TestCase):
                                                 r'QGIS-3\.28\.1']),
             ],
             'Geant4': [('11.0.1;', [r'GATE-9\.2-foss-2021b'])],
-            # ncbi-vdb v2.x requires HDF5 v1.10.x (HISAT2, SKESA, shovill depend on ncbi-vdb)
-            'HDF5': [
-                (r'1\.10\.', [r'ncbi-vdb-2\.11\.', r'HISAT2-2\.2\.', r'SKESA-2\.4\.',
-                              r'shovill-1\.1\.']),
-            ],
             # VMTK 1.4.x requires ITK 4.13.x
             'ITK': [(r'4\.13\.', [r'VMTK-1\.4\.'])],
             # Kraken 1.x requires Jellyfish 1.x (Roary & metaWRAP depend on Kraken 1.x)


### PR DESCRIPTION
`ncbi-vdb` 2.11.2 depending on HDF5 1.10.x makes it incompatible with other easyconfigs of the `2021b` generation, `R/4.1.2-foss-2021b` for example, which causes problems (cfr. #17686)

There's an easy fix to make `ncbi-vdb` compatible with HDF5 1.12.x, which we already did for `ncbi-vdb` 3.0.0, see #17140