### PR TITLE
add checksum for RISC-V version to Java 21.0.2 easyconfig

### DIFF
--- a/easybuild/easyconfigs/j/Java/Java-21.0.2.eb
+++ b/easybuild/easyconfigs/j/Java/Java-21.0.2.eb
@@ -24,6 +24,8 @@ checksums = [
             '3ce6a2b357e2ef45fd6b53d6587aa05bfec7771e7fb982f2c964f6b771b7526a',
         local_tarball_tmpl % ('ppc64le', local_build):
             'd08de863499d8851811c893e8915828f2cd8eb67ed9e29432a6b4e222d80a12f',
+        local_tarball_tmpl % ('riscv64', local_build):
+            '791a37ddb040e1a02bbfc61abfbc7e7321431a28054c9ac59ba1738fd5320b02',
     }
 ]
 


### PR DESCRIPTION
This version supports RISC-V, see https://github.com/adoptium/temurin21-binaries/releases/tag/jdk-21.0.2%2B13.

Requires https://github.com/easybuilders/easybuild-easyblocks/pull/3323.