### PR TITLE
add GMP and MPFR as dependencies to OpenFOAM v2306 and v2312

### DIFF
--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2306-foss-2022b.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2306-foss-2022b.eb
@@ -30,6 +30,8 @@ builddependencies = [
     ('CMake', '3.24.3'),
     ('flex', '2.6.4'),
     ('CGAL', '5.5.2'),  # header only
+    ('GMP', '6.2.1'),
+    ('MPFR', '4.2.0'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2312-foss-2023a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2312-foss-2023a.eb
@@ -39,6 +39,8 @@ dependencies = [
     ('SCOTCH', '7.0.3'),
     ('KaHIP', '3.16'),
     ('CGAL', '5.6'),
+    ('GMP', '6.2.1'),
+    ('MPFR', '4.2.0'),
     ('ParaView', '5.11.2'),
     ('gnuplot', '5.4.8'),
 ]


### PR DESCRIPTION
See https://github.com/easybuilders/easybuild-easyblocks/pull/3366.