### PR TITLE
add alternate checksum to OpenMolcas v23.06

### DIFF
--- a/easybuild/easyconfigs/o/OpenMolcas/OpenMolcas-23.06-intel-2023a.eb
+++ b/easybuild/easyconfigs/o/OpenMolcas/OpenMolcas-23.06-intel-2023a.eb
@@ -13,8 +13,11 @@ source_urls = ['https://gitlab.com/Molcas/OpenMolcas/-/archive/v%(version)s/']
 sources = ["%(name)s-v%(version)s.tar.gz"]
 patches = ['%(name)s-%(version)s_mcpdft_deps.patch']
 checksums = [
-    {'%(name)s-v%(version)s.tar.gz': 'fe0299ed39af6e84f249f91452c411f9845c9ae4a0ce78641c867dea8056f280'},
-    {'%(name)s-%(version)s_mcpdft_deps.patch': 'a798ec6f93a19539aa2211a978da461d4ecd31c5521b9dab6f2a9b1c2fa65f0e'},
+    # OpenMolcas-v23.06.tar.gz
+    ('fe0299ed39af6e84f249f91452c411f9845c9ae4a0ce78641c867dea8056f280',
+     'c3c8f31c22e028e1ac3bd8fb405cea83e8a6fcf21f00e71e81a92941cb026415'),
+    # OpenMolcas-23.06_mcpdft_deps.patch
+    'a798ec6f93a19539aa2211a978da461d4ecd31c5521b9dab6f2a9b1c2fa65f0e',
 ]
 
 builddependencies = [('CMake', '3.26.3')]


### PR DESCRIPTION
no substantive changes:
```
[jfg508@login2[viking2] openmolcas]$ diff -Nru OpenMolcas-v23.06.{old,new}
diff -Nru OpenMolcas-v23.06.old/.tags OpenMolcas-v23.06.new/.tags
--- OpenMolcas-v23.06.old/.tags	2023-06-12 12:58:03.000000000 +0100
+++ OpenMolcas-v23.06.new/.tags	2023-06-12 12:58:03.000000000 +0100
@@ -1,2 +1,2 @@
 1cda3772686cbf99a4af695929a12d563c795ca2
- (tag: v23.06, refs/merge-requests/635/head, refs/keep-around/1cda3772686cbf99a4af695929a12d563c795ca2)
+ (tag: v23.06, refs/keep-around/1cda3772686cbf99a4af695929a12d563c795ca2)
```

I checked other versions, and the only other one affected was 18.09 (which was already fixed)

(created using `eb --new-pr`)

