### PR TITLE
move kim-api/2.2.1-GCCcore-10.3.0 to GCC

### DIFF
--- a/easybuild/easyconfigs/k/kim-api/kim-api-2.2.1-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/k/kim-api/kim-api-2.2.1-GCC-10.3.0.eb
@@ -18,13 +18,11 @@ or
 to install them all.
  """
 
-toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
+toolchain = {'name': 'GCC', 'version': '10.3.0'}
 
 source_urls = ['https://s3.openkim.org/kim-api/']
 sources = ['%(name)s-%(version)s.txz']
 checksums = ['1d5a12928f7e885ebe74759222091e48a7e46f77e98d9147e26638c955efbc8e']
-
-builddependencies = [('binutils', '2.36.1')]
 
 dependencies = [
     ('CMake', '3.20.1'),  # Also needed to install models, thus not just a builddependency.


### PR DESCRIPTION
There are Fortran .mod files in kim-api, so we should move it (see https://github.com/easybuilders/easybuild-framework/pull/4389)