### PR TITLE
fix `incompatible types` errors when building the R extension `dbarts` on Arm

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2023.12-foss-2023a.eb
+++ b/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2023.12-foss-2023a.eb
@@ -64,6 +64,14 @@ local_ext_version_check = "pkgver = packageVersion('%(ext_name)s'); if (pkgver !
 local_stop_msg = "stop('%(ext_name)s %(ext_version)s not installed, found ', pkgver, ' instead')"
 exts_filter = ("R -q --no-save", "%s { %s }" % (local_ext_version_check, local_stop_msg))
 
+# the dbarts extension needs an additional compiler flag on Arm systems to prevent "incompatible types" errors
+# cfr. https://github.com/vdorie/dbarts/issues/66
+if ARCH == 'aarch64':
+    local_dbarts_preinstallopts = 'sed -i "s|-c partition_neon.c|-flax-vector-conversions -c partition_neon.c|"'
+    local_dbarts_preinstallopts += ' src/misc/Makefile && '
+else:
+    local_dbarts_preinstallopts = ''
+
 # !! order of packages is important !!
 # packages updated on 10th December 2023
 exts_list = [
@@ -2577,6 +2585,7 @@ exts_list = [
     }),
     ('dbarts', '0.9-25', {
         'checksums': ['39a78228ead17c92bd88fe5f959c888412a22a7cbbc0edfa9c09072b4182d870'],
+        'preinstallopts': local_dbarts_preinstallopts,
     }),
     ('proftools', '0.99-3', {
         'checksums': ['e034eb1531af54013143da3e15229e1d4c2260f8eb79c93846014db3bdefb724'],

--- a/easybuild/easyconfigs/r/R/R-4.2.0-foss-2021b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.2.0-foss-2021b.eb
@@ -78,6 +78,14 @@ exts_default_options = {
     'source_tmpl': '%(name)s_%(version)s.tar.gz',
 }
 
+# the dbarts extension needs an additional compiler flag on Arm systems to prevent "incompatible types" errors
+# cfr. https://github.com/vdorie/dbarts/issues/66
+if ARCH == 'aarch64':
+    local_dbarts_preinstallopts = 'sed -i "s|-c partition_neon.c|-flax-vector-conversions -c partition_neon.c|"'
+    local_dbarts_preinstallopts += ' src/misc/Makefile && '
+else:
+    local_dbarts_preinstallopts = ''
+
 # !! order of packages is important !!
 # packages updated on 27th April 2022
 exts_list = [
@@ -2796,6 +2804,7 @@ exts_list = [
     }),
     ('dbarts', '0.9-22', {
         'checksums': ['68fa2bfe274811c91ea7b67da46c4ffe527eb662d75edbec26ffe934ddc7150a'],
+        'preinstallopts': local_dbarts_preinstallopts,
     }),
     ('proftools', '0.99-3', {
         'checksums': ['e034eb1531af54013143da3e15229e1d4c2260f8eb79c93846014db3bdefb724'],

--- a/easybuild/easyconfigs/r/R/R-4.2.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/r/R/R-4.2.1-foss-2022a.eb
@@ -77,6 +77,14 @@ exts_default_options = {
     'source_tmpl': '%(name)s_%(version)s.tar.gz',
 }
 
+# the dbarts extension needs an additional compiler flag on Arm systems to prevent "incompatible types" errors
+# cfr. https://github.com/vdorie/dbarts/issues/66
+if ARCH == 'aarch64':
+    local_dbarts_preinstallopts = 'sed -i "s|-c partition_neon.c|-flax-vector-conversions -c partition_neon.c|"'
+    local_dbarts_preinstallopts += ' src/misc/Makefile && '
+else:
+    local_dbarts_preinstallopts = ''
+
 # !! order of packages is important !!
 # packages updated on 23rd June 2022
 exts_list = [
@@ -2797,6 +2805,7 @@ exts_list = [
     }),
     ('dbarts', '0.9-22', {
         'checksums': ['68fa2bfe274811c91ea7b67da46c4ffe527eb662d75edbec26ffe934ddc7150a'],
+        'preinstallopts': local_dbarts_preinstallopts,
     }),
     ('proftools', '0.99-3', {
         'checksums': ['e034eb1531af54013143da3e15229e1d4c2260f8eb79c93846014db3bdefb724'],

--- a/easybuild/easyconfigs/r/R/R-4.2.2-foss-2022b.eb
+++ b/easybuild/easyconfigs/r/R/R-4.2.2-foss-2022b.eb
@@ -77,6 +77,14 @@ exts_default_options = {
     'source_tmpl': '%(name)s_%(version)s.tar.gz',
 }
 
+# the dbarts extension needs an additional compiler flag on Arm systems to prevent "incompatible types" errors
+# cfr. https://github.com/vdorie/dbarts/issues/66
+if ARCH == 'aarch64':
+    local_dbarts_preinstallopts = 'sed -i "s|-c partition_neon.c|-flax-vector-conversions -c partition_neon.c|"'
+    local_dbarts_preinstallopts += ' src/misc/Makefile && '
+else:
+    local_dbarts_preinstallopts = ''
+
 # !! order of packages is important !!
 # packages updated on 17th March 2023
 exts_list = [
@@ -2856,6 +2864,7 @@ exts_list = [
     }),
     ('dbarts', '0.9-23', {
         'checksums': ['e1ac65fd89c321895d4f0e77d9cd8dcda5f1103485008afd4e19e6c9137557a3'],
+        'preinstallopts': local_dbarts_preinstallopts,
     }),
     ('proftools', '0.99-3', {
         'checksums': ['e034eb1531af54013143da3e15229e1d4c2260f8eb79c93846014db3bdefb724'],


### PR DESCRIPTION
See https://github.com/vdorie/dbarts/issues/66. We've run into this with EESSI for versions R-bundle-CRAN-2023.12-foss-2023a.eb and R-4.2.2-foss-2022b.eb, but I've also applied the fix to the other R 4.2.x versions.