### PR TITLE
assembly-stats/1.0.1-GCCcore-11.3.0

### DIFF
--- a/easybuild/easyconfigs/a/assembly-stats/assembly-stats-1.0.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/a/assembly-stats/assembly-stats-1.0.1-GCCcore-11.3.0.eb
@@ -20,8 +20,10 @@ sources = [{
 }]
 patches = ['%(name)s-1.0.1_fix_str_cast.patch']
 checksums = [
-    'ab8fd8a3ab79b9141d09b9f46d86aa8458ec244b568fa1e55c6eccc210f4984e', #assembly-stats-1.0.1.tar.gz
-    'e17ab66e72d5355c9f84b06da1133ca8370c15a195b77c515b9a1ee5de888c5a', #assembly-stats-1.0.1_fix_str_cast.patch
+    # assembly-stats-1.0.1.tar.gz 
+    'ab8fd8a3ab79b9141d09b9f46d86aa8458ec244b568fa1e55c6eccc210f4984e',
+    # assembly-stats-1.0.1_fix_str_cast.patch 
+    'e17ab66e72d5355c9f84b06da1133ca8370c15a195b77c515b9a1ee5de888c5a',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/a/assembly-stats/assembly-stats-1.0.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/a/assembly-stats/assembly-stats-1.0.1-GCCcore-11.3.0.eb
@@ -1,0 +1,46 @@
+easyblock = 'CMakeMake'
+
+name = 'assembly-stats'
+version = '1.0.1'
+
+homepage = 'https://github.com/sanger-pathogens/assembly-stats'
+description = 'Get assembly statistics from FASTA and FASTQ files.'
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = ['https://github.com/sanger-pathogens/assembly-stats/releases']
+sources = [{
+    'git_config': {
+        'url': 'https://github.com/sanger-pathogens',
+        'repo_name': name,
+        'tag': 'v%(version)s',
+        'recursive': True,
+    },
+    'filename': SOURCE_TAR_GZ,
+}]
+patches = ['%(name)s-1.0.1_fix_str_cast.patch']
+checksums = [
+    'ab8fd8a3ab79b9141d09b9f46d86aa8458ec244b568fa1e55c6eccc210f4984e', #assembly-stats-1.0.1.tar.gz
+    'e17ab66e72d5355c9f84b06da1133ca8370c15a195b77c515b9a1ee5de888c5a', #assembly-stats-1.0.1_fix_str_cast.patch
+]
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('CMake', '3.24.3'),
+    ('pkgconf', '1.8.0'),
+]
+
+dependencies = [
+    ('zlib', '1.2.12'),
+]
+
+configopts = '-DINSTALL_DIR=%(installdir)s/bin'
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['bin/assembly-stats'],
+    'dirs': []
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/a/assembly-stats/assembly-stats-1.0.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/a/assembly-stats/assembly-stats-1.0.1-GCCcore-11.3.0.eb
@@ -1,3 +1,5 @@
+# Author: Ehsan Moravveji (VSCentrum, KU Leuven)
+
 easyblock = 'CMakeMake'
 
 name = 'assembly-stats'
@@ -8,22 +10,14 @@ description = 'Get assembly statistics from FASTA and FASTQ files.'
 
 toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 
