### PR TITLE
stop RStudio-Server 2023.09 from installing R packages (+ move to `foss/2023a` toolchain)

### DIFF
--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2023.09.1+494-foss-2023a-Java-11-R-4.3.2.eb
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2023.09.1+494-foss-2023a-Java-11-R-4.3.2.eb
@@ -18,7 +18,7 @@ and then used with:
   rserver ... --database-config-file="${MYTMP}/db.conf"
 """
 
-toolchain = {'name': 'gfbf', 'version': '2023a'}
+toolchain = {'name': 'foss', 'version': '2023a'}
 
 source_urls = ['https://github.com/rstudio/rstudio/archive']
 sources = ['v%(version)s.tar.gz']

--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2023.09.1+494-gfbf-2023a-Java-11-R-4.3.2.eb
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2023.09.1+494-gfbf-2023a-Java-11-R-4.3.2.eb
@@ -36,6 +36,7 @@ dependencies = [
     ('Boost', '1.82.0'),
     ('Java', '11', '', SYSTEM),
     ('R', '4.3.2'),
+    ('R-bundle-CRAN', '2023.12'),
     ('SOCI', '4.0.3'),
     ('yaml-cpp', '0.7.0'),
 ]
@@ -52,7 +53,6 @@ preconfigopts = " && ".join([
     "./install-dictionaries",
     "./install-mathjax",
     "./install-pandoc",
-    "./install-packages",
     "./install-panmirror",
     "./install-npm-dependencies)",
     ""


### PR DESCRIPTION
This looks to fix https://github.com/easybuilders/easybuild-easyconfigs/pull/21167#issuecomment-2286625820

We only look to have been having this problem with https://github.com/branfosj/easybuild-easyconfigs/blob/rstudio/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2023.12.1%2B402-gfbf-2023b-Java-11-R-4.3.3.eb and https://github.com/branfosj/easybuild-easyconfigs/blob/rstudio/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2023.09.1%2B494-foss-2023a-Java-11-R-4.3.2.eb, but not with the older versions of RStudio-Server. This PR fixes `RStudio-Server-2023.09.1+494-foss-2023a-Java-11-R-4.3.2.eb`. However, there is no (merged) R-bundle-CRAN (to provide `renv`) that we can use for `RStudio-Server-2023.12.1+402-gfbf-2023b-Java-11-R-4.3.3.eb`, so I've not fixed that one.