### PR TITLE
Refactor `check_dep_vars`

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -380,12 +380,6 @@ class EasyConfigTest(TestCase):
 
         version_regex = re.compile('^version: (?P<version>[^;]+);')
 
-        # filter out binutils with empty versionsuffix which is used to build toolchain compiler
-        if dep == 'binutils' and len(dep_vars) > 1:
-            empty_vsuff_vars = [v for v in dep_vars.keys() if v.endswith('versionsuffix: ')]
-            if len(empty_vsuff_vars) == 1:
-                dep_vars = dict((k, v) for (k, v) in dep_vars.items() if k != empty_vsuff_vars[0])
-
         # multiple variants of HTSlib is OK as long as they are deps for a matching version of BCFtools;
         # same goes for WRF and WPS; Gurobi and Rgurobi; ncbi-vdb and SRA-Toolkit
         multiple_allowed_variants = [('HTSlib', 'BCFtools'),
@@ -410,46 +404,51 @@ class EasyConfigTest(TestCase):
                 if all(ec.startswith('Boost.Python-%s-' % boost_ver) for ec in ecs):
                     dep_vars.pop(key)
 
-        # filter out Perl with -minimal versionsuffix which are only used in makeinfo-minimal
-        if dep == 'Perl':
-            minimal_vsuff_vars = [v for v in dep_vars.keys() if v.endswith('versionsuffix: -minimal')]
-            if len(minimal_vsuff_vars) == 1:
-                dep_vars = dict((k, v) for (k, v) in dep_vars.items() if k != minimal_vsuff_vars[0])
-
-        # filter out FFTW and imkl with -serial versionsuffix which are used in non-MPI subtoolchains
-        if dep in ['FFTW', 'imkl']:
-            serial_vsuff_vars = [v for v in dep_vars.keys() if v.endswith('versionsuffix: -serial')]
-            if len(serial_vsuff_vars) == 1:
-                dep_vars = dict((k, v) for (k, v) in dep_vars.items() if k != serial_vsuff_vars[0])
-
-        # filter out BLIS and libFLAME with -amd versionsuffix
-        # (AMD forks, used in gobff/*-amd toolchains)
-        if dep in ['BLIS', 'libFLAME']:
-            amd_vsuff_vars = [v for v in dep_vars.keys() if v.endswith('versionsuffix: -amd')]
-            if len(amd_vsuff_vars) == 1:
-                dep_vars = dict((k, v) for (k, v) in dep_vars.items() if k != amd_vsuff_vars[0])
-
-        # filter out ScaLAPACK with -BLIS-* versionsuffix, used in goblf toolchain
-        if dep == 'ScaLAPACK':
-            blis_vsuff_vars = [v for v in dep_vars.keys() if '; versionsuffix: -BLIS-' in v]
-            if len(blis_vsuff_vars) == 1:
-                dep_vars = dict((k, v) for (k, v) in dep_vars.items() if k != blis_vsuff_vars[0])
-
-        if dep == 'ScaLAPACK':
+        # Pairs of name, versionsuffix that should be removed from dep_vars if exactly one matching key is found.
+        # The name is checked against 'dep' and can be a list to allow multiple.
+        # If the versionsuffix is a 2-element tuple, the second element should be set to True
+        # to interpret the first element as the start of the suffix (e.g. to include trailing version numbers).
+        # Otherwise the whole versionsuffix must match for the filter to apply.
+        filter_variants = [
+            # filter out binutils with empty versionsuffix which is used to build toolchain compiler
+            ('binutils', ''),
+            # filter out Perl with -minimal versionsuffix which are only used in makeinfo-minimal
+            ('Perl', '-minimal'),
+            # filter out FFTW and imkl with -serial versionsuffix which are used in non-MPI subtoolchains
+            # Same for HDF5 with -serial versionsuffix which is used in HDF5 for Python (h5py)
+            (['FFTW', 'imkl', 'HDF5'], '-serial'),
+            # filter out BLIS and libFLAME with -amd versionsuffix
+            # (AMD forks, used in gobff/*-amd toolchains)
+            (['BLIS', 'libFLAME'], '-amd'),
+            # filter out ScaLAPACK with -BLIS-* versionsuffix, used in goblf toolchain
+            ('ScaLAPACK', ('-BLIS-', True)),
             # filter out ScaLAPACK with -bf versionsuffix, used in gobff toolchain
-            bf_vsuff_vars = [v for v in dep_vars.keys() if '; versionsuffix: -bf' in v]
-            if len(bf_vsuff_vars) == 1:
-                dep_vars = dict((k, v) for (k, v) in dep_vars.items() if k != bf_vsuff_vars[0])
+            ('ScaLAPACK', '-bf'),
             # filter out ScaLAPACK with -bl versionsuffix, used in goblf toolchain
-            bl_vsuff_vars = [v for v in dep_vars.keys() if '; versionsuffix: -bl' in v]
-            if len(bl_vsuff_vars) == 1:
-                dep_vars = dict((k, v) for (k, v) in dep_vars.items() if k != bl_vsuff_vars[0])
-
-        # filter out HDF5 with -serial versionsuffix which is used in HDF5 for Python (h5py)
-        if dep in ['HDF5']:
-            serial_vsuff_vars = [v for v in dep_vars.keys() if v.endswith('versionsuffix: -serial')]
-            if len(serial_vsuff_vars) == 1:
-                dep_vars = dict((k, v) for (k, v) in dep_vars.items() if k != serial_vsuff_vars[0])
+            ('ScaLAPACK', '-bl'),
+            # filter out ELSI variants with -PEXSI suffix
+            ('ELSI', '-PEXSI'),
+        ]
+        for dep_name, version_suffix in filter_variants:
+            # always retain at least one dep variant
+            if len(dep_vars) == 1:
+                break
+            if isinstance(dep_name, string_type):
+                if dep != dep_name:
+                    continue
+            elif dep not in dep_name:
+                continue
+            if isinstance(version_suffix, string_type):
+                match_prefix = False
+            else:
+                version_suffix, match_prefix = version_suffix
+            search = 'versionsuffix: ' + version_suffix
+            if match_prefix:
+                matches = [v for v in dep_vars if search in v]
+            else:
+                matches = [v for v in dep_vars if v.endswith(search)]
+            if len(matches) == 1:
+                del dep_vars[matches[0]]
 
         # for some dependencies, we allow exceptions for software that depends on a particular version,
         # as long as that's indicated by the versionsuffix
@@ -624,12 +623,6 @@ class EasyConfigTest(TestCase):
                         # only filter if the easyconfig using this dep variants is known
                         if all(any(re.search(p, x) for p in parents) for x in dep_vars[key]):
                             dep_vars.pop(key)
-
-        # filter out ELSI variants with -PEXSI suffix
-        if dep == 'ELSI' and len(dep_vars) > 1:
-            pexsi_vsuff_vars = [v for v in dep_vars.keys() if v.endswith('versionsuffix: -PEXSI')]
-            if len(pexsi_vsuff_vars) == 1:
-                dep_vars = dict((k, v) for (k, v) in dep_vars.items() if k != pexsi_vsuff_vars[0])
 
         # only single variant is always OK
         if len(dep_vars) == 1:
@@ -858,6 +851,7 @@ class EasyConfigTest(TestCase):
         # which throws off the pattern matching done below for toolchain versions
         false_positives_regex = re.compile('^MATLAB-Engine-20[0-9][0-9][ab]')
 
+        multi_dep_vars_msg = ''
         # restrict to checking dependencies of easyconfigs using common toolchains (start with 2018a)
         # and GCCcore subtoolchain for common toolchains, starting with GCCcore 7.x
         for pattern in ['20(1[89]|[2-9][0-9])[ab]', r'GCCcore-([7-9]|[1-9][0-9])\.[0-9]']:
@@ -883,19 +877,15 @@ class EasyConfigTest(TestCase):
                         dep_variants.setdefault(variant, set()).add(ec_file)
 
             # check which dependencies have more than 1 variant
-            multi_dep_vars, multi_dep_vars_msg = [], ''
-            for tc_gen in sorted(all_deps.keys()):
-                for dep in sorted(all_deps[tc_gen].keys()):
-                    dep_vars = all_deps[tc_gen][dep]
+            for tc_gen, deps in sorted(all_deps.items()):
+                for dep, dep_vars in sorted(deps.items()):
                     if not self.check_dep_vars(tc_gen, dep, dep_vars):
-                        multi_dep_vars.append(dep)
-                        multi_dep_vars_msg += "\nfound %s variants of '%s' dependency " % (len(dep_vars), dep)
+                        multi_dep_vars_msg += "Found %s variants of '%s' dependency " % (len(dep_vars), dep)
                         multi_dep_vars_msg += "in easyconfigs using '%s' toolchain generation\n* " % tc_gen
-                        multi_dep_vars_msg += '\n* '.join("%s as dep for %s" % v for v in sorted(dep_vars.items()))
+                        multi_dep_vars_msg += '\n  * '.join("%s as dep for %s" % v for v in sorted(dep_vars.items()))
                         multi_dep_vars_msg += '\n'
-
-            error_msg = "No multi-variant deps found for '%s' easyconfigs:\n%s" % (regex.pattern, multi_dep_vars_msg)
-            self.assertFalse(multi_dep_vars, error_msg)
+        if multi_dep_vars_msg:
+            self.fail('Should not have multiple variants of dependencies.\n' + multi_dep_vars_msg)
 
     def test_sanity_check_paths(self):
         """Make sure specified sanity check paths adher to the requirements."""


### PR DESCRIPTION
Remove the C&P code for filtering a `dep_var` with a specific version_suffix if exactly 1 match was found.
Replace by a list similar to `multiple_allowed_variants` and the code to directly delete the key instead of rebuilding the dict. Also assert only once with all found issues.

Allows easier extension. Used by #19354 