### PR TITLE
add `hidden=True` to `run_shell_cmd` use in testsuite

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -111,7 +111,7 @@ def get_files_from_diff(diff_filter, ext):
     # first determine the 'merge base' between target branch and PR branch
     # cfr. https://git-scm.com/docs/git-merge-base
     cmd = "git merge-base %s HEAD" % target_branch
-    res = run_shell_cmd(cmd, fail_on_error=False)
+    res = run_shell_cmd(cmd, fail_on_error=False, hidden=True)
     if res.exit_code == 0:
         merge_base = res.output.strip()
         print("Merge base for %s and HEAD: %s" % (target_branch, merge_base))
@@ -123,7 +123,7 @@ def get_files_from_diff(diff_filter, ext):
 
     # determine list of changed files using 'git diff' and merge base determined above
     cmd = "git diff --name-only --diff-filter=%s %s..HEAD --" % (diff_filter, merge_base)
-    res = run_shell_cmd(cmd)
+    res = run_shell_cmd(cmd, hidden=True)
     files = [os.path.join(top_dir, f) for f in res.output.strip().split('\n') if f.endswith(ext)]
 
     change_dir(cwd)


### PR DESCRIPTION
Currently we see the information for the [command we run](https://github.com/easybuilders/easybuild-easyconfigs/actions/runs/7947681784/job/21696808255?pr=19887#step:8:137) repeated several times.
```
   >> running command:
	[started at: 2024-02-18 08:25:30]
	[working dir: /home/runner/work/easybuild-easyconfigs/easybuild-easyconfigs]
	[output saved to /tmp/eb-ezpo529j/eb-6nea9o24/run-shell-cmd-output/git-wp5r1raf/out.txt]
	git merge-base 5.0.x HEAD
  >> command completed: exit 0, ran in < 1s
Merge base for 5.0.x and HEAD: f92b7bda2b783094292b158b2ac99ff248ac39c1
```

This change removes this, so the [output is much cleaner](https://github.com/easybuilders/easybuild-easyconfigs/actions/runs/7942197227/job/21685268172?pr=19886#step:8:137).


This is also closer to the existing output, see https://github.com/easybuilders/easybuild-easyconfigs/actions/runs/7945029976/job/21691174270?pr=19877 for example.