### PR TITLE
use the included gmxapi for GROMACS 2024.1

### DIFF
--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2024.1-foss-2023b.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2024.1-foss-2023b.eb
@@ -54,7 +54,7 @@ checksums = [
 
 builddependencies = [
     ('CMake', '3.27.6'),
-    ('scikit-build', '0.17.6'),
+    ('scikit-build-core', '0.9.3'),
 ]
 
 dependencies = [


### PR DESCRIPTION
Seems like https://github.com/easybuilders/easybuild-easyconfigs/pull/20102 forgot to bump the gmxapi version and source tarball, it was still using an older version from the 2023.3 tarball. Looking at https://gitlab.com/gromacs/gromacs/-/blob/v2024.1/python_packaging/gmxapi/src/gmxapi/version.py?ref_type=tags#L68, the 2024.1 release includes gmxapi 0.5.0.