### PR TITLE
use Python version of Z3 as dependency for Clang 16.0.6

### DIFF
--- a/easybuild/easyconfigs/c/Clang/Clang-16.0.6-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-16.0.6-GCCcore-12.3.0.eb
@@ -38,7 +38,7 @@ dependencies = [
     ('libxml2', '2.11.4'),
     ('ncurses', '6.4'),
     ('GMP', '6.2.1'),
-    ('Z3', '4.12.2'),
+    ('Z3', '4.12.2', '-Python-%(pyver)s'),
 ]
 
 # enabling RTTI makes the flang compiler need to link to libc++ so instead of


### PR DESCRIPTION
Without python version it fails to load either the Clang and PyTorch - has same version of Z3 but with python version.