### PR TITLE
Remove flake8 suppressions for invalid escape sequences

### DIFF
--- a/easybuild/easyconfigs/d/Delft3D/Delft3D-4.04.01-foss-2022a-FLOW.eb
+++ b/easybuild/easyconfigs/d/Delft3D/Delft3D-4.04.01-foss-2022a-FLOW.eb
@@ -56,7 +56,7 @@ preconfigopts += 'export FFLAGS="$FFLAGS -fallow-argument-mismatch -I${CPATH//:/
 # syntax was made invalid in c++11
 preconfigopts += "sed -i 's/if (spec < 0)/if (spec == nullptr)/g' utils_lgpl/delftonline/src/delftonline/server.cpp && "
 # avoid comparing logical with integer
-preconfigopts += "sed -i 's/if (has_umean \/= 0)/if (has_umean .neqv. .false.)/g' "  # noqa: W605
+preconfigopts += r"sed -i 's/if (has_umean \/= 0)/if (has_umean .neqv. .false.)/g' "
 preconfigopts += "engines_gpl/flow2d3d/packages/flow2d3d_io/src/input/restart_trim_flow.f90 && "
 preconfigopts += "sed -i -e 's/-recursive/-frecursive/g' -e 's/-traceback/-fbacktrace/g' configure.ac && "
 # copy ESMF_RegridWeightGen_in_Delft3D-WAVE.sh script

--- a/easybuild/easyconfigs/o/OmegaFold/OmegaFold-1.1.0-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/o/OmegaFold/OmegaFold-1.1.0-foss-2022a-CUDA-11.7.0.eb
@@ -22,7 +22,7 @@ sanity_pip_check = True
 # add missing version for OmegaFold
 exts_list = [
     (name, version, {
-        'preinstallopts': """sed -i '/^setup(/a \    version="%(version)s",' setup.py && """,  # noqa: W605
+        'preinstallopts': """sed -i '/^setup(/a version="%(version)s",' setup.py && """,
         'source_tmpl': 'v%(version)s.tar.gz',
         'source_urls': ['https://github.com/HeliXonProtein/OmegaFold/archive/'],
         'checksums': ['ab3b48fe7721539b6943b49cdbafc9799e15b4425a324cc25daf15a24e3f9e37'],

--- a/easybuild/easyconfigs/r/ReaxFF/ReaxFF-2.0-GCC-11.3.0-sim.eb
+++ b/easybuild/easyconfigs/r/ReaxFF/ReaxFF-2.0-GCC-11.3.0-sim.eb
@@ -24,7 +24,7 @@ Register at https://www.engr.psu.edu/adri/Home.aspx and follow instructions
 
 start_dir = 'src'
 
-prebuildopts = r"sed -ie 's/^\(\s\)gcc /\1gfortran /g' makefile && "  # noqa: W605
+prebuildopts = r"sed -ie 's/^\(\s\)gcc /\1gfortran /g' makefile && "
 prebuildopts += 'rm *.o && '
 
 buildopts = 'SUFFIX="-c -O3 -std=legacy"'


### PR DESCRIPTION
Those will become a SyntaxError in some Python version, so that suppression to make CI pass isn't a good idea, because that sequence **IS invalid**, no matter what flake8 says.

Solution is either to use raw strings or remove the escapes.

For OmegaFold it isn't required as an escaped space is used just to make for nice indentation which isn't required at this place.

FYI: `ReaxFF-2.0-GCC-11.3.0-sim.eb` requires a registration to download the source. However in that file only the comment was removed, so a rebuild isn't exactly required to check