### PR TITLE
Add missing description to patch file for flook

### DIFF
--- a/easybuild/easyconfigs/f/flook/flook-0.8.1-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/f/flook/flook-0.8.1-GCC-11.3.0.eb
@@ -15,7 +15,7 @@ patches = [
 checksums = [
     {'flook-0.8.1.tar.gz': 'beb15b8cb57b7a2facc7a5094326aaa877fda4fe35f8aabac023232c2e12d97e'},
     {'flook-0.8.1_setup.make': '6df3f53faa8a8fe61534ded997c5e748d0327c13b18972fbbf49eacbda30d6e0'},
-    {'flook-0.8.1_flook.pc.in.patch': '1aa3635d83f0f9bad2ef2f9457183aefa94c8f07e66d3ef31e8897190752b42c'},
+    {'flook-0.8.1_flook.pc.in.patch': '73ff61d8bc224c32cb285313615a465c0ce0a6b34e22ef5cf08291a27cee8796'},
 ]
 
 dependencies = [('Lua', '5.4.4')]

--- a/easybuild/easyconfigs/f/flook/flook-0.8.1_flook.pc.in.patch
+++ b/easybuild/easyconfigs/f/flook/flook-0.8.1_flook.pc.in.patch
@@ -1,3 +1,6 @@
+Patch to fix missing link libraries in pkgconfig
+for correctly linking with external Lua.
+author: Arnold H. Kole (Utrecht University)
 diff --git a/flook.pc.in b/flook.pc.in
 index 680b5e0..b46f8ad 100644
 --- a/flook.pc.in


### PR DESCRIPTION
Description and author for patch file was missing for flook. This has now been added.