### PR TITLE
Ensure right Python version is used in DP3, WSClean and dependencies

### DIFF
--- a/easybuild/easyconfigs/a/AOFlagger/AOFlagger-3.4.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/a/AOFlagger/AOFlagger-3.4.0-foss-2022a.eb
@@ -32,6 +32,9 @@ dependencies = [
     ('libxml2', '2.9.13'),
 ]
 
+# make sure the right Python is used
+configopts = '-DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python '
+
 sanity_check_paths = {
     'files': ['include/aoflagger.h', 'bin/aoflagger'],
     'dirs': ['bin'],

--- a/easybuild/easyconfigs/c/casacore/casacore-3.5.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/c/casacore/casacore-3.5.0-foss-2022a.eb
@@ -42,7 +42,9 @@ dependencies = [
 ]
 
 configopts = '-DBUILD_PYTHON=NO -DBUILD_PYTHON3=YES -Wno-dev -DCXX11="ON" -DDATA_DIR=%(installdir)s/data '
-configopts += '-DUSE_OPENMP=ON -DUSE_HDF5=ON -DUSE_MPI=ON'
+configopts += '-DUSE_OPENMP=ON -DUSE_HDF5=ON -DUSE_MPI=ON '
+# make sure the right Python is used
+configopts += '-DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python '
 
 sanity_check_paths = {
     'files': ['lib/libcasa_casa.%s' % SHLIB_EXT, 'lib/libcasa_mirlib.%s' % SHLIB_EXT,

--- a/easybuild/easyconfigs/d/DP3/DP3-6.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/d/DP3/DP3-6.0-foss-2022a.eb
@@ -36,6 +36,9 @@ dependencies = [
     ('AOFlagger', '3.4.0')
 ]
 
+# make sure the right Python is used
+configopts = '-DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python '
+
 sanity_check_paths = {
     'files': ['include/include/dp3/base/DP3.h', 'bin/DP3'],
     'dirs': ['bin'],

--- a/easybuild/easyconfigs/e/EveryBeam/EveryBeam-0.5.2-foss-2022a.eb
+++ b/easybuild/easyconfigs/e/EveryBeam/EveryBeam-0.5.2-foss-2022a.eb
@@ -36,6 +36,9 @@ dependencies = [
     ('libxml2', '2.9.13'),
 ]
 
+# make sure the right Python is used
+configopts = '-DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python '
+
 sanity_check_paths = {
     'files': ['include/EveryBeam/beamformer.h', 'lib/libeverybeam.so'],
     'dirs': [],

--- a/easybuild/easyconfigs/w/WSClean/WSClean-3.4-foss-2022a.eb
+++ b/easybuild/easyconfigs/w/WSClean/WSClean-3.4-foss-2022a.eb
@@ -31,6 +31,9 @@ dependencies = [
     ('Python', '3.10.4'),
 ]
 
+# make sure the right Python is used
+configopts = '-DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python '
+
 sanity_check_paths = {
     'files': ['include/wscleaninterface.h', 'bin/wsclean'],
     'dirs': ['bin'],


### PR DESCRIPTION
CMake will pick up the newest Python version available instead of the Python version listed in the dependencies. 
This issue was discovered while using the EESSI pipeline. For more information, see https://github.com/EESSI/software-layer/pull/370#issuecomment-1786829356 and https://gitlab.com/eessi/support/-/issues/17 