### PR TITLE
update libarchive OpenSSL to 3, fix missing libxml dependency

### DIFF
--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.7.2-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.7.2-GCCcore-13.2.0.eb
@@ -27,7 +27,8 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.2.13'),
     ('XZ', '5.4.4'),
-    ('OpenSSL', '1.1', '', SYSTEM),
+    ('libxml2', '2.11.5'),
+    ('OpenSSL', '3', '', SYSTEM),
 ]
 
 sanity_check_paths = {


### PR DESCRIPTION
Build fails without libxml dependency with an xmlParser error for -lxml2