### PR TITLE
change base for intel/2023.03 to GCCcore/12.3.0

### DIFF
--- a/easybuild/easyconfigs/i/impi/impi-2021.9.0-intel-compilers-2023.1.0.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2021.9.0-intel-compilers-2023.1.0.eb
@@ -11,6 +11,6 @@ source_urls = ['https://registrationcenter-download.intel.com/akdlm/IRC_NAS/718d
 sources = ['l_mpi_oneapi_p_%(version)s.43482_offline.sh']
 checksums = ['5c170cdf26901311408809ced28498b630a494428703685203ceef6e62735ef8']
 
-dependencies = [('UCX', '1.14.0')]
+dependencies = [('UCX', '1.14.1')]
 
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/i/intel-compilers/intel-compilers-2023.1.0.eb
+++ b/easybuild/easyconfigs/i/intel-compilers/intel-compilers-2023.1.0.eb
@@ -28,10 +28,10 @@ checksums = [
      '7639af4b6c928e9e3ba92297a054f78a55f4f4d0db9db0d144cc6653004e4f24'},
 ]
 
-local_gccver = '12.2.0'
+local_gccver = '12.3.0'
 dependencies = [
     ('GCCcore', local_gccver),
-    ('binutils', '2.39', '', ('GCCcore', local_gccver)),
+    ('binutils', '2.40', '', ('GCCcore', local_gccver)),
 ]
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/i/intel/intel-2023.03.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2023.03.eb
@@ -9,10 +9,10 @@ description = "Compiler toolchain including Intel compilers, Intel MPI and Intel
 toolchain = SYSTEM
 
 local_comp_ver = '2023.1.0'
-local_gccver = '12.2.0'
+local_gccver = '12.3.0'
 dependencies = [
     ('GCCcore', local_gccver),
-    ('binutils', '2.39', '', ('GCCcore', local_gccver)),
+    ('binutils', '2.40', '', ('GCCcore', local_gccver)),
     ('intel-compilers', local_comp_ver),
     ('impi', '2021.9.0', '', ('intel-compilers', local_comp_ver)),
     ('imkl', local_comp_ver, '', SYSTEM),


### PR DESCRIPTION
Since there's no newer Intel compilers release than 2023 update 1, which is used in `intel/2023.03`, we need to change the base compiler to `GCCcore/12.3.0`, since that's the one used for `foss/2023.05` (which will become `foss/2023a`).