### PR TITLE
consistently fix homepage + source URL for `HDF` + `h4toh5`

### DIFF
--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.11-intel-2016a.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.11-intel-2016a.eb
@@ -3,15 +3,16 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.11'
 
-homepage = 'http://www.hdfgroup.org/products/hdf4/'
+homepage = 'http://support.hdfgroup.org/products/hdf4/'
 description = """HDF (also known as HDF4) is a library and multi-object file format for storing and managing data
  between machines."""
 
 toolchain = {'name': 'intel', 'version': '2016a'}
 toolchainopts = {'pic': True}
 
+source_urls = ['http://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+checksums = ['c3f7753b2fb9b27d09eced4d2164605f111f270c9a60b37a578f7de02de86d24']
 
 builddependencies = [
     ('flex', '2.6.0'),

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.12-intel-2017a.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.12-intel-2017a.eb
@@ -3,15 +3,16 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.12'
 
-homepage = 'http://www.hdfgroup.org/products/hdf4/'
+homepage = 'http://support.hdfgroup.org/products/hdf4/'
 description = """HDF (also known as HDF4) is a library and multi-object file format for storing and managing data
  between machines."""
 
 toolchain = {'name': 'intel', 'version': '2017a'}
 toolchainopts = {'pic': True}
 
+source_urls = ['http://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+checksums = ['dd419c55e85d1a0e13f3ea5ed35d00710033ccb16c85df088eb7925d486e040c']
 
 builddependencies = [
     ('flex', '2.6.3'),

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.13-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.13-GCCcore-6.4.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.13'
 
-homepage = 'http://www.hdfgroup.org/products/hdf4/'
+homepage = 'http://support.hdfgroup.org/products/hdf4/'
 
 description = """
  HDF (also known as HDF4) is a library and multi-object file format for
@@ -14,7 +14,7 @@ toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+source_urls = ['http://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 checksums = ['be9813c1dc3712c2df977d4960e1f13f20f447dfa8c3ce53331d610c1f470483']
 
 builddependencies = [

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.13-intel-2017a-no-netcdf.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.13-intel-2017a-no-netcdf.eb
@@ -4,7 +4,7 @@ name = 'HDF'
 version = '4.2.13'
 versionsuffix = '-no-netcdf'
 
-homepage = 'http://www.hdfgroup.org/products/hdf4/'
+homepage = 'http://support.hdfgroup.org/products/hdf4/'
 description = """HDF (also known as HDF4) is a library and multi-object file format for storing and managing data
  between machines.  This version suppresses the netcdf api, that gives issues with some applications"""
 
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2017a'}
 toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+source_urls = ['http://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 checksums = ['be9813c1dc3712c2df977d4960e1f13f20f447dfa8c3ce53331d610c1f470483']
 
 builddependencies = [

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.14-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.14-GCCcore-6.4.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.14'
 
-homepage = 'http://www.hdfgroup.org/products/hdf4/'
+homepage = 'http://support.hdfgroup.org/products/hdf4/'
 
 description = """
  HDF (also known as HDF4) is a library and multi-object file format for
@@ -13,7 +13,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+source_urls = ['http://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['2d383e87c8a0ca6a5352adbd1d5546e6cc43dc21ff7d90f93efa644d85c0b14a']
 

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.14-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.14-GCCcore-7.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.14'
 
-homepage = 'https://www.hdfgroup.org/products/hdf4/'
+homepage = 'https://support.hdfgroup.org/products/hdf4/'
 
 description = """
  HDF (also known as HDF4) is a library and multi-object file format for
@@ -13,7 +13,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['2d383e87c8a0ca6a5352adbd1d5546e6cc43dc21ff7d90f93efa644d85c0b14a']
 

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.14-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.14-GCCcore-8.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.14'
 
-homepage = 'https://www.hdfgroup.org/products/hdf4/'
+homepage = 'https://support.hdfgroup.org/products/hdf4/'
 
 description = """
  HDF (also known as HDF4) is a library and multi-object file format for
@@ -13,7 +13,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+source_urls = ['http://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['2d383e87c8a0ca6a5352adbd1d5546e6cc43dc21ff7d90f93efa644d85c0b14a']
 

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.14-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.14-GCCcore-8.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.14'
 
-homepage = 'https://www.hdfgroup.org/products/hdf4/'
+homepage = 'https://support.hdfgroup.org/products/hdf4/'
 
 description = """
  HDF (also known as HDF4) is a library and multi-object file format for
@@ -13,7 +13,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+source_urls = ['http://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['2d383e87c8a0ca6a5352adbd1d5546e6cc43dc21ff7d90f93efa644d85c0b14a']
 

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.15-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.15-GCCcore-10.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.15'
 
-homepage = 'https://www.hdfgroup.org/products/hdf4/'
+homepage = 'https://support.hdfgroup.org/products/hdf4/'
 
 description = """
  HDF (also known as HDF4) is a library and multi-object file format for
@@ -13,7 +13,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+source_urls = ['http://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
 patches = ['HDF-4.2.15_fix-aarch64.patch']
 checksums = [

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.15-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.15-GCCcore-10.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.15'
 
-homepage = 'https://www.hdfgroup.org/products/hdf4/'
+homepage = 'https://support.hdfgroup.org/products/hdf4/'
 
 description = """
  HDF (also known as HDF4) is a library and multi-object file format for
@@ -13,7 +13,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+source_urls = ['http://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
 patches = ['HDF-4.2.15_fix-aarch64.patch']
 checksums = [

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.15-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.15-GCCcore-11.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.15'
 
-homepage = 'https://www.hdfgroup.org/products/hdf4/'
+homepage = 'https://support.hdfgroup.org/products/hdf4/'
 
 description = """
  HDF (also known as HDF4) is a library and multi-object file format for
@@ -13,7 +13,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+source_urls = ['http://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
 patches = ['HDF-4.2.15_fix-aarch64.patch']
 checksums = [

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.15-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.15-GCCcore-11.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.15'
 
-homepage = 'https://www.hdfgroup.org/products/hdf4/'
+homepage = 'https://support.hdfgroup.org/products/hdf4/'
 
 description = """
  HDF (also known as HDF4) is a library and multi-object file format for
@@ -13,7 +13,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+source_urls = ['http://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
 patches = ['HDF-4.2.15_fix-aarch64.patch']
 checksums = [

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.15-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.15-GCCcore-12.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.15'
 
-homepage = 'https://www.hdfgroup.org/products/hdf4/'
+homepage = 'https://support.hdfgroup.org/products/hdf4/'
 
 description = """
  HDF (also known as HDF4) is a library and multi-object file format for
@@ -13,7 +13,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+source_urls = ['http://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
 patches = ['HDF-4.2.15_fix-aarch64.patch']
 checksums = [

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.15-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.15-GCCcore-9.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.15'
 
-homepage = 'https://www.hdfgroup.org/products/hdf4/'
+homepage = 'https://support.hdfgroup.org/products/hdf4/'
 
 description = """
  HDF (also known as HDF4) is a library and multi-object file format for
@@ -13,7 +13,7 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+source_urls = ['http://support.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
 sources = [SOURCELOWER_TAR_GZ]
 patches = ['HDF-4.2.15_fix-aarch64.patch']
 checksums = [

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.16-2-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.16-2-GCCcore-12.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.16-2'
 
-homepage = 'https://www.hdfgroup.org/products/hdf4/'
+homepage = 'https://support.hdfgroup.org/products/hdf4/'
 description = """
  HDF (also known as HDF4) is a library and multi-object file format for
  storing and managing data between machines.

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.16-2-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.16-2-GCCcore-13.2.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.16-2'
 
-homepage = 'https://www.hdfgroup.org/products/hdf4/'
+homepage = 'https://support.hdfgroup.org/products/hdf4/'
 description = """
  HDF (also known as HDF4) is a library and multi-object file format for
  storing and managing data between machines.

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.16-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.16-GCCcore-12.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'HDF'
 version = '4.2.16'
 
-homepage = 'https://www.hdfgroup.org/products/hdf4/'
+homepage = 'https://support.hdfgroup.org/products/hdf4/'
 
 description = """
  HDF (also known as HDF4) is a library and multi-object file format for

--- a/easybuild/easyconfigs/h/h4toh5/h4toh5-2.2.3-foss-2018b.eb
+++ b/easybuild/easyconfigs/h/h4toh5/h4toh5-2.2.3-foss-2018b.eb
@@ -3,13 +3,13 @@ easyblock = 'ConfigureMake'
 name = 'h4toh5'
 version = '2.2.3'
 
-homepage = 'http://www.hdfgroup.org/h4toh5/'
+homepage = "https://docs.hdfgroup.org/archive/support/products/hdf5_tools/h4toh5/index.html"
 description = """The h4toh5 software consists of the h4toh5 and h5toh4 command-line utilities,
  as well as a conversion library for converting between individual HDF4 and HDF5 objects."""
 
 toolchain = {'name': 'foss', 'version': '2018b'}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/tools/%s/src' % name]
+source_urls = ['http://support.hdfgroup.org/ftp/HDF5/tools/%s/src' % name]
 sources = ['h4h5tools-%(version)s.tar.gz']
 checksums = ['ba167d9e5ec1f9014a95e3f5d0621f814caa6e83508e235ce60cfd315e3a9d3f']
 

--- a/easybuild/easyconfigs/h/h4toh5/h4toh5-2.2.3-gompi-2019b.eb
+++ b/easybuild/easyconfigs/h/h4toh5/h4toh5-2.2.3-gompi-2019b.eb
@@ -3,13 +3,13 @@ easyblock = 'ConfigureMake'
 name = 'h4toh5'
 version = '2.2.3'
 
-homepage = 'http://www.hdfgroup.org/h4toh5/'
+homepage = "https://docs.hdfgroup.org/archive/support/products/hdf5_tools/h4toh5/index.html"
 description = """The h4toh5 software consists of the h4toh5 and h5toh4 command-line utilities,
  as well as a conversion library for converting between individual HDF4 and HDF5 objects."""
 
 toolchain = {'name': 'gompi', 'version': '2019b'}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/tools/%s/src' % name]
+source_urls = ['http://support.hdfgroup.org/ftp/HDF5/tools/%s/src' % name]
 sources = ['h4h5tools-%(version)s%(versionsuffix)s.tar.gz']
 checksums = ['ba167d9e5ec1f9014a95e3f5d0621f814caa6e83508e235ce60cfd315e3a9d3f']
 

--- a/easybuild/easyconfigs/h/h4toh5/h4toh5-2.2.3-gompi-2020b.eb
+++ b/easybuild/easyconfigs/h/h4toh5/h4toh5-2.2.3-gompi-2020b.eb
@@ -3,13 +3,13 @@ easyblock = 'ConfigureMake'
 name = 'h4toh5'
 version = '2.2.3'
 
-homepage = 'http://www.hdfgroup.org/h4toh5/'
+homepage = "https://docs.hdfgroup.org/archive/support/products/hdf5_tools/h4toh5/index.html"
 description = """The h4toh5 software consists of the h4toh5 and h5toh4 command-line utilities,
  as well as a conversion library for converting between individual HDF4 and HDF5 objects."""
 
 toolchain = {'name': 'gompi', 'version': '2020b'}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/tools/%s/src' % name]
+source_urls = ['http://support.hdfgroup.org/ftp/HDF5/tools/%s/src' % name]
 sources = ['h4h5tools-%(version)s%(versionsuffix)s.tar.gz']
 checksums = ['ba167d9e5ec1f9014a95e3f5d0621f814caa6e83508e235ce60cfd315e3a9d3f']
 

--- a/easybuild/easyconfigs/h/h4toh5/h4toh5-2.2.5-gompi-2022a.eb
+++ b/easybuild/easyconfigs/h/h4toh5/h4toh5-2.2.5-gompi-2022a.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'h4toh5'
 version = '2.2.5'
 
-homepage = 'http://www.hdfgroup.org/h4toh5/'
+homepage = "https://docs.hdfgroup.org/archive/support/products/hdf5_tools/h4toh5/index.html"
 description = """The h4toh5 software consists of the h4toh5 and h5toh4 command-line utilities,
  as well as a conversion library for converting between individual HDF4 and HDF5 objects."""
 


### PR DESCRIPTION
Implemented from #21131.

Not sure what the policy is regarding `__archive__`.
Not sure if the exact versions of h4toh5 are still there, but the site seems in principle there.