### PR TITLE
statically link Boost 1.75 in Cufflinks v20190706 installed with GCC/11.2.0, so Boost can be changed to build dependency

### DIFF
--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-20190706-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-20190706-GCC-11.2.0.eb
@@ -19,16 +19,26 @@ builddependencies = [
     ('Eigen', '3.3.9'),
     ('Autotools', '20210726'),
     ('SAMtools', '1.14'),
+    ('Boost', '1.75.0'),
+    ('XZ', '5.2.5'),
+    ('bzip2', '1.0.8'),
+    ('cURL', '7.78.0'),
+    ('OpenSSL', '1.1', '', SYSTEM),
+    ('zstd', '1.5.0'),
 ]
 
 dependencies = [
-    ('Boost', '1.75.0'),
     ('zlib', '1.2.11'),
     ('HTSlib', '1.14'),
 ]
 
 preconfigopts = 'autoreconf -i && export LIBS="${LIBS} -lhts" && export CFLAGS="$CFLAGS -fcommon" && '
 configopts = '--with-boost=${EBROOTBOOST} --with-bam=${EBROOTSAMTOOLS}'
+
+buildopts = "BOOST_FILESYSTEM_LIB=$EBROOTBOOST/lib/libboost_filesystem.a "
+buildopts += "BOOST_SERIALIZATION_LIB=$EBROOTBOOST/lib/libboost_serialization.a "
+buildopts += "BOOST_SYSTEM_LIB=$EBROOTBOOST/lib/libboost_system.a "
+buildopts += "BOOST_THREAD_LIB=$EBROOTBOOST/lib/libboost_thread.a "
 
 sanity_check_paths = {
     'files': ['bin/%(namelower)s'],

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-20190706-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-20190706-GCC-11.2.0.eb
@@ -36,8 +36,10 @@ buildopts += "BOOST_SYSTEM_LIB=$EBROOTBOOST/lib/libboost_system.a "
 buildopts += "BOOST_THREAD_LIB=$EBROOTBOOST/lib/libboost_thread.a "
 
 sanity_check_paths = {
-    'files': ['bin/%(namelower)s'],
+    'files': ['bin/cufflinks'],
     'dirs': []
 }
+
+sanity_check_commands = ["cufflinks 2>&1 | grep 'Usage:.* cufflinks'"]
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-20190706-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-20190706-GCC-11.2.0.eb
@@ -20,11 +20,6 @@ builddependencies = [
     ('Autotools', '20210726'),
     ('SAMtools', '1.14'),
     ('Boost', '1.75.0'),
-    ('XZ', '5.2.5'),
-    ('bzip2', '1.0.8'),
-    ('cURL', '7.78.0'),
-    ('OpenSSL', '1.1', '', SYSTEM),
-    ('zstd', '1.5.0'),
 ]
 
 dependencies = [


### PR DESCRIPTION
This version of Cufflinks easyconfig statically links Boost libraries, so it can be used with packages that require more recent Boost versions.
(for example see  https://github.com/easybuilders/easybuild-easyconfigs/pull/16356)