### PR TITLE
rename `notebook` to `JupyterNotebook`

### DIFF
--- a/easybuild/easyconfigs/j/JupyterNotebook/JupyterNotebook-7.0.2-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/j/JupyterNotebook/JupyterNotebook-7.0.2-GCCcore-12.3.0.eb
@@ -27,6 +27,8 @@ download_dep_fail = True
 sanity_pip_check = True
 use_pip = True
 
+options = {'modulename': 'notebook'}
+
 sanity_check_paths = {
     'files': ['bin/jupyter-notebook'],
     'dirs': ['etc/jupyter', 'share/jupyter'],

--- a/easybuild/easyconfigs/j/JupyterNotebook/JupyterNotebook-7.0.2-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/j/JupyterNotebook/JupyterNotebook-7.0.2-GCCcore-12.3.0.eb
@@ -1,6 +1,6 @@
 easyblock = 'PythonPackage'
 
-name = 'notebook'
+name = 'JupyterNotebook'
 version = '7.0.2'
 
 homepage = 'https://jupyter.org/'
@@ -8,6 +8,10 @@ description = """The Jupyter Notebook is the original web application for creati
  sharing computational documents. It offers a simple, streamlined, document-centric experience."""
 
 toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+
+source_urls = ['https://pypi.python.org/packages/source/n/notebook']
+sources = ['notebook-%(version)s.tar.gz']
+checksums = ['d70d6a07418c829bd5f54337ce993b7105261d9026f9d3fe68e9b8aa1a20da9a']
 
 builddependencies = [
     ('binutils', '2.40'),
@@ -18,9 +22,6 @@ dependencies = [
     ('jupyter-server', '2.7.2'),
     ('JupyterLab', '4.0.5'),
 ]
-
-sources = [SOURCE_TAR_GZ]
-checksums = ['d70d6a07418c829bd5f54337ce993b7105261d9026f9d3fe68e9b8aa1a20da9a']
 
 download_dep_fail = True
 sanity_pip_check = True


### PR DESCRIPTION
Renames `notebook` easyconfig that was added by @casparvl in #18617

`JupyterNotebook` makes a lot more sense since it matches better with the `JupyterHub` and `JupyterLab` we already have.