### PR TITLE
{numlib}[foss/2023a] PETSc v3.19.4, Hypre v2.28.0, MUMPS v5.5.1, mpi4py v3.1.4, SuiteSparse v5.13.0, SuperLU_DIST v8.1.2, ParMETIS v4.0.3

### DIFF
--- a/easybuild/easyconfigs/h/Hypre/Hypre-2.28.0-foss-2023a.eb
+++ b/easybuild/easyconfigs/h/Hypre/Hypre-2.28.0-foss-2023a.eb
@@ -1,0 +1,18 @@
+name = 'Hypre'
+version = '2.28.0'
+
+homepage = 'https://computation.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods'
+description = """Hypre is a library for solving large, sparse linear systems of equations on massively
+ parallel computers. The problems of interest arise in the simulation codes being developed at LLNL
+ and elsewhere to study physical phenomena in the defense, environmental, energy, and biological sciences."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/hypre-space/hypre/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['2eea68740cdbc0b49a5e428f06ad7af861d1e169ce6a12d2cf0aa2fc28c4a2ae']
+
+start_dir = 'src'
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/m/MUMPS/MUMPS-5.5.1-foss-2023a-metis.eb
+++ b/easybuild/easyconfigs/m/MUMPS/MUMPS-5.5.1-foss-2023a-metis.eb
@@ -1,0 +1,35 @@
+name = 'MUMPS'
+version = '5.5.1'
+versionsuffix = '-metis'
+
+homepage = 'https://graal.ens-lyon.fr/MUMPS/'
+description = "A parallel sparse direct solver"
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['https://graal.ens-lyon.fr/MUMPS/']
+sources = ['%(name)s_%(version)s.tar.gz']
+patches = [
+    '%(name)s-%(version)s_shared-pord.patch',    # builds the shared libs of PORD
+    '%(name)s-%(version)s_shared-mumps.patch',   # builds shared libs of MUMPS
+]
+checksums = [
+    '1abff294fa47ee4cfd50dfd5c595942b72ebfcedce08142a75a99ab35014fa15',  # MUMPS_5.5.1.tar.gz
+    '7990ca13c37aa72daa9e646cc7e6303f3eda01b9c463accea5f0f595fbc13566',  # MUMPS-5.5.0_shared-pord.patch
+    '83c346a16dae059a2f4792ce2f847ca9e8423ef8c6949c3de12960f09383d564',  # MUMPS-5.5.0_shared-mumps.patch
+]
+
+dependencies = [
+    ('SCOTCH', '7.0.3'),
+    ('METIS', '5.1.0'),
+]
+
+parallel = 1
+
+# fix 'Type mismatch between actual argument' errors with GCC 10.x
+prebuildopts = 'export FFLAGS="$FFLAGS -fallow-argument-mismatch" && '
+
+buildopts = 'all SONAME_VERSION="%(version)s"'
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/mpi4py/mpi4py-3.1.4-gompi-2023a.eb
+++ b/easybuild/easyconfigs/m/mpi4py/mpi4py-3.1.4-gompi-2023a.eb
@@ -1,0 +1,25 @@
+easyblock = 'PythonBundle'
+
+name = 'mpi4py'
+version = '3.1.4'
+
+homepage = 'https://github.com/mpi4py/mpi4py'
+description = """MPI for Python (mpi4py) provides bindings of the Message Passing Interface (MPI) standard for
+ the Python programming language, allowing any Python program to exploit multiple processors."""
+
+toolchain = {'name': 'gompi', 'version': '2023a'}
+
+dependencies = [
+    ('Python', '3.11.3'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    (name, version, {
+        'checksums': ['17858f2ebc623220d0120d1fa8d428d033dde749c4bc35b33d81a66ad7f93480'],
+    }),
+]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.19.4-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.19.4-foss-2023a.eb
@@ -34,7 +34,7 @@ dependencies = [
     ('Boost', '1.82.0'),
     ('METIS', '5.1.0'),
     ('SCOTCH', '7.0.3'),
-    ('MUMPS', '5.5.1', '-metis'), # PETSc-3.19.4 supports MUMPS up to v5.5.1
+    ('MUMPS', '5.5.1', '-metis'),
     ('SuiteSparse', '5.13.0', '-METIS-5.1.0'),
     ('Hypre', '2.28.0'),
     ('ParMETIS', '4.0.3'),

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.19.4-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.19.4-foss-2023a.eb
@@ -1,0 +1,54 @@
+##
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+# Author:    Jasper Grimm (UoY)
+##
+name = 'PETSc'
+version = '3.19.4'
+
+homepage = 'https://www.mcs.anl.gov/petsc'
+description = """PETSc, pronounced PET-see (the S is silent), is a suite of data structures and routines for the
+ scalable (parallel) solution of scientific applications modeled by partial differential equations."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+toolchainopts = {'openmp': True, 'usempi': True, 'pic': True}
+
+source_urls = [
+    'https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/',
+    'ftp://ftp.mcs.anl.gov/pub/petsc/release-snapshots/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'PETSc-%(version)s_fix_ranlib.patch',
+]
+checksums = [
+    '7c941b71be52c3b764214e492df60109d12f97f7d854c97a44df0c4d958b3906',  # petsc-3.19.4.tar.gz
+    '7921894ff1fca1a80dc7586b16714ccf81a2de3e5c678c447241f3288d304b20',  # PETSc-3.19.4_fix_ranlib.patch
+]
+
+builddependencies = [('CMake', '3.26.3')]
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('SciPy-bundle', '2023.07'),
+    ('mpi4py', '3.1.4'),
+    ('Boost', '1.82.0'),
+    ('METIS', '5.1.0'),
+    ('SCOTCH', '7.0.3'),
+    ('MUMPS', '5.5.1', '-metis'), # PETSc-3.19.4 supports MUMPS up to v5.5.1
+    ('SuiteSparse', '5.13.0', '-METIS-5.1.0'),
+    ('Hypre', '2.28.0'),
+    ('ParMETIS', '4.0.3'),
+    ('SuperLU_DIST', '8.1.2'),
+]
+
+# enabling --with-mpi4py seems to be totally broken, leads to make errors like:
+# No rule to make target 'mpi4py-build'
+configopts = '--LIBS="$LIBS -lrt" --with-mpi4py=0 '
+
+shared_libs = 1
+
+# only required when building PETSc in a SLURM job environment
+# configopts += '--with-batch=1 --known-mpi-shared-libraries=1 --known-64-bit-blas-indices=0 '
+# prebuildopts = "srun ./conftest-arch-linux2-c-opt && ./reconfigure-arch-linux2-c-opt.py && "
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.19.4_fix_ranlib.patch
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.19.4_fix_ranlib.patch
@@ -1,0 +1,12 @@
+diff -Nru petsc-3.19.4.orig/config/BuildSystem/config/setCompilers.py petsc-3.19.4/config/BuildSystem/config/setCompilers.py
+--- petsc-3.19.4.orig/config/BuildSystem/config/setCompilers.py	2023-07-31 17:00:55.000000000 +0200
++++ petsc-3.19.4/config/BuildSystem/config/setCompilers.py	2023-08-16 12:24:03.847163699 +0200
+@@ -2181,7 +2181,7 @@
+       path = os.path.join(os.getcwd(),'lib','petsc','bin')
+       war  = os.path.join(path,'win_lib')
+       yield (war,self.getArchiverFlags(war),'true')
+-    yield ('ar',self.getArchiverFlags('ar'),'ranlib -c')
++    #yield ('ar',self.getArchiverFlags('ar'),'ranlib -c')
+     yield ('ar',self.getArchiverFlags('ar'),'ranlib')
+     yield ('ar',self.getArchiverFlags('ar'),'true')
+     # IBM with 64-bit pointers

