### PR TITLE
add patch to fix for libarchive to fix error reporting in tar

### DIFF
--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.6.0_fix-tar-error-reporting.patch
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.6.0_fix-tar-error-reporting.patch
@@ -1,0 +1,27 @@
+see https://github.com/libarchive/libarchive/pull/2101
+From e200fd8abfb4cf895a1cab4d89b67e6eefe83942 Mon Sep 17 00:00:00 2001
+From: Ed Maste <emaste@FreeBSD.org>
+Date: Fri, 29 Mar 2024 16:38:11 -0400
+Subject: [PATCH] tar: make error reporting more robust and use correct errno
+
+As discussed in #1609.
+---
+ tar/read.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/tar/read.c b/tar/read.c
+index af3d3f423..a7f14a07b 100644
+--- a/tar/read.c
++++ b/tar/read.c
+@@ -371,8 +371,9 @@ read_archive(struct bsdtar *bsdtar, char mode, struct archive *writer)
+ 			if (r != ARCHIVE_OK) {
+ 				if (!bsdtar->verbose)
+ 					safe_fprintf(stderr, "%s", archive_entry_pathname(entry));
+-				fprintf(stderr, ": %s: ", archive_error_string(a));
+-				fprintf(stderr, "%s", strerror(errno));
++				safe_fprintf(stderr, ": %s: %s",
++				    archive_error_string(a),
++				    strerror(archive_errno(a)));
+ 				if (!bsdtar->verbose)
+ 					fprintf(stderr, "\n");
+ 				bsdtar->return_value = 1;

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.6.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.6.1-GCCcore-11.3.0.eb
@@ -13,7 +13,12 @@ toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 
 source_urls = ['https://www.libarchive.org/downloads/']
 sources = [SOURCE_TAR_GZ]
-checksums = ['c676146577d989189940f1959d9e3980d28513d74eedfbc6b7f15ea45fe54ee2']
+patches = ['libarchive-3.6.0_fix-tar-error-reporting.patch']
+checksums = [
+    {'libarchive-3.6.1.tar.gz': 'c676146577d989189940f1959d9e3980d28513d74eedfbc6b7f15ea45fe54ee2'},
+    {'libarchive-3.6.0_fix-tar-error-reporting.patch':
+     'cf11f2d6e403cbb700f8ad1f67141f2a54884fa25e07d6a7919b0b6865d2cba2'},
+]
 
 builddependencies = [
     ('binutils', '2.38'),

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.6.1-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.6.1-GCCcore-12.2.0.eb
@@ -13,7 +13,12 @@ toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 
 source_urls = ['https://www.libarchive.org/downloads/']
 sources = [SOURCE_TAR_GZ]
-checksums = ['c676146577d989189940f1959d9e3980d28513d74eedfbc6b7f15ea45fe54ee2']
+patches = ['libarchive-3.6.0_fix-tar-error-reporting.patch']
+checksums = [
+    {'libarchive-3.6.1.tar.gz': 'c676146577d989189940f1959d9e3980d28513d74eedfbc6b7f15ea45fe54ee2'},
+    {'libarchive-3.6.0_fix-tar-error-reporting.patch':
+     'cf11f2d6e403cbb700f8ad1f67141f2a54884fa25e07d6a7919b0b6865d2cba2'},
+]
 
 builddependencies = [
     ('binutils', '2.39'),

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.6.2-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.6.2-GCCcore-12.3.0.eb
@@ -13,7 +13,12 @@ toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 
 source_urls = ['https://www.libarchive.org/downloads/']
 sources = [SOURCE_TAR_GZ]
-checksums = ['ba6d02f15ba04aba9c23fd5f236bb234eab9d5209e95d1c4df85c44d5f19b9b3']
+patches = ['libarchive-3.6.0_fix-tar-error-reporting.patch']
+checksums = [
+    {'libarchive-3.6.2.tar.gz': 'ba6d02f15ba04aba9c23fd5f236bb234eab9d5209e95d1c4df85c44d5f19b9b3'},
+    {'libarchive-3.6.0_fix-tar-error-reporting.patch':
+     'cf11f2d6e403cbb700f8ad1f67141f2a54884fa25e07d6a7919b0b6865d2cba2'},
+]
 
 builddependencies = [
     ('binutils', '2.40'),

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.6.2-GCCcore-13.1.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.6.2-GCCcore-13.1.0.eb
@@ -13,7 +13,12 @@ toolchain = {'name': 'GCCcore', 'version': '13.1.0'}
 
 source_urls = ['https://www.libarchive.org/downloads/']
 sources = [SOURCE_TAR_GZ]
-checksums = ['ba6d02f15ba04aba9c23fd5f236bb234eab9d5209e95d1c4df85c44d5f19b9b3']
+patches = ['libarchive-3.6.0_fix-tar-error-reporting.patch']
+checksums = [
+    {'libarchive-3.6.2.tar.gz': 'ba6d02f15ba04aba9c23fd5f236bb234eab9d5209e95d1c4df85c44d5f19b9b3'},
+    {'libarchive-3.6.0_fix-tar-error-reporting.patch':
+     'cf11f2d6e403cbb700f8ad1f67141f2a54884fa25e07d6a7919b0b6865d2cba2'},
+]
 
 builddependencies = [
     ('binutils', '2.40'),

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.7.2-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.7.2-GCCcore-13.2.0.eb
@@ -13,7 +13,12 @@ toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 
 source_urls = ['https://www.libarchive.org/downloads/']
 sources = [SOURCE_TAR_GZ]
-checksums = ['df404eb7222cf30b4f8f93828677890a2986b66ff8bf39dac32a804e96ddf104']
+patches = ['libarchive-3.6.0_fix-tar-error-reporting.patch']
+checksums = [
+    {'libarchive-3.7.2.tar.gz': 'df404eb7222cf30b4f8f93828677890a2986b66ff8bf39dac32a804e96ddf104'},
+    {'libarchive-3.6.0_fix-tar-error-reporting.patch':
+     'cf11f2d6e403cbb700f8ad1f67141f2a54884fa25e07d6a7919b0b6865d2cba2'},
+]
 
 builddependencies = [
     ('binutils', '2.40'),


### PR DESCRIPTION
This is more out of abundance of caution than anything else, there's a link here to the [XZ backdoor situation](https://boehs.org/node/everything-i-know-about-the-xz-backdoor)