### PR TITLE
include MPFR 4.1.0 patch in MPFR 4.2.0 easyconfigs to fix failing tsprintf test with glibc >= 2.37

### DIFF
--- a/easybuild/easyconfigs/m/MPFR/MPFR-4.2.0-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/m/MPFR/MPFR-4.2.0-GCCcore-12.2.0.eb
@@ -14,7 +14,11 @@ toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 
 source_urls = ['https://www.mpfr.org/mpfr-%(version)s/']
 sources = [SOURCELOWER_TAR_BZ2]
-checksums = ['691db39178e36fc460c046591e4b0f2a52c8f2b3ee6d750cc2eab25f1eaa999d']
+patches = ['MPFR-4.1.0_patch-fix-tsprintf-test.patch']
+checksums = [
+    {'mpfr-4.2.0.tar.bz2': '691db39178e36fc460c046591e4b0f2a52c8f2b3ee6d750cc2eab25f1eaa999d'},
+    {'MPFR-4.1.0_patch-fix-tsprintf-test.patch': '039fad7a79ec4a9fd9ce77c9a73d9278187b8430087bc1afec18883df40321ae'},
+]
 
 builddependencies = [
     ('binutils', '2.39'),

--- a/easybuild/easyconfigs/m/MPFR/MPFR-4.2.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/m/MPFR/MPFR-4.2.0-GCCcore-12.3.0.eb
@@ -14,7 +14,11 @@ toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 
 source_urls = ['https://www.mpfr.org/mpfr-%(version)s/']
 sources = [SOURCELOWER_TAR_BZ2]
-checksums = ['691db39178e36fc460c046591e4b0f2a52c8f2b3ee6d750cc2eab25f1eaa999d']
+patches = ['MPFR-4.1.0_patch-fix-tsprintf-test.patch']
+checksums = [
+    {'mpfr-4.2.0.tar.bz2': '691db39178e36fc460c046591e4b0f2a52c8f2b3ee6d750cc2eab25f1eaa999d'},
+    {'MPFR-4.1.0_patch-fix-tsprintf-test.patch': '039fad7a79ec4a9fd9ce77c9a73d9278187b8430087bc1afec18883df40321ae'},
+]
 
 builddependencies = [
     ('binutils', '2.40'),


### PR DESCRIPTION
This patch was originally added to MPFR 4.1.0 easyconfigs (in https://github.com/easybuilders/easybuild-easyconfigs/pull/18746), but was removed in version 4.2.0. However, we are still seeing failures for the `tsprintf` test in the EESSI environment (glibc 2.37) for version 4.2.0. 

I was just reading the MPFR changelog and this page is really confusing; the page for 4.2.1 (https://www.mpfr.org/mpfr-4.2.1/#changes) refers to the changelog page of 4.2.0 (https://www.mpfr.org/mpfr-4.2.0/#fixed), and the latter does seem to suggest that the bug has been solved (first item in the list). However, the code does not confirm this:

4.1.0 -> https://gitlab.inria.fr/mpfr/mpfr/-/blob/4.1.0/tests/tsprintf.c?ref_type=tags#L1653
4.2.0 -> https://gitlab.inria.fr/mpfr/mpfr/-/blob/4.2.0/tests/tsprintf.c?ref_type=tags#L1717
4.2.1 -> https://gitlab.inria.fr/mpfr/mpfr/-/blob/4.2.1/tests/tsprintf.c?ref_type=tags#L1775

So, it looks like it's only fixed in 4.2.1. Also the source tarballs confirm this. Hence, I'm applying the 4.1.0 patch to the 4.2.0 easyconfigs as well.