### PR TITLE
adding easyconfigs: TINKER-8.10.5-foss-2022b.eb

### DIFF
--- a/easybuild/easyconfigs/t/TINKER/TINKER-8.10.5-buildfix.patch
+++ b/easybuild/easyconfigs/t/TINKER/TINKER-8.10.5-buildfix.patch
@@ -1,0 +1,35 @@
+# https://github.com/TinkerTools/tinker/pull/138
+diff --git a/linux/gfortran/compile.make b/linux/gfortran/compile.make
+index c8085106..cfb0a1dc 100755
+--- a/linux/gfortran/compile.make
++++ b/linux/gfortran/compile.make
+@@ -51,6 +51,7 @@ gfortran -c -Ofast -mavx -fopenmp dsppot.f
+ gfortran -c -Ofast -mavx -fopenmp energi.f
+ gfortran -c -Ofast -mavx -fopenmp ewald.f
+ gfortran -c -Ofast -mavx -fopenmp expol.f
++gfortran -c -Ofast -mavx -fopenmp extfld.f
+ gfortran -c -Ofast -mavx -fopenmp faces.f
+ gfortran -c -Ofast -mavx -fopenmp fft.f
+ gfortran -c -Ofast -mavx -fopenmp fields.f
+@@ -363,6 +364,7 @@ gfortran -c -Ofast -mavx -fopenmp eurey1.f
+ gfortran -c -Ofast -mavx -fopenmp eurey2.f
+ gfortran -c -Ofast -mavx -fopenmp eurey3.f
+ gfortran -c -Ofast -mavx -fopenmp evcorr.f
++gfortran -c -Ofast -mavx -fopenmp exfield.f
+ gfortran -c -Ofast -mavx -fopenmp extra.f
+ gfortran -c -Ofast -mavx -fopenmp extra1.f
+ gfortran -c -Ofast -mavx -fopenmp extra2.f
+diff --git a/linux/gfortran/library.make b/linux/gfortran/library.make
+index 818e2982..958a22e7 100755
+--- a/linux/gfortran/library.make
++++ b/linux/gfortran/library.make
+@@ -211,7 +211,9 @@ eurey2.o \
+ eurey3.o \
+ evcorr.o \
+ ewald.o \
++exfield.o \
+ expol.o \
++extfld.o \
+ extra.o \
+ extra1.o \
+ extra2.o \

--- a/easybuild/easyconfigs/t/TINKER/TINKER-8.10.5-foss-2022b.eb
+++ b/easybuild/easyconfigs/t/TINKER/TINKER-8.10.5-foss-2022b.eb
@@ -1,0 +1,23 @@
+name = 'TINKER'
+version = '8.10.5'
+
+homepage = 'https://dasher.wustl.edu/tinker'
+description = """The TINKER molecular modeling software is a complete and general package for molecular mechanics
+ and dynamics, with some special features for biopolymers."""
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+
+source_urls = ['https://dasher.wustl.edu/tinker/downloads/']
+sources = [SOURCELOWER_TAR_GZ]
+patches = ['TINKER-8.10.5-buildfix.patch']
+
+checksums = [
+    '4673783f1d8f369c9e90add6f8be4aeb8a6969525fd8c09b6f97b7ca93294e94',  # tinker-8.10.5.tar.gz
+    '0605dfc13a09434d338fc74f6395b4faaf7bfcb64481c7e71162b5a81fec7d52',  # TINKER-8.10.5-buildfix.patch
+]
+
+runtest = True
+
+# sanity_check_commands is not possible since all the programs require multiple other inputs
+
+moduleclass = 'chem'


### PR DESCRIPTION
The build system used by the TINKER easyblock (running compile.make, library.make and link.make) is currently broken upstream and needs a small patch. It was submitted upstream at https://github.com/TinkerTools/tinker/pull/138.

The tests performed after building TINKER for me took about 15 hours on a 128 core machine. That's maybe not optimal but would have to be dealt with in the TINKER easyblock. There are already two tests disabled due to long runtime: https://github.com/easybuilders/easybuild-easyblocks/blob/fa9468436edba63d681179dd50bed48372a3bc60/easybuild/easyblocks/t/tinker.py#L129