### PR TITLE
{bio}[GCC/10.3.0] Flye v2.9.3

### DIFF
--- a/easybuild/easyconfigs/f/Flye/Flye-2.9.3-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/f/Flye/Flye-2.9.3-GCC-10.3.0.eb
@@ -7,7 +7,7 @@ homepage = 'https://github.com/fenderglass/Flye'
 description = """Flye is a de novo assembler for long and noisy reads, such as those produced by PacBio
  and Oxford Nanopore Technologies."""
 
-toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
+toolchain = {'name': 'GCC', 'version': '10.3.0'}
 
 source_urls = ['https://github.com/fenderglass/Flye/archive/']
 sources = ['%(version)s.tar.gz']

--- a/easybuild/easyconfigs/f/Flye/Flye-2.9.3-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/f/Flye/Flye-2.9.3-GCCcore-10.3.0.eb
@@ -1,0 +1,33 @@
+easyblock = 'PythonPackage'
+
+name = 'Flye'
+version = '2.9.3'
+
+homepage = 'https://github.com/fenderglass/Flye'
+description = """Flye is a de novo assembler for long and noisy reads, such as those produced by PacBio
+ and Oxford Nanopore Technologies."""
+
+toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
+
+source_urls = ['https://github.com/fenderglass/Flye/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['09580390ed0558c131ca0b836a2374d3cc7993cba2a6500024c2ee1d96666edc']
+
+dependencies = [('Python', '3.9.5')]
+
+download_dep_fail = True
+use_pip = True
+
+if ARCH == "aarch64":
+    preinstallopts = 'export arm_neon=1 && export aarch64=1 && '
+
+sanity_check_paths = {
+    'files': ['bin/flye'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ['%(namelower)s --help']
+
+sanity_pip_check = True
+
+moduleclass = 'bio'


### PR DESCRIPTION
I am installing a deck of bioinformatics tools for a number of trainings, all under the 2021a toolchain. That's why this latest version of Flye is compiled with an older toolchain.