### PR TITLE
HDF v4.2.16-2: Rename source URL

### DIFF
--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.16-2-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.16-2-GCCcore-12.3.0.eb
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/%(name)s/releases/%(name)s%(version)s/src/']
+source_urls = ['http://support.hdfgroup.org/ftp/%(name)s/releases/%(name)s%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
 
 checksums = [

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.16-2-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.16-2-GCCcore-13.2.0.eb
@@ -12,7 +12,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/%(name)s/releases/%(name)s%(version)s/src/']
+source_urls = ['http://support.hdfgroup.org/ftp/%(name)s/releases/%(name)s%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
 
 checksums = [

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.16-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.16-GCCcore-12.3.0.eb
@@ -13,7 +13,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+source_urls = ['http://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['2bd48dcefb5ab4829fba27dca6fad20b842d495dfd64944b2412b2b0968bf167']
 


### PR DESCRIPTION
* based on issue #21105
* source_url location www.hdf5group.org no longer working. support.hdf5group.org works.