### PR TITLE
replace SYSTEM-level GCC dependency in git-annex with binutils

### DIFF
--- a/easybuild/easyconfigs/g/GHC/GHC-9.2.2-x86_64.eb
+++ b/easybuild/easyconfigs/g/GHC/GHC-9.2.2-x86_64.eb
@@ -53,7 +53,7 @@ components = [
             '8c471fc2b1961a6e6e5981b7f7b3512e7fe58fcb04461aa4520157d4c1159998',
             '027f7bd5876b761b48db624ddbdd106fa1c535dfb2752ef5a0eddeb2a8896cfd',
         ],
-        'preconfigopts': "export CPPFLAGS='-P' && ",
+        'preconfigopts': 'export CPPFLAGS="-P" CXXFLAGS="$CXXFLAGS -std=c++14" && ',
         'configopts': ' --with-shared --enable-overwrite --with-termlib=tinfo',
     }),
     (name, version, {

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.2.0.eb
@@ -10,9 +10,10 @@ power and distributed nature of git to bear on your large files with git-annex."
 
 toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 
+builddependencies = [('binutils', '2.39')]
+
 dependencies = [
     ('GHC', '9.2.2', '-x86_64', SYSTEM),
-    ('GCC', '12.2.0', '', SYSTEM),
     ('Stack', '2.11.1', '-x86_64', SYSTEM),
     ('git', '2.38.1', '-nodocs'),
 ]


### PR DESCRIPTION
despite using the `GCCcore 12.2.0` toolchain, `git-annex-10.20230802-GCCcore-12.2.0.eb` currently has a runtime dependency on `('GCC', '12.2.0', '', SYSTEM)`

also adds `-std=c++14` to `CXXFLAGS` for the `ncurses` component, to let it build with newer system compilers

(created using `eb --new-pr`)
