### PR TITLE
{toolchain} foss/2023a

### DIFF
--- a/easybuild/easyconfigs/f/FFTW.MPI/FFTW.MPI-3.3.10-gompi-2023a.eb
+++ b/easybuild/easyconfigs/f/FFTW.MPI/FFTW.MPI-3.3.10-gompi-2023a.eb
@@ -5,7 +5,7 @@ homepage = 'https://www.fftw.org'
 description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
 in one or more dimensions, of arbitrary input size, and of both real and complex data."""
 
-toolchain = {'name': 'gompi', 'version': '2023.05'}
+toolchain = {'name': 'gompi', 'version': '2023a'}
 toolchainopts = {'pic': True}
 
 source_urls = [homepage]

--- a/easybuild/easyconfigs/f/foss/foss-2023a.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2023a.eb
@@ -1,7 +1,7 @@
 easyblock = 'Toolchain'
 
 name = 'foss'
-version = '2023.05'
+version = '2023a'
 
 homepage = 'https://easybuild.readthedocs.io/en/master/Common-toolchains.html#foss-toolchain'
 description = """GNU Compiler Collection (GCC) based compiler toolchain, including

--- a/easybuild/easyconfigs/g/gfbf/gfbf-2023a.eb
+++ b/easybuild/easyconfigs/g/gfbf/gfbf-2023a.eb
@@ -1,7 +1,7 @@
 easyblock = 'Toolchain'
 
 name = 'gfbf'
-version = '2023.05'
+version = '2023a'
 
 homepage = '(none)'
 description = """GNU Compiler Collection (GCC) based compiler toolchain, including

--- a/easybuild/easyconfigs/g/gompi/gompi-2023a.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2023a.eb
@@ -1,7 +1,7 @@
 easyblock = 'Toolchain'
 
 name = 'gompi'
-version = '2023.05'
+version = '2023a'
 
 homepage = '(none)'
 description = """GNU Compiler Collection (GCC) based compiler toolchain,

--- a/easybuild/easyconfigs/h/HPL/HPL-2.3-foss-2023a.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.3-foss-2023a.eb
@@ -6,7 +6,7 @@ description = """HPL is a software package that solves a (random) dense linear s
  arithmetic on distributed-memory computers. It can thus be regarded as a portable as well as freely available
  implementation of the High Performance Computing Linpack Benchmark."""
 
-toolchain = {'name': 'foss', 'version': '2023.05'}
+toolchain = {'name': 'foss', 'version': '2023a'}
 toolchainopts = {'usempi': True}
 
 source_urls = ['https://www.netlib.org/benchmark/%(namelower)s']

--- a/easybuild/easyconfigs/o/OSU-Micro-Benchmarks/OSU-Micro-Benchmarks-7.1-1-gompi-2023a.eb
+++ b/easybuild/easyconfigs/o/OSU-Micro-Benchmarks/OSU-Micro-Benchmarks-7.1-1-gompi-2023a.eb
@@ -6,7 +6,7 @@ version = '7.1-1'
 homepage = 'https://mvapich.cse.ohio-state.edu/benchmarks/'
 description = """OSU Micro-Benchmarks"""
 
-toolchain = {'name': 'gompi', 'version': '2023.05'}
+toolchain = {'name': 'gompi', 'version': '2023a'}
 toolchainopts = {'usempi': True}
 
 source_urls = ['https://mvapich.cse.ohio-state.edu/download/mvapich/']

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.2.0-gompi-2023a-fb.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.2.0-gompi-2023a-fb.eb
@@ -6,7 +6,7 @@ homepage = 'https://www.netlib.org/scalapack/'
 description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
  redesigned for distributed memory MIMD parallel computers."""
 
-toolchain = {'name': 'gompi', 'version': '2023.05'}
+toolchain = {'name': 'gompi', 'version': '2023a'}
 toolchainopts = {'pic': True}
 
 source_urls = [homepage]


### PR DESCRIPTION
Since `foss/2023.05` is only in `develop` (and not included in an EasyBuild release yet), we can rename it to `foss/2023a` rather than copying and retaining `foss/2023.05` as well.