### PR TITLE
add patch to fix hardcoded `/bin/mv` path in Rhdf5lib extension included in R-bundle-Bioconductor v3.16 + v3.18

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb
@@ -322,7 +322,12 @@ exts_list = [
         'checksums': ['3dabec627b5e21da365979d6980565bd338e5a6ec8c3a016f3726ebb6184da70'],
     }),
     ('Rhdf5lib', '1.20.0', {
-        'checksums': ['a73b462be309c9df11afc9b941282dcefb36b4a38d15c050fd98bb3c05bbaf7f'],
+        'patches': ['Rhdf5lib-1.20.0_fix_hardcoded_path_to_mv.patch'],
+        'checksums': [
+            {'Rhdf5lib_1.20.0.tar.gz': 'a73b462be309c9df11afc9b941282dcefb36b4a38d15c050fd98bb3c05bbaf7f'},
+            {'Rhdf5lib-1.20.0_fix_hardcoded_path_to_mv.patch':
+             'fd35fd20166aa67cf5fbc194861d9196a2220fd40057b0524722ecc3de4774e8'},
+        ],
     }),
     ('rhdf5filters', '1.10.0', {
         'checksums': ['e1bf2ada5070b4b8d48b90db13ea750c812eaa2a82536571faa35621c250a29f'],

--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb
@@ -328,7 +328,12 @@ exts_list = [
         'checksums': ['ec1ad9959f3c290fb3b4c37c1b9719f10bac0d5d59ef6b99a56b86607442d145'],
     }),
     ('Rhdf5lib', '1.24.1', {
-        'checksums': ['90eb76a2f6b73e18c8fb560ab14e5e3a2c85ae747f278d66e67d3bebfe6c6551'],
+        'patches': ['Rhdf5lib-1.20.0_fix_hardcoded_path_to_mv.patch'],
+        'checksums': [
+            {'Rhdf5lib_1.24.1.tar.gz': '90eb76a2f6b73e18c8fb560ab14e5e3a2c85ae747f278d66e67d3bebfe6c6551'},
+            {'Rhdf5lib-1.20.0_fix_hardcoded_path_to_mv.patch':
+             'fd35fd20166aa67cf5fbc194861d9196a2220fd40057b0524722ecc3de4774e8'},
+        ],
     }),
     ('rhdf5filters', '1.14.1', {
         'checksums': ['6636612d28ea6f2e658400cbd186066926fe3d4b8d07261ad7a49299c23c0e33'],

--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/Rhdf5lib-1.20.0_fix_hardcoded_path_to_mv.patch
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/Rhdf5lib-1.20.0_fix_hardcoded_path_to_mv.patch
@@ -1,0 +1,15 @@
+Replace the call to /bin/mv by mv in the configure file of the included HDF5 source tarball.
+This prevents issues when building with a non-default sysroot.
+
+Author: Bob Dröge (University of Groningen)
+diff -ru Rhdf5lib.orig/src/Makevars.in Rhdf5lib/src/Makevars.in
+--- Rhdf5lib.orig/src/Makevars.in	2022-11-01 20:04:33.000000000 +0100
++++ Rhdf5lib/src/Makevars.in	2024-04-16 20:32:22.028694313 +0200
+@@ -48,6 +48,7 @@
+ 
+ build-hdf5: @REQUIRE_SZIP@ @EXTRACT_SOURCE@
+ 	cd hdf5; \
++	sed -i "s|/bin/mv|mv|" ./configure; \
+ 	./configure --with-pic --enable-shared=no --enable-cxx --enable-hl \
+ 	--enable-tests=no --enable-tools=no \
+ 	--with-szlib=@SZIP_HOME@ --with-zlib=@ZLIB_HOME@ \


### PR DESCRIPTION
This is now using a patch instead of the nested `sed` commands used in #20316.