### PR TITLE
use regular `configure` instead of wrapper script for recent UCX easyconfigs

### DIFF
--- a/easybuild/easyconfigs/u/UCX/UCX-1.13.1-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.13.1-GCCcore-12.2.0.eb
@@ -40,10 +40,10 @@ dependencies = [
     ('numactl', '2.0.16'),
 ]
 
-configure_cmd = "contrib/configure-release"
-
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
 configopts += '--without-java --without-go --disable-doxygen-doc '
+# include the configure options from contrib/configure-release
+configopts += '--disable-logging --disable-debug --disable-assertions --disable-params-check '
 
 buildopts = 'V=1'
 

--- a/easybuild/easyconfigs/u/UCX/UCX-1.14.0-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.14.0-GCCcore-12.2.0.eb
@@ -37,10 +37,10 @@ dependencies = [
     ('numactl', '2.0.16'),
 ]
 
-configure_cmd = "contrib/configure-release"
-
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
 configopts += '--without-java --without-go --disable-doxygen-doc '
+# include the configure options from contrib/configure-release
+configopts += '--disable-logging --disable-debug --disable-assertions --disable-params-check '
 
 buildopts = 'V=1'
 

--- a/easybuild/easyconfigs/u/UCX/UCX-1.14.1-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.14.1-GCCcore-12.3.0.eb
@@ -37,10 +37,10 @@ dependencies = [
     ('numactl', '2.0.16'),
 ]
 
-configure_cmd = "contrib/configure-release"
-
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
 configopts += '--without-java --without-go --disable-doxygen-doc '
+# include the configure options from contrib/configure-release
+configopts += '--disable-logging --disable-debug --disable-assertions --disable-params-check '
 
 buildopts = 'V=1'
 

--- a/easybuild/easyconfigs/u/UCX/UCX-1.15.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.15.0-GCCcore-13.2.0.eb
@@ -37,10 +37,10 @@ dependencies = [
     ('numactl', '2.0.16'),
 ]
 
-configure_cmd = "contrib/configure-release"
-
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
 configopts += '--without-java --without-go --disable-doxygen-doc '
+# include the configure options from contrib/configure-release
+configopts += '--disable-logging --disable-debug --disable-assertions --disable-params-check '
 
 buildopts = 'V=1'
 

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.2.0.eb
@@ -35,10 +35,10 @@ dependencies = [
     ('numactl', '2.0.14'),
 ]
 
-configure_cmd = "contrib/configure-release"
-
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
 configopts += '--without-java --without-go --disable-doxygen-doc '
+# include the configure options from contrib/configure-release
+configopts += '--disable-logging --disable-debug --disable-assertions --disable-params-check '
 
 buildopts = 'V=1'
 

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-11.3.0.eb
@@ -35,10 +35,10 @@ dependencies = [
     ('numactl', '2.0.14'),
 ]
 
-configure_cmd = "contrib/configure-release"
-
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
 configopts += '--without-java --without-go --disable-doxygen-doc '
+# include the configure options from contrib/configure-release
+configopts += '--disable-logging --disable-debug --disable-assertions --disable-params-check '
 
 buildopts = 'V=1'
 

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.2.0.eb
@@ -35,10 +35,10 @@ dependencies = [
     ('numactl', '2.0.16'),
 ]
 
-configure_cmd = "contrib/configure-release"
-
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
 configopts += '--without-java --without-go --disable-doxygen-doc '
+# include the configure options from contrib/configure-release
+configopts += '--disable-logging --disable-debug --disable-assertions --disable-params-check '
 
 buildopts = 'V=1'
 

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-12.3.0.eb
@@ -35,10 +35,10 @@ dependencies = [
     ('numactl', '2.0.16'),
 ]
 
-configure_cmd = "contrib/configure-release"
-
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
 configopts += '--without-java --without-go --disable-doxygen-doc '
+# include the configure options from contrib/configure-release
+configopts += '--disable-logging --disable-debug --disable-assertions --disable-params-check '
 
 buildopts = 'V=1'
 

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-rc4-GCCcore-13.2.0.eb
@@ -35,10 +35,10 @@ dependencies = [
     ('numactl', '2.0.16'),
 ]
 
-configure_cmd = "contrib/configure-release"
-
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
 configopts += '--without-java --without-go --disable-doxygen-doc '
+# include the configure options from contrib/configure-release
+configopts += '--disable-logging --disable-debug --disable-assertions --disable-params-check '
 
 buildopts = 'V=1'
 


### PR DESCRIPTION
The UCX easyconfigs for version 1.9.0 and newer are currently using `configure_cmd = contrib/configure-release`; this is a wrapper script around `./configure` which passed some predefined flags (these haven't changed for many years), see:
https://github.com/openucx/ucx/blob/master/contrib/configure-release

While trying to install UCX on RISC-V, I ran into issues with the outdated `config.guess` included with UCX. The ConfigureMake easyblock should download a newer version and use that one, but it turns out that it only does that when the `configure_cmd` script includes a certain string (`Generated by GNU Autoconf`). Though the `configure` script does include it, this is not the case for the `contrib/configure-release` wrapper script, hence that step is skipped. By appending the options that this wrapper uses to `configopts`, we can just call `./configure` itself, and then EB does make sure that an updated `config.guess` is being used. Additionally, it's more explicit in the easyconfig which flags are being passed.