### PR TITLE
replace incorrect scikit-bio 0.5.9 with scikit-bio 0.6.0 as dependency for scCODA

### DIFF
--- a/easybuild/easyconfigs/b/biom-format/biom-format-2.1.15-foss-2023a.eb
+++ b/easybuild/easyconfigs/b/biom-format/biom-format-2.1.15-foss-2023a.eb
@@ -1,0 +1,48 @@
+##
+# This is a contribution from DeepThought HPC Service, Flinders University, Adelaide, Australia
+# Homepage:     https://staff.flinders.edu.au/research/deep-thought
+#
+# Authors::     Robert Qiao <rob.qiao@flinders.edu.au>
+# License::     Revised BSD
+#
+# Notes:: updated by Kenneth Hoste (HPC-UGent) for foss/2021b
+##
+# Updated: Petr Král (INUITS)
+
+easyblock = 'PythonPackage'
+
+name = 'biom-format'
+version = '2.1.15'
+
+homepage = 'https://biom-format.org'
+description = """
+The BIOM file format (canonically pronounced biome) is designed to be
+ a general-use format for representing biological sample by observation
+ contingency tables. BIOM is a recognized standard for the Earth Microbiome
+ Project and is a Genomics Standards Consortium supported project.
+"""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+toolchainopts = {'usempi': True}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['3bda2096e663dc1cb6f90f51b394da0838b9be5164a44370c134ce5b3b2a4dd3']
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('SciPy-bundle', '2023.07'),
+    ('h5py', '3.9.0'),
+]
+
+use_pip = True
+sanity_pip_check = True
+download_dep_fail = True
+
+sanity_check_paths = {
+    'files': ['bin/biom'],
+    'dirs': ['lib'],
+}
+
+options = {'modulename': 'biom'}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/s/scCODA/scCODA-0.1.9-foss-2023a.eb
+++ b/easybuild/easyconfigs/s/scCODA/scCODA-0.1.9-foss-2023a.eb
@@ -16,7 +16,7 @@ dependencies = [
     ('TensorFlow', '2.13.0'),
     ('tensorflow-probability', '0.20.0'),
     ('scanpy', '1.9.8'),
-    ('scikit-bio', '0.5.9'),
+    ('scikit-bio', '0.6.0'),
     ('rpy2', '3.5.15'),
     ('ArviZ', '0.16.1'),
 ]

--- a/easybuild/easyconfigs/s/scikit-bio/scikit-bio-0.6.0-foss-2023a.eb
+++ b/easybuild/easyconfigs/s/scikit-bio/scikit-bio-0.6.0-foss-2023a.eb
@@ -1,8 +1,7 @@
 easyblock = 'PythonBundle'
 
 name = 'scikit-bio'
-version = '0.5.9'
-local_commit = '7565847'
+version = '0.6.0'
 
 homepage = 'http://scikit-bio.org'
 description = """scikit-bio is an open-source, BSD-licensed Python 3 package providing data structures, algorithms
@@ -18,6 +17,7 @@ dependencies = [
     ('scikit-learn', '1.3.1'),
     ('IPython', '8.14.0'),
     ('h5py', '3.9.0'),
+    ('biom-format', '2.1.15'),
 ]
 
 use_pip = True
@@ -32,10 +32,7 @@ exts_list = [
     }),
     (name, version, {
         'modulename': 'skbio',
-        # download from commit to get rid of restriction of scipy version
-        'source_urls': ['https://github.com/scikit-bio/scikit-bio/archive/'],
-        'sources': [{'download_filename': '7565847.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
-        'checksums': ['b2a1054e1bc89df9775335d31eaa6bfa0cce4487d568cff96e215fba8624d153'],
+        'checksums': ['10105a7c3c15ae5910244927f29ba7aa35234b19ebe6513b8484547343b2c10f'],
     }),
 ]
 


### PR DESCRIPTION
The easyconfig for `scikit-bio` 0.5.9 that got merged via #20067 was using a commit ID that doesn't correspond to the 0.5.9 release at all (commit `7565847` is from 2024-03-05, while `0.5.9` release is from 2023-08-03).

This was done because `scikit-bio` 0.5.9 required a `scipy` version <= 1.10.1, which is older than what we have in SciPy-bundle 2023.07 (scipy 1.11.1).

`scikit-bio` 0.6.0 was not released yet at the time of PR #20067, but it is now (2024-03-28), so we should rectify this...
Going with 0.6.0 makes most sense, since the commit that was used is quite close to that version already (was closer than it was to 0.5.9).

The easyconfig for `biom-format` is there because `scikit-bio` 0.6.0 now requires it (it didn't yet in v0.5.9)