### PR TITLE
use PyYAML 6.0.1 instead of 6.0 for recent ReFrame versions

### DIFF
--- a/easybuild/easyconfigs/r/ReFrame/ReFrame-4.3.2.eb
+++ b/easybuild/easyconfigs/r/ReFrame/ReFrame-4.3.2.eb
@@ -28,7 +28,8 @@ exts_list = [
         'checksums': ['4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a'],
     }),
     ('reframe', version, {
-        'preinstallopts': "export PATH=%(installdir)s/bin:$PATH && "
+        'preinstallopts': "sed -i 's@PyYAML==6.0@PyYAML==6.0.1@' requirements.txt && "
+                          "export PATH=%(installdir)s/bin:$PATH && "
                           "./bootstrap.sh +docs +pygelf && cp -r external %(installdir)s && "
                           "PYTHONPATH=%(builddir)s/reframe/reframe-%(version)s/external:$PYTHONPATH ",
         'source_tmpl': 'v%(version)s.tar.gz',

--- a/easybuild/easyconfigs/r/ReFrame/ReFrame-4.3.2.eb
+++ b/easybuild/easyconfigs/r/ReFrame/ReFrame-4.3.2.eb
@@ -28,7 +28,8 @@ exts_list = [
         'checksums': ['4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a'],
     }),
     ('reframe', version, {
-        'preinstallopts': "sed -i 's@PyYAML==6.0@PyYAML==6.0.1@' requirements.txt && "
+        'preinstallopts': # use PyYAML 6.0.1 to solve Cython 3 incompatibility issues
+                          "sed -i 's@PyYAML==6.0@PyYAML==6.0.1@' requirements.txt && "
                           "export PATH=%(installdir)s/bin:$PATH && "
                           "./bootstrap.sh +docs +pygelf && cp -r external %(installdir)s && "
                           "PYTHONPATH=%(builddir)s/reframe/reframe-%(version)s/external:$PYTHONPATH ",

--- a/easybuild/easyconfigs/r/ReFrame/ReFrame-4.3.2.eb
+++ b/easybuild/easyconfigs/r/ReFrame/ReFrame-4.3.2.eb
@@ -28,9 +28,9 @@ exts_list = [
         'checksums': ['4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a'],
     }),
     ('reframe', version, {
-        'preinstallopts': # use PyYAML 6.0.1 to solve Cython 3 incompatibility issues
+        'preinstallopts': "export PATH=%(installdir)s/bin:$PATH && "
+                          # use PyYAML 6.0.1 to solve Cython 3 incompatibility issues
                           "sed -i 's@PyYAML==6.0@PyYAML==6.0.1@' requirements.txt && "
-                          "export PATH=%(installdir)s/bin:$PATH && "
                           "./bootstrap.sh +docs +pygelf && cp -r external %(installdir)s && "
                           "PYTHONPATH=%(builddir)s/reframe/reframe-%(version)s/external:$PYTHONPATH ",
         'source_tmpl': 'v%(version)s.tar.gz',

--- a/easybuild/easyconfigs/r/ReFrame/ReFrame-4.3.3.eb
+++ b/easybuild/easyconfigs/r/ReFrame/ReFrame-4.3.3.eb
@@ -29,7 +29,8 @@ exts_list = [
         'checksums': ['4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a'],
     }),
     ('reframe', version, {
-        'preinstallopts': "sed -i 's@PyYAML==6.0@PyYAML==6.0.1@' requirements.txt && "
+        'preinstallopts': # use PyYAML 6.0.1 to solve Cython 3 incompatibility issues
+                          "sed -i 's@PyYAML==6.0@PyYAML==6.0.1@' requirements.txt && "
                           "export PATH=%(installdir)s/bin:$PATH && "
                           "./bootstrap.sh +docs +pygelf && cp -r external %(installdir)s && "
                           "PYTHONPATH=%(builddir)s/reframe/reframe-%(version)s/external:$PYTHONPATH ",

--- a/easybuild/easyconfigs/r/ReFrame/ReFrame-4.3.3.eb
+++ b/easybuild/easyconfigs/r/ReFrame/ReFrame-4.3.3.eb
@@ -29,7 +29,8 @@ exts_list = [
         'checksums': ['4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a'],
     }),
     ('reframe', version, {
-        'preinstallopts': "export PATH=%(installdir)s/bin:$PATH && "
+        'preinstallopts': "sed -i 's@PyYAML==6.0@PyYAML==6.0.1@' requirements.txt && "
+                          "export PATH=%(installdir)s/bin:$PATH && "
                           "./bootstrap.sh +docs +pygelf && cp -r external %(installdir)s && "
                           "PYTHONPATH=%(builddir)s/reframe/reframe-%(version)s/external:$PYTHONPATH ",
         'source_tmpl': 'v%(version)s.tar.gz',

--- a/easybuild/easyconfigs/r/ReFrame/ReFrame-4.3.3.eb
+++ b/easybuild/easyconfigs/r/ReFrame/ReFrame-4.3.3.eb
@@ -29,9 +29,9 @@ exts_list = [
         'checksums': ['4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a'],
     }),
     ('reframe', version, {
-        'preinstallopts': # use PyYAML 6.0.1 to solve Cython 3 incompatibility issues
+        'preinstallopts': "export PATH=%(installdir)s/bin:$PATH && "
+                          # use PyYAML 6.0.1 to solve Cython 3 incompatibility issues
                           "sed -i 's@PyYAML==6.0@PyYAML==6.0.1@' requirements.txt && "
-                          "export PATH=%(installdir)s/bin:$PATH && "
                           "./bootstrap.sh +docs +pygelf && cp -r external %(installdir)s && "
                           "PYTHONPATH=%(builddir)s/reframe/reframe-%(version)s/external:$PYTHONPATH ",
         'source_tmpl': 'v%(version)s.tar.gz',


### PR DESCRIPTION
I ran into this when installing ReFrame on a system with Cython 3:
```
==> [+pygelf] python3 -m pip install --no-cache-dir -q -r /tmp/eb-myh20jsw/tmp.V9e2PYU6tR --target=external/ --upgrade
DEPRECATION: Loading egg at /cvmfs/riscv.eessi.io/versions/20240402/software/linux/riscv64/generic/software/ReFrame/4.3.3/lib/python3.11/site-packages/pip-21.3.1-py3.11.egg is deprecated. pi
p 24.3 will enforce this behaviour change. A possible replacement is to use pip for package installation. Discussion can be found at https://github.com/pypa/pip/issues/12330
  error: subprocess-exited-with-error
  
   Getting requirements to build wheel did not run successfully.
   exit code: 1
  > [54 lines of output]
      running egg_info
      writing lib/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/tmp/eb/easybuild/build/ReFrame/4.3.3/system-system/reframe/reframe-4.3.3/external/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/tmp/eb/easybuild/build/ReFrame/4.3.3/system-system/reframe/reframe-4.3.3/external/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/eb/easybuild/build/ReFrame/4.3.3/system-system/reframe/reframe-4.3.3/external/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 327, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 297, in _get_build_requires
          self.run_setup()
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 313, in run_setup
          exec(code, locals())
        File "<string>", line 288, in <module>
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/__init__.py", line 103, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 184, in setup
          return run_commands(dist)
                 ^^^^^^^^^^^^^^^^^^
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 200, in run_commands
          dist.run_commands()
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/dist.py", line 976, in run_command
          super().run_command(command)
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 321, in run
          self.find_sources()
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 329, in find_sources
          mm.run()
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 550, in run
          self.add_defaults()
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 588, in add_defaults
          sdist.add_defaults(self)
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/command/sdist.py", line 102, in add_defaults
          super().add_defaults()
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 250, in add_defaults
          self._add_defaults_ext()
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 335, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "<string>", line 204, in get_source_files
        File "/tmp/eb-myh20jsw/pip-build-env-afkyp1z7/overlay/lib/python3.11/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

 Getting requirements to build wheel did not run successfully.
 exit code: 1
```

Apparently PyYAML 6.0 has a known issue regarding Cython 3, and is not compatible with this version:
https://github.com/yaml/pyyaml/issues/736
They worked around it by pinning the Cython build constraint to < 3.0:
https://github.com/yaml/pyyaml/pull/702
And they released 6.0.1 with (only) this workaround: https://github.com/yaml/pyyaml/blob/6.0.1/announcement.msg

This PR replaces 6.0 in the requirements.txt by 6.0.1 for recent ReFrame version. Since nothing else is changed in PyYAML, this should be a safe change.

ReFrame 4.4.x and newer already use 6.0.1, so this fix can be removed for those versions.