-source_urls = ['https://github.com/sanger-pathogens/assembly-stats/releases']
-sources = [{
-    'git_config': {
-        'url': 'https://github.com/sanger-pathogens',
-        'repo_name': name,
-        'tag': 'v%(version)s',
-        'recursive': True,
-    },
-    'filename': SOURCE_TAR_GZ,
-}]
+github_account = 'sanger-pathogens'
+#source_urls = ['https://github.com/sanger-pathogens/assembly-stats/releases']
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s.tar.gz']
 patches = ['%(name)s-1.0.1_fix_str_cast.patch']
 checksums = [
-    # assembly-stats-1.0.1.tar.gz 
-    'ab8fd8a3ab79b9141d09b9f46d86aa8458ec244b568fa1e55c6eccc210f4984e',
-    # assembly-stats-1.0.1_fix_str_cast.patch 
-    'e17ab66e72d5355c9f84b06da1133ca8370c15a195b77c515b9a1ee5de888c5a',
+    {'v1.0.1.tar.gz': '02be614da4d244673bcd0adc6917749681d52a58cb0a039c092d01cdeabd8575'},
+    {'assembly-stats-1.0.1_fix_str_cast.patch': '2c1d63e7b1246b290ddfeea2604076ae892dfe337e5092e83575c2c3cbcfd7fd'},
 ]
 
 builddependencies = [
@@ -44,5 +38,7 @@ sanity_check_paths = {
     'files': ['bin/assembly-stats'],
     'dirs': []
 }
+
+sanity_check_commands = ['assembly-stats -v']
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/a/assembly-stats/assembly-stats-1.0.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/a/assembly-stats/assembly-stats-1.0.1-GCCcore-11.3.0.eb
@@ -11,7 +11,6 @@ description = 'Get assembly statistics from FASTA and FASTQ files.'
 toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 
 github_account = 'sanger-pathogens'
-#source_urls = ['https://github.com/sanger-pathogens/assembly-stats/releases']
 source_urls = [GITHUB_SOURCE]
 sources = ['v%(version)s.tar.gz']
 patches = ['%(name)s-1.0.1_fix_str_cast.patch']

--- a/easybuild/easyconfigs/a/assembly-stats/assembly-stats-1.0.1_fix_str_cast.patch
+++ b/easybuild/easyconfigs/a/assembly-stats/assembly-stats-1.0.1_fix_str_cast.patch
@@ -1,0 +1,39 @@
+diff -ruN assembly-stats-original/fasta_unittest.cpp assembly-stats/fasta_unittest.cpp
+--- assembly-stats-original/fasta_unittest.cpp	2024-04-03 11:45:32.230992000 +0200
++++ assembly-stats/fasta_unittest.cpp	2024-04-03 11:50:08.868140000 +0200
+@@ -1,4 +1,5 @@
+ #include <iostream>
++#include <string>
+ #include "fasta.h"
+ #include "gtest/gtest.h"
+ 
+@@ -94,8 +95,7 @@
+     while (fa.fillFromFile(inStream))
+     {
+         counter++;
+-        string expectedName = static_cast<ostringstream*>( &(ostringstream() << counter) )->str();
+-        EXPECT_EQ(0, fa.name().compare(expectedName));
++        EXPECT_EQ(0, fa.name().compare(std::to_string(counter)));
+         EXPECT_EQ(0, fa.seq().compare("ACGT"));
+     }
+ 
+diff -ruN assembly-stats-original/fastq_unittest.cpp assembly-stats/fastq_unittest.cpp
+--- assembly-stats-original/fastq_unittest.cpp	2024-04-03 11:45:32.226036000 +0200
++++ assembly-stats/fastq_unittest.cpp	2024-04-03 12:29:04.830873000 +0200
+@@ -1,5 +1,6 @@
+ #include <list>
+ #include <iostream>
++#include <string>
+ #include <sstream>
+ #include "fastq.h"
+ #include "gtest/gtest.h"
+@@ -50,8 +51,7 @@
+     while (fq.fillFromFile(inStream))
+     {
+         counter++;
+-        string expectedName = static_cast<ostringstream*>( &(ostringstream() << counter) )->str();
+-        EXPECT_EQ(0, fq.name().compare(expectedName));
++        EXPECT_EQ(0, fq.name().compare(std::to_string(counter)));
+         EXPECT_EQ(0, fq.seq().compare("ACGT"));
+     }
+ }

--- a/easybuild/easyconfigs/a/assembly-stats/assembly-stats-1.0.1_fix_str_cast.patch
+++ b/easybuild/easyconfigs/a/assembly-stats/assembly-stats-1.0.1_fix_str_cast.patch
@@ -1,3 +1,7 @@
+# Author: Ehsan Moravveji (VSCentrum, KU Leuven)
+# Purpose: This patch prevents the compile-time error "taking address of rvalue [-fpermissive]"
+#          by redefining a simple casting from integer to string. Consequently, the additional
+#          "-fpermissive" compiler flag need not be included to supress the error.
 diff -ruN assembly-stats-original/fasta_unittest.cpp assembly-stats/fasta_unittest.cpp
 --- assembly-stats-original/fasta_unittest.cpp	2024-04-03 11:45:32.230992000 +0200
 +++ assembly-stats/fasta_unittest.cpp	2024-04-03 11:50:08.868140000 +0200


### PR DESCRIPTION
I was asked to install `assembly-stats` for a specific bioinformatics training, and I realized that this is the first easyconfig file for this tool. A patch file is needed to improve two lines of code in the source file and make the compiler happy.
The provided easyconfig+patch file build successfully on our Intel Skylake, Cascadelake and Icelake nodes under Rocky 8.9 OS, and using `GCCcore/11.3.0` from `2022a` toolchain.