### PR TITLE
Adding missing GSL dependency to casacore-3.4.0-foss-2021b

### DIFF
--- a/easybuild/easyconfigs/c/casacore/casacore-3.4.0-foss-2021b.eb
+++ b/easybuild/easyconfigs/c/casacore/casacore-3.4.0-foss-2021b.eb
@@ -31,6 +31,7 @@ dependencies = [
     ('CFITSIO', '3.49'),
     ('WCSLIB', '7.11'),
     ('HDF5', '1.12.1'),
+    ('GSL', '2.7'),
     ('SciPy-bundle', '2021.10'),
     ('Boost.Python', '1.77.0'),
     ('ncurses', '6.2'),


### PR DESCRIPTION
Running tests for casacore 3.5.0, we discovered that GSL was missing as a dependency for casacore 3.4.0

The test report:
https://gist.github.com/boegelbot/3e68e69278124da4ab5ab1b64d497db4

