### PR TITLE
rename unpacked sources for components of EasyBuild v4.9.2, to ensure that '`--install-latest-eb-release`' works with older EasyBuild versions

### DIFF
--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-4.9.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-4.9.2.eb
@@ -18,10 +18,22 @@ source_urls = [
     # easybuild-easyconfigs
     'https://files.pythonhosted.org/packages/99/b2/d899b4310bc54a10e0fb46995a2abc333857db16d116f22a53b0313d13d7/',
 ]
+# note: subdirectory for each unpacked source tarball is renamed because custom easyblock in older EasyBuild version
+# that is used for installing EasyBuild with EasyBuild expects subdirectories with '-' rather than '_';
+# see also https://github.com/easybuilders/easybuild-easyblocks/pull/3358
 sources = [
-    'easybuild_framework-%(version)s.tar.gz',
-    'easybuild_easyblocks-%(version)s.tar.gz',
-    'easybuild_easyconfigs-%(version)s.tar.gz',
+    {
+        'filename': 'easybuild_framework-%(version)s.tar.gz',
+        'extract_cmd': "tar xfvz %s && mv easybuild_framework-%(version)s easybuild-framework-%(version)s",
+    },
+    {
+        'filename': 'easybuild_easyblocks-%(version)s.tar.gz',
+        'extract_cmd': "tar xfvz %s && mv easybuild_easyblocks-%(version)s easybuild-easyblocks-%(version)s",
+    },
+    {
+        'filename': 'easybuild_easyconfigs-%(version)s.tar.gz',
+        'extract_cmd': "tar xfvz %s && mv easybuild_easyconfigs-%(version)s easybuild-easyconfigs-%(version)s",
+    },
 ]
 checksums = [
     {'easybuild_framework-4.9.2.tar.gz': 'cc6e0fe7bab2a96d424656ed70bf33e3b083eef5ceaa5d5fed88aa7b91dd3d63'},


### PR DESCRIPTION
When this is merged, "`eb --install-latest-eb-release`" (which pulls the easyconfig for the latest EasyBuild release) will work again, without having to use `--include-easyblocks-from-pr 3358`, see also https://github.com/easybuilders/easybuild-easyblocks/pull/3358