### PR TITLE
add RISC-v support to recent LAME easyconfigs by removing workaround for finding libncurses

### DIFF
--- a/easybuild/easyconfigs/l/LAME/LAME-3.100-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/l/LAME/LAME-3.100-GCCcore-11.2.0.eb
@@ -25,9 +25,6 @@ dependencies = [('ncurses', '6.2')]
 
 preconfigopts = "autoconf && "
 
-# configure is broken: add workaround to find libncurses...
-configure_cmd_prefix = "FRONTEND_LDADD='-L${EBROOTNCURSES}/lib' "
-
 sanity_check_paths = {
     'files': ['bin/lame', 'include/lame/lame.h', 'lib/libmp3lame.%s' % SHLIB_EXT],
     'dirs': [],

--- a/easybuild/easyconfigs/l/LAME/LAME-3.100-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/l/LAME/LAME-3.100-GCCcore-11.3.0.eb
@@ -25,9 +25,6 @@ dependencies = [('ncurses', '6.3')]
 
 preconfigopts = "autoconf && "
 
-# configure is broken: add workaround to find libncurses...
-configure_cmd_prefix = "FRONTEND_LDADD='-L${EBROOTNCURSES}/lib' "
-
 sanity_check_paths = {
     'files': ['bin/lame', 'include/lame/lame.h', 'lib/libmp3lame.%s' % SHLIB_EXT],
     'dirs': [],

--- a/easybuild/easyconfigs/l/LAME/LAME-3.100-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/l/LAME/LAME-3.100-GCCcore-12.2.0.eb
@@ -25,9 +25,6 @@ dependencies = [('ncurses', '6.3')]
 
 preconfigopts = "autoconf && "
 
-# configure is broken: add workaround to find libncurses...
-configure_cmd_prefix = "FRONTEND_LDADD='-L${EBROOTNCURSES}/lib' "
-
 sanity_check_paths = {
     'files': ['bin/lame', 'include/lame/lame.h', 'lib/libmp3lame.%s' % SHLIB_EXT],
     'dirs': [],

--- a/easybuild/easyconfigs/l/LAME/LAME-3.100-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/LAME/LAME-3.100-GCCcore-12.3.0.eb
@@ -25,9 +25,6 @@ dependencies = [('ncurses', '6.4')]
 
 preconfigopts = "autoconf && "
 
-# configure is broken: add workaround to find libncurses...
-configure_cmd_prefix = "FRONTEND_LDADD='-L${EBROOTNCURSES}/lib' "
-
 sanity_check_paths = {
     'files': ['bin/lame', 'include/lame/lame.h', 'lib/libmp3lame.%s' % SHLIB_EXT],
     'dirs': [],

--- a/easybuild/easyconfigs/l/LAME/LAME-3.100-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/l/LAME/LAME-3.100-GCCcore-13.2.0.eb
@@ -25,9 +25,6 @@ dependencies = [('ncurses', '6.4')]
 
 preconfigopts = "autoconf && "
 
-# configure is broken: add workaround to find libncurses...
-configure_cmd_prefix = "FRONTEND_LDADD='-L${EBROOTNCURSES}/lib' "
-
 sanity_check_paths = {
     'files': ['bin/lame', 'include/lame/lame.h', 'lib/libmp3lame.%s' % SHLIB_EXT],
     'dirs': [],


### PR DESCRIPTION
This workaround would set an environment variable with `configure_cmd_prefix`, and this is somewhat ugly. It also breaks the config.guess update functionality in the configuremake easyblock, as this will check if `configure_command` exists, and it will think it doesn't exist if the command includes this environment variable (as it's basically doing `os.path.exists("FRONTEND_LDADD='-L${EBROOTNCURSES}/lib' ./configure"`). See https://github.com/easybuilders/easybuild-easyblocks/blob/develop/easybuild/easyblocks/generic/configuremake.py#L303. As LAME includes a very old config.guess, it doesn't build on RISC-V this way.

I couldn't reproduce any issues with the workaround removed, and without it LAME would indeed build fine on RISC-V, as the easyblock then does update the config.guess. So I'm proposing that we remove this workaround. If it would still be needed for any reason, we should just set it in `(pre)configopts`.