### PR TITLE
{bio}[foss/2022a] Clair3 v1.0.4

### DIFF
--- a/easybuild/easyconfigs/c/Clair3/Clair3-1.0.4-foss-2022a.eb
+++ b/easybuild/easyconfigs/c/Clair3/Clair3-1.0.4-foss-2022a.eb
@@ -30,7 +30,7 @@ dependencies = [
     ('pigz', '2.7'),
     ('cffi', '1.15.1'),
     ('parallel', '20220722'),
-    ('SAMtools', '1.13'),
+    ('SAMtools', '1.16.1'),
     ('WhatsHap', '1.7'),
     ('zlib', '1.2.12'),
     ('bzip2', '1.0.8'),
@@ -46,4 +46,8 @@ files_to_copy = [
     (['libclair3.so', 'libclair3.o', 'libclair3.cpython-310-x86_64-linux-gnu.so', 'libclair3.c', 'longphase', ], 'lib'),
 ]
 
+sanity_check_paths = {
+    'files': ['bin/run_clair3.sh', 'bin/clair3.py', 'lib/libclair3.so'],
+    'dirs': ['bin/clair3'],
+}
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/c/Clair3/Clair3-1.0.4-foss-2022a.eb
+++ b/easybuild/easyconfigs/c/Clair3/Clair3-1.0.4-foss-2022a.eb
@@ -1,0 +1,49 @@
+easyblock = 'MakeCp'
+
+name = 'Clair3'
+version = '1.0.4'
+
+homepage = 'https://github.com/HKU-BAL/Clair3'
+description = """Clair3 is a germline small variant caller for long-reads.
+Clair3 makes the best of two major method categories: pileup calling handles
+most variant candidates with speed, and full-alignment tackles complicated candidates
+to maximize precision and recall. Clair3 runs fast and has superior performance,
+especially at lower coverage. Clair3 is simple and modular for easy deployment and
+integration."""
+
+toolchain = {'name': 'foss', 'version': '2022a'}
+
+github_account = 'HKU-BAL'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['v%(version)s.tar.gz']
+patches = ['Clair3-remove_htslib.patch']
+checksums = [
+    {'v1.0.4.tar.gz': '56cc4cf43f1cc652958cc1aea95d87d0811531a924ca5c68dd564d41834654c0'},
+    {'Clair3-remove_htslib.patch': '0e1f5f17dc56850766fa19c6b0cca4ea23b3ed50b47126a41549c75e76d2cda7'},
+]
+
+dependencies = [
+    ('Python', '3.10.4'),
+    ('mpath', '1.1.3'),
+    ('TensorFlow', '2.11.0'),
+    ('PyTables', '3.8.0'),
+    ('pigz', '2.7'),
+    ('cffi', '1.15.1'),
+    ('parallel', '20220722'),
+    ('SAMtools', '1.13'),
+    ('WhatsHap', '1.7'),
+    ('zlib', '1.2.12'),
+    ('bzip2', '1.0.8'),
+    ('Automake', '1.16.5'),
+    ('cURL', '7.83.0'),
+    ('zstd', '1.5.2'),
+    ('HTSlib', '1.15.1'),
+    ('libdeflate', '1.10'),
+]
+
+files_to_copy = [
+    (['run_clair3.sh', 'longphase', 'clair3.py', 'clair3'], 'bin'),
+    (['libclair3.so', 'libclair3.o', 'libclair3.cpython-310-x86_64-linux-gnu.so', 'libclair3.c', 'longphase', ], 'lib'),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/c/Clair3/Clair3-1.0.4-foss-2022a.eb
+++ b/easybuild/easyconfigs/c/Clair3/Clair3-1.0.4-foss-2022a.eb
@@ -43,11 +43,17 @@ dependencies = [
 
 files_to_copy = [
     (['run_clair3.sh', 'longphase', 'clair3.py', 'clair3'], 'bin'),
-    (['libclair3.so', 'libclair3.o', 'libclair3.cpython-310-x86_64-linux-gnu.so', 'libclair3.c', 'longphase', ], 'lib'),
+    (['libclair3.*'], 'lib'),
 ]
 
 sanity_check_paths = {
-    'files': ['bin/run_clair3.sh', 'bin/clair3.py', 'lib/libclair3.so'],
+    'files': ['bin/run_clair3.sh', 'bin/clair3.py', 'bin/longphase', 'lib/libclair3.%s' % SHLIB_EXT],
     'dirs': ['bin/clair3'],
 }
+
+sanity_check_commands = [
+    "longphase --help",
+    "run_clair3.sh --help",
+]
+
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/c/Clair3/Clair3-remove_htslib.patch
+++ b/easybuild/easyconfigs/c/Clair3/Clair3-remove_htslib.patch
@@ -1,0 +1,80 @@
+Remove building of dependencies we provide via easybuild
+Author: Denis Kristak (Inuits)
+diff -ruN Clair3-1.0.4_orig/build.py Clair3-1.0.4/build.py
+--- Clair3-1.0.4_orig/build.py	2023-09-07 14:28:29.842168186 +0100
++++ Clair3-1.0.4/build.py	2023-09-08 12:31:06.300472155 +0100
+@@ -52,8 +52,7 @@
+             'clair3_pileup.c',
+             'clair3_full_alignment.c')],
+     extra_compile_args=extra_compile_args,
+-    extra_link_args=extra_link_args,
+-    extra_objects=[os.path.join(htslib_dir, 'libhts.a')]
++    extra_link_args=extra_link_args
+ )
+ 
+ cdef = [
+diff -ruN Clair3-1.0.4_orig/Makefile Clair3-1.0.4/Makefile
+--- Clair3-1.0.4_orig/Makefile	2023-09-07 14:28:29.842168186 +0100
++++ Clair3-1.0.4/Makefile	2023-09-07 14:35:52.320773700 +0100
+@@ -3,8 +3,10 @@
+ 
+ PYTHON ?= python3
+ 
+-all : libhts.a longphase libclair3.so
+-clean : clean_htslib clean_longphase clean_libclair3
++# all : libhts.a longphase libclair3.so
++# clean : clean_htslib clean_longphase clean_libclair3
++all : longphase libclair3.so
++clean : clean_longphase clean_libclair3
+ 
+ SAMVER	=	1.15.1
+ LPVER	=	1.3
+@@ -16,16 +18,16 @@
+ CPPFLAGS	=	-std=c++11 -Wall -O3 -I ${PREFIX}/include -L ${PREFIX}/lib -Wl,-rpath=${PREFIX}/lib
+ LP_CPPFLAGS	 =	-std=c++11 -Wall -g -O3 -I ${PREFIX}/include -L ${PREFIX}/lib -Wl,-rpath=${PREFIX}/lib
+ 
+-samtools-$(SAMVER)/Makefile:
+-		curl -L -o samtools-${SAMVER}.tar.bz2 https://github.com/samtools/samtools/releases/download/${SAMVER}/samtools-${SAMVER}.tar.bz2; \
+-		tar -xjf samtools-${SAMVER}.tar.bz2; \
+-		rm samtools-${SAMVER}.tar.bz2
+-
+-libhts.a: samtools-$(SAMVER)/Makefile
+-	# this is required only to add in -fpic so we can build python module
+-	@echo "\x1b[1;33mMaking $(@F)\x1b[0m"
+-	cd samtools-${SAMVER}/htslib-${SAMVER}; CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" ./configure; make CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
+-	cp samtools-${SAMVER}/htslib-${SAMVER}/$@ $@
++# samtools-$(SAMVER)/Makefile:
++# 		curl -L -o samtools-${SAMVER}.tar.bz2 https://github.com/samtools/samtools/releases/download/${SAMVER}/samtools-${SAMVER}.tar.bz2; \
++# 		tar -xjf samtools-${SAMVER}.tar.bz2; \
++# 		rm samtools-${SAMVER}.tar.bz2
++
++# libhts.a: samtools-$(SAMVER)/Makefile
++# 	# this is required only to add in -fpic so we can build python module
++# 	@echo "\x1b[1;33mMaking $(@F)\x1b[0m"
++# 	cd samtools-${SAMVER}/htslib-${SAMVER}; CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" ./configure; make CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
++# 	cp samtools-${SAMVER}/htslib-${SAMVER}/$@ $@
+ 
+ 
+ longphase-$(LPVER)/Makefile:
+@@ -39,15 +41,15 @@
+ 	cp longphase-${LPVER}/$@ $@
+ 
+ 
+-libclair3.so: samtools-${SAMVER}/htslib-${SAMVER}
++libclair3.so:
+ 	${PYTHON} build.py
+ 
+ 
+-.PHONY: clean_htslib
+-clean_htslib:
+-	cd samtools-${SAMVER} && make clean || exit 0
+-	cd samtools-${SAMVER}/htslib-${SAMVER} && make clean || exit 0
+-	rm libhts.a
++# .PHONY: clean_htslib
++# clean_htslib:
++# 	cd samtools-${SAMVER} && make clean || exit 0
++# 	cd samtools-${SAMVER}/htslib-${SAMVER} && make clean || exit 0
++# 	rm libhts.a
+ 
+ .PHONY: clean_longphase
+ clean_longphase:

--- a/easybuild/easyconfigs/c/cffi/cffi-1.15.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/c/cffi/cffi-1.15.1-GCCcore-11.3.0.eb
@@ -1,0 +1,38 @@
+easyblock = "PythonBundle"
+
+name = 'cffi'
+version = '1.15.1'
+
+homepage = 'https://cffi.readthedocs.io/en/latest/'
+description = """C Foreign Function Interface for Python. Interact with almost any C code from
+Python, based on C-like declarations that you can often copy-paste from header
+files or documentation.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+toolchainopts = {'pic': True}
+
+builddependencies = [
+    ('binutils', '2.38'),
+]
+
+dependencies = [
+    ('Python', '3.10.4'),
+]
+
+exts_default_options = {
+    'download_dep_fail': True,
+    'sanity_pip_check': True,
+    'use_pip': True,
+}
+
+exts_list = [
+    ('pycparser', '2.21', {
+        'checksums': ['e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206'],
+    }),
+    (name, version, {
+        'checksums': ['d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9'],
+    }),
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/mpath/mpath-1.1.3-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/m/mpath/mpath-1.1.3-GCCcore-11.3.0.eb
@@ -1,0 +1,29 @@
+easyblock = 'PythonBundle'
+
+name = 'mpath'
+version = '1.1.3'
+
+homepage = 'https://pypi.org/project/mpath/'
+description = """For now it's quit simple and get_path_info()
+method returns information about given path. It can be either
+a directory or a file path."""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+dependencies = [
+    ('Python', '3.10.4'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('mclass', '1.3.4', {
+        'checksums': ['414f786287b80a80261125fc9ed844dbf9093907e96999a2f0391a7b32a1cb60'],
+    }),
+    (name, version, {
+        'checksums': ['f8ecaf91bded57e12676d0373bf27acc154dea56c386f6ad05b476bc2c6ddc4f'],
+    }),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/mpath/mpath-1.1.3-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/m/mpath/mpath-1.1.3-GCCcore-11.3.0.eb
@@ -10,6 +10,9 @@ a directory or a file path."""
 
 toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 
+builddependencies = [
+    ('binutils', '2.38'),
+]
 dependencies = [
     ('Python', '3.10.4'),
 ]


### PR DESCRIPTION
adding easyconfigs: cffi-1.15.1-GCCcore-11.3.0.eb, Clair3-1.0.4-foss-2022a.eb, mpath-1.1.3-GCCcore-11.3.0.eb and patches: Clair3-remove_htslib.patch

comes from https://github.com/vscentrum/vsc-software-stack/issues/146