### PR TITLE
remove Bioconductor's dependency on HDF5 and fix hardcoded `/bin/mv` path

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb
@@ -16,7 +16,7 @@ dependencies = [
     ('R', '4.2.2'),
     ('Boost', '1.81.0'),  # for mzR
     ('GSL', '2.7'),  # for flowClust
-    ('HDF5', '1.14.0'),  # for rhdf5
+    # ('HDF5', '1.14.0'),  # for rhdf5 - disabled, as it should be provided by Rhdf5lib
     ('arrow-R', '11.0.0.3', versionsuffix),  # required by RcisTarget
 ]
 

--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb
@@ -41,6 +41,10 @@ local_ext_version_check = "pkgver = packageVersion('%(ext_name)s'); if (pkgver !
 local_stop_msg = "stop('%(ext_name)s %(ext_version)s not installed, found ', pkgver, ' instead')"
 exts_filter = ("R -q --no-save", "%s { %s }" % (local_ext_version_check, local_stop_msg))
 
+local_rhdf5lib_preinstallopts = """
+sed -i 's@cd hdf5; \\\\@cd hdf5; \\\\\\n\\tsed -i "s|/bin/mv|mv|" ./configure; \\\\@' %(start_dir)s/src/Makevars.in &&
+"""
+
 # CRAN packages on which these Bioconductor packages depend are available in R module on which this depends
 # !! order of packages is important !!
 # packages updated on 18th March 2023
@@ -323,6 +327,7 @@ exts_list = [
     }),
     ('Rhdf5lib', '1.20.0', {
         'checksums': ['a73b462be309c9df11afc9b941282dcefb36b4a38d15c050fd98bb3c05bbaf7f'],
+        'preinstallopts': local_rhdf5lib_preinstallopts,
     }),
     ('rhdf5filters', '1.10.0', {
         'checksums': ['e1bf2ada5070b4b8d48b90db13ea750c812eaa2a82536571faa35621c250a29f'],

--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb
@@ -16,7 +16,7 @@ dependencies = [
     ('R', '4.3.2'),
     ('Boost', '1.82.0'),  # for mzR
     ('GSL', '2.7'),  # for flowClust
-    ('HDF5', '1.14.0'),  # for rhdf5
+    # ('HDF5', '1.14.0'),  # for rhdf5 - disabled, as it should be provided by Rhdf5lib
     ('arrow-R', '14.0.0.2', versionsuffix),  # required by RcisTarget
 ]
 

--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb
@@ -41,6 +41,10 @@ local_ext_version_check = "pkgver = packageVersion('%(ext_name)s'); if (pkgver !
 local_stop_msg = "stop('%(ext_name)s %(ext_version)s not installed, found ', pkgver, ' instead')"
 exts_filter = ("R -q --no-save", "%s { %s }" % (local_ext_version_check, local_stop_msg))
 
+local_rhdf5lib_preinstallopts = """
+sed -i 's@cd hdf5; \\\\@cd hdf5; \\\\\\n\\tsed -i "s|/bin/mv|mv|" ./configure; \\\\@' %(start_dir)s/src/Makevars.in &&
+"""
+
 # CRAN packages on which these Bioconductor packages depend are available in R module on which this depends
 # !! order of packages is important !!
 # packages updated on 18th March 2023
@@ -329,6 +333,7 @@ exts_list = [
     }),
     ('Rhdf5lib', '1.24.1', {
         'checksums': ['90eb76a2f6b73e18c8fb560ab14e5e3a2c85ae747f278d66e67d3bebfe6c6551'],
+        'preinstallopts': local_rhdf5lib_preinstallopts,
     }),
     ('rhdf5filters', '1.14.1', {
         'checksums': ['6636612d28ea6f2e658400cbd186066926fe3d4b8d07261ad7a49299c23c0e33'],


### PR DESCRIPTION
The installation of the Rhdf5lib extension fails in the EESSI build environment (non-default sysroot, using RPATH, and filtering `$LD_LIBRARY_PATH`), because the included HDF5 build tries to call `/bin/mv` with `$LD_LIBRARY_PATH` set to many paths to software installation paths. This then fails because it's mixing up things from the EESSI sysroot and the build host's sysroot:
```
/bin/mv: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_ABI_DT_RELR' not found (required by /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/lib/../lib64/libm.so.6)
```

This PR modifies that call to just `mv`; with newer versions of `Rhdf5lib` this is already done that way as well and seems to work fine. That's also the reason why I didn't choose to prefix `/bin/mv` with `%(sysroot)s`, which would perhaps be even cleaner and would also solve the issue.
Note that the fix is somewhat tricky, as the file that calls `/bin/mv` is extracted during the build. So it now uses `sed` to insert another `sed` command into the `Makevars` file that does the extraction. I could also change it into a patch file if that's more readable :wink: 

Furthermore, while debugging this issue, I started wondering if the dependency on HDF5 in Bioconductor's easyconfig makes any sense. From what I understand, `Rhdf5lib` provides the C/C++ headers and libraries of HDF5, which is the reason why its source tarball includes a tarball of an (ancient and customized :disappointed:  ) HDF5 version. The `Rhdf5` extension, also part of Bioconductor, depends on `Rhdf5lib` and provides the interface between R and HDF5. The easyconfig had a comment `('HDF5', '1.14.0'),  # for rhdf5`, but I don't think that's correct, as `Rhdf5` will be using whatever `Rhdf5lib` provides. So, I've disabled that dependency and added a comment.
Also see:
https://www.bioconductor.org/packages/release/bioc/html/Rhdf5lib.html
https://bioconductor.org/packages/release/bioc/html/rhdf5.html