### PR TITLE
{lib}[GCC 11.2.0-13.2.0] UCX 1.16.0-rc4

### DIFF
--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.2.0.eb
@@ -35,7 +35,6 @@ dependencies = [
     ('numactl', '2.0.14'),
 ]
 
-preconfigopts = "./autogen.sh && "
 configure_cmd = "contrib/configure-release"
 
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.2.0.eb
@@ -1,0 +1,53 @@
+easyblock = 'ConfigureMake'
+
+name = 'UCX'
+version = '1.16.0-rc4'
+
+homepage = 'https://www.openucx.org/'
+description = """Unified Communication X
+An open-source production grade communication framework for data centric
+and high-performance applications
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
+sources = ['%(namelower)s-%(version)s.tar.gz']
+patches = [
+    'UCX-1.13.1-dynamic_modules.patch',
+]
+checksums = [
+    {'ucx-1.16.0-rc4.tar.gz': '49b60afaa8fe4da7074b7e2061176d3ab476901ec1c7e92685b6b14f1daf7711'},
+    {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
+]
+
+builddependencies = [
+    ('binutils', '2.37'),
+    ('Autotools', '20210726'),
+    ('pkg-config', '0.29.2'),
+]
+
+osdependencies = [OS_PKG_IBVERBS_DEV]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('numactl', '2.0.14'),
+]
+
+preconfigopts = "./autogen.sh && "
+configure_cmd = "contrib/configure-release"
+
+configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
+configopts += '--without-java --without-go --disable-doxygen-doc '
+
+buildopts = 'V=1'
+
+sanity_check_paths = {
+    'files': ['bin/ucx_info', 'bin/ucx_perftest', 'bin/ucx_read_profile'],
+    'dirs': ['include', 'lib', 'share']
+}
+
+sanity_check_commands = ["ucx_info -d"]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.2.0.eb
@@ -13,12 +13,12 @@ toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
-sources = ['%(namelower)s-%(version)s.tar.gz']
+sources = [{'download_filename': 'ucx-%s.tar.gz' % version.split('-')[0], 'filename': SOURCELOWER_TAR_GZ}]
 patches = [
     'UCX-1.13.1-dynamic_modules.patch',
 ]
 checksums = [
-    {'ucx-1.16.0-rc4.tar.gz': '49b60afaa8fe4da7074b7e2061176d3ab476901ec1c7e92685b6b14f1daf7711'},
+    {'ucx-1.16.0-rc4.tar.gz': 'bc82ba145bec5de2eb3a7428a4d11a066090b5c307d8daed4e75351f9f3919b0'},
     {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
 ]
 

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.3.0.eb
@@ -35,7 +35,6 @@ dependencies = [
     ('numactl', '2.0.14'),
 ]
 
-preconfigopts = "./autogen.sh && "
 configure_cmd = "contrib/configure-release"
 
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.3.0.eb
@@ -13,12 +13,12 @@ toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
-sources = ['%(namelower)s-%(version)s.tar.gz']
+sources = [{'download_filename': 'ucx-%s.tar.gz' % version.split('-')[0], 'filename': SOURCELOWER_TAR_GZ}]
 patches = [
     'UCX-1.13.1-dynamic_modules.patch',
 ]
 checksums = [
-    {'ucx-1.16.0-rc4.tar.gz': '49b60afaa8fe4da7074b7e2061176d3ab476901ec1c7e92685b6b14f1daf7711'},
+    {'ucx-1.16.0-rc4.tar.gz': 'bc82ba145bec5de2eb3a7428a4d11a066090b5c307d8daed4e75351f9f3919b0'},
     {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
 ]
 

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.3.0.eb
@@ -1,0 +1,53 @@
+easyblock = 'ConfigureMake'
+
+name = 'UCX'
+version = '1.16.0-rc4'
+
+homepage = 'https://www.openucx.org/'
+description = """Unified Communication X
+An open-source production grade communication framework for data centric
+and high-performance applications
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
+sources = ['%(namelower)s-%(version)s.tar.gz']
+patches = [
+    'UCX-1.13.1-dynamic_modules.patch',
+]
+checksums = [
+    {'ucx-1.16.0-rc4.tar.gz': '49b60afaa8fe4da7074b7e2061176d3ab476901ec1c7e92685b6b14f1daf7711'},
+    {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
+]
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('Autotools', '20220317'),
+    ('pkgconf', '1.8.0'),
+]
+
+osdependencies = [OS_PKG_IBVERBS_DEV]
+
+dependencies = [
+    ('zlib', '1.2.12'),
+    ('numactl', '2.0.14'),
+]
+
+preconfigopts = "./autogen.sh && "
+configure_cmd = "contrib/configure-release"
+
+configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
+configopts += '--without-java --without-go --disable-doxygen-doc '
+
+buildopts = 'V=1'
+
+sanity_check_paths = {
+    'files': ['bin/ucx_info', 'bin/ucx_perftest', 'bin/ucx_read_profile'],
+    'dirs': ['include', 'lib', 'share']
+}
+
+sanity_check_commands = ["ucx_info -d"]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.2.0.eb
@@ -1,0 +1,53 @@
+easyblock = 'ConfigureMake'
+
+name = 'UCX'
+version = '1.16.0-rc4'
+
+homepage = 'https://www.openucx.org/'
+description = """Unified Communication X
+An open-source production grade communication framework for data centric
+and high-performance applications
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
+sources = ['%(namelower)s-%(version)s.tar.gz']
+patches = [
+    'UCX-1.13.1-dynamic_modules.patch',
+]
+checksums = [
+    {'ucx-1.16.0-rc4.tar.gz': '49b60afaa8fe4da7074b7e2061176d3ab476901ec1c7e92685b6b14f1daf7711'},
+    {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
+]
+
+builddependencies = [
+    ('binutils', '2.39'),
+    ('Autotools', '20220317'),
+    ('pkgconf', '1.9.3'),
+]
+
+osdependencies = [OS_PKG_IBVERBS_DEV]
+
+dependencies = [
+    ('zlib', '1.2.12'),
+    ('numactl', '2.0.16'),
+]
+
+preconfigopts = "./autogen.sh && "
+configure_cmd = "contrib/configure-release"
+
+configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
+configopts += '--without-java --without-go --disable-doxygen-doc '
+
+buildopts = 'V=1'
+
+sanity_check_paths = {
+    'files': ['bin/ucx_info', 'bin/ucx_perftest', 'bin/ucx_read_profile'],
+    'dirs': ['include', 'lib', 'share']
+}
+
+sanity_check_commands = ["ucx_info -d"]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.2.0.eb
@@ -13,12 +13,12 @@ toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
-sources = ['%(namelower)s-%(version)s.tar.gz']
+sources = [{'download_filename': 'ucx-%s.tar.gz' % version.split('-')[0], 'filename': SOURCELOWER_TAR_GZ}]
 patches = [
     'UCX-1.13.1-dynamic_modules.patch',
 ]
 checksums = [
-    {'ucx-1.16.0-rc4.tar.gz': '49b60afaa8fe4da7074b7e2061176d3ab476901ec1c7e92685b6b14f1daf7711'},
+    {'ucx-1.16.0-rc4.tar.gz': 'bc82ba145bec5de2eb3a7428a4d11a066090b5c307d8daed4e75351f9f3919b0'},
     {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
 ]
 

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.2.0.eb
@@ -35,7 +35,6 @@ dependencies = [
     ('numactl', '2.0.16'),
 ]
 
-preconfigopts = "./autogen.sh && "
 configure_cmd = "contrib/configure-release"
 
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.3.0.eb
@@ -13,12 +13,12 @@ toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
-sources = ['%(namelower)s-%(version)s.tar.gz']
+sources = [{'download_filename': 'ucx-%s.tar.gz' % version.split('-')[0], 'filename': SOURCELOWER_TAR_GZ}]
 patches = [
     'UCX-1.13.1-dynamic_modules.patch',
 ]
 checksums = [
-    {'ucx-1.16.0-rc4.tar.gz': '49b60afaa8fe4da7074b7e2061176d3ab476901ec1c7e92685b6b14f1daf7711'},
+    {'ucx-1.16.0-rc4.tar.gz': 'bc82ba145bec5de2eb3a7428a4d11a066090b5c307d8daed4e75351f9f3919b0'},
     {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
 ]
 

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.3.0.eb
@@ -1,0 +1,53 @@
+easyblock = 'ConfigureMake'
+
+name = 'UCX'
+version = '1.16.0-rc4'
+
+homepage = 'https://www.openucx.org/'
+description = """Unified Communication X
+An open-source production grade communication framework for data centric
+and high-performance applications
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
+sources = ['%(namelower)s-%(version)s.tar.gz']
+patches = [
+    'UCX-1.13.1-dynamic_modules.patch',
+]
+checksums = [
+    {'ucx-1.16.0-rc4.tar.gz': '49b60afaa8fe4da7074b7e2061176d3ab476901ec1c7e92685b6b14f1daf7711'},
+    {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
+]
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('Autotools', '20220317'),
+    ('pkgconf', '1.9.5'),
+]
+
+osdependencies = [OS_PKG_IBVERBS_DEV]
+
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('numactl', '2.0.16'),
+]
+
+preconfigopts = "./autogen.sh && "
+configure_cmd = "contrib/configure-release"
+
+configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
+configopts += '--without-java --without-go --disable-doxygen-doc '
+
+buildopts = 'V=1'
+
+sanity_check_paths = {
+    'files': ['bin/ucx_info', 'bin/ucx_perftest', 'bin/ucx_read_profile'],
+    'dirs': ['include', 'lib', 'share']
+}
+
+sanity_check_commands = ["ucx_info -d"]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.3.0.eb
@@ -35,7 +35,6 @@ dependencies = [
     ('numactl', '2.0.16'),
 ]
 
