### PR TITLE
move kim-api/2.2.1-GCCcore-10.2.0 to GCC

### DIFF
--- a/easybuild/easyconfigs/k/kim-api/kim-api-2.2.1-GCC-10.2.0.eb
+++ b/easybuild/easyconfigs/k/kim-api/kim-api-2.2.1-GCC-10.2.0.eb
@@ -18,13 +18,11 @@ or
 to install them all.
  """
 
-toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+toolchain = {'name': 'GCC', 'version': '10.2.0'}
 
 source_urls = ['https://s3.openkim.org/kim-api/']
 sources = ['%(name)s-%(version)s.txz']
 checksums = ['1d5a12928f7e885ebe74759222091e48a7e46f77e98d9147e26638c955efbc8e']
-
-builddependencies = [('binutils', '2.35')]
 
 dependencies = [
     ('CMake', '3.18.4'),  # Also needed to install models, thus not just a builddependency.

--- a/easybuild/easyconfigs/o/openkim-models/openkim-models-20190725-GCC-10.2.0.eb
+++ b/easybuild/easyconfigs/o/openkim-models/openkim-models-20190725-GCC-10.2.0.eb
@@ -1,7 +1,7 @@
 easyblock = 'CMakeMake'
 
 name = 'openkim-models'
-version = '20210128'
+version = '20190725'
 
 homepage = 'https://openkim.org/'
 description = """Open Knowledgebase of Interatomic Models.
@@ -14,10 +14,9 @@ This EasyBuild installs the models.  The API itself is in the kim-api
 package.
  """
 
-toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+toolchain = {'name': 'GCC', 'version': '10.2.0'}
 
 builddependencies = [
-    ('binutils', '2.35'),
     ('pkg-config', '0.29.2'),
 ]
 
@@ -26,8 +25,8 @@ dependencies = [
 ]
 
 source_urls = ['https://s3.openkim.org/archives/collection/']
-sources = ['openkim-models-2021-01-28.txz']
-checksums = ['8824adee02ae4583bd378cc81140fbb49515c5965708ee98d856d122d48dd95f']
+sources = ['openkim-models-2019-07-25.txz']
+checksums = ['50338084ece92ec0fb13b0bbdf357b5d7450e26068ba501f23c315f814befc26']
 
 separate_build_dir = True
 abs_path_compilers = True   # Otherwise some KIM-API magic breaks cmake.

--- a/easybuild/easyconfigs/o/openkim-models/openkim-models-20210128-GCC-10.2.0.eb
+++ b/easybuild/easyconfigs/o/openkim-models/openkim-models-20210128-GCC-10.2.0.eb
@@ -1,7 +1,7 @@
 easyblock = 'CMakeMake'
 
 name = 'openkim-models'
-version = '20190725'
+version = '20210128'
 
 homepage = 'https://openkim.org/'
 description = """Open Knowledgebase of Interatomic Models.
@@ -14,10 +14,9 @@ This EasyBuild installs the models.  The API itself is in the kim-api
 package.
  """
 
-toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+toolchain = {'name': 'GCC', 'version': '10.2.0'}
 
 builddependencies = [
-    ('binutils', '2.35'),
     ('pkg-config', '0.29.2'),
 ]
 
@@ -26,8 +25,8 @@ dependencies = [
 ]
 
 source_urls = ['https://s3.openkim.org/archives/collection/']
-sources = ['openkim-models-2019-07-25.txz']
-checksums = ['50338084ece92ec0fb13b0bbdf357b5d7450e26068ba501f23c315f814befc26']
+sources = ['openkim-models-2021-01-28.txz']
+checksums = ['8824adee02ae4583bd378cc81140fbb49515c5965708ee98d856d122d48dd95f']
 
 separate_build_dir = True
 abs_path_compilers = True   # Otherwise some KIM-API magic breaks cmake.


### PR DESCRIPTION
There are Fortran .mod files in kim-api, so we should move it (see https://github.com/easybuilders/easybuild-framework/pull/4389)