### PR TITLE
add support for JupyterHub to TensorBoard

### DIFF
--- a/easybuild/easyconfigs/t/tensorboard/tensorboard-2.10.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/t/tensorboard/tensorboard-2.10.0-foss-2022a.eb
@@ -9,6 +9,14 @@ and graphs."""
 
 toolchain = {'name': 'foss', 'version': '2022a'}
 
+postinstallpatches = [
+    ('tensorboard-2.10_jupyterhub-support.patch', 'lib/python%(pyshortver)s/site-packages'),
+]
+checksums = [
+    {'tensorboard-2.10_jupyterhub-support.patch':
+     '50a292e6ee518aecb5644595e0f3db4867be4f82e328e008e5a3f6a1f19baf87'},
+]
+
 dependencies = [
     ('Python', '3.10.4'),
     ('SciPy-bundle', '2022.05'),

--- a/easybuild/easyconfigs/t/tensorboard/tensorboard-2.10_jupyterhub-support.patch
+++ b/easybuild/easyconfigs/t/tensorboard/tensorboard-2.10_jupyterhub-support.patch
@@ -1,0 +1,103 @@
+From: qzchenwl <qzchenwl@gmail.com>
+Date: Tue, 14 Jan 2020 15:22:27 +0800
+Subject: support jupyterhub with jupyter-server-proxy
+Issue: https://github.com/tensorflow/tensorboard/pull/3142
+
+--- a/tensorboard/notebook.py	2024-06-13 16:04:51.656772000 +0200
++++ b/tensorboard/notebook.py	2024-06-13 16:06:38.749780722 +0200
+@@ -34,6 +34,7 @@
+ # details).
+ _CONTEXT_COLAB = "_CONTEXT_COLAB"
+ _CONTEXT_IPYTHON = "_CONTEXT_IPYTHON"
++_CONTEXT_JUPYTERHUB = "_CONTEXT_JUPYTERHUB"
+ _CONTEXT_NONE = "_CONTEXT_NONE"
+ 
+ 
+@@ -70,12 +71,31 @@
+     else:
+         ipython = IPython.get_ipython()
+         if ipython is not None and ipython.has_trait("kernel"):
++            if os.environ.get("JUPYTERHUB_SERVICE_PREFIX") is not None:
++                return _CONTEXT_JUPYTERHUB
+             return _CONTEXT_IPYTHON
+ 
+     # Otherwise, we're not in a known notebook context.
+     return _CONTEXT_NONE
+ 
+ 
++def _prefix_jupyterhub(port):
++    prefix = os.path.join(
++        os.environ["JUPYTERHUB_SERVICE_PREFIX"], "proxy/absolute"
++    )
++    return "%s/%d/" % (prefix, port)
++
++
++def _patch_args_jupyterhub(parsed_args):
++    if "--port" in parsed_args:
++        arg_idx = parsed_args.index("--port")
++        port = int(parsed_args[arg_idx + 1])
++    else:
++        port = 6006
++        parsed_args += ["--port", str(port)]
++    return parsed_args + ["--path_prefix", _prefix_jupyterhub(port)]
++
++
+ def load_ipython_extension(ipython):
+     """Deprecated: use `%load_ext tensorboard` instead.
+ 
+@@ -149,6 +169,9 @@
+             handle.update(IPython.display.Pretty(message))
+ 
+     parsed_args = shlex.split(args_string, comments=True, posix=True)
++    if context == _CONTEXT_JUPYTERHUB:
++        parsed_args = _patch_args_jupyterhub(parsed_args)
++
+     start_result = manager.start(parsed_args)
+ 
+     if isinstance(start_result, manager.StartLaunched):
+@@ -305,6 +328,7 @@
+     fn = {
+         _CONTEXT_COLAB: _display_colab,
+         _CONTEXT_IPYTHON: _display_ipython,
++        _CONTEXT_JUPYTERHUB: _display_jupyterhub,
+         _CONTEXT_NONE: _display_cli,
+     }[_get_context()]
+     return fn(port=port, height=height, display_handle=display_handle)
+@@ -401,6 +425,36 @@
+     for (k, v) in replacements:
+         shell = shell.replace(k, v)
+     iframe = IPython.display.HTML(shell)
++    if display_handle:
++        display_handle.update(iframe)
++    else:
++        IPython.display.display(iframe)
++
++
++def _display_jupyterhub(port, height, display_handle):
++    import IPython.display
++
++    frame_id = "tensorboard-frame-{:08x}".format(random.getrandbits(64))
++    shell = """
++      <iframe id="%HTML_ID%" width="100%" height="%HEIGHT%" frameborder="0">
++      </iframe>
++      <script>
++        (function() {
++          const frame = document.getElementById(%JSON_ID%);
++          const url = new URL("%PREFIX%", window.location);
++          frame.src = url;
++        })();
++      </script>
++  """
++    replacements = [
++        ("%HTML_ID%", html.escape(frame_id, quote=True)),
++        ("%JSON_ID%", json.dumps(frame_id)),
++        ("%PREFIX%", _prefix_jupyterhub(port)),
++        ("%HEIGHT%", "%d" % height),
++    ]
++    for (k, v) in replacements:
++        shell = shell.replace(k, v)
++    iframe = IPython.display.HTML(shell)
+     if display_handle:
+         display_handle.update(iframe)
+     else:
+From 5615204ba44a6b8718e58c9b4b875fef5027baaf Mon Sep 17 00:00:00 2001

