### PR TITLE
compile LERC test binary in `postinstallcmds` to fix sanity check error when RPATH linking is enabled

### DIFF
--- a/easybuild/easyconfigs/l/LERC/LERC-3.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-3.0-GCCcore-10.2.0.eb
@@ -29,7 +29,7 @@ postinstallcmds = [
     "cd %(builddir)s/lerc-%(version)s/src/LercTest && sed -i -e 's@../LercLib/include/@@' main.cpp",
     "mkdir %(installdir)s/LercTest",
     "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/LercTest/main.cpp",
-    "cd %(installdir)s/LercTest && g++ main.cpp -o LercTest -I../include -L../lib -lLerc",
+    "cd %(installdir)s/LercTest && ${CXX} ${CXXFLAGS} main.cpp -o LercTest -I../include -L../lib -lLerc",
 ]
 
 sanity_check_commands = [

--- a/easybuild/easyconfigs/l/LERC/LERC-3.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-3.0-GCCcore-10.2.0.eb
@@ -22,12 +22,16 @@ builddependencies = [
 ]
 
 postinstallcmds = [
+    # copy the LercTest source file to a LercTest subdir in the installation directory and compile it
+    # (needs to be done here instead of in the sanity check, else it won't work when RPATH linking is enabled)
     "cd %(builddir)s/lerc-%(version)s/src/LercTest && sed -i -e 's@../LercLib/include/@@' main.cpp",
-    "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/test.c",
+    "mkdir %(installdir)s/LercTest",
+    "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/LercTest/main.cpp",
+    "cd %(installdir)s/LercTest && g++ main.cpp -o LercTest -I../include -L../lib -lLerc",
 ]
 
 sanity_check_commands = [
-    "mkdir -p %(builddir)s && cd %(builddir)s && g++ %(installdir)s/test.c -o lerctest -lLerc && ./lerctest",
+    "%(installdir)s/LercTest/LercTest",
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LERC/LERC-3.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-3.0-GCCcore-10.2.0.eb
@@ -21,6 +21,8 @@ builddependencies = [
     ('CMake', '3.18.4'),
 ]
 
+configopts = '-DCMAKE_INSTALL_LIBDIR=lib'
+
 postinstallcmds = [
     # copy the LercTest source file to a LercTest subdir in the installation directory and compile it
     # (needs to be done here instead of in the sanity check, else it won't work when RPATH linking is enabled)

--- a/easybuild/easyconfigs/l/LERC/LERC-3.0-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-3.0-GCCcore-10.3.0.eb
@@ -30,7 +30,7 @@ postinstallcmds = [
     "cd %(builddir)s/lerc-%(version)s/src/LercTest && sed -i -e 's@../LercLib/include/@@' main.cpp",
     "mkdir %(installdir)s/LercTest",
     "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/LercTest/main.cpp",
-    "cd %(installdir)s/LercTest && g++ main.cpp -o LercTest -I../include -L../lib -lLerc",
+    "cd %(installdir)s/LercTest && ${CXX} ${CXXFLAGS} main.cpp -o LercTest -I../include -L../lib -lLerc",
 ]
 
 sanity_check_commands = [

--- a/easybuild/easyconfigs/l/LERC/LERC-3.0-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-3.0-GCCcore-10.3.0.eb
@@ -22,6 +22,8 @@ builddependencies = [
     ('CMake', '3.20.1'),
 ]
 
+configopts = '-DCMAKE_INSTALL_LIBDIR=lib'
+
 postinstallcmds = [
     # copy the LercTest source file to a LercTest subdir in the installation directory and compile it
     # (needs to be done here instead of in the sanity check, else it won't work when RPATH linking is enabled)

--- a/easybuild/easyconfigs/l/LERC/LERC-3.0-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-3.0-GCCcore-10.3.0.eb
@@ -23,12 +23,16 @@ builddependencies = [
 ]
 
 postinstallcmds = [
+    # copy the LercTest source file to a LercTest subdir in the installation directory and compile it
+    # (needs to be done here instead of in the sanity check, else it won't work when RPATH linking is enabled)
     "cd %(builddir)s/lerc-%(version)s/src/LercTest && sed -i -e 's@../LercLib/include/@@' main.cpp",
-    "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/test.c",
+    "mkdir %(installdir)s/LercTest",
+    "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/LercTest/main.cpp",
+    "cd %(installdir)s/LercTest && g++ main.cpp -o LercTest -I../include -L../lib -lLerc",
 ]
 
 sanity_check_commands = [
-    "mkdir -p %(builddir)s && cd %(builddir)s && g++ %(installdir)s/test.c -o lerctest -lLerc && ./lerctest",
+    "%(installdir)s/LercTest/LercTest",
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-11.3.0.eb
@@ -30,7 +30,7 @@ postinstallcmds = [
     "cd %(builddir)s/lerc-%(version)s/src/LercTest && sed -i -e 's@../LercLib/include/@@' main.cpp",
     "mkdir %(installdir)s/LercTest",
     "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/LercTest/main.cpp",
-    "cd %(installdir)s/LercTest && g++ main.cpp -o LercTest -I../include -L../lib -lLerc",
+    "cd %(installdir)s/LercTest && ${CXX} ${CXXFLAGS} main.cpp -o LercTest -I../include -L../lib -lLerc",
 ]
 
 sanity_check_commands = [

--- a/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-11.3.0.eb
@@ -22,6 +22,8 @@ builddependencies = [
     ('CMake', '3.23.1'),
 ]
 
+configopts = '-DCMAKE_INSTALL_LIBDIR=lib'
+
 postinstallcmds = [
     # copy the LercTest source file to a LercTest subdir in the installation directory and compile it
     # (needs to be done here instead of in the sanity check, else it won't work when RPATH linking is enabled)

--- a/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-11.3.0.eb
@@ -23,12 +23,16 @@ builddependencies = [
 ]
 
 postinstallcmds = [
+    # copy the LercTest source file to a LercTest subdir in the installation directory and compile it
+    # (needs to be done here instead of in the sanity check, else it won't work when RPATH linking is enabled)
     "cd %(builddir)s/lerc-%(version)s/src/LercTest && sed -i -e 's@../LercLib/include/@@' main.cpp",
-    "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/test.c",
+    "mkdir %(installdir)s/LercTest",
+    "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/LercTest/main.cpp",
+    "cd %(installdir)s/LercTest && g++ main.cpp -o LercTest -I../include -L../lib -lLerc",
 ]
 
 sanity_check_commands = [
-    "mkdir -p %(builddir)s && cd %(builddir)s && g++ %(installdir)s/test.c -o lerctest -lLerc && ./lerctest",
+    "%(installdir)s/LercTest/LercTest",
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-12.2.0.eb
@@ -30,7 +30,7 @@ postinstallcmds = [
     "cd %(builddir)s/lerc-%(version)s/src/LercTest && sed -i -e 's@../LercLib/include/@@' main.cpp",
     "mkdir %(installdir)s/LercTest",
     "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/LercTest/main.cpp",
-    "cd %(installdir)s/LercTest && g++ main.cpp -o LercTest -I../include -L../lib -lLerc",
+    "cd %(installdir)s/LercTest && ${CXX} ${CXXFLAGS} main.cpp -o LercTest -I../include -L../lib -lLerc",
 ]
 
 sanity_check_commands = [

--- a/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-12.2.0.eb
@@ -22,6 +22,8 @@ builddependencies = [
     ('CMake', '3.24.3'),
 ]
 
+configopts = '-DCMAKE_INSTALL_LIBDIR=lib'
+
 postinstallcmds = [
     # copy the LercTest source file to a LercTest subdir in the installation directory and compile it
     # (needs to be done here instead of in the sanity check, else it won't work when RPATH linking is enabled)

--- a/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-12.2.0.eb
@@ -23,12 +23,16 @@ builddependencies = [
 ]
 
 postinstallcmds = [
+    # copy the LercTest source file to a LercTest subdir in the installation directory and compile it
+    # (needs to be done here instead of in the sanity check, else it won't work when RPATH linking is enabled)
     "cd %(builddir)s/lerc-%(version)s/src/LercTest && sed -i -e 's@../LercLib/include/@@' main.cpp",
-    "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/test.c",
+    "mkdir %(installdir)s/LercTest",
+    "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/LercTest/main.cpp",
+    "cd %(installdir)s/LercTest && g++ main.cpp -o LercTest -I../include -L../lib -lLerc",
 ]
 
 sanity_check_commands = [
-    "mkdir -p %(builddir)s && cd %(builddir)s && g++ %(installdir)s/test.c -o lerctest -lLerc && ./lerctest",
+    "%(installdir)s/LercTest/LercTest",
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-12.3.0.eb
@@ -30,7 +30,7 @@ postinstallcmds = [
     "cd %(builddir)s/lerc-%(version)s/src/LercTest && sed -i -e 's@../LercLib/include/@@' main.cpp",
     "mkdir %(installdir)s/LercTest",
     "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/LercTest/main.cpp",
-    "cd %(installdir)s/LercTest && g++ main.cpp -o LercTest -I../include -L../lib -lLerc",
+    "cd %(installdir)s/LercTest && ${CXX} ${CXXFLAGS} main.cpp -o LercTest -I../include -L../lib -lLerc",
 ]
 
 sanity_check_commands = [

--- a/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-12.3.0.eb
@@ -23,12 +23,16 @@ builddependencies = [
 ]
 
 postinstallcmds = [
+    # copy the LercTest source file to a LercTest subdir in the installation directory and compile it
+    # (needs to be done here instead of in the sanity check, else it won't work when RPATH linking is enabled)
     "cd %(builddir)s/lerc-%(version)s/src/LercTest && sed -i -e 's@../LercLib/include/@@' main.cpp",
-    "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/test.c",
+    "mkdir %(installdir)s/LercTest",
+    "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/LercTest/main.cpp",
+    "cd %(installdir)s/LercTest && g++ main.cpp -o LercTest -I../include -L../lib -lLerc",
 ]
 
 sanity_check_commands = [
-    "mkdir -p %(builddir)s && cd %(builddir)s && g++ %(installdir)s/test.c -o lerctest -lLerc && ./lerctest",
+    "%(installdir)s/LercTest/LercTest",
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-12.3.0.eb
@@ -22,6 +22,8 @@ builddependencies = [
     ('CMake', '3.26.3'),
 ]
 
+configopts = '-DCMAKE_INSTALL_LIBDIR=lib'
+
 postinstallcmds = [
     # copy the LercTest source file to a LercTest subdir in the installation directory and compile it
     # (needs to be done here instead of in the sanity check, else it won't work when RPATH linking is enabled)


### PR DESCRIPTION
The LERC test binary was compiled in the sanity check step, but that doesn't pick up the RPATH wrappers when RPATH linking is enabled. This, in turn, leads to errors when `$LD_LIBRARY_PATH` is filtered as well:
```
./lerctest: error while loading shared libraries: libLerc.so.4: cannot open shared object file: No such file or directory
```

This PR fixes that by doing the compilation of the test binary as part of `postinstallcmds`, and also stores both the source and binary in a subdir of the installation directory. The latter should make sure that it still works if `--sanity-check-only` is used.