### PR TITLE
Fix build error with numpy with some compilers

### DIFF
--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2021.05-foss-2021a.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2021.05-foss-2021a.eb
@@ -23,12 +23,15 @@ exts_list = [
     ('numpy', '1.20.3', {
         'sources': [SOURCE_ZIP],
         'patches': [
+            'numpy-1.20.3_fix-fortran-compiler-error.patch',
             'numpy-1.20.3_skip-ppc-long-complex-test.patch',
             'numpy-1.20.3_xfail-test-nan.patch',
             'numpy-1.20.3_fix-target-test-ccompiler-opt.patch',
         ],
         'checksums': [
             'e55185e51b18d788e49fe8305fd73ef4470596b33fc2c1ceb304566b99c71a69',  # numpy-1.20.3.zip
+            {'numpy-1.20.3_fix-fortran-compiler-error.patch':
+             '016e0d02ffabe013248c4fd203a4456edee76839f747c05daf92ac1fe9925189'},
             # numpy-1.20.3_skip-ppc-long-complex-test.patch
             '2f9a12e3a352b39076db84a7622fc8f4796abd3cb7f97f71958a495e864659a4',
             'f0ce961f7d79551598e23050d92f46e827e300f6a7e5a6112e58efcc10385d4d',  # numpy-1.20.3_xfail-test-nan.patch

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2021.05-gomkl-2021a.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2021.05-gomkl-2021a.eb
@@ -25,6 +25,7 @@ exts_list = [
             'numpy-1.18.2-mkl.patch',
             'numpy-1.20.3_disable-broken-override-test.patch',
             'numpy-1.20.3_fix-cpu-feature-detection-intel-compilers.patch',
+            'numpy-1.20.3_fix-fortran-compiler-error.patch',
             'numpy-1.20.3_fix-target-test-ccompiler-opt.patch',
             'numpy-1.20.3_disable_fortran_callback_test.patch',
         ],
@@ -36,6 +37,8 @@ exts_list = [
             '43cc2e675c52db1776efcc6c84ebd5fc008b48e6355c81087420d5e790e4af9b',
             # numpy-1.20.3_fix-cpu-feature-detection-intel-compilers.patch
             '4c0b194c9d2e2c6b9798ebc271d4517f4c3cdbf2b3cbd68de16c7d4b068bb046',
+            {'numpy-1.20.3_fix-fortran-compiler-error.patch':
+             '016e0d02ffabe013248c4fd203a4456edee76839f747c05daf92ac1fe9925189'},
             # numpy-1.20.3_fix-target-test-ccompiler-opt.patch
             '3d84e8b7d48387778974a5f6ae342a690ab5989547206b6add9d9667f8d7572a',
             # numpy-1.20.3_disable_fortran_callback_test.patch

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2021.05-intel-2021a.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2021.05-intel-2021a.eb
@@ -25,6 +25,7 @@ exts_list = [
             'numpy-1.18.2-mkl.patch',
             'numpy-1.20.3_disable-broken-override-test.patch',
             'numpy-1.20.3_fix-cpu-feature-detection-intel-compilers.patch',
+            'numpy-1.20.3_fix-fortran-compiler-error.patch',
             'numpy-1.20.3_fix-target-test-ccompiler-opt.patch',
             'numpy-1.20.3_disable_fortran_callback_test.patch',
         ],
@@ -36,6 +37,8 @@ exts_list = [
             '43cc2e675c52db1776efcc6c84ebd5fc008b48e6355c81087420d5e790e4af9b',
             # numpy-1.20.3_fix-cpu-feature-detection-intel-compilers.patch
             '4c0b194c9d2e2c6b9798ebc271d4517f4c3cdbf2b3cbd68de16c7d4b068bb046',
+            {'numpy-1.20.3_fix-fortran-compiler-error.patch':
+             '016e0d02ffabe013248c4fd203a4456edee76839f747c05daf92ac1fe9925189'},
             # numpy-1.20.3_fix-target-test-ccompiler-opt.patch
             '3d84e8b7d48387778974a5f6ae342a690ab5989547206b6add9d9667f8d7572a',
             # numpy-1.20.3_disable_fortran_callback_test.patch

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2021.10-foss-2021b-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2021.10-foss-2021b-Python-2.7.18.eb
@@ -29,6 +29,7 @@ exts_list = [
             'numpy-1.16.2_relax-long-complex-test.patch',
             'numpy-1.16.6_add_flexiblas_detection.patch',
             'numpy-1.16.6_handle_failing_linalg_test.patch',
+            'numpy-1.20.3_fix-fortran-compiler-error.patch',
         ],
         'sources': ['%(name)s-%(version)s.zip'],
         'checksums': [
@@ -39,6 +40,8 @@ exts_list = [
             '32ca32dd7ee8d6fcdce5875067acd50970c731cbb2603c6d1ad84ff81ff8c6d5',
             # numpy-1.16.6_handle_failing_linalg_test.patch
             'be9dce98649626b7322ed8d1241b74a4e28c1d1de070a8072dc912cad3eb143d',
+            {'numpy-1.20.3_fix-fortran-compiler-error.patch':
+             '016e0d02ffabe013248c4fd203a4456edee76839f747c05daf92ac1fe9925189'},
         ],
     }),
     ('ply', '3.11', {

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2021.10-foss-2021b.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2021.10-foss-2021b.eb
@@ -25,9 +25,14 @@ use_pip = True
 exts_list = [
     ('numpy', '1.21.3', {
         'sources': ['%(name)s-%(version)s.zip'],
-        'patches': ['numpy-1.20.3_skip-ppc-long-complex-test.patch'],
+        'patches': [
+            'numpy-1.20.3_fix-fortran-compiler-error.patch',
+            'numpy-1.20.3_skip-ppc-long-complex-test.patch',
+        ],
         'checksums': [
             '63571bb7897a584ca3249c86dd01c10bcb5fe4296e3568b2e9c1a55356b6410e',  # numpy-1.21.3.zip
+            {'numpy-1.20.3_fix-fortran-compiler-error.patch':
+             '016e0d02ffabe013248c4fd203a4456edee76839f747c05daf92ac1fe9925189'},
             # numpy-1.20.3_skip-ppc-long-complex-test.patch
             '2f9a12e3a352b39076db84a7622fc8f4796abd3cb7f97f71958a495e864659a4',
         ],

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2021.10-intel-2021b.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2021.10-intel-2021b.eb
@@ -29,6 +29,7 @@ exts_list = [
             'numpy-1.18.2-mkl.patch',
             'numpy-1.20.3_disable-broken-override-test.patch',
             'numpy-1.20.3_disable_fortran_callback_test.patch',
+            'numpy-1.20.3_fix-fortran-compiler-error.patch',
         ],
         'checksums': [
             '63571bb7897a584ca3249c86dd01c10bcb5fe4296e3568b2e9c1a55356b6410e',  # numpy-1.21.3.zip
@@ -37,6 +38,8 @@ exts_list = [
             '43cc2e675c52db1776efcc6c84ebd5fc008b48e6355c81087420d5e790e4af9b',
             # numpy-1.20.3_disable_fortran_callback_test.patch
             '44975a944544fd0e771b7e63c32590d257a3713070f8f7fdf60105dc516f1d75',
+            {'numpy-1.20.3_fix-fortran-compiler-error.patch':
+             '016e0d02ffabe013248c4fd203a4456edee76839f747c05daf92ac1fe9925189'},
         ],
     }),
     ('ply', '3.11', {

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2022.05-foss-2022.05.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2022.05-foss-2022.05.eb
@@ -26,6 +26,7 @@ exts_list = [
     ('numpy', '1.22.3', {
         'patches': [
             'numpy-1.20.3_disable_fortran_callback_test.patch',
+            'numpy-1.20.3_fix-fortran-compiler-error.patch',
             'numpy-1.22.3_disable-broken-override-test.patch',
         ],
         'sources': ['%(name)s-%(version)s.zip'],
@@ -33,6 +34,8 @@ exts_list = [
             'dbc7601a3b7472d559dc7b933b18b4b66f9aa7452c120e87dfb33d02008c8a18',  # numpy-1.22.3.zip
             # numpy-1.20.3_disable_fortran_callback_test.patch
             '44975a944544fd0e771b7e63c32590d257a3713070f8f7fdf60105dc516f1d75',
+            {'numpy-1.20.3_fix-fortran-compiler-error.patch':
+             '016e0d02ffabe013248c4fd203a4456edee76839f747c05daf92ac1fe9925189'},
             # numpy-1.22.3_disable-broken-override-test.patch
             '9c589bb073b28b25ff45eb3c63c57966aa508dd8b318d0b885b6295271e4983c',
         ],

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2022.05-foss-2022a.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2022.05-foss-2022a.eb
@@ -26,6 +26,7 @@ exts_list = [
     ('numpy', '1.22.3', {
         'patches': [
             'numpy-1.20.3_disable_fortran_callback_test.patch',
+            'numpy-1.20.3_fix-fortran-compiler-error.patch',
             'numpy-1.22.3_disable-broken-override-test.patch',
             '%(name)s-%(version)s_skip-ppc-long-complex-test.patch',
         ],
@@ -34,6 +35,8 @@ exts_list = [
             'dbc7601a3b7472d559dc7b933b18b4b66f9aa7452c120e87dfb33d02008c8a18',  # numpy-1.22.3.zip
             # numpy-1.20.3_disable_fortran_callback_test.patch
             '44975a944544fd0e771b7e63c32590d257a3713070f8f7fdf60105dc516f1d75',
+            {'numpy-1.20.3_fix-fortran-compiler-error.patch':
+             '016e0d02ffabe013248c4fd203a4456edee76839f747c05daf92ac1fe9925189'},
             # numpy-1.22.3_disable-broken-override-test.patch
             '9c589bb073b28b25ff45eb3c63c57966aa508dd8b318d0b885b6295271e4983c',
             # numpy-1.22.3_skip-ppc-long-complex-test.patch

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2022.05-intel-2022.05.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2022.05-intel-2022.05.eb
@@ -27,6 +27,7 @@ exts_list = [
         'patches': [
             'numpy-1.18.2-mkl.patch',
             'numpy-1.20.3_disable_fortran_callback_test.patch',
+            'numpy-1.20.3_fix-fortran-compiler-error.patch',
             'numpy-1.22.3_disable-broken-override-test.patch',
         ],
         'sources': ['%(name)s-%(version)s.zip'],
@@ -35,6 +36,8 @@ exts_list = [
             'ea25ad5c0148c1398d282f0424e642fb9815a1a80f4512659b018e2adc378bcf',  # numpy-1.18.2-mkl.patch
             # numpy-1.20.3_disable_fortran_callback_test.patch
             '44975a944544fd0e771b7e63c32590d257a3713070f8f7fdf60105dc516f1d75',
+            {'numpy-1.20.3_fix-fortran-compiler-error.patch':
+             '016e0d02ffabe013248c4fd203a4456edee76839f747c05daf92ac1fe9925189'},
             # numpy-1.22.3_disable-broken-override-test.patch
             '9c589bb073b28b25ff45eb3c63c57966aa508dd8b318d0b885b6295271e4983c',
         ],

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2022.05-intel-2022a.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2022.05-intel-2022a.eb
@@ -27,6 +27,7 @@ exts_list = [
         'patches': [
             'numpy-1.18.2-mkl.patch',
             'numpy-1.20.3_disable_fortran_callback_test.patch',
+            'numpy-1.20.3_fix-fortran-compiler-error.patch',
             'numpy-1.22.3_disable-broken-override-test.patch',
         ],
         'sources': ['%(name)s-%(version)s.zip'],
@@ -35,6 +36,8 @@ exts_list = [
             'ea25ad5c0148c1398d282f0424e642fb9815a1a80f4512659b018e2adc378bcf',  # numpy-1.18.2-mkl.patch
             # numpy-1.20.3_disable_fortran_callback_test.patch
             '44975a944544fd0e771b7e63c32590d257a3713070f8f7fdf60105dc516f1d75',
+            {'numpy-1.20.3_fix-fortran-compiler-error.patch':
+             '016e0d02ffabe013248c4fd203a4456edee76839f747c05daf92ac1fe9925189'},
             # numpy-1.22.3_disable-broken-override-test.patch
             '9c589bb073b28b25ff45eb3c63c57966aa508dd8b318d0b885b6295271e4983c',
         ],

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2023.02-gfbf-2022b.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2023.02-gfbf-2022b.eb
@@ -28,9 +28,14 @@ use_pip = True
 # order is important!
 exts_list = [
     ('numpy', '1.24.2', {
-        'patches': ['numpy-1.22.3_disable-broken-override-test.patch'],
+        'patches': [
+            'numpy-1.20.3_fix-fortran-compiler-error.patch',
+            'numpy-1.22.3_disable-broken-override-test.patch',
+        ],
         'checksums': [
             {'numpy-1.24.2.tar.gz': '003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22'},
+            {'numpy-1.20.3_fix-fortran-compiler-error.patch':
+             '016e0d02ffabe013248c4fd203a4456edee76839f747c05daf92ac1fe9925189'},
             {'numpy-1.22.3_disable-broken-override-test.patch':
              '9c589bb073b28b25ff45eb3c63c57966aa508dd8b318d0b885b6295271e4983c'},
         ],

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2023.07-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2023.07-gfbf-2023a.eb
@@ -30,6 +30,7 @@ use_pip = True
 exts_list = [
     ('numpy', '1.25.1', {
         'patches': [
+            'numpy-1.20.3_fix-fortran-compiler-error.patch',
             'numpy-1.22.3_disable-broken-override-test.patch',
             ('numpy-1.25.1_fix-duplicate-avx512-symbols.patch', 'numpy/core/src/npysort/x86-simd-sort'),
             'numpy-1.25.1_fix-undefined-avx512-reference.patch',
@@ -38,6 +39,8 @@ exts_list = [
         ],
         'checksums': [
             {'numpy-1.25.1.tar.gz': '9a3a9f3a61480cc086117b426a8bd86869c213fc4072e606f01c4e4b66eb92bf'},
+            {'numpy-1.20.3_fix-fortran-compiler-error.patch':
+             '016e0d02ffabe013248c4fd203a4456edee76839f747c05daf92ac1fe9925189'},
             {'numpy-1.22.3_disable-broken-override-test.patch':
              '9c589bb073b28b25ff45eb3c63c57966aa508dd8b318d0b885b6295271e4983c'},
             {'numpy-1.25.1_fix-duplicate-avx512-symbols.patch':

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2023.07-iimkl-2023a.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2023.07-iimkl-2023a.eb
@@ -31,6 +31,7 @@ exts_list = [
     ('numpy', '1.25.1', {
         'patches': [
             'numpy-1.18.2-mkl.patch',
+            'numpy-1.20.3_fix-fortran-compiler-error.patch',
             'numpy-1.25.1_disable_fortran_callback_test.patch',
             'numpy-1.22.3_disable-broken-override-test.patch',
             'numpy-1.25.1_disable-broken-test_long_long_map.patch',
@@ -41,6 +42,8 @@ exts_list = [
         'checksums': [
             {'numpy-1.25.1.tar.gz': '9a3a9f3a61480cc086117b426a8bd86869c213fc4072e606f01c4e4b66eb92bf'},
             {'numpy-1.18.2-mkl.patch': 'ea25ad5c0148c1398d282f0424e642fb9815a1a80f4512659b018e2adc378bcf'},
+            {'numpy-1.20.3_fix-fortran-compiler-error.patch':
+             '016e0d02ffabe013248c4fd203a4456edee76839f747c05daf92ac1fe9925189'},
             {'numpy-1.25.1_disable_fortran_callback_test.patch':
              '3c02bd9973b7082fde9f9d18edfeb05798226ccb5731a56f5677269200c345cf'},
             {'numpy-1.22.3_disable-broken-override-test.patch':

--- a/easybuild/easyconfigs/s/SciPy-bundle/numpy-1.20.3_fix-fortran-compiler-error.patch
+++ b/easybuild/easyconfigs/s/SciPy-bundle/numpy-1.20.3_fix-fortran-compiler-error.patch
@@ -1,0 +1,43 @@
+Using Fortran compilers which differ "too much" from GCC fails building NumPy with something like
+> A valid Fortran version was not found in this string: [...]
+
+See https://github.com/easybuilders/easybuild-easyblocks/issues/2518 and https://github.com/numpy/numpy/pull/26502
+
+Fix by converting the hard error into a warning as the issue would be handled later if required.
+E.g. for building NumPy we don't need a Fortran compiler at all.
+
+Author: Alexander Grund (TU Dresden)
+
+diff --git a/numpy/distutils/fcompiler/gnu.py b/numpy/distutils/fcompiler/gnu.py
+index eac4cbb477..8a1043fe26 100644
+--- a/numpy/distutils/fcompiler/gnu.py
++++ b/numpy/distutils/fcompiler/gnu.py
+@@ -8,6 +8,7 @@ import hashlib
+ import base64
+ import subprocess
+ from subprocess import Popen, PIPE, STDOUT
++from distutils import log
+ from numpy.distutils.exec_command import filepath_from_subprocess_output
+ from numpy.distutils.fcompiler import FCompiler
+ from distutils.version import LooseVersion
+@@ -69,9 +70,9 @@ class GnuFCompiler(FCompiler):
+                     # from the version string
+                     return ('gfortran', v)
+ 
+-        # If still nothing, raise an error to make the problem easy to find.
+-        err = 'A valid Fortran version was not found in this string:\n'
+-        raise ValueError(err + version_string)
++        # If still nothing, warn to make the problem easy to find.
++        log.warn('A valid Fortran version was not found in this string:\n'
++                 + version_string)
+ 
+     def version_match(self, version_string):
+         v = self.gnu_version_match(version_string)
+@@ -539,7 +540,6 @@ def _can_target(cmd, arch):
+ 
+ 
+ if __name__ == '__main__':
+-    from distutils import log
+     from numpy.distutils import customized_fcompiler
+     log.set_verbosity(2)
+ 


### PR DESCRIPTION
NumPy doesn't need Fortran for building but still initializes the Fortran compiler which fails when the compiler requires a different commandline argument than GCC, e.g. the Fujitsu compiler. Failure message starts with
> A valid Fortran version was not found in this string:

See https://github.com/easybuilders/easybuild-easyblocks/issues/2518 Patch is from https://github.com/numpy/numpy/pull/26502 which won't get merged but isn't necessary in numpy 1.26+

CC @migueldiascosta 