### PR TITLE
add `--disable-htmlpages` to recent FFmpeg easyconfigs

### DIFF
--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-5.0.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-5.0.1-GCCcore-11.3.0.eb
@@ -33,7 +33,7 @@ dependencies = [
 
 configopts = '--enable-pic --enable-shared --enable-gpl --enable-version3 --enable-nonfree --cc="$CC" --cxx="$CXX" '
 configopts += '--enable-libx264 --enable-libx265 --enable-libmp3lame --enable-libfreetype --enable-fontconfig '
-configopts += '--enable-libfribidi --enable-sdl2'
+configopts += '--enable-libfribidi --enable-sdl2 --disable-htmlpages'
 
 sanity_check_paths = {
     'files': ['bin/ff%s' % x for x in ['mpeg', 'probe', 'play']] +

--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-5.1.2-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-5.1.2-GCCcore-12.2.0.eb
@@ -33,7 +33,7 @@ dependencies = [
 
 configopts = '--enable-pic --enable-shared --enable-gpl --enable-version3 --enable-nonfree --cc="$CC" --cxx="$CXX" '
 configopts += '--enable-libx264 --enable-libx265 --enable-libmp3lame --enable-libfreetype --enable-fontconfig '
-configopts += '--enable-libfribidi --enable-sdl2'
+configopts += '--enable-libfribidi --enable-sdl2 --disable-htmlpages'
 
 sanity_check_paths = {
     'files': ['bin/ff%s' % x for x in ['mpeg', 'probe', 'play']] +

--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-6.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-6.0-GCCcore-12.3.0.eb
@@ -33,7 +33,7 @@ dependencies = [
 
 configopts = '--enable-pic --enable-shared --enable-gpl --enable-version3 --enable-nonfree --cc="$CC" --cxx="$CXX" '
 configopts += '--enable-libx264 --enable-libx265 --enable-libmp3lame --enable-libfreetype --enable-fontconfig '
-configopts += '--enable-libfribidi --enable-sdl2'
+configopts += '--enable-libfribidi --enable-sdl2 --disable-htmlpages'
 
 sanity_check_paths = {
     'files': ['bin/ff%s' % x for x in ['mpeg', 'probe', 'play']] +

--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-6.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-6.0-GCCcore-13.2.0.eb
@@ -33,7 +33,7 @@ dependencies = [
 
 configopts = '--enable-pic --enable-shared --enable-gpl --enable-version3 --enable-nonfree --cc="$CC" --cxx="$CXX" '
 configopts += '--enable-libx264 --enable-libx265 --enable-libmp3lame --enable-libfreetype --enable-fontconfig '
-configopts += '--enable-libfribidi --enable-sdl2'
+configopts += '--enable-libfribidi --enable-sdl2 --disable-htmlpages'
 
 sanity_check_paths = {
     'files': ['bin/ff%s' % x for x in ['mpeg', 'probe', 'play']] +


### PR DESCRIPTION
Building those pages apparently requires `texinfo`, as I ran into the following issue:
```
GENTEXI doc/avoptions_format.texi
GENTEXI doc/avoptions_codec.texi
HTML    doc/ffmpeg.html
makeinfo: error parsing ./doc/t2h.pm: Undefined subroutine &Texinfo::Config::set_from_init_file called at ./doc/t2h.pm line 24.
make: *** [doc/Makefile:70: doc/ffmpeg.html] Error 1
```

A `texinfo` package (version 7.1) is actually available on my system, but it looks like that specific version is causing issues: 
https://groups.google.com/g/linux.debian.bugs.dist/c/1f_eeuQd_2U

Instead of adding `texinfo` as a (heavy) build/OS dependency, this PR adds a `--disable-htmlpages` flag to recent versions, which will not build these pages.