### PR TITLE
add `download_instructions` to WIEN2k easyconfigs

### DIFF
--- a/easybuild/easyconfigs/w/WIEN2k/WIEN2k-19.2-intel-2020b.eb
+++ b/easybuild/easyconfigs/w/WIEN2k/WIEN2k-19.2-intel-2020b.eb
@@ -19,6 +19,10 @@ dependencies = [
     ('libxc', '4.3.4'),
 ]
 
+download_instructions = """
+WIEN2k can be ordered at http://susi.theochem.tuwien.ac.at/index.html.
+"""
+
 osdependencies = [('glibc-static', 'libc6-dev')]  # required for libpthread.a
 
 remote = 'pbsssh'

--- a/easybuild/easyconfigs/w/WIEN2k/WIEN2k-21.1-intel-2021a.eb
+++ b/easybuild/easyconfigs/w/WIEN2k/WIEN2k-21.1-intel-2021a.eb
@@ -21,6 +21,10 @@ checksums = [
     'cdba467b0b6f2b310c2e1e2a3e6cabe75f8fd15ee0f7c14f8ef80c7e48073bdd',
 ]
 
+download_instructions = """
+WIEN2k can be ordered at http://susi.theochem.tuwien.ac.at/index.html.
+"""
+
 dependencies = [
     ('Python', '3.9.5'),
     ('Perl', '5.32.1'),


### PR DESCRIPTION
#19881

This copies over the instructions from the newer `WIEN2k` easyconfigs.