### PR TITLE
make sure Python dependency included for ESPResSo is actually used by specifying `-DPYTHON_EXECUTABLE`

### DIFF
--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2021a-CUDA-11.3.1.eb
@@ -29,7 +29,8 @@ dependencies = [
 ]
 
 configopts = ' -DCMAKE_SKIP_RPATH=OFF -DWITH_TESTS=ON -DWITH_CUDA=ON'
-configopts += ' -DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python '  # Make sure the right python is used
+# make sure the right Python is used (note: -DPython3_EXECUTABLE or -DPython_EXECUTABLE does not work!)
+configopts += ' -DPYTHON_EXECUTABLE=$EBROOTPYTHON/bin/python '
 
 runtest = 'check_unit_tests && make check_python'
 

--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2021a-CUDA-11.3.1.eb
@@ -29,6 +29,7 @@ dependencies = [
 ]
 
 configopts = ' -DCMAKE_SKIP_RPATH=OFF -DWITH_TESTS=ON -DWITH_CUDA=ON'
+configopts += ' -DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python '  # Make sure the right python is used
 
 runtest = 'check_unit_tests && make check_python'
 

--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2021a.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2021a.eb
@@ -27,6 +27,7 @@ dependencies = [
 ]
 
 configopts = ' -DCMAKE_SKIP_RPATH=OFF -DWITH_TESTS=ON -DWITH_CUDA=OFF'
+configopts += ' -DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python '  # Make sure the right python is used
 
 runtest = 'check_unit_tests && make check_python'
 

--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2021a.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2021a.eb
@@ -27,7 +27,8 @@ dependencies = [
 ]
 
 configopts = ' -DCMAKE_SKIP_RPATH=OFF -DWITH_TESTS=ON -DWITH_CUDA=OFF'
-configopts += ' -DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python '  # Make sure the right python is used
+# make sure the right Python is used (note: -DPython3_EXECUTABLE or -DPython_EXECUTABLE does not work!)
+configopts += ' -DPYTHON_EXECUTABLE=$EBROOTPYTHON/bin/python '
 
 runtest = 'check_unit_tests && make check_python'
 

--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2022a-CUDA-11.8.0.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2022a-CUDA-11.8.0.eb
@@ -29,7 +29,8 @@ dependencies = [
 ]
 
 configopts = ' -DCMAKE_SKIP_RPATH=OFF -DWITH_TESTS=ON -DWITH_CUDA=ON'
-configopts += ' -DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python '  # Make sure the right python is used
+# make sure the right Python is used (note: -DPython3_EXECUTABLE or -DPython_EXECUTABLE does not work!)
+configopts += ' -DPYTHON_EXECUTABLE=$EBROOTPYTHON/bin/python '
 
 runtest = 'check_unit_tests && make check_python'
 

--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2022a-CUDA-11.8.0.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2022a-CUDA-11.8.0.eb
@@ -29,6 +29,7 @@ dependencies = [
 ]
 
 configopts = ' -DCMAKE_SKIP_RPATH=OFF -DWITH_TESTS=ON -DWITH_CUDA=ON'
+configopts += ' -DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python '  # Make sure the right python is used
 
 runtest = 'check_unit_tests && make check_python'
 

--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2022a.eb
@@ -27,6 +27,7 @@ dependencies = [
 ]
 
 configopts = ' -DCMAKE_SKIP_RPATH=OFF -DWITH_TESTS=ON -DWITH_CUDA=OFF'
+configopts += ' -DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python '  # Make sure the right python is used
 
 runtest = 'check_unit_tests && make check_python'
 

--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-4.2.1-foss-2022a.eb
@@ -27,7 +27,8 @@ dependencies = [
 ]
 
 configopts = ' -DCMAKE_SKIP_RPATH=OFF -DWITH_TESTS=ON -DWITH_CUDA=OFF'
-configopts += ' -DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python '  # Make sure the right python is used
+# make sure the right Python is used (note: -DPython3_EXECUTABLE or -DPython_EXECUTABLE does not work!)
+configopts += ' -DPYTHON_EXECUTABLE=$EBROOTPYTHON/bin/python '
 
 runtest = 'check_unit_tests && make check_python'
 


### PR DESCRIPTION
Specify python in ESPResSo. See comment [here](https://github.com/EESSI/software-layer/pull/331#issuecomment-1743480608).