### PR TITLE
dialog-1.3-20231002-GCCcore-10.3.0

### DIFF
--- a/easybuild/easyconfigs/d/dialog-1.3-20231002-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/d/dialog-1.3-20231002-GCCcore-10.3.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'dialog'
+version = '1.3-20231002'
+
+homepage = 'https://invisible-island.net/'
+description = 'A utility for creating TTY dialog boxes'
+
+toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
+
+sources = ['https://invisible-island.net/archives/dialog/%(name)s-%(version)s.tgz']
+checksums = ['315640ab0719225d5cbcab130585c05f0791fcf073072a5fe9479969aa2b833b']
+
+builddependencies = [
+    ('Autotools', '20210128'),
+]
+
+dependencies = [
+    ('ncurses', '6.2'),
+]
+
+sanity_check_paths = {
+    'files': ["bin/dialog", "lib/libdialog.a"],
+    'dirs': ["lib", "share"],
+}
+
+moduleclass = 'devel'
+


### PR DESCRIPTION
This PR adds a contribution for a new software called `dialog` where there were no easyconfigs before.