### PR TITLE
Ignore EasyConfig cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 *.ropeproject/
 eb-*.log
 /MANIFEST
+/easybuild/easyconfigs/.eb-path-index


### PR DESCRIPTION
EasyBuild creates the file `.eb-path-index` in `easybuild/easyconfigs` to cache searches which shows up in git checkouts when used directly.

As we never want to add this file to git ignore it explicitly