### PR TITLE
(draft/WIP) LAMMPS for Hopper GPUs

### DIFF
--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-15Jun2023-foss-2022a-kokkos-sm90.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-15Jun2023-foss-2022a-kokkos-sm90.eb
@@ -1,0 +1,173 @@
+name = 'LAMMPS'
+version = '15Jun2023'
+versionsuffix = '-kokkos'
+_cuda_suffix = '-CUDA-%(cudaver)s'
+versionsuffix += _cuda_suffix
+cuda_compute_capabilities = ['9.0']
+versionsuffix += '-sm90'
+
+homepage = 'https://www.lammps.org'
+description = """LAMMPS is a classical molecular dynamics code, and an acronym
+for Large-scale Atomic/Molecular Massively Parallel Simulator. LAMMPS has
+potentials for solid-state materials (metals, semiconductors) and soft matter
+(biomolecules, polymers) and coarse-grained or mesoscopic systems. It can be
+used to model atoms or, more generically, as a parallel particle simulator at
+the atomic, meso, or continuum scale. LAMMPS runs on single processors or in
+parallel using message-passing techniques and a spatial-decomposition of the
+simulation domain. The code is designed to be easy to modify or extend with new
+functionality.
+"""
+
+toolchain = {'name': 'foss', 'version': '2022a'}
+toolchainopts = {'openmp': True, 'cstd': 'c++14', 'usempi': True}
+
+# 'https://github.com/lammps/lammps/archive/'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['patch_%(version)s.tar.gz']
+checksums = ['8470ed7b26ccd3728f4b44a7f1c520f1af23a648af685fd30b42b840fdfae2ff']
+
+builddependencies = [
+    ('CMake', '3.23.1'),
+    ('pkgconf', '1.8.0'),
+    ('archspec', '0.1.4'),
+]
+dependencies = [
+    ('CUDA', '11.8.0', '', SYSTEM),
+    ('UCX-CUDA', '1.12.1', _cuda_suffix),
+    ('NCCL', '2.12.12', _cuda_suffix),
+    ('Python', '3.10.4'),
+    ('libpng', '1.6.37'),
+    ('libjpeg-turbo', '2.1.3'),
+    ('netCDF', '4.9.0'),
+    ('GSL', '2.7'),
+    ('zlib', '1.2.12'),
+    ('gzip', '1.12'),
+    ('cURL', '7.83.0'),
+    ('HDF5', '1.12.2'),
+    ('tbb', '2021.5.0'),
+    ('PCRE', '8.45'),
+    ('libxml2', '2.9.13'),
+    ('FFmpeg', '4.4.2'),
+    ('Voro++', '0.4.6'),
+    ('kim-api', '2.3.0'),
+    ('Eigen', '3.4.0'),
+    ('PLUMED', '2.8.1'),
+    ('ScaFaCoS', '1.0.4'),
+    ('SciPy-bundle', '2022.05'),
+    # VTK package is auto-disabled if this dep is not available
+    ('VTK', '9.2.2'),
+]
+
+install_cmd = 'make install install-python'
+
+# To use additional custom configuration options, use the 'configopts' easyconfig parameter
+# See docs and lammps easyblock for more information.
+# https://github.com/lammps/lammps/blob/master/cmake/README.md#lammps-configuration-options
+
+# OpenMP-Kokkos build is default in the current easyblock. One can switch to serial backend of Kokkos,
+# which is claimed to be faster in pure MPI calculations
+# configopts  = "-DKokkos_ENABLE_SERIAL=yes "
+
+
+# packages auto-enabled by easyblock
+# 'GPU'    - if cuda package is present and kokkos is disabled
+# 'KOKKOS' - if kokkos is enabled (by default)
+# 'INTEL'  - if builing on Intel CPU
+# 'OPENMP' - if OpenMP swithed on in 'toolchainopts'
+
+# include the following extra packages into the build
+general_packages = [
+    'AMOEBA',
+    'ASPHERE',
+    'ATC',
+    'AWPMD',
+    'BOCS',
+    'BODY',
+    'BPM',
+    'BROWNIAN',
+    'CG-DNA',
+    'CG-SPICA',
+    'CLASS2',
+    'COLLOID',
+    'COLVARS',
+    'COMPRESS',
+    'CORESHELL',
+    'DIELECTRIC',
+    'DIFFRACTION',
+    'DIPOLE',
+    'DPD-BASIC',
+    'DPD-MESO',
+    'DPD-REACT',
+    'DPD-SMOOTH',
+    'DRUDE',
+    'EFF',
+    'ELECTRODE',
+    'EXTRA-COMPUTE',
+    'EXTRA-DUMP',
+    'EXTRA-FIX',
+    'EXTRA-MOLECULE',
+    'EXTRA-PAIR',
+    'FEP',
+    'GRANULAR',
+    'H5MD',
+    'INTERLAYER',
+    'KIM',
+    'KSPACE',
+    'LATBOLTZ',
+    'LEPTON',
+    'MACHDYN',
+    'MANIFOLD',
+    'MANYBODY',
+    'MC',
+    'MEAM',
+    'MGPT',
+    'MISC',
+    'ML-IAP',
+    'ML-PACE',
+    'ML-POD',
+    'ML-RANN',
+    'ML-SNAP',
+    'MOFFF',
+    'MOLECULE',
+    'MOLFILE',
+    'MPIIO',
+    'NETCDF',
+    'OPT',
+    'ORIENT',
+    'PERI',
+    'PHONON',
+    'PLUGIN',
+    'PLUMED',
+    'POEMS',
+    'PTM',
+    'PYTHON',
+    'QEQ',
+    'QTB',
+    'REACTION',
+    'REAXFF',
+    'REPLICA',
+    'RIGID',
+    'SCAFACOS',
+    'SHOCK',
+    'SMTBQ',
+    'SPH',
+    'SPIN',
+    'SRD',
+    'TALLY',
+    'UEF',
+    'VORONOI',
+    'VTK',
+    'YAFF',
+]
+
+# Excluded packages due to requiring additional (non-trivial) deps
+# - ADIOS
+# - LATTE and its replacement MDI
+# - MESONT (requires very large files downloaded during build)
+# - ML-HDNNP (requires N2P2)
+# - ML-QUIP
+# - MSCG
+# - QMMM (setup seems complex)
+
+
+moduleclass = 'chem'


### PR DESCRIPTION
Howdy Y'all, 

I was able to get LAMMPS to build for Hopper GPUs. My Easyconfig is not perfect, but it at least mostly works. That's progress. If you wanted to help me finish this out, that would be great. Of course, since the H100 are so new, hardly anyone has them... likely this isn't a high priority. 

Known bug: python module is not installed. The new LAMMPS build procedure doesn't install the python module by default. I was too lazy to put the optional install command into the easyconfig. 
Known bug: only sm90 libraries are built. It's common practice to build for multiple targets and give the executables different names. E.g., lmp_mpi. I have not done that, instead I just force-picked the sm90. 
Known bug: lammps complains that OpenMP builds are not the best for GPU-only runs. Probably we should consider turning that off at build time. 

Richard