### PR TITLE
Ensure that recent BioPerl easyconfigs use `Bundle` easyblock

### DIFF
--- a/easybuild/easyconfigs/b/BioPerl/BioPerl-1.7.8-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/b/BioPerl/BioPerl-1.7.8-GCCcore-12.2.0.eb
@@ -5,7 +5,7 @@
 #  Fred Hutchinson Cancer Research Center
 #  Thomas Eylenbosch - Gluo NV 
 
-easyblock = 'PerlModule'
+easyblock = 'Bundle'
 
 name = 'BioPerl'
 version = '1.7.8'

--- a/easybuild/easyconfigs/b/BioPerl/BioPerl-1.7.8-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/b/BioPerl/BioPerl-1.7.8-GCCcore-12.3.0.eb
@@ -5,7 +5,7 @@
 #  Fred Hutchinson Cancer Research Center
 #  Thomas Eylenbosch - Gluo NV 
 
-easyblock = 'PerlModule'
+easyblock = 'Bundle'
 
 name = 'BioPerl'
 version = '1.7.8'

--- a/easybuild/easyconfigs/b/BioPerl/BioPerl-1.7.8-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/b/BioPerl/BioPerl-1.7.8-GCCcore-13.3.0.eb
@@ -5,7 +5,7 @@
 #  Fred Hutchinson Cancer Research Center
 #  Thomas Eylenbosch - Gluo NV 
 
-easyblock = 'PerlModule'
+easyblock = 'Bundle'
 
 name = 'BioPerl'
 version = '1.7.8'


### PR DESCRIPTION
This was causing problems in https://github.com/EESSI/software-layer/pull/658 as `eb` was attempting to copy the same easyblock twice and that was failing if `EasyBuild` had a read-only installation.