### PR TITLE
Fix some typos found in software descriptions

### DIFF
--- a/easybuild/easyconfigs/a/AutoDock-GPU/AutoDock-GPU-1.5.3-GCC-10.3.0-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/a/AutoDock-GPU/AutoDock-GPU-1.5.3-GCC-10.3.0-CUDA-11.3.1.eb
@@ -5,7 +5,7 @@ version = '1.5.3'
 versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://github.com/ccsb-scripps/AutoDock-GPU'
-description = """OpenCL and Cuda accelerated version of AutoDock. It leverages its embarrasingly
+description = """OpenCL and Cuda accelerated version of AutoDock. It leverages its embarrassingly
 parallelizable LGA by processing ligand-receptor poses in parallel over
 multiple compute units.
 AutoDock is a suite of automated docking tools. It is designed to predict how

--- a/easybuild/easyconfigs/a/AutoDock-GPU/AutoDock-GPU-1.5.3-GCC-11.3.0-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/a/AutoDock-GPU/AutoDock-GPU-1.5.3-GCC-11.3.0-CUDA-11.7.0.eb
@@ -5,7 +5,7 @@ version = '1.5.3'
 versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://github.com/ccsb-scripps/AutoDock-GPU'
-description = """OpenCL and Cuda accelerated version of AutoDock. It leverages its embarrasingly
+description = """OpenCL and Cuda accelerated version of AutoDock. It leverages its embarrassingly
 parallelizable LGA by processing ligand-receptor poses in parallel over
 multiple compute units.
 AutoDock is a suite of automated docking tools. It is designed to predict how

--- a/easybuild/easyconfigs/b/BayesTraits/BayesTraits-3.0.2-Linux.eb
+++ b/easybuild/easyconfigs/b/BayesTraits/BayesTraits-3.0.2-Linux.eb
@@ -12,7 +12,7 @@ versionsuffix = '-Linux'
 homepage = 'https://github.com/AndrewPMeade/BayesTraits-Public'
 description = """ BayesTraits is a computer package for performing analyses of trait 
  evolution among groups of species for which a phylogeny or sample of phylogenies is 
- available. This new package incoporates our earlier and separate programes Multistate, 
+ available. This new package incorporates our earlier and separate programes Multistate, 
  Discrete and Continuous. BayesTraits can be applied to the analysis of traits that adopt 
  a finite number of discrete states, or to the analysis of continuously varying traits. 
  Hypotheses can be tested about models of evolution, about ancestral states and about 

--- a/easybuild/easyconfigs/e/EZC3D/EZC3D-1.5.2-foss-2022a.eb
+++ b/easybuild/easyconfigs/e/EZC3D/EZC3D-1.5.2-foss-2022a.eb
@@ -6,7 +6,7 @@ version = '1.5.2'
 homepage = 'https://pyomeca.github.io/Documentation/ezc3d/index.html'
 description = """EZC3D is an easy to use reader, modifier and writer for C3D format files. It is
 written en C++ with proper binders for Python and MATLAB/Octave scripting
-langages."""
+languages."""
 
 toolchain = {'name': 'foss', 'version': '2022a'}
 

--- a/easybuild/easyconfigs/f/f90wrap/f90wrap-0.2.8-foss-2021a.eb
+++ b/easybuild/easyconfigs/f/f90wrap/f90wrap-0.2.8-foss-2021a.eb
@@ -8,7 +8,7 @@ description = """f90wrap is a tool to automatically generate Python extension mo
 interface to Fortran code that makes use of derived types. It builds on the
 capabilities of the popular f2py utility by generating a simpler Fortran 90
 interface to the original Fortran code which is then suitable for wrapping with
-f2py, together with a higher-level Pythonic wrapper that makes the existance of
+f2py, together with a higher-level Pythonic wrapper that makes the existence of
 an additional layer transparent to the final user."""
 
 toolchain = {'name': 'foss', 'version': '2021a'}

