### PR TITLE
Extrae: Make libunwind dependency architecture specific

### DIFF
--- a/easybuild/easyconfigs/e/Extrae/Extrae-4.2.0-gompi-2023b.eb
+++ b/easybuild/easyconfigs/e/Extrae/Extrae-4.2.0-gompi-2023b.eb
@@ -32,24 +32,20 @@ builddependencies = [
     ('Automake', '1.16.5'),
 ]
 
-if ARCH == 'aarch64':
-    dependencies = [
-        ('zlib', '1.2.13'),
-        ('Boost', '1.83.0'),
-        ('libxml2', '2.11.5'),
-        ('libdwarf', '0.9.2'),
-        ('PAPI', '7.1.0'),
-    ]
-    configopts = '--without-unwind'
-else:
-    dependencies = [
-        ('zlib', '1.2.13'),
-        ('Boost', '1.83.0'),
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('Boost', '1.83.0'),
+    ('libunwind', '1.6.2'),
+    ('libxml2', '2.11.5'),
+    ('libdwarf', '0.9.2'),
+    ('PAPI', '7.1.0'),
+]
+
+# libunwind causes segv errors on aarch64
+if ARCH != 'aarch64':
+    dependencies.append(
         ('libunwind', '1.6.2'),
-        ('libxml2', '2.11.5'),
-        ('libdwarf', '0.9.2'),
-        ('PAPI', '7.1.0'),
-    ]
+    )
 
 # Disable dynamic memory instrumentation for this release, has been seen to sometimes cause MPI test failures
 configopts += '--disable-instrument-dynamic-memory'

--- a/easybuild/easyconfigs/e/Extrae/Extrae-4.2.0-gompi-2023b.eb
+++ b/easybuild/easyconfigs/e/Extrae/Extrae-4.2.0-gompi-2023b.eb
@@ -35,7 +35,6 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.2.13'),
     ('Boost', '1.83.0'),
-    ('libunwind', '1.6.2'),
     ('libxml2', '2.11.5'),
     ('libdwarf', '0.9.2'),
     ('PAPI', '7.1.0'),
@@ -48,7 +47,7 @@ if ARCH != 'aarch64':
     )
 
 # Disable dynamic memory instrumentation for this release, has been seen to sometimes cause MPI test failures
-configopts += '--disable-instrument-dynamic-memory'
+configopts = '--disable-instrument-dynamic-memory'
 
 runtest = 'check'
 

--- a/easybuild/easyconfigs/e/Extrae/Extrae-4.2.0-gompi-2023b.eb
+++ b/easybuild/easyconfigs/e/Extrae/Extrae-4.2.0-gompi-2023b.eb
@@ -32,17 +32,27 @@ builddependencies = [
     ('Automake', '1.16.5'),
 ]
 
-dependencies = [
-    ('zlib', '1.2.13'),
-    ('Boost', '1.83.0'),
-    ('libunwind', '1.6.2'),
-    ('libxml2', '2.11.5'),
-    ('libdwarf', '0.9.2'),
-    ('PAPI', '7.1.0'),
-]
+if ARCH == 'aarch64':
+    dependencies = [
+        ('zlib', '1.2.13'),
+        ('Boost', '1.83.0'),
+        ('libxml2', '2.11.5'),
+        ('libdwarf', '0.9.2'),
+        ('PAPI', '7.1.0'),
+    ]
+    configopts = '--without-unwind'
+else:
+    dependencies = [
+        ('zlib', '1.2.13'),
+        ('Boost', '1.83.0'),
+        ('libunwind', '1.6.2'),
+        ('libxml2', '2.11.5'),
+        ('libdwarf', '0.9.2'),
+        ('PAPI', '7.1.0'),
+    ]
 
 # Disable dynamic memory instrumentation for this release, has been seen to sometimes cause MPI test failures
-configopts = '--disable-instrument-dynamic-memory'
+configopts += '--disable-instrument-dynamic-memory'
 
 runtest = 'check'
 


### PR DESCRIPTION
Extrae produces segmentation faults when using libunwind in ARM architectures