### PR TITLE
prevent configure script of recent BLAST+ versions from prepending system paths to $PATH

### DIFF
--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.13.0-gompi-2022a.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.13.0-gompi-2022a.eb
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 # remove line that prepends system paths to $PATH from configure script
-preconfigopts = 'sed -i "s|^PATH=\(.*\)$|#PATH=\1 |" %(start_dir)s/src/build-system/configure && '
+preconfigopts = r'sed -i "s|^PATH=\(.*\)$|#PATH=\1 |" %(start_dir)s/src/build-system/configure && '
 
 configopts = "--with-64 --with-z=$EBROOTZLIB --with-bz2=$EBROOTBZIP2 "
 configopts += "--with-pcre=$EBROOTPCRE --with-boost=$EBROOTBOOST "

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.13.0-gompi-2022a.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.13.0-gompi-2022a.eb
@@ -40,6 +40,9 @@ dependencies = [
     ('LMDB', '0.9.29'),
 ]
 
+# remove line that prepends system paths to $PATH from configure script
+preconfigopts = 'sed -i "s|^PATH=\(.*\)$|#PATH=\1 |" %(start_dir)s/src/build-system/configure && '
+
 configopts = "--with-64 --with-z=$EBROOTZLIB --with-bz2=$EBROOTBZIP2 "
 configopts += "--with-pcre=$EBROOTPCRE --with-boost=$EBROOTBOOST "
 configopts += "--with-gmp=$EBROOTGMP --with-png=$EBROOTLIBPNG "

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.14.0-gompi-2022b.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.14.0-gompi-2022b.eb
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 # remove line that prepends system paths to $PATH from configure script
-preconfigopts = 'sed -i "s|^PATH=\(.*\)$|#PATH=\1 |" %(start_dir)s/src/build-system/configure && '
+preconfigopts = r'sed -i "s|^PATH=\(.*\)$|#PATH=\1 |" %(start_dir)s/src/build-system/configure && '
 
 configopts = "--with-64 --with-z=$EBROOTZLIB --with-bz2=$EBROOTBZIP2 "
 configopts += "--with-pcre=$EBROOTPCRE --with-boost=$EBROOTBOOST "

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.14.0-gompi-2022b.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.14.0-gompi-2022b.eb
@@ -40,6 +40,9 @@ dependencies = [
     ('LMDB', '0.9.29'),
 ]
 
+# remove line that prepends system paths to $PATH from configure script
+preconfigopts = 'sed -i "s|^PATH=\(.*\)$|#PATH=\1 |" %(start_dir)s/src/build-system/configure && '
+
 configopts = "--with-64 --with-z=$EBROOTZLIB --with-bz2=$EBROOTBZIP2 "
 configopts += "--with-pcre=$EBROOTPCRE --with-boost=$EBROOTBOOST "
 configopts += "--with-gmp=$EBROOTGMP --with-png=$EBROOTLIBPNG "

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.14.1-gompi-2023a.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.14.1-gompi-2023a.eb
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 # remove line that prepends system paths to $PATH from configure script
-preconfigopts = 'sed -i "s|^PATH=\(.*\)$|#PATH=\1 |" %(start_dir)s/src/build-system/configure && '
+preconfigopts = r'sed -i "s|^PATH=\(.*\)$|#PATH=\1 |" %(start_dir)s/src/build-system/configure && '
 
 configopts = "--with-64 --with-z=$EBROOTZLIB --with-bz2=$EBROOTBZIP2 "
 configopts += "--with-pcre=$EBROOTPCRE --with-boost=$EBROOTBOOST "

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.14.1-gompi-2023a.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.14.1-gompi-2023a.eb
@@ -40,6 +40,9 @@ dependencies = [
     ('LMDB', '0.9.31'),
 ]
 
+# remove line that prepends system paths to $PATH from configure script
+preconfigopts = 'sed -i "s|^PATH=\(.*\)$|#PATH=\1 |" %(start_dir)s/src/build-system/configure && '
+
 configopts = "--with-64 --with-z=$EBROOTZLIB --with-bz2=$EBROOTBZIP2 "
 configopts += "--with-pcre=$EBROOTPCRE --with-boost=$EBROOTBOOST "
 configopts += "--with-gmp=$EBROOTGMP --with-png=$EBROOTLIBPNG "


### PR DESCRIPTION
@TopRichard found that when RPATH support is enabled BLAST+ fails on some systems (mostly on distros with more recent GCC versions, it seems) due to:
```
WARNING No '(RPATH)' found in 'readelf -d' output for /path/to/BLAST+/2.14.1-gompi-2023a/bin/run_with_lock
```

Only this executable was using RUNPATH instead of RPATH, all the other ones in the installation did have RPATH. This executable actually gets compiled at the end of the `configure` script, and it turned out that it's using the system GCC compiler (and using `--enable-new-dtags`). By debugging it a bit more and replacing my system compiler by a bash script that spits out some more information, I found that `$PATH` was actually changed, and this lead me to the following line `src/build-system/configure`:
```
PATH="$HOME/bin:/bin:/usr/bin:\$PATH"
```

By commenting that line, it now picks up the right compiler (or actually the RPATH wrappers, assuming RPATH support enabled), and it gets compiled with the proper flags. The RPATH wrappers make sure that `--enable-new-dtags` is changed into `--disable-new-dtags`, which ensures that RPATH instead of RUNPATH is used.