--- a/easybuild/easyconfigs/g/garnett/garnett-0.1.20-foss-2020b-R-4.0.3.eb
+++ b/easybuild/easyconfigs/g/garnett/garnett-0.1.20-foss-2020b-R-4.0.3.eb
@@ -6,7 +6,7 @@ version = '0.1.20'
 versionsuffix = '-R-%(rver)s'
 
 homepage = 'https://cole-trapnell-lab.github.io/garnett'
-description = """Garnett is a software package that faciliates automated cell type classification from single-cell
+description = """Garnett is a software package that facilitates automated cell type classification from single-cell
 expression data."""
 
 toolchain = {'name': 'foss', 'version': '2020b'}

--- a/easybuild/easyconfigs/g/gmsh/gmsh-4.11.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/g/gmsh/gmsh-4.11.1-foss-2022a.eb
@@ -4,7 +4,7 @@ name = 'gmsh'
 version = '4.11.1'
 
 homepage = 'https://gmsh.info/'
-description = "Gmsh is a 3D finite element grid generator with a build-in CAD engine and post-processor."
+description = "Gmsh is a 3D finite element grid generator with a built-in CAD engine and post-processor."
 
 toolchain = {'name': 'foss', 'version': '2022a'}
 toolchainopts = {'usempi': True}

--- a/easybuild/easyconfigs/g/gmsh/gmsh-4.7.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/g/gmsh/gmsh-4.7.1-foss-2020a-Python-3.8.2.eb
@@ -5,7 +5,7 @@ version = '4.7.1'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://gmsh.info/'
-description = """Gmsh is a 3D finite element grid generator with a build-in CAD engine and post-processor."""
+description = """Gmsh is a 3D finite element grid generator with a built-in CAD engine and post-processor."""
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 toolchainopts = {"usempi": True}

--- a/easybuild/easyconfigs/g/gmsh/gmsh-4.7.1-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/g/gmsh/gmsh-4.7.1-intel-2020a-Python-3.8.2.eb
@@ -5,7 +5,7 @@ version = '4.7.1'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://gmsh.info/'
-description = """Gmsh is a 3D finite element grid generator with a build-in CAD engine and post-processor."""
+description = """Gmsh is a 3D finite element grid generator with a built-in CAD engine and post-processor."""
 
 toolchain = {'name': 'intel', 'version': '2020a'}
 toolchainopts = {"usempi": True}

--- a/easybuild/easyconfigs/g/gmsh/gmsh-4.9.0-foss-2021a.eb
+++ b/easybuild/easyconfigs/g/gmsh/gmsh-4.9.0-foss-2021a.eb
@@ -4,7 +4,7 @@ name = 'gmsh'
 version = '4.9.0'
 
 homepage = 'https://gmsh.info/'
-description = """Gmsh is a 3D finite element grid generator with a build-in CAD engine and post-processor."""
+description = """Gmsh is a 3D finite element grid generator with a built-in CAD engine and post-processor."""
 
 toolchain = {'name': 'foss', 'version': '2021a'}
 toolchainopts = {"usempi": True}

--- a/easybuild/easyconfigs/k/KMC/KMC-3.2.1-GCC-11.2.0-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/k/KMC/KMC-3.2.1-GCC-11.2.0-Python-2.7.18.eb
@@ -5,7 +5,7 @@ version = '3.2.1'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://sun.aei.polsl.pl/kmc'
-description = "KMC is a disk-based programm for counting k-mers from (possibly gzipped) FASTQ/FASTA files."
+description = "KMC is a disk-based program for counting k-mers from (possibly gzipped) FASTQ/FASTA files."
 
 toolchain = {'name': 'GCC', 'version': '11.2.0'}
 

--- a/easybuild/easyconfigs/k/KMC/KMC-3.2.1-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/k/KMC/KMC-3.2.1-GCC-11.2.0.eb
@@ -4,7 +4,7 @@ name = 'KMC'
 version = '3.2.1'
 
 homepage = 'http://sun.aei.polsl.pl/kmc'
-description = "KMC is a disk-based programm for counting k-mers from (possibly gzipped) FASTQ/FASTA files."
+description = "KMC is a disk-based program for counting k-mers from (possibly gzipped) FASTQ/FASTA files."
 
 toolchain = {'name': 'GCC', 'version': '11.2.0'}
 

--- a/easybuild/easyconfigs/k/KMC/KMC-3.2.2-GCC-12.2.0.eb
+++ b/easybuild/easyconfigs/k/KMC/KMC-3.2.2-GCC-12.2.0.eb
@@ -4,7 +4,7 @@ name = 'KMC'
 version = '3.2.2'
 
 homepage = 'http://sun.aei.polsl.pl/kmc'
-description = "KMC is a disk-based programm for counting k-mers from (possibly gzipped) FASTQ/FASTA files."
+description = "KMC is a disk-based program for counting k-mers from (possibly gzipped) FASTQ/FASTA files."
 
 toolchain = {'name': 'GCC', 'version': '12.2.0'}
 

--- a/easybuild/easyconfigs/m/meshtool/meshtool-16-GCC-10.2.0.eb
+++ b/easybuild/easyconfigs/m/meshtool/meshtool-16-GCC-10.2.0.eb
@@ -4,7 +4,7 @@ name = 'meshtool'
 version = '16'
 
 homepage = 'https://bitbucket.org/aneic/meshtool'
-description = """Meshtool is a comand-line tool written in C++. It is designed to apply various manipulations to
+description = """Meshtool is a command-line tool written in C++. It is designed to apply various manipulations to
 volumetric meshes."""
 
 toolchain = {'name': 'GCC', 'version': '10.2.0'}

