### PR TITLE
Move ASE from foss/2023a tol gfbf/2023a

### DIFF
--- a/easybuild/easyconfigs/a/ASE/ASE-3.22.1-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.22.1-gfbf-2023a.eb
@@ -10,25 +10,24 @@ description = """ASE is a python package providing an open source Atomic Simulat
 From version 3.20.1 we also include the ase-ext package, it contains optional reimplementations
 in C of functions in ASE.  ASE uses it automatically when installed."""
 
-toolchain = {'name': 'foss', 'version': '2023a'}
+toolchain = {'name': 'gfbf', 'version': '2023a'}
 
 dependencies = [
     ('Python', '3.11.3'),
+    ('Python-bundle-PyPI', '2023.06'),
     ('SciPy-bundle', '2023.07'),
     ('Flask', '2.3.3'),
     ('matplotlib', '3.7.2'),
-    ('Tkinter', '3.11.3'),
+    ('Tkinter', '%(pyver)s'),     # Needed by GUI of ASE
     ('spglib-python', '2.1.0'),  # optional
 ]
 
-sanity_pip_check = True
 use_pip = True
+sanity_pip_check = True
 
 exts_list = [
     ('pytest-mock', '3.11.1', {
-        'checksums': [
-            '7f6b125602ac6d743e523ae0bfa71e1a697a2f5534064528c6ff84c2f7c2fc7f',
-        ]
+        'checksums': ['7f6b125602ac6d743e523ae0bfa71e1a697a2f5534064528c6ff84c2f7c2fc7f'],
     }),
     ('ase', version, {
         'patches': [
@@ -38,22 +37,24 @@ exts_list = [
             'ASE-3.22.1-Compatibility-with-Flask-2-2-2.patch',
         ],
         'checksums': [
-            '004df6b0ea04b1114c790fadfe45d4125eb0e53125c66a93425af853d82ab432',
-            '8184765ecc9e14081b183fee5c4470da716d77caa67c25164018ac1fdd225eac',
-            '3a3473912f5f96ffc625119d87227781ba4ea581de15d4af6a58ba960cdf4601',
-            'c1cb07160b063d432f098efd40dd4b3c9f015b7966572c838a908613a482e0c8',
-            '2a05f98291dc970cb759904988783d1ecc3512ba6a0da852af1d3205667b398d',
-        ]
+            {'ase-3.22.1.tar.gz': '004df6b0ea04b1114c790fadfe45d4125eb0e53125c66a93425af853d82ab432'},
+            {'ASE-3.22.1-Compatibility-with-pytest-from-Python-3-10.patch':
+             '8184765ecc9e14081b183fee5c4470da716d77caa67c25164018ac1fdd225eac'},
+            {'ASE-3.22.1-Compatibility-with-pytest-part-2.patch':
+             '3a3473912f5f96ffc625119d87227781ba4ea581de15d4af6a58ba960cdf4601'},
+            {'ASE-3.22.1-Compatibility-with-Scipy-2022-05.patch':
+             'c1cb07160b063d432f098efd40dd4b3c9f015b7966572c838a908613a482e0c8'},
+            {'ASE-3.22.1-Compatibility-with-Flask-2-2-2.patch':
+             '2a05f98291dc970cb759904988783d1ecc3512ba6a0da852af1d3205667b398d'},
+        ],
     }),
     ('ase-ext', '20.9.0', {
-        'checksums': [
-            'a348b0e42cf9fdd11f04b3df002b0bf150002c8df2698ff08d3c8fc7a1223aed',
-        ]
+        'checksums': ['a348b0e42cf9fdd11f04b3df002b0bf150002c8df2698ff08d3c8fc7a1223aed'],
     }),
 ]
 
 sanity_check_paths = {
-    'files': ['bin/%(namelower)s'],
+    'files': ['bin/ase'],
     'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 


### PR DESCRIPTION
Since 2022b, the ASE package has been on the gfbf toolchain level, not foss.

Unfortunately, somebody beat me to adding ASE to the 2023a toolchain, and it is back at the foss level, forcing packages that depend on ASE to be at that level too. It has not yet been released, so it is not too late to move it to gfbf/2023a.

Fixes issue #19039 .
