### PR TITLE
remove `--with-64` from `configopts` for recent BLAST+ versions

### DIFF
--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.13.0-gompi-2022a.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.13.0-gompi-2022a.eb
@@ -43,7 +43,7 @@ dependencies = [
 # remove line that prepends system paths to $PATH from configure script
 preconfigopts = r'sed -i "s|^PATH=\(.*\)$|#PATH=\1 |" %(start_dir)s/src/build-system/configure && '
 
-configopts = "--with-64 --with-z=$EBROOTZLIB --with-bz2=$EBROOTBZIP2 "
+configopts = "--with-z=$EBROOTZLIB --with-bz2=$EBROOTBZIP2 "
 configopts += "--with-pcre=$EBROOTPCRE --with-boost=$EBROOTBOOST "
 configopts += "--with-gmp=$EBROOTGMP --with-png=$EBROOTLIBPNG "
 configopts += "--with-jpeg=$EBROOTLIBJPEGMINTURBO --with-lmdb=$EBROOTLMDB"

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.14.0-gompi-2022b.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.14.0-gompi-2022b.eb
@@ -43,7 +43,7 @@ dependencies = [
 # remove line that prepends system paths to $PATH from configure script
 preconfigopts = r'sed -i "s|^PATH=\(.*\)$|#PATH=\1 |" %(start_dir)s/src/build-system/configure && '
 
-configopts = "--with-64 --with-z=$EBROOTZLIB --with-bz2=$EBROOTBZIP2 "
+configopts = "--with-z=$EBROOTZLIB --with-bz2=$EBROOTBZIP2 "
 configopts += "--with-pcre=$EBROOTPCRE --with-boost=$EBROOTBOOST "
 configopts += "--with-gmp=$EBROOTGMP --with-png=$EBROOTLIBPNG "
 configopts += "--with-jpeg=$EBROOTLIBJPEGMINTURBO --with-lmdb=$EBROOTLMDB"

--- a/easybuild/easyconfigs/b/BLAST+/BLAST+-2.14.1-gompi-2023a.eb
+++ b/easybuild/easyconfigs/b/BLAST+/BLAST+-2.14.1-gompi-2023a.eb
@@ -43,7 +43,7 @@ dependencies = [
 # remove line that prepends system paths to $PATH from configure script
 preconfigopts = r'sed -i "s|^PATH=\(.*\)$|#PATH=\1 |" %(start_dir)s/src/build-system/configure && '
 
-configopts = "--with-64 --with-z=$EBROOTZLIB --with-bz2=$EBROOTBZIP2 "
+configopts = "--with-z=$EBROOTZLIB --with-bz2=$EBROOTBZIP2 "
 configopts += "--with-pcre=$EBROOTPCRE --with-boost=$EBROOTBOOST "
 configopts += "--with-gmp=$EBROOTGMP --with-png=$EBROOTLIBPNG "
 configopts += "--with-jpeg=$EBROOTLIBJPEGMINTURBO --with-lmdb=$EBROOTLMDB"


### PR DESCRIPTION
Compiling BLAST+ on Arm fails in the configure step:
```
checking whether this system supports --with(out)-64... no
configure: error: cannot continue; please try different options
```

The `--with-64` adds `-m64` to the compiler flags, and this is not supported on Arm (and neither on for instance RISC-V). Without the flag, it just doesn't add `-m64` (which should be fine too) and I preferred that over having to add if statements for distinguishing between the different architectures.