### PR TITLE
disable detection of Dbus broker for `at-spi2-core` (+ bump at-spi2-core v2.49.90 to v2.49.91)

### DIFF
--- a/easybuild/easyconfigs/a/at-spi2-atk/at-spi2-atk-2.38.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-atk/at-spi2-atk-2.38.0-GCCcore-12.3.0.eb
@@ -22,7 +22,7 @@ builddependencies = [
 dependencies = [
     ('GLib', '2.77.1'),
     ('DBus', '1.15.4'),
-    ('at-spi2-core', '2.49.90'),
+    ('at-spi2-core', '2.49.91'),
     ('libxml2', '2.11.4'),
     ('ATK', '2.38.0'),
 ]

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.36.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.36.0-GCCcore-9.3.0.eb
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 # Hard disable Dbus broker detection
-preconfigopts = "sed -i s/dbus_broker.found\(\)/false/ ../*/bus/meson.build &&"
+preconfigopts = "sed -i s/'dbus_broker.found()'/false/ ../*/bus/meson.build &&"
 configopts = "--libdir lib "
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.36.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.36.0-GCCcore-9.3.0.eb
@@ -29,6 +29,8 @@ dependencies = [
     ('X11', '20200222'),
 ]
 
+# Hard disable Dbus broker detection
+preconfigopts = "sed -i s/dbus_broker.found\(\)/false/ ../*/bus/meson.build &&"
 configopts = "--libdir lib "
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.38.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.38.0-GCCcore-10.2.0.eb
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 # Hard disable Dbus broker detection
-preconfigopts = "sed -i s/dbus_broker.found\(\)/false/ ../*/bus/meson.build &&"
+preconfigopts = "sed -i s/'dbus_broker.found()'/false/ ../*/bus/meson.build &&"
 configopts = "--libdir lib "
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.38.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.38.0-GCCcore-10.2.0.eb
@@ -29,6 +29,8 @@ dependencies = [
     ('X11', '20201008'),
 ]
 
+# Hard disable Dbus broker detection
+preconfigopts = "sed -i s/dbus_broker.found\(\)/false/ ../*/bus/meson.build &&"
 configopts = "--libdir lib "
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.40.2-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.40.2-GCCcore-10.3.0.eb
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 # Hard disable Dbus broker detection
-preconfigopts = "sed -i s/dbus_broker.found\(\)/false/ ../*/bus/meson.build &&"
+preconfigopts = "sed -i s/'dbus_broker.found()'/false/ ../*/bus/meson.build &&"
 configopts = "--libdir lib "
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.40.2-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.40.2-GCCcore-10.3.0.eb
@@ -29,6 +29,8 @@ dependencies = [
     ('X11', '20210518'),
 ]
 
+# Hard disable Dbus broker detection
+preconfigopts = "sed -i s/dbus_broker.found\(\)/false/ ../*/bus/meson.build &&"
 configopts = "--libdir lib "
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.40.3-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.40.3-GCCcore-11.2.0.eb
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 # Hard disable Dbus broker detection
-preconfigopts = "sed -i s/dbus_broker.found\(\)/false/ ../*/bus/meson.build &&"
+preconfigopts = "sed -i s/'dbus_broker.found()'/false/ ../*/bus/meson.build &&"
 configopts = "--libdir lib "
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.40.3-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.40.3-GCCcore-11.2.0.eb
@@ -29,6 +29,8 @@ dependencies = [
     ('X11', '20210802'),
 ]
 
+# Hard disable Dbus broker detection
+preconfigopts = "sed -i s/dbus_broker.found\(\)/false/ ../*/bus/meson.build &&"
 configopts = "--libdir lib "
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.44.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.44.1-GCCcore-11.3.0.eb
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 # Hard disable Dbus broker detection
-preconfigopts = "sed -i s/dbus_broker.found\(\)/false/ ../*/bus/meson.build &&"
+preconfigopts = "sed -i s/'dbus_broker.found()'/false/ ../*/bus/meson.build &&"
 configopts = "--libdir lib "
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.44.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.44.1-GCCcore-11.3.0.eb
@@ -29,6 +29,8 @@ dependencies = [
     ('X11', '20220504'),
 ]
 
+# Hard disable Dbus broker detection
+preconfigopts = "sed -i s/dbus_broker.found\(\)/false/ ../*/bus/meson.build &&"
 configopts = "--libdir lib "
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.46.0-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.46.0-GCCcore-12.2.0.eb
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 # Hard disable Dbus broker detection
-preconfigopts = "sed -i s/dbus_broker.found\(\)/false/ ../*/bus/meson.build &&"
+preconfigopts = "sed -i s/'dbus_broker.found()'/false/ ../*/bus/meson.build &&"
 configopts = "--libdir lib "
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.46.0-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.46.0-GCCcore-12.2.0.eb
@@ -29,6 +29,8 @@ dependencies = [
     ('X11', '20221110'),
 ]
 
+# Hard disable Dbus broker detection
+preconfigopts = "sed -i s/dbus_broker.found\(\)/false/ ../*/bus/meson.build &&"
 configopts = "--libdir lib "
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.49.90-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.49.90-GCCcore-12.3.0.eb
@@ -29,7 +29,8 @@ dependencies = [
     ('X11', '20230603'),
 ]
 
-configopts = "--libdir lib "
+# Hard disable Dbus broker detection and (potential) use of systemd
+configopts = "--libdir lib -Duse_systemd=false -Ddefault_bus=dbus-daemon"
 
 sanity_check_paths = {
     'files': ['lib/libatspi.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.49.91-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/a/at-spi2-core/at-spi2-core-2.49.91-GCCcore-12.3.0.eb
@@ -1,7 +1,7 @@
 easyblock = 'MesonNinja'
 
 name = 'at-spi2-core'
-version = '2.49.90'
+version = '2.49.91'
 
 homepage = 'https://wiki.gnome.org/Accessibility'
 description = """
@@ -12,7 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 
 source_urls = [FTPGNOME_SOURCE]
 sources = [SOURCELOWER_TAR_XZ]
-checksums = ['1e6612755d71bbe952156dc051b281d1a4326a5696ac3bbc8cfd5ac8fd971f18']
+checksums = ['aa72bbb12188ee3d0152cc6ea935415e6dc623ffa751b6a7cc23e9025f0410fd']
 
 builddependencies = [
     ('binutils', '2.40'),


### PR DESCRIPTION
Systems that have Dbus broker installed have this detected by `at-spi2-core` (which is an `R` dependency) and this has been seen to cause issues with builds.