### PR TITLE
{tools}[foss/2023a] AiiDA

### DIFF
--- a/easybuild/easyconfigs/a/AiiDA/AiiDA-2.5.1-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/a/AiiDA/AiiDA-2.5.1-gfbf-2023a.eb
@@ -3,8 +3,8 @@ easyblock = 'Binary'
 name = 'AiiDA'
 version = '2.5.1'
 
-homepage = ''
-description = """"""
+homepage = 'https://www.aiida.net/'
+description = """Scripts for bootstrapping and cleaning up an AiiDA installation."""
 
 toolchain = {'name': 'gfbf', 'version': '2023a'}
 

--- a/easybuild/easyconfigs/a/AiiDA/AiiDA-2.5.1-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/a/AiiDA/AiiDA-2.5.1-gfbf-2023a.eb
@@ -12,7 +12,10 @@ sources = [
     'aiida_bootstrap.sh',
     'aiida_cleanup.sh',
 ]
-checksums = []
+checksums = [
+    {'aiida_bootstrap.sh': 'c92bc1c0ff23b2d54be2a5367df88abc94a413555b34fab830c5dcea84507650'},
+    {'aiida_cleanup.sh': '5f6a46c1f9b4381fe012c94323c38e72d8a314e5f7b81a4f3517ebe6034f3cfd'},
+]
 
 builddependencies = [
     ('binutils', '2.40'),

--- a/easybuild/easyconfigs/a/AiiDA/AiiDA-2.5.1-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/a/AiiDA/AiiDA-2.5.1-gfbf-2023a.eb
@@ -1,0 +1,47 @@
+import os
+
+easyblock = 'Binary'
+
+name = 'AiiDA'
+version = '2.5.1'
+
+homepage = ''
+description = """"""
+
+toolchain = {'name': 'gfbf', 'version': '2023a'}
+
+sources = [
+    'aiida_bootstrap.sh',
+    'aiida_cleanup.sh',
+]
+checksums = []
+
+builddependencies = [
+    ('binutils', '2.40'),
+]
+dependencies = [
+    ('aiida-core', '2.5.1'),
+    ('RabbitMQ', '3.13.1'),
+    ('PostgreSQL', '16.1'),
+]
+
+extract_sources = True
+
+install_cmd = "chmod +x *.sh && mkdir -p %(installdir)s/bin && cp *.sh %(installdir)s/bin"
+
+sanity_check_paths = {
+    'files': ['bin/aiida_bootstrap.sh', 'bin/aiida_cleanup.sh'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'
+
+modluafooter = """
+local home = os.getenv("HOME")
+local eb_config_dir = pathJoin(home, ".eb_aiida")
+
+setenv("EB_CONFIG_DIR", eb_config_dir)
+setenv("PGHOST", eb_config_dir)
+setenv("RABBITMQ_NODENAME", "rabbit-" .. os.getenv("USER"))
+setenv("AIIDA_PATH", eb_config_dir)
+"""

--- a/easybuild/easyconfigs/a/AiiDA/AiiDA-2.5.1-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/a/AiiDA/AiiDA-2.5.1-gfbf-2023a.eb
@@ -1,5 +1,3 @@
-import os
-
 easyblock = 'Binary'
 
 name = 'AiiDA'
@@ -42,6 +40,7 @@ local eb_config_dir = pathJoin(home, ".eb_aiida")
 
 setenv("EB_CONFIG_DIR", eb_config_dir)
 setenv("PGHOST", eb_config_dir)
+setenv("RMQ_BASEDIR", pathJoin(eb_config_dir, "rabbitmq"))
 setenv("RABBITMQ_NODENAME", "rabbit-" .. os.getenv("USER"))
 setenv("AIIDA_PATH", eb_config_dir)
 """

--- a/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
+++ b/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
@@ -26,6 +26,7 @@ function database_set_port {
     fi
     echo "${PG_LOGHEADER} setting PORT to $PG_PORT"
     sed -i "s/.*port = .*/port = ${PG_PORT}/" ${PG_CONF}
+    echo ${PG_PORT} > ${EB_CONFIG_DIR}/psql_port
 }
 
 function database_get_port {
@@ -221,7 +222,7 @@ function rabbitmq_get_set_password {
 }
 
 function rabbitmq_aiida_config {
-    if [ `grep 'consumer_timeout, undefined' $RABBITMQ_ADVANCED_CONFIG_FILE | wc -l` -eq 0 ]; then
+    if [ "`grep -c 'consumer_timeout, undefined' $RABBITMQ_ADVANCED_CONFIG_FILE 2>/dev/null`" == "" ]; then
         echo "Adding consumer_timeout to $RABBITMQ_ADVANCED_CONFIG_FILE"
         echo "[{rabbit, [{consumer_timeout, undefined}]}]." >> $RABBITMQ_ADVANCED_CONFIG_FILE
     fi
@@ -287,6 +288,7 @@ function aiida_create_profile {
     read -r -p "${AIIDA_LOGHEADER} Enter data repository directory (default to ${EB_CONFIG_DIR}/aiida): " AIIDA_DIR
     if [ -z ${AIIDA_DIR} ]; then
         AIIDA_DIR=${EB_CONFIG_DIR}/aiida
+        echo "${AIIDA_DIR}" > ${EB_CONFIG_DIR}/aiida_dir
     fi
 
     database_get_password

--- a/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
+++ b/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
@@ -73,6 +73,10 @@ function database_bootstrap {
     if [ $? -ne 0 ]; then
         echo "${PG_LOGHEADER} starting server..."
         pg_ctl start -D ${PGDATA} -l ${PGDATA}/logfile
+        if [ $? -ne 0 ]; then
+            echo "${PG_LOGHEADER} failed to start server"
+            exit 1
+fi
     else
         echo "${PG_LOGHEADER} server already running"
     fi
@@ -250,7 +254,9 @@ function rabbitmq_bootstrap {
 #######################################################################
 AIIDA_LOGHEADER="${LOGHEADER}AiiDA:"
 
-export AIIDA_PATH=${HOME}
+if [ -z ${AIIDA_PATH} ]; then
+    export AIIDA_PATH=${HOME}
+fi
 AIIDA_CONFIG_FILE=${AIIDA_PATH}/.aiida/config.json
 
 function aiida_create_profile {
@@ -342,23 +348,13 @@ function aiida_bootstrap {
 }
 
 database_bootstrap
-if [ $? -ne 0 ]; then
-    echo "${PG_LOGHEADER} failed to start server"
-    exit 1
-fi
+echo "PostgreSQL is ready to use"
 echo ""
 
 rabbitmq_bootstrap
-if [ $? -ne 0 ]; then
-    echo "${RMQ_LOGHEADER} failed to start server"
-    exit 1
-fi
+echo "RabbitMQ is ready to use"
 echo ""
 
 # exit 0
 aiida_bootstrap
-if [ $? -ne 0 ]; then
-    echo "${AIIDA_LOGHEADER} failed to start server"
-    exit 1
-fi
 echo "AiiDA is ready to use"

--- a/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
+++ b/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+module load RabbitMQ
+module load PostgreSQL
+module load aiida-core
+
+LOGHEADER="== "
+PG_LOGHEADER="${LOGHEADER}PostgreSQL:"
+EB_CONFIG_DIR=$HOME/.eb_aiida
+export PGDATA=${EB_CONFIG_DIR}/TEST
+PG_CONF=$PGDATA/postgresql.conf
+PG_PORT=25432
+
+function database_set_port {
+    # Set the PG_port number
+    while [ $PG_PORT -le 65535 ]; do
+        ss -tln | grep -q ":$PG_PORT " || break
+        PG_PORT=$((PG_PORT + 1))
+    done
+    if [ $PG_PORT -gt 65535 ]; then
+        echo "${PG_LOGHEADER} no free PORT available"
+        exit 1
+    fi
+    echo "${PG_LOGHEADER} setting PORT to $PG_PORT"
+    sed -i "s/.*port = .*/port = ${PG_PORT}/" ${PG_CONF}
+}
+
+function database_get_set_port {
+    # Get the PG_port number
+    if [ "x`grep -e '# *port *= *' ${PG_CONF}`" != "x" ]; then
+        echo "${PG_LOGHEADER} PORT not set"
+        database_set_port
+    else
+        PG_PORT=$(grep '^port = ' ${PG_CONF} | awk '{print $3}')
+        echo "${PG_LOGHEADER} Running on PORT $PG_PORT"
+    fi
+}
+
+function database_get_set_pgdata {
+    if [ -f ${EB_CONFIG_DIR}/psql_datadir ]; then
+        PGDATA=$(cat ${EB_CONFIG_DIR}/psql_datadir)
+    else
+        echo "${PG_LOGHEADER} PGDATA not set"
+        read -r -p "${PG_LOGHEADER} Enter PGDATA directory (default: $PGDATA): " _PGDATA
+        if [ ! -z $_PGDATA ]; then
+            PGDATA=$_PGDATA
+        fi
+        echo "${PG_LOGHEADER} Setting PGDATA to $PGDATA"
+        echo $PGDATA > ${EB_CONFIG_DIR}/psql_datadir
+    fi
+}
+
+function database_init {
+    echo "${PG_LOGHEADER} Initializing database..."
+    read -r -s -p "${PG_LOGHEADER} Enter the database (new) password: " PG_PASSWORD
+    initdb -D ${PGDATA} -A scram-sha-256 --pwfile=<(echo ${PG_PASSWORD})
+}
+
+function database_start {
+   # Check if postgresql is already running
+    pg_ctl status -D $PGDATA 2>&1 > /dev/null
+    if [ $? -ne 0 ]; then
+        echo "${PG_LOGHEADER} starting server..."
+        pg_ctl start -D ${PGDATA} -l ${PGDATA}/logfile
+    else
+        echo "${PG_LOGHEADER} server already running"
+    fi
+}
+
+function database_bootstrap {
+    if [ ! -d ${EB_CONFIG_DIR} ]; then
+        mkdir -p ${EB_CONFIG_DIR}
+    fi
+
+    database_get_set_pgdata
+    if [ ! -d ${PGDATA} ]; then
+        database_init
+    fi
+    database_get_set_port
+    database_start
+}
+
+# database_bootstrap
+# if [ $? -ne 0 ]; then
+#     echo "${PG_LOGHEADER} failed to start server"
+#     exit 1
+# fi
+# echo "PASSWORD: $PG_PASSWORD"
+
+RMQ_LOGHEADER="${LOGHEADER}RabbitMQ:"
+RMQ_BASEDIR=${EB_CONFIG_DIR}/rabbitmq
+
+
+export RABBITMQ_NODENAME=rabbit-${USER}
+export RABBITMQ_MNESIA_BASE=${RMQ_BASEDIR}/mnesia
+export RABBITMQ_LOG_BASE=${RMQ_BASEDIR}/logs
+export RABBITMQ_CONFIG_FILES=${RMQ_BASEDIR}/config
+export RABBITMQ_ADVANCED_CONFIG_FILE=${RMQ_BASEDIR}/advanced.config
+export RABBITMQ_NODE_IP_ADDRESS="localhost"
+
+function rabbitmq_set_port {
+    _RMQ_PORT=25672
+    while [ $_RMQ_PORT -le 65535 ]; do
+        ss -tln | grep -q ":$_RMQ_PORT " || break
+        _RMQ_PORT=$((_RMQ_PORT + 1))
+    done
+    if [ $_RMQ_PORT -gt 65535 ]; then
+        echo "${RMQ_LOGHEADER} no free PORT available"
+        exit 1
+    fi
+    export RABBITMQ_NODE_PORT=$_RMQ_PORT
+    echo "${RMQ_LOGHEADER} Setting PORT to $RABBITMQ_NODE_PORT"
+    echo $RABBITMQ_NODE_PORT > ${EB_CONFIG_DIR}/rmq_port
+}
+
+function rabbitmq_get_port {
+    if [ -f ${EB_CONFIG_DIR}/rmq_port ]; then
+        export RABBITMQ_NODE_PORT=$(cat ${EB_CONFIG_DIR}/rmq_port)
+    fi
+}
+
+function rabbitmq_set_dist_port {
+    _RMQ_PORT=25672
+    while [ $_RMQ_PORT -le 65535 ]; do
+        ss -tln | grep -q ":$_RMQ_PORT " || break
+        _RMQ_PORT=$((_RMQ_PORT + 1))
+    done
+    if [ $_RMQ_PORT -gt 65535 ]; then
+        echo "${RMQ_LOGHEADER} no free PORT available"
+        exit 1
+    fi
+    export RABBITMQ_DIST_PORT=$_RMQ_PORT
+    echo "${RMQ_LOGHEADER} Setting DIST_PORT to $RABBITMQ_DIST_PORT"
+    echo $RABBITMQ_DIST_PORT > ${EB_CONFIG_DIR}/rmq_dist_port
+}
+
+function rabbitmq_get_dist_port {
+    if [ -f ${EB_CONFIG_DIR}/rmq_dist_port ]; then
+        export RABBITMQ_DISTPORT=$(cat ${EB_CONFIG_DIR}/rmq_port)
+    fi
+}
+
+function rabbitmq_check_running {
+    rabbitmqctl status | grep -q "RabbitMQ is running"
+    if [ $? -ne 0 ]; then
+        echo "${RMQ_LOGHEADER} server not running"
+        return 1
+    fi
+    return 0
+
+
+
+function rabbitmq_bootstrap {
+    echo "${RMQ_LOGHEADER} starting server..."
+
+    rabbitmq_get_port
+    rabbitmq_get_dist_port
+
+    rabbitmq-server -detached
+    if [ $? -ne 0 ]; then
+        echo "${RMQ_LOGHEADER} failed to start server"
+        exit 1
+    fi
+}

--- a/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
+++ b/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
@@ -5,7 +5,6 @@ module load PostgreSQL
 module load aiida-core
 
 LOGHEADER="== "
-EB_CONFIG_DIR=$HOME/.eb_aiida
 
 #######################################################################
 # PostgreSQL
@@ -89,8 +88,6 @@ fi
 RMQ_LOGHEADER="${LOGHEADER}RabbitMQ:"
 RMQ_BASEDIR=${EB_CONFIG_DIR}/rabbitmq
 
-
-export RABBITMQ_NODENAME=rabbit-${USER}
 export RABBITMQ_MNESIA_BASE=${RMQ_BASEDIR}/mnesia
 export RABBITMQ_LOG_BASE=${RMQ_BASEDIR}/logs
 export RABBITMQ_CONFIG_FILES=${RMQ_BASEDIR}/config

--- a/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
+++ b/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
@@ -5,8 +5,12 @@ module load PostgreSQL
 module load aiida-core
 
 LOGHEADER="== "
-PG_LOGHEADER="${LOGHEADER}PostgreSQL:"
 EB_CONFIG_DIR=$HOME/.eb_aiida
+
+#######################################################################
+# PostgreSQL
+#######################################################################
+PG_LOGHEADER="${LOGHEADER}PostgreSQL:"
 export PGDATA=${EB_CONFIG_DIR}/TEST
 PG_CONF=$PGDATA/postgresql.conf
 PG_PORT=25432
@@ -50,9 +54,26 @@ function database_get_set_pgdata {
     fi
 }
 
+function database_get_password {
+    if [ -f ${EB_CONFIG_DIR}/psql_password ]; then
+        PG_PASSWORD=$(cat ${EB_CONFIG_DIR}/psql_password)
+    fi
+}
+
+function database_get_set_password {
+    if [ -f ${EB_CONFIG_DIR}/psql_password ]; then
+        PG_PASSWORD=$(cat ${EB_CONFIG_DIR}/psql_password)
+    else
+        PG_PASSWORD=$(uuidgen)
+        echo $PG_PASSWORD > ${EB_CONFIG_DIR}/psql_password
+        chmod 600 ${EB_CONFIG_DIR}/psql_password
+    fi
+
+}
+
 function database_init {
     echo "${PG_LOGHEADER} Initializing database..."
-    read -r -s -p "${PG_LOGHEADER} Enter the database (new) password: " PG_PASSWORD
+    database_get_set_password
     initdb -D ${PGDATA} -A scram-sha-256 --pwfile=<(echo ${PG_PASSWORD})
 }
 
@@ -67,7 +88,14 @@ function database_start {
     fi
 }
 
+function database_cleanup_vars {
+    unset PGDATA
+    unset PG_PORT
+    unset PG_PASSWORD
+}
+
 function database_bootstrap {
+    echo "${PG_LOGHEADER} Bootstrapping..."
     if [ ! -d ${EB_CONFIG_DIR} ]; then
         mkdir -p ${EB_CONFIG_DIR}
     fi
@@ -80,13 +108,10 @@ function database_bootstrap {
     database_start
 }
 
-# database_bootstrap
-# if [ $? -ne 0 ]; then
-#     echo "${PG_LOGHEADER} failed to start server"
-#     exit 1
-# fi
-# echo "PASSWORD: $PG_PASSWORD"
 
+#######################################################################
+# RabbitMQ
+#######################################################################
 RMQ_LOGHEADER="${LOGHEADER}RabbitMQ:"
 RMQ_BASEDIR=${EB_CONFIG_DIR}/rabbitmq
 
@@ -96,10 +121,15 @@ export RABBITMQ_MNESIA_BASE=${RMQ_BASEDIR}/mnesia
 export RABBITMQ_LOG_BASE=${RMQ_BASEDIR}/logs
 export RABBITMQ_CONFIG_FILES=${RMQ_BASEDIR}/config
 export RABBITMQ_ADVANCED_CONFIG_FILE=${RMQ_BASEDIR}/advanced.config
-export RABBITMQ_NODE_IP_ADDRESS="localhost"
+# export RABBITMQ_NODE_IP_ADDRESS="localhost"
+export RABBITMQ_DEFAULT_USER=aiida
 
 function rabbitmq_set_port {
-    _RMQ_PORT=25672
+    if [ ! -z ${RABBITMQ_NODE_PORT} ]; then
+        _RMQ_PORT=${RABBITMQ_NODE_PORT}
+    else
+        _RMQ_PORT=25672
+    fi
     while [ $_RMQ_PORT -le 65535 ]; do
         ss -tln | grep -q ":$_RMQ_PORT " || break
         _RMQ_PORT=$((_RMQ_PORT + 1))
@@ -120,7 +150,15 @@ function rabbitmq_get_port {
 }
 
 function rabbitmq_set_dist_port {
-    _RMQ_PORT=25672
+    if [ ! -z ${RABBITMQ_DIST_PORT} ]; then
+        _RMQ_PORT=${RABBITMQ_DIST_PORT}
+    else
+        if [ ! -z ${RABBITMQ_NODE_PORT} ]; then
+            _RMQ_PORT=$((RABBITMQ_NODE_PORT + 1))
+        else
+            _RMQ_PORT=25673
+        fi
+    fi
     while [ $_RMQ_PORT -le 65535 ]; do
         ss -tln | grep -q ":$_RMQ_PORT " || break
         _RMQ_PORT=$((_RMQ_PORT + 1))
@@ -136,29 +174,217 @@ function rabbitmq_set_dist_port {
 
 function rabbitmq_get_dist_port {
     if [ -f ${EB_CONFIG_DIR}/rmq_dist_port ]; then
-        export RABBITMQ_DISTPORT=$(cat ${EB_CONFIG_DIR}/rmq_port)
+        export RABBITMQ_DIST_PORT=$(cat ${EB_CONFIG_DIR}/rmq_dist_port)
     fi
 }
 
 function rabbitmq_check_running {
-    rabbitmqctl status | grep -q "RabbitMQ is running"
+    rabbitmqctl status 2>&1 | grep -q "Node data directory: "
     if [ $? -ne 0 ]; then
         echo "${RMQ_LOGHEADER} server not running"
         return 1
     fi
+    echo "${RMQ_LOGHEADER} server running"
+    DATA=`rabbitmqctl status 2>&1`
+    echo "$DATA" | grep -q "Node data directory: ${RABBITMQ_MNESIA_BASE}/${RABBITMQ_NODENAME}@${HOSTNAME}"
+    if [ $? -ne 0 ]; then
+        echo "${RMQ_LOGHEADER} server not running on correct data directory"
+        exit 1
+    fi
+
+    _PORT=`echo "$DATA" | grep "amqp" | cut -d, -f2 | awk '{print $2}' | head -n 1`
+    if [ ! -z ${RABBITMQ_NODE_PORT} ] && [ ${_PORT} -ne ${RABBITMQ_NODE_PORT} ]; then
+        echo "${RMQ_LOGHEADER} server not running on correct PORT"
+        exit 1
+    else
+        export RABBITMQ_NODE_PORT=${_PORT}
+        echo "${RMQ_LOGHEADER} server running on PORT ${RABBITMQ_NODE_PORT}"
+        echo ${RABBITMQ_NODE_PORT} > ${EB_CONFIG_DIR}/rmq_port
+    fi
+    _DIST_PORT=`echo "$DATA" | grep "clustering" | cut -d, -f2 | awk '{print $2}' | head -n 1`
+    if [ ! -z ${RABBITMQ_DIST_PORT} ] && [ ${_DIST_PORT} -ne ${RABBITMQ_DIST_PORT} ]; then
+        echo "${RMQ_LOGHEADER} server not running on correct DIST_PORT"
+        exit 1
+    else
+        export RABBITMQ_DIST_PORT=${_DIST_PORT}
+        echo "${RMQ_LOGHEADER} server running on DIST_PORT ${RABBITMQ_DIST_PORT}"
+        echo ${RABBITMQ_DIST_PORT} > ${EB_CONFIG_DIR}/rmq_dist_port
+    fi
+
     return 0
+}
 
+function rabbitmq_get_password {
+    if [ -f ${EB_CONFIG_DIR}/rmq_password ]; then
+        export RABBITMQ_DEFAULT_PASS=$(cat ${EB_CONFIG_DIR}/rmq_password)
+    fi
+}
 
+function rabbitmq_get_set_password {
+    if [ -f ${EB_CONFIG_DIR}/rmq_password ]; then
+        export RABBITMQ_DEFAULT_PASS=$(cat ${EB_CONFIG_DIR}/rmq_password)
+    else
+        export RABBITMQ_DEFAULT_PASS=$(uuidgen)
+        echo $RABBITMQ_DEFAULT_PASS > ${EB_CONFIG_DIR}/rmq_password
+        chmod 600 ${EB_CONFIG_DIR}/rmq_password
+    fi
+
+}
+
+function rabbitmq_aiida_config {
+    if [ `grep 'consumer_timeout, undefined' $RABBITMQ_ADVANCED_CONFIG_FILE | wc -l` -eq 0 ]; then
+        echo "Adding consumer_timeout to $RABBITMQ_ADVANCED_CONFIG_FILE"
+        echo "[{rabbit, [{consumer_timeout, undefined}]}]." >> $RABBITMQ_ADVANCED_CONFIG_FILE
+    fi
+}
 
 function rabbitmq_bootstrap {
-    echo "${RMQ_LOGHEADER} starting server..."
+    echo "${RMQ_LOGHEADER} Bootstrapping..."
+
+    if [ ! -d ${RMQ_BASEDIR} ]; then
+        echo "${RMQ_LOGHEADER} creating directories..."
+        mkdir -p ${RABBITMQ_MNESIA_BASE}
+        mkdir -p ${RABBITMQ_LOG_BASE}
+        mkdir -p ${RABBITMQ_CONFIG_FILES}
+    fi
 
     rabbitmq_get_port
     rabbitmq_get_dist_port
 
+    rabbitmq_check_running
+    if [ $? -eq 0 ]; then
+        return 0
+    fi
+
+    rabbitmq_set_port
+    rabbitmq_set_dist_port
+    rabbitmq_get_set_password
+
+    rabbitmq_aiida_config
+
+    echo "${RMQ_LOGHEADER} starting server..."
     rabbitmq-server -detached
     if [ $? -ne 0 ]; then
         echo "${RMQ_LOGHEADER} failed to start server"
         exit 1
     fi
 }
+
+#######################################################################
+# AiiDA
+#######################################################################
+AIIDA_LOGHEADER="${LOGHEADER}AiiDA:"
+
+export AIIDA_PATH=${HOME}
+AIIDA_CONFIG_FILE=${AIIDA_PATH}/.aiida/config.json
+
+function aiida_create_profile {
+    read -r -p "${AIIDA_LOGHEADER} Enter email address (default to ${USER}@${HOSTNAME}.xz): " AIIDA_EMAIL
+    if [ -z ${AIIDA_EMAIL} ]; then
+        AIIDA_EMAIL=${USER}@${HOSTNAME}.xz
+    fi
+    read -r -p "${AIIDA_LOGHEADER} Enter first name (default to ${USER}): " AIIDA_FIRSTNAME
+    if [ -z ${AIIDA_FIRSTNAME} ]; then
+        AIIDA_FIRSTNAME=${USER}
+    fi
+    read -r -p "${AIIDA_LOGHEADER} Enter last name (default to ${USER}): " AIIDA_LASTNAME
+    if [ -z ${AIIDA_LASTNAME} ]; then
+        AIIDA_LASTNAME=${USER}
+    fi
+    read -r -p "${AIIDA_LOGHEADER} Enter institution (default to ${HOSTNAME}): " AIIDA_INSTITUTION
+    if [ -z ${AIIDA_INSTITUTION} ]; then
+        AIIDA_INSTITUTION=${HOSTNAME}
+    fi
+    read -r -p "${AIIDA_LOGHEADER} Enter data repository directory (default to ${EB_CONFIG_DIR}/aiida): " AIIDA_DIR
+    if [ -z ${AIIDA_DIR} ]; then
+        AIIDA_DIR=${EB_CONFIG_DIR}/aiida
+    fi
+
+    database_get_password
+    rabbitmq_get_password
+
+    echo "${AIIDA_LOGHEADER} Creating profile..."
+    verdi quicksetup \
+        --non-interactive \
+        --profile ${USER} \
+        --email ${AIIDA_EMAIL} \
+        --first-name ${AIIDA_FIRSTNAME} \
+        --last-name ${AIIDA_LASTNAME} \
+        --institution ${AIIDA_INSTITUTION} \
+        --db-host localhost \
+        --db-port ${PG_PORT} \
+        --su-db-name postgres \
+        --su-db-username ${USER} \
+        --su-db-password ${PG_PASSWORD} \
+        --broker-port ${RABBITMQ_NODE_PORT} \
+        --broker-username ${RABBITMQ_DEFAULT_USER} \
+        --broker-password ${RABBITMQ_DEFAULT_PASS}
+
+    if [ $? -ne 0 ]; then
+        echo "${AIIDA_LOGHEADER} failed to create profile"
+        exit 1
+    fi
+}
+
+function aiida_verify_db_port {
+    _AIIDA_PORT=$(verdi profile show ${USER} | grep "database_port" | awk '{print $2}')
+    if [ $_AIIDA_PORT -ne $PG_PORT ]; then
+        echo "${AIIDA_LOGHEADER} AiiDA database PORT mismatch, updating the profile..."
+        sed -i "s/: *${_AIIDA_PORT}/: ${PG_PORT}/" ${AIIDA_CONFIG_FILE}
+    fi
+}
+
+function aiida_verify_rmq_port {
+    _AIIDA_PORT=$(verdi profile show ${USER} | grep "broker_port" | awk '{print $2}')
+    if [ $_AIIDA_PORT -ne $RABBITMQ_NODE_PORT ]; then
+        echo "${AIIDA_LOGHEADER} AiiDA RabbitMQ PORT mismatch, updating the profile..."
+        sed -i "s/: *${_AIIDA_PORT}/: ${RABBITMQ_NODE_PORT}/" ${AIIDA_CONFIG_FILE}
+    fi
+}
+
+function aiida_verify_rabbitmq {
+    if [ "rabbitmqctl environment | grep consumer_timeout | grep undefined" != "" ]; then
+        echo "${AIIDA_LOGHEADER} consumer_timeout was properly set in RabbitMQ, disabling warnings..."
+        verdi config set warnings.rabbitmq_version false
+    else
+        echo "${AIIDA_LOGHEADER} consumer_timeout was wrongly set in RabbitMQ"
+        echo "${AIIDA_LOGHEADER}   Manually kill the RabbitMQ server and relaunch the bootstrap script"
+        exit 1
+    fi
+}
+
+function aiida_bootstrap {
+    echo "${AIIDA_LOGHEADER} Bootstrapping..."
+
+    if [ "`verdi profile list 2>&1 | grep 'no profiles'`" != "" ]; then
+        aiida_create_profile
+    fi
+
+    aiida_verify_rabbitmq
+
+    aiida_verify_db_port
+    aiida_verify_rmq_port
+}
+
+database_bootstrap
+if [ $? -ne 0 ]; then
+    echo "${PG_LOGHEADER} failed to start server"
+    exit 1
+fi
+echo "PASSWORD: $PG_PASSWORD"
+echo ""
+
+rabbitmq_bootstrap
+if [ $? -ne 0 ]; then
+    echo "${RMQ_LOGHEADER} failed to start server"
+    exit 1
+fi
+echo "PASSWORD: $RABBITMQ_DEFAULT_PASS"
+echo ""
+
+aiida_bootstrap
+if [ $? -ne 0 ]; then
+    echo "${AIIDA_LOGHEADER} failed to start server"
+    exit 1
+fi
+echo "AiiDA is ready to use"

--- a/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
+++ b/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
@@ -11,13 +11,13 @@ LOGHEADER="== "
 #######################################################################
 PG_LOGHEADER="${LOGHEADER}PostgreSQL:"
 export PGDATA=${EB_CONFIG_DIR}/postgres
-PG_CONF="${PGDATA}/postgresql.conf"
-export PGHOST="${EB_CONFIG_DIR}"
 export PGPORT=5432
+PG_CONF="${PGDATA}/postgresql.conf"
 
 function database_get_set_pgdata {
     if [ -f ${EB_CONFIG_DIR}/psql_datadir ]; then
-        PGDATA=$(cat ${EB_CONFIG_DIR}/psql_datadir)
+        export PGDATA=$(cat ${EB_CONFIG_DIR}/psql_datadir)
+        echo "${PG_LOGHEADER} Re-using PGDATA from config: $PGDATA"
     else
         echo "${PG_LOGHEADER} PGDATA not set"
         read -r -p "${PG_LOGHEADER} Enter PGDATA directory (default: ${PGDATA}): " _PGDATA
@@ -75,7 +75,7 @@ function database_bootstrap {
         if [ $? -ne 0 ]; then
             echo "${PG_LOGHEADER} failed to start server"
             exit 1
-fi
+        fi
     else
         echo "${PG_LOGHEADER} server already running"
     fi

--- a/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
+++ b/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
@@ -173,7 +173,7 @@ function rabbitmq_check_running {
         echo "${RMQ_LOGHEADER} server not running"
         return 1
     fi
-    echo "${RMQ_LOGHEADER} server running"
+    echo "${RMQ_LOGHEADER} server already running"
     DATA=`rabbitmqctl status 2>&1`
     echo "$DATA" | grep -q "Node data directory: ${RABBITMQ_MNESIA_BASE}/${RABBITMQ_NODENAME}@${HOSTNAME}"
     if [ $? -ne 0 ]; then

--- a/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
+++ b/easybuild/easyconfigs/a/AiiDA/aiida_bootstrap.sh
@@ -342,6 +342,15 @@ function aiida_verify_rabbitmq {
     fi
 }
 
+function aiida_start_daemon {
+    if [ "`verdi daemon status 2>&1 | grep 'not running'`" != "" ]; then
+        echo "${AIIDA_LOGHEADER} Starting AiiDA Daemon..."
+        verdi daemon start
+    else
+        echo "${AIIDA_LOGHEADER} AiiDA Daemon already running"
+    fi
+}
+
 function aiida_bootstrap {
     echo "${AIIDA_LOGHEADER} Bootstrapping..."
 
@@ -353,6 +362,8 @@ function aiida_bootstrap {
 
     aiida_verify_db_port
     aiida_verify_rmq_port
+
+    aiida_start_daemon
 }
 
 database_bootstrap

--- a/easybuild/easyconfigs/a/AiiDA/aiida_cleanup.sh
+++ b/easybuild/easyconfigs/a/AiiDA/aiida_cleanup.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+module load RabbitMQ
+module load PostgreSQL
+module load aiida-core
+
+echo "WARNING: this script will completely remove all data from the AiiDA database, repository and configuration."
+read -p "Are you sure you want to continue? [y/N] " -n 1 -r REPLY
+
+if [[ $REPLY =~ ^[nN]$ ]]; then
+    echo "Aborting."
+    exit 1
+fi
+
+LOGHEADER="== "
+EB_CONFIG_DIR=$HOME/.eb_aiida
+
+AIIDA_LOGHEADER="${LOGHEADER}AiiDA:"
+RMQ_LOGHEADER="${LOGHEADER}RabbitMQ:"
+PG_LOGHEADER="${LOGHEADER}PostgreSQL:"
+
+PGDATA="`cat $EB_CONFIG_DIR/psql_datadir`"
+AIIDA_DIR="`cat ${EB_CONFIG_DIR}/aiida_dir`"
+
+export RABBITMQ_NODENAME=rabbit-$USER
+
+
+echo "${AIIDA_LOGHEADER} Stopping AiiDA daemon"
+verdi daemon stop
+echo "${RMQ_LOGHEADER} Stopping RabbitMQ"
+rabbitmqctl stop 2> /dev/null
+echo "${PG_LOGHEADER} Stopping PostgreSQL"
+pg_ctl stop -D $PGDATA 2> /dev/null
+
+echo "${AIIDA_LOGHEADER} Removing AiiDA database"
+rm -rf $PGDATA
+echo "${AIIDA_LOGHEADER} Removing AiiDA repository"
+rm -rf $AIIDA_DIR
+echo "${AIIDA_LOGHEADER} Removing the AiiDA configuration file"
+rm -rf $HOME/.aiida
+echo "${LOGHEADER} Removing the configuration folder"
+rm -rf $EB_CONFIG_DIR

--- a/easybuild/easyconfigs/a/AiiDA/aiida_cleanup.sh
+++ b/easybuild/easyconfigs/a/AiiDA/aiida_cleanup.sh
@@ -7,13 +7,12 @@ module load aiida-core
 echo "WARNING: this script will completely remove all data from the AiiDA database, repository and configuration."
 read -p "Are you sure you want to continue? [y/N] " -n 1 -r REPLY
 
-if [[ $REPLY =~ ^[nN]$ ]]; then
+if [[ ! "$REPLY" == "y" ]]; then
     echo "Aborting."
     exit 1
 fi
 
 LOGHEADER="== "
-EB_CONFIG_DIR=$HOME/.eb_aiida
 
 AIIDA_LOGHEADER="${LOGHEADER}AiiDA:"
 RMQ_LOGHEADER="${LOGHEADER}RabbitMQ:"
@@ -21,9 +20,6 @@ PG_LOGHEADER="${LOGHEADER}PostgreSQL:"
 
 PGDATA="`cat $EB_CONFIG_DIR/psql_datadir`"
 AIIDA_DIR="`cat ${EB_CONFIG_DIR}/aiida_dir`"
-
-export RABBITMQ_NODENAME=rabbit-$USER
-
 
 echo "${AIIDA_LOGHEADER} Stopping AiiDA daemon"
 verdi daemon stop


### PR DESCRIPTION
Set of bootstrap/cleanup scripts for aiida

Depends on PRs:

- #20456 
- #20441 

The bootstrap script will

- PostgreSQL
  - Create a database in user space
  - Set the database to make use of UNIX sockets only to avoid opening ports
  - Launch the database
- RabbitMQ
  - Create a rabbitmq instance
  - Looks for 2 open ports above 25672
  - Launch the rabbitmq instance
  - Add advanced configuration for avoiding timeouts [SEE HERE](https://aiida.readthedocs.io/projects/aiida-core/en/latest/intro/troubleshooting.html#rabbitmq-incompatibility)
- AiiDA
  - Setup the profile with the information about the created database and rabbitmq instances
    - Updates the rabbitMQ ports in case the services where stopped and the ports changed after rerunning the bootstrap script.
  - launch the daemon

The user can specify the following:

- Location of the PostgreSQL datadir (to allow running on a fast and/or backed up partition)
- Name/Surname/Email/Affiliation for the AiiDA profile (defaults are generated based on the username and hostname)
- Location of the aiida repository

After the first run of the bootstrap script, configuration details are stored under `$HOME/.eb_aiida` and will be recalled in future runs:

- Location of the database data dir
- Database user password (with 600 permission)
- Ports for RabbitMQ
- RabbitMQ user password (with 600 permission) (this is also stored by AiiDA in its configuration file)
- Location of the aiida repository
