### PR TITLE
add RISC-V support to UCC 1.2.0

### DIFF
--- a/easybuild/easyconfigs/u/UCC/UCC-1.2.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/u/UCC/UCC-1.2.0-GCCcore-13.2.0.eb
@@ -22,7 +22,7 @@ checksums = [
 
 if ARCH == "riscv64":
     patches += ['UCC-1.2.0_add-riscv-support.patch']
-    checksums += [{'UCC-1.2.0_add-riscv-support.patch': 
+    checksums += [{'UCC-1.2.0_add-riscv-support.patch':
                    'e9e2a4c206dad2367af97d92c12b796b454992cfce23984b132e9e78a07ff55b'}]
 
 builddependencies = [

--- a/easybuild/easyconfigs/u/UCC/UCC-1.2.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/u/UCC/UCC-1.2.0-GCCcore-13.2.0.eb
@@ -22,7 +22,8 @@ checksums = [
 
 if ARCH == "riscv64":
     patches += ['UCC-1.2.0_add-riscv-support.patch']
-    checksums += [{'UCC-1.2.0_add-riscv-support.patch': 'e9e2a4c206dad2367af97d92c12b796b454992cfce23984b132e9e78a07ff55b'}]
+    checksums += [{'UCC-1.2.0_add-riscv-support.patch': 
+                   'e9e2a4c206dad2367af97d92c12b796b454992cfce23984b132e9e78a07ff55b'}]
 
 builddependencies = [
     ('binutils', '2.40'),

--- a/easybuild/easyconfigs/u/UCC/UCC-1.2.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/u/UCC/UCC-1.2.0-GCCcore-13.2.0.eb
@@ -20,6 +20,10 @@ checksums = [
     {'UCC-1.1.0-multiple_component_paths.patch': '3081d0f694331daa4a88a0fa3fb54b9a918015248ae5eb7b3157b924abd31bee'},
 ]
 
+if ARCH == "riscv64":
+    patches += ['UCC-1.2.0_add-riscv-support.patch']
+    checksums += [{'UCC-1.2.0_add-riscv-support.patch': 'e9e2a4c206dad2367af97d92c12b796b454992cfce23984b132e9e78a07ff55b'}]
+
 builddependencies = [
     ('binutils', '2.40'),
     ('Autotools', '20220317'),

--- a/easybuild/easyconfigs/u/UCC/UCC-1.2.0_add-riscv-support.patch
+++ b/easybuild/easyconfigs/u/UCC/UCC-1.2.0_add-riscv-support.patch
@@ -1,0 +1,91 @@
+Add RISC-V support to UCC 1.2.0 using https://github.com/openucx/ucc/pull/829.
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index b3fe5ed1c2..85496f83dd 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -50,6 +50,7 @@ noinst_HEADERS =                      \
+ 	coll_score/ucc_coll_score.h       \
+ 	utils/arch/aarch64/cpu.h          \
+ 	utils/arch/ppc64/cpu.h            \
++	utils/arch/riscv64/cpu.h          \
+ 	utils/arch/x86_64/cpu.h           \
+ 	utils/arch/cpu.h                  \
+ 	utils/arch/cuda_def.h             \
+diff --git a/src/utils/arch/cpu.h b/src/utils/arch/cpu.h
+index 8025f7a9d8..17a74195b7 100644
+--- a/src/utils/arch/cpu.h
++++ b/src/utils/arch/cpu.h
+@@ -2,6 +2,7 @@
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2023. ALL RIGHTS RESERVED.
+ * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
+ * Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
++* Copyright (C) Rivos Inc. 2023
+ *
+ * See file LICENSE for terms.
+ */
+@@ -44,6 +45,7 @@ typedef enum ucc_cpu_vendor {
+     UCC_CPU_VENDOR_AMD,
+     UCC_CPU_VENDOR_GENERIC_ARM,
+     UCC_CPU_VENDOR_GENERIC_PPC,
++    UCC_CPU_VENDOR_GENERIC_RISCV,
+     UCC_CPU_VENDOR_FUJITSU_ARM,
+     UCC_CPU_VENDOR_ZHAOXIN,
+     UCC_CPU_VENDOR_LAST
+@@ -59,6 +61,8 @@ static inline ucc_cpu_vendor_t ucc_get_vendor_from_str(const char *v_name)
+         return UCC_CPU_VENDOR_GENERIC_ARM;
+     if (strcasecmp(v_name, "ppc") == 0)
+         return UCC_CPU_VENDOR_GENERIC_PPC;
++    if (strcasecmp(v_name, "riscv") == 0)
++        return UCC_CPU_VENDOR_GENERIC_RISCV;
+     if (strcasecmp(v_name, "fujitsu") == 0)
+         return UCC_CPU_VENDOR_FUJITSU_ARM;
+     if (strcasecmp(v_name, "zhaoxin") == 0)
+@@ -107,6 +111,8 @@ static inline ucc_cpu_model_t ucc_get_model_from_str(const char *m_name)
+ #  include "ppc64/cpu.h"
+ #elif defined(__aarch64__)
+ #  include "aarch64/cpu.h"
++#elif defined(__riscv) && (__riscv_xlen == 64)
++#  include "riscv64/cpu.h"
+ #else
+ #  error "Unsupported architecture"
+ #endif
+diff --git a/src/utils/arch/riscv64/cpu.h b/src/utils/arch/riscv64/cpu.h
+new file mode 100644
+index 0000000000..c93cdb3db1
+--- /dev/null
++++ b/src/utils/arch/riscv64/cpu.h
+@@ -0,0 +1,33 @@
++/**
++* Copyright (c) 2001-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
++* Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
++* Copyright (C) Rivos Inc. 2023
++*
++* See file LICENSE for terms.
++*/
++
++#ifndef UCC_UTILS_ARCH_RISCV64_CPU_H_
++#define UCC_UTILS_ARCH_RISCV64_CPU_H_
++
++#define UCC_ARCH_CACHE_LINE_SIZE 64
++
++/* RVWMO rules */
++#define ucc_memory_bus_fence()       asm volatile("fence iorw, iorw" ::: "memory")
++#define ucc_memory_bus_store_fence() asm volatile("fence ow, ow" ::: "memory")
++#define ucc_memory_bus_load_fence()  asm volatile("fence ir, ir" ::: "memory")
++
++#define ucc_memory_cpu_fence()       asm volatile("fence rw, rw" ::: "memory")
++#define ucc_memory_cpu_store_fence() asm volatile("fence rw, w" ::: "memory")
++#define ucc_memory_cpu_load_fence()  asm volatile("fence r, rw" ::: "memory")
++
++static inline ucc_cpu_model_t ucc_arch_get_cpu_model()
++{
++    return UCC_CPU_MODEL_UNKNOWN;
++}
++
++static inline ucc_cpu_vendor_t ucc_arch_get_cpu_vendor()
++{
++    return UCC_CPU_VENDOR_GENERIC_RISCV;
++}
++
++#endif


### PR DESCRIPTION
RISC-V support was added after the 1.2.0 release, but the patch file of the PR seems to work fine for 1.2.0 as well. As it's not officially supported, I'm only applying the patch on RISC-V build hosts.