--- a/easybuild/easyconfigs/p/ParMETIS/ParMETIS-4.0.3-gompi-2023a.eb
+++ b/easybuild/easyconfigs/p/ParMETIS/ParMETIS-4.0.3-gompi-2023a.eb
@@ -1,0 +1,29 @@
+##
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+##
+name = 'ParMETIS'
+version = '4.0.3'
+
+homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview'
+description = """ParMETIS is an MPI-based parallel library that implements a variety of algorithms for partitioning
+ unstructured graphs, meshes, and for computing fill-reducing orderings of sparse matrices. ParMETIS extends the
+ functionality provided by METIS and includes routines that are especially suited for parallel AMR computations and
+ large scale numerical simulations. The algorithms implemented in ParMETIS are based on the parallel multilevel k-way
+ graph-partitioning, adaptive repartitioning, and parallel multi-constrained partitioning schemes."""
+
+toolchain = {'name': 'gompi', 'version': '2023a'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = [
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis',
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/OLD',
+]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['f2d9a231b7cf97f1fee6e8c9663113ebf6c240d407d3c118c55b3633d6be6e5f']
+
+builddependencies = [('CMake', '3.26.3')]
+
+# Build static and shared libraries
+configopts = ['', '-DSHARED=1']
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/s/SuiteSparse/SuiteSparse-5.13.0-foss-2023a-METIS-5.1.0.eb
+++ b/easybuild/easyconfigs/s/SuiteSparse/SuiteSparse-5.13.0-foss-2023a-METIS-5.1.0.eb
@@ -1,0 +1,31 @@
+name = 'SuiteSparse'
+version = '5.13.0'
+local_metis_ver = '5.1.0'
+versionsuffix = '-METIS-%s' % local_metis_ver
+
+homepage = 'https://faculty.cse.tamu.edu/davis/suitesparse.html'
+description = """SuiteSparse is a collection of libraries to manipulate sparse matrices."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+toolchainopts = {'unroll': True, 'pic': True}
+
+source_urls = ['https://github.com/DrTimothyAldenDavis/SuiteSparse/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['59c6ca2959623f0c69226cf9afb9a018d12a37fab3a8869db5f6d7f83b6b147d']
+
+builddependencies = [
+    ('CMake', '3.26.3'),
+    ('M4', '1.4.19'),
+]
+
+dependencies = [
+    ('METIS', local_metis_ver),
+    ('MPFR', '4.2.0'),
+]
+
+# make sure that bin/demo can find libsuitesparseconfig.so.5 during build
+prebuildopts = "export LD_LIBRARY_PATH=%(builddir)s/SuiteSparse-%(version)s/lib:$LD_LIBRARY_PATH && "
+# remove broken symlink
+prebuildopts += "rm GraphBLAS/CUDA/test/graphblascuda_test && "
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/SuperLU_DIST/SuperLU_DIST-8.1.2-foss-2023a.eb
+++ b/easybuild/easyconfigs/s/SuperLU_DIST/SuperLU_DIST-8.1.2-foss-2023a.eb
@@ -1,0 +1,40 @@
+easyblock = "EB_SuperLU"
+
+name = 'SuperLU_DIST'
+version = '8.1.2'
+
+homepage = 'https://crd-legacy.lbl.gov/~xiaoye/SuperLU/'
+description = """SuperLU is a general purpose library for the direct solution of large, sparse, nonsymmetric systems
+ of linear equations on high performance machines."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+toolchainopts = {'pic': True, 'openmp': True}
+
+github_account = 'xiaoyeli'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ["v%(version)s.tar.gz"]
+checksums = ['7b16c442bb01ea8b298c0aab9a2584aa4615d09786aac968cb2f3118c058206b']
+
+builddependencies = [('CMake', '3.26.3')]
+
+dependencies = [
+    ('ParMETIS', '4.0.3'),
+]
+
+configopts = '-DTPL_PARMETIS_INCLUDE_DIRS="${EBROOTPARMETIS}/include" '
+configopts += '-DTPL_PARMETIS_LIBRARIES="${EBROOTPARMETIS}/lib/libparmetis.a;${EBROOTPARMETIS}/lib/libmetis.a" '
+
+# Some tests run longer than default 1500s timeout on fairly big machine (36 cores).
+# Include only first four tests, which should be fairly small to run
+pretestopts = 'export ARGS="$ARGS --tests-regex pdtest_[21]x1_[13]_2_8_20_SP" && '
+
+postinstallcmds = [
+    "rm %(installdir)s/lib64/libsuperlu.a",  # remove broken symlink to libsuperlu.a
+]
+
+sanity_check_paths = {
+    'files': ['lib64/libsuperlu_dist.a'],
+    'dirs': ['include']
+}
+
+moduleclass = 'numlib'


### PR DESCRIPTION
PETSc is not compatible with the latest releases of MUMPS, SuiteSparse and Hyper. So, I had to use older versions.