### PR TITLE
Szip: Update source and homepage URLs

### DIFF
--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-10.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'Szip'
 version = '2.1.1'
 
-homepage = 'https://www.hdfgroup.org/doc_resource/SZIP/'
+homepage = 'https://support.hdfgroup.org/doc_resource/SZIP/'
 
 description = """
  Szip compression software, providing lossless compression of scientific data
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-10.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'Szip'
 version = '2.1.1'
 
-homepage = 'https://www.hdfgroup.org/doc_resource/SZIP/'
+homepage = 'https://support.hdfgroup.org/doc_resource/SZIP/'
 
 description = """
  Szip compression software, providing lossless compression of scientific data
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-11.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'Szip'
 version = '2.1.1'
 
-homepage = 'https://www.hdfgroup.org/doc_resource/SZIP/'
+homepage = 'https://support.hdfgroup.org/doc_resource/SZIP/'
 
 description = """
  Szip compression software, providing lossless compression of scientific data
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-11.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'Szip'
 version = '2.1.1'
 
-homepage = 'https://www.hdfgroup.org/doc_resource/SZIP/'
+homepage = 'https://support.hdfgroup.org/doc_resource/SZIP/'
 
 description = """
  Szip compression software, providing lossless compression of scientific data
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-12.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'Szip'
 version = '2.1.1'
 
-homepage = 'https://www.hdfgroup.org/doc_resource/SZIP/'
+homepage = 'https://support.hdfgroup.org/doc_resource/SZIP/'
 
 description = """
  Szip compression software, providing lossless compression of scientific data
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-12.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'Szip'
 version = '2.1.1'
 
-homepage = 'https://www.hdfgroup.org/doc_resource/SZIP/'
+homepage = 'https://support.hdfgroup.org/doc_resource/SZIP/'
 
 description = """
  Szip compression software, providing lossless compression of scientific data
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-13.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'Szip'
 version = '2.1.1'
 
-homepage = 'https://www.hdfgroup.org/doc_resource/SZIP/'
+homepage = 'https://support.hdfgroup.org/doc_resource/SZIP/'
 
 description = """
  Szip compression software, providing lossless compression of scientific data
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-6.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'Szip'
 version = '2.1.1'
 
-homepage = 'http://www.hdfgroup.org/doc_resource/SZIP/'
+homepage = 'http://support.hdfgroup.org/doc_resource/SZIP/'
 
 description = """
  Szip compression software, providing lossless compression of scientific data
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['http://support.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-6.4.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'Szip'
 version = '2.1.1'
 
-homepage = 'http://www.hdfgroup.org/doc_resource/SZIP/'
+homepage = 'http://support.hdfgroup.org/doc_resource/SZIP/'
 
 description = """
  Szip compression software, providing lossless compression of scientific data
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['http://support.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-7.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'Szip'
 version = '2.1.1'
 
-homepage = 'http://www.hdfgroup.org/doc_resource/SZIP/'
+homepage = 'http://support.hdfgroup.org/doc_resource/SZIP/'
 
 description = """
  Szip compression software, providing lossless compression of scientific data
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['http://support.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-8.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'Szip'
 version = '2.1.1'
 
-homepage = 'http://www.hdfgroup.org/doc_resource/SZIP/'
+homepage = 'http://support.hdfgroup.org/doc_resource/SZIP/'
 
 description = """
  Szip compression software, providing lossless compression of scientific data
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['http://support.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-8.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'Szip'
 version = '2.1.1'
 
-homepage = 'https://www.hdfgroup.org/doc_resource/SZIP/'
+homepage = 'https://support.hdfgroup.org/doc_resource/SZIP/'
 
 description = """
  Szip compression software, providing lossless compression of scientific data
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1.1-GCCcore-9.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'Szip'
 version = '2.1.1'
 
-homepage = 'https://www.hdfgroup.org/doc_resource/SZIP/'
+homepage = 'https://support.hdfgroup.org/doc_resource/SZIP/'
 
 description = """
  Szip compression software, providing lossless compression of scientific data
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412']
 


### PR DESCRIPTION
Szip seems to have moved, update both the download links and the homepage.