### PR TITLE
consistently use ON/OFF for -DBUILD_SHARED_LIBS

### DIFF
--- a/easybuild/easyconfigs/b/BUFRLIB/BUFRLIB-11.3.0.2-iccifort-2020.1.217.eb
+++ b/easybuild/easyconfigs/b/BUFRLIB/BUFRLIB-11.3.0.2-iccifort-2020.1.217.eb
@@ -14,7 +14,7 @@ sources = ['v%(version)s.tar.gz']
 checksums = ['1023eb590e2112d5bc213c568a212390fc65ff98732ac8d2ccdda5062e6bc8c6']
 
 builddependencies = [('CMake', '3.16.4')]
-configopts = " -DBUILD_STATIC_LIBS=1 -DBUILD_SHARED_LIBS=1"
+configopts = '-DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=ON'
 
 sanity_check_paths = {
     'files': ['lib/libbufr.a', 'lib/libbufr.so'],

--- a/easybuild/easyconfigs/c/crossguid/crossguid-20190529-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/c/crossguid/crossguid-20190529-GCCcore-11.3.0.eb
@@ -37,7 +37,7 @@ dependencies = [
 
 # build demo 
 # build static and shared libraries
-configopts = ["-DCROSSGUID_TESTS=ON", "-DBUILD_SHARED_LIBS=TRUE"]
+configopts = ["-DCROSSGUID_TESTS=ON -DBUILD_SHARED_LIBS=%s" % local_shared for local_shared in ('OFF', 'ON')]
 
 # we want to have the crossguid-test
 postinstallcmds = [

--- a/easybuild/easyconfigs/g/gflags/gflags-2.1.2-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/gflags/gflags-2.1.2-foss-2016a.eb
@@ -20,7 +20,7 @@ builddependencies = [
     ('CMake', '3.4.3'),
 ]
 
-configopts = '-DBUILD_SHARED_LIBS=on -DBUILD_STATIC_LIBS=on'
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON'
 
 sanity_check_paths = {
     'files': ['bin/gflags_completions.sh'] +

--- a/easybuild/easyconfigs/g/gflags/gflags-2.1.2-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/gflags/gflags-2.1.2-foss-2016a.eb
@@ -15,6 +15,7 @@ toolchainopts = {'pic': True}
 
 sources = ['v%(version)s.tar.gz']
 source_urls = ['https://github.com/gflags/gflags/archive/']
+checksums = ['d8331bd0f7367c8afd5fcb5f5e85e96868a00fd24b7276fa5fcee1e5575c2662']
 
 builddependencies = [
     ('CMake', '3.4.3'),

--- a/easybuild/easyconfigs/g/gflags/gflags-2.2.1-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/g/gflags/gflags-2.2.1-GCCcore-6.4.0.eb
@@ -23,7 +23,7 @@ builddependencies = [
     ('CMake', '3.10.2'),
 ]
 
-configopts = '-DBUILD_SHARED_LIBS=on -DBUILD_STATIC_LIBS=on'
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON'
 
 sanity_check_paths = {
     'files': ['bin/gflags_completions.sh'] +

--- a/easybuild/easyconfigs/g/gflags/gflags-2.2.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/g/gflags/gflags-2.2.1-intel-2017a.eb
@@ -29,7 +29,7 @@ builddependencies = [
     ('CMake', '3.9.1')
 ]
 
-configopts = '-DBUILD_SHARED_LIBS=on -DBUILD_STATIC_LIBS=on'
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON'
 
 sanity_check_paths = {
     'files': ['bin/gflags_completions.sh'] +

--- a/easybuild/easyconfigs/g/gflags/gflags-2.2.1-intel-2017b.eb
+++ b/easybuild/easyconfigs/g/gflags/gflags-2.2.1-intel-2017b.eb
@@ -29,7 +29,7 @@ builddependencies = [
     ('CMake', '3.9.1')
 ]
 
-configopts = '-DBUILD_SHARED_LIBS=on -DBUILD_STATIC_LIBS=on'
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON'
 
 sanity_check_paths = {
     'files': ['bin/gflags_completions.sh'] +

--- a/easybuild/easyconfigs/g/gflags/gflags-2.2.2-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/g/gflags/gflags-2.2.2-GCCcore-10.2.0.eb
@@ -22,7 +22,7 @@ builddependencies = [
     ('CMake', '3.18.4'),
 ]
 
-configopts = '-DBUILD_SHARED_LIBS=on -DBUILD_STATIC_LIBS=on'
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON'
 
 sanity_check_paths = {
     'files': ['bin/gflags_completions.sh'] +

--- a/easybuild/easyconfigs/g/gflags/gflags-2.2.2-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/g/gflags/gflags-2.2.2-GCCcore-10.3.0.eb
@@ -22,7 +22,7 @@ builddependencies = [
     ('CMake', '3.20.1'),
 ]
 
-configopts = '-DBUILD_SHARED_LIBS=on -DBUILD_STATIC_LIBS=on'
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON'
 
 sanity_check_paths = {
     'files': ['bin/gflags_completions.sh'] +

--- a/easybuild/easyconfigs/g/gflags/gflags-2.2.2-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/g/gflags/gflags-2.2.2-GCCcore-11.2.0.eb
@@ -22,7 +22,7 @@ builddependencies = [
     ('CMake', '3.21.1'),
 ]
 
-configopts = '-DBUILD_SHARED_LIBS=on -DBUILD_STATIC_LIBS=on'
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON'
 
 sanity_check_paths = {
     'files': ['bin/gflags_completions.sh'] +

--- a/easybuild/easyconfigs/g/gflags/gflags-2.2.2-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/g/gflags/gflags-2.2.2-GCCcore-8.2.0.eb
@@ -22,7 +22,7 @@ builddependencies = [
     ('CMake', '3.13.3'),
 ]
 
-configopts = '-DBUILD_SHARED_LIBS=on -DBUILD_STATIC_LIBS=on'
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON'
 
 sanity_check_paths = {
     'files': ['bin/gflags_completions.sh'] +

--- a/easybuild/easyconfigs/g/gflags/gflags-2.2.2-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/gflags/gflags-2.2.2-GCCcore-8.3.0.eb
@@ -22,7 +22,7 @@ builddependencies = [
     ('CMake', '3.15.3'),
 ]
 
-configopts = '-DBUILD_SHARED_LIBS=on -DBUILD_STATIC_LIBS=on'
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON'
 
 sanity_check_paths = {
     'files': ['bin/gflags_completions.sh'] +

--- a/easybuild/easyconfigs/g/gflags/gflags-2.2.2-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/g/gflags/gflags-2.2.2-GCCcore-9.3.0.eb
@@ -22,7 +22,7 @@ builddependencies = [
     ('CMake', '3.16.4'),
 ]
 
-configopts = '-DBUILD_SHARED_LIBS=on -DBUILD_STATIC_LIBS=on'
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON'
 
 sanity_check_paths = {
     'files': ['bin/gflags_completions.sh'] +

--- a/easybuild/easyconfigs/l/LEMON/LEMON-1.3.1-GCC-8.2.0-2.31.1.eb
+++ b/easybuild/easyconfigs/l/LEMON/LEMON-1.3.1-GCC-8.2.0-2.31.1.eb
@@ -19,7 +19,7 @@ builddependencies = [('CMake', '3.13.3')]
 
 separate_build_dir = True
 
-configopts = ['', '-DBUILD_SHARED_LIBS=TRUE']
+configopts = ['-DBUILD_SHARED_LIBS=OFF', '-DBUILD_SHARED_LIBS=ON']
 
 runtest = 'check'
 

--- a/easybuild/easyconfigs/m/mctc-lib/mctc-lib-0.3.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/m/mctc-lib/mctc-lib-0.3.1-GCCcore-11.3.0.eb
@@ -22,7 +22,7 @@ builddependencies = [
     ('CMake', '3.23.1'),
 ]
 
-configopts = '-DBUILD_SHARED_LIBS=1'
+configopts = '-DBUILD_SHARED_LIBS=ON'
 
 sanity_check_paths = {
     'files': ['bin/mctc-convert', 'lib/libmctc-lib.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/m/mstore/mstore-0.2.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/m/mstore/mstore-0.2.0-GCCcore-11.3.0.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('mctc-lib', '0.3.1'),
 ]
 
-configopts = '-DBUILD_SHARED_LIBS=1'
+configopts = '-DBUILD_SHARED_LIBS=ON'
 
 sanity_check_paths = {
     'files': ['bin/mstore-fortranize', 'bin/mstore-info', 'lib/libmstore.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/n/NTPoly/NTPoly-2.5.1-foss-2020b.eb
+++ b/easybuild/easyconfigs/n/NTPoly/NTPoly-2.5.1-foss-2020b.eb
@@ -14,7 +14,7 @@ source_urls = ['https://github.com/william-dawson/NTPoly/archive/ntpoly-v%(versi
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['5d1abd3dc3286167caf0c326ef14838ac8360aa1e912bd7bd6d212259fbff1ac']
 
-configopts = ['-DBUILD_SHARED_LIBS=on']
+configopts = '-DBUILD_SHARED_LIBS=ON'
 
 builddependencies = [('CMake', '3.18.4')]
 

--- a/easybuild/easyconfigs/n/NTPoly/NTPoly-2.5.1-intel-2020b.eb
+++ b/easybuild/easyconfigs/n/NTPoly/NTPoly-2.5.1-intel-2020b.eb
@@ -14,7 +14,7 @@ source_urls = ['https://github.com/william-dawson/NTPoly/archive/ntpoly-v%(versi
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['5d1abd3dc3286167caf0c326ef14838ac8360aa1e912bd7bd6d212259fbff1ac']
 
-configopts = ['-DBUILD_SHARED_LIBS=on']
+configopts = '-DBUILD_SHARED_LIBS=ON'
 
 builddependencies = [('CMake', '3.18.4')]
 

--- a/easybuild/easyconfigs/u/utf8proc/utf8proc-2.3.0-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/u/utf8proc/utf8proc-2.3.0-GCCcore-8.2.0.eb
@@ -20,7 +20,7 @@ builddependencies = [
 
 separate_build_dir = True
 
-configopts = ['', '-DBUILD_SHARED_LIBS=true']
+configopts = ['-DBUILD_SHARED_LIBS=OFF', '-DBUILD_SHARED_LIBS=ON']
 
 sanity_check_paths = {
     'files': ['include/utf8proc.h', 'lib/libutf8proc.a', 'lib/libutf8proc.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/u/utf8proc/utf8proc-2.5.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/u/utf8proc/utf8proc-2.5.0-GCCcore-10.2.0.eb
@@ -20,7 +20,7 @@ builddependencies = [
 
 separate_build_dir = True
 
-configopts = ['', '-DBUILD_SHARED_LIBS=true']
+configopts = ['-DBUILD_SHARED_LIBS=OFF', '-DBUILD_SHARED_LIBS=ON']
 
 sanity_check_paths = {
     'files': ['include/utf8proc.h', 'lib/libutf8proc.a', 'lib/libutf8proc.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/u/utf8proc/utf8proc-2.5.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/u/utf8proc/utf8proc-2.5.0-GCCcore-8.3.0.eb
@@ -20,7 +20,7 @@ builddependencies = [
 
 separate_build_dir = True
 
-configopts = ['', '-DBUILD_SHARED_LIBS=true']
+configopts = ['-DBUILD_SHARED_LIBS=OFF', '-DBUILD_SHARED_LIBS=ON']
 
 sanity_check_paths = {
     'files': ['include/utf8proc.h', 'lib/libutf8proc.a', 'lib/libutf8proc.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/u/utf8proc/utf8proc-2.5.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/u/utf8proc/utf8proc-2.5.0-GCCcore-9.3.0.eb
@@ -20,7 +20,7 @@ builddependencies = [
 
 separate_build_dir = True
 
-configopts = ['', '-DBUILD_SHARED_LIBS=true']
+configopts = ['-DBUILD_SHARED_LIBS=OFF', '-DBUILD_SHARED_LIBS=ON']
 
 sanity_check_paths = {
     'files': ['include/utf8proc.h', 'lib/libutf8proc.a', 'lib/libutf8proc.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/u/utf8proc/utf8proc-2.6.1-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/u/utf8proc/utf8proc-2.6.1-GCCcore-10.3.0.eb
@@ -20,7 +20,7 @@ builddependencies = [
 
 separate_build_dir = True
 
-configopts = ['', '-DBUILD_SHARED_LIBS=true']
+configopts = ['-DBUILD_SHARED_LIBS=OFF', '-DBUILD_SHARED_LIBS=ON']
 
 sanity_check_paths = {
     'files': ['include/utf8proc.h', 'lib/libutf8proc.a', 'lib/libutf8proc.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/u/utf8proc/utf8proc-2.6.1-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/u/utf8proc/utf8proc-2.6.1-GCCcore-11.2.0.eb
@@ -20,7 +20,7 @@ builddependencies = [
 
 separate_build_dir = True
 
-configopts = ['', '-DBUILD_SHARED_LIBS=true']
+configopts = ['-DBUILD_SHARED_LIBS=OFF', '-DBUILD_SHARED_LIBS=ON']
 
 sanity_check_paths = {
     'files': ['include/utf8proc.h', 'lib/libutf8proc.a', 'lib/libutf8proc.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/u/utf8proc/utf8proc-2.7.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/u/utf8proc/utf8proc-2.7.0-GCCcore-11.3.0.eb
@@ -20,7 +20,7 @@ builddependencies = [
 
 separate_build_dir = True
 
-configopts = ['', '-DBUILD_SHARED_LIBS=true']
+configopts = ['-DBUILD_SHARED_LIBS=OFF', '-DBUILD_SHARED_LIBS=ON']
 
 sanity_check_paths = {
     'files': ['include/utf8proc.h', 'lib/libutf8proc.a', 'lib/libutf8proc.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/u/utf8proc/utf8proc-2.8.0-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/u/utf8proc/utf8proc-2.8.0-GCCcore-12.2.0.eb
@@ -20,7 +20,7 @@ builddependencies = [
 
 separate_build_dir = True
 
-configopts = ['', '-DBUILD_SHARED_LIBS=true']
+configopts = ['-DBUILD_SHARED_LIBS=OFF', '-DBUILD_SHARED_LIBS=ON']
 
 sanity_check_paths = {
     'files': ['include/utf8proc.h', 'lib/libutf8proc.a', 'lib/libutf8proc.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/u/utf8proc/utf8proc-2.8.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/u/utf8proc/utf8proc-2.8.0-GCCcore-12.3.0.eb
@@ -20,7 +20,7 @@ builddependencies = [
 
 separate_build_dir = True
 
-configopts = ['', '-DBUILD_SHARED_LIBS=true']
+configopts = ['-DBUILD_SHARED_LIBS=OFF', '-DBUILD_SHARED_LIBS=ON']
 
 sanity_check_paths = {
     'files': ['include/utf8proc.h', 'lib/libutf8proc.a', 'lib/libutf8proc.%s' % SHLIB_EXT],


### PR DESCRIPTION
CMake defines options as uppercase:
> True if the constant is 1, ON, YES, TRUE, Y, or a non-zero number
> False if the constant is 0, OFF, NO, FALSE, N, IGNORE, NOTFOUND, the empty string, or ends in the suffix -NOTFOUND

Although it (now?) says "Named boolean constants are case-insensitive." this may not have always been the case.
So make all values for `-DBUILD_SHARED_LIBS`  ON/OFF to be consistent.