### PR TITLE
remove dependency on HDF5 in recent Bioconductor easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.13-foss-2021a-R-4.1.0.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.13-foss-2021a-R-4.1.0.eb
@@ -16,7 +16,6 @@ dependencies = [
     ('R', '4.1.0'),
     ('Boost', '1.76.0'),  # for mzR
     ('GSL', '2.7'),  # for flowClust
-    ('HDF5', '1.10.7'),  # for rhdf5
     ('ncdf4', '1.17', versionsuffix),  # for mzR
     ('arrow-R', '6.0.0.2', versionsuffix),  # required by RcisTarget
 ]

--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.14-foss-2021b-R-4.1.2.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.14-foss-2021b-R-4.1.2.eb
@@ -18,7 +18,6 @@ dependencies = [
     ('R', '4.1.2'),
     ('Boost', '1.77.0'),  # for mzR  ######
     ('GSL', '2.7'),  # for flowClust
-    ('HDF5', '1.12.1'),  # for rhdf5
     ('arrow-R', '6.0.0.2', versionsuffix),  # required by RcisTarget
 ]
 

--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.15-foss-2021b-R-4.2.0.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.15-foss-2021b-R-4.2.0.eb
@@ -16,7 +16,6 @@ dependencies = [
     ('R', '4.2.0'),
     ('Boost', '1.77.0'),  # for mzR
     ('GSL', '2.7'),  # for flowClust
-    ('HDF5', '1.12.1'),  # for rhdf5
     ('arrow-R', '6.0.0.2', versionsuffix),  # required by RcisTarget
 ]
 

--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.15-foss-2022a-R-4.2.1.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.15-foss-2022a-R-4.2.1.eb
@@ -18,7 +18,6 @@ dependencies = [
     ('R', '4.2.1'),
     ('Boost', '1.79.0'),  # for mzR
     ('GSL', '2.7'),  # for flowClust
-    ('HDF5', '1.12.2'),  # for rhdf5
     ('arrow-R', '8.0.0', versionsuffix),  # required by RcisTarget
 ]
 

--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb
@@ -16,7 +16,6 @@ dependencies = [
     ('R', '4.2.2'),
     ('Boost', '1.81.0'),  # for mzR
     ('GSL', '2.7'),  # for flowClust
-    ('HDF5', '1.14.0'),  # for rhdf5
     ('arrow-R', '11.0.0.3', versionsuffix),  # required by RcisTarget
 ]
 

--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb
@@ -16,7 +16,6 @@ dependencies = [
     ('R', '4.3.2'),
     ('Boost', '1.82.0'),  # for mzR
     ('GSL', '2.7'),  # for flowClust
-    ('HDF5', '1.14.0'),  # for rhdf5
     ('arrow-R', '14.0.0.2', versionsuffix),  # required by RcisTarget
 ]
 


### PR DESCRIPTION
While debugging an Rhdf5lib build issue, I started wondering if the dependency on HDF5 in Bioconductor easyconfigs makes any sense. Rhdf5lib provides the C/C++ headers and libraries of HDF5, which is the reason why its source tarball includes a tarball of an (ancient and customized 😞 ) HDF5 version.

The Rhdf5 extension, also part of Bioconductor, depends on Rhdf5lib and provides the interface between R and HDF5. The easyconfigs had a comment `('HDF5', '1.14.0'),  # for rhdf5`, but that doesn't seem to be correct, as Rhdf5 will be using whatever Rhdf5lib provides.

Having the EB-provided HDF5 in there as well seems like a potential cause for issues, which is why I've removed it from (recent) Bioconductor easyconfigs.

Also see:
https://www.bioconductor.org/packages/release/bioc/html/Rhdf5lib.html
https://bioconductor.org/packages/release/bioc/html/rhdf5.html