### PR TITLE
{tools}[foss/2023a] aiida-atomictools

### DIFF
--- a/easybuild/easyconfigs/a/aiida-atomictools/aiida-atomictools-2.5.1-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/a/aiida-atomictools/aiida-atomictools-2.5.1-gfbf-2023a.eb
@@ -1,6 +1,6 @@
 easyblock = 'Bundle'
 
-name = 'aiida-atomistictools'
+name = 'aiida-atomictools'
 version = '2.5.1'
 
 homepage = 'https://www.aiida.net/'

--- a/easybuild/easyconfigs/a/aiida-atomistictools/aiida-atomistictools-2.5.1-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/a/aiida-atomistictools/aiida-atomistictools-2.5.1-gfbf-2023a.eb
@@ -1,0 +1,21 @@
+easyblock = 'Bundle'
+
+name = 'aiida-atomistictools'
+version = '2.5.1'
+
+homepage = 'https://www.aiida.net/'
+description = "Bundle of Python packages required to run AiiDA with enabled atomistic tools functionalities."
+
+toolchain = {'name': 'gfbf', 'version': '2023a'}
+toolchainopts = {'pic': True}
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('ASE', '3.22.1'),  # ase, matplotlib, spglib
+    ('PyCifRW', '4.4.2'),  # CifFIle
+    ('pymatgen', '2023.12.18'),  # pymatgen
+    ('pymysql', '0.9.3'),  # pymysql
+    ('seekpath', '1.9.7')
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/PyCifRW/PyCifRW-4.4.2-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/p/PyCifRW/PyCifRW-4.4.2-GCCcore-12.3.0.eb
@@ -1,0 +1,26 @@
+easyblock = 'PythonPackage'
+
+name = 'PyCifRW'
+version = '4.4.2'
+
+homepage = "https://bitbucket.org/jamesrhester/pycifrw/src/development"
+description = """PyCIFRW provides support for reading and writing CIF
+(Crystallographic Information Format) files using Python."""
+
+toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['a1b6ca0098c9c986b80a50f6cf05122ad65434a18b97a1120f83304ba485acc7']
+
+builddependencies = [('binutils', '2.40')]
+
+dependencies = [('Python', '3.11.3')]
+
+use_pip = True
+# download_dep_fail =  True
+
+options = {'modulename': 'CifFile'}
+
+sanity_pip_check = True
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/pymatgen/pymatgen-2023.12.18-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/p/pymatgen/pymatgen-2023.12.18-gfbf-2023a.eb
@@ -1,0 +1,138 @@
+easyblock = 'PythonBundle'
+
+name = 'pymatgen'
+version = '2023.12.18'
+
+homepage = 'https://pymatgen.org/'
+description = """Python Materials Genomics is a robust materials analysis code that defines core object
+ representations for structures and molecules with support for many electronic structure codes."""
+
+toolchain = {'name': 'gfbf', 'version': '2023a'}
+
+builddependencies = [
+    ('hatchling', '1.18.0'),
+    ('hypothesis', '6.82.0'),  # required for tests
+    ('maturin', '1.1.0'),
+    ('poetry', '1.5.1'),
+]
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('PyYAML', '6.0'),
+    ('PyZMQ', '25.1.1'),
+    ('bcrypt', '4.0.1'),
+    ('boto3', '1.28.70'),
+    ('Flask', '2.3.3'),
+    ('matplotlib', '3.7.2'),
+    ('networkx', '3.1'),
+    ('paramiko', '3.2.0'),
+    ('plotly.py', '5.16.0'),
+    ('pydantic', '2.5.3'),
+    ('ruamel.yaml', '0.17.32'),
+    ('spglib-python', '2.1.0'),
+    ('sympy', '1.12'),
+    ('tqdm', '4.66.1'),
+    ('uncertainties', '3.1.7'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('palettable', '3.3.0', {
+        'checksums': ['72feca71cf7d79830cd6d9181b02edf227b867d503bec953cf9fa91bf44896bd'],
+    }),
+    ('latexcodec', '2.0.1', {
+        'checksums': ['2aa2551c373261cefe2ad3a8953a6d6533e68238d180eb4bb91d7964adb3fe9a'],
+    }),
+    ('pybtex', '0.24.0', {
+        'checksums': ['818eae35b61733e5c007c3fcd2cfb75ed1bc8b4173c1f70b56cc4c0802d34755'],
+    }),
+    ('h11', '0.14.0', {
+        'checksums': ['8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d'],
+    }),
+    ('uvicorn', '0.25.0', {
+        'checksums': ['6dddbad1d7ee0f5140aba5ec138ddc9612c5109399903828b4874c9937f009c2'],
+    }),
+    ('sshtunnel', '0.4.0', {
+        'checksums': ['e7cb0ea774db81bf91844db22de72a40aae8f7b0f9bb9ba0f666d474ef6bf9fc'],
+    }),
+    ('dnspython', '2.4.2', {
+        'modulename': False,
+        'checksums': ['8dcfae8c7460a2f84b4072e26f1c9f4101ca20c071649cb7c34e8b6a93d58984'],
+    }),
+    ('pymongo', '4.6.1', {
+        'checksums': ['31dab1f3e1d0cdd57e8df01b645f52d43cc1b653ed3afd535d2891f4fc4f9712'],
+    }),
+    ('pydash', '7.0.6', {
+        'checksums': ['7d9df7e9f36f2bbb08316b609480e7c6468185473a21bdd8e65dda7915565a26'],
+    }),
+    ('python-dotenv', '1.0.0', {
+        'modulename': 'dotenv',
+        'checksums': ['a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba'],
+    }),
+    ('pydantic-settings', '2.1.0', {
+        'sources': {'source_urls': ['https://github.com/pydantic/pydantic-settings/archive/refs/tags/'],
+                    'download_filename': 'v%(version)s.tar.gz',
+                    'filename': SOURCE_TAR_GZ},
+        'checksums': ['be83f7a7da10a0686a00da1b9e62856072bbcfb7d6a420ea3c78c66b145fcd93'],
+    }),
+    ('emmet-core', '0.75.0', {
+        'modulename': 'emmet',
+        'patches': ['emmet-core-0.75.0-fix-readme.patch'],
+        'checksums': [
+            {'emmet-core-0.75.0.tar.gz': '2d4b20d542e56c97009d05d03f5595be9395ac27c2fe9809d617f28596c40640'},
+            {'emmet-core-0.75.0-fix-readme.patch':
+             'd299f388044fdcff32fc246b0215ae4b656bc20d9d3c759d545cbe3167df08b8'},
+        ],
+    }),
+    ('orjson', '3.9.10', {
+        'checksums': ['9ebbdbd6a046c304b1845e96fbcc5559cd296b4dfd3ad2509e33c4d9ce07d6a1'],
+    }),
+    ('monty', '2023.11.3', {
+        'checksums': ['d961c14b0b20901c7603aa00d275e62dee8333fbdaf1179f5d862c6fb3f3c52f'],
+    }),
+    ('sentinels', '1.0.0', {
+        'checksums': ['7be0704d7fe1925e397e92d18669ace2f619c92b5d4eb21a89f31e026f9ff4b1'],
+    }),
+    ('mongomock', '4.1.2', {
+        'checksums': ['f06cd62afb8ae3ef63ba31349abd220a657ef0dd4f0243a29587c5213f931b7d'],
+    }),
+    ('mongogrant', '0.3.3', {
+        'checksums': ['ad494b8638adfa840cdd5568af44448dd43771b58102550cf7c61402b1620ab4'],
+    }),
+    ('sniffio', '1.3.0', {  # Same version as in jupyter-server
+        'checksums': ['e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101'],
+    }),
+    ('anyio', '3.7.1', {  # Same version as in jupyter-server
+        'checksums': ['44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780'],
+    }),
+    ('starlette', '0.27.0', {
+        'checksums': ['6a6b0d042acb8d469a01eba54e9cda6cbd24ac602c4cd016723117d6a7e73b75'],
+    }),
+    ('fastapi', '0.105.0', {
+        'checksums': ['4d12838819aa52af244580675825e750ad67c9df4614f557a769606af902cf22'],
+    }),
+    ('aioitertools', '0.11.0', {
+        'checksums': ['42c68b8dd3a69c2bf7f2233bf7df4bb58b557bca5252ac02ed5187bbc67d6831'],
+    }),
+    ('maggma', '0.60.2', {
+        'checksums': ['12e8da1f80505f39432b972cbe47fb378cd9aa51fab968877a2d3b2588c96c69'],
+    }),
+    ('mp-api', '0.39.4', {
+        'checksums': ['692abefd6adec36eb4fa193f914e08167ed33a5a3a9714ec3c15606839649f32'],
+    }),
+    (name, version, {
+        'checksums': ['56c0041fe5431ac1b8f8c0c17d06091c4d61082c3a99924f3940d73ebb6656eb'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/pmg'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["pmg --help"]
+
+sanity_pip_check = True
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/p/pymysql/pymysql-0.9.3-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/p/pymysql/pymysql-0.9.3-GCCcore-12.3.0.eb
@@ -1,0 +1,23 @@
+easyblock = 'PythonPackage'
+
+name = 'pymysql'
+version = '0.9.3'
+
+homepage = "https://bitbucket.org/jamesrhester/pycifrw/src/development"
+description = """PyCIFRW provides support for reading and writing CIF
+(Crystallographic Information Format) files using Python."""
+
+toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+
+sources = ['PyMySQL-%(version)s.tar.gz']
+checksums = ['d8c059dcd81dedb85a9f034d5e22dcb4442c0b201908bede99e306d65ea7c8e7']
+
+builddependencies = [('binutils', '2.40')]
+
+dependencies = [('Python', '3.11.3')]
+
+use_pip = True
+
+sanity_pip_check = True
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/s/seekpath/seekpath-1.9.7-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/s/seekpath/seekpath-1.9.7-gfbf-2023a.eb
@@ -1,0 +1,26 @@
+easyblock = 'PythonPackage'
+
+name = 'seekpath'
+version = '1.9.7'
+
+homepage = "https://github.com/giovannipizzi/seekpath"
+description = """SeeK-path is a python module to obtain band paths in the Brillouin zone of crystal structures."""
+
+toolchain = {'name': 'gfbf', 'version': '2023a'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['b83ea23b54209b7f34f3fcabe7248cebbcc3cc164c394f1659b35942edaedb1c']
+
+builddependencies = [('binutils', '2.40')]
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('Python-bundle-PyPI', '2023.06'),
+    ('spglib-python', '2.1.0'),  # spglib
+]
+
+use_pip = True
+
+sanity_pip_check = True
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/u/uncertainties/uncertainties-3.1.7-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/u/uncertainties/uncertainties-3.1.7-gfbf-2023a.eb
@@ -1,0 +1,24 @@
+easyblock = 'PythonPackage'
+
+name = 'uncertainties'
+version = '3.1.7'
+
+homepage = 'http://uncertainties-python-package.readthedocs.io'
+description = """Transparent calculations with uncertainties on the quantities involved (aka error propagation);
+ fast calculation of derivatives"""
+
+toolchain = {'name': 'gfbf', 'version': '2023a'}
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('SciPy-bundle', '2023.07'),
+]
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['80111e0839f239c5b233cb4772017b483a0b7a1573a581b92ab7746a35e6faab']
+
+use_pip = True
+download_dep_fail = True
+sanity_pip_check = True
+
+moduleclass = 'lib'


### PR DESCRIPTION
Provides a `Bundle` of dependencies that would be installed by `pip install aiida-core[atomic_tools]` on top of a base installation of `aiida-core`.

The needed dependencies are implemented as separate `PythonBundle`s in order to provide the lowest required toolchain for each

- PyCifRW-4.4.2-GCCcore-12.3.0
- pymatgen-2023.12.18-gfbf-2023a
  - (added EC for 2 dependencies downgraded from `foss2023a` to `gfbf2023a` as the usage of pymatgen in AiiDA is not compute intensive)
- pymysql-0.9.3-GCCcore-12.3.0
- seekpath-1.9.7-gfbf-2023a