### PR TITLE
move kim-api/2.3.0-GCCcore-12.3.0 to GCC

### DIFF
--- a/easybuild/easyconfigs/k/kim-api/kim-api-2.3.0-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/k/kim-api/kim-api-2.3.0-GCC-12.3.0.eb
@@ -18,13 +18,11 @@ or
 to install them all.
  """
 
-toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+toolchain = {'name': 'GCC', 'version': '12.3.0'}
 
 source_urls = ['https://s3.openkim.org/kim-api/']
 sources = ['%(name)s-%(version)s.txz']
 checksums = ['93673bb8fbc0625791f2ee67915d1672793366d10cabc63e373196862c14f991']
-
-builddependencies = [('binutils', '2.40')]
 
 dependencies = [
     ('CMake', '3.26.3'),  # Also needed to install models, thus not just a builddependency.

--- a/easybuild/easyconfigs/o/openkim-models/openkim-models-20210811-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/o/openkim-models/openkim-models-20210811-GCC-12.3.0.eb
@@ -14,10 +14,9 @@ This EasyBuild installs the models.  The API itself is in the kim-api
 package.
  """
 
-toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+toolchain = {'name': 'GCC', 'version': '12.3.0'}
 
 builddependencies = [
-    ('binutils', '2.40'),
     ('pkgconf', '1.9.5'),
 ]
 


### PR DESCRIPTION
There are Fortran .mod files in kim-api, so we should move it (see https://github.com/easybuilders/easybuild-framework/pull/4389)