### PR TITLE
move kim-api/2.3.0-GCCcore-11.3.0 to GCC

### DIFF
--- a/easybuild/easyconfigs/k/kim-api/kim-api-2.3.0-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/k/kim-api/kim-api-2.3.0-GCC-11.3.0.eb
@@ -18,13 +18,11 @@ or
 to install them all.
  """
 
-toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+toolchain = {'name': 'GCC', 'version': '11.3.0'}
 
 source_urls = ['https://s3.openkim.org/kim-api/']
 sources = ['%(name)s-%(version)s.txz']
 checksums = ['93673bb8fbc0625791f2ee67915d1672793366d10cabc63e373196862c14f991']
-
-builddependencies = [('binutils', '2.38')]
 
 dependencies = [
     ('CMake', '3.23.1'),  # Also needed to install models, thus not just a builddependency.


### PR DESCRIPTION
There are Fortran .mod files in kim-api, so we should move it (see https://github.com/easybuilders/easybuild-framework/pull/4389)