### PR TITLE
add multiarch support for RISC-V to all GCCcore 12.x and 13.x easyconfigs

### DIFF
--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-12.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-12.1.0.eb
@@ -38,6 +38,7 @@ patches = [
     'GCCcore-12.1.0_fix-Wuninitialized-in-AVX-headers.patch',
     'GCCcore-12.2.0_fix-avx512-misoptimization.patch',
     'GCCcore-12.2.0_fix-vectorizer.patch',
+    'GCCcore-12.x_riscv_multiarch_support.patch',
 ]
 checksums = [
     {'gcc-12.1.0.tar.gz': 'e88a004a14697bbbaba311f38a938c716d9a652fd151aaaa4cf1b5b99b90e2de'},
@@ -57,6 +58,7 @@ checksums = [
     {'GCCcore-12.2.0_fix-avx512-misoptimization.patch':
      'bb3db707727b9975b0005346ef04230a96b3ad896f004a34262a82a244b5d436'},
     {'GCCcore-12.2.0_fix-vectorizer.patch': '0b76fc379308fd189ee39c4a3a49facacf8ede08dbec4280f289341083f1632b'},
+    {'GCCcore-12.x_riscv_multiarch_support.patch': '92fc2b17b6943611a657904500fbf3db8160eddbcea320828d4a50a885e2778f'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-12.2.0.eb
@@ -39,6 +39,7 @@ patches = [
     'GCCcore-12.2.0_fix-avx512-misoptimization.patch',
     'GCCcore-12.2.0_fix-vectorizer.patch',
     'GCCcore-12.2.0_improve-cuda-compatibility.patch',
+    'GCCcore-12.x_riscv_multiarch_support.patch',
 ]
 checksums = [
     {'gcc-12.2.0.tar.gz': 'ac6b317eb4d25444d87cf29c0d141dedc1323a1833ec9995211b13e1a851261c'},
@@ -60,6 +61,7 @@ checksums = [
     {'GCCcore-12.2.0_fix-vectorizer.patch': '0b76fc379308fd189ee39c4a3a49facacf8ede08dbec4280f289341083f1632b'},
     {'GCCcore-12.2.0_improve-cuda-compatibility.patch':
      '91d00122554b56381592229398540e63baa26d03633292a7fdf338407a4a62d5'},
+    {'GCCcore-12.x_riscv_multiarch_support.patch': '92fc2b17b6943611a657904500fbf3db8160eddbcea320828d4a50a885e2778f'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-12.3.0.eb
@@ -36,6 +36,7 @@ patches = [
     'GCCcore-12.1.0_fix-double-destruct.patch',
     'GCCcore-12.2.0_fix-avx512-misoptimization.patch',
     'GCCcore-12.2.0_improve-cuda-compatibility.patch',
+    'GCCcore-12.x_riscv_multiarch_support.patch',
 ]
 checksums = [
     {'gcc-12.3.0.tar.gz': '11275aa7bb34cd8ab101d01b341015499f8d9466342a2574ece93f954d92273b'},
@@ -52,6 +53,7 @@ checksums = [
      'bb3db707727b9975b0005346ef04230a96b3ad896f004a34262a82a244b5d436'},
     {'GCCcore-12.2.0_improve-cuda-compatibility.patch':
      '91d00122554b56381592229398540e63baa26d03633292a7fdf338407a4a62d5'},
+    {'GCCcore-12.x_riscv_multiarch_support.patch': '92fc2b17b6943611a657904500fbf3db8160eddbcea320828d4a50a885e2778f'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-12.x_riscv_multiarch_support.patch
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-12.x_riscv_multiarch_support.patch
@@ -1,0 +1,33 @@
+https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=47f95bc4be4eb14730ab3eaaaf8f6e71fda47690
+https://gcc.gnu.org/PR106271
+
+From 47f95bc4be4eb14730ab3eaaaf8f6e71fda47690 Mon Sep 17 00:00:00 2001
+From: Raphael Moreira Zinsly <rzinsly@ventanamicro.com>
+Date: Tue, 22 Aug 2023 11:37:04 -0600
+Subject: [PATCH] RISC-V: Add multiarch support on riscv-linux-gnu
+
+This adds multiarch support to the RISC-V port so that bootstraps work with
+Debian out-of-the-box.  Without this patch the stage1 compiler is unable to
+find headers/libraries when building the stage1 runtime.
+
+This is functionally (and possibly textually) equivalent to Debian's fix for
+the same problem.
+
+gcc/
+	* config/riscv/t-linux: Add MULTIARCH_DIRNAME.
+---
+ gcc/config/riscv/t-linux | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/gcc/config/riscv/t-linux b/gcc/config/riscv/t-linux
+index 216d2776a18..a6f64f88d25 100644
+--- a/gcc/config/riscv/t-linux
++++ b/gcc/config/riscv/t-linux
+@@ -1,3 +1,5 @@
+ # Only XLEN and ABI affect Linux multilib dir names, e.g. /lib32/ilp32d/
+ MULTILIB_DIRNAMES := $(patsubst rv32%,lib32,$(patsubst rv64%,lib64,$(MULTILIB_DIRNAMES)))
+ MULTILIB_OSDIRNAMES := $(patsubst lib%,../lib%,$(MULTILIB_DIRNAMES))
++
++MULTIARCH_DIRNAME := $(call if_multiarch,$(firstword $(subst -, ,$(target)))-linux-gnu)
+-- 
+2.39.3

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-13.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-13.1.0.eb
@@ -35,6 +35,7 @@ patches = [
     'GCCcore-9.3.0_gmp-c99.patch',
     'GCCcore-12.1.0_fix-double-destruct.patch',
     'GCCcore-12.2.0_fix-avx512-misoptimization.patch',
+    'GCCcore-12.x_riscv_multiarch_support.patch',
 ]
 checksums = [
     {'gcc-13.1.0.tar.gz': 'bacd4c614d8bd5983404585e53478d467a254249e0f1bb747c8bc6d787bd4fa2'},
@@ -49,6 +50,7 @@ checksums = [
     {'GCCcore-12.1.0_fix-double-destruct.patch': '2e09c125318b6c15ec60f1807d77fb7d1f32b64a4e5d1c9a3da89ba2ca738d35'},
     {'GCCcore-12.2.0_fix-avx512-misoptimization.patch':
      'bb3db707727b9975b0005346ef04230a96b3ad896f004a34262a82a244b5d436'},
+    {'GCCcore-12.x_riscv_multiarch_support.patch': '92fc2b17b6943611a657904500fbf3db8160eddbcea320828d4a50a885e2778f'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-13.2.0.eb
@@ -64,7 +64,9 @@ builddependencies = [
 languages = ['c', 'c++', 'fortran']
 
 withisl = True
-if ARCH != 'riscv64':
+if ARCH == 'riscv64':
+    withnvptx = False
+else:
     withnvptx = True
 
 # Perl is only required when building with NVPTX support

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-13.2.0.eb
@@ -36,6 +36,7 @@ patches = [
     'GCCcore-12.1.0_fix-double-destruct.patch',
     'GCCcore-12.2.0_fix-avx512-misoptimization.patch',
     'GCCcore-13.2.0_fix_slp_and_loop_mask_len.patch',
+    'GCCcore-12.x_riscv_multiarch_support.patch',
 ]
 checksums = [
     {'gcc-13.2.0.tar.gz': '8cb4be3796651976f94b9356fa08d833524f62420d6292c5033a9a26af315078'},
@@ -52,6 +53,7 @@ checksums = [
      'bb3db707727b9975b0005346ef04230a96b3ad896f004a34262a82a244b5d436'},
     {'GCCcore-13.2.0_fix_slp_and_loop_mask_len.patch':
      'e1d63e04bf494a2f79346ac7454372f117b63288cc18c68876a5b8bdc453cf88'},
+    {'GCCcore-12.x_riscv_multiarch_support.patch': '92fc2b17b6943611a657904500fbf3db8160eddbcea320828d4a50a885e2778f'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-13.2.0.eb
@@ -64,10 +64,7 @@ builddependencies = [
 languages = ['c', 'c++', 'fortran']
 
 withisl = True
-if ARCH == 'riscv64':
-    withnvptx = False
-else:
-    withnvptx = True
+withnvptx = True
 
 # Perl is only required when building with NVPTX support
 if withnvptx:

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-13.2.0.eb
@@ -64,7 +64,8 @@ builddependencies = [
 languages = ['c', 'c++', 'fortran']
 
 withisl = True
-withnvptx = True
+if ARCH != 'riscv64':
+    withnvptx = True
 
 # Perl is only required when building with NVPTX support
 if withnvptx:


### PR DESCRIPTION
This fixes an issue where building GCC on RISC-V will fail due to:
```
/usr/include/stdio.h:27:10: fatal error: bits/libc-header-start.h: No such file or directory
   27 | #include <bits/libc-header-start.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106271 and https://bugs.gentoo.org/890636.

Also depends on https://github.com/easybuilders/easybuild-easyblocks/pull/3256.