--- a/easybuild/easyconfigs/m/meshtool/meshtool-16-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/m/meshtool/meshtool-16-GCC-9.3.0.eb
@@ -4,7 +4,7 @@ name = 'meshtool'
 version = '16'
 
 homepage = 'https://bitbucket.org/aneic/meshtool'
-description = """Meshtool is a comand-line tool written in C++. It is designed to apply various manipulations to
+description = """Meshtool is a command-line tool written in C++. It is designed to apply various manipulations to
 volumetric meshes."""
 
 toolchain = {'name': 'GCC', 'version': '9.3.0'}

--- a/easybuild/easyconfigs/m/molmod/molmod-1.4.5-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/m/molmod/molmod-1.4.5-foss-2020a-Python-3.8.2.eb
@@ -5,7 +5,7 @@ version = '1.4.5'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://molmod.github.io/molmod/'
-description = "MolMod is a Python library with many compoments that are useful to write molecular modeling programs."
+description = "MolMod is a Python library with many components that are useful to write molecular modeling programs."
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 

--- a/easybuild/easyconfigs/m/molmod/molmod-1.4.5-intel-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/m/molmod/molmod-1.4.5-intel-2020a-Python-3.8.2.eb
@@ -5,7 +5,7 @@ version = '1.4.5'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://molmod.github.io/molmod/'
-description = "MolMod is a Python library with many compoments that are useful to write molecular modeling programs."
+description = "MolMod is a Python library with many components that are useful to write molecular modeling programs."
 
 toolchain = {'name': 'intel', 'version': '2020a'}
 

--- a/easybuild/easyconfigs/m/molmod/molmod-1.4.8-foss-2020b.eb
+++ b/easybuild/easyconfigs/m/molmod/molmod-1.4.8-foss-2020b.eb
@@ -4,7 +4,7 @@ name = 'molmod'
 version = '1.4.8'
 
 homepage = 'https://molmod.github.io/molmod/'
-description = "MolMod is a Python library with many compoments that are useful to write molecular modeling programs."
+description = "MolMod is a Python library with many components that are useful to write molecular modeling programs."
 
 toolchain = {'name': 'foss', 'version': '2020b'}
 

--- a/easybuild/easyconfigs/m/molmod/molmod-1.4.8-foss-2021a.eb
+++ b/easybuild/easyconfigs/m/molmod/molmod-1.4.8-foss-2021a.eb
@@ -4,7 +4,7 @@ name = 'molmod'
 version = '1.4.8'
 
 homepage = 'https://molmod.github.io/molmod/'
-description = "MolMod is a Python library with many compoments that are useful to write molecular modeling programs."
+description = "MolMod is a Python library with many components that are useful to write molecular modeling programs."
 
 toolchain = {'name': 'foss', 'version': '2021a'}
 

--- a/easybuild/easyconfigs/m/molmod/molmod-1.4.8-foss-2021b.eb
+++ b/easybuild/easyconfigs/m/molmod/molmod-1.4.8-foss-2021b.eb
@@ -4,7 +4,7 @@ name = 'molmod'
 version = '1.4.8'
 
 homepage = 'https://molmod.github.io/molmod/'
-description = "MolMod is a Python library with many compoments that are useful to write molecular modeling programs."
+description = "MolMod is a Python library with many components that are useful to write molecular modeling programs."
 
 toolchain = {'name': 'foss', 'version': '2021b'}
 

--- a/easybuild/easyconfigs/p/Paraver/Paraver-4.11.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/p/Paraver/Paraver-4.11.1-foss-2022a.eb
@@ -4,7 +4,7 @@ version = '4.11.1'
 homepage = 'https://tools.bsc.es/paraver'
 description = """A very powerful performance visualization and analysis tool based on
  traces that can be used to analyse any information that is expressed on its input trace format.
