### PR TITLE
{bio}[foss/2022a] NanoPlot v1.42.0, nanoget v1.19.1, pauve v0.2.3, and use nanoget 1.19.1 for Nanostat 1.6.0

### DIFF
--- a/easybuild/easyconfigs/n/NanoPlot/NanoPlot-1.42.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/n/NanoPlot/NanoPlot-1.42.0-foss-2022a.eb
@@ -21,9 +21,7 @@ dependencies = [
     ('Pysam', '0.19.1'),
     ('nanomath', '1.3.0'),
     ('nanoget', '1.19.1'),
-    ('Seaborn', '0.12.1'),
     ('plotly.py', '5.12.0'),
-    ('pauvre', '0.2.3'),
     ('statsmodels', '0.13.1'),
     ('Arrow', '8.0.0'),  # for pyarrow
     ('Kaleido', '0.2.1'),

--- a/easybuild/easyconfigs/n/NanoPlot/NanoPlot-1.42.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/n/NanoPlot/NanoPlot-1.42.0-foss-2022a.eb
@@ -1,0 +1,44 @@
+# Author: Pavel Grochal (INUITS)
+# License: GPLv2
+
+easyblock = 'PythonPackage'
+
+name = 'NanoPlot'
+version = '1.42.0'
+
+homepage = 'https://github.com/wdecoster/NanoPlot'
+description = "Plotting suite for long read sequencing data and alignments"
+
+toolchain = {'name': 'foss', 'version': '2022a'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['0f8fd2cffd33a346b3306716058c6cb4091c931e8ab502f10b17a28749e8b6d9']
+
+dependencies = [
+    ('Python', '3.10.4'),
+    ('SciPy-bundle', '2022.05'),
+    ('Biopython', '1.79'),
+    ('Pysam', '0.19.1'),
+    ('nanomath', '1.3.0'),
+    ('nanoget', '1.19.1'),
+    ('Seaborn', '0.12.1'),
+    ('plotly.py', '5.12.0'),
+    ('pauvre', '0.2.3'),
+    ('statsmodels', '0.13.1'),
+    ('Arrow', '8.0.0'),  # for pyarrow
+    ('Kaleido', '0.2.1'),
+]
+
+download_dep_fail = True
+use_pip = True
+
+sanity_check_paths = {
+    'files': ['bin/NanoPlot'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["NanoPlot --help"]
+
+sanity_pip_check = True
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/n/NanoStat/NanoStat-1.6.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/n/NanoStat/NanoStat-1.6.0-foss-2022a.eb
@@ -11,7 +11,7 @@ toolchain = {'name': 'foss', 'version': '2022a'}
 
 dependencies = [
     ('Python', '3.10.4'),
-    ('nanoget', '1.18.1'),
+    ('nanoget', '1.19.1'),
     ('nanomath', '1.3.0'),
 ]
 

--- a/easybuild/easyconfigs/n/nanoget/nanoget-1.19.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/n/nanoget/nanoget-1.19.1-foss-2022a.eb
@@ -1,0 +1,30 @@
+# Author: Pavel Grochal (INUITS)
+# License: GPLv2
+# Update: Petr Král (INUITS)
+
+easyblock = 'PythonPackage'
+
+name = 'nanoget'
+version = '1.19.1'
+
+homepage = 'https://github.com/wdecoster/nanoget'
+description = "Functions to extract information from Oxford Nanopore sequencing data and alignments"
+
+toolchain = {'name': 'foss', 'version': '2022a'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['14f4883a995503dbae757b55cb42fcb4430c58ce2201b79abd4e8e0e3d10ca18']
+
+dependencies = [
+    ('Python', '3.10.4'),
+    ('SciPy-bundle', '2022.05'),
+    ('Biopython', '1.79'),
+    ('Pysam', '0.19.1'),
+    ('nanomath', '1.3.0'),
+]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/p/pauvre/pauvre-0.2.3-foss-2022a.eb
+++ b/easybuild/easyconfigs/p/pauvre/pauvre-0.2.3-foss-2022a.eb
@@ -1,0 +1,40 @@
+# Author: Pavel Grochal (INUITS)
+# License: GPLv2
+
+easyblock = 'PythonPackage'
+
+name = 'pauvre'
+version = '0.2.3'
+
+homepage = 'https://github.com/conchoecia/pauvre'
+description = "Tools for plotting Oxford Nanopore and other long-read data"
+
+toolchain = {'name': 'foss', 'version': '2022a'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['ba756bc9025ae7edafd91092d12a57864f018958fd46b548e9eeda7167ee197d']
+
+dependencies = [
+    ('Python', '3.10.4'),
+    ('SciPy-bundle', '2022.05'),
+    ('Biopython', '1.79'),
+    ('scikit-learn', '1.1.2'),
+    ('matplotlib', '3.5.2'),
+]
+
+download_dep_fail = True
+use_pip = True
+
+# fix incorrect requirement, correct name is 'scikit-learn'
+preinstallopts = "sed -i 's/sklearn/scikit-learn/g' setup.py && "
+
+sanity_check_paths = {
+    'files': ['bin/pauvre'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["pauvre --help"]
+
+sanity_pip_check = True
+
+moduleclass = 'math'


### PR DESCRIPTION
This PR adds three easyconfigs for building `pauvre/0.2.3-foss-2022a`, `nanoget/1.19.1-foss-2022a` and eventually `NanoPlot/1.42.0-foss-2022a`.