### PR TITLE
remove `easybuild_version = '3.5.0'` from R easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2023.12-foss-2023a.eb
+++ b/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2023.12-foss-2023a.eb
@@ -43,10 +43,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_defaultclass = 'RPackage'
 
 exts_default_options = {

--- a/easybuild/easyconfigs/r/R/R-3.6.3-foss-2020a.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.3-foss-2020a.eb
@@ -55,10 +55,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive

--- a/easybuild/easyconfigs/r/R/R-4.0.0-foss-2020a.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.0-foss-2020a.eb
@@ -61,10 +61,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive

--- a/easybuild/easyconfigs/r/R/R-4.0.0-fosscuda-2020a.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.0-fosscuda-2020a.eb
@@ -71,10 +71,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive

--- a/easybuild/easyconfigs/r/R/R-4.0.3-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.3-foss-2020b.eb
@@ -58,10 +58,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive

--- a/easybuild/easyconfigs/r/R/R-4.0.3-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.3-fosscuda-2020b.eb
@@ -67,10 +67,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive

--- a/easybuild/easyconfigs/r/R/R-4.0.4-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.4-foss-2020b.eb
@@ -65,10 +65,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive

--- a/easybuild/easyconfigs/r/R/R-4.0.4-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.4-fosscuda-2020b.eb
@@ -69,10 +69,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive

--- a/easybuild/easyconfigs/r/R/R-4.0.5-foss-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.5-foss-2020b.eb
@@ -62,10 +62,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive

--- a/easybuild/easyconfigs/r/R/R-4.0.5-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.0.5-fosscuda-2020b.eb
@@ -72,10 +72,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive

--- a/easybuild/easyconfigs/r/R/R-4.1.0-foss-2021a.eb
+++ b/easybuild/easyconfigs/r/R/R-4.1.0-foss-2021a.eb
@@ -63,10 +63,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive

--- a/easybuild/easyconfigs/r/R/R-4.1.2-foss-2021b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.1.2-foss-2021b.eb
@@ -64,10 +64,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive

--- a/easybuild/easyconfigs/r/R/R-4.2.0-foss-2021b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.2.0-foss-2021b.eb
@@ -65,10 +65,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive

--- a/easybuild/easyconfigs/r/R/R-4.2.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/r/R/R-4.2.1-foss-2022a.eb
@@ -64,10 +64,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive

--- a/easybuild/easyconfigs/r/R/R-4.2.2-foss-2022b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.2.2-foss-2022b.eb
@@ -62,10 +62,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive

--- a/easybuild/easyconfigs/r/R/R-4.3.2-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/r/R/R-4.3.2-gfbf-2023a.eb
@@ -49,10 +49,6 @@ configopts = "--with-pic --enable-threads --enable-R-shlib"
 # we're installing them anyway below
 configopts += " --with-recommended-packages=no"
 
-# specify that at least EasyBuild v3.5.0 is required,
-# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
-easybuild_version = '3.5.0'
-
 exts_default_options = {
     'source_urls': [
         'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive


### PR DESCRIPTION
This removes
```
# specify that at least EasyBuild v3.5.0 is required,
# since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK
easybuild_version = '3.5.0'
```
from all not-archived R easyconfigs in the `5.0.x` branch. I cannot see that having this set serves any useful purpose in EasyBuild 5.