--- a/easybuild/easyconfigs/t/tensorboard/tensorboard-2.15.1-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/t/tensorboard/tensorboard-2.15.1-gfbf-2023a.eb
@@ -9,6 +9,14 @@ understanding your TensorFlow runs and graphs."""
 
 toolchain = {'name': 'gfbf', 'version': '2023a'}
 
+postinstallpatches = [
+    ('tensorboard-2.10_jupyterhub-support.patch', 'lib/python%(pyshortver)s/site-packages'),
+]
+checksums = [
+    {'tensorboard-2.10_jupyterhub-support.patch':
+     '50a292e6ee518aecb5644595e0f3db4867be4f82e328e008e5a3f6a1f19baf87'},
+]
+
 builddependencies = [
     ('poetry', '1.5.1'),
 ]
@@ -17,6 +25,7 @@ dependencies = [
     ('Python', '3.11.3'),
     ('SciPy-bundle', '2023.07'),
     ('protobuf-python', '4.24.0'),
+    ('grpcio', '1.57.0'),
 ]
 
 exts_list = [
@@ -46,11 +55,6 @@ exts_list = [
     ('google-auth-oauthlib', '1.2.0', {
         'checksums': ['292d2d3783349f2b0734a0a0207b1e1e322ac193c2c09d8f7c613fb7cc501ea8'],
     }),
-    ('grpcio', '1.60.0', {
-        'modulename': 'grpc',
-        'preinstallopts': "export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=%(parallel)s && ",
-        'checksums': ['2199165a1affb666aa24adf0c97436686d0a61bc5fc113c037701fb7c7fceb96'],
-    }),
     ('Markdown', '3.5.2', {
         'checksums': ['e1ac7b3dc550ee80e602e71c1d168002f062e49f1b11e26a36264dafd4df2ef8'],
     }),
@@ -58,9 +62,13 @@ exts_list = [
         'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
         'checksums': ['7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb'],
     }),
-    ('tensorboard_plugin_wit', '1.8.1', {
-        'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
-        'checksums': ['ff26bdd583d155aa951ee3b152b3d0cffae8005dc697f72b44a8e8c2a77a8cbe'],
+    ('gviz-api', '1.10.0', {
+        'source_tmpl': 'gviz_api-%(version)s.tar.gz',
+        'checksums': ['846692dd8cc73224fc31b18e41589bd934e1cc05090c6576af4b4b26c2e71b90'],
+    }),
+    ('tensorboard-plugin-profile', '2.15.1', {
+        'source_tmpl': 'tensorboard_plugin_profile-%(version)s.tar.gz',
+        'checksums': ['84bb33e446eb4a9c0616f669fc6a42cdd40eadd9ae1d74bf756f4f0479993273'],
     }),
     ('Werkzeug', '3.0.1', {
         'source_tmpl': '%(namelower)s-%(version)s.tar.gz',
@@ -79,8 +87,5 @@ postinstallcmds = [
     'sed -i "s/Requires-Dist: protobuf.*/Requires-Dist: protobuf >=3.19.6/g" ' +
     '%(installdir)s/lib/python%(pyshortver)s/site-packages/%(name)s-%(version)s.dist-info/METADATA',
 ]
-
-use_pip = True
-sanity_pip_check = True
 
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/tensorboard/tensorboard-2.15.1-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/t/tensorboard/tensorboard-2.15.1-gfbf-2023a.eb
@@ -28,6 +28,9 @@ dependencies = [
     ('grpcio', '1.57.0'),
 ]
 
+use_pip = True
+sanity_pip_check = True
+
 exts_list = [
     ('absl-py', '2.1.0', {
         'modulename': 'absl',


### PR DESCRIPTION
Changelog:

* fix issue https://github.com/tensorflow/tensorboard/pull/3142 in `tensorboard-2.10.0-foss-2022a.eb` and `tensorboard-2.15.1-gfbf-2023a.eb`
* `tensorboard-2.15.1-gfbf-2023a.eb`: replace extension on `grpcio` with regular dependency
* `tensorboard-2.15.1-gfbf-2023a.eb`: remove deprecated `tensorboard_plugin_wit` and add `tensorboard-plugin-profile` to be on par with TensorFlow v2.15.1