-preconfigopts = "./autogen.sh && "
 configure_cmd = "contrib/configure-release"
 
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-13.2.0.eb
@@ -1,0 +1,53 @@
+easyblock = 'ConfigureMake'
+
+name = 'UCX'
+version = '1.16.0-rc4'
+
+homepage = 'https://www.openucx.org/'
+description = """Unified Communication X
+An open-source production grade communication framework for data centric
+and high-performance applications
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
+sources = ['%(namelower)s-%(version)s.tar.gz']
+patches = [
+    'UCX-1.13.1-dynamic_modules.patch',
+]
+checksums = [
+    {'ucx-1.16.0-rc4.tar.gz': '49b60afaa8fe4da7074b7e2061176d3ab476901ec1c7e92685b6b14f1daf7711'},
+    {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
+]
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('Autotools', '20220317'),
+    ('pkgconf', '2.0.3'),
+]
+
+osdependencies = [OS_PKG_IBVERBS_DEV]
+
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('numactl', '2.0.16'),
+]
+
+preconfigopts = "./autogen.sh && "
+configure_cmd = "contrib/configure-release"
+
+configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
+configopts += '--without-java --without-go --disable-doxygen-doc '
+
+buildopts = 'V=1'
+
+sanity_check_paths = {
+    'files': ['bin/ucx_info', 'bin/ucx_perftest', 'bin/ucx_read_profile'],
+    'dirs': ['include', 'lib', 'share']
+}
+
+sanity_check_commands = ["ucx_info -d"]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-13.2.0.eb
@@ -13,12 +13,12 @@ toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
-sources = ['%(namelower)s-%(version)s.tar.gz']
+sources = [{'download_filename': 'ucx-%s.tar.gz' % version.split('-')[0], 'filename': SOURCELOWER_TAR_GZ}]
 patches = [
     'UCX-1.13.1-dynamic_modules.patch',
 ]
 checksums = [
-    {'ucx-1.16.0-rc4.tar.gz': '49b60afaa8fe4da7074b7e2061176d3ab476901ec1c7e92685b6b14f1daf7711'},
+    {'ucx-1.16.0-rc4.tar.gz': 'bc82ba145bec5de2eb3a7428a4d11a066090b5c307d8daed4e75351f9f3919b0'},
     {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
 ]
 

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-13.2.0.eb
@@ -35,7 +35,6 @@ dependencies = [
     ('numactl', '2.0.16'),
 ]
 
-preconfigopts = "./autogen.sh && "
 configure_cmd = "contrib/configure-release"
 
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '


### PR DESCRIPTION
Recent intel MPI might need ucx >=1.16.0 if MLNX/NVIDIA OFED >= 23.10 is installed. 
(We experienced infinite hangs with FDS/6.8.0-intel-2022b, and swapping to UCX-1.16.0-rc4 solved the problem. UCX < 1.16 did not solve the problem) Note that only AMD CPUs are affected, we did not get the same problem with Intel CPUs.
With our previous OFED 23.04 version, we did not have the problem.