### PR TITLE
replace format tag with explicit extension name in Optuna v3.0.3

### DIFF
--- a/easybuild/easyconfigs/o/Optuna/Optuna-3.1.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/o/Optuna/Optuna-3.1.0-foss-2022a.eb
@@ -42,7 +42,7 @@ exts_list = [
     ('SQLAlchemy', '2.0.3', {
         'checksums': ['c2b924f6d0162ed1c0d8f47db1e56498702b1c3c953ad84f0eefbf5b4e53bb05'],
     }),
-    ('%(namelower)s', version, {
+    ('optuna', version, {
         'use_pip_extras': 'optional',
         'checksums': ['96c7c92860c8692d3aa569d749e72b121422cb4af0ed3ad4bfbc445b61416919'],
     }),


### PR DESCRIPTION
```
ERROR: Traceback (most recent call last):
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/main.py", line 135, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/framework/easyblock.py", line 4256, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/framework/easyblock.py", line 4135, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/framework/easyblock.py", line 3970, in run_step
    step_method(self)()
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-easyblocks/easybuild/easyblocks/generic/pythonbundle.py", line 125, in extensions_step
    super(PythonBundle, self).extensions_step(*args, **kwargs)
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/framework/easyblock.py", line 2872, in extensions_step
    fake_mod_data = self.load_fake_module(purge=True, extra_modules=build_dep_mods)
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/framework/easyblock.py", line 1700, in load_fake_module
    fake_mod_path = self.make_module_step(fake=True)
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/framework/easyblock.py", line 3737, in make_module_step
    txt += self.make_module_description()
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/framework/easyblock.py", line 1382, in make_module_description
    return self.module_generator.get_description()
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/tools/module_generator.py", line 1303, in get_description
    'homepage': self.app.cfg['homepage'],
KeyError: 'namelower'
```