### PR TITLE
{chem,devel}[foss/2023a] f90wrap v0.2.13, MetalWalls v21.06.1

### DIFF
--- a/easybuild/easyconfigs/f/f90wrap/f90wrap-0.2.13-foss-2023a.eb
+++ b/easybuild/easyconfigs/f/f90wrap/f90wrap-0.2.13-foss-2023a.eb
@@ -1,0 +1,44 @@
+easyblock = 'PythonPackage'
+
+name = 'f90wrap'
+version = '0.2.13'
+
+homepage = 'https://github.com/jameskermode/f90wrap'
+description = """f90wrap is a tool to automatically generate Python extension modules which
+interface to Fortran code that makes use of derived types. It builds on the
+capabilities of the popular f2py utility by generating a simpler Fortran 90
+interface to the original Fortran code which is then suitable for wrapping with
+f2py, together with a higher-level Pythonic wrapper that makes the existance of
+an additional layer transparent to the final user."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+sources = [SOURCE_TAR_GZ]
+patches = ['f90wrap-0.2.13_fix_old_typing.patch']
+checksums = [
+    'a61b73bb1cf028db54ad4b0c48627080d88e14463803dd55713c70f3e88b911e',  # f90wrap-0.2.13.tar.gz
+    'da8b6e551a486f42182773fa4b4d852317c5d240e930183fa5e1fa84aeab825b',  # f90wrap-0.2.13_fix_old_typing.patch
+]
+
+builddependencies = [
+    ('meson-python', '0.15.0')
+]
+dependencies = [
+    ('Python', '3.11.3'),
+    ("SciPy-bundle", "2023.07"),
+]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+sanity_check_paths = {
+    'files': ['bin/f2py-f90wrap', 'bin/f90doc', 'bin/f90wrap'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s'],
+}
+
+sanity_check_commands = [
+    ('f90wrap', '--help'),
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/f/f90wrap/f90wrap-0.2.13-foss-2023a.eb
+++ b/easybuild/easyconfigs/f/f90wrap/f90wrap-0.2.13-foss-2023a.eb
@@ -16,8 +16,8 @@ toolchain = {'name': 'foss', 'version': '2023a'}
 sources = [SOURCE_TAR_GZ]
 patches = ['f90wrap-0.2.13_fix_old_typing.patch']
 checksums = [
-    'a61b73bb1cf028db54ad4b0c48627080d88e14463803dd55713c70f3e88b911e',  # f90wrap-0.2.13.tar.gz
-    'da8b6e551a486f42182773fa4b4d852317c5d240e930183fa5e1fa84aeab825b',  # f90wrap-0.2.13_fix_old_typing.patch
+    {'f90wrap-0.2.13.tar.gz': 'a61b73bb1cf028db54ad4b0c48627080d88e14463803dd55713c70f3e88b911e'},
+    {'f90wrap-0.2.13_fix_old_typing.patch': 'e6fad329e4436b0ad2bd093d0a8dd22bf03fe6128dfe9e38d0db6bd0c2ed79e1'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/f/f90wrap/f90wrap-0.2.13_fix_old_typing.patch
+++ b/easybuild/easyconfigs/f/f90wrap/f90wrap-0.2.13_fix_old_typing.patch
@@ -1,3 +1,4 @@
+Fixed old numpy API usage in f90wrap. This has been fixed in commit 108f819 and version 0.2.14
 --- f90wrap/arraydatamodule.c.orig	2024-04-19 14:22:57.488265190 +0200
 +++ f90wrap/arraydatamodule.c	2024-04-19 14:30:08.923493156 +0200
 @@ -59,13 +59,13 @@

--- a/easybuild/easyconfigs/f/f90wrap/f90wrap-0.2.13_fix_old_typing.patch
+++ b/easybuild/easyconfigs/f/f90wrap/f90wrap-0.2.13_fix_old_typing.patch
@@ -1,0 +1,36 @@
+--- f90wrap/arraydatamodule.c.orig	2024-04-19 14:22:57.488265190 +0200
++++ f90wrap/arraydatamodule.c	2024-04-19 14:30:08.923493156 +0200
+@@ -59,13 +59,13 @@
+   /* Processing variable this */
+   this_Dims[0]=sizeof_fortran_t;
+   capi_this_intent |= F2PY_INTENT_IN;
+-  capi_this_tmp = array_from_pyobj(PyArray_INT,this_Dims,this_Rank,capi_this_intent,this_capi);
++  capi_this_tmp = array_from_pyobj(NPY_INT,this_Dims,this_Rank,capi_this_intent,this_capi);
+   if (capi_this_tmp == NULL) {
+     if (!PyErr_Occurred())
+       PyErr_SetString(PyExc_TypeError,"failed in converting 1st argument `this' of get_array to C/Fortran array" );
+     goto fail;
+   } else {
+-    this = (int *)(capi_this_tmp->data);
++    this = (int *)(PyArray_DATA(capi_this_tmp));
+   }
+ 
+   /* Processing variable arrayfunc */
+@@ -107,7 +107,7 @@
+   /* Construct array */
+   descr = PyArray_DescrNewFromType(typenum);
+   array = (PyArrayObject*) PyArray_NewFromDescr(&PyArray_Type, descr, nd, dimensions, NULL, 
+-                                                data, NPY_FORTRAN | NPY_WRITEABLE | NPY_ALIGNED, NULL);
++                                                data, NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_WRITEABLE | NPY_ARRAY_ALIGNED, NULL);
+   free(dimensions);
+   if((PyObject *)capi_this_tmp!=this_capi) {
+     Py_XDECREF(capi_this_tmp);
+@@ -125,7 +125,7 @@
+ 
+ static PyMethodDef arraydata_methods[] = {
+   {"get_array", get_array, METH_VARARGS, 
+-   "Make an array from integer(sizeof_fortran_t) array containing reference to derived type object,\n and fortran array function.\n\get_array(sizeof_fortran_t, fpointer,array_fobj[,key]) -> array"},
++   "Make an array from integer(sizeof_fortran_t) array containing reference to derived type object,\n and fortran array function.\n\\get_array(sizeof_fortran_t, fpointer,array_fobj[,key]) -> array"},
+   {NULL, NULL}
+ };
+ 

--- a/easybuild/easyconfigs/m/MetalWalls/MetalWalls-21.06.1-foss-2023a.eb
+++ b/easybuild/easyconfigs/m/MetalWalls/MetalWalls-21.06.1-foss-2023a.eb
@@ -21,7 +21,10 @@ sources = [
     },
 ]
 checksums = [
-    '8852bf5bd3591868cc2af6be378ac4dbfcd209d53acc176536038dbe69892b3d',
+    #     # Holding off checksum checks untill 5.0.x
+    #     # https://github.com/easybuilders/easybuild-framework/pull/4248
+    # '8852bf5bd3591868cc2af6be378ac4dbfcd209d53acc176536038dbe69892b3d',
+    None
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/m/MetalWalls/MetalWalls-21.06.1-foss-2023a.eb
+++ b/easybuild/easyconfigs/m/MetalWalls/MetalWalls-21.06.1-foss-2023a.eb
@@ -42,5 +42,6 @@ files_to_copy = [
 ]
 
 runtest = 'test'
+pretestopts = 'export OMPI_MCA_rmaps_base_oversubscribe=true && '  # Test-suite requires minimum number of cores
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/m/MetalWalls/MetalWalls-21.06.1-foss-2023a.eb
+++ b/easybuild/easyconfigs/m/MetalWalls/MetalWalls-21.06.1-foss-2023a.eb
@@ -36,13 +36,7 @@ dependencies = [
 
 files_to_copy = [
     (['mw'], 'bin'),
-    'build/python'
 ]
-
-sanity_check_paths = {
-    'files': ['bin/mw', 'python/mw.py', 'python/metalwalls.py'],
-    'dirs': ['python']
-}
 
 runtest = 'test'
 

--- a/easybuild/easyconfigs/m/MetalWalls/MetalWalls-21.06.1-foss-2023a.eb
+++ b/easybuild/easyconfigs/m/MetalWalls/MetalWalls-21.06.1-foss-2023a.eb
@@ -1,0 +1,49 @@
+name = 'MetalWalls'
+version = '21.06.1'
+
+homepage = 'https://gitlab.com/ampere2/metalwalls'
+description = """MetalWalls (MW) is a molecular dynamics code dedicated to the modelling of electrochemical systems.
+Its main originality is the inclusion of a series of methods allowing to apply a constant potential within the
+electrode materials."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+toolchainopts = {'usempi': True}
+
+sources = [
+    {
+        "filename": "metalwalls-%(version)s.tar.gz",
+        "git_config": {
+            "url": "https://gitlab.com/ampere2",
+            "repo_name": "metalwalls",
+            "tag": '%(version)s',
+
+        },
+    },
+]
+checksums = [
+    '8852bf5bd3591868cc2af6be378ac4dbfcd209d53acc176536038dbe69892b3d',
+]
+
+builddependencies = [
+    ("Python", "3.11.3"),
+    ("SciPy-bundle", "2023.07"),
+]
+dependencies = [
+    ("PLUMED", "2.9.0"),
+    ("f90wrap", "0.2.13"),
+    ("mpi4py", "3.1.4")
+]
+
+files_to_copy = [
+    (['mw'], 'bin'),
+    'build/python'
+]
+
+sanity_check_paths = {
+    'files': ['bin/mw', 'python/mw.py', 'python/metalwalls.py'],
+    'dirs': ['python']
+}
+
+runtest = 'test'
+
+moduleclass = 'chem'


### PR DESCRIPTION
Depends on easyblock from https://github.com/easybuilders/easybuild-easyblocks/pull/3311

Adds the following EC files:

- MetalWalls (https://gitlab.com/ampere2/metalwalls)
- f90wrap (with a patch not yet included in the main distribution) as a dependency to build the python interface of MetalWalls