- Traces for parallel MPI, OpenMP and other programs can be genereated with Extrae."""
+ Traces for parallel MPI, OpenMP and other programs can be generated with Extrae."""
 
 toolchain = {'name': 'foss', 'version': '2022a'}
 

--- a/easybuild/easyconfigs/p/Paraver/Paraver-4.9.2-foss-2021a.eb
+++ b/easybuild/easyconfigs/p/Paraver/Paraver-4.9.2-foss-2021a.eb
@@ -4,7 +4,7 @@ version = '4.9.2'
 homepage = 'https://tools.bsc.es/paraver'
 description = """A very powerful performance visualization and analysis tool based on
  traces that can be used to analyse any information that is expressed on its input trace format.
- Traces for parallel MPI, OpenMP and other programs can be genereated with Extrae."""
+ Traces for parallel MPI, OpenMP and other programs can be generated with Extrae."""
 
 toolchain = {'name': 'foss', 'version': '2021a'}
 

--- a/easybuild/easyconfigs/p/popscle/popscle-0.1-beta-20210505-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/p/popscle/popscle-0.1-beta-20210505-GCC-11.3.0.eb
@@ -10,7 +10,7 @@ local_commit = 'da70fc7'
 homepage = 'https://github.com/statgen/popscle'
 description = """A suite of
 population scale analysis tools for single-cell genomics data including
-implementation of Demuxlet / Freemuxlet methods and auxilary tools """
+implementation of Demuxlet / Freemuxlet methods and auxiliary tools """
 
 toolchain = {'name': 'GCC', 'version': '11.3.0'}
 toolchainopts = {'pic': True, 'cstd': 'c++14'}

--- a/easybuild/easyconfigs/q/Qualimap/Qualimap-2.2.1-foss-2020b-R-4.0.3.eb
+++ b/easybuild/easyconfigs/q/Qualimap/Qualimap-2.2.1-foss-2020b-R-4.0.3.eb
@@ -6,7 +6,7 @@ versionsuffix = '-R-%(rver)s'
 
 homepage = 'http://qualimap.bioinfo.cipf.es/'
 description = """Qualimap 2 is a platform-independent application written in Java and R that provides both
- a Graphical User Inteface (GUI) and a command-line interface to facilitate the quality control of
+ a Graphical User Interface (GUI) and a command-line interface to facilitate the quality control of
  alignment sequencing data and its derivatives like feature counts."""
 
 toolchain = {'name': 'foss', 'version': '2020b'}

