### PR TITLE
{perf}[gompi/2022a,gompi/2023b] CubeGUI 4.8.2 & Scalasca 2.6.1 for 2023b | Patch to fix configure after OpenMP

### DIFF
--- a/easybuild/easyconfigs/c/CubeGUI/CubeGUI-4.8.2-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/c/CubeGUI/CubeGUI-4.8.2-GCCcore-13.2.0.eb
@@ -29,7 +29,7 @@ description = """
 
 toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 
-source_urls = ['https://apps.fz-juelich.de/scalasca/releases/cube/%(version)s/dist']
+source_urls = ['https://apps.fz-juelich.de/scalasca/releases/cube/%(version_major_minor)s/dist']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['1df8fcaea95323e7eaf0cc010784a41243532c2123a27ce93cb7e3241557ff76']
 

--- a/easybuild/easyconfigs/c/CubeGUI/CubeGUI-4.8.2-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/c/CubeGUI/CubeGUI-4.8.2-GCCcore-13.2.0.eb
@@ -1,0 +1,53 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2019 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+# Authors::   Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'CubeGUI'
+version = '4.8.2'
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+description = """
+ Cube, which is used as performance report explorer for Scalasca and Score-P,
+ is a generic tool for displaying a multi-dimensional performance space
+ consisting of the dimensions (i) performance metric, (ii) call path, and
+ (iii) system resource. Each dimension can be represented as a tree, where
+ non-leaf nodes of the tree can be collapsed or expanded to achieve the
+ desired level of granularity.
+
+ This module provides the Cube graphical report explorer.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+source_urls = ['https://apps.fz-juelich.de/scalasca/releases/cube/%(version)s/dist']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['1df8fcaea95323e7eaf0cc010784a41243532c2123a27ce93cb7e3241557ff76']
+
+builddependencies = [('binutils', '2.40')]
+
+dependencies = [
+    ('Qt6', '6.6.3'),
+    ('CubeLib', '4.8.2'),
+]
+
+configopts = [
+    '--with-qt=$EBROOTQT6/bin ',
+]
+
+sanity_check_paths = {
+    'files': ['bin/cube', 'bin/cubegui-config',
+              'lib/libcube4gui.a', 'lib/libcube4gui.%s' % SHLIB_EXT],
+    'dirs': ['include/cubegui', 'lib/cube-plugins'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeGUI/CubeGUI-4.8.2-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/c/CubeGUI/CubeGUI-4.8.2-GCCcore-13.2.0.eb
@@ -31,7 +31,7 @@ toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 
 source_urls = ['https://apps.fz-juelich.de/scalasca/releases/cube/%(version_major_minor)s/dist']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['1df8fcaea95323e7eaf0cc010784a41243532c2123a27ce93cb7e3241557ff76']
+checksums = ['bf2e02002bb2e5c4f61832ce37b62a440675c6453463014b33b2474aac78f86d']
 
 builddependencies = [('binutils', '2.40')]
 

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-gompi-2023b.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-gompi-2023b.eb
@@ -25,7 +25,7 @@ description = """
  in exploring their causes.
 """
 
-toolchain = {'name': 'gompi', 'version': '2022a'}
+toolchain = {'name': 'gompi', 'version': '2023b'}
 
 source_urls = ['https://apps.fz-juelich.de/scalasca/releases/scalasca/%(version_major_minor)s/dist']
 sources = [SOURCELOWER_TAR_GZ]
@@ -40,14 +40,14 @@ checksums = [
 ]
 
 builddependencies = [
-    ('CubeWriter', '4.8'),
+    ('CubeWriter', '4.8.2'),
 ]
 
 dependencies = [
-    ('CubeGUI', '4.8'),
-    ('CubeLib', '4.8'),
-    ('OTF2', '3.0.2'),
-    ('Score-P', '8.0'),
+    ('CubeGUI', '4.8.2'),
+    ('CubeLib', '4.8.2'),
+    ('OTF2', '3.0.3'),
+    ('Score-P', '8.4'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1_nowarn_omp_pragmas.patch
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1_nowarn_omp_pragmas.patch
@@ -1,0 +1,39 @@
+This patch fixes a missing $ in configure, which causes following checks to
+fail if they produce any output to stdout or stderr.
+
+diff -Nrup scalasca-2.6.1.orig/build-config/m4/scalasca_nowarn_omp_pragmas.m4 scalasca-2.6.1/build-config/m4/scalasca_nowarn_omp_pragmas.m4
+--- scalasca-2.6.1.orig/build-config/m4/scalasca_nowarn_omp_pragmas.m4	2022-12-14 11:55:38.810618928 +0100
++++ scalasca-2.6.1/build-config/m4/scalasca_nowarn_omp_pragmas.m4	2023-09-27 09:47:31.155201804 +0200
+@@ -62,7 +62,7 @@ AS_CASE([$_scalasca_nowarn_omp_pragmas],
+ AC_SUBST([NOWARN_OMP_PRAGMAS_]_AC_LANG_PREFIX[FLAGS])
+ 
+ dnl Reset environment
+-ac_[]_AC_LANG_ABBREV[]_werror_flag=_scalasca_save_[]_AC_LANG_ABBREV[]_werror_flag
++ac_[]_AC_LANG_ABBREV[]_werror_flag=$_scalasca_save_[]_AC_LANG_ABBREV[]_werror_flag
+ ])
+ 
+ 
+diff -Nrup scalasca-2.6.1.orig/build-backend/configure scalasca-2.6.1/build-backend/configure
+--- scalasca-2.6.1.orig/build-backend/configure	2022-12-14 11:56:16.350709778 +0100
++++ scalasca-2.6.1/build-backend/configure	2023-09-27 09:49:35.847822426 +0200
+@@ -21128,7 +21128,7 @@ case $_scalasca_nowarn_omp_pragmas in #(
+ esac
+ 
+ 
+-ac_cxx_werror_flag=_scalasca_save_cxx_werror_flag
++ac_cxx_werror_flag=$_scalasca_save_cxx_werror_flag
+ 
+  if test "x${ac_cv_prog_cxx_openmp}" != "xunsupported" \
+                 && test "x${enable_openmp}" != "xno"; then
+diff -Nrup scalasca-2.6.1.orig/build-mpi/configure scalasca-2.6.1/build-mpi/configure
+--- scalasca-2.6.1.orig/build-mpi/configure	2022-12-14 11:56:33.574751469 +0100
++++ scalasca-2.6.1/build-mpi/configure	2023-09-27 09:49:06.135678364 +0200
+@@ -21878,7 +21878,7 @@ case $_scalasca_nowarn_omp_pragmas in #(
+ esac
+ 
+ 
+-ac_cxx_werror_flag=_scalasca_save_cxx_werror_flag
++ac_cxx_werror_flag=$_scalasca_save_cxx_werror_flag
+ 
+  if test "x${ac_cv_prog_cxx_openmp}" != "xunsupported" \
+                 && test "x${enable_openmp}" != "xno"; then


### PR DESCRIPTION
This PR adds Scalasca to 2023b, using the latest versions of Cube[x], OTF2 and Score-P. 

In addition, a patch was added, which is being used on the JSC systems for some time (see [here](https://github.com/easybuilders/JSC/blob/2024/Golden_Repo/s/Scalasca/Scalasca-2.6.1_nowarn_omp_pragmas.patch)). This patch fixes a typo, which causes all checks after the OpenMP check to fail when they produce any output on `stdout` or `stderr`. This can cause issues in detecting compiler flags or the environment correctly.