### PR TITLE
Added QuantumESPRESSO easyconfigs for 7.3 (both intel and foss)

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-foss-2023a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-foss-2023a.eb
@@ -1,0 +1,58 @@
+name = 'QuantumESPRESSO'
+version = '7.3'
+
+homepage = 'https://www.quantum-espresso.org'
+description = """Quantum ESPRESSO  is an integrated suite of computer codes
+for electronic-structure calculations and materials modeling at the nanoscale.
+It is based on density-functional theory, plane waves, and pseudopotentials
+(both norm-conserving and ultrasoft).
+"""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+toolchainopts = {
+    'usempi': True,
+    'openmp': True,
+    }
+
+sources = [
+    {
+        'filename': 'q-e-qe-%(version)s.tar.gz',
+        'extract_cmd': 'mkdir -p %(builddir)s/qe-%(version)s && tar xzvf %s --strip-components=1 -C $_',
+        'source_urls': ['https://gitlab.com/QEF/q-e/-/archive/qe-%(version)s']
+    },
+    {
+        'filename': 'qe-gipaw-%(version)s.tar.gz',
+        'source_urls': ['https://github.com/dceresoli/qe-gipaw/releases/download/%(version)s/']},
+    {
+        'filename': 'wannier90-3.1.0.tar.gz',
+        'download_filename': 'v3.1.0.tar.gz',
+        'source_urls': ['https://github.com/wannier-developers/wannier90/archive/']
+    },
+]
+checksums = [
+    {'q-e-qe-%(version)s.tar.gz': 'edc2a0f3315c69966df4f82ec86ab9f682187bc9430ef6d2bacad5f27f08972c'},
+    {'qe-gipaw-%(version)s.tar.gz': 'a24d328ec068043d36fdf69fe4f8d1904d7befeba7962cb85be059ea0fe6f026'},
+    {'wannier90-3.1.0.tar.gz': '40651a9832eb93dec20a8360dd535262c261c34e13c41b6755fa6915c936b254'},
+]
+
+builddependencies = [
+    ('M4', '1.4.19'),
+]
+dependencies = [
+    ('HDF5', '1.14.0'),
+    ('ELPA', '2023.05.001'),
+    ('libxc', '6.2.2'),
+]
+
+# The third party packages should be installed separately and added as
+# dependencies.  The exception is w90, which is force built, and gipaw
+# which depends on qe source
+buildopts = "all gwl xspectra couple epw gipaw w90"
+with_fox = True # Needed from QE7.2 to build GIPAW
+
+# parallel build tends to fail
+parallel = 1
+
+
+moduleclass = 'chem'
+

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-foss-2023a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-foss-2023a.eb
@@ -52,5 +52,4 @@ buildopts = "all gwl xspectra couple epw gipaw w90"
 # parallel build tends to fail
 parallel = 1
 
