### PR TITLE
{bio}[foss/2022a] GROMACS v2023.3 w/ AdaptiveCpp 23.10.0 ROCm 5.6.0

### DIFF
--- a/easybuild/easyconfigs/a/AdaptiveCpp/AdaptiveCpp-23.10.0-GCC-11.3.0-ROCm-5.6.0.eb
+++ b/easybuild/easyconfigs/a/AdaptiveCpp/AdaptiveCpp-23.10.0-GCC-11.3.0-ROCm-5.6.0.eb
@@ -1,0 +1,88 @@
+easyblock = 'CMakeMake'
+
+name = 'AdaptiveCpp'
+version = '23.10.0'
+local_rocmver = '5.6.0'
+versionsuffix = '-ROCm-%s' % local_rocmver
+
+homepage = 'https://adaptivecpp.github.io/'
+
+whatis = [
+    "Description: AdaptiveCpp is the independent, community-driven modern platform for C++-based heterogeneous programming models targeting CPUs and GPUs from all major vendors. AdaptiveCpp lets applications adapt themselves to all the hardware found in the system. This includes use cases where a single binary needs to be able to target all supported hardware, or utilize hardware from different vendors simultaneously."
+]
+
+description = """
+AdaptiveCpp is the independent, community-driven modern platform for C++-based heterogeneous programming models targeting CPUs and GPUs from all major vendors. AdaptiveCpp lets applications adapt themselves to all the hardware found in the system. This includes use cases where a single binary needs to be able to target all supported hardware, or utilize hardware from different vendors simultaneously.
+
+This module (only) provides support for AMD GPUs with HIP/ROCm.
+"""
+
+toolchain = {'name': 'GCC', 'version': '11.3.0'}
+toolchainopts = {'verbose': False, 'openmp': True}
+
+source_urls = ["https://github.com/AdaptiveCpp/AdaptiveCpp/archive/tags/"]
+sources = ["v%(version)s.tar.gz"]
+
+dependencies = [
+    ('Boost', '1.79.0'),
+    ('Python', '3.10.4'),
+    ('HIP', local_rocmver, '-amd'),
+]
+
+builddependencies = [
+    ('CMake', '3.23.1'),
+]
+
+local_gpuarch = 'gfx908'  # MI100
+
+configopts = '-DROCM_PATH="${ROCM_PATH}" '
+configopts += '-DCMAKE_C_COMPILER="${EBROOTCLANGMINAOMP}/bin/clang" '
+configopts += '-DCMAKE_CXX_COMPILER="${EBROOTCLANGMINAOMP}/bin/clang++" '
+configopts += '-DLLVM_INCLUDE_DIRS="${EBROOTCLANGMINAOMP}/include/llvm" '
+configopts += '-DLLVM_DIR="${EBROOTCLANGMINAOMP}/lib/cmake/llvm/" '
+configopts += '-DCLANG_EXECUTABLE_PATH="${EBROOTCLANGMINAOMP}/bin/clang++" '
+configopts += '-DCLANG_INCLUDE_PATH="${EBROOTCLANGMINAOMP}/lib/clang/16.0.0" '
+configopts += '-DWITH_ACCELERATED_CPU=ON '
+configopts += '-DWITH_CPU_BACKEND=ON '
+configopts += '-DWITH_CUDA_BACKEND=OFF '
+configopts += '-DWITH_ROCM_BACKEND=ON '
+configopts += '-DWITH_OPENCL_BACKEND=OFF '
+configopts += '-DWITH_LEVEL_ZERO_BACKEND=OFF '
+configopts += '-DDEFAULT_GPU_ARCH="%s" ' % local_gpuarch
+configopts += '-DAMDGPU_TARGETS="%s" ' % local_gpuarch
+configopts += '-DGPU_TARGETS="%s" ' % local_gpuarch
+configopts += '-DWITH_SSCP_COMPILER=OFF '
+# Additional option needed due to CMake-related bug in 23.10.0 release
+# https://github.com/AdaptiveCpp/AdaptiveCpp/issues/1268
+configopts += '-DACPP_VERSION_SUFFIX="-" '
+
+sanity_check_paths = {
+    'files': ['bin/syclcc-clang',
+              'include/AdaptiveCpp/sycl/sycl.hpp',
+              'lib/hipSYCL/librt-backend-omp.%s' % SHLIB_EXT,
+              'lib/hipSYCL/librt-backend-hip.%s' % SHLIB_EXT,
+              'lib/libacpp-clang.%s' % SHLIB_EXT,
+              'lib/libacpp-rt.%s' % SHLIB_EXT],
+    'dirs': ['include/AdaptiveCpp/CL',
+             'include/AdaptiveCpp/hipSYCL',
+             'include/AdaptiveCpp/SYCL'],
+}
+sanity_check_commands = [
+    'acpp --help',
+    'acpp-info',
+    'syclcc --help',
+]
+
+modluafooter = """
+setenv('HIPSYCL_PATH', os.getenv('EBROOTADAPTIVECPP'))
+setenv('HIPSYCL_ROCM_PATH', os.getenv('EBROOTCLANGMINAOMP'))
+setenv('HIPSYCL_TARGETS', 'hip:%s')
+""" % local_gpuarch
+
+modtclfooter = """
+setenv HIPSYCL_PATH $::env(EBROOTADAPTIVECPP)
+setenv HIPSYCL_ROCM_PATH $::env(EBROOTCLANGMINAOMP)
+setenv HIPSYCL_TARGETS hip:%s
+""" % local_gpuarch
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2023.3-foss-2022a-ROCm-5.6.0.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2023.3-foss-2022a-ROCm-5.6.0.eb
@@ -1,0 +1,81 @@
+name = 'GROMACS'
+version = '2023.3'
+local_rocmver = '5.6.0'
+versionsuffix = '-ROCm-%s' % local_rocmver
+
+homepage = 'https://www.gromacs.org'
+description = """
+GROMACS is a versatile package to perform molecular dynamics, i.e. simulate the
+Newtonian equations of motion for systems with hundreds to millions of
+particles.
+
+This is a GPU enabled build, containing both MPI and threadMPI binaries.
+
+It also contains the gmxapi extension for the single precision MPI build.
+"""
+
+toolchain = {'name': 'foss', 'version': '2022a'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = [
+    'https://ftp.gromacs.org/pub/gromacs/',
+    'ftp://ftp.gromacs.org/pub/gromacs/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'GROMACS-2023.1_set_omp_num_threads_env_for_ntomp_tests.patch',
+    'GROMACS-2023.1_fix_tests_for_gmx_thread_mpi.patch',
+]
+checksums = [
+    {'gromacs-2023.3.tar.gz': '4ec8f8d0c7af76b13f8fd16db8e2c120e749de439ae9554d9f653f812d78d1cb'},
+    {'GROMACS-2023.1_set_omp_num_threads_env_for_ntomp_tests.patch':
+     '7f41bda16c9c2837624265dda4be252f655d1288ddc4486b1a2422af30d5d199'},
+    {'GROMACS-2023.1_fix_tests_for_gmx_thread_mpi.patch':
+     '6df844bb3bbc51180446a3595c61a4ef195e5f975533a04cef76841aa763aec1'},
+]
+
+builddependencies = [
+    ('CMake', '3.24.3'),
+    ('scikit-build', '0.15.0'),
+    ('AdaptiveCpp', '23.10.0', versionsuffix, ('GCC', '11.3.0')),
+]
+
+dependencies = [
+    ('ROCm', local_rocmver, '', ('GCCcore', '11.3.0')),
+    ('UCX-ROCm', '1.14.1', versionsuffix, ('GCCcore', '11.3.0')),
+    ('Python', '3.10.4'),
+    ('SciPy-bundle', '2022.05'),
+    ('networkx', '2.8.4'),
+    # The GROMACS build finds and uses the Boost module required by AdaptiveCpp
+    # and as a result we also need Boost as a GROMACS runtime dependency
+    ('Boost', '1.79.0'),
+]
+
+exts_defaultclass = 'PythonPackage'
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True,
+    'download_dep_fail': True,
+    'sanity_pip_check': True,
+}
+
+exts_list = [
+    ('gmxapi', '0.4.2', {
+        'preinstallopts': 'export CMAKE_ARGS="-Dgmxapi_ROOT=%(installdir)s ' +
+                          '-C %(installdir)s/share/cmake/gromacs_mpi/gromacs-hints_mpi.cmake" && ',
+        'source_tmpl': 'gromacs-2023.3.tar.gz',
+        'start_dir': 'python_packaging/gmxapi',
+        'checksums': ['4ec8f8d0c7af76b13f8fd16db8e2c120e749de439ae9554d9f653f812d78d1cb'],
+    }),
+]
+
+# Use the same C and C++ compilers for which the AdaptiveCpp module has been configured
+configopts = '-DCMAKE_C_COMPILER="${EBROOTCLANGMINAOMP}/bin/clang" '
+configopts += '-DCMAKE_CXX_COMPILER="${EBROOTCLANGMINAOMP}/bin/clang++" '
+
+modextrapaths = {
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/u/UCX-ROCm/UCX-ROCm-1.10.0_fix_rocm_component_detection.patch
+++ b/easybuild/easyconfigs/u/UCX-ROCm/UCX-ROCm-1.10.0_fix_rocm_component_detection.patch
@@ -1,0 +1,24 @@
+The original build setup assumes that all ROCm components can be found
+in the location given by the --with-rocm=... configure option.
+But in EB the required components are split between Clang-AOMP and HIP.
+This patch inserts those two locations in the corresponding M4 script.
+
+Maxime Van den Bossche
+--- config/m4/rocm.m4.orig      2024-01-12 13:51:45.096182724 +0100
++++ config/m4/rocm.m4   2024-01-12 13:55:21.435617990 +0100
+@@ -60,6 +60,7 @@
+ rocm_happy=no
+ hip_happy=no
+ AS_IF([test "x$with_rocm" != "xno"],
++    with_rocm=$EBROOTCLANGMINAOMP
+     [AS_CASE(["x$with_rocm"],
+         [x|xguess|xyes],
+             [AC_MSG_NOTICE([ROCm path was not specified. Guessing ...])
+@@ -102,6 +103,7 @@
+     LDFLAGS="$SAVE_LDFLAGS"
+     LIBS="$SAVE_LIBS"
+
++    with_rocm=$EBROOTHIP
+     HIP_BUILD_FLAGS([$with_rocm], [HIP_LIBS], [HIP_LDFLAGS], [HIP_CPPFLAGS])
+
+     CPPFLAGS="$HIP_CPPFLAGS $CPPFLAGS"

--- a/easybuild/easyconfigs/u/UCX-ROCm/UCX-ROCm-1.14.1-GCCcore-11.3.0-ROCm-5.6.0.eb
+++ b/easybuild/easyconfigs/u/UCX-ROCm/UCX-ROCm-1.14.1-GCCcore-11.3.0-ROCm-5.6.0.eb
@@ -1,0 +1,46 @@
+easyblock = 'EB_UCX_Plugins'
+
+name = 'UCX-ROCm'
+version = '1.14.1'
+_rocm_version = '5.6.0'
+versionsuffix = '-ROCm-%s' % _rocm_version
+
+homepage = 'http://www.openucx.org/'
+description = """Unified Communication X
+An open-source production grade communication framework for data centric
+and high-performance applications
+
+This module adds the UCX ROCm support.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
+sources = [{'filename': 'ucx-%(version)s.tar.gz', 'alt_location': 'UCX'}]
+patches = [
+    {'name': 'UCX-CUDA-1.11.0_link_against_existing_UCX_libs.patch',
+     'alt_location': 'UCX-CUDA'},
+    'UCX-ROCm-1.10.0_fix_rocm_component_detection.patch',
+]
+checksums = [
+    {'ucx-1.14.1.tar.gz': 'baa0634cafb269a3112f626eb226bcd2ca8c9fcf0fec3b8e2a3553baad5f77aa'},
+    {'UCX-CUDA-1.11.0_link_against_existing_UCX_libs.patch':
+     '457187fa020e526609ba91e7750c9941d57bd57d60d6eed317b40ad8824aca93'},
+    {'UCX-ROCm-1.10.0_fix_rocm_component_detection.patch':
+     '5805edd07a3dd2fc79d6a2b5aa4f66654a995b6bd7865ff8a50119b2b2cb2419'},
+]
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('Autotools', '20220317'),
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('zlib', '1.2.12'),
+    ('UCX', version),
+    ('ROCm',  _rocm_version),
+]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/u/UCX/UCX-1.14.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.14.1-GCCcore-11.3.0.eb
@@ -1,0 +1,52 @@
+easyblock = 'ConfigureMake'
+
+name = 'UCX'
+version = '1.14.1'
+
+homepage = 'https://www.openucx.org/'
+description = """Unified Communication X
+An open-source production grade communication framework for data centric
+and high-performance applications
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
+sources = ['%(namelower)s-%(version)s.tar.gz']
+patches = [
+    'UCX-1.13.1-dynamic_modules.patch',
+]
+checksums = [
+    {'ucx-1.14.1.tar.gz': 'baa0634cafb269a3112f626eb226bcd2ca8c9fcf0fec3b8e2a3553baad5f77aa'},
+    {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
+]
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('Autotools', '20220317'),
+    ('pkgconf', '1.8.0'),
+]
+
+osdependencies = [OS_PKG_IBVERBS_DEV]
+
+dependencies = [
+    ('zlib', '1.2.12'),
+    ('numactl', '2.0.14'),
+]
+
+configure_cmd = "contrib/configure-release"
+
+configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
+configopts += '--without-java --without-go --disable-doxygen-doc '
+
+buildopts = 'V=1'
+
+sanity_check_paths = {
+    'files': ['bin/ucx_info', 'bin/ucx_perftest', 'bin/ucx_read_profile'],
+    'dirs': ['include', 'lib', 'share']
+}
+
+sanity_check_commands = ["ucx_info -d"]
+
+moduleclass = 'lib'


### PR DESCRIPTION
This adds easyconfigs for GROMACS v2023.3 with support for AMD GPUs via the SYCL backend (in the implementation provided by AdaptiveCpp). I went for a quite recent UCX version because the standard one for 2022a (v1.12.1) resulted in segfaults in GROMACS runs in "libMPI" mode using multiple GPUs.

Note: I just called it `GROMACS-2023.3-foss-2022a-ROCm-5.6.0.eb` because using AdaptiveCpp's SYCL implementation would be the regular way of building GROMACS for AMD GPUs (AMD provies a HIP port but that version is not officially supported). But please tell if you judge that e.g.  `GROMACS-2023.3-foss-2022a-ROCm-5.6.0-AdaptiveCpp-23.10.0.eb` would be more appropriate.

I've tested this on the arcturus partition on Vaughan (with MI100 GPUs) and got quite decent single-GPU performance on the `stmv` benchmark (~80% of the speed of AMD's HIP port of GROMACS). Using multiple GPUs for that benchmark brings less benefit than expected, but this is presumably related to the [incomplete support for direct GPU-GPU communication](https://gitlab.com/gromacs/gromacs/-/issues/4372) in the SYCL backend of GROMACS.

Depends on:

- https://github.com/easybuilders/easybuild-easyblocks/pull/3077
- https://github.com/easybuilders/easybuild-easyconfigs/pull/19591 (and all its dependencies, of course :)