### PR TITLE
enable PIC in recent x265 easyconfigs to solve compilation errors on RISC-V

### DIFF
--- a/easybuild/easyconfigs/x/x265/x265-3.5-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/x/x265/x265-3.5-GCCcore-11.2.0.eb
@@ -25,7 +25,7 @@ builddependencies = [
 
 start_dir = 'source'
 
-configopts = '-DGIT_ARCHETYPE=1'
+configopts = '-DGIT_ARCHETYPE=1 -DENABLE_PIC=ON'
 
 sanity_check_paths = {
     'files': ['bin/x265', 'include/x265_config.h', 'include/x265.h', 'lib/libx265.a', 'lib/libx265.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/x/x265/x265-3.5-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/x/x265/x265-3.5-GCCcore-11.3.0.eb
@@ -22,7 +22,7 @@ builddependencies = [
     ('Yasm', '1.3.0'),
 ]
 
-configopts = '-DGIT_ARCHETYPE=1'
+configopts = '-DGIT_ARCHETYPE=1 -DENABLE_PIC=ON'
 
 start_dir = 'source'
 

--- a/easybuild/easyconfigs/x/x265/x265-3.5-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/x/x265/x265-3.5-GCCcore-12.2.0.eb
@@ -22,7 +22,7 @@ builddependencies = [
     ('Yasm', '1.3.0'),
 ]
 
-configopts = '-DGIT_ARCHETYPE=1'
+configopts = '-DGIT_ARCHETYPE=1 -DENABLE_PIC=ON'
 
 start_dir = 'source'
 

--- a/easybuild/easyconfigs/x/x265/x265-3.5-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/x/x265/x265-3.5-GCCcore-12.3.0.eb
@@ -22,7 +22,7 @@ builddependencies = [
     ('Yasm', '1.3.0'),
 ]
 
-configopts = '-DGIT_ARCHETYPE=1'
+configopts = '-DGIT_ARCHETYPE=1 -DENABLE_PIC=ON'
 
 start_dir = 'source'
 

--- a/easybuild/easyconfigs/x/x265/x265-3.5-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/x/x265/x265-3.5-GCCcore-13.2.0.eb
@@ -22,7 +22,7 @@ builddependencies = [
     ('Yasm', '1.3.0'),
 ]
 
-configopts = '-DGIT_ARCHETYPE=1'
+configopts = '-DGIT_ARCHETYPE=1 -DENABLE_PIC=ON'
 
 start_dir = 'source'
 


### PR DESCRIPTION
This solves the following issue on RISC-V:
```
/cvmfs/riscv.eessi.io/versions/20240402/compat/linux/riscv64/usr/bin/ld: encoder/CMakeFiles/encoder.dir/analysis.cpp.o: relocation R_RISCV_HI20 against `_ZN4x26510g_log2SizeE' can not be used when making a shared object; recompile with -fPIC
/cvmfs/riscv.eessi.io/versions/20240402/compat/linux/riscv64/usr/bin/ld: encoder/CMakeFiles/encoder.dir/search.cpp.o: relocation R_RISCV_HI20 against `a local symbol' can not be used when making a shared object; recompile with -fPIC
/cvmfs/riscv.eessi.io/versions/20240402/compat/linux/riscv64/usr/bin/ld: encoder/CMakeFiles/encoder.dir/bitcost.cpp.o: relocation R_RISCV_HI20 against `a local symbol' can not be used when making a shared object; recompile with -fPIC

<more of those....>

/cvmfs/riscv.eessi.io/versions/20240402/compat/linux/riscv64/usr/bin/ld: common/CMakeFiles/common.dir/deblock.cpp.o: relocation R_RISCV_HI20 against `_ZN4x26515g_zscanToRasterE' can not be used when making a shared object; recompile with -fPIC
/cvmfs/riscv.eessi.io/versions/20240402/compat/linux/riscv64/usr/bin/ld: common/CMakeFiles/common.dir/scaler.cpp.o: relocation R_RISCV_HI20 against `_ZTVN4x26512ScalerFilterE' can not be used when making a shared object; recompile with -fPIC
/cvmfs/riscv.eessi.io/versions/20240402/compat/linux/riscv64/usr/bin/ld: unresolvable R_RISCV_CALL_PLT relocation against symbol `log@@GLIBC_2.27'
/cvmfs/riscv.eessi.io/versions/20240402/compat/linux/riscv64/usr/bin/ld: unresolvable R_RISCV_CALL_PLT relocation against symbol `__cxa_atexit@@GLIBC_2.27'
/tmp/eb-xqbykceq/tmp9gre4wcp/rpath_wrappers/ld_wrapper/ld: line 69: 234648 Segmentation fault      /cvmfs/riscv.eessi.io/versions/20240402/compat/linux/riscv64/usr/bin/ld "${CMD_ARGS[@]}"
collect2: error: ld returned 139 exit status
```

Note that adding `'pic': True` to `toolchainopts` didn't work, the CMake configuration of x265 has a specific option to enable this.