-
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-foss-2023a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-foss-2023a.eb
@@ -48,7 +48,6 @@ dependencies = [
 # dependencies.  The exception is w90, which is force built, and gipaw
 # which depends on qe source
 buildopts = "all gwl xspectra couple epw gipaw w90"
-with_fox = True # Needed from QE7.2 to build GIPAW
 
 # parallel build tends to fail
 parallel = 1

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-foss-2023a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-foss-2023a.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'foss', 'version': '2023a'}
 toolchainopts = {
     'usempi': True,
     'openmp': True,
-    }
+}
 
 sources = [
     {
@@ -54,4 +54,3 @@ parallel = 1
 
 
 moduleclass = 'chem'
-

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-intel-2023a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-intel-2023a.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2023a'}
 toolchainopts = {
     'usempi': True,
     'openmp': True,
-    }
+}
 
 sources = [
     {

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-intel-2023a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-intel-2023a.eb
@@ -52,5 +52,7 @@ buildopts = "all gwl xspectra couple epw gipaw w90"
 # parallel build tends to fail
 parallel = 1
 
+# allow some test failures
+test_suite_max_failed = 1
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-intel-2023a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-intel-2023a.eb
@@ -48,7 +48,6 @@ dependencies = [
 # dependencies.  The exception is w90, which is force built, and gipaw
 # which depends on qe source
 buildopts = "all gwl xspectra couple epw gipaw w90"
-with_fox = True # Needed from QE7.2 to build GIPAW
 
 # parallel build tends to fail
 parallel = 1

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-intel-2023a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-intel-2023a.eb
@@ -1,0 +1,57 @@
+name = 'QuantumESPRESSO'
+version = '7.3'
+
+homepage = 'https://www.quantum-espresso.org'
+description = """Quantum ESPRESSO  is an integrated suite of computer codes
+for electronic-structure calculations and materials modeling at the nanoscale.
+It is based on density-functional theory, plane waves, and pseudopotentials
+(both norm-conserving and ultrasoft).
+"""
+
+toolchain = {'name': 'intel', 'version': '2023a'}
+toolchainopts = {
+    'usempi': True,
+    'openmp': True,
+    }
+
+sources = [
+    {
+        'filename': 'q-e-qe-%(version)s.tar.gz',
+        'extract_cmd': 'mkdir -p %(builddir)s/qe-%(version)s && tar xzvf %s --strip-components=1 -C $_',
+        'source_urls': ['https://gitlab.com/QEF/q-e/-/archive/qe-%(version)s']
+    },
+    {
+        'filename': 'qe-gipaw-%(version)s.tar.gz',
+        'source_urls': ['https://github.com/dceresoli/qe-gipaw/releases/download/%(version)s/']},
+    {
+        'filename': 'wannier90-3.1.0.tar.gz',
+        'download_filename': 'v3.1.0.tar.gz',
+        'source_urls': ['https://github.com/wannier-developers/wannier90/archive/']
+    },
+]
+checksums = [
+    {'q-e-qe-%(version)s.tar.gz': 'edc2a0f3315c69966df4f82ec86ab9f682187bc9430ef6d2bacad5f27f08972c'},
+    {'qe-gipaw-%(version)s.tar.gz': 'a24d328ec068043d36fdf69fe4f8d1904d7befeba7962cb85be059ea0fe6f026'},
+    {'wannier90-3.1.0.tar.gz': '40651a9832eb93dec20a8360dd535262c261c34e13c41b6755fa6915c936b254'},
+]
+
+builddependencies = [
+    ('M4', '1.4.19'),
+]
+dependencies = [
+    ('HDF5', '1.14.0'),
+    ('ELPA', '2023.05.001'),
+    ('libxc', '6.2.2'),
+]
+
+# The third party packages should be installed separately and added as
+# dependencies.  The exception is w90, which is force built, and gipaw
+# which depends on qe source
+buildopts = "all gwl xspectra couple epw gipaw w90"
+with_fox = True # Needed from QE7.2 to build GIPAW
+
+# parallel build tends to fail
+parallel = 1
+
+
+moduleclass = 'chem'


### PR DESCRIPTION
Added easyconfig files for QE 7.3 working with new easyblock from [PR-3241](https://github.com/easybuilders/easybuild-easyblocks/pull/3241)

Also ran some performance testing on a workstations with an intel i9-13900k.
After taking into account the presence of both performance and efficiency cores, and running all tests with the same pinning for reproducibility, both the `-O3` and `-ffast-math` do not give any visible improvement at the scale this tests are being ran.

In order to properly compare the efficiency with respect to the EESSI version (compiled with older easyblock), a multi-node heavy run would be needed as what has been fixed is mostly related to Scalapack and ELPA libraries usage.

![image](https://github.com/easybuilders/easybuild-easyconfigs/assets/34096612/128a2b98-0503-4185-9210-e6b166e2d69c)

The run reported are generated using the ReFrame test from [PR-3134](https://github.com/reframe-hpc/reframe/pull/3134) with `ecut=100` and `nbnd=100`