### PR TITLE
{chem}[foss/2021a] ESPResSo v4.2.1

### DIFF
--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2021a.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2021a.eb
@@ -2,7 +2,6 @@ easyblock = 'CMakeMake'
 
 name = 'ESPResSo'
 version = '4.2.1'
-versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://espressomd.org/wordpress'
 description = """A software package for performing and analyzing scientific Molecular Dynamics simulations."""
@@ -18,7 +17,6 @@ builddependencies = [('CMake', '3.20.1')]
 
 dependencies = [
     ('Python', '3.9.5'),
-    ('CUDA', '11.3.1', '', SYSTEM),
     ('SciPy-bundle', '2021.05'),
     ('Boost.MPI', '1.76.0'),
     ('HDF5', '1.10.7'),
@@ -28,7 +26,7 @@ dependencies = [
     ('Pint', '0.20.1'),
 ]
 
-configopts = ' -DCMAKE_SKIP_RPATH=OFF -DWITH_TESTS=ON -DWITH_CUDA=ON'
+configopts = ' -DCMAKE_SKIP_RPATH=OFF -DWITH_TESTS=ON -DWITH_CUDA=OFF'
 
 runtest = 'check_unit_tests && make check_python'
 
@@ -37,7 +35,7 @@ modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 _binaries = ['ipypresso',  'pypresso']
 _libs = [
     'Espresso_config', 'Espresso_core', 'Espresso_script_interface', 'Espresso_shapes',
-    '_init', 'analyze', 'code_info', 'cuda_init', 'electrokinetics', 'galilei',
+    '_init', 'analyze', 'code_info', 'electrokinetics', 'galilei',
     'integrate', 'interactions', 'lb', 'particle_data', 'polymer', 'profiler',
     'script_interface', 'system', 'thermostat', 'utils', 'version',
 ]


### PR DESCRIPTION
This update includes `-DWITH_CUDA=OFF` and `-DWITH_CUDA=ON` flags to distinguish between CPU and GPU builds.