### PR TITLE
add `download_instructions` to PEAR easyconfigs

### DIFF
--- a/easybuild/easyconfigs/p/PEAR/PEAR-0.9.11-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/p/PEAR/PEAR-0.9.11-GCC-10.3.0.eb
@@ -9,8 +9,7 @@ description = """PEAR is an ultrafast, memory-efficient and highly accurate pair
 
 toolchain = {'name': 'GCC', 'version': '10.3.0'}
 
-# Needs manual download via web-form,
-# https://www.h-its.org/en/research/sco/software/#NextGenerationSequencingSequenceAnalysis
+download_instructions = "Manual download via web form, see https://www.h-its.org/software/pear-paired-end-read-merger"
 sources = ['%(namelower)s-src-%(version)s.tar.gz']
 checksums = ['94f4a1835cd75ec6fab83405c2545ddba6b6bb1644579222e9cc2ad57a59d654']
 

--- a/easybuild/easyconfigs/p/PEAR/PEAR-0.9.11-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/p/PEAR/PEAR-0.9.11-GCC-11.2.0.eb
@@ -9,8 +9,7 @@ description = """PEAR is an ultrafast, memory-efficient and highly accurate pair
 
 toolchain = {'name': 'GCC', 'version': '11.2.0'}
 
-# Needs manual download via web-form,
-# https://www.h-its.org/en/research/sco/software/#NextGenerationSequencingSequenceAnalysis
+download_instructions = "Manual download via web form, see https://www.h-its.org/software/pear-paired-end-read-merger"
 sources = ['%(namelower)s-src-%(version)s.tar.gz']
 checksums = ['94f4a1835cd75ec6fab83405c2545ddba6b6bb1644579222e9cc2ad57a59d654']
 

--- a/easybuild/easyconfigs/p/PEAR/PEAR-0.9.11-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/p/PEAR/PEAR-0.9.11-GCCcore-9.3.0.eb
@@ -9,8 +9,7 @@ description = """PEAR is an ultrafast, memory-efficient and highly accurate pair
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
-# Needs manual download via web-form,
-# https://www.h-its.org/en/research/sco/software/#NextGenerationSequencingSequenceAnalysis
+download_instructions = "Manual download via web form, see https://www.h-its.org/software/pear-paired-end-read-merger"
 sources = ['%(namelower)s-src-%(version)s.tar.gz']
 checksums = ['94f4a1835cd75ec6fab83405c2545ddba6b6bb1644579222e9cc2ad57a59d654']
 


### PR DESCRIPTION
for https://github.com/easybuilders/easybuild-easyconfigs/pull/19881

This copies in the instructions from the latest easyconfig (`PEAR-0.9.11-GCC-11.3.0.eb`) which uses a more direct link to the download page.