--- a/easybuild/easyconfigs/q/Qualimap/Qualimap-2.2.1-foss-2021b-R-4.1.2.eb
+++ b/easybuild/easyconfigs/q/Qualimap/Qualimap-2.2.1-foss-2021b-R-4.1.2.eb
@@ -6,7 +6,7 @@ versionsuffix = '-R-%(rver)s'
 
 homepage = 'http://qualimap.bioinfo.cipf.es/'
 description = """Qualimap 2 is a platform-independent application written in Java and R that provides both
- a Graphical User Inteface (GUI) and a command-line interface to facilitate the quality control of
+ a Graphical User Interface (GUI) and a command-line interface to facilitate the quality control of
  alignment sequencing data and its derivatives like feature counts."""
 
 toolchain = {'name': 'foss', 'version': '2021b'}

--- a/easybuild/easyconfigs/t/TCLAP/TCLAP-1.2.4-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/t/TCLAP/TCLAP-1.2.4-GCCcore-10.2.0.eb
@@ -5,7 +5,7 @@ version = '1.2.4'
 
 homepage = 'http://tclap.sourceforge.net/'
 description = """TCLAP is a small, flexible library that provides a simple interface for defining and accessing
-command line arguments. It was intially inspired by the user friendly CLAP libary."""
+command line arguments. It was initially inspired by the user friendly CLAP library."""
 
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 toolchainopts = {'pic': True}

--- a/easybuild/easyconfigs/t/TCLAP/TCLAP-1.2.4-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/t/TCLAP/TCLAP-1.2.4-GCCcore-9.3.0.eb
@@ -5,7 +5,7 @@ version = '1.2.4'
 
 homepage = 'http://tclap.sourceforge.net/'
 description = """TCLAP is a small, flexible library that provides a simple interface for defining and accessing
-command line arguments. It was intially inspired by the user friendly CLAP libary."""
+command line arguments. It was initially inspired by the user friendly CLAP library."""
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 toolchainopts = {'pic': True}

--- a/easybuild/easyconfigs/t/TCLAP/TCLAP-1.2.5-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/t/TCLAP/TCLAP-1.2.5-GCCcore-10.3.0.eb
@@ -5,7 +5,7 @@ version = '1.2.5'
 
 homepage = 'http://tclap.sourceforge.net/'
 description = """TCLAP is a small, flexible library that provides a simple interface for defining and accessing
-command line arguments. It was intially inspired by the user friendly CLAP libary."""
+command line arguments. It was initially inspired by the user friendly CLAP library."""
 
 toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
 toolchainopts = {'pic': True}

--- a/easybuild/easyconfigs/t/TCLAP/TCLAP-1.2.5-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/t/TCLAP/TCLAP-1.2.5-GCCcore-11.2.0.eb
@@ -5,7 +5,7 @@ version = '1.2.5'
 
 homepage = 'http://tclap.sourceforge.net/'
 description = """TCLAP is a small, flexible library that provides a simple interface for defining and accessing
-command line arguments. It was intially inspired by the user friendly CLAP libary."""
+command line arguments. It was initially inspired by the user friendly CLAP library."""
 
 toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
 toolchainopts = {'pic': True}


### PR DESCRIPTION
There are some typos in the docs/version-specific/supported-software.md document reported by codespell tool [1]. Most often these issues comes from the upstream description of the software, which has usually been corrected since the creation of the easyconfig file.

This commit fixes the typo issues in software description for non-archived easyconfig files.

[1] https://github.com/codespell-project/codespell