### PR TITLE
add easyconfig files for openmc software stack

### DIFF
--- a/easybuild/easyconfigs/d/DAGMC/DAGMC-3.2.2-foss-2022a.eb
+++ b/easybuild/easyconfigs/d/DAGMC/DAGMC-3.2.2-foss-2022a.eb
@@ -1,0 +1,35 @@
+name = 'DAGMC'
+version = '3.2.2'
+
+homepage = 'https://svalinn.github.io/DAGMC/index.html'
+description = "Direct Accelerated Geometry Monte Carlo (DAGMC) is a software package that allows users to perform Monte Carlo radiation transport directly on CAD models."
+software_license_urls = ['https://github.com/svalinn/DAGMC/blob/develop/LICENSE.txt']
+toolchain = {'name': 'foss', 'version': '2022a'}
+
+sources = [{
+    'filename': f'DAGMC-{version}.tar.gz',
+    'git_config': {
+        'url': 'https://github.com/svalinn/',
+        'repo_name': 'DAGMC',
+        'recursive':True,
+        'tag': f'v{version}'
+    },
+}]
+
+# patch needed for correct path handling to find MOAB
+patches = ['DAGMC-3.2.2_find-MOAB.patch']
+
+builddependencies = [('CMake', '3.23.1'),('make','4.3')]
+
+dependencies = [
+    ('HDF5', '1.12.2'),
+    ('Eigen','3.4.0'),
+    ('MOAB','5.5.0'),
+    ('double-down','1.1.0')
+]
+
+easyblock = 'CMakeMake'
+
+_moab_dir = '$EBROOTMOAB'
+_double_down_dir = '$EBROOTDOUBLEMINDOWN' + '/lib/cmake/dd'
+configopts = f"-DMOAB_DIR={_moab_dir} -DBUILDTALLY=ON -DDOUBLE_DOWN=ON -DBUILD_STATIC_EXE=OFF -DBUILD_STATIC_LIBS=OFF -DDOUBLE_DOWN_DIR={_double_down_dir} -DBUILD_UWUW=OFF"

--- a/easybuild/easyconfigs/d/DAGMC/DAGMC-3.2.2_find-MOAB.patch
+++ b/easybuild/easyconfigs/d/DAGMC/DAGMC-3.2.2_find-MOAB.patch
@@ -1,0 +1,21 @@
+--- /home/myuser/.local/easybuild/build/dagmc_dev/3.2.2/foss-2022a/DAGMC/cmake/FindMOAB.cmake.orig	2024-04-11 11:00:09.538052758 +0000
++++ /home/myuser/.local/easybuild/build/dagmc_dev/3.2.2/foss-2022a/DAGMC/cmake/FindMOAB.cmake	2024-04-11 11:06:11.078058472 +0000
+@@ -2,9 +2,15 @@
+ 
+ # Find MOAB cmake config file
+ # Only used to determine the location of the HDF5 with which MOAB was built
+-set(MOAB_SEARCH_DIRS)
+-file(GLOB MOAB_SEARCH_DIRS ${MOAB_SEARCH_DIRS} "${MOAB_DIR}/lib*/cmake/MOAB")
+-string(REPLACE "\n" ";" MOAB_SEARCH_DIRS ${MOAB_SEARCH_DIRS})
++
++# Directly set MOAB_SEARCH_DIRS
++set(MOAB_SEARCH_DIRS
++    "${MOAB_DIR}/lib/cmake/MOAB"
++    "${MOAB_DIR}/lib64/cmake/MOAB"
++    "${MOAB_DIR}/cmake/MOAB"
++    "${MOAB_DIR}/MOAB"
++    "${MOAB_DIR}"
++    )
+ find_path(MOAB_CMAKE_CONFIG
+   NAMES MOABConfig.cmake
+   PATHS ${MOAB_SEARCH_DIRS}

--- a/easybuild/easyconfigs/d/double-down/double-down-1.1.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/d/double-down/double-down-1.1.0-foss-2022a.eb
@@ -1,0 +1,36 @@
+name = 'double-down'
+version = '1.1.0'
+
+homepage = 'https://github.com/pshriwise/double-down'
+description = "double-down is a double precision interface to Embree via the Mesh Oriented dAtaBase (MOAB)."
+software_license = 'LicenseGCC'
+software_license_urls = ['https://github.com/pshriwise/double-down/blob/develop/LICENSE']
+toolchain = {'name': 'foss', 'version': '2022a'}
+
+sources = [{
+    'filename': 'double-down.tar.gz',
+    'git_config': {
+        'url': 'https://github.com/pshriwise',
+        'repo_name': 'double-down',
+        'tag': f'v{version}'
+    },
+}]
+
+builddependencies = [('CMake', '3.23.1'),('make','4.3')]
+
+dependencies = [
+    ('Doxygen','1.9.4'),
+    ('Embree','3.13.4','',{'name': 'system', 'version': ''}),
+    ('MOAB','5.5.0'),
+    ('tbb','2021.5.0')
+]
+
+easyblock = 'CMakeMake'
+
+_moab_dir = '$EBROOTMOAB'
+configopts = f"-DMOAB_DIR={_moab_dir}"
+
+sanity_check_paths = {
+    'files':['lib/libdd.so'],
+    'dirs': ['lib','include','tools']
+}

--- a/easybuild/easyconfigs/m/MOAB/MOAB-5.5.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/m/MOAB/MOAB-5.5.0-foss-2022a.eb
@@ -1,0 +1,34 @@
+name = 'MOAB'
+version = '5.5.0'
+
+homepage = 'https://sigma.mcs.anl.gov/moab-library/'
+description = "The Mesh-Oriented datABase (MOAB) is a component for representing and evaluating mesh data."
+software_license = 'LicenseGCC'
+software_license_urls = ['https://bitbucket.org/fathomteam/moab/src/master/LICENSE']
+toolchain = {'name': 'foss', 'version': '2022a'}
+
+sources = [{
+    'filename': 'moab.tar.gz',
+    'git_config': {
+        'url': 'https://bitbucket.org/fathomteam',
+        'repo_name': 'moab',
+        'tag':'5.5.0'
+    },
+}]
+
+# patch needed for cmake handling of pythonpath variable within easybuild build environment 
+patches = ['MOAB-5.5.0_fix-cmake-pythonpath.patch']
+
+builddependencies = [('CMake', '3.23.1'),('make','4.3')]
+
+dependencies = [
+    ('Cython','0.29.33'),
+    ('Eigen', '3.4.0'),
+    ('HDF5', '1.12.2'),
+    ('netCDF','4.9.0'),
+    ('SciPy-bundle','2022.05')
+]
+
+easyblock = 'CMakeMake'
+
+configopts = f"-DENABLE_HDF5=ON -DENABLE_PYMOAB=ON -DENABLE_FORTRAN=OFF -DBUILD_SHARED_LIBS=ON -DENABLE_BLASLAPACK=OFF"

--- a/easybuild/easyconfigs/m/MOAB/MOAB-5.5.0_fix-cmake-pythonpath.patch
+++ b/easybuild/easyconfigs/m/MOAB/MOAB-5.5.0_fix-cmake-pythonpath.patch
@@ -1,0 +1,21 @@
+--- /home/myuser/.local/easybuild/build/moab/5.5.0/foss-2022a/moab/pymoab/CMakeLists.txt.orig	2024-04-11 08:40:36.794586636 +0000
++++ /home/myuser/.local/easybuild/build/moab/5.5.0/foss-2022a/moab/pymoab/CMakeLists.txt	2024-04-11 08:44:10.771256623 +0000
+@@ -79,10 +79,15 @@
+ 
+   # python setuptools build/install local version of pymoab for testing
+   # add test install path to PYTHONPATH for compatibility with newer versions of pip/setuptools
++
++  # some explicit path handling so python path will be inherited by ADD_CUSTOM_TARGET
++  # get the current PYTHONPATH environment variable
++  set(MY_CURRENT_PYTHONPATH "$ENV{PYTHONPATH}")
++  set(MY_PYTHONPATH "${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_CURRENT_BINARY_DIR}/lib/${PYMOAB_RELATIVE_INSTALL}:${MY_CURRENT_PYTHONPATH}")
++  set(ENV{PYTHONPATH} "${MY_PYTHONPATH}")
+   ADD_CUSTOM_TARGET(pymoab-local-install ALL
+-    COMMAND export CFLAGS='-w' &&
+-    PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_CURRENT_BINARY_DIR}/lib/${PYMOAB_RELATIVE_INSTALL}:${PYTHONPATH}
+-               ${PYTHON_EXECUTABLE} -m pip install -e ${CMAKE_CURRENT_BINARY_DIR} --prefix ${CMAKE_CURRENT_BINARY_DIR}
++    COMMAND ${CMAKE_COMMAND} -E env CFLAGS='-w' PYTHONPATH="${MY_PYTHONPATH}"
++    ${PYTHON_EXECUTABLE} -m pip install -e ${CMAKE_CURRENT_BINARY_DIR} --prefix ${CMAKE_CURRENT_BINARY_DIR}
+     DEPENDS ${DEPS} MOAB)
+ 
+   # move pymoab egg into the correct location for a --user setuptools install based on username

--- a/easybuild/easyconfigs/m/mcpl/mcpl-1.6.2-foss-2022a.eb
+++ b/easybuild/easyconfigs/m/mcpl/mcpl-1.6.2-foss-2022a.eb
@@ -1,0 +1,21 @@
+name = 'mcpl'
+version = '1.6.2'
+
+homepage = 'https://github.com/mctools/mcpl'
+description = "Utilities for reading and writing .mcpl files: A binary format with lists of particle state information."
+# software_license = 'LicenseCC0'
+software_license_urls = ['https://github.com/mctools/mcpl/blob/master/LICENSE']
+toolchain = {'name': 'foss', 'version': '2022a'}
+
+sources = [{
+    'filename': f'mcpl-{version}.tar.gz',
+    'git_config': {
+        'url': 'https://github.com/mctools/',
+        'repo_name': 'mcpl',
+        'tag': f'v{version}'
+    },
+}]
+
+builddependencies = [('CMake', '3.23.1'),('make','4.3')]
+
+easyblock = 'CMakeMake'

--- a/easybuild/easyconfigs/o/openmc/openmc-0.15.0-foss-2022a-DAGMC-3.2.2.eb
+++ b/easybuild/easyconfigs/o/openmc/openmc-0.15.0-foss-2022a-DAGMC-3.2.2.eb
@@ -1,0 +1,38 @@
+name = 'openmc'
+version = '0.15.0'
+versionsuffix = '-dagmc-3.2.2'
+
+homepage = 'https://openmc.org/'
+description = "OpenMC is a community-developed Monte Carlo neutron and photon transport simulation code."
+docurls = ['https://docs.openmc.org/en/develop/']
+software_license = 'LicenseGCC'
+software_license_urls = ['https://docs.openmc.org/en/latest/license.html']
+toolchain = {'name': 'foss', 'version': '2022a'}
+
+sources = [{
+    'filename': f'openmc-{version}.tar.gz',
+    'git_config': {
+        'url': 'https://github.com/openmc-dev',
+        'repo_name': 'openmc',
+        'tag': f'v{version}',
+        'recursive':True
+    },
+}]
+
+builddependencies = [('CMake', '3.23.1'),('make','4.3')]
+
+dependencies = [
+    ('Python', '3.10.4'),
+    ('HDF5', '1.12.2'),
+    ('SciPy-bundle','2022.05'),
+    ('h5py','3.7.0'),
+    ('matplotlib','3.5.2'),
+    ('lxml','4.9.1'),
+    ('DAGMC','3.2.2'),
+    ('mcpl','1.6.2')
+]
+
+easyblock = 'CMakeMake'
+
+configopts = f"-DOPENMC_USE_DAGMC=ON -DOPENMC_USE_OPENMP=ON -DOPENMC_USE_MPI=ON -DHDF5_PREFER_PARALLEL=OFF -DOPENMC_USE_MCPL=ON -DOPENMC_USE_UWUW=OFF"
+postinstallcmds = ['pip install ../openmc/']

--- a/easybuild/easyconfigs/o/openmc/openmc-0.15.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/o/openmc/openmc-0.15.0-foss-2022a.eb
@@ -1,0 +1,36 @@
+name = 'openmc'
+version = '0.15.0'
+
+homepage = 'https://openmc.org/'
+description = "OpenMC is a community-developed Monte Carlo neutron and photon transport simulation code."
+docurls = ['https://docs.openmc.org/en/develop/']
+software_license = 'LicenseGCC'
+software_license_urls = ['https://docs.openmc.org/en/latest/license.html']
+toolchain = {'name': 'foss', 'version': '2022a'}
+
+sources = [{
+    'filename': f'openmc-{version}.tar.gz',
+    'git_config': {
+        'url': 'https://github.com/openmc-dev',
+        'repo_name': 'openmc',
+        'tag': f'v{version}',
+        'recursive':True
+    },
+}]
+
+builddependencies = [('CMake', '3.23.1'),('make','4.3')]
+
+dependencies = [
+    ('Python', '3.10.4'),
+    ('HDF5', '1.12.2'),
+    ('SciPy-bundle','2022.05'),
+    ('h5py','3.7.0'),
+    ('matplotlib','3.5.2'),
+    ('lxml','4.9.1'),
+    ('mcpl','1.6.2')
+]
+
+easyblock = 'CMakeMake'
+
+configopts = f"-DOPENMC_USE_DAGMC=OFF -DOPENMC_USE_OPENMP=ON -DOPENMC_USE_MPI=ON -DHDF5_PREFER_PARALLEL=OFF -DOPENMC_USE_MCPL=ON -DOPENMC_USE_UWUW=OFF"
+postinstallcmds = ['pip install ../openmc/']

--- a/easybuild/easyconfigs/u/uncertainties/uncertainties-3.1.7-foss-2022a.eb
+++ b/easybuild/easyconfigs/u/uncertainties/uncertainties-3.1.7-foss-2022a.eb
@@ -1,0 +1,24 @@
+easyblock = 'PythonPackage'
+
+name = 'uncertainties'
+version = '3.1.7'
+
+homepage = 'http://uncertainties-python-package.readthedocs.io'
+description = """Transparent calculations with uncertainties on the quantities involved (aka error propagation);
+ fast calculation of derivatives"""
+
+toolchain = {'name': 'foss', 'version': '2022a'}
+
+dependencies = [
+    ('Python', '3.10.4'),
+    ('SciPy-bundle', '2022.05'),
+]
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['80111e0839f239c5b233cb4772017b483a0b7a1573a581b92ab7746a35e6faab']
+
+use_pip = True
+download_dep_fail = True
+sanity_pip_check = True
+
+moduleclass = 'lib'


### PR DESCRIPTION
This pr introduces a set of easyconfig files for the [OpenMC](https://github.com/openmc-dev/openmc) software stack. OpenMC is a monte-carlo particle transport software. It can be configured with or without [DAGMC](https://github.com/svalinn/DAGMC), a geometry engine for running particle transport on CAD models, and thus includes an easyconfig and relevant dependencies for both cases. 