### PR TITLE
{lib}[gompi/2023b,iimpi/2023b] dlb v3.4

### DIFF
--- a/easybuild/easyconfigs/d/dlb/dlb-3.4-gompi-2023b.eb
+++ b/easybuild/easyconfigs/d/dlb/dlb-3.4-gompi-2023b.eb
@@ -1,0 +1,35 @@
+# vim: set syntax=python:
+easyblock = 'ConfigureMake'
+
+name = 'dlb'
+version = '3.4'
+
+description = """
+DLB is a dynamic library designed to speed up HPC hybrid applications (i.e.,
+two levels of parallelism) by improving the load balance of the outer level of
+parallelism (e.g., MPI) by dynamically redistributing the computational
+resources at the inner level of parallelism (e.g., OpenMP). at run time.
+"""
+homepage = 'https://pm.bsc.es/dlb/'
+docurls = ['https://pm.bsc.es/ftp/dlb/doc/user-guide/']
+
+toolchain = {'name': 'gompi', 'version': '2023b'}
+builddependencies = [('Python', '3.11.5', '', ('GCCcore', '13.2.0'))]
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://pm.bsc.es/ftp/dlb/releases']
+
+checksums = ['6091d032c11a094a3ce0bec11c0a164783fdff83cb4ec870c9d8e192410c353a']
+
+configopts = '--with-mpi'
+
+sanity_check_paths = {
+    'files': [
+        'bin/dlb',
+        'lib/libdlb.a', 'lib/libdlb.%s' % SHLIB_EXT,
+        'lib64/libdlb.%s' % SHLIB_EXT
+    ],
+    'dirs': ['include'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/d/dlb/dlb-3.4-gompi-2023b.eb
+++ b/easybuild/easyconfigs/d/dlb/dlb-3.4-gompi-2023b.eb
@@ -14,7 +14,7 @@ homepage = 'https://pm.bsc.es/dlb/'
 docurls = ['https://pm.bsc.es/ftp/dlb/doc/user-guide/']
 
 toolchain = {'name': 'gompi', 'version': '2023b'}
-builddependencies = [('Python', '3.11.5', '', ('GCCcore', '13.2.0'))]
+builddependencies = [('Python', '3.11.5')]
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['https://pm.bsc.es/ftp/dlb/releases']

--- a/easybuild/easyconfigs/d/dlb/dlb-3.4-iimpi-2023b.eb
+++ b/easybuild/easyconfigs/d/dlb/dlb-3.4-iimpi-2023b.eb
@@ -14,7 +14,7 @@ homepage = 'https://pm.bsc.es/dlb/'
 docurls = ['https://pm.bsc.es/ftp/dlb/doc/user-guide/']
 
 toolchain = {'name': 'iimpi', 'version': '2023b'}
-builddependencies = [('Python', '3.11.5', '', ('GCCcore', '13.2.0'))]
+builddependencies = [('Python', '3.11.5')]
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['https://pm.bsc.es/ftp/dlb/releases']

--- a/easybuild/easyconfigs/d/dlb/dlb-3.4-iimpi-2023b.eb
+++ b/easybuild/easyconfigs/d/dlb/dlb-3.4-iimpi-2023b.eb
@@ -1,0 +1,35 @@
+# vim: set syntax=python:
+easyblock = 'ConfigureMake'
+
+name = 'dlb'
+version = '3.4'
+
+description = """
+DLB is a dynamic library designed to speed up HPC hybrid applications (i.e.,
+two levels of parallelism) by improving the load balance of the outer level of
+parallelism (e.g., MPI) by dynamically redistributing the computational
+resources at the inner level of parallelism (e.g., OpenMP). at run time.
+"""
+homepage = 'https://pm.bsc.es/dlb/'
+docurls = ['https://pm.bsc.es/ftp/dlb/doc/user-guide/']
+
+toolchain = {'name': 'iimpi', 'version': '2023b'}
+builddependencies = [('Python', '3.11.5', '', ('GCCcore', '13.2.0'))]
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://pm.bsc.es/ftp/dlb/releases']
+
+checksums = ['6091d032c11a094a3ce0bec11c0a164783fdff83cb4ec870c9d8e192410c353a']
+
+configopts = '--with-mpi'
+
+sanity_check_paths = {
+    'files': [
+        'bin/dlb',
+        'lib/libdlb.a', 'lib/libdlb.%s' % SHLIB_EXT,
+        'lib64/libdlb.%s' % SHLIB_EXT
+    ],
+    'dirs': ['include'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
Add dlb version 3.4 for gompi and iimpi toolchains.

I have been suggested before to remove the toolchain from the Python dependency, but I have not been able to build it this time for some reason. Feel free to correct if there's a better way.
