### PR TITLE
add `pixman` and `FriBidi` dependencies to recent ImageMagick easyconfigs

### DIFF
--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.11-14-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.0.11-14-GCCcore-10.3.0.eb
@@ -25,6 +25,8 @@ dependencies = [
     ('LibTIFF', '4.2.0'),
     ('LittleCMS', '2.12'),
     ('Pango', '1.48.5'),
+    ('pixman', 0.40.0'),
+    ('FriBidi', '1.0.10'),
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.1.0-37-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.1.0-37-GCCcore-11.3.0.eb
@@ -21,6 +21,8 @@ dependencies = [
     ('LibTIFF', '4.3.0'),
     ('LittleCMS', '2.13.1'),
     ('Pango', '1.50.7'),
+    ('pixman', '0.40.0'),
+    ('FriBidi', '1.0.12'),
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.1.0-4-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.1.0-4-GCCcore-11.2.0.eb
@@ -21,6 +21,8 @@ dependencies = [
     ('LibTIFF', '4.3.0'),
     ('LittleCMS', '2.12'),
     ('Pango', '1.48.8'),
+    ('pixman', '0.40.0'),
+    ('FriBidi', '1.0.10'),
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.1.0-53-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.1.0-53-GCCcore-12.2.0.eb
@@ -21,6 +21,8 @@ dependencies = [
     ('LibTIFF', '4.4.0'),
     ('LittleCMS', '2.14'),
     ('Pango', '1.50.12'),
+    ('pixman', '0.42.2'),
+    ('FriBidi', '1.0.12'),
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.1.1-15-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-7.1.1-15-GCCcore-12.3.0.eb
@@ -25,6 +25,8 @@ dependencies = [
     ('LibTIFF', '4.5.0'),
     ('LittleCMS', '2.15'),
     ('Pango', '1.50.14'),
+    ('pixman', '0.42.2'),
+    ('FriBidi', '1.0.12'),
 ]
 
 configopts = "--with-gslib --with-x"


### PR DESCRIPTION
In EESSI we're seeing these errors when building `ImageMagick`:
```
/cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/usr/bin/ld: warning: libfribidi.so.0, needed by /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/software/Pango/1.50.14-GCCcore-12.3.0/lib64/libpango-1.0.so, not found (try using -rpath or -rpath-link)
/cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/usr/bin/ld: warning: libpixman-1.so.0, needed by /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/software/cairo/1.17.8-GCCcore-12.3.0/lib64/libcairo.so, not found (try using -rpath or -rpath-link)
```

Not sure why it apparently has only popped up here, maybe it's due to the combination of RPATH and filtering `$LD_LIBRARY_PATH`? But adding these libraries (which are at least indirect dependencies of ImageMagick anyway, as they're dependencies of Pango and Cairo) to the `dependencies` list in the easyconfig seems to solve the issue.