### PR TITLE
Update postinstallcmds to fix bin paths set for overlap.sh fixes #18699

### DIFF
--- a/easybuild/easyconfigs/m/MaSuRCA/MaSuRCA-4.0.9-foss-2021a-Perl-5.32.1.eb
+++ b/easybuild/easyconfigs/m/MaSuRCA/MaSuRCA-4.0.9-foss-2021a-Perl-5.32.1.eb
@@ -52,6 +52,16 @@ postinstallcmds = [
     "sed -i $'s|^$bin =.*|$bin = \"$ENV{\'EBROOTMASURCA\'}/bin\";|g' %(installdir)s/bin/runCA-dedupe",
     # fix hardcoded path in masurca script, just point back to 'bin' subdirectory instead
     "sed -i 's@../CA8/Linux-amd64/bin@../bin@g' %(installdir)s/bin/masurca",
+    # This four fix the bin path for getBinDirectoryShellCode function used as part as the code to create overlap.sh
+    "sed -i  's/\$installDir\/\\\$syst-\\\$arch/\\\${EBROOTMASURCA}/'g %(installdir)s/bin/runCA",
+    "sed -i  's/\$installDir\/\\\$syst-\\\$arch/\\\${EBROOTMASURCA}/'g %(installdir)s/bin/runCA-dedupe",
+    "sed -i  's/\$installDir\/\\\$syst-\\\$arch/\\\${EBROOTMASURCA}/'g %(installdir)s/bin/runCA-overlapStoreBuild",
+    "sed -i  's/\$installDir\/\\\$syst-\\\$arch/\\\${EBROOTMASURCA}/'g %(installdir)s/bin/PBcR",
+    # This four fix the bin path for getBinDirectory function
+    "sed -i $'s|my $path = \"$installDir/$syst-$arch/bin\"|my $path = \"$ENV{\'EBROOTMASURCA\'}/bin\"|g' %(installdir)s/bin/runCA",
+    "sed -i $'s|my $path = \"$installDir/$syst-$arch/bin\"|my $path = \"$ENV{\'EBROOTMASURCA\'}/bin\"|g' %(installdir)s/bin/runCA-dedupe",
+    "sed -i $'s|return(\"$installDir/$syst-$arch/bin\"|return(\"$ENV{\'EBROOTMASURCA\'}/bin\"|g' %(installdir)s/bin/runCA-overlapStoreBuild",
+    "sed -i $'s|my $path = \"$installDir/$syst-$arch/bin\"|my $path = \"$ENV{\'EBROOTMASURCA\'}/bin\"|g' %(installdir)s/bin/PBcR",
     # commands to install built-in version of Flye
     "cd ../Flye && make && cp -a ../Flye %(installdir)s",
     # fix missing RPATH


### PR DESCRIPTION
I have updated the postinstallcmds to match the missing strings that manipulate the bin path in several executables from `MaSuRCA`:
- `PBcR`
- `runCA`
- `runCA-dedupe`
- `runCA-overlapStoreBuild`

The PR only fixes the issue for `MaSuRCA-4.0.9-foss-2021a-Perl-5.32.1` but I have looked at the installed by `MaSuRCA-4.1.0-GCC-11.3.0` and the fix also works there.

