### PR TITLE
Update netCDF-4.9.2-gompi-2023b.eb, netCDF-4.9.2-iimpi-2023b.eb

### DIFF
--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.14.4.3-gompi-2023b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.14.4.3-gompi-2023b.eb
@@ -1,0 +1,31 @@
+name = 'HDF5'
+# Note: Odd minor releases are only RCs and should not be used.
+version = '1.14.4.3'
+
+homepage = 'https://portal.hdfgroup.org/display/support'
+description = """HDF5 is a data model, library, and file format for storing and managing data.
+ It supports an unlimited variety of datatypes, and is designed for flexible
+ and efficient I/O and for high volume and complex data."""
+
+toolchain = {'name': 'gompi', 'version': '2023b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+# to enable debug symbols, use:
+# configopts = ['--enable-build-mode=debug']
+
+# HDF5 tags are prefixed with '%(namelower)s_' for some redundant reason
+github_account = 'HDFGroup'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = [{'download_filename': '%(namelower)s_%(version)s.tar.gz', 'filename': SOURCELOWER_TAR_GZ}]
+checksums = ['690c1db7ba0fed4ffac61709236675ffd99d95d191e8920ee79c58d7e7ea3361']
+
+# replace src include path with installation dir for $H5BLD_CPPFLAGS
+_regex = 's, -I[^[:space:]]+H5FDsubfiling , -I%(installdir)s/include ,g'
+postinstallcmds = ['sed -i -r "%s" %%(installdir)s/bin/%s' % (_regex, x) for x in ['h5c++', 'h5pcc']]
+
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('Szip', '2.1.1'),
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.14.4.3-iimpi-2023b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.14.4.3-iimpi-2023b.eb
@@ -1,0 +1,31 @@
+name = 'HDF5'
+# Note: Odd minor releases are only RCs and should not be used.
+version = '1.14.4.3'
+
+homepage = 'https://portal.hdfgroup.org/display/support'
+description = """HDF5 is a data model, library, and file format for storing and managing data.
+ It supports an unlimited variety of datatypes, and is designed for flexible
+ and efficient I/O and for high volume and complex data."""
+
+toolchain = {'name': 'iimpi', 'version': '2023b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+# to enable debug symbols, use:
+# configopts = ['--enable-build-mode=debug']
+
+# HDF5 tags are prefixed with '%(namelower)s_' for some redundant reason
+github_account = 'HDFGroup'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = [{'download_filename': '%(namelower)s_%(version)s.tar.gz', 'filename': SOURCELOWER_TAR_GZ}]
+checksums = ['690c1db7ba0fed4ffac61709236675ffd99d95d191e8920ee79c58d7e7ea3361']
+
+# replace src include path with installation dir for $H5BLD_CPPFLAGS
+_regex = 's, -I[^[:space:]]+H5FDsubfiling , -I%(installdir)s/include ,g'
+postinstallcmds = ['sed -i -r "%s" %%(installdir)s/bin/%s' % (_regex, x) for x in ['h5c++', 'h5pcc']]
+
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('Szip', '2.1.1'),
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.2-gompi-2023b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.2-gompi-2023b.eb
@@ -26,7 +26,7 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('HDF5', '1.14.3'),
+    ('HDF5', '1.14.4.3'),
     ('cURL', '8.3.0'),
     ('Szip', '2.1.1'),
     ('zstd', '1.5.5'),
@@ -48,6 +48,7 @@ configopts = [
     "-DENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=OFF",
     "-DENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
 ]
+# add " -DCMAKE_BUILD_TYPE=Debug" to enable debug symbols
 
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests
 pretestopts = "OMPI_MCA_rmaps_base_oversubscribe=1 "

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.2-iimpi-2023b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.2-iimpi-2023b.eb
@@ -26,7 +26,7 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('HDF5', '1.14.3'),
+    ('HDF5', '1.14.4.3'),
     ('cURL', '8.3.0'),
     ('Szip', '2.1.1'),
     ('zstd', '1.5.5'),
@@ -50,6 +50,7 @@ configopts = [
     "-DENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=OFF",
     "-DENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
 ]
+# add " -DCMAKE_BUILD_TYPE=Debug" to enable debug symbols
 
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests
 pretestopts = "OMPI_MCA_rmaps_base_oversubscribe=1 "


### PR DESCRIPTION
Bump dependency to HDF5-1.14.4.3
Because HDF5-1.14.3 is a broken release: https://github.com/HDFGroup/hdf5/issues/3831