### PR TITLE
{bio}[foss/2022b] MitoHiFi v3.2

### DIFF
--- a/easybuild/easyconfigs/b/bcbio-gff/bcbio-gff-0.7.0-foss-2022b.eb
+++ b/easybuild/easyconfigs/b/bcbio-gff/bcbio-gff-0.7.0-foss-2022b.eb
@@ -1,0 +1,42 @@
+# Contribution by
+# DeepThought, Flinders University
+# Updated to v0.6.7
+# R.QIAO <rob.qiao@flinders.edu.au>
+
+easyblock = 'PythonPackage'
+
+name = 'bcbio-gff'
+version = '0.7.0'
+
+homepage = 'https://github.com/chapmanb/bcbb/tree/master/gff'
+
+description = """
+Read and write Generic Feature Format (GFF) with Biopython integration.
+"""
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+
+sources = ['%(name)s-%(version)s.tar.gz']
+checksums = ['f7b3922ee274106f8716703f41f05a1795aa9d73e903f4e481995ed8f5f65d2d']
+
+dependencies = [
+    ('Python', '3.10.8'),
+    ('SciPy-bundle', '2023.02'),
+    ('Biopython', '1.81'),
+]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+local_bcbiogffroot = 'lib/python%(pyshortver)s/site-packages'
+local_targets = ['GFFOutput.py', 'GFFParser.py']
+
+sanity_check_paths = {
+    'files': [local_bcbiogffroot + '/BCBio/GFF/%s' % x for x in local_targets],
+    'dirs': [local_bcbiogffroot],
+}
+
+options = {'modulename': 'BCBio.GFF'}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/bcbio-gff/bcbio-gff-0.7.0-foss-2022b.eb
+++ b/easybuild/easyconfigs/b/bcbio-gff/bcbio-gff-0.7.0-foss-2022b.eb
@@ -2,6 +2,7 @@
 # DeepThought, Flinders University
 # Updated to v0.6.7
 # R.QIAO <rob.qiao@flinders.edu.au>
+# Updated to v0.7.0 by Denis Kristak (Inuits)
 
 easyblock = 'PythonPackage'
 

--- a/easybuild/easyconfigs/h/hifiasm/hifiasm-0.19.7-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/h/hifiasm/hifiasm-0.19.7-GCCcore-12.2.0.eb
@@ -1,0 +1,42 @@
+# Author: Jasper Grimm (UoY)
+# Update: Sebastien Moretti (SIB)
+
+easyblock = 'MakeCp'
+
+name = 'hifiasm'
+version = '0.19.7'
+
+homepage = 'https://github.com/chhylp123/hifiasm'
+description = """Hifiasm: a haplotype-resolved assembler for accurate Hifi reads."""
+# software_license = 'LicenseMIT'
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+github_account = 'chhylp123'
+source_urls = [GITHUB_SOURCE]
+sources = ['%(version)s.tar.gz']
+checksums = ['16d6127c7efb2d450630f25402a05e7d691b411465b304950d84d8afd53d5ee6']
+
+builddependencies = [
+    ('binutils', '2.39'),
+]
+
+dependencies = [
+    ('zlib', '1.2.12'),
+]
+
+buildopts = 'CC="$CC" CXX="$CXX" CPPFLAGS="$CPPFLAGS"'
+
+files_to_copy = [
+    ([name], 'bin'),
+    (['*.h'], 'include/hifiasm'),
+    'LICENSE', 'README.md',
+]
+
+sanity_check_paths = {
+    'files': ['bin/%(name)s'],
+    'dirs': [],
+}
+sanity_check_commands = ["%(name)s -h"]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/h/hifiasm/hifiasm-0.19.7-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/h/hifiasm/hifiasm-0.19.7-GCCcore-12.2.0.eb
@@ -1,5 +1,5 @@
 # Author: Jasper Grimm (UoY)
-# Update: Sebastien Moretti (SIB)
+# Update: Sebastien Moretti (SIB), Denis Kristak (Inuits)
 
 easyblock = 'MakeCp'
 

--- a/easybuild/easyconfigs/m/MitoHiFi/MitoHiFi-3.2-foss-2022b.eb
+++ b/easybuild/easyconfigs/m/MitoHiFi/MitoHiFi-3.2-foss-2022b.eb
@@ -21,7 +21,6 @@ dependencies = [
     ('BEDTools', '2.30.0'),
     ('Pillow', '9.4.0'),
     ('bcbio-gff', '0.7.0'),
-    # ('MitoFinder', '1.4.1'),
     ('BLAST+', '2.14.0'),
 ]
 
@@ -45,11 +44,10 @@ exts_list = [
         'source_urls': ['https://github.com/marcelauliano/MitoHiFi/archive/'],
         'sources': ['v%(version)s.tar.gz'],
         'checksums': ['68f1eb69a54288d58ac920885aac82d4beae744e54023f409623125c084d5430'],
-        # TODO: patch wasn't applied without any error message (workaround in postinstallcmds)
-        # 'patches': ['MitoHiFi-%(version)s-use_mitos_annotation.patch'],
     }),
 ]
 
