### PR TITLE
demote meson-python to a build dep in matplotlib

### DIFF
--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-3.7.2-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-3.7.2-gfbf-2023a.eb
@@ -13,6 +13,7 @@ toolchain = {'name': 'gfbf', 'version': '2023a'}
 builddependencies = [
     ('pkgconf', '1.9.5'),
     ('cppy', '1.2.1'),
+    ('meson-python', '0.13.2'),
 ]
 
 dependencies = [
@@ -23,7 +24,6 @@ dependencies = [
     ('Tkinter', '%(pyver)s'),
     ('Pillow', '10.0.0'),
     ('Qhull', '2020.2'),
-    ('meson-python', '0.13.2'),
 ]
 
 use_pip = True

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-3.8.2-gfbf-2023b.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-3.8.2-gfbf-2023b.eb
@@ -13,6 +13,7 @@ toolchain = {'name': 'gfbf', 'version': '2023b'}
 builddependencies = [
     ('pkgconf', '2.0.3'),
     ('cppy', '1.2.1'),
+    ('meson-python', '0.15.0'),
 ]
 
 dependencies = [
@@ -23,7 +24,6 @@ dependencies = [
     ('Tkinter', '%(pyver)s'),
     ('Pillow', '10.2.0'),
     ('Qhull', '2020.2'),
-    ('meson-python', '0.15.0'),
 ]
 
 use_pip = True


### PR DESCRIPTION
`meson(-python)` is not a runtime requirement for `maplotlib`

(created using `eb --new-pr`)
