### PR TITLE
{numlib,chem,tollchain}[NVHPC/23.7-CUDA-12.1.1] nvofbf-2023a + QuantumESPRESSO-7.3.1 (GPU enabled)

### DIFF
--- a/easybuild/easyconfigs/f/FFTW.MPI/FFTW.MPI-3.3.10-nvompi-2023a.eb
+++ b/easybuild/easyconfigs/f/FFTW.MPI/FFTW.MPI-3.3.10-nvompi-2023a.eb
@@ -1,0 +1,22 @@
+name = 'FFTW.MPI'
+version = '3.3.10'
+
+homepage = 'https://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+in one or more dimensions, of arbitrary input size, and of both real and complex data."""
+
+toolchain = {'name': 'nvompi', 'version': '2023a'}
+toolchainopts = {'pic': True}
+
+source_urls = [homepage]
+sources = ['fftw-%(version)s.tar.gz']
+checksums = ['56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467']
+
+local_cuda = '12.1.1'
+local_compiler = ('NVHPC', '23.7-CUDA-%s' % local_cuda)
+
+dependencies = [('FFTW', '3.3.10', '', local_compiler)]
+
+runtest = 'check'
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.10-NVHPC-23.7-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.10-NVHPC-23.7-CUDA-12.1.1.eb
@@ -1,0 +1,20 @@
+name = 'FFTW'
+version = '3.3.10'
+
+homepage = 'https://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+in one or more dimensions, of arbitrary input size, and of both real and complex data."""
+
+toolchain = {'name': 'NVHPC', 'version': '23.7-CUDA-12.1.1'}
+toolchainopts = {'pic': True}
+
+source_urls = [homepage]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467']
+
+# Does not work with nvc
+with_quad_prec = False
+
+runtest = 'check'
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/f/FlexiBLAS/FlexiBLAS-3.3.1-NVHPC-23.7-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/f/FlexiBLAS/FlexiBLAS-3.3.1-NVHPC-23.7-CUDA-12.1.1.eb
@@ -1,0 +1,75 @@
+easyblock = 'Bundle'
+
+name = 'FlexiBLAS'
+version = '3.3.1'
+
+homepage = 'https://gitlab.mpi-magdeburg.mpg.de/software/flexiblas-release'
+description = """FlexiBLAS is a wrapper library that enables the exchange of the BLAS and LAPACK implementation
+used by a program without recompiling or relinking it."""
+
+toolchain = {'name': 'NVHPC', 'version': '23.7-CUDA-12.1.1'}
+local_extra_flags = "-D__ELF__"
+toolchainopts = {'pic': True, 'extra_cflags': local_extra_flags, 'extra_fflags': local_extra_flags}
+
+builddependencies = [
+    ('CMake', '3.26.3'),
+    ('Python', '3.11.3'),  # required for running the tests
+]
+
+dependencies = [
+    ('OpenBLAS', '0.3.24'),
+]
+
+# note: first listed backend will be used as default by FlexiBLAS,
+# unless otherwise specified via easyconfig parameter flexiblas_default
+local_backends = ['OpenBLAS',]
+
+# imkl supplies its backend via the imkl module, not as a dependency
+if ARCH == 'x86_64':
+    local_backends.append('imkl')
+
+default_component_specs = {'start_dir': '%(namelower)s-%(version)s'}
+sanity_check_all_components = True
+
+# Also build and install LAPACKE, which FlexiBLAS does not support yet
+components = [
+    (name, version, {
+        'source_urls':
+        ['https://gitlab.mpi-magdeburg.mpg.de/api/v4/projects/386/packages/generic/flexiblas-source/v3.3.1/'],
+        'sources': [SOURCELOWER_TAR_GZ],
+        'patches': [
+            'FlexiBLAS-3.0.4_fix-imkl.patch',
+            'FlexiBLAS-3.0.4_fix-wrapper_blas_intel.patch',
+            'FlexiBLAS-3.0.4_remove-semicolon.patch',
+            'FlexiBLAS-3.2.0_remove-intel-suffix.patch',
+        ],
+        'checksums': [
+            'bbeebf5e5a006924558fec43f49affbe1aaa4cbacfc472a9ff6066ffda142e18',  # flexiblas-3.3.1.tar.gz
+            'a078e46ad126574cc42314abd5b40461cdc6e950af79d105dbf92875c254c87c',  # FlexiBLAS-3.0.4_fix-imkl.patch
+            # FlexiBLAS-3.0.4_fix-wrapper_blas_intel.patch
+            '30ae7d1edbcff2beb18bca9b751dcaf0bf9a996d41fbe669b0a11592ec01c7ac',
+            # FlexiBLAS-3.0.4_remove-semicolon.patch
+            'a3bbcff7aeca6f8bab989e7e3a8069f2b7b660e4559042221eecaa30dc0ce300',
+            # FlexiBLAS-3.2.0_remove-intel-suffix.patch
+            '98b70ac9b10c9e45cd7c2251f8b710cda704b04311b33b6fe1a56be51aa43bc4',
+        ],
+        # 'configopts': '-DABI=GNU',
+        # 'configopts': '-DABI=Intel',
+        'backends': local_backends,
+    }),
+    ('LAPACK', '3.11.0', {
+        'easyblock': 'CMakeMake',
+        'source_urls': ['https://github.com/Reference-LAPACK/lapack/archive/'],
+        'sources': ['v%(version)s.tar.gz'],
+        'checksums': ['4b9ba79bfd4921ca820e83979db76ab3363155709444a787979e81c22285ffa9'],
+        'configopts': ('-DBUILD_SHARED_LIBS=ON -DUSE_OPTIMIZED_BLAS=ON -DLAPACKE=ON '
+                       '-DUSE_OPTIMIZED_LAPACK=ON -DBUILD_DEPRECATED=ON '
+                       '-DCMAKE_INSTALL_INCLUDEDIR=%(installdir)s/include/flexiblas'),
+        'sanity_check_paths': {
+            'files': ['lib/liblapacke.%s' % SHLIB_EXT, 'include/flexiblas/lapacke.h'],
+            'dirs': [],
+        },
+    }),
+]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/nvofbf/nvofbf-2023a.eb
+++ b/easybuild/easyconfigs/n/nvofbf/nvofbf-2023a.eb
@@ -1,0 +1,28 @@
+easyblock = 'Toolchain'
+
+name = 'nvofbf'
+version = '2023a'
+
+homepage = '(none)'
+description = """NVHPC based toolchain, including OpenMPI for MPI support,
+OpenBLAS (via FlexiBLAS for BLAS and LAPACK support), FFTW and ScaLAPACK."""
+
+toolchain = SYSTEM
+
+local_cuda = '12.1.1'
+local_compiler = ('NVHPC', '23.7-CUDA-%s' % local_cuda)
+
+local_comp_mpi_tc = ('nvompi', '%(version)s')
+
+dependencies = [
+    local_compiler,
+    ('OpenMPI', '4.1.5', '', local_compiler),
+    # ('OpenBLAS', '0.3.24', '', local_compiler),
+    ('FlexiBLAS', '3.3.1', '', local_compiler),
+    ('FFTW', '3.3.10', '', local_compiler),
+    ('FFTW.MPI', '3.3.10', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.2.0', '-fb', local_comp_mpi_tc),
+    # ('ScaLAPACK', '2.2.0', '', local_comp_mpi_tc),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/n/nvompi/nvompi-2023a.eb
+++ b/easybuild/easyconfigs/n/nvompi/nvompi-2023a.eb
@@ -1,0 +1,20 @@
+easyblock = 'Toolchain'
+
+name = 'nvompi'
+version = '2023a'
+
+homepage = '(none)'
+description = 'NVHPC based compiler toolchain, including OpenMPI for MPI support.'
+
+toolchain = SYSTEM
+
+local_cuda = '12.1.1'
+local_compiler = ('NVHPC', '23.7-CUDA-%s' % local_cuda)
+
+dependencies = [
+    local_compiler,
+    ('CUDA', local_cuda, '', SYSTEM),
+    ('OpenMPI', '4.1.5', '', local_compiler),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.23_lapack_test_nomain.patch
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.23_lapack_test_nomain.patch
@@ -1,0 +1,24 @@
+Linking of C object files with the nvfortran compiler in lapack-test
+failes with a "multiple definition of `main'" error.
+See issue https://github.com/OpenMathLib/OpenBLAS/issues/4625
+Tested with NVHPC-23.7-CUDA-12.1.1
+--- lapack-netlib/INSTALL/Makefile.orig	2023-04-01 22:18:01.000000000 +0200
++++ lapack-netlib/INSTALL/Makefile	2024-04-11 11:55:15.489833571 +0200
+@@ -6,7 +6,7 @@
+ 
+ ifneq ($(C_LAPACK), 1)
+ testlsame: lsame.o lsametst.o
+-	$(FC) $(FFLAGS) $(LDFLAGS) -o $@ $^
++	$(FC) $(FFLAGS) $(LDFLAGS) -Mnomain -o $@ $^
+ 
+ testslamch: slamch.o lsame.o slamchtst.o
+ 	$(FC) $(FFLAGS) $(LDFLAGS) -o $@ $^
+@@ -16,7 +16,7 @@
+ 
+ testsecond: second_$(TIMER).o secondtst.o
+ 	@echo "[INFO] : TIMER value: $(TIMER) (given by make.inc)"
+-	$(FC) $(FFLAGS) $(LDFLAGS) -o $@ $^
++	$(FC) $(FFLAGS) $(LDFLAGS) -Mnomain -o $@ $^
+ 
+ testdsecnd: dsecnd_$(TIMER).o dsecndtst.o
+ 	@echo "[INFO] : TIMER value: $(TIMER) (given by make.inc)"

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.24-NVHPC-23.7-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.24-NVHPC-23.7-CUDA-12.1.1.eb
@@ -1,0 +1,62 @@
+name = 'OpenBLAS'
+version = '0.3.24'
+
+homepage = 'http://www.openblas.net/'
+description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
+
+toolchain = {'name': 'NVHPC', 'version': '23.7-CUDA-12.1.1'}
+toolchainopts = {
+    # https://github.com/OpenMathLib/OpenBLAS/issues/4625
+    'precise': True,
+    'optarch': 'GENERIC',
+}
+
+source_urls = [
+    # order matters, trying to download the large.tgz/timing.tgz LAPACK tarballs from GitHub causes trouble
+    'https://www.netlib.org/lapack/timing/',
+    'https://github.com/xianyi/OpenBLAS/archive/',
+]
+sources = ['v%(version)s.tar.gz']
+patches = [
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
+    'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch',
+    # 'OpenBLAS-0.3.20_fix-x86-cpuid.patch',
+    'OpenBLAS-0.3.20_use-xASUM-microkernels-on-new-intel-cpus.patch',
+    'OpenBLAS-0.3.21_fix-order-vectorization.patch',
+    'OpenBLAS-0.3.23_disable-xDRGES-LAPACK-test.patch',
+    # 'OpenBLAS-0.3.23_fix-parallel-build.patch',
+    # 'OpenBLAS-0.3.23_fix-tests-hang.patch',
+    'OpenBLAS-0.3.23_lapack_test_nomain.patch'  # https://github.com/OpenMathLib/OpenBLAS/issues/4625
+]
+checksums = [
+    {'v0.3.24.tar.gz': 'ceadc5065da97bd92404cac7254da66cc6eb192679cf1002098688978d4d5132'},
+    {'large.tgz': 'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1'},
+    {'timing.tgz': '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af'},
+    {'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch':
+     'e6b326fb8c4a8a6fd07741d9983c37a72c55c9ff9a4f74a80e1352ce5f975971'},
+    # {'OpenBLAS-0.3.20_fix-x86-cpuid.patch': '57e8384404e136b9f0dafc26573adeb7dc69e60d84a7e189643b91d6299888fc'},
+    {'OpenBLAS-0.3.20_use-xASUM-microkernels-on-new-intel-cpus.patch':
+     '1dbd0f9473963dbdd9131611b455d8a801f1e995eae82896186d3d3ffe6d5f03'},
+    {'OpenBLAS-0.3.21_fix-order-vectorization.patch':
+     '08af834e5d60441fd35c128758ed9c092ba6887c829e0471ecd489079539047d'},
+    {'OpenBLAS-0.3.23_disable-xDRGES-LAPACK-test.patch':
+     'ab7e0af05f9b2a2ced32f3875e1e3767d9c3531a455421a38f7324350178a0ff'},
+    # {'OpenBLAS-0.3.23_fix-parallel-build.patch': 'abe10ba3b0ca54772dbf235596e35325a5159018f6a60cfc88824c2c220d99d9'},
+    # {'OpenBLAS-0.3.23_fix-tests-hang.patch': '9de1fdee6edf3b2bb55e4639fdd92d2877b5f0ac880f7df2cfea47ecebf16609'},
+    {'OpenBLAS-0.3.23_lapack_test_nomain.patch': '63e14e2cb67dd81ecc13fa0e07685f853abe0669d4cadd520247b88789346948'},
+]
+
+builddependencies = [
+    ('make', '4.4.1'),
+    # required by LAPACK test suite
+    ('Python', '3.11.3'),
+]
+
+run_lapack_tests = True
+max_failing_lapack_tests_num_errors = 150
+
+# extensive testing can be enabled by uncommenting the line below
+# runtest = 'PATH=.:$PATH lapack-timing'
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.26_lapack_qr_noninittest.patch
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.26_lapack_qr_noninittest.patch
@@ -1,0 +1,639 @@
+See https://github.com/OpenMathLib/OpenBLAS/issues/4625
+Uninitialized test results in the GEQP3RK routines introduced with LAPACK 3.12
+and in OpenBLAS 0.3.26 are causing abnormal number of errors.
+diff --git a/TESTING/LIN/cchkqp3rk.f b/TESTING/LIN/cchkqp3rk.f
+index 79d6add72e..b794d4664c 100644
+--- lapack-netlib/TESTING/LIN/cchkqp3rk.f.orig
++++ lapack-netlib/TESTING/LIN/cchkqp3rk.f
+@@ -608,6 +608,9 @@ SUBROUTINE CCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+                   CALL CLACPY( 'All', M, NRHS, COPYB, LDA,
+      $                         B,  LDA )
+                   CALL ICOPY( N, IWORK( 1 ), 1, IWORK( N+1 ), 1 )
++                  DO I = 1, NTESTS
++                    RESULT( I ) = ZERO
++                  END DO
+ *
+                   ABSTOL = -1.0
+                   RELTOl = -1.0
+@@ -652,16 +655,6 @@ SUBROUTINE CCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+                      RESULT( 1 ) = CQRT12( M, N, A, LDA, S, WORK,
+      $                                     LWORK , RWORK )
+ *
+-                     DO T = 1, 1
+-                        IF( RESULT( T ).GE.THRESH ) THEN
+-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                        CALL ALAHD( NOUT, PATH )
+-                           WRITE( NOUT, FMT = 9999 ) 'CGEQP3RK', M, N,
+-     $                        NRHS, KMAX, ABSTOL, RELTOL, NB, NX,
+-     $                        IMAT, T, RESULT( T )
+-                           NFAIL = NFAIL + 1
+-                        END IF
+-                     END DO
+                      NRUN = NRUN + 1
+ *
+ *                   End test 1
+@@ -675,7 +668,7 @@ SUBROUTINE CCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *                 1-norm( A*P - Q*R ) / ( max(M,N) * 1-norm(A) * EPS )
+ *
+                   RESULT( 2 ) = CQPT01( M, N, KFACT, COPYA, A, LDA, TAU,
+-     $                          IWORK( N+1 ), WORK, LWORK )
++     $                                  IWORK( N+1 ), WORK, LWORK )
+ *
+ *                 Compute test 3:
+ *
+@@ -684,21 +677,8 @@ SUBROUTINE CCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *                 1-norm( Q**T * Q - I ) / ( M * EPS )
+ *
+                   RESULT( 3 ) = CQRT11( M, KFACT, A, LDA, TAU, WORK,
+-     $                          LWORK )
++     $                                  LWORK )
+ *
+-*                 Print information about the tests that did not pass
+-*                 the threshold.
+-*
+-                  DO T = 2, 3
+-                     IF( RESULT( T ).GE.THRESH ) THEN
+-                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                     CALL ALAHD( NOUT, PATH )
+-                        WRITE( NOUT, FMT = 9999 ) 'CGEQP3RK', M, N,
+-     $                      NRHS, KMAX, ABSTOL, RELTOL,
+-     $                      NB, NX, IMAT, T, RESULT( T )
+-                        NFAIL = NFAIL + 1
+-                     END IF
+-                  END DO
+                   NRUN = NRUN + 2
+ *
+ *                 Compute test 4:
+@@ -717,8 +697,8 @@ SUBROUTINE CCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *
+                      DO J = 1, KFACT-1, 1
+ *
+-                        DTEMP = (( ABS( A( (J-1)*M+J ) ) -
+-     $                          ABS( A( (J)*M+J+1 ) ) ) /
++                        DTEMP = (( ABS( A( (J-1)*LDA+J ) ) -
++     $                          ABS( A( (J)*LDA+J+1 ) ) ) /
+      $                          ABS( A(1) ) )
+ *
+                         IF( DTEMP.LT.ZERO ) THEN
+@@ -727,20 +707,6 @@ SUBROUTINE CCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *
+                      END DO
+ *
+-*                    Print information about the tests that did not
+-*                    pass the threshold.
+-*
+-                     DO T = 4, 4
+-                        IF( RESULT( T ).GE.THRESH ) THEN
+-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                        CALL ALAHD( NOUT, PATH )
+-                           WRITE( NOUT, FMT = 9999 ) 'CGEQP3RK',
+-     $                        M, N, NRHS, KMAX, ABSTOL, RELTOL,
+-     $                        NB, NX, IMAT, T,
+-     $                        RESULT( T )
+-                           NFAIL = NFAIL + 1
+-                        END IF
+-                     END DO
+                      NRUN = NRUN + 1
+ *
+ *                    End test 4.
+@@ -762,42 +728,41 @@ SUBROUTINE CCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *
+                      LWORK_MQR = MAX(1, NRHS)
+                      CALL CUNMQR( 'Left', 'Conjugate transpose',
+-     $                         M, NRHS, KFACT, A, LDA, TAU, B, LDA,
+-     $                         WORK, LWORK_MQR, INFO )
++     $                            M, NRHS, KFACT, A, LDA, TAU, B, LDA,
++     $                            WORK, LWORK_MQR, INFO )
+ *
+                      DO I = 1, NRHS
+ *
+ *                       Compare N+J-th column of A and J-column of B.
+ *
+                         CALL CAXPY( M, -CONE, A( ( N+I-1 )*LDA+1 ), 1,
+-     $                                    B( ( I-1 )*LDA+1 ), 1 )
++     $                              B( ( I-1 )*LDA+1 ), 1 )
+                      END DO
+ *
+-                     RESULT( 5 ) =
+-     $               ABS(
+-     $               CLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
+-     $               ( REAL( M )*SLAMCH( 'Epsilon' ) )
+-     $               )
+-*
+-*                    Print information about the tests that did not pass
+-*                    the threshold.
+-*
+-                     DO T = 5, 5
+-                        IF( RESULT( T ).GE.THRESH ) THEN
+-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                        CALL ALAHD( NOUT, PATH )
+-                           WRITE( NOUT, FMT = 9999 ) 'CGEQP3RK', M, N,
+-     $                        NRHS, KMAX, ABSTOL, RELTOL,
+-     $                        NB, NX, IMAT, T, RESULT( T )
+-                           NFAIL = NFAIL + 1
+-                        END IF
+-                     END DO
++                     RESULT( 5 ) = ABS(
++     $                  CLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
++     $                  ( REAL( M )*SLAMCH( 'Epsilon' ) ) )
++*
+                      NRUN = NRUN + 1
+ *
+ *                    End compute test 5.
+ *
+                   END IF
+ *
++*                 Print information about the tests that did not pass
++*                 the threshold.
++*
++                  DO T = 1, NTESTS
++                     IF( RESULT( T ).GE.THRESH ) THEN
++                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
++     $                     CALL ALAHD( NOUT, PATH )
++                        WRITE( NOUT, FMT = 9999 ) 'CGEQP3RK', M, N,
++     $                      NRHS, KMAX, ABSTOL, RELTOL,
++     $                      NB, NX, IMAT, T, RESULT( T )
++                        NFAIL = NFAIL + 1
++                     END IF
++                  END DO
++*
+ *                 END DO KMAX = 1, MIN(M,N)+1
+ *
+                   END DO
+diff --git a/TESTING/LIN/dchkqp3rk.f b/TESTING/LIN/dchkqp3rk.f
+index 434d2067e2..1834e63282 100755
+--- lapack-netlib/TESTING/LIN/dchkqp3rk.f.orig
++++ lapack-netlib/TESTING/LIN/dchkqp3rk.f
+@@ -605,6 +605,9 @@ SUBROUTINE DCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+                   CALL DLACPY( 'All', M, NRHS, COPYB, LDA,
+      $                         B,  LDA )
+                   CALL ICOPY( N, IWORK( 1 ), 1, IWORK( N+1 ), 1 )
++                  DO I = 1, NTESTS
++                    RESULT( I ) = ZERO
++                  END DO
+ *
+                   ABSTOL = -1.0
+                   RELTOL = -1.0
+@@ -648,16 +651,6 @@ SUBROUTINE DCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+                      RESULT( 1 ) = DQRT12( M, N, A, LDA, S, WORK,
+      $                                     LWORK )
+ *
+-                     DO T = 1, 1
+-                        IF( RESULT( T ).GE.THRESH ) THEN
+-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                        CALL ALAHD( NOUT, PATH )
+-                           WRITE( NOUT, FMT = 9999 ) 'DGEQP3RK', M, N,
+-     $                        NRHS, KMAX, ABSTOL, RELTOL, NB, NX,
+-     $                        IMAT, T, RESULT( T )
+-                           NFAIL = NFAIL + 1
+-                        END IF
+-                     END DO
+                      NRUN = NRUN + 1
+ *
+ *                   End test 1
+@@ -671,7 +664,7 @@ SUBROUTINE DCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *                 1-norm( A*P - Q*R ) / ( max(M,N) * 1-norm(A) * EPS )
+ *
+                   RESULT( 2 ) = DQPT01( M, N, KFACT, COPYA, A, LDA, TAU,
+-     $                          IWORK( N+1 ), WORK, LWORK )
++     $                                  IWORK( N+1 ), WORK, LWORK )
+ *
+ *                 Compute test 3:
+ *
+@@ -680,21 +673,8 @@ SUBROUTINE DCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *                 1-norm( Q**T * Q - I ) / ( M * EPS )
+ *
+                   RESULT( 3 ) = DQRT11( M, KFACT, A, LDA, TAU, WORK,
+-     $                          LWORK )
+-*
+-*                 Print information about the tests that did not pass
+-*                 the threshold.
++     $                                  LWORK )
+ *
+-                  DO T = 2, 3
+-                     IF( RESULT( T ).GE.THRESH ) THEN
+-                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                     CALL ALAHD( NOUT, PATH )
+-                        WRITE( NOUT, FMT = 9999 ) 'DGEQP3RK', M, N,
+-     $                      NRHS, KMAX, ABSTOL, RELTOL,
+-     $                      NB, NX, IMAT, T, RESULT( T )
+-                        NFAIL = NFAIL + 1
+-                     END IF
+-                  END DO
+                   NRUN = NRUN + 2
+ *
+ *                 Compute test 4:
+@@ -713,8 +693,8 @@ SUBROUTINE DCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *
+                      DO J = 1, KFACT-1, 1
+ 
+-                        DTEMP = (( ABS( A( (J-1)*M+J ) ) -
+-     $                          ABS( A( (J)*M+J+1 ) ) ) /
++                        DTEMP = (( ABS( A( (J-1)*LDA+J ) ) -
++     $                          ABS( A( (J)*LDA+J+1 ) ) ) /
+      $                          ABS( A(1) ) )
+ *
+                         IF( DTEMP.LT.ZERO ) THEN
+@@ -723,20 +703,6 @@ SUBROUTINE DCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *
+                      END DO
+ *
+-*                    Print information about the tests that did not
+-*                    pass the threshold.
+-*
+-                     DO T = 4, 4
+-                        IF( RESULT( T ).GE.THRESH ) THEN
+-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                        CALL ALAHD( NOUT, PATH )
+-                           WRITE( NOUT, FMT = 9999 ) 'DGEQP3RK',
+-     $                        M, N, NRHS, KMAX, ABSTOL, RELTOL,
+-     $                        NB, NX, IMAT, T,
+-     $                        RESULT( T )
+-                           NFAIL = NFAIL + 1
+-                        END IF
+-                     END DO
+                      NRUN = NRUN + 1
+ *
+ *                    End test 4.
+@@ -758,42 +724,41 @@ SUBROUTINE DCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *
+                      LWORK_MQR = MAX(1, NRHS)
+                      CALL DORMQR( 'Left', 'Transpose',
+-     $                         M, NRHS, KFACT, A, LDA, TAU, B, LDA,
+-     $                         WORK, LWORK_MQR, INFO )
++     $                            M, NRHS, KFACT, A, LDA, TAU, B, LDA,
++     $                            WORK, LWORK_MQR, INFO )
+ *
+                      DO I = 1, NRHS
+ *
+ *                       Compare N+J-th column of A and J-column of B.
+ *
+                         CALL DAXPY( M, -ONE, A( ( N+I-1 )*LDA+1 ), 1,
+-     $                                 B( ( I-1 )*LDA+1 ), 1 )
++     $                              B( ( I-1 )*LDA+1 ), 1 )
+                      END DO
+ *
+-                   RESULT( 5 ) =
+-     $               ABS(
+-     $               DLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
+-     $               ( DBLE( M )*DLAMCH( 'Epsilon' ) )
+-     $               )
+-*
+-*                    Print information about the tests that did not pass
+-*                    the threshold.
+-*
+-                     DO T = 5, 5
+-                        IF( RESULT( T ).GE.THRESH ) THEN
+-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                        CALL ALAHD( NOUT, PATH )
+-                           WRITE( NOUT, FMT = 9999 ) 'DGEQP3RK', M, N,
+-     $                        NRHS, KMAX, ABSTOL, RELTOL,
+-     $                        NB, NX, IMAT, T, RESULT( T )
+-                           NFAIL = NFAIL + 1
+-                        END IF
+-                     END DO
++                     RESULT( 5 ) = ABS(
++     $                  DLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
++     $                  ( DBLE( M )*DLAMCH( 'Epsilon' ) ) )
++*
+                      NRUN = NRUN + 1
+ *
+ *                    End compute test 5.
+ *
+                   END IF
+ *
++*                 Print information about the tests that did not
++*                 pass the threshold.
++*
++                  DO T = 1, NTESTS
++                     IF( RESULT( T ).GE.THRESH ) THEN
++                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
++     $                     CALL ALAHD( NOUT, PATH )
++                        WRITE( NOUT, FMT = 9999 ) 'DGEQP3RK', M, N,
++     $                     NRHS, KMAX, ABSTOL, RELTOL, NB, NX,
++     $                     IMAT, T, RESULT( T )
++                        NFAIL = NFAIL + 1
++                     END IF
++                  END DO
++*
+ *                 END DO KMAX = 1, MIN(M,N)+1
+ *
+                   END DO
+diff --git a/TESTING/LIN/schkqp3rk.f b/TESTING/LIN/schkqp3rk.f
+index 36cf9370ea..c5ce7ff609 100755
+--- lapack-netlib/TESTING/LIN/schkqp3rk.f.orig
++++ lapack-netlib/TESTING/LIN/schkqp3rk.f
+@@ -604,6 +604,9 @@ SUBROUTINE SCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+                   CALL SLACPY( 'All', M, NRHS, COPYB, LDA,
+      $                         B,  LDA )
+                   CALL ICOPY( N, IWORK( 1 ), 1, IWORK( N+1 ), 1 )
++                  DO I = 1, NTESTS
++                    RESULT( I ) = ZERO
++                  END DO
+ *
+                   ABSTOL = -1.0
+                   RELTOL = -1.0
+@@ -647,16 +650,6 @@ SUBROUTINE SCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+                      RESULT( 1 ) = SQRT12( M, N, A, LDA, S, WORK,
+      $                                     LWORK )
+ *
+-                     DO T = 1, 1
+-                        IF( RESULT( T ).GE.THRESH ) THEN
+-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                        CALL ALAHD( NOUT, PATH )
+-                           WRITE( NOUT, FMT = 9999 ) 'SGEQP3RK', M, N,
+-     $                        NRHS, KMAX, ABSTOL, RELTOL, NB, NX,
+-     $                        IMAT, T, RESULT( T )
+-                           NFAIL = NFAIL + 1
+-                        END IF
+-                     END DO
+                      NRUN = NRUN + 1
+ *
+ *                   End test 1
+@@ -670,7 +663,7 @@ SUBROUTINE SCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *                 1-norm( A*P - Q*R ) / ( max(M,N) * 1-norm(A) * EPS )
+ *
+                   RESULT( 2 ) = SQPT01( M, N, KFACT, COPYA, A, LDA, TAU,
+-     $                          IWORK( N+1 ), WORK, LWORK )
++     $                                  IWORK( N+1 ), WORK, LWORK )
+ *
+ *                 Compute test 3:
+ *
+@@ -679,21 +672,8 @@ SUBROUTINE SCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *                 1-norm( Q**T * Q - I ) / ( M * EPS )
+ *
+                   RESULT( 3 ) = SQRT11( M, KFACT, A, LDA, TAU, WORK,
+-     $                          LWORK )
++     $                                  LWORK )
+ *
+-*                 Print information about the tests that did not pass
+-*                 the threshold.
+-*
+-                  DO T = 2, 3
+-                     IF( RESULT( T ).GE.THRESH ) THEN
+-                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                     CALL ALAHD( NOUT, PATH )
+-                        WRITE( NOUT, FMT = 9999 ) 'SGEQP3RK', M, N,
+-     $                      NRHS, KMAX, ABSTOL, RELTOL,
+-     $                      NB, NX, IMAT, T, RESULT( T )
+-                        NFAIL = NFAIL + 1
+-                     END IF
+-                  END DO
+                   NRUN = NRUN + 2
+ *
+ *                 Compute test 4:
+@@ -712,8 +692,8 @@ SUBROUTINE SCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *
+                      DO J = 1, KFACT-1, 1
+ 
+-                        DTEMP = (( ABS( A( (J-1)*M+J ) ) -
+-     $                          ABS( A( (J)*M+J+1 ) ) ) /
++                        DTEMP = (( ABS( A( (J-1)*LDA+J ) ) -
++     $                          ABS( A( (J)*LDA+J+1 ) ) ) /
+      $                          ABS( A(1) ) )
+ *
+                         IF( DTEMP.LT.ZERO ) THEN
+@@ -722,20 +702,6 @@ SUBROUTINE SCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *
+                      END DO
+ *
+-*                    Print information about the tests that did not
+-*                    pass the threshold.
+-*
+-                     DO T = 4, 4
+-                        IF( RESULT( T ).GE.THRESH ) THEN
+-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                        CALL ALAHD( NOUT, PATH )
+-                           WRITE( NOUT, FMT = 9999 ) 'SGEQP3RK',
+-     $                        M, N, NRHS, KMAX, ABSTOL, RELTOL,
+-     $                        NB, NX, IMAT, T,
+-     $                        RESULT( T )
+-                           NFAIL = NFAIL + 1
+-                        END IF
+-                     END DO
+                      NRUN = NRUN + 1
+ *
+ *                    End test 4.
+@@ -757,42 +723,41 @@ SUBROUTINE SCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *
+                      LWORK_MQR = MAX(1, NRHS)
+                      CALL SORMQR( 'Left', 'Transpose',
+-     $                         M, NRHS, KFACT, A, LDA, TAU, B, LDA,
+-     $                         WORK, LWORK_MQR, INFO )
++     $                            M, NRHS, KFACT, A, LDA, TAU, B, LDA,
++     $                            WORK, LWORK_MQR, INFO )
+ *
+                      DO I = 1, NRHS
+ *
+ *                       Compare N+J-th column of A and J-column of B.
+ *
+                         CALL SAXPY( M, -ONE, A( ( N+I-1 )*LDA+1 ), 1,
+-     $                                 B( ( I-1 )*LDA+1 ), 1 )
++     $                              B( ( I-1 )*LDA+1 ), 1 )
+                      END DO
+ *
+-                   RESULT( 5 ) =
+-     $               ABS(
+-     $               SLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
+-     $               ( REAL( M )*SLAMCH( 'Epsilon' ) )
+-     $               )
+-*
+-*                    Print information about the tests that did not pass
+-*                    the threshold.
+-*
+-                     DO T = 5, 5
+-                        IF( RESULT( T ).GE.THRESH ) THEN
+-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                        CALL ALAHD( NOUT, PATH )
+-                           WRITE( NOUT, FMT = 9999 ) 'SGEQP3RK', M, N,
+-     $                        NRHS, KMAX, ABSTOL, RELTOL,
+-     $                        NB, NX, IMAT, T, RESULT( T )
+-                           NFAIL = NFAIL + 1
+-                        END IF
+-                     END DO
++                     RESULT( 5 ) = ABS(
++     $                  SLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
++     $                  ( REAL( M )*SLAMCH( 'Epsilon' ) ) )
++*
+                      NRUN = NRUN + 1
+ *
+ *                    End compute test 5.
+ *
+                   END IF
+ *
++*                 Print information about the tests that did not pass
++*                 the threshold.
++*
++                  DO T = 1, NTESTS
++                     IF( RESULT( T ).GE.THRESH ) THEN
++                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
++     $                     CALL ALAHD( NOUT, PATH )
++                        WRITE( NOUT, FMT = 9999 ) 'SGEQP3RK', M, N,
++     $                      NRHS, KMAX, ABSTOL, RELTOL,
++     $                      NB, NX, IMAT, T, RESULT( T )
++                        NFAIL = NFAIL + 1
++                     END IF
++                  END DO
++*
+ *                 END DO KMAX = 1, MIN(M,N)+1
+ *
+                   END DO
+diff --git a/TESTING/LIN/zchkqp3rk.f b/TESTING/LIN/zchkqp3rk.f
+index 302c7b1a87..5092058837 100644
+--- lapack-netlib/TESTING/LIN/zchkqp3rk.f.orig
++++ lapack-netlib/TESTING/LIN/zchkqp3rk.f
+@@ -608,6 +608,9 @@ SUBROUTINE ZCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+                   CALL ZLACPY( 'All', M, NRHS, COPYB, LDA,
+      $                         B,  LDA )
+                   CALL ICOPY( N, IWORK( 1 ), 1, IWORK( N+1 ), 1 )
++                  DO I = 1, NTESTS
++                    RESULT( I ) = ZERO
++                  END DO
+ *
+                   ABSTOL = -1.0
+                   RELTOl = -1.0
+@@ -652,16 +655,6 @@ SUBROUTINE ZCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+                      RESULT( 1 ) = ZQRT12( M, N, A, LDA, S, WORK,
+      $                                     LWORK , RWORK )
+ *
+-                     DO T = 1, 1
+-                        IF( RESULT( T ).GE.THRESH ) THEN
+-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                        CALL ALAHD( NOUT, PATH )
+-                           WRITE( NOUT, FMT = 9999 ) 'ZGEQP3RK', M, N,
+-     $                        NRHS, KMAX, ABSTOL, RELTOL, NB, NX,
+-     $                        IMAT, T, RESULT( T )
+-                           NFAIL = NFAIL + 1
+-                        END IF
+-                     END DO
+                      NRUN = NRUN + 1
+ *
+ *                   End test 1
+@@ -675,7 +668,7 @@ SUBROUTINE ZCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *                 1-norm( A*P - Q*R ) / ( max(M,N) * 1-norm(A) * EPS )
+ *
+                   RESULT( 2 ) = ZQPT01( M, N, KFACT, COPYA, A, LDA, TAU,
+-     $                          IWORK( N+1 ), WORK, LWORK )
++     $                                  IWORK( N+1 ), WORK, LWORK )
+ *
+ *                 Compute test 3:
+ *
+@@ -684,21 +677,8 @@ SUBROUTINE ZCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *                 1-norm( Q**T * Q - I ) / ( M * EPS )
+ *
+                   RESULT( 3 ) = ZQRT11( M, KFACT, A, LDA, TAU, WORK,
+-     $                          LWORK )
++     $                                  LWORK )
+ *
+-*                 Print information about the tests that did not pass
+-*                 the threshold.
+-*
+-                  DO T = 2, 3
+-                     IF( RESULT( T ).GE.THRESH ) THEN
+-                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                     CALL ALAHD( NOUT, PATH )
+-                        WRITE( NOUT, FMT = 9999 ) 'ZGEQP3RK', M, N,
+-     $                      NRHS, KMAX, ABSTOL, RELTOL,
+-     $                      NB, NX, IMAT, T, RESULT( T )
+-                        NFAIL = NFAIL + 1
+-                     END IF
+-                  END DO
+                   NRUN = NRUN + 2
+ *
+ *                 Compute test 4:
+@@ -717,8 +697,8 @@ SUBROUTINE ZCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *
+                      DO J = 1, KFACT-1, 1
+ *
+-                        DTEMP = (( ABS( A( (J-1)*M+J ) ) -
+-     $                          ABS( A( (J)*M+J+1 ) ) ) /
++                        DTEMP = (( ABS( A( (J-1)*LDA+J ) ) -
++     $                          ABS( A( (J)*LDA+J+1 ) ) ) /
+      $                          ABS( A(1) ) )
+ *
+                         IF( DTEMP.LT.ZERO ) THEN
+@@ -727,20 +707,6 @@ SUBROUTINE ZCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *
+                      END DO
+ *
+-*                    Print information about the tests that did not
+-*                    pass the threshold.
+-*
+-                     DO T = 4, 4
+-                        IF( RESULT( T ).GE.THRESH ) THEN
+-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                        CALL ALAHD( NOUT, PATH )
+-                           WRITE( NOUT, FMT = 9999 ) 'ZGEQP3RK',
+-     $                        M, N, NRHS, KMAX, ABSTOL, RELTOL,
+-     $                        NB, NX, IMAT, T,
+-     $                        RESULT( T )
+-                           NFAIL = NFAIL + 1
+-                        END IF
+-                     END DO
+                      NRUN = NRUN + 1
+ *
+ *                    End test 4.
+@@ -762,42 +728,41 @@ SUBROUTINE ZCHKQP3RK( DOTYPE, NM, MVAL, NN, NVAL, NNS, NSVAL,
+ *
+                      LWORK_MQR = MAX(1, NRHS)
+                      CALL ZUNMQR( 'Left', 'Conjugate transpose',
+-     $                         M, NRHS, KFACT, A, LDA, TAU, B, LDA,
+-     $                         WORK, LWORK_MQR, INFO )
++     $                            M, NRHS, KFACT, A, LDA, TAU, B, LDA,
++     $                            WORK, LWORK_MQR, INFO )
+ *
+                      DO I = 1, NRHS
+ *
+ *                       Compare N+J-th column of A and J-column of B.
+ *
+                         CALL ZAXPY( M, -CONE, A( ( N+I-1 )*LDA+1 ), 1,
+-     $                                    B( ( I-1 )*LDA+1 ), 1 )
++     $                              B( ( I-1 )*LDA+1 ), 1 )
+                      END DO
+ *
+-                     RESULT( 5 ) =
+-     $               ABS(
+-     $               ZLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
+-     $               ( DBLE( M )*DLAMCH( 'Epsilon' ) )
+-     $               )
+-*
+-*                    Print information about the tests that did not pass
+-*                    the threshold.
+-*
+-                     DO T = 5, 5
+-                        IF( RESULT( T ).GE.THRESH ) THEN
+-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+-     $                        CALL ALAHD( NOUT, PATH )
+-                           WRITE( NOUT, FMT = 9999 ) 'ZGEQP3RK', M, N,
+-     $                        NRHS, KMAX, ABSTOL, RELTOL,
+-     $                        NB, NX, IMAT, T, RESULT( T )
+-                           NFAIL = NFAIL + 1
+-                        END IF
+-                     END DO
++                     RESULT( 5 ) = ABS(
++     $                  ZLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
++     $                  ( DBLE( M )*DLAMCH( 'Epsilon' ) ) )
++*
+                      NRUN = NRUN + 1
+ *
+ *                    End compute test 5.
+ *
+                   END IF
+ *
++*                 Print information about the tests that did not pass
++*                 the threshold.
++*
++                  DO T = 1, NTESTS
++                     IF( RESULT( T ).GE.THRESH ) THEN
++                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
++     $                     CALL ALAHD( NOUT, PATH )
++                        WRITE( NOUT, FMT = 9999 ) 'ZGEQP3RK', M, N,
++     $                      NRHS, KMAX, ABSTOL, RELTOL,
++     $                      NB, NX, IMAT, T, RESULT( T )
++                        NFAIL = NFAIL + 1
++                     END IF
++                  END DO
++*
+ *                 END DO KMAX = 1, MIN(M,N)+1
+ *
+                   END DO

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.27-NVHPC-23.7-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.27-NVHPC-23.7-CUDA-12.1.1.eb
@@ -1,0 +1,47 @@
+name = 'OpenBLAS'
+version = '0.3.27'
+
+homepage = 'http://www.openblas.net/'
+description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
+
+toolchain = {'name': 'NVHPC', 'version': '23.7-CUDA-12.1.1'}
+
+source_urls = [
+    # order matters, trying to download the large.tgz/timing.tgz LAPACK tarballs from GitHub causes trouble
+    'https://www.netlib.org/lapack/timing/',
+    'https://github.com/xianyi/OpenBLAS/archive/',
+]
+sources = ['v%(version)s.tar.gz']
+patches = [
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
+    'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch',
+    'OpenBLAS-0.3.21_fix-order-vectorization.patch',
+    'OpenBLAS-0.3.23_lapack_test_nomain.patch'
+    'OpenBLAS-0.3.26_lapack_qr_noninittest.patch'
+]
+checksums = [
+    {'v0.3.27.tar.gz': 'aa2d68b1564fe2b13bc292672608e9cdeeeb6dc34995512e65c3b10f4599e897'},
+    {'large.tgz': 'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1'},
+    {'timing.tgz': '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af'},
+    {'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch':
+     'e6b326fb8c4a8a6fd07741d9983c37a72c55c9ff9a4f74a80e1352ce5f975971'},
+    {'OpenBLAS-0.3.21_fix-order-vectorization.patch':
+     '08af834e5d60441fd35c128758ed9c092ba6887c829e0471ecd489079539047d'},
+    {'OpenBLAS-0.3.23_lapack_test_nomain.patch': '63e14e2cb67dd81ecc13fa0e07685f853abe0669d4cadd520247b88789346948'},
+    {'OpenBLAS-0.3.26_lapack_qr_noninittest.patch': '1915a216e90c3349c54d422bda45d8d9b9a3ce36b24d4efc8a417e2de40d7e6f'},
+]
+
+builddependencies = [
+    ('make', '4.4.1'),
+    # required by LAPACK test suite
+    ('Python', '3.11.3'),
+]
+
+run_lapack_tests = True
+max_failing_lapack_tests_num_errors = 150
+
+# extensive testing can be enabled by uncommenting the line below
+# runtest = 'PATH=.:$PATH lapack-timing'
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.5-NVHPC-23.7-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.5-NVHPC-23.7-CUDA-12.1.1.eb
@@ -1,0 +1,72 @@
+name = 'OpenMPI'
+version = '4.1.5'
+
+homepage = 'https://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-3 implementation."""
+
+toolchain = {'name': 'NVHPC', 'version': '23.7-CUDA-12.1.1'}
+toolchainopts = {
+    'extra_fcflags': '-Mstandard',  # https://forums.developer.nvidia.com/t/howto-build-openmpi-with-nvhpc-24-1/283219
+}
+
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+sources = [SOURCELOWER_TAR_BZ2]
+patches = [
+    'OpenMPI-4.1.1_build-with-internal-cuda-header.patch',
+    'OpenMPI-4.1.1_opal-datatype-cuda-performance.patch',
+    'OpenMPI-4.1.5_fix-pmix3x.patch',
+    'OpenMPI-4.1.x_add_atomic_wmb.patch',
+]
+checksums = [
+    {'openmpi-4.1.5.tar.bz2': 'a640986bc257389dd379886fdae6264c8cfa56bc98b71ce3ae3dfbd8ce61dbe3'},
+    {'OpenMPI-4.1.1_build-with-internal-cuda-header.patch':
+     '63eac52736bdf7644c480362440a7f1f0ae7c7cae47b7565f5635c41793f8c83'},
+    {'OpenMPI-4.1.1_opal-datatype-cuda-performance.patch':
+     'b767c7166cf0b32906132d58de5439c735193c9fd09ec3c5c11db8d5fa68750e'},
+    {'OpenMPI-4.1.5_fix-pmix3x.patch': '46edac3dbf32f2a611d45e8a3c8edd3ae2f430eec16a1373b510315272115c40'},
+    {'OpenMPI-4.1.x_add_atomic_wmb.patch': '9494bbc546d661ba5189e44b4c84a7f8df30a87cdb9d96ce2e73a7c8fecba172'},
+]
+
+builddependencies = [
+    ('pkgconf', '1.9.5'),
+    ('Perl', '5.36.1'),
+    ('Autotools', '20220317'),
+]
+
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('hwloc', '2.9.1'),
+    ('libevent', '2.1.12'),
+    ('UCX', '1.14.1'),
+    ('UCX-CUDA', '1.14.1', '-CUDA-%(cudaver)s'),
+    ('libfabric', '1.18.0'),
+    ('PMIx', '4.2.4'),
+    ('UCC', '1.2.0'),
+    ('UCC-CUDA', '1.2.0', '-CUDA-%(cudaver)s'),
+]
+
+# Update configure to include changes from the "internal-cuda" patch
+# by running a subset of autogen.pl sufficient to achieve this
+# without doing the full, long-running regeneration.
+preconfigopts = ' && '.join([
+    'cd config',
+    'autom4te --language=m4sh opal_get_version.m4sh -o opal_get_version.sh',
+    'cd ..',
+    'autoconf',
+    'autoheader',
+    'aclocal',
+    'automake',
+    ''
+])
+
+# CUDA related patches and custom configure option can be removed if CUDA support isn't wanted.
+configopts = '--with-cuda=internal '
+configopts += ' CC=pgcc CXX=pgc++ FC=pgfortran'
+
+# disable MPI1 compatibility for now, see what breaks...
+# configopts += '--enable-mpi1-compatibility '
+
+# to enable SLURM integration (site-specific)
+# configopts += '--with-slurm --with-pmi=/usr/include/slurm --with-pmi-libdir=/usr'
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3.1-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3.1-foss-2023a-CUDA-12.1.1.eb
@@ -1,0 +1,157 @@
+easyblock = "EB_QuantumESPRESSOcmake"
+
+name = "QuantumESPRESSO"
+version = "7.3.1"
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = "https://www.quantum-espresso.org"
+description = """Quantum ESPRESSO  is an integrated suite of computer codes
+for electronic-structure calculations and materials modeling at the nanoscale.
+It is based on density-functional theory, plane waves, and pseudopotentials
+(both norm-conserving and ultrasoft).
+"""
+
+toolchain = {"name": "foss", "version": "2023a"}
+toolchainopts = {
+    "usempi": True,
+    "openmp": True,
+}
+
+# Check hashes inside external/submodule_commit_hash_records when making file for new version
+local_lapack_hash = "12d825396fcef1e0a1b27be9f119f9e554621e55"
+local_mbd_hash = "82005cbb65bdf5d32ca021848eec8f19da956a77"
+local_devxlib_hash = "a6b89ef77b1ceda48e967921f1f5488d2df9226d"
+local_fox_hash = "3453648e6837658b747b895bb7bef4b1ed2eac40"
+# Different from the one at tag qe-7.3.1 because of:
+# https://gitlab.com/QEF/q-e/-/issues/666
+local_d3q_hash = "de4718351e7bbb9d1d12aad2b7ca232d06775b83"
+local_qe_gipaw_hash = "75b01b694c9ba4df55d294cacc27cf28591b2161"
+local_qmcpack_hash = "f72ab25fa4ea755c1b4b230ae8074b47d5509c70"
+local_w90_hash = "1d6b187374a2d50b509e5e79e2cab01a79ff7ce1"
+
+
+sources = [
+    {
+        "filename": "q-e-qe-%(version)s.tar.gz",
+        "extract_cmd": "mkdir -p %(builddir)s/qe-%(version)s && tar xzvf %s --strip-components=1 -C $_",
+        "source_urls": ["https://gitlab.com/QEF/q-e/-/archive/qe-%(version)s"],
+    },
+    {
+        "filename": "lapack-%s.tar.gz" % local_lapack_hash,
+        "git_config": {
+            "url": "https://github.com/Reference-LAPACK",
+            "repo_name": "lapack",
+            "commit": local_lapack_hash,
+        },
+    },
+    {
+        "filename": "mbd-%s.tar.gz" % local_mbd_hash,
+        "git_config": {
+            "url": "https://github.com/libmbd",
+            "repo_name": "libmbd",
+            "commit": local_mbd_hash,
+            'clone_into': 'mbd',
+        },
+    },
+    {
+        "filename": "devxlib-%s.tar.gz" % local_devxlib_hash,
+        "git_config": {
+            "url": "https://gitlab.com/max-centre/components",
+            "repo_name": "devicexlib",
+            "commit": local_devxlib_hash,
+            'clone_into': 'devxlib',
+        },
+    },
+    {
+        "filename": "d3q-%s.tar.gz" % local_d3q_hash,
+        "git_config": {
+            "url": "https://github.com/anharmonic",
+            "repo_name": "d3q",
+            "commit": local_d3q_hash,
+        },
+    },
+    {
+        "filename": "fox-%s.tar.gz" % local_fox_hash,
+        "git_config": {
+            "url": "https://github.com/pietrodelugas",
+            "repo_name": "fox",
+            "commit": local_fox_hash,
+        },
+    },
+    {
+        "filename": "qe-gipaw-%s.tar.gz" % local_qe_gipaw_hash,
+        "git_config": {
+            "url": "https://github.com/dceresoli",
+            "repo_name": "qe-gipaw",
+            "commit": local_qe_gipaw_hash,
+        },
+    },
+    {
+        "filename": "pw2qmcpack-%s.tar.gz" % local_qmcpack_hash,
+        "git_config": {
+            "url": "https://github.com/QMCPACK",
+            "repo_name": "pw2qmcpack",
+            "commit": local_qmcpack_hash,
+        },
+    },
+    {
+        "filename": "wannier90-%s.tar.gz" % local_w90_hash,
+        "git_config": {
+            "url": "https://github.com/wannier-developers",
+            "repo_name": "wannier90",
+            "commit": local_w90_hash,
+        },
+    },
+]
+checksums = [
+    {'q-e-qe-7.3.1.tar.gz': '2c58b8fadfe4177de5a8b69eba447db5e623420b070dea6fd26c1533b081d844'},
+    # Holding off checksum checks untill 5.0.x
+    # https://github.com/easybuilders/easybuild-framework/pull/4248
+
+    # {'lapack-%s.tar.gz' % local_lapack_hash: 'c05532ae0e5fe35f473206dda12970da5f2e2214620487d71837ddcf0ea6b21d'},
+    # {'mbd-%s.tar.gz' % local_mbd_hash: 'a180682c00bb890c9b1e26a98addbd68e32f970c06439acf7582415f4c589800'},
+    # {'devxlib-%s.tar.gz' % local_devxlib_hash: '76da8fe5a2050f58efdc92fa8831efec25c19190df7f4e5e39c173a5fbae83b4'},
+    # {'d3q-%s.tar.gz' % local_d3q_hash: '43e50753a56af05d181b859d3e29d842fb3fc4352f00cb7fe229a435a1f20c31'},
+    # {'fox-%s.tar.gz' % local_fox_hash: '99b6a899a3f947d7763aa318e86f9f08db684568bfdcd293f3318bee9d7f1948'},
+    # {'qe-gipaw-%s.tar.gz' % local_qe_gipaw_hash: '9ac8314363d29cc2f1ce85abd8f26c1a3ae311d54f6e6034d656442dd101c928'},
+    # {'pw2qmcpack-%s.tar.gz' % local_qmcpack_hash: 'a8136da8429fc49ab560ef7356cd6f0a2714dfbb137baff7961f46dfe32061eb'},
+    # {'wannier90-%s.tar.gz' % local_w90_hash: 'f989497790ec9777bdc159945bbf42156edb7268011f972874dec67dd4f58658'},
+]
+
+builddependencies = [
+    ("M4", "1.4.19"),
+    ("CMake", "3.26.3"),
+]
+dependencies = [
+    ('CUDA', '12.1.1', '', SYSTEM),
+    ('UCX-CUDA', '1.15.0', versionsuffix),
+    ("HDF5", "1.14.0"),
+    ("ELPA", "2023.05.001"),
+    ("libxc", "6.2.2"),
+]
+
+# Disabled because of
+# https://gitlab.com/QEF/q-e/-/issues/667
+# https://github.com/anharmonic/d3q/issues/15
+with_cuda = True
+build_shared_libs = False
+with_scalapack = True
+with_gipaw = False  # https://github.com/dceresoli/qe-gipaw/issues/19
+with_d3q = True
+with_qmcpack = True
+
+moduleclass = "chem"
+
+test_suite_threshold = (
+    0.4  # Low threshold because of https://gitlab.com/QEF/q-e/-/issues/665
+)
+test_suite_max_failed = (
+    5  # Allow for some flaky tests (failed due to strict thresholds)
+)
+test_suite_allow_failures = [
+    "test_qe_xclib_",  # 7.3.1:  https://gitlab.com/QEF/q-e/-/issues/640
+    "--hp_",  # 7.3.1:  Broken testsuite (https://gitlab.com/QEF/q-e/-/issues/665)
+    "--ph_",  # 7.3.1:  Broken testsuite (https://gitlab.com/QEF/q-e/-/issues/665)
+    "--epw_",  # 7.3.1:  Broken testsuite (https://gitlab.com/QEF/q-e/-/issues/665)
+    "--tddfpt_",  # 7.3.1:  Broken testsuite (https://gitlab.com/QEF/q-e/-/issues/665)
+]

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3.1-nvofbf-2023a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3.1-nvofbf-2023a.eb
@@ -2,7 +2,7 @@ easyblock = "EB_QuantumESPRESSOcmake"
 
 name = "QuantumESPRESSO"
 version = "7.3.1"
