### PR TITLE
explicitly specify Fortran compiler for recent CDO versions to fix issues on non-x86_64 architectures

### DIFF
--- a/easybuild/easyconfigs/c/CDO/CDO-2.0.5-gompi-2021b.eb
+++ b/easybuild/easyconfigs/c/CDO/CDO-2.0.5-gompi-2021b.eb
@@ -42,6 +42,9 @@ configopts += "--with-curl=$EBROOTCURL --with-eccodes=$EBROOTECCODES --with-fftw
 configopts += "--with-netcdf=$EBROOTNETCDF --with-proj=$EBROOTPROJ --with-szlib=$EBROOTSZIP "
 configopts += "--with-udunits2=$EBROOTUDUNITS --with-util-linux-uuid=$EBROOTUTILMINLINUX "
 
+# Make sure that right Fortran compiler is used, also on non-x86_64 architectures
+configopts += 'CPPFLAGS="$CPPFLAGS -DgFortran" '
+
 sanity_check_paths = {
     'files': ['bin/cdo', 'lib/libcdi.a', 'lib/libcdi.%s' % SHLIB_EXT],
     'dirs': ['include'],

--- a/easybuild/easyconfigs/c/CDO/CDO-2.0.6-gompi-2022a.eb
+++ b/easybuild/easyconfigs/c/CDO/CDO-2.0.6-gompi-2022a.eb
@@ -43,6 +43,9 @@ configopts += "--with-curl=$EBROOTCURL --with-eccodes=$EBROOTECCODES --with-fftw
 configopts += "--with-netcdf=$EBROOTNETCDF --with-proj=$EBROOTPROJ --with-szlib=$EBROOTSZIP "
 configopts += "--with-udunits2=$EBROOTUDUNITS --with-util-linux-uuid=$EBROOTUTILMINLINUX "
 
+# Make sure that right Fortran compiler is used, also on non-x86_64 architectures
+configopts += 'CPPFLAGS="$CPPFLAGS -DgFortran" '
+
 sanity_check_paths = {
     'files': ['bin/cdo', 'lib/libcdi.a', 'lib/libcdi.%s' % SHLIB_EXT],
     'dirs': ['include'],

--- a/easybuild/easyconfigs/c/CDO/CDO-2.1.1-gompi-2021a.eb
+++ b/easybuild/easyconfigs/c/CDO/CDO-2.1.1-gompi-2021a.eb
@@ -43,6 +43,9 @@ configopts += "--with-curl=$EBROOTCURL --with-eccodes=$EBROOTECCODES --with-fftw
 configopts += "--with-netcdf=$EBROOTNETCDF --with-proj=$EBROOTPROJ --with-szlib=$EBROOTSZIP "
 configopts += "--with-udunits2=$EBROOTUDUNITS --with-util-linux-uuid=$EBROOTUTILMINLINUX "
 
+# Make sure that right Fortran compiler is used, also on non-x86_64 architectures
+configopts += 'CPPFLAGS="$CPPFLAGS -DgFortran" '
+
 sanity_check_paths = {
     'files': ['bin/cdo', 'lib/libcdi.a', 'lib/libcdi.%s' % SHLIB_EXT],
     'dirs': ['include'],

--- a/easybuild/easyconfigs/c/CDO/CDO-2.2.2-gompi-2023a.eb
+++ b/easybuild/easyconfigs/c/CDO/CDO-2.2.2-gompi-2023a.eb
@@ -43,6 +43,9 @@ configopts += "--with-curl=$EBROOTCURL --with-eccodes=$EBROOTECCODES --with-fftw
 configopts += "--with-netcdf=$EBROOTNETCDF --with-proj=$EBROOTPROJ --with-szlib=$EBROOTSZIP "
 configopts += "--with-udunits2=$EBROOTUDUNITS --with-util-linux-uuid=$EBROOTUTILMINLINUX "
 
+# Make sure that right Fortran compiler is used, also on non-x86_64 architectures
+configopts += 'CPPFLAGS="$CPPFLAGS -DgFortran" '
+
 sanity_check_paths = {
     'files': ['bin/cdo', 'lib/libcdi.a', 'lib/libcdi.%s' % SHLIB_EXT],
     'dirs': ['include'],


### PR DESCRIPTION
For EESSI we ran into an issue when building `CDO` on Arm CPUs (also see https://github.com/EESSI/software-layer/pull/427#issuecomment-1910422096):

```
cfortran.h:193:2: warning: #warning "Please specify the fortran compiler using -D flags. Try to guess the compiler used" [-Wcpp]
  193 | #warning "Please specify the fortran compiler using -D flags. Try to guess the compiler used"
      |  ^~~~~~~
cfortran.h:265:2: error: #error "cfortran.h:  Can't find your environment among:    - GNU gcc (gfortran) on Linux.                                           - MIPS cc and f7
7 2.0. (e.g. Silicon Graphics, DECstations, ...)         - IBM AIX XL C and FORTRAN Compiler/6000 Version 01.01.0000.0000         - VAX   VMS CC 3.1 and FORTRAN 5.4.        
                              - Alpha VMS DEC C 1.3 and DEC FORTRAN 6.0.                               - Alpha OSF DEC C and DEC Fortran for OSF/1 AXP Version 1.2           
   - Apollo DomainOS 10.2 (sys5.3) with f77 10.7 and cc 6.7.                - CRAY                                                                   - NEC SX-4 SUPER-UX     
                                                 - CONVEX                                                                 - Sun                                              
                      - PowerStation Fortran with Visual C++                                   - HP9000s300/s700/s800 Latest test with: HP-UX A.08.07 A 9000/730        - Lyn
xOS: cc or gcc with f2c.                                            - VAXUltrix: vcc,cc or gcc with f2c. gcc or cc with f77.                 -            f77 with vcc works;
 but missing link magic for f77 I/O.     -            NO fort. None of gcc, cc or vcc generate required names.    - f2c/g77:   Use #define    f2cFortran, or cc -Df2cFortran 
              - gfortran:  Use #define    gFortran,   or cc -DgFortran                              (also necessary for g77 with -fno-f2c option)               - NAG f90: Us
e #define NAGf90Fortran, or cc -DNAGf90Fortran              - Absoft UNIX F77: Use #define AbsoftUNIXFortran or cc -DAbsoftUNIXFortran     - Absoft Pro Fortran: Use #define 
AbsoftProFortran     - Portland Group Fortran: Use #define pgiFortran     - Intel Fortran: Use #define INTEL_COMPILER"
  265 | #error "cfortran.h:  Can't find your environment among:\
      |  ^~~~~
```

CDO's `configure` script does have some logic that sets `-DgFortran` on `x86_64` Linux systems, but it doesn't do this for `aarch64`. This PR explicitly adds this flag to `$CPPFLAGS` for recent CDO versions, which resolves the issue.