### PR TITLE
easyconfigs for chrombpnet 0.1.7 and its dependencies

### DIFF
--- a/easybuild/easyconfigs/b/bokeh/bokeh-2.4.2-foss-2021b.eb 
+++ b/easybuild/easyconfigs/b/bokeh/bokeh-2.4.2-foss-2021b.eb 
@@ -1,0 +1,38 @@
+easyblock = 'PythonBundle'
+
+name = 'bokeh'
+version = '2.4.2'
+
+homepage = 'https://github.com/bokeh/bokeh'
+description = "Statistical and novel interactive HTML plots for Python"
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+dependencies = [
+    ('Python', '3.9.6'),
+    ('PyYAML', '5.4.1'),
+    ('Pillow', '8.3.2'),
+    ('SciPy-bundle', '2021.10'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('tornado', '6.2', {
+        'checksums': ['9b630419bde84ec666bfd7ea0a4cb2a8a651c2d5cccdbdd1972a0c859dfc3c13'],
+    }),
+    (name, version, {
+        'checksums': ['f0a4b53364ed3b7eb936c5cb1a4f4132369e394c7ae0a8ef420459410958033d'],
+    }),
+]
+
+sanity_pip_check = True
+
+sanity_check_paths = {
+    'files': ['bin/bokeh'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["bokeh --help"]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/c/cffi/cffi-1.14.5-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/c/cffi/cffi-1.14.5-GCCcore-11.2.0.eb
@@ -1,0 +1,38 @@
+easyblock = "PythonBundle"
+
+name = 'cffi'
+version = '1.14.5'
+
+homepage = 'https://cffi.readthedocs.io/en/latest/'
+description = """C Foreign Function Interface for Python. Interact with almost any C code from
+Python, based on C-like declarations that you can often copy-paste from header
+files or documentation.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
+toolchainopts = {'pic': True}
+
+builddependencies = [
+    ('binutils', '2.37'),
+]
+
+dependencies = [
+    ('Python', '3.9.6'),
+]
+
+exts_default_options = {
+    'download_dep_fail': True,
+    'sanity_pip_check': True,
+    'use_pip': True,
+}
+
+exts_list = [
+    ('pycparser', '2.20', {
+        'checksums': ['2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0'],
+    }),
+    (name, version, {
+        'checksums': ['fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c'],
+    }),
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/c/chrombpnet/chrombpnet-0.1.7-foss-2021b.eb
+++ b/easybuild/easyconfigs/c/chrombpnet/chrombpnet-0.1.7-foss-2021b.eb
@@ -1,0 +1,71 @@
+easyblock = 'PythonBundle'
+
+name = 'chrombpnet'
+version = '0.1.7'
+
+homepage = 'https://github.com/kundajelab/chrombpnet'
+description = """ ChromBPNet is a fully convolutional neural network that uses dilated convolutions with residual connections to enable large receptive fields with efficient parameterization. It also performs automatic assay bias correction. """
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+dependencies = [
+    ('SAMtools', '1.15.1'),
+    ('BEDTools', '2.30.0'),
+    ('Kent_tools', '422'),
+    ('pyBigWig', '0.3.18'),
+    ('MEME', '5.4.1'),
+    ('Python', '3.9.6'),    
+    ('h5py', '3.6.0'),
+    ('pyfaidx', '0.7.0'),    
+    ('deepdish', '0.3.7'),    
+    ('matplotlib', '3.4.3'),
+    ('modisco', '0.5.16.0'),
+    ('modisco-lite', '2.0.7'),
+    ('scikit-learn', '1.0.2'), 
+    ('TensorFlow', '2.8.4'),
+    ('tensorflow-probability', '0.16.0'),        
+    ('protobuf-python', '3.17.3'),    
+    ('tqdm', '4.62.3'),    
+    ('kundajelab-shap', '1'),
+    ('SciPy-bundle', '2021.10'), # for numpy=1.21.3, pandas=1.3.4  and scipy=1.7.1
+    ('WeasyPrint', '52.5'),
+]
+
+use_pip = True
+
+# Loosen unnecessarily strict version dependencies
+local_preinstallopts = "sed -i 's|pyfaidx==|pyfaidx>=|g' requirements.txt && "
+local_preinstallopts += "sed -i 's|scikit-learn>=1.1.2|scikit-learn>=1.0.0|g' requirements.txt && "
+local_preinstallopts += "sed -i 's|tensorflow==|tensorflow>=|g' requirements.txt && "
+local_preinstallopts += "sed -i 's|tensorflow-probability==|tensorflow-probability>=|g' requirements.txt && "
+local_preinstallopts += "sed -i 's|protobuf==3.20|protobuf>=3.17.0|g' requirements.txt && "
+local_preinstallopts += "sed -i 's|tqdm==|tqdm>=|g' requirements.txt && "
+local_preinstallopts += "sed -i 's|numpy== 1.23.4|numpy>=1.21.0|g' requirements.txt && "
+
+exts_list = [
+    ( 'matplotlib-venn', '0.11.6', {
+		'checksums': ['d209a9845bb3a54c4247f1ef3f745e4819660ecc9208137097d2a51281f2a478'],
+    }),
+    ('tensorflow-estimator', '2.8.0', {
+        'source_tmpl': 'tensorflow_estimator-%(version)s-py2.py3-none-any.whl',
+        'checksums': ['bee8e0520c60ae7eaf6ca8cb46c5a9f4b45725531380db8fbe38fcb48478b6bb'],
+    }),
+    ( 'deeplift', '0.6.13.0', {
+        'checksums': ['354ac5a00630b2df0856e8c948262e38c7eb83a719f71d6b5bf8ec4b064cb432'],
+	}),
+    (name, version, {
+        'preinstallopts': local_preinstallopts,
+        'checksums': ['e5fae544d8e533d770c72313b9902097ffd32ef66d5962e90546c3cd9ecce759'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/chrombpnet'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["chrombpnet --help"]
+
+sanity_pip_check = True
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/c/coverage/coverage-6.4-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/c/coverage/coverage-6.4-GCCcore-11.2.0.eb
@@ -1,0 +1,35 @@
+easyblock = 'PythonPackage'
+
+name = 'coverage'
+version = '6.4'
+
+homepage = 'https://coverage.readthedocs.io'
+description = """ Coverage.py is a tool for measuring code coverage of Python programs.
+ It monitors your program, noting which parts of the code have been executed,
+ then analyzes the source to identify code that could have been executed but was not. """
+
+toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['727dafd7f67a6e1cad808dc884bd9c5a2f6ef1f8f6d2f22b37b96cb0080d4f49']
+
+builddependencies = [
+    ('binutils', '2.37'),
+]
+
+dependencies = [
+    ('Python', '3.9.6'),
+]
+
+use_pip = True
+sanity_pip_check = True
+download_dep_fail = True
+
+sanity_check_paths = {
+    'files': ['bin/coverage%s' % x for x in ['', '3', '-%(pyshortver)s']],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s'],
+}
+
+sanity_check_commands = ["coverage --help"]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/d/deepdish/deepdish-0.3.7-foss-2021b.eb
+++ b/easybuild/easyconfigs/d/deepdish/deepdish-0.3.7-foss-2021b.eb
@@ -1,0 +1,32 @@
+easyblock = 'PythonPackage'
+
+name = 'deepdish'
+version = '0.3.7'
+
+homepage = 'https://github.com/uchicago-cs/deepdish'
+description = """Flexible HDF5 saving/loading and other 
+data science tools from the University of Chicago."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['6aff3abef693cec34438f183f29d1a2d9862aba27bb959d4f24d56e007e41ff3']
+
+builddependencies = [
+    ('binutils', '2.37'),
+]
+
+dependencies = [
+    ('Python', '3.9.6'),
+    ('SciPy-bundle', '2021.10'),
+    ('scikit-image', '0.19.1'),
+    ('PyTables', '3.6.1'),
+]
+
+preinstallopts = """python setup.py build && """
+
+use_pip = True
+sanity_pip_check = True
+download_dep_fail = True
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/h/hdf5plugin/hdf5plugin-3.2.0-foss-2021b.eb
+++ b/easybuild/easyconfigs/h/hdf5plugin/hdf5plugin-3.2.0-foss-2021b.eb
@@ -1,0 +1,34 @@
+easyblock = 'PythonPackage'
+
+name = 'hdf5plugin'
+version = '3.2.0'
+
+homepage = "https://github.com/silx-kit/hdf5plugin"
+description = """hdf5plugin provides HDF5 compression filters 
+(namely: Blosc, Blosc2, BitShuffle, BZip2, FciDecomp, LZ4, SZ, 
+SZ3, Zfp, ZStd) and makes them usable from h5py."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+builddependencies = [
+    ('binutils', '2.37'),
+]
+
+dependencies = [
+    ('h5py', '3.6.0'),
+    ('py-cpuinfo', '9.0.0'),
+    ('Python', '3.9.6'),
+]
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['8900ab06df2a20f88c9c56ecf45a99655e08ba4d730706f8798b4ea2158b291a']
+
+download_dep_fail = True
+sanity_pip_check = True
+use_pip = True
+
+modextrapaths = {
+    'HDF5_PLUGIN_PATH': 'lib/python%(pyshortver)s/site-packages/hdf5plugin/plugins',
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/k/kundajelab-shap/kundajelab-shap-1-foss-2021b
+++ b/easybuild/easyconfigs/k/kundajelab-shap/kundajelab-shap-1-foss-2021b
@@ -1,0 +1,49 @@
+easyblock = 'PythonBundle'
+
+name = 'kundajelab-shap'
+version = '1'
+
+homepage = "https://github.com/kundajelab/shap"
+description = """This is a custom fork of the shap repository that has support 
+for computing hypothetical importance scores, for use with TF-MoDISco. 
+It was originally forked under AvantiShri/shap."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+builddependencies = [
+    ('CMake', '3.21.1'),
+]
+
+dependencies = [
+    ('Python', '3.9.6'),
+    ('IPython', '7.26.0'),
+    ('matplotlib', '3.4.3'),
+    ('SciPy-bundle', '2021.10'),
+    ('scikit-learn', '1.0.2'),
+    ('scikit-image', '0.19.1'),
+    ('tqdm', '4.62.3'),
+    ('numba', '0.54.1'),
+    ('nose3', '1.3.8'),
+    ('XGBoost', '1.6.1'),
+]
+
+sanity_pip_check = True
+use_pip = True
+
+exts_list = [
+    ('cloudpickle', '2.0.0', {
+        'checksums': ['5cd02f3b417a783ba84a4ec3e290ff7929009fe51f6405423cfccfadd43ba4a4'],
+    }),
+    ('slicer', '0.0.7', {
+        'checksums': ['f5d5f7b45f98d155b9c0ba6554fa9770c6b26d5793a3e77a1030fb56910ebeec'],
+    }),
+    ('lightgbm', '3.3.2', {
+        'checksums': ['5d25d16e77c844c297ece2044df57651139bc3c8ad8c4108916374267ac68b64'],
+    }),
+    (name, version, {
+        'modulename': 'shap',
+        'checksums': ['0269759677ae8a71544e34168c680588703c2e983a20ff8bce93cd73dc6004ff'],
+    }),
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/m/modisco-lite/modisco-lite-foss-2021b
+++ b/easybuild/easyconfigs/m/modisco-lite/modisco-lite-foss-2021b
@@ -1,0 +1,62 @@
+easyblock = 'PythonBundle'
+
+name = 'modisco-lite'
+version = '2.0.7'
+
+homepage = 'https://github.com/jmschrei/tfmodisco-lite'
+description = """TF-MoDISco is a motif detection algorithm that takes in nucleotide
+    sequence and the attributions from a neural network model and return motifs
+    that are repeatedly enriched for attriution score across the examples.
+    This tool will take in one-hot encoded sequence, the corresponding
+    attribution scores, and a few other parameters, and return the motifs."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+dependencies = [
+    ('h5py', '3.6.0'),    
+    ('hdf5plugin', '3.2.0'),
+    ('igraph', '0.9.5'), 
+    ('python-igraph', '0.9.8'),    
+    ('leidenalg', '0.8.8'),
+    ('matplotlib', '3.4.3'),
+    ('numba', '0.54.1'),
+    ('Python', '3.9.6'),
+    ('SciPy-bundle', '2021.10'), # for numpy=1.21.3, pandas=1.3.4  and scipy=1.7.1
+    ('scikit-learn', '1.0.2'),    
+    ('tqdm', '4.62.3'),
+]
+
+use_pip = True 
+
+# Loosen unnecessarily strict version dependencies
+local_preinstallopts = "sed -i 's|numpy >= 1.21.5|numpy >= 1.21.3|g' setup.py && "
+local_preinstallopts += "sed -i 's|pandas >= 1.4.3|pandas >= 1.3.4|g' setup.py && "
+local_preinstallopts += "sed -i 's|leidenalg == 0.8.10|leidenalg >= 0.8.8|g' setup.py && "
+local_preinstallopts += "sed -i 's|igraph == 0.9.11|igraph >= 0.9.5|g' setup.py && "
+local_preinstallopts += "sed -i 's|h5py >= 3.7.0|h5py >= 3.6.0|g' setup.py && "
+
+exts_list = [
+    ('logomaker', '0.8', {
+        'checksums': ['d8c7501a7d6d7961cd68e5a44e939000ebf1b0c4197a0c9198351e1d681d3f6d'],
+    }),
+    (name, version, {
+        'modulename': 'modiscolite',
+        'preinstallopts': local_preinstallopts,
+        'checksums': ['937a570cd0b5cff67daddb05215f5ee4820b2f67bf8bb0e2088424a217953eef'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/modisco'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_pip_check = True
+
+sanity_check_commands = [
+    "modisco -h",
+    "modisco motifs -h",
+    "modisco report -h",
+] 
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/modisco/modisco-0.5.16.0-foss-2021b
+++ b/easybuild/easyconfigs/m/modisco/modisco-0.5.16.0-foss-2021b
@@ -1,0 +1,57 @@
+easyblock = 'PythonBundle'
+
+name = 'modisco'
+version = '0.5.16.0'
+
+homepage = 'https://github.com/kundajelab/tfmodisco'
+description = """TF-MoDISco: Transcription-Factor Motif Discovery from Importance Scores."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+dependencies = [
+    ('h5py', '3.6.0'),
+    ('igraph', '0.9.5'),
+    ('leidenalg', '0.8.8'), 
+    ('matplotlib', '3.4.3'),
+    ('numba', '0.54.1'), # for pynndescent
+    ('psutil', '5.9.4'),
+    ('Python', '3.9.6'),
+    ('SciPy-bundle', '2021.10'), # for numpy 1.21 and pandas 1.3.4  
+    ('scikit-learn', '1.0.2'),
+    ('tqdm', '4.62.3'),
+    ('TensorFlow', '2.8.4'),
+]
+
+use_pip = True 
+
+exts_list = [
+    ('joblib', '1.0.1', {
+        'checksums': ['9c17567692206d2f3fb9ecf5e991084254fe631665c450b443761c4186a613f7'],
+    }),
+    ('pynndescent', '0.5.8', {
+        'checksums': ['a7c552569bf604a101fd54bba1d27c12389e065945dee3a6777a518c63a46f2b'],
+    }),
+    (name, version, {
+        'checksums': ['24d1eef8f7e3617a8da7e595252fe9f5a20803b79453a8d11132769f04f49085'],
+        # Loosen unnecessarily strict version dependency for numpy
+        'preinstallopts': "sed -i 's|numpy>=1.9|numpy>=1.2|g' setup.py &&",
+        'postinstallcmds': ["cp -a test %(installdir)s"],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/run_leiden'],
+    'dirs': ['test', 'lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_pip_check = True
+
+sanity_check_commands = [
+    "python -c 'from modisco import core' "
+    # copy test to build directory, after making sure it exists, so --sanity-check-only works;
+    # enable write permissions, since installation directory may be read-only
+    "mkdir -p %(builddir)s && cp -a %(installdir)s/test %(builddir)s/ && chmod -R u+wx %(builddir)s/test",
+    "cd %(builddir)s/test && python test_core.py && python test_tfmodisco_workflow.py",
+] 
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/n/nose3/nose3-1.3.8-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/n/nose3/nose3-1.3.8-GCCcore-11.2.0.eb
@@ -1,0 +1,36 @@
+easyblock = 'PythonPackage'
+
+name = 'nose3'
+version = '1.3.8'
+
+homepage = 'https://nose.readthedocs.io/'
+description = """Nose extends unittest to make testing easier."""
+
+toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['762aae22cadb898b00b9d4f4bbb9f8e87f8e0dde6c49a88cd0c554f4e5925b76']
+
+builddependencies = [
+    ('binutils', '2.37'),
+]
+
+dependencies = [
+    ('Python', '3.9.6'),
+    ('coverage', '6.4'),
+]
+
+use_pip = True
+sanity_pip_check = True
+download_dep_fail = True
+
+sanity_check_paths = {
+    'files': ['bin/nosetests'],
+    'dirs': [],
+}
+
+options = {'modulename': 'nose'}
+
+sanity_check_commands = ["nosetests --help"]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/s/setuptools/setuptools-54.2.0-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/s/setuptools/setuptools-54.2.0-GCCcore-11.2.0.eb
@@ -1,0 +1,26 @@
+easyblock = 'PythonPackage'
+
+name = 'setuptools'
+version = '54.2.0'
+
+homepage = "https://pypi.org/project/setuptools"
+description = """Easily download, build, install, upgrade, and uninstall Python packages"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
+
+builddependencies = [
+    ('binutils', '2.37'),
+]
+
+dependencies = [
+    ('Python', '3.9.6'),
+]
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['aa9c24fb83a9116b8d425e53bec24c7bfdbffc313c2159f9ed036d4a6dd32d7d']
+
+download_dep_fail = True
+sanity_pip_check = True
+use_pip = True
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/w/WeasyPrint/WeasyPrint-52.2-foss-2021b
+++ b/easybuild/easyconfigs/w/WeasyPrint/WeasyPrint-52.2-foss-2021b
@@ -1,0 +1,73 @@
+easyblock = 'PythonBundle'
+
+name = 'WeasyPrint'
+version = '52.5'
+
+homepage = 'https://github.com/Kozea/WeasyPrint'
+description = """WeasyPrint is a smart solution helping web developers to create 
+PDF documents. It turns simple HTML pages into gorgeous statistical reports, 
+invoices, tickets."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+dependencies = [
+	('cairo', '1.16.0'),
+	('setuptools', '54.2.0'),
+	('cffi', '1.14.5'),
+	('Gdk-Pixbuf', '2.42.6'),	
+    ('Pango', '1.48.8'),
+    ('Python', '3.9.6'),
+    ('Pillow', '8.3.2'),
+]
+
+use_pip = True 
+
+exts_list = [
+    ('cssselect2', '0.4.1', {
+        'checksums': ['93fbb9af860e95dd40bf18c3b2b6ed99189a07c0f29ba76f9c5be71344664ec8'],
+    }),
+    ('cairocffi', '1.2.0', {
+	    'modulename': 'cairocffi',
+        'source_tmpl': 'cairocffi-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/c/cairocffi'],
+		'checksums': ['9a979b500c64c8179fec286f337e8fe644eca2f2cd05860ce0b62d25f22ea140'],
+	}),  
+	('CairoSVG', '2.5.1', {
+        'checksums': ['bfa0deea7fa0b9b2f29e41b747a915c249dbca731a4667c2917e47ff96e773e0'],
+    }),
+    ('html5lib', '1.1', {
+        'checksums': ['b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f'],
+    }),
+    ('tinycss2', '1.1.0', {
+        'checksums': ['fbdcac3044d60eb85fdb2aa840ece43cf7dbe798e373e6ee0be545d4d134e18a'],
+    }),
+    ('pydyf', '0.0.2', {
+        'checksums': ['7c7f417413877edfc882f200834ee2415aa21c8cbfbc87802d78e12334a16581'],
+    }),
+	('pyphen', '0.10.0', {
+	    'modulename': 'pyphen',
+        'source_tmpl': 'Pyphen-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/P/Pyphen'],
+		'checksums': ['719b21dfb4b04fbc11cc0f6112418535fe35474021120cccfffc43a25fe63128'],
+	}),
+    ('fonttools', '4.34.0', {
+        'modulename': 'fontTools',
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'checksums': ['73d3fab85790f076d56db431bfdf9ce51b566816ff74d51e050e11ab1ffa8f8b'],
+    }),    
+    (name, version, {
+    	'modulename': 'weasyprint',
+        'checksums': ['b37ea02d75ca04babd7becad7341426be332ae560d8f02d664bfa1e9afb18481'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/weasyprint'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["weasyprint --help"]
+
+sanity_pip_check = True
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/x/XGBoost/XGBoost-1.6.1-foss-2021b.eb
+++ b/easybuild/easyconfigs/x/XGBoost/XGBoost-1.6.1-foss-2021b.eb
@@ -1,0 +1,29 @@
+easyblock = 'PythonPackage'
+
+name = 'XGBoost'
+version = '1.6.1'
+
+homepage = 'https://github.com/dmlc/xgboost'
+description = """XGBoost is an optimized distributed gradient boosting library designed to be highly efficient,
+ flexible and portable."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['24072028656f3428e7b8aabf77340ece057f273e41f7f85d67ccaefb7454bb18']
+
+builddependencies = [('CMake', '3.21.1')]
+
+dependencies = [
+    ('Python', '3.9.6'),
+    ('SciPy-bundle', '2021.10'),
+]
+
+use_pip = True
+download_dep_fail = True
+sanity_pip_check = True
+
+# use the parallel parameter from EB instead of total procs in the system
+preinstallopts = "sed -i 's/nproc = os.cpu_count.*$/nproc = %(parallel)s/' setup.py &&"
+
+moduleclass = 'lib'


### PR DESCRIPTION
Easyconfig for chrompnet 0.1.7

It also includes other necessary easyconfigs:
Aeasybuild/easyconfigs/b/bokeh/bokeh-2.4.2-foss-2021b.eb 
A	easybuild/easyconfigs/c/cffi/cffi-1.14.5-GCCcore-11.2.0.eb
A	easybuild/easyconfigs/c/coverage/coverage-6.4-GCCcore-11.2.0.eb
A	easybuild/easyconfigs/d/deepdish/deepdish-0.3.7-foss-2021b.eb
A	easybuild/easyconfigs/h/hdf5plugin/hdf5plugin-3.2.0-foss-2021b.eb
A	easybuild/easyconfigs/k/kundajelab-shap/kundajelab-shap-1-foss-2021b
A	easybuild/easyconfigs/m/modisco-lite/modisco-lite-foss-2021b
A	easybuild/easyconfigs/m/modisco/modisco-0.5.16.0-foss-2021b
A	easybuild/easyconfigs/n/nose3/nose3-1.3.8-GCCcore-11.2.0.eb
A	easybuild/easyconfigs/s/setuptools/setuptools-54.2.0-GCCcore-11.2.0.eb
A	easybuild/easyconfigs/w/WeasyPrint/WeasyPrint-52.2-foss-2021b
A	easybuild/easyconfigs/x/XGBoost/XGBoost-1.6.1-foss-2021b.eb