-versionsuffix = '-CUDA-%(cudaver)s'
+# versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = "https://www.quantum-espresso.org"
 description = """Quantum ESPRESSO  is an integrated suite of computer codes
@@ -11,10 +11,16 @@ It is based on density-functional theory, plane waves, and pseudopotentials
 (both norm-conserving and ultrasoft).
 """
 
-toolchain = {"name": "foss", "version": "2023a"}
+# toolchain = {"name": "foss", "version": "2023a"}
+# toolchain = {"name": "NVHPC", "version": "23.7%(versionsuffix)s"}
+# toolchain = {"name": "nvompi", "version": "2023a"}
+toolchain = {"name": "nvofbf", "version": "2023a"}
 toolchainopts = {
     "usempi": True,
     "openmp": True,
+
+    # "debug": True,
+    # "vectorize": False
 }
 
 # Check hashes inside external/submodule_commit_hash_records when making file for new version
@@ -103,45 +109,62 @@ sources = [
         },
     },
 ]
-checksums = [
-    {'q-e-qe-7.3.1.tar.gz': '2c58b8fadfe4177de5a8b69eba447db5e623420b070dea6fd26c1533b081d844'},
-    # Holding off checksum checks untill 5.0.x
-    # https://github.com/easybuilders/easybuild-framework/pull/4248
+patches = [
+    # "QuantumESPRESSO-7.3.1_noninit.patch"
+]
+# checksums = [
+#     {'q-e-qe-7.3.1.tar.gz': '2c58b8fadfe4177de5a8b69eba447db5e623420b070dea6fd26c1533b081d844'},
+#     # Holding off checksum checks untill 5.0.x
+#     # https://github.com/easybuilders/easybuild-framework/pull/4248
 
-    # {'lapack-%s.tar.gz' % local_lapack_hash: 'c05532ae0e5fe35f473206dda12970da5f2e2214620487d71837ddcf0ea6b21d'},
-    # {'mbd-%s.tar.gz' % local_mbd_hash: 'a180682c00bb890c9b1e26a98addbd68e32f970c06439acf7582415f4c589800'},
-    # {'devxlib-%s.tar.gz' % local_devxlib_hash: '76da8fe5a2050f58efdc92fa8831efec25c19190df7f4e5e39c173a5fbae83b4'},
-    # {'d3q-%s.tar.gz' % local_d3q_hash: '43e50753a56af05d181b859d3e29d842fb3fc4352f00cb7fe229a435a1f20c31'},
-    # {'fox-%s.tar.gz' % local_fox_hash: '99b6a899a3f947d7763aa318e86f9f08db684568bfdcd293f3318bee9d7f1948'},
-    # {'qe-gipaw-%s.tar.gz' % local_qe_gipaw_hash: '9ac8314363d29cc2f1ce85abd8f26c1a3ae311d54f6e6034d656442dd101c928'},
-    # {'pw2qmcpack-%s.tar.gz' % local_qmcpack_hash: 'a8136da8429fc49ab560ef7356cd6f0a2714dfbb137baff7961f46dfe32061eb'},
-    # {'wannier90-%s.tar.gz' % local_w90_hash: 'f989497790ec9777bdc159945bbf42156edb7268011f972874dec67dd4f58658'},
+#     # {'lapack-%s.tar.gz' % local_lapack_hash: 'c05532ae0e5fe35f473206dda12970da5f2e2214620487d71837ddcf0ea6b21d'},
+#     # {'mbd-%s.tar.gz' % local_mbd_hash: 'a180682c00bb890c9b1e26a98addbd68e32f970c06439acf7582415f4c589800'},
+#     # {'devxlib-%s.tar.gz' % local_devxlib_hash: '76da8fe5a2050f58efdc92fa8831efec25c19190df7f4e5e39c173a5fbae83b4'},
+#     # {'d3q-%s.tar.gz' % local_d3q_hash: '43e50753a56af05d181b859d3e29d842fb3fc4352f00cb7fe229a435a1f20c31'},
+#     # {'fox-%s.tar.gz' % local_fox_hash: '99b6a899a3f947d7763aa318e86f9f08db684568bfdcd293f3318bee9d7f1948'},
+#     # {'qe-gipaw-%s.tar.gz' % local_qe_gipaw_hash: '9ac8314363d29cc2f1ce85abd8f26c1a3ae311d54f6e6034d656442dd101c928'},
+#     # {'pw2qmcpack-%s.tar.gz' % local_qmcpack_hash: 'a8136da8429fc49ab560ef7356cd6f0a2714dfbb137baff7961f46dfe32061eb'},
+#     # {'wannier90-%s.tar.gz' % local_w90_hash: 'f989497790ec9777bdc159945bbf42156edb7268011f972874dec67dd4f58658'},
+# ]
+checksums = [
+    '2c58b8fadfe4177de5a8b69eba447db5e623420b070dea6fd26c1533b081d844',
+    None, None, None, None, None, None, None, None,
 ]
 
+local_gcc_compiler = ('GCCcore', '12.3.0')
+local_compiler = ('NVHPC', '23.7-CUDA-12.1.1')
+
 builddependencies = [
-    ("M4", "1.4.19"),
-    ("CMake", "3.26.3"),
+    ("M4", "1.4.19", '', local_gcc_compiler),
+    ("CMake", "3.26.3", '', local_gcc_compiler),
+    ("cURL", "8.0.1", '', local_gcc_compiler),
 ]
 dependencies = [
     ('CUDA', '12.1.1', '', SYSTEM),
-    ('UCX-CUDA', '1.15.0', versionsuffix),
-    ("HDF5", "1.14.0"),
-    ("ELPA", "2023.05.001"),
-    ("libxc", "6.2.2"),
+    # ('OpenBLAS', '0.3.24', '', local_compiler),
+    # ('FlexiBLAS', '3.3.1', '', local_compiler),
+    # ('FFTW', '3.3.10', '', local_compiler),
+    # ('FFTW.MPI', '3.3.10'),
+    # ('ScaLAPACK', '2.2.0', '-fb', local_comp_mpi_tc),
+    # ('ScaLAPACK', '2.2.0'),
+    # ("HDF5", "1.14.0"),
+    # ("ELPA", "2023.05.001"),
+    # ("libxc", "6.2.2"),
 ]
 
 # Disabled because of
 # https://gitlab.com/QEF/q-e/-/issues/667
 # https://github.com/anharmonic/d3q/issues/15
-with_cuda = True
 build_shared_libs = False
 with_scalapack = True
 with_gipaw = False  # https://github.com/dceresoli/qe-gipaw/issues/19
-with_d3q = True
-with_qmcpack = True
+with_d3q = False
+# with_qmcpack = True
 
 moduleclass = "chem"
 
+test_suite_nprocs = 1  # Unless multiple GPUs are available or GPU should be oversubscribed
+test_suite_concurrent = 4  # Avoid oversubscribing single GPU with too many test jobs
 test_suite_threshold = (
     0.4  # Low threshold because of https://gitlab.com/QEF/q-e/-/issues/665
 )
@@ -150,8 +173,15 @@ test_suite_max_failed = (
 )
 test_suite_allow_failures = [
     "test_qe_xclib_",  # 7.3.1:  https://gitlab.com/QEF/q-e/-/issues/640
-    "--hp_",  # 7.3.1:  Broken testsuite (https://gitlab.com/QEF/q-e/-/issues/665)
-    "--ph_",  # 7.3.1:  Broken testsuite (https://gitlab.com/QEF/q-e/-/issues/665)
-    "--epw_",  # 7.3.1:  Broken testsuite (https://gitlab.com/QEF/q-e/-/issues/665)
-    "--tddfpt_",  # 7.3.1:  Broken testsuite (https://gitlab.com/QEF/q-e/-/issues/665)
+
+    # 7.3.1: Broken testsuite (https://gitlab.com/QEF/q-e/-/issues/665)
+    "--hp_",
+    "--ph_",
+    "--epw_",
+    "--tddfpt_",
+
+    # 7.3.1: https://gitlab.com/QEF/q-e/-/issues/675
+    "system--pw_noncolin--noncolin-rmm",
+    "system--pw_scf--scf-rmm-k",
+    "system--pw_scf--scf-rmm-paro-k"
 ]

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.2.0-nvompi-2023a-fb.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.2.0-nvompi-2023a-fb.eb
@@ -1,0 +1,40 @@
+name = 'ScaLAPACK'
+version = '2.2.0'
+versionsuffix = '-fb'
+
+homepage = 'https://www.netlib.org/scalapack/'
+description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
+ redesigned for distributed memory MIMD parallel computers."""
+
+toolchain = {'name': 'nvompi', 'version': '2023a'}
+toolchainopts = {'extra_fflags': '-lpthread', 'openmp': True, 'pic': True, 'usempi': True}
+
+source_urls = [homepage]
+sources = [SOURCELOWER_TGZ]
+patches = ['ScaLAPACK-%(version)s_fix-GCC-10.patch']
+checksums = [
+    '40b9406c20735a9a3009d863318cb8d3e496fb073d201c5463df810e01ab2a57',  # scalapack-2.2.0.tgz
+    'f6bc3c6dee012ba4a696548a2e12b6aae932ce4fd5a142153b338839f52b5906',  # ScaLAPACK-2.2.0_fix-GCC-10.patch
+]
+
+builddependencies = [
+    ('CMake', '3.26.3'),
+]
+
+dependencies = [
+    ('FlexiBLAS', '3.3.1'),
+]
+
+# Config Opts based on AOCL User Guide:
+# https://developer.amd.com/wp-content/resources/AOCL_User%20Guide_2.2.pdf
+
+configopts = '-DBUILD_SHARED_LIBS=ON '
+configopts += '-DBLAS_LIBRARIES="$EBROOTFLEXIBLAS/lib/libflexiblas.%s" ' % SHLIB_EXT
+configopts += '-DLAPACK_LIBRARIES="$EBROOTFLEXIBLAS/lib/libflexiblas.%s" ' % SHLIB_EXT
+
+sanity_check_paths = {
+    'files': ['lib/libscalapack.%s' % SHLIB_EXT, 'lib64/libscalapack.%s' % SHLIB_EXT],
+    'dirs': ["lib", "lib64"],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.2.0-nvompi-2023a.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.2.0-nvompi-2023a.eb
@@ -1,0 +1,39 @@
+name = 'ScaLAPACK'
+version = '2.2.0'
+
+homepage = 'https://www.netlib.org/scalapack/'
+description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
+ redesigned for distributed memory MIMD parallel computers."""
+
+toolchain = {'name': 'nvompi', 'version': '2023a'}
+toolchainopts = {'extra_fflags': '-lpthread', 'openmp': True, 'pic': True, 'usempi': True}
+
+source_urls = [homepage]
+sources = [SOURCELOWER_TGZ]
+patches = ['ScaLAPACK-%(version)s_fix-GCC-10.patch']
+checksums = [
+    '40b9406c20735a9a3009d863318cb8d3e496fb073d201c5463df810e01ab2a57',  # scalapack-2.2.0.tgz
+    'f6bc3c6dee012ba4a696548a2e12b6aae932ce4fd5a142153b338839f52b5906',  # ScaLAPACK-2.2.0_fix-GCC-10.patch
+]
+
+builddependencies = [
+    ('CMake', '3.26.3'),
+]
+
+dependencies = [
+    ('OpenBLAS', '0.3.24'),
+]
+
+# Config Opts based on AOCL User Guide:
+# https://developer.amd.com/wp-content/resources/AOCL_User%20Guide_2.2.pdf
+
+configopts = '-DBUILD_SHARED_LIBS=ON '
+# configopts += '-DBLAS_LIBRARIES="$EBROOTFLEXIBLAS/lib/libflexiblas.%s" ' % SHLIB_EXT
+# configopts += '-DLAPACK_LIBRARIES="$EBROOTFLEXIBLAS/lib/libflexiblas.%s" ' % SHLIB_EXT
+
+sanity_check_paths = {
+    'files': ['lib/libscalapack.%s' % SHLIB_EXT, 'lib64/libscalapack.%s' % SHLIB_EXT],
+    'dirs': ["lib", "lib64"],
+}
+
+moduleclass = 'numlib'


### PR DESCRIPTION
Added easyconfig files for nvofbf toolchain + QE 7.3.1

local compilers:

- `GCC/12.3.0`
- `CUDA/12.1.1`

Added toolchain

- `nvofbf-2023a`
  - `nvompi-2023a`
    - `NVHPC-23.7-CUDA-12.1.1`
    - `OpenMPI-4.1.5`
  - `FlexiBLAS-3.3.1`
    - `OpenBLAS-0.3.24`
  - `FFTW-3.3.10`
  - `FFTW.MPI-3.3.10`
  - `ScaLAPACK-2.2.0-fb`

Solved issues:

- High number of failures in OpenBLAS lapack-testsuite: https://github.com/OpenMathLib/OpenBLAS/issues/4625

Open issue:

- Segfault in QE test-suite due to FlexiBLAS *occasionally* when calling the `ZHEEV` BLAS routine
  - Bug does not manifest when running the code with `cuda-gdb` 
  - Tested starting from `nvompi` linking directly to OpenBLAS and the error was not present
- Segfault in 3 test cases with `RMM-DIS` diagonalization with k points other than GAMMA, most likely a QE bug (https://gitlab.com/QEF/q-e/-/issues/675)