### PR TITLE
remove duplicate (explicit) versionsuffix from UCC-CUDA

### DIFF
--- a/easybuild/easyconfigs/u/UCC-CUDA/UCC-CUDA-1.0.0-GCCcore-11.3.0-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/u/UCC-CUDA/UCC-CUDA-1.0.0-GCCcore-11.3.0-CUDA-11.7.0.eb
@@ -34,8 +34,8 @@ builddependencies = [
 dependencies = [
     ('UCC', '1.0.0'),
     ('CUDA',  '11.7.0', '', SYSTEM),
-    ('UCX-CUDA', '1.12.1', '-CUDA-%(cudaver)s'),
-    ('NCCL', '2.12.12', '-CUDA-%(cudaver)s'),
+    ('UCX-CUDA', '1.12.1', versionsuffix),
+    ('NCCL', '2.12.12', versionsuffix),
 ]
 
 preconfigopts = "./autogen.sh && "

--- a/easybuild/easyconfigs/u/UCC-CUDA/UCC-CUDA-1.1.0-GCCcore-12.2.0-CUDA-12.0.0.eb
+++ b/easybuild/easyconfigs/u/UCC-CUDA/UCC-CUDA-1.1.0-GCCcore-12.2.0-CUDA-12.0.0.eb
@@ -36,8 +36,8 @@ builddependencies = [
 dependencies = [
     ('UCC', '1.1.0'),
     ('CUDA',  '12.0.0', '', SYSTEM),
-    ('UCX-CUDA', '1.13.1', '-CUDA-%(cudaver)s'),
-    ('NCCL', '2.16.2', '-CUDA-%(cudaver)s'),
+    ('UCX-CUDA', '1.13.1', versionsuffix),
+    ('NCCL', '2.16.2', versionsuffix),
 ]
 
 preconfigopts = "./autogen.sh && "

--- a/easybuild/easyconfigs/u/UCC-CUDA/UCC-CUDA-1.2.0-GCCcore-12.3.0-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/u/UCC-CUDA/UCC-CUDA-1.2.0-GCCcore-12.3.0-CUDA-12.1.1.eb
@@ -34,8 +34,8 @@ builddependencies = [
 dependencies = [
     ('UCC', version),
     ('CUDA',  '12.1.1', '', SYSTEM),
-    ('UCX-CUDA', '1.14.1', '-CUDA-%(cudaver)s'),
-    ('NCCL', '2.18.3', '-CUDA-%(cudaver)s'),
+    ('UCX-CUDA', '1.14.1', versionsuffix),
+    ('NCCL', '2.18.3', versionsuffix),
 ]
 
 preconfigopts = "./autogen.sh && "


### PR DESCRIPTION
It is cleaner with less room for mistakes to use the existing variable instead of redefining the same string multiple times.

I suggest to do the same for all other ECs using a (CUDA) versionsuffix and dependencies using the same.