### PR TITLE
strip iconv from pkgconfig file for libarchive v3.6.2

### DIFF
--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.6.2-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.6.2-GCCcore-12.3.0.eb
@@ -25,6 +25,8 @@ dependencies = [
     ('OpenSSL', '1.1', '', SYSTEM),
 ]
 
+postinstallcmds = ["sed -i 's/iconv//g' %(installdir)s/lib/pkgconfig/libarchive.pc"] 
+
 sanity_check_paths = {
     'files': ['include/archive.h', 'lib/libarchive.%s' % SHLIB_EXT],
     'dirs': ['bin', 'share/man/man3'],

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.6.2-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.6.2-GCCcore-12.3.0.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('OpenSSL', '1.1', '', SYSTEM),
 ]
 
-postinstallcmds = ["sed -i 's/iconv//g' %(installdir)s/lib/pkgconfig/libarchive.pc"] 
+postinstallcmds = ["sed -i 's/iconv//g' %(installdir)s/lib/pkgconfig/libarchive.pc"]
 
 sanity_check_paths = {
     'files': ['include/archive.h', 'lib/libarchive.%s' % SHLIB_EXT],


### PR DESCRIPTION
we're not building `libarchive` with `libiconv` as a dependency, and it's not hard required. However, the `libarchive.pc` file has an `iconv` entry, causing software picking up `libarchive` via `pkg{conf,-config}`  to error. Building with `libiconv` doesn't even fix this, since `libiconv` installs no `libiconv.pc` file 


(created using `eb --new-pr`)