+# using Mitos rather than MitoFinder (which is only available on Python-2)
 postinstallcmds = [
     'sed -i "s|# Set log message format|args.mitos = True|" %(installdir)s/MitoHiFi-%(version)s/src/mitohifi.py',
     "mkdir -p %(installdir)s/bin",

--- a/easybuild/easyconfigs/m/MitoHiFi/MitoHiFi-3.2-foss-2022b.eb
+++ b/easybuild/easyconfigs/m/MitoHiFi/MitoHiFi-3.2-foss-2022b.eb
@@ -1,0 +1,77 @@
+easyblock = 'PythonBundle'
+
+name = 'MitoHiFi'
+version = '3.2'
+
+homepage = 'https://github.com/marcelauliano/MitoHiFi'
+description = "MitoHiFi is a Python workflow that assembles mitogenomes from Pacbio HiFi reads"
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+
+dependencies = [
+    ('Python', '3.10.8'),
+    ('SciPy-bundle', '2023.02'),  # for pandas
+    ('SAMtools', '1.17'),
+    ('CD-HIT', '4.8.1'),
+    ('minimap2', '2.26'),
+    ('hifiasm', '0.19.7'),
+    ('MAFFT', '7.505', '-with-extensions'),
+    ('Biopython', '1.81'),
+    ('matplotlib', '3.7.0'),
+    ('BEDTools', '2.30.0'),
+    ('Pillow', '9.4.0'),
+    ('bcbio-gff', '0.7.0'),
+    # ('MitoFinder', '1.4.1'),
+    ('BLAST+', '2.14.0'),
+]
+
+# https://github.com/RemiAllio/MitoFinder
+# MitoFinder=v1.4.0
+
+use_pip = True
+
+exts_list = [
+    ('dna-features-viewer', '3.1.2', {
+        'sources': ['dna_features_viewer-%(version)s.tar.gz'],
+        'checksums': ['b8b2b7657e2a9f165edd6f68fb679abfa0c2fdeb887cbd04c22b514997f52d12'],
+    }),
+    ('mitos', '2.1.3', {
+        'checksums': ['0a5bee0882a957457426baaa36655d968fbd36523e3fb06d96e2401f9f9bd285'],
+        'preinstallopts': """sed -i 's|biopython==1.73|biopython|' setup.py && """,
+    }),
+    (name, version, {
+        'easyblock': 'Tarball',
+        'modulename': False,
+        'source_urls': ['https://github.com/marcelauliano/MitoHiFi/archive/'],
+        'sources': ['v%(version)s.tar.gz'],
+        'checksums': ['68f1eb69a54288d58ac920885aac82d4beae744e54023f409623125c084d5430'],
+        # TODO: patch wasn't applied without any error message (workaround in postinstallcmds)
+        # 'patches': ['MitoHiFi-%(version)s-use_mitos_annotation.patch'],
+    }),
+]
+
+postinstallcmds = [
+    'sed -i "s|# Set log message format|args.mitos = True|" %(installdir)s/MitoHiFi-%(version)s/src/mitohifi.py',
+    "mkdir -p %(installdir)s/bin",
+    "cp %(installdir)s/MitoHiFi-%(version)s/src/* %(installdir)s/bin/ ",
+    "chmod a+x  %(installdir)s/bin/* ",
+]
+
+fix_python_shebang_for = ['bin/*']
+
+sanity_check_paths = {
+    'files': ['bin/mitohifi.py'],
+    'dirs': [],
+}
+
+local_test_cmd = 'findMitoReference.py --species "Deilephila porcellus" '
+local_test_cmd += '--outfolder %(installdir)s/MitoHiFi-%(version)s/out --min_length 14000'
+
+sanity_check_commands = [
+    "mitohifi.py -h",
+    local_test_cmd
+]
+
+sanity_pip_check = True
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/MitoHiFi/MitoHiFi-3.2-foss-2022b.eb
+++ b/easybuild/easyconfigs/m/MitoHiFi/MitoHiFi-3.2-foss-2022b.eb
@@ -24,9 +24,6 @@ dependencies = [
     ('BLAST+', '2.14.0'),
 ]
 
-# https://github.com/RemiAllio/MitoFinder
-# MitoFinder=v1.4.0
-
 use_pip = True
 
 exts_list = [


### PR DESCRIPTION
TODO:
- fix non-functional patch (now there's a workaround in `postinstallcmds`)

adding easyconfigs: bcbio-gff-0.7.0-foss-2022b.eb, hifiasm-0.19.7-GCCcore-12.2.0.eb, MitoHiFi-3.2-foss-2022b.eb