### PR TITLE
Provide SciPy-bundle-2023.12 and dependents for intel and foss alike

### DIFF
--- a/easybuild/easyconfigs/a/Armadillo/Armadillo-12.8.0-intel-2023b.eb
+++ b/easybuild/easyconfigs/a/Armadillo/Armadillo-12.8.0-intel-2023b.eb
@@ -1,0 +1,25 @@
+name = 'Armadillo'
+version = '12.8.0'
+
+homepage = 'https://arma.sourceforge.net/'
+description = """Armadillo is an open-source C++ linear algebra library (matrix maths) aiming towards
+ a good balance between speed and ease of use. Integer, floating point and complex numbers are supported,
+ as well as a subset of trigonometric and statistics functions."""
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+
+source_urls = ['https://sourceforge.net/projects/arma/files']
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['a89bb6fece5ce9fdd1d01a4bc145cf7cc0b939c5777cca46de69c2f5e3412cf0']
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+]
+dependencies = [
+    ('Boost', '1.83.0'),
+    ('HDF5', '1.14.3'),
+    ('arpack-ng', '3.9.0'),
+]
+
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/a/Arrow/Arrow-16.1.0-gfbf-2023b-b.eb
+++ b/easybuild/easyconfigs/a/Arrow/Arrow-16.1.0-gfbf-2023b-b.eb
@@ -1,0 +1,87 @@
+easyblock = 'CMakeMake'
+
+name = 'Arrow'
+version = '16.1.0'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://arrow.apache.org'
+description = """Apache Arrow (incl. PyArrow Python bindings), a cross-language development platform
+ for in-memory data."""
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+source_urls = ['https://archive.apache.org/dist/%(namelower)s/%(namelower)s-%(version)s']
+sources = ['apache-arrow-%(version)s.tar.gz']
+checksums = ['c9e60c7e87e59383d21b20dc874b17153729ee153264af6d21654b7dff2c60d7']
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('Autotools', '20220317'),
+    ('flex', '2.6.4'),
+    ('Bison', '3.8.2'),
+    ('pkgconf', '2.0.3'),
+]
+
+# Arrow strongly prefers included jemalloc, so not including it as a dependency
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),  # for numpy
+    ('Boost', '1.83.0'),
+    ('lz4', '1.9.4'),
+    ('zlib', '1.2.13'),
+    ('bzip2', '1.0.8'),
+    ('zstd', '1.5.5'),
+    ('snappy', '1.1.10'),
+    ('RapidJSON', '1.1.0-20240409'),
+    ('RE2', '2024-03-01'),
+    ('utf8proc', '2.9.0'),
+]
+
+start_dir = 'cpp'
+
+# see https://arrow.apache.org/docs/developers/python.html
+configopts = "-DARROW_DATASET=on -DARROW_PYTHON=on -DARROW_PARQUET=ON -DARROW_WITH_SNAPPY=ON "
+configopts += "-DCMAKE_INSTALL_LIBDIR=lib -DPython3_ROOT_DIR=$EBROOTPYTHON "
+configopts += "-DARROW_WITH_ZLIB=ON -DARROW_WITH_BZ2=ON -DARROW_WITH_ZSTD=ON -DARROW_WITH_LZ4=ON "
+configopts += "-DZSTD_ROOT=$EBROOTZSTD "
+
+# install Python bindings
+_pyarrow_preinstall_opts = "export PKG_CONFIG_PATH=%(installdir)s/lib/pkgconfig:$PKG_CONFIG_PATH && "
+_pyarrow_preinstall_opts += "export Arrow_DIR=%(installdir)s && export ArrowDataset_DIR=%(installdir)s && "
+_pyarrow_preinstall_opts += "export ArrowAcero_DIR=%(installdir)s && export Parquet_DIR=%(installdir)s && "
+_pyarrow_preinstall_opts += "export XDG_CACHE_HOME=$TMPDIR && "
+_pyarrow_preinstall_opts += "sed -i 's/numpy==[0-9.]*/numpy/g' pyproject.toml && "
+_pyarrow_preinstall_opts += "Python3_ROOT_DIR=$EBROOTPYTHON "
+_pyarrow_preinstall_opts += "PYARROW_CMAKE_OPTIONS='-DZSTD_LIB=$EBROOTZSTD/lib/libzstd.%s ' " % SHLIB_EXT
+_pyarrow_preinstall_opts += "PYARROW_WITH_DATASET=1 PYARROW_WITH_PARQUET=1 "
+
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'download_dep_fail': True,
+    'use_pip': True,
+    'sanity_pip_check': True,
+}
+exts_list = [
+    ('pyarrow', version, {
+        'sources': ['apache-arrow-%(version)s.tar.gz'],
+        'checksums': ['c9e60c7e87e59383d21b20dc874b17153729ee153264af6d21654b7dff2c60d7'],
+        'start_dir': '%(builddir)s/apache-arrow-%(version)s/python',
+        'preinstallopts': _pyarrow_preinstall_opts,
+    }),
+]
+
+modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+
+sanity_check_paths = {
+    'files': ['lib/libarrow.a', 'lib/libarrow.%s' % SHLIB_EXT,
+              'lib/python%%(pyshortver)s/site-packages/pyarrow/libarrow_python.%s' % SHLIB_EXT],
+    'dirs': ['include/arrow', 'lib/cmake/Arrow', 'lib/pkgconfig', 'lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [
+    "python -c 'import pyarrow'",
+    "python -c 'import pyarrow.dataset'",
+    "python -c 'import pyarrow.parquet'",
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/a/Arrow/Arrow-16.1.0-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/a/Arrow/Arrow-16.1.0-iimkl-2023b.eb
@@ -1,0 +1,86 @@
+easyblock = 'CMakeMake'
+
+name = 'Arrow'
+version = '16.1.0'
+
+homepage = 'https://arrow.apache.org'
+description = """Apache Arrow (incl. PyArrow Python bindings), a cross-language development platform
+ for in-memory data."""
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+
+source_urls = ['https://archive.apache.org/dist/%(namelower)s/%(namelower)s-%(version)s']
+sources = ['apache-arrow-%(version)s.tar.gz']
+checksums = ['c9e60c7e87e59383d21b20dc874b17153729ee153264af6d21654b7dff2c60d7']
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('Autotools', '20220317'),
+    ('flex', '2.6.4'),
+    ('Bison', '3.8.2'),
+    ('pkgconf', '2.0.3'),
+]
+
+# Arrow strongly prefers included jemalloc, so not including it as a dependency
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),  # for numpy
+    ('Boost', '1.83.0'),
+    ('lz4', '1.9.4'),
+    ('zlib', '1.2.13'),
+    ('bzip2', '1.0.8'),
+    ('zstd', '1.5.5'),
+    ('snappy', '1.1.10'),
+    ('RapidJSON', '1.1.0-20240409'),
+    ('RE2', '2024-03-01'),
+    ('utf8proc', '2.9.0'),
+]
+
+start_dir = 'cpp'
+
+# see https://arrow.apache.org/docs/developers/python.html
+configopts = "-DARROW_DATASET=on -DARROW_PYTHON=on -DARROW_PARQUET=ON -DARROW_WITH_SNAPPY=ON "
+configopts += "-DCMAKE_INSTALL_LIBDIR=lib -DPython3_ROOT_DIR=$EBROOTPYTHON "
+configopts += "-DARROW_WITH_ZLIB=ON -DARROW_WITH_BZ2=ON -DARROW_WITH_ZSTD=ON -DARROW_WITH_LZ4=ON "
+configopts += "-DZSTD_ROOT=$EBROOTZSTD "
+
+# install Python bindings
+_pyarrow_preinstall_opts = "export PKG_CONFIG_PATH=%(installdir)s/lib/pkgconfig:$PKG_CONFIG_PATH && "
+_pyarrow_preinstall_opts += "export Arrow_DIR=%(installdir)s && export ArrowDataset_DIR=%(installdir)s && "
+_pyarrow_preinstall_opts += "export ArrowAcero_DIR=%(installdir)s && export Parquet_DIR=%(installdir)s && "
+_pyarrow_preinstall_opts += "export XDG_CACHE_HOME=$TMPDIR && "
+_pyarrow_preinstall_opts += "sed -i 's/numpy==[0-9.]*/numpy/g' pyproject.toml && "
+_pyarrow_preinstall_opts += "Python3_ROOT_DIR=$EBROOTPYTHON "
+_pyarrow_preinstall_opts += "PYARROW_CMAKE_OPTIONS='-DZSTD_LIB=$EBROOTZSTD/lib/libzstd.%s ' " % SHLIB_EXT
+_pyarrow_preinstall_opts += "PYARROW_WITH_DATASET=1 PYARROW_WITH_PARQUET=1 "
+
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'download_dep_fail': True,
+    'use_pip': True,
+    'sanity_pip_check': True,
+}
+exts_list = [
+    ('pyarrow', version, {
+        'sources': ['apache-arrow-%(version)s.tar.gz'],
+        'checksums': ['c9e60c7e87e59383d21b20dc874b17153729ee153264af6d21654b7dff2c60d7'],
+        'start_dir': '%(builddir)s/apache-arrow-%(version)s/python',
+        'preinstallopts': _pyarrow_preinstall_opts,
+    }),
+]
+
+modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+
+sanity_check_paths = {
+    'files': ['lib/libarrow.a', 'lib/libarrow.%s' % SHLIB_EXT,
+              'lib/python%%(pyshortver)s/site-packages/pyarrow/libarrow_python.%s' % SHLIB_EXT],
+    'dirs': ['include/arrow', 'lib/cmake/Arrow', 'lib/pkgconfig', 'lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [
+    "python -c 'import pyarrow'",
+    "python -c 'import pyarrow.dataset'",
+    "python -c 'import pyarrow.parquet'",
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/b/Biopython/Biopython-1.84-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/b/Biopython/Biopython-1.84-foss-2023b-b.eb
@@ -1,0 +1,47 @@
+# Updated from previous easyconfig
+# Author: Robert Mijakovic <robert.mijakovic@lxp.lu>
+# Update: Pavel Tománek (INUITS)
+
+easyblock = 'PythonPackage'
+
+name = 'Biopython'
+version = '1.84'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://www.biopython.org'
+description = """Biopython is a set of freely available tools for biological
+ computation written in Python by an international team of developers. It is
+ a distributed collaborative effort to develop Python libraries and
+ applications which address the needs of current and future work in
+ bioinformatics. """
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+
+source_urls = ['https://biopython.org/DIST']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['60fbe6f996e8a6866a42698c17e552127d99a9aab3259d6249fbaabd0e0cc7b4']
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+# Run only tests that don't require internet connection
+runtest = 'python setup.py test --offline'
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/Bio',
+             'lib/python%(pyshortver)s/site-packages/BioSQL']
+}
+
+# extra check to ensure numpy dependency is available
+sanity_check_commands = ["python -c 'import Bio.MarkovModel'"]
+
+options = {'modulename': 'Bio'}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/Biopython/Biopython-1.84-intel-2023b.eb
+++ b/easybuild/easyconfigs/b/Biopython/Biopython-1.84-intel-2023b.eb
@@ -1,0 +1,46 @@
+# Updated from previous easyconfig
+# Author: Robert Mijakovic <robert.mijakovic@lxp.lu>
+# Update: Pavel Tománek (INUITS)
+
+easyblock = 'PythonPackage'
+
+name = 'Biopython'
+version = '1.84'
+
+homepage = 'https://www.biopython.org'
+description = """Biopython is a set of freely available tools for biological
+ computation written in Python by an international team of developers. It is
+ a distributed collaborative effort to develop Python libraries and
+ applications which address the needs of current and future work in
+ bioinformatics. """
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+
+source_urls = ['https://biopython.org/DIST']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['60fbe6f996e8a6866a42698c17e552127d99a9aab3259d6249fbaabd0e0cc7b4']
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+# Run only tests that don't require internet connection
+runtest = 'python setup.py test --offline'
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/Bio',
+             'lib/python%(pyshortver)s/site-packages/BioSQL']
+}
+
+# extra check to ensure numpy dependency is available
+sanity_check_commands = ["python -c 'import Bio.MarkovModel'"]
+
+options = {'modulename': 'Bio'}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.83.0-intel-compilers-2023.2.1.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.83.0-intel-compilers-2023.2.1.eb
@@ -1,0 +1,36 @@
+##
+# Authors::   Denis Kristak <thenis@inuits.eu>
+##
+name = 'Boost'
+version = '1.83.0'
+
+homepage = 'https://www.boost.org/'
+description = """Boost provides free peer-reviewed portable C++ source libraries."""
+
+toolchain = {'name': 'intel-compilers', 'version': '2023.2.1'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
+patches = ['%(name)s-%(version)s_icpx_fix_unsupported_argument.patch']
+checksums = [
+    {'boost_1_83_0.tar.gz': 'c0685b68dd44cc46574cce86c4e17c0f611b15e195be9848dfd0769a0a207628'},
+    {'Boost-1.83.0_icpx_fix_unsupported_argument.patch':
+     'ada377759fcda0146c744f103d9e3cd58cae1c6e8cd3132bb958166171539c61'},
+]
+
+dependencies = [
+    ('bzip2', '1.0.8'),
+    ('zlib', '1.2.13'),
+    ('XZ', '5.4.4'),
+    ('zstd', '1.5.5'),
+    ('ICU', '74.1'),
+]
+
+configopts = '--without-libraries=python,mpi'
+
+# disable MPI, build Boost libraries with tagged layout
+boost_mpi = False
+tagged_layout = True
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.83.0_icpx_fix_unsupported_argument.patch
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.83.0_icpx_fix_unsupported_argument.patch
@@ -1,0 +1,15 @@
+# Fix build for Intel compiler following:
+# https://www.intel.com/content/www/us/en/developer/articles/technical/building-boost-with-oneapi.html
+# S.D.Pinches
+diff -Nru boost_1_81_0-orig/tools/build/src/tools/intel-linux.jam boost_1_81_0/tools/build/src/tools/intel-linux.jam
+--- boost_1_81_0-orig/tools/build/src/tools/intel-linux.jam	2022-12-08 02:02:50.000000000 +0100
++++ boost_1_81_0/tools/build/src/tools/intel-linux.jam	2023-09-25 14:18:09.460485592 +0200
+@@ -277,7 +277,7 @@
+ #
+ actions compile.c++.pch
+ {
+-    rm -f "$(<)" && LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -pch-create "$(<)" "$(>)"
++    rm -f "$(<)" && LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -Xclang -emit-pch -o "$(<)" "$(>)"
+ }
+ 
+ actions compile.fortran

--- a/easybuild/easyconfigs/b/biom-format/biom-format-2.1.16-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/b/biom-format/biom-format-2.1.16-foss-2023b-b.eb
@@ -1,0 +1,50 @@
+##
+# This is a contribution from DeepThought HPC Service, Flinders University, Adelaide, Australia
+# Homepage:     https://staff.flinders.edu.au/research/deep-thought
+#
+# Authors::     Robert Qiao <rob.qiao@flinders.edu.au>
+# License::     Revised BSD
+#
+# Notes:: updated by Kenneth Hoste (HPC-UGent) for foss/2021b
+##
+# Updated: Petr Král (INUITS)
+# Updated: Lara Peeters (Ghent University)
+
+easyblock = 'PythonPackage'
+
+name = 'biom-format'
+version = '2.1.16'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://biom-format.org'
+description = """
+The BIOM file format (canonically pronounced biome) is designed to be
+ a general-use format for representing biological sample by observation
+ contingency tables. BIOM is a recognized standard for the Earth Microbiome
+ Project and is a Genomics Standards Consortium supported project.
+"""
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+toolchainopts = {'usempi': True}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['47f88d57a94ecaa4d06f3578ca394e78db6d12e46ab0886634743181e67dcfc9']
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('h5py', '3.11.0', '-b'),  # alternative version of SciPy-bundle dependency
+]
+
+use_pip = True
+sanity_pip_check = True
+download_dep_fail = True
+
+sanity_check_paths = {
+    'files': ['bin/biom'],
+    'dirs': ['lib'],
+}
+
+options = {'modulename': 'biom'}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/biom-format/biom-format-2.1.16-intel-2023b.eb
+++ b/easybuild/easyconfigs/b/biom-format/biom-format-2.1.16-intel-2023b.eb
@@ -1,0 +1,49 @@
+##
+# This is a contribution from DeepThought HPC Service, Flinders University, Adelaide, Australia
+# Homepage:     https://staff.flinders.edu.au/research/deep-thought
+#
+# Authors::     Robert Qiao <rob.qiao@flinders.edu.au>
+# License::     Revised BSD
+#
+# Notes:: updated by Kenneth Hoste (HPC-UGent) for foss/2021b
+##
+# Updated: Petr Král (INUITS)
+# Updated: Lara Peeters (Ghent University)
+
+easyblock = 'PythonPackage'
+
+name = 'biom-format'
+version = '2.1.16'
+
+homepage = 'https://biom-format.org'
+description = """
+The BIOM file format (canonically pronounced biome) is designed to be
+ a general-use format for representing biological sample by observation
+ contingency tables. BIOM is a recognized standard for the Earth Microbiome
+ Project and is a Genomics Standards Consortium supported project.
+"""
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+toolchainopts = {'usempi': True}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['47f88d57a94ecaa4d06f3578ca394e78db6d12e46ab0886634743181e67dcfc9']
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('h5py', '3.11.0'),
+]
+
+use_pip = True
+sanity_pip_check = True
+download_dep_fail = True
+
+sanity_check_paths = {
+    'files': ['bin/biom'],
+    'dirs': ['lib'],
+}
+
+options = {'modulename': 'biom'}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/bokeh/bokeh-3.4.1-gfbf-2023b-b.eb
+++ b/easybuild/easyconfigs/b/bokeh/bokeh-3.4.1-gfbf-2023b-b.eb
@@ -1,0 +1,51 @@
+easyblock = 'PythonBundle'
+
+name = 'bokeh'
+version = '3.4.1'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://github.com/bokeh/bokeh'
+description = "Statistical and novel interactive HTML plots for Python"
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+builddependencies = [
+    ('meson-python', '0.15.0'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('SciPy-bundle', '2023.12'),
+    ('matplotlib', '3.8.2'),
+    ('PyYAML', '6.0.1'),
+    ('Pillow', '10.2.0'),
+    ('tornado', '6.4'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('contourpy', '1.2.1', {
+        'checksums': ['4d8908b3bee1c889e547867ca4cdc54e5ab6be6d3e078556814a22457f49423c'],
+    }),
+    ('xyzservices', '2024.4.0', {
+        'checksums': ['6a04f11487a6fb77d92a98984cd107fbd9157fd5e65f929add9c3d6e604ee88c'],
+    }),
+    (name, version, {
+        # bokeh uses git tags to get version, so we'll instead inject the version into setup.py
+        'preinstallopts': """sed -i 's/setup(/setup(version="%(version)s",/g' setup.py && """,
+        'checksums': ['d824961e4265367b0750ce58b07e564ad0b83ca64b335521cd3421e9b9f10d89'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/bokeh'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["bokeh --help"]
+
+sanity_pip_check = True
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bokeh/bokeh-3.4.1-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/b/bokeh/bokeh-3.4.1-iimkl-2023b.eb
@@ -1,0 +1,50 @@
+easyblock = 'PythonBundle'
+
+name = 'bokeh'
+version = '3.4.1'
+
+homepage = 'https://github.com/bokeh/bokeh'
+description = "Statistical and novel interactive HTML plots for Python"
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+
+builddependencies = [
+    ('meson-python', '0.15.0'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('SciPy-bundle', '2023.12'),
+    ('matplotlib', '3.8.2'),
+    ('PyYAML', '6.0.1'),
+    ('Pillow', '10.2.0'),
+    ('tornado', '6.4'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('contourpy', '1.2.1', {
+        'checksums': ['4d8908b3bee1c889e547867ca4cdc54e5ab6be6d3e078556814a22457f49423c'],
+    }),
+    ('xyzservices', '2024.4.0', {
+        'checksums': ['6a04f11487a6fb77d92a98984cd107fbd9157fd5e65f929add9c3d6e604ee88c'],
+    }),
+    (name, version, {
+        # bokeh uses git tags to get version, so we'll instead inject the version into setup.py
+        'preinstallopts': """sed -i 's/setup(/setup(version="%(version)s",/g' setup.py && """,
+        'checksums': ['d824961e4265367b0750ce58b07e564ad0b83ca64b335521cd3421e9b9f10d89'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/bokeh'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["bokeh --help"]
+
+sanity_pip_check = True
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/d/dask/dask-2024.5.1-gfbf-2023b-b.eb
+++ b/easybuild/easyconfigs/d/dask/dask-2024.5.1-gfbf-2023b-b.eb
@@ -1,0 +1,68 @@
+easyblock = 'PythonBundle'
+
+name = 'dask'
+version = '2024.5.1'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://dask.org/'
+description = """ Dask natively scales Python. Dask provides advanced parallelism for analytics,
+enabling performance at scale for the tools you love."""
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('SciPy-bundle', '2023.12'),
+    ('PyYAML', '6.0.1'),
+    ('bokeh', '3.4.1'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('toolz', '0.12.1', {
+        'checksums': ['ecca342664893f177a13dac0e6b41cbd8ac25a358e5f215316d43e2100224f4d'],
+    }),
+    ('locket', '1.0.0', {
+        'checksums': ['5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632'],
+    }),
+    ('partd', '1.4.2', {
+        'checksums': ['d022c33afbdc8405c226621b015e8067888173d85f7f5ecebb3cafed9a20f02c'],
+    }),
+    ('HeapDict', '1.0.1', {
+        'checksums': ['8495f57b3e03d8e46d5f1b2cc62ca881aca392fd5cc048dc0aa2e1a6d23ecdb6'],
+    }),
+    ('zict', '3.0.0', {
+        'checksums': ['e321e263b6a97aafc0790c3cfb3c04656b7066e6738c37fffcca95d803c9fba5'],
+    }),
+    ('tblib', '3.0.0', {
+        'checksums': ['93622790a0a29e04f0346458face1e144dc4d32f493714c6c3dff82a4adb77e6'],
+    }),
+    (name, version, {
+        'checksums': ['e071fda67031c314569e37ca70b3e88bb30f1d91ff8ee4122b541845847cc264'],
+    }),
+    ('distributed', version, {
+        'checksums': ['c4e641e5fc014de3b43c584c70f703a7d44557b51b1143db812b8bc861aa84e2'],
+    }),
+    ('dask-mpi', '2022.4.0', {
+        'checksums': ['0a04f1d7d35a06cdff506593330d4414ea242c9172498ce191f5742eac499e17'],
+    }),
+    ('docrep', '0.3.2', {
+        'checksums': ['ed8a17e201abd829ef8da78a0b6f4d51fb99a4cbd0554adbed3309297f964314'],
+    }),
+    ('dask-jobqueue', '0.8.5', {
+        'checksums': ['f6923f9d7ff894b96efbf706118b2cd37fd37751d567e91c22dfd3e2eaa93202'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/dask-%s' % x for x in ['mpi', 'scheduler', 'ssh', 'worker']],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["dask-scheduler --help"]
+
+sanity_pip_check = True
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/d/dask/dask-2024.5.1-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/d/dask/dask-2024.5.1-iimkl-2023b.eb
@@ -1,0 +1,67 @@
+easyblock = 'PythonBundle'
+
+name = 'dask'
+version = '2024.5.1'
+
+homepage = 'https://dask.org/'
+description = """ Dask natively scales Python. Dask provides advanced parallelism for analytics,
+enabling performance at scale for the tools you love."""
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('SciPy-bundle', '2023.12'),
+    ('PyYAML', '6.0.1'),
+    ('bokeh', '3.4.1'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('toolz', '0.12.1', {
+        'checksums': ['ecca342664893f177a13dac0e6b41cbd8ac25a358e5f215316d43e2100224f4d'],
+    }),
+    ('locket', '1.0.0', {
+        'checksums': ['5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632'],
+    }),
+    ('partd', '1.4.2', {
+        'checksums': ['d022c33afbdc8405c226621b015e8067888173d85f7f5ecebb3cafed9a20f02c'],
+    }),
+    ('HeapDict', '1.0.1', {
+        'checksums': ['8495f57b3e03d8e46d5f1b2cc62ca881aca392fd5cc048dc0aa2e1a6d23ecdb6'],
+    }),
+    ('zict', '3.0.0', {
+        'checksums': ['e321e263b6a97aafc0790c3cfb3c04656b7066e6738c37fffcca95d803c9fba5'],
+    }),
+    ('tblib', '3.0.0', {
+        'checksums': ['93622790a0a29e04f0346458face1e144dc4d32f493714c6c3dff82a4adb77e6'],
+    }),
+    (name, version, {
+        'checksums': ['e071fda67031c314569e37ca70b3e88bb30f1d91ff8ee4122b541845847cc264'],
+    }),
+    ('distributed', version, {
+        'checksums': ['c4e641e5fc014de3b43c584c70f703a7d44557b51b1143db812b8bc861aa84e2'],
+    }),
+    ('dask-mpi', '2022.4.0', {
+        'checksums': ['0a04f1d7d35a06cdff506593330d4414ea242c9172498ce191f5742eac499e17'],
+    }),
+    ('docrep', '0.3.2', {
+        'checksums': ['ed8a17e201abd829ef8da78a0b6f4d51fb99a4cbd0554adbed3309297f964314'],
+    }),
+    ('dask-jobqueue', '0.8.5', {
+        'checksums': ['f6923f9d7ff894b96efbf706118b2cd37fd37751d567e91c22dfd3e2eaa93202'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/dask-%s' % x for x in ['mpi', 'scheduler', 'ssh', 'worker']],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["dask-scheduler --help"]
+
+sanity_pip_check = True
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.9.0-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.9.0-foss-2023b-b.eb
@@ -1,0 +1,82 @@
+easyblock = 'CMakeMake'
+
+name = 'GDAL'
+version = '3.9.0'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://www.gdal.org'
+description = """GDAL is a translator library for raster geospatial data formats that is released under an X/MIT style
+ Open Source license by the Open Source Geospatial Foundation. As a library, it presents a single abstract data model
+ to the calling application for all supported formats. It also comes with a variety of useful commandline utilities for
+ data translation and processing."""
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://download.osgeo.org/%(namelower)s/%(version)s/']
+sources = [SOURCELOWER_TAR_XZ]
+patches = ['%(name)s-3.6.2_fix-python-CC-CXX.patch']
+checksums = [
+    {'gdal-3.9.0.tar.xz': '577f80e9d14ff7c90b6bfbc34201652b4546700c01543efb4f4c3050e0b3fda2'},
+    {'GDAL-3.6.2_fix-python-CC-CXX.patch': '859b874b0c8ff7626a76d51f008bf05b7f89a35b325bdd1d126d2364154acc63'},
+]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('pkgconf', '2.0.3'),
+    ('Bison', '3.8.2'),
+]
+dependencies = [
+    ('Python', '3.11.5'),
+    ('netCDF', '4.9.2'),
+    ('expat', '2.5.0'),
+    ('GEOS', '3.12.1'),
+    ('SQLite', '3.43.1'),
+    ('libarchive', '3.7.2'),
+    ('libxml2', '2.11.5'),
+    ('libpng', '1.6.40'),
+    ('libjpeg-turbo', '3.0.1'),
+    ('LibTIFF', '4.6.0'),
+    ('zlib', '1.2.13'),
+    ('cURL', '8.3.0'),
+    ('PCRE', '8.45'),
+    ('PROJ', '9.3.1'),
+    ('libgeotiff', '1.7.3'),
+    ('SciPy-bundle', '2023.12'),
+    ('HDF5', '1.14.3'),
+    ('HDF', '4.2.16-2'),
+    ('Armadillo', '12.8.0'),
+    ('CFITSIO', '4.3.1'),
+    ('zstd', '1.5.5'),
+    ('giflib', '5.2.1'),
+    ('json-c', '0.17'),
+    ('Xerces-C++', '3.2.5'),
+    ('PCRE2', '10.42'),
+    ('OpenEXR', '3.2.0'),
+    ('Brunsli', '0.1'),
+    ('Qhull', '2020.2'),
+    ('LERC', '4.0.0'),
+    ('OpenJPEG', '2.5.0'),
+    ('SWIG', '4.1.1'),
+]
+
+# iterative build for both static and shared libraries
+local_configopts_common = "-DGDAL_USE_INTERNAL_LIBS=OFF -DGDAL_USE_MYSQL=OFF "
+local_configopts_common += "-DGEOTIFF_INCLUDE_DIR=$EBROOTLIBGEOTIFF/include -DPython_ROOT=$EBROOTPYTHON "
+
+configopts = [
+    local_configopts_common + "-DBUILD_SHARED_LIBS=OFF",
+    local_configopts_common
+]
+
+
+sanity_check_paths = {
+    'files': ['lib/libgdal.a', 'lib/libgdal.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'include', 'lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["python -c 'import osgeo.%(namelower)s'"]
+
+modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.9.0-intel-2023b.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.9.0-intel-2023b.eb
@@ -1,0 +1,81 @@
+easyblock = 'CMakeMake'
+
+name = 'GDAL'
+version = '3.9.0'
+
+homepage = 'https://www.gdal.org'
+description = """GDAL is a translator library for raster geospatial data formats that is released under an X/MIT style
+ Open Source license by the Open Source Geospatial Foundation. As a library, it presents a single abstract data model
+ to the calling application for all supported formats. It also comes with a variety of useful commandline utilities for
+ data translation and processing."""
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://download.osgeo.org/%(namelower)s/%(version)s/']
+sources = [SOURCELOWER_TAR_XZ]
+patches = ['%(name)s-3.6.2_fix-python-CC-CXX.patch']
+checksums = [
+    {'gdal-3.9.0.tar.xz': '577f80e9d14ff7c90b6bfbc34201652b4546700c01543efb4f4c3050e0b3fda2'},
+    {'GDAL-3.6.2_fix-python-CC-CXX.patch': '859b874b0c8ff7626a76d51f008bf05b7f89a35b325bdd1d126d2364154acc63'},
+]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('pkgconf', '2.0.3'),
+    ('Bison', '3.8.2'),
+]
+dependencies = [
+    ('Python', '3.11.5'),
+    ('netCDF', '4.9.2'),
+    ('expat', '2.5.0'),
+    ('GEOS', '3.12.1'),
+    ('SQLite', '3.43.1'),
+    ('libarchive', '3.7.2'),
+    ('libxml2', '2.11.5'),
+    ('libpng', '1.6.40'),
+    ('libjpeg-turbo', '3.0.1'),
+    ('LibTIFF', '4.6.0'),
+    ('zlib', '1.2.13'),
+    ('cURL', '8.3.0'),
+    ('PCRE', '8.45'),
+    ('PROJ', '9.3.1'),
+    ('libgeotiff', '1.7.3'),
+    ('SciPy-bundle', '2023.12'),
+    ('HDF5', '1.14.3'),
+    ('HDF', '4.2.16-2'),
+    ('Armadillo', '12.8.0'),
+    ('CFITSIO', '4.3.1'),
+    ('zstd', '1.5.5'),
+    ('giflib', '5.2.1'),
+    ('json-c', '0.17'),
+    ('Xerces-C++', '3.2.5'),
+    ('PCRE2', '10.42'),
+    ('OpenEXR', '3.2.0'),
+    ('Brunsli', '0.1'),
+    ('Qhull', '2020.2'),
+    ('LERC', '4.0.0'),
+    ('OpenJPEG', '2.5.0'),
+    ('SWIG', '4.1.1'),
+]
+
+# iterative build for both static and shared libraries
+local_configopts_common = "-DGDAL_USE_INTERNAL_LIBS=OFF -DGDAL_USE_MYSQL=OFF "
+local_configopts_common += "-DGEOTIFF_INCLUDE_DIR=$EBROOTLIBGEOTIFF/include -DPython_ROOT=$EBROOTPYTHON "
+
+configopts = [
+    local_configopts_common + "-DBUILD_SHARED_LIBS=OFF",
+    local_configopts_common
+]
+
+
+sanity_check_paths = {
+    'files': ['lib/libgdal.a', 'lib/libgdal.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'include', 'lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["python -c 'import osgeo.%(namelower)s'"]
+
+modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2024.1-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2024.1-foss-2023b-b.eb
@@ -1,0 +1,91 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
+#                                 Ghent University / The Francis Crick Institute
+# Authors::
+# * Wiktor Jurkowski <wiktor.jurkowski@gmail.com>
+# * Fotis Georgatos <fotis@cern.ch>
+# * George Tsouloupas <g.tsouloupas@cyi.ac.cy>
+# * Kenneth Hoste <kenneth.hoste@ugent.be>
+# * Adam Huffman <adam.huffman@crick.ac.uk>
+# * Ake Sandgren <ake.sandgren@hpc2n.umu.se>
+# * J. Sassmannshausen <Crick HPC team>
+# * Dugan Witherick <dugan.witherick@warwick.ac.uk>
+# * Christoph Siegert <christoph.siegert@uni-leipzig.de>
+# License::   MIT/GPL
+
+name = 'GROMACS'
+version = '2024.1'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://www.gromacs.org'
+description = """
+GROMACS is a versatile package to perform molecular dynamics, i.e. simulate the
+Newtonian equations of motion for systems with hundreds to millions of
+particles.
+
+This is a CPU only build, containing both MPI and threadMPI binaries
+for both single and double precision.
+
+It also contains the gmxapi extension for the single precision MPI build.
+"""
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = [
+    'https://ftp.gromacs.org/pub/gromacs/',
+    'ftp://ftp.gromacs.org/pub/gromacs/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'GROMACS-2023.1_set_omp_num_threads_env_for_ntomp_tests.patch',
+    'GROMACS-2023.1_fix_tests_for_gmx_thread_mpi.patch',
+    'GROMACS-2024.1_fix-tests-filesystem-race.patch',
+]
+checksums = [
+    {'gromacs-2024.1.tar.gz': '937d8f12a36fffbf2af7add71adbb5aa5c5537892d46c9a76afbecab1aa0aac7'},
+    {'GROMACS-2023.1_set_omp_num_threads_env_for_ntomp_tests.patch':
+     '7f41bda16c9c2837624265dda4be252f655d1288ddc4486b1a2422af30d5d199'},
+    {'GROMACS-2023.1_fix_tests_for_gmx_thread_mpi.patch':
+     '6df844bb3bbc51180446a3595c61a4ef195e5f975533a04cef76841aa763aec1'},
+    {'GROMACS-2024.1_fix-tests-filesystem-race.patch':
+     '25b933b37bc40576ee25ebae24442ae15fafe7cd5ac4b066e1dc8de488d58b4c'},
+]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('scikit-build-core', '0.9.3'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('networkx', '3.2.1'),
+    ('mpi4py', '3.1.5'),
+]
+
+exts_defaultclass = 'PythonPackage'
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True,
+    'download_dep_fail': True,
+    'sanity_pip_check': True,
+}
+
+exts_list = [
+    ('gmxapi', '0.5.0', {
+        'preinstallopts': 'export CMAKE_ARGS="-Dgmxapi_ROOT=%(installdir)s ' +
+                          '-C %(installdir)s/share/cmake/gromacs_mpi/gromacs-hints_mpi.cmake" && ',
+        'source_tmpl': 'gromacs-2024.1.tar.gz',
+        'start_dir': 'python_packaging/gmxapi',
+        'checksums': ['937d8f12a36fffbf2af7add71adbb5aa5c5537892d46c9a76afbecab1aa0aac7'],
+    }),
+]
+
+modextrapaths = {
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2024.1-intel-2023b.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2024.1-intel-2023b.eb
@@ -1,0 +1,90 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
+#                                 Ghent University / The Francis Crick Institute
+# Authors::
+# * Wiktor Jurkowski <wiktor.jurkowski@gmail.com>
+# * Fotis Georgatos <fotis@cern.ch>
+# * George Tsouloupas <g.tsouloupas@cyi.ac.cy>
+# * Kenneth Hoste <kenneth.hoste@ugent.be>
+# * Adam Huffman <adam.huffman@crick.ac.uk>
+# * Ake Sandgren <ake.sandgren@hpc2n.umu.se>
+# * J. Sassmannshausen <Crick HPC team>
+# * Dugan Witherick <dugan.witherick@warwick.ac.uk>
+# * Christoph Siegert <christoph.siegert@uni-leipzig.de>
+# License::   MIT/GPL
+
+name = 'GROMACS'
+version = '2024.1'
+
+homepage = 'https://www.gromacs.org'
+description = """
+GROMACS is a versatile package to perform molecular dynamics, i.e. simulate the
+Newtonian equations of motion for systems with hundreds to millions of
+particles.
+
+This is a CPU only build, containing both MPI and threadMPI binaries
+for both single and double precision.
+
+It also contains the gmxapi extension for the single precision MPI build.
+"""
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = [
+    'https://ftp.gromacs.org/pub/gromacs/',
+    'ftp://ftp.gromacs.org/pub/gromacs/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'GROMACS-2023.1_set_omp_num_threads_env_for_ntomp_tests.patch',
+    'GROMACS-2023.1_fix_tests_for_gmx_thread_mpi.patch',
+    'GROMACS-2024.1_fix-tests-filesystem-race.patch',
+]
+checksums = [
+    {'gromacs-2024.1.tar.gz': '937d8f12a36fffbf2af7add71adbb5aa5c5537892d46c9a76afbecab1aa0aac7'},
+    {'GROMACS-2023.1_set_omp_num_threads_env_for_ntomp_tests.patch':
+     '7f41bda16c9c2837624265dda4be252f655d1288ddc4486b1a2422af30d5d199'},
+    {'GROMACS-2023.1_fix_tests_for_gmx_thread_mpi.patch':
+     '6df844bb3bbc51180446a3595c61a4ef195e5f975533a04cef76841aa763aec1'},
+    {'GROMACS-2024.1_fix-tests-filesystem-race.patch':
+     '25b933b37bc40576ee25ebae24442ae15fafe7cd5ac4b066e1dc8de488d58b4c'},
+]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('scikit-build-core', '0.9.3'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('networkx', '3.2.1'),
+    ('mpi4py', '3.1.5'),
+]
+
+exts_defaultclass = 'PythonPackage'
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True,
+    'download_dep_fail': True,
+    'sanity_pip_check': True,
+}
+
+exts_list = [
+    ('gmxapi', '0.5.0', {
+        'preinstallopts': 'export CMAKE_ARGS="-Dgmxapi_ROOT=%(installdir)s ' +
+                          '-C %(installdir)s/share/cmake/gromacs_mpi/gromacs-hints_mpi.cmake" && ',
+        'source_tmpl': 'gromacs-2024.1.tar.gz',
+        'start_dir': 'python_packaging/gmxapi',
+        'checksums': ['937d8f12a36fffbf2af7add71adbb5aa5c5537892d46c9a76afbecab1aa0aac7'],
+    }),
+]
+
+modextrapaths = {
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/gmpy2/gmpy2-2.1.5-intel-compilers-2023.2.1.eb
+++ b/easybuild/easyconfigs/g/gmpy2/gmpy2-2.1.5-intel-compilers-2023.2.1.eb
@@ -1,0 +1,25 @@
+easyblock = 'PythonPackage'
+
+name = 'gmpy2'
+version = '2.1.5'
+
+homepage = 'https://github.com/aleaxit/gmpy'
+description = "GMP/MPIR, MPFR, and MPC interface to Python 2.6+ and 3.x"
+
+toolchain = {'name': 'intel-compilers', 'version': '2023.2.1'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['bc297f1fd8c377ae67a4f493fc0f926e5d1b157e5c342e30a4d84dc7b9f95d96']
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('GMP', '6.3.0'),
+    ('MPFR', '4.2.1'),
+    ('MPC', '1.3.1'),
+]
+
+download_dep_fail = True
+sanity_pip_check = True
+use_pip = True
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.14.4.3-gompi-2023b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.14.4.3-gompi-2023b.eb
@@ -1,0 +1,31 @@
+name = 'HDF5'
+# Note: Odd minor releases are only RCs and should not be used.
+version = '1.14.4.3'
+
+homepage = 'https://portal.hdfgroup.org/display/support'
+description = """HDF5 is a data model, library, and file format for storing and managing data.
+ It supports an unlimited variety of datatypes, and is designed for flexible
+ and efficient I/O and for high volume and complex data."""
+
+toolchain = {'name': 'gompi', 'version': '2023b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+# to enable debug symbols, use:
+# configopts = ['--enable-build-mode=debug']
+
+# HDF5 tags are prefixed with '%(namelower)s_' for some redundant reason
+github_account = 'HDFGroup'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = [{'download_filename': '%(namelower)s_%(version)s.tar.gz', 'filename': SOURCELOWER_TAR_GZ}]
+checksums = ['690c1db7ba0fed4ffac61709236675ffd99d95d191e8920ee79c58d7e7ea3361']
+
+# replace src include path with installation dir for $H5BLD_CPPFLAGS
+_regex = 's, -I[^[:space:]]+H5FDsubfiling , -I%(installdir)s/include ,g'
+postinstallcmds = ['sed -i -r "%s" %%(installdir)s/bin/%s' % (_regex, x) for x in ['h5c++', 'h5pcc']]
+
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('Szip', '2.1.1'),
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.14.4.3-iimpi-2023b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.14.4.3-iimpi-2023b.eb
@@ -1,0 +1,31 @@
+name = 'HDF5'
+# Note: Odd minor releases are only RCs and should not be used.
+version = '1.14.4.3'
+
+homepage = 'https://portal.hdfgroup.org/display/support'
+description = """HDF5 is a data model, library, and file format for storing and managing data.
+ It supports an unlimited variety of datatypes, and is designed for flexible
+ and efficient I/O and for high volume and complex data."""
+
+toolchain = {'name': 'iimpi', 'version': '2023b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+# to enable debug symbols, use:
+# configopts = ['--enable-build-mode=debug']
+
+# HDF5 tags are prefixed with '%(namelower)s_' for some redundant reason
+github_account = 'HDFGroup'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = [{'download_filename': '%(namelower)s_%(version)s.tar.gz', 'filename': SOURCELOWER_TAR_GZ}]
+checksums = ['690c1db7ba0fed4ffac61709236675ffd99d95d191e8920ee79c58d7e7ea3361']
+
+# replace src include path with installation dir for $H5BLD_CPPFLAGS
+_regex = 's, -I[^[:space:]]+H5FDsubfiling , -I%(installdir)s/include ,g'
+postinstallcmds = ['sed -i -r "%s" %%(installdir)s/bin/%s' % (_regex, x) for x in ['h5c++', 'h5pcc']]
+
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('Szip', '2.1.1'),
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/h/HiGHS/HiGHS-1.7.0-gfbf-2023b-b.eb
+++ b/easybuild/easyconfigs/h/HiGHS/HiGHS-1.7.0-gfbf-2023b-b.eb
@@ -1,0 +1,50 @@
+easyblock = 'CMakeMake'
+
+name = 'HiGHS'
+version = '1.7.0'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://ergo-code.github.io/HiGHS'
+description = """Open source serial and parallel solvers for large-scale sparse linear programming (LP),
+mixed-integer programming (MIP), and quadratic programming (QP) models."""
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+source_urls = ['https://github.com/ERGO-Code/HiGHS/archive/']
+sources = [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}]
+checksums = ['d10175ad66e7f113ac5dc00c9d6650a620663a6884fbf2942d6eb7a3d854604f']
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'download_dep_fail': True,
+    'use_pip': True,
+    'sanity_pip_check': True,
+    'installopts': '',
+}
+
+exts_list = [
+    ('highspy', version, {
+        'source_urls': ['https://github.com/ERGO-Code/HiGHS/archive/'],
+        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'checksums': ['d10175ad66e7f113ac5dc00c9d6650a620663a6884fbf2942d6eb7a3d854604f'],
+    }),
+]
+
+modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+
+sanity_check_paths = {
+    'files': ['bin/highs'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/h/HiGHS/HiGHS-1.7.0-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/h/HiGHS/HiGHS-1.7.0-iimkl-2023b.eb
@@ -1,0 +1,49 @@
+easyblock = 'CMakeMake'
+
+name = 'HiGHS'
+version = '1.7.0'
+
+homepage = 'https://ergo-code.github.io/HiGHS'
+description = """Open source serial and parallel solvers for large-scale sparse linear programming (LP),
+mixed-integer programming (MIP), and quadratic programming (QP) models."""
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+
+source_urls = ['https://github.com/ERGO-Code/HiGHS/archive/']
+sources = [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}]
+checksums = ['d10175ad66e7f113ac5dc00c9d6650a620663a6884fbf2942d6eb7a3d854604f']
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'download_dep_fail': True,
+    'use_pip': True,
+    'sanity_pip_check': True,
+    'installopts': '',
+}
+
+exts_list = [
+    ('highspy', version, {
+        'source_urls': ['https://github.com/ERGO-Code/HiGHS/archive/'],
+        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'checksums': ['d10175ad66e7f113ac5dc00c9d6650a620663a6884fbf2942d6eb7a3d854604f'],
+    }),
+]
+
+modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+
+sanity_check_paths = {
+    'files': ['bin/highs'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/h/h5py/h5py-3.11.0-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.11.0-foss-2023b-b.eb
@@ -1,0 +1,36 @@
+easyblock = 'PythonPackage'
+
+name = 'h5py'
+version = '3.11.0'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://www.h5py.org/'
+description = """HDF5 for Python (h5py) is a general-purpose Python interface to the Hierarchical Data Format library,
+ version 5. HDF5 is a versatile, mature scientific software library designed for the fast, flexible storage of enormous
+ amounts of data."""
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+toolchainopts = {'usempi': True}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['7b7e8f78072a2edec87c9836f25f34203fd492a4475709a18b417a33cfb21fa9']
+
+builddependencies = [('pkgconf', '2.0.3')]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('mpi4py', '3.1.5'),
+    ('HDF5', '1.14.4.3'),
+]
+
+use_pip = True
+sanity_pip_check = True
+download_dep_fail = True
+
+# h5py's setup.py will disable setup_requires if H5PY_SETUP_REQUIRES is set to 0
+# without this environment variable, pip will fetch the minimum numpy version h5py supports during install,
+# even though SciPy-bundle provides a newer version that satisfies h5py's install_requires dependency.
+preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" H5PY_SETUP_REQUIRES=0 '
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-3.11.0-intel-2023b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.11.0-intel-2023b.eb
@@ -8,17 +8,21 @@ description = """HDF5 for Python (h5py) is a general-purpose Python interface to
  version 5. HDF5 is a versatile, mature scientific software library designed for the fast, flexible storage of enormous
  amounts of data."""
 
-toolchain = {'name': 'foss', 'version': '2023b'}
+toolchain = {'name': 'intel', 'version': '2023b'}
 toolchainopts = {'usempi': True}
 
 sources = [SOURCE_TAR_GZ]
-checksums = ['7b7e8f78072a2edec87c9836f25f34203fd492a4475709a18b417a33cfb21fa9']
+patches = ['%(name)s-%(version)s_fix_dtype_locking.patch']
+checksums = [
+    {'h5py-3.11.0.tar.gz': '7b7e8f78072a2edec87c9836f25f34203fd492a4475709a18b417a33cfb21fa9'},
+    {'h5py-3.11.0_fix_dtype_locking.patch': 'fb1641d4ad2217c5a33413acee120f1ae99548bf1db2acfd9760b9e7556c69c7'},
+]
 
 builddependencies = [('pkgconf', '2.0.3')]
 
 dependencies = [
     ('Python', '3.11.5'),
-    ('SciPy-bundle', '2023.11'),
+    ('SciPy-bundle', '2023.12'),
     ('mpi4py', '3.1.5'),
     ('HDF5', '1.14.4.3'),
 ]

--- a/easybuild/easyconfigs/h/h5py/h5py-3.11.0_fix_dtype_locking.patch
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.11.0_fix_dtype_locking.patch
@@ -1,0 +1,55 @@
+From a27a1f49ce92d985e14b8a24fa80d30e5174add2 Mon Sep 17 00:00:00 2001
+From: Aleksandar Jelenak <ajelenak@hdfgroup.org>
+Date: Sun, 5 May 2024 20:19:35 +0100
+Subject: [PATCH] Lock native float16 dtype only if available
+
+---
+ h5py/api_types_hdf5.pxd | 2 ++
+ h5py/h5i.pyx            | 1 +
+ h5py/h5t.pyx            | 5 ++++-
+ 3 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/h5py/api_types_hdf5.pxd b/h5py/api_types_hdf5.pxd
+index ff96b6ed..5da00e32 100644
+--- a/h5py/api_types_hdf5.pxd
++++ b/h5py/api_types_hdf5.pxd
+@@ -385,6 +385,8 @@ cdef extern from "hdf5.h":
+ 
+ # === H5I - Identifier and reflection interface ===============================
+ 
++  int H5I_INVALID_HID
++
+   IF HDF5_VERSION < VOL_MIN_HDF5_VERSION:
+     ctypedef enum H5I_type_t:
+       H5I_UNINIT       = -2,  # uninitialized Group
+diff --git a/h5py/h5i.pyx b/h5py/h5i.pyx
+index 9033d506..075d46f3 100644
+--- a/h5py/h5i.pyx
++++ b/h5py/h5i.pyx
+@@ -18,6 +18,7 @@ from ._objects import phil, with_phil
+ 
+ # === Public constants and data structures ====================================
+ 
++INVALID_HID = H5I_INVALID_HID
+ BADID       = H5I_BADID
+ FILE        = H5I_FILE
+ GROUP       = H5I_GROUP
+diff --git a/h5py/h5t.pyx b/h5py/h5t.pyx
+index 3cc085fd..31220f10 100644
+--- a/h5py/h5t.pyx
++++ b/h5py/h5t.pyx
+@@ -232,7 +232,10 @@ LDOUBLE_BE.set_order(H5T_ORDER_BE)
+ LDOUBLE_BE.lock()
+ 
+ IF HDF5_VERSION > (1, 14, 3):
+-    NATIVE_FLOAT16 = lockid(H5T_NATIVE_FLOAT16)
++    if H5T_NATIVE_FLOAT16 != H5I_INVALID_HID:
++        NATIVE_FLOAT16 = lockid(H5T_NATIVE_FLOAT16)
++    else:
++        NATIVE_FLOAT16 = H5I_INVALID_HID
+ 
+ # Unix time types
+ UNIX_D32LE = lockid(H5T_UNIX_D32LE)
+-- 
+2.39.3
+

--- a/easybuild/easyconfigs/m/MetaDecoder/MetaDecoder-1.0.19-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/m/MetaDecoder/MetaDecoder-1.0.19-foss-2023b-b.eb
@@ -1,0 +1,31 @@
+easyblock = 'PythonBundle'
+
+name = 'MetaDecoder'
+version = '1.0.19'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://github.com/liu-congcong/MetaDecoder'
+description = "An algorithm for clustering metagenomic sequences"
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),  # threadpoolctl
+    ('SciPy-bundle', '2023.12'),
+    ('scikit-learn', '1.4.0'),
+]
+
+use_pip = True
+
+exts_list = [
+    (name, version, {
+        'source_urls': ['https://github.com/liu-congcong/MetaDecoder/archive/'],
+        'sources': ['v%(version)s.tar.gz'],
+        'checksums': ['8b88813a97787bc56baa3100a576a9e56a0de02811c573573a2fffeb7e80623e'],
+    }),
+]
+
+sanity_pip_check = True
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/MetaDecoder/MetaDecoder-1.0.19-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MetaDecoder/MetaDecoder-1.0.19-intel-2023b.eb
@@ -1,0 +1,30 @@
+easyblock = 'PythonBundle'
+
+name = 'MetaDecoder'
+version = '1.0.19'
+
+homepage = 'https://github.com/liu-congcong/MetaDecoder'
+description = "An algorithm for clustering metagenomic sequences"
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),  # threadpoolctl
+    ('SciPy-bundle', '2023.12'),
+    ('scikit-learn', '1.4.0'),
+]
+
+use_pip = True
+
+exts_list = [
+    (name, version, {
+        'source_urls': ['https://github.com/liu-congcong/MetaDecoder/archive/'],
+        'sources': ['v%(version)s.tar.gz'],
+        'checksums': ['8b88813a97787bc56baa3100a576a9e56a0de02811c573573a2fffeb7e80623e'],
+    }),
+]
+
+sanity_pip_check = True
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-3.8.2-gfbf-2023b-b.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-3.8.2-gfbf-2023b-b.eb
@@ -1,0 +1,85 @@
+easyblock = 'PythonBundle'
+
+name = 'matplotlib'
+version = '3.8.2'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://matplotlib.org'
+description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
+ hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
+ and ipython shell, web application servers, and six graphical user interface toolkits."""
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+builddependencies = [
+    ('pkgconf', '2.0.3'),
+    ('cppy', '1.2.1'),
+    ('meson-python', '0.15.0'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('libpng', '1.6.40'),
+    ('freetype', '2.13.2'),
+    ('Tkinter', '%(pyver)s'),
+    ('Pillow', '10.2.0'),
+    ('Qhull', '2020.2'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+# avoid that matplotlib downloads and builds its own copies of freetype and qhull
+_fix_setup = "sed -e 's/#system_freetype = False/system_freetype = True/g' "
+_fix_setup += "-e 's/#system_qhull = False/system_qhull = True/g' mplsetup.cfg.template >mplsetup.cfg && "
+
+_include_path = "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && "
+
+local_preinstallopts = "sed -e 's/#system_freetype = False/system_freetype = True/g' -e "
+local_preinstallopts += "'s/#system_qhull = False/system_qhull = True/g' mplsetup.cfg.template >mplsetup.cfg"
+local_preinstallopts += "&& export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && "
+
+exts_list = [
+    ('fonttools', '4.47.0', {
+        'modulename': 'fontTools',
+        'source_tmpl': '%(name)s-%(version)s.tar.gz',
+        'checksums': ['ec13a10715eef0e031858c1c23bfaee6cba02b97558e4a7bfa089dba4a8c2ebf'],
+    }),
+    ('Cycler', '0.12.1', {
+        'modulename': 'cycler',
+        'source_tmpl': 'cycler-%(version)s.tar.gz',
+        'checksums': ['88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c'],
+    }),
+    ('kiwisolver', '1.4.5', {
+        'patches': ['kiwisolver-1.4.4-fix_version.patch'],
+        'checksums': [
+            {'kiwisolver-1.4.5.tar.gz': 'e57e563a57fb22a142da34f38acc2fc1a5c864bc29ca1517a88abc963e60d6ec'},
+            {'kiwisolver-1.4.4-fix_version.patch': '6753afbb3a88856493fcfa0b33989f35742f57bfd41ff3b7f71a98797e1bfbd0'},
+        ],
+    }),
+    ('contourpy', '1.2.0', {
+        'checksums': ['171f311cb758de7da13fc53af221ae47a5877be5a0843a9fe150818c51ed276a'],
+    }),
+    (name, version, {
+        'patches': ['matplotlib-3.8.2-fix_setup.patch'],
+        'preinstallopts': "sed -e 's/#system_freetype = False/system_freetype = True/g' "
+                          "-e 's/#system_qhull = False/system_qhull = True/g' mplsetup.cfg.template >mplsetup.cfg"
+                          "&& export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'checksums': [
+            {'matplotlib-3.8.2.tar.gz': '01a978b871b881ee76017152f1f1a0cbf6bd5f7b8ff8c96df0df1bd57d8755a1'},
+            {'matplotlib-3.8.2-fix_setup.patch': '16e1610aec49af402e324e0b71c69d6b7ae106732088318e727b48282492a932'},
+        ],
+    }),
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("Agg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
+
+# use non-interactive plotting backend as default
+# see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
+modextravars = {'MPLBACKEND': 'Agg'}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-3.8.2-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-3.8.2-iimkl-2023b.eb
@@ -1,0 +1,84 @@
+easyblock = 'PythonBundle'
+
+name = 'matplotlib'
+version = '3.8.2'
+
+homepage = 'https://matplotlib.org'
+description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
+ hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
+ and ipython shell, web application servers, and six graphical user interface toolkits."""
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+
+builddependencies = [
+    ('pkgconf', '2.0.3'),
+    ('cppy', '1.2.1'),
+    ('meson-python', '0.15.0'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('libpng', '1.6.40'),
+    ('freetype', '2.13.2'),
+    ('Tkinter', '%(pyver)s'),
+    ('Pillow', '10.2.0'),
+    ('Qhull', '2020.2'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+# avoid that matplotlib downloads and builds its own copies of freetype and qhull
+_fix_setup = "sed -e 's/#system_freetype = False/system_freetype = True/g' "
+_fix_setup += "-e 's/#system_qhull = False/system_qhull = True/g' mplsetup.cfg.template >mplsetup.cfg && "
+
+_include_path = "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && "
+
+local_preinstallopts = "sed -e 's/#system_freetype = False/system_freetype = True/g' -e "
+local_preinstallopts += "'s/#system_qhull = False/system_qhull = True/g' mplsetup.cfg.template >mplsetup.cfg"
+local_preinstallopts += "&& export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && "
+
+exts_list = [
+    ('fonttools', '4.47.0', {
+        'modulename': 'fontTools',
+        'source_tmpl': '%(name)s-%(version)s.tar.gz',
+        'checksums': ['ec13a10715eef0e031858c1c23bfaee6cba02b97558e4a7bfa089dba4a8c2ebf'],
+    }),
+    ('Cycler', '0.12.1', {
+        'modulename': 'cycler',
+        'source_tmpl': 'cycler-%(version)s.tar.gz',
+        'checksums': ['88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c'],
+    }),
+    ('kiwisolver', '1.4.5', {
+        'patches': ['kiwisolver-1.4.4-fix_version.patch'],
+        'checksums': [
+            {'kiwisolver-1.4.5.tar.gz': 'e57e563a57fb22a142da34f38acc2fc1a5c864bc29ca1517a88abc963e60d6ec'},
+            {'kiwisolver-1.4.4-fix_version.patch': '6753afbb3a88856493fcfa0b33989f35742f57bfd41ff3b7f71a98797e1bfbd0'},
+        ],
+    }),
+    ('contourpy', '1.2.0', {
+        'checksums': ['171f311cb758de7da13fc53af221ae47a5877be5a0843a9fe150818c51ed276a'],
+    }),
+    (name, version, {
+        'patches': ['matplotlib-3.8.2-fix_setup.patch'],
+        'preinstallopts': "sed -e 's/#system_freetype = False/system_freetype = True/g' "
+                          "-e 's/#system_qhull = False/system_qhull = True/g' mplsetup.cfg.template >mplsetup.cfg"
+                          "&& export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'checksums': [
+            {'matplotlib-3.8.2.tar.gz': '01a978b871b881ee76017152f1f1a0cbf6bd5f7b8ff8c96df0df1bd57d8755a1'},
+            {'matplotlib-3.8.2-fix_setup.patch': '16e1610aec49af402e324e0b71c69d6b7ae106732088318e727b48282492a932'},
+        ],
+    }),
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("Agg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
+
+# use non-interactive plotting backend as default
+# see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
+modextravars = {'MPLBACKEND': 'Agg'}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/meshio/meshio-5.3.5-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/m/meshio/meshio-5.3.5-foss-2023b-b.eb
@@ -1,0 +1,40 @@
+easyblock = 'PythonBundle'
+
+name = 'meshio'
+version = '5.3.5'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://github.com/nschloe/meshio'
+description = "meshio is a tool for reading/writing various mesh formats representing unstructured meshes"
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),  # includes rich
+    ('SciPy-bundle', '2023.12'),  # includes numpy
+    ('h5py', '3.11.0', '-b'),  # alternative version of SciPy-bundle dependency
+    ('VTK', '9.3.0'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('appdirs', '1.4.4', {
+        'checksums': ['7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41'],
+    }),
+    ('pipdate', '0.5.6', {
+        'checksums': ['1b6b7ec2c5468fb7036ec9d6b2ced7a8a538db55aaca03f30199216d3bbd264b'],
+    }),
+    (name, version, {
+        'checksums': ['f21f01abd9f29ba06ea119304b3d39e610421cfe93b9dd23362834919f87586d'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/meshio', 'bin/pipdate'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'cae'

--- a/easybuild/easyconfigs/m/meshio/meshio-5.3.5-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/meshio/meshio-5.3.5-intel-2023b.eb
@@ -1,0 +1,39 @@
+easyblock = 'PythonBundle'
+
+name = 'meshio'
+version = '5.3.5'
+
+homepage = 'https://github.com/nschloe/meshio'
+description = "meshio is a tool for reading/writing various mesh formats representing unstructured meshes"
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),  # includes rich
+    ('SciPy-bundle', '2023.12'),  # includes numpy
+    ('h5py', '3.11.0'),
+    ('VTK', '9.3.0'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('appdirs', '1.4.4', {
+        'checksums': ['7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41'],
+    }),
+    ('pipdate', '0.5.6', {
+        'checksums': ['1b6b7ec2c5468fb7036ec9d6b2ced7a8a538db55aaca03f30199216d3bbd264b'],
+    }),
+    (name, version, {
+        'checksums': ['f21f01abd9f29ba06ea119304b3d39e610421cfe93b9dd23362834919f87586d'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/meshio', 'bin/pipdate'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'cae'

--- a/easybuild/easyconfigs/m/mpi4py/mpi4py-3.1.5-iimpi-2023b.eb
+++ b/easybuild/easyconfigs/m/mpi4py/mpi4py-3.1.5-iimpi-2023b.eb
@@ -1,0 +1,25 @@
+easyblock = 'PythonBundle'
+
+name = 'mpi4py'
+version = '3.1.5'
+
+homepage = 'https://github.com/mpi4py/mpi4py'
+description = """MPI for Python (mpi4py) provides bindings of the Message Passing Interface (MPI) standard for
+ the Python programming language, allowing any Python program to exploit multiple processors."""
+
+toolchain = {'name': 'iimpi', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    (name, version, {
+        'checksums': ['a706e76db9255135c2fb5d1ef54cb4f7b0e4ad9e33cbada7de27626205f2a153'],
+    }),
+]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/m/msgpack-c/msgpack-c-6.0.0-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/m/msgpack-c/msgpack-c-6.0.0-GCC-13.2.0.eb
@@ -1,0 +1,37 @@
+# Thomas Hoffmann, EMBL Heidelberg, structures-it@embl.de, 2021/04
+easyblock = 'CMakeMake'
+
+name = 'msgpack-c'
+version = '6.0.0'
+
+homepage = 'http://msgpack.org/'
+description = """MessagePack is an efficient binary serialization format, which lets you exchange
+data among multiple languages like JSON, except that it's faster and smaller.   
+Small integers are encoded into a single byte while typical short strings       
+require only one extra byte in addition to the strings themselves."""
+
+toolchain = {'name': 'GCC', 'version': '13.2.0'}
+
+source_urls = ['https://github.com/msgpack/msgpack-c/releases/download/c-%(version)s']
+sources = ['msgpack-c-%(version)s.tar.gz']
+checksums = ['3654f5e2c652dc52e0a993e270bb57d5702b262703f03771c152bba51602aeba']
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('binutils', '2.40'),
+    ('googletest', '1.14.0'),
+]
+
+dependencies = [
+    ('Boost', '1.83.0'),
+]
+
+sanity_check_paths = {
+    'files': [
+        ['lib/libmsgpack-c.%s' % x for x in ['a', '%s' % SHLIB_EXT]],
+        ['include/msgpack.%s' % x for x in ['h']]
+    ],
+    'dirs': ['lib/pkgconfig', 'include/msgpack'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/m/msgpack-c/msgpack-c-6.0.0-intel-compilers-2023.2.1.eb
+++ b/easybuild/easyconfigs/m/msgpack-c/msgpack-c-6.0.0-intel-compilers-2023.2.1.eb
@@ -1,0 +1,37 @@
+# Thomas Hoffmann, EMBL Heidelberg, structures-it@embl.de, 2021/04
+easyblock = 'CMakeMake'
+
+name = 'msgpack-c'
+version = '6.0.0'
+
+homepage = 'http://msgpack.org/'
+description = """MessagePack is an efficient binary serialization format, which lets you exchange
+data among multiple languages like JSON, except that it's faster and smaller.   
+Small integers are encoded into a single byte while typical short strings       
+require only one extra byte in addition to the strings themselves."""
+
+toolchain = {'name': 'intel-compilers', 'version': '2023.2.1'}
+
+source_urls = ['https://github.com/msgpack/msgpack-c/releases/download/c-%(version)s']
+sources = ['msgpack-c-%(version)s.tar.gz']
+checksums = ['3654f5e2c652dc52e0a993e270bb57d5702b262703f03771c152bba51602aeba']
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('binutils', '2.40'),
+    ('googletest', '1.14.0'),
+]
+
+dependencies = [
+    ('Boost', '1.83.0'),
+]
+
+sanity_check_paths = {
+    'files': [
+        ['lib/libmsgpack-c.%s' % x for x in ['a', '%s' % SHLIB_EXT]],
+        ['include/msgpack.%s' % x for x in ['h']]
+    ],
+    'dirs': ['lib/pkgconfig', 'include/msgpack'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/NLTK/NLTK-3.8.1-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/n/NLTK/NLTK-3.8.1-foss-2023b-b.eb
@@ -1,0 +1,54 @@
+easyblock = 'PythonBundle'
+
+name = 'NLTK'
+version = '3.8.1'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://www.nltk.org/'
+description = "NLTK is a leading platform for building Python programs to work with human language data."
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('scikit-learn', '1.4.0'),
+    ('matplotlib', '3.8.2'),
+    ('tqdm', '4.66.2'),
+]
+
+local_nltk_data_install = []
+# Install NLTK data sets (7.4 GB)
+# local_nltk_data = '/path/to/database/nltk_data'
+# local_nltk_data_install = [
+#     "mkdir -p %s && NLTK_DATA=%s python -m nltk.downloader all" % (local_nltk_data, local_nltk_data)
+# ]
+# modextravars = {'NLTK_DATA': local_nltk_data}
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('regex', '2023.12.25', {
+        'checksums': ['29171aa128da69afdf4bde412d5bedc335f2ca8fcfe4489038577d05f16181e5'],
+    }),
+    ('python-crfsuite', '0.9.10', {
+        'modulename': 'pycrfsuite',
+        'checksums': ['f38524631e2b533341f10f2c77689270dc6ecd5985495dccf7aa37b1045bc2e5'],
+    }),
+    (name, version, {
+        'postinstallcmds': [],
+        'source_tmpl': '%(namelower)s-%(version)s.zip',
+        'use_pip_extras': 'corenlp,machine_learning,plot,tgrep',
+        'checksums': ['1834da3d0682cba4f2cede2f9aad6b0fafb6461ba451db0efb6f9c39798d64d3'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(namelower)s'],
+}
+
+sanity_check_commands = [('%(namelower)s', '--version')]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/n/NLTK/NLTK-3.8.1-intel-2023b.eb
+++ b/easybuild/easyconfigs/n/NLTK/NLTK-3.8.1-intel-2023b.eb
@@ -1,0 +1,53 @@
+easyblock = 'PythonBundle'
+
+name = 'NLTK'
+version = '3.8.1'
+
+homepage = 'https://www.nltk.org/'
+description = "NLTK is a leading platform for building Python programs to work with human language data."
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('scikit-learn', '1.4.0'),
+    ('matplotlib', '3.8.2'),
+    ('tqdm', '4.66.2'),
+]
+
+local_nltk_data_install = []
+# Install NLTK data sets (7.4 GB)
+# local_nltk_data = '/path/to/database/nltk_data'
+# local_nltk_data_install = [
+#     "mkdir -p %s && NLTK_DATA=%s python -m nltk.downloader all" % (local_nltk_data, local_nltk_data)
+# ]
+# modextravars = {'NLTK_DATA': local_nltk_data}
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('regex', '2023.12.25', {
+        'checksums': ['29171aa128da69afdf4bde412d5bedc335f2ca8fcfe4489038577d05f16181e5'],
+    }),
+    ('python-crfsuite', '0.9.10', {
+        'modulename': 'pycrfsuite',
+        'checksums': ['f38524631e2b533341f10f2c77689270dc6ecd5985495dccf7aa37b1045bc2e5'],
+    }),
+    (name, version, {
+        'postinstallcmds': [],
+        'source_tmpl': '%(namelower)s-%(version)s.zip',
+        'use_pip_extras': 'corenlp,machine_learning,plot,tgrep',
+        'checksums': ['1834da3d0682cba4f2cede2f9aad6b0fafb6461ba451db0efb6f9c39798d64d3'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(namelower)s'],
+}
+
+sanity_check_commands = [('%(namelower)s', '--version')]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.6.5-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.6.5-foss-2023b-b.eb
@@ -1,0 +1,58 @@
+easyblock = 'PythonBundle'
+
+name = 'netcdf4-python'
+version = '1.6.5'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://unidata.github.io/netcdf4-python/'
+description = """Python/numpy interface to netCDF."""
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+toolchainopts = {'usempi': True}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('netCDF', '4.9.2'),
+    ('cURL', '8.3.0'),
+    ('mpi4py', '3.1.5'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('cftime', '1.6.2', {
+        'checksums': ['8614c00fb8a5046de304fdd86dbd224f99408185d7b245ac6628d0276596e6d2'],
+    }),
+    (name, version, {
+        'patches': [
+            'netcdf4-python-1.1.8-avoid-diskless-test.patch',
+            'netcdf4-python-1.6.1_relax_tolerance_compression_test.patch',
+        ],
+        'source_tmpl': 'netCDF4-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/n/netCDF4'],
+        'checksums': [
+            {'netCDF4-1.6.5.tar.gz': '824881d0aacfde5bd982d6adedd8574259c85553781e7b83e0ce82b890bfa0ef'},
+            {'netcdf4-python-1.1.8-avoid-diskless-test.patch':
+             'a8b262fa201d55f59015e1bc14466c1d113f807543bc1e05a22481ab0d216d72'},
+            {'netcdf4-python-1.6.1_relax_tolerance_compression_test.patch':
+             '64d192a5d1e3e00af78f053da78f5a35015fa713c7f97b10b622be6a44347166'},
+        ],
+    }),
+]
+
+fix_python_shebang_for = ['bin/*']
+
+sanity_check_paths = {
+    'files': ['bin/nc3tonc4', 'bin/nc4tonc3', 'bin/ncinfo'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [
+    "nc4tonc3 --help",
+    "nc3tonc4 --help",
+    "ncinfo --help",
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.6.5-intel-2023b.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf4-python-1.6.5-intel-2023b.eb
@@ -1,0 +1,57 @@
+easyblock = 'PythonBundle'
+
+name = 'netcdf4-python'
+version = '1.6.5'
+
+homepage = 'https://unidata.github.io/netcdf4-python/'
+description = """Python/numpy interface to netCDF."""
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+toolchainopts = {'usempi': True}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('netCDF', '4.9.2'),
+    ('cURL', '8.3.0'),
+    ('mpi4py', '3.1.5'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('cftime', '1.6.2', {
+        'checksums': ['8614c00fb8a5046de304fdd86dbd224f99408185d7b245ac6628d0276596e6d2'],
+    }),
+    (name, version, {
+        'patches': [
+            'netcdf4-python-1.1.8-avoid-diskless-test.patch',
+            'netcdf4-python-1.6.1_relax_tolerance_compression_test.patch',
+        ],
+        'source_tmpl': 'netCDF4-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/n/netCDF4'],
+        'checksums': [
+            {'netCDF4-1.6.5.tar.gz': '824881d0aacfde5bd982d6adedd8574259c85553781e7b83e0ce82b890bfa0ef'},
+            {'netcdf4-python-1.1.8-avoid-diskless-test.patch':
+             'a8b262fa201d55f59015e1bc14466c1d113f807543bc1e05a22481ab0d216d72'},
+            {'netcdf4-python-1.6.1_relax_tolerance_compression_test.patch':
+             '64d192a5d1e3e00af78f053da78f5a35015fa713c7f97b10b622be6a44347166'},
+        ],
+    }),
+]
+
+fix_python_shebang_for = ['bin/*']
+
+sanity_check_paths = {
+    'files': ['bin/nc3tonc4', 'bin/nc4tonc3', 'bin/ncinfo'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [
+    "nc4tonc3 --help",
+    "nc3tonc4 --help",
+    "ncinfo --help",
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/n/networkx/networkx-3.2.1-gfbf-2023b-b.eb
+++ b/easybuild/easyconfigs/n/networkx/networkx-3.2.1-gfbf-2023b-b.eb
@@ -1,0 +1,25 @@
+easyblock = 'PythonPackage'
+
+name = 'networkx'
+version = '3.2.1'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://pypi.python.org/pypi/networkx'
+description = """NetworkX is a Python package for the creation, manipulation,
+and study of the structure, dynamics, and functions of complex networks."""
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['9f1bb5cf3409bf324e0a722c20bdb4c20ee39bf1c30ce8ae499c8502b0b5e0c6']
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),  # required for numpy, scipy, ...
+]
+
+use_pip = True
+download_dep_fail = True
+sanity_pip_check = True
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/n/networkx/networkx-3.2.1-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/n/networkx/networkx-3.2.1-iimkl-2023b.eb
@@ -1,0 +1,24 @@
+easyblock = 'PythonPackage'
+
+name = 'networkx'
+version = '3.2.1'
+
+homepage = 'https://pypi.python.org/pypi/networkx'
+description = """NetworkX is a Python package for the creation, manipulation,
+and study of the structure, dynamics, and functions of complex networks."""
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['9f1bb5cf3409bf324e0a722c20bdb4c20ee39bf1c30ce8ae499c8502b0b5e0c6']
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),  # required for numpy, scipy, ...
+]
+
+use_pip = True
+download_dep_fail = True
+sanity_pip_check = True
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/n/nf-core/nf-core-2.13.1-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/n/nf-core/nf-core-2.13.1-foss-2023b-b.eb
@@ -1,0 +1,108 @@
+easyblock = 'PythonBundle'
+
+name = 'nf-core'
+version = '2.13.1'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://github.com/nf-core/tools'
+description = """Python package with helper tools for the nf-core community."""
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+
+builddependencies = [('poetry', '1.6.1')]
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('GitPython', '3.1.42'),
+    ('Markdown', '3.6'),
+    ('Pillow', '10.2.0'),
+    ('prompt-toolkit', '3.0.36'),
+    ('pydantic', '2.6.4'),
+    ('pyfaidx', '0.8.1.1'),
+    ('pytest-workflow', '2.1.0'),
+    ('PyYAML', '6.0.1'),
+    ('tqdm', '4.66.2'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('pdiff', '1.1.4', {
+        'checksums': ['9d8f6f8e7ed2ee61aa2f2526106c0047a2bd80eab7d1237f7086139a6e921c45'],
+    }),
+    ('textual', '0.54.0', {
+        'checksums': ['0cfd134dde5ae49d64dd73bb32a2fb5a86d878d9caeacecaa1d640082f31124e'],
+    }),
+    ('trogon', '0.5.0', {
+        'checksums': ['61a57f0f1a38227d90601cd020f46960be8e36947b5e56c6932c2e01ecc5042a'],
+    }),
+    ('url-normalize', '1.4.3', {
+        'checksums': ['d23d3a070ac52a67b83a1c59a0e68f8608d1cd538783b401bc9de2c0fac999b2'],
+    }),
+    ('cattrs', '23.2.3', {
+        'checksums': ['a934090d95abaa9e911dac357e3a8699e0b4b14f8529bcc7d2b1ad9d51672b9f'],
+    }),
+    ('requests-cache', '1.2.0', {
+        'source_tmpl': 'requests_cache-%(version)s.tar.gz',
+        'checksums': ['db1c709ca343cc1cd5b6c8b1a5387298eceed02306a6040760db538c885e3838'],
+    }),
+    ('ubiquerg', '0.7.0', {
+        'checksums': ['b873ff87651e500fb32ac24a7850abe6261fde65c4c07bf6e0b5f14e32cd9387'],
+    }),
+    ('oyaml', '1.0', {
+        'checksums': ['ed8fc096811f4763e1907dce29c35895d6d5936c4d0400fe843a91133d4744ed'],
+    }),
+    ('attmap', '0.13.2', {
+        'checksums': ['fdffa45f8671c13428eb8c3a1702bfdd1123badb99f7af14d72ad53cc7e770de'],
+    }),
+    ('yacman', '0.9.3', {
+        'checksums': ['91f29ecad7abf32425be034619bd5b00a50fe2be23447b1827c34e1fd68c055d'],
+    }),
+    ('refgenconf', '0.12.2', {
+        'checksums': ['6c9f9ecd8b91b4f75a535cfbdbdfb136f2dc9e9864142d07aa0352c61cf0cf78'],
+    }),
+    ('logmuse', '0.2.7', {
+        'checksums': ['a4692c44ddfa912c3cb149ca4c7545f80119aa7485868fd1412e7c647e9a7e7e'],
+    }),
+    ('peppy', '0.40.1', {
+        'checksums': ['22ed51ae042ec2e1fbfa213205967133319fa498a7f09aa438eccfebfae5e78f'],
+    }),
+    ('eido', '0.2.2', {
+        'checksums': ['3966c8e91296189d5827d6415843eb300d204c9da9b8a780807ebc5403be2800'],
+    }),
+    ('pipestat', '0.8.2', {
+        'checksums': ['b1bf52bc6f47a617a597d674e1a0d9a5c66d9771a6fcd8f115039c017021b9c7'],
+    }),
+    ('piper', '0.14.0', {
+        'modulename': 'pypiper',
+        'checksums': ['2d2b226689f2e992da0735f25ea432f16f230bfaef51e732ef50b1b495ce153c'],
+    }),
+    ('refgenie', '0.12.1', {
+        'checksums': ['cfd007ed0981e00d019deb49aaea896952341096494165cb8378488850eec451'],
+    }),
+    ('questionary', '2.0.1', {
+        'checksums': ['bcce898bf3dbb446ff62830c86c5c6fb9a22a54146f0f5597d3da43b10d8fc8b'],
+    }),
+    ('nodeenv', '1.8.0', {
+        'checksums': ['d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2'],
+    }),
+    ('identify', '2.5.35', {
+        'checksums': ['10a7ca245cfcd756a554a7288159f72ff105ad233c7c4b9c6f0f4d108f5f6791'],
+    }),
+    ('cfgv', '3.4.0', {
+        'checksums': ['e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560'],
+    }),
+    ('pre-commit', '3.7.0', {
+        'source_tmpl': 'pre_commit-%(version)s.tar.gz',
+        'checksums': ['e209d61b8acdcf742404408531f0c37d49d2c734fd7cff2d6076083d191cb060'],
+    }),
+    ('filetype', '1.2.0', {
+        'checksums': ['66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb'],
+    }),
+    (name, version, {
+        'checksums': ['297bb52144a0651b3b718325726b10a14bef0b1b3a1d65a0eadb4badb47c8a6f'],
+    }),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/n/nf-core/nf-core-2.13.1-intel-2023b.eb
+++ b/easybuild/easyconfigs/n/nf-core/nf-core-2.13.1-intel-2023b.eb
@@ -1,0 +1,107 @@
+easyblock = 'PythonBundle'
+
+name = 'nf-core'
+version = '2.13.1'
+
+homepage = 'https://github.com/nf-core/tools'
+description = """Python package with helper tools for the nf-core community."""
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+
+builddependencies = [('poetry', '1.6.1')]
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('GitPython', '3.1.42'),
+    ('Markdown', '3.6'),
+    ('Pillow', '10.2.0'),
+    ('prompt-toolkit', '3.0.36'),
+    ('pydantic', '2.6.4'),
+    ('pyfaidx', '0.8.1.1'),
+    ('pytest-workflow', '2.1.0'),
+    ('PyYAML', '6.0.1'),
+    ('tqdm', '4.66.2'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('pdiff', '1.1.4', {
+        'checksums': ['9d8f6f8e7ed2ee61aa2f2526106c0047a2bd80eab7d1237f7086139a6e921c45'],
+    }),
+    ('textual', '0.54.0', {
+        'checksums': ['0cfd134dde5ae49d64dd73bb32a2fb5a86d878d9caeacecaa1d640082f31124e'],
+    }),
+    ('trogon', '0.5.0', {
+        'checksums': ['61a57f0f1a38227d90601cd020f46960be8e36947b5e56c6932c2e01ecc5042a'],
+    }),
+    ('url-normalize', '1.4.3', {
+        'checksums': ['d23d3a070ac52a67b83a1c59a0e68f8608d1cd538783b401bc9de2c0fac999b2'],
+    }),
+    ('cattrs', '23.2.3', {
+        'checksums': ['a934090d95abaa9e911dac357e3a8699e0b4b14f8529bcc7d2b1ad9d51672b9f'],
+    }),
+    ('requests-cache', '1.2.0', {
+        'source_tmpl': 'requests_cache-%(version)s.tar.gz',
+        'checksums': ['db1c709ca343cc1cd5b6c8b1a5387298eceed02306a6040760db538c885e3838'],
+    }),
+    ('ubiquerg', '0.7.0', {
+        'checksums': ['b873ff87651e500fb32ac24a7850abe6261fde65c4c07bf6e0b5f14e32cd9387'],
+    }),
+    ('oyaml', '1.0', {
+        'checksums': ['ed8fc096811f4763e1907dce29c35895d6d5936c4d0400fe843a91133d4744ed'],
+    }),
+    ('attmap', '0.13.2', {
+        'checksums': ['fdffa45f8671c13428eb8c3a1702bfdd1123badb99f7af14d72ad53cc7e770de'],
+    }),
+    ('yacman', '0.9.3', {
+        'checksums': ['91f29ecad7abf32425be034619bd5b00a50fe2be23447b1827c34e1fd68c055d'],
+    }),
+    ('refgenconf', '0.12.2', {
+        'checksums': ['6c9f9ecd8b91b4f75a535cfbdbdfb136f2dc9e9864142d07aa0352c61cf0cf78'],
+    }),
+    ('logmuse', '0.2.7', {
+        'checksums': ['a4692c44ddfa912c3cb149ca4c7545f80119aa7485868fd1412e7c647e9a7e7e'],
+    }),
+    ('peppy', '0.40.1', {
+        'checksums': ['22ed51ae042ec2e1fbfa213205967133319fa498a7f09aa438eccfebfae5e78f'],
+    }),
+    ('eido', '0.2.2', {
+        'checksums': ['3966c8e91296189d5827d6415843eb300d204c9da9b8a780807ebc5403be2800'],
+    }),
+    ('pipestat', '0.8.2', {
+        'checksums': ['b1bf52bc6f47a617a597d674e1a0d9a5c66d9771a6fcd8f115039c017021b9c7'],
+    }),
+    ('piper', '0.14.0', {
+        'modulename': 'pypiper',
+        'checksums': ['2d2b226689f2e992da0735f25ea432f16f230bfaef51e732ef50b1b495ce153c'],
+    }),
+    ('refgenie', '0.12.1', {
+        'checksums': ['cfd007ed0981e00d019deb49aaea896952341096494165cb8378488850eec451'],
+    }),
+    ('questionary', '2.0.1', {
+        'checksums': ['bcce898bf3dbb446ff62830c86c5c6fb9a22a54146f0f5597d3da43b10d8fc8b'],
+    }),
+    ('nodeenv', '1.8.0', {
+        'checksums': ['d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2'],
+    }),
+    ('identify', '2.5.35', {
+        'checksums': ['10a7ca245cfcd756a554a7288159f72ff105ad233c7c4b9c6f0f4d108f5f6791'],
+    }),
+    ('cfgv', '3.4.0', {
+        'checksums': ['e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560'],
+    }),
+    ('pre-commit', '3.7.0', {
+        'source_tmpl': 'pre_commit-%(version)s.tar.gz',
+        'checksums': ['e209d61b8acdcf742404408531f0c37d49d2c734fd7cff2d6076083d191cb060'],
+    }),
+    ('filetype', '1.2.0', {
+        'checksums': ['66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb'],
+    }),
+    (name, version, {
+        'checksums': ['297bb52144a0651b3b718325726b10a14bef0b1b3a1d65a0eadb4badb47c8a6f'],
+    }),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.12.0-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.12.0-foss-2023b-b.eb
@@ -1,0 +1,74 @@
+easyblock = 'CMakeMake'
+
+name = 'ParaView'
+version = '5.12.0'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://www.paraview.org'
+description = "ParaView is a scientific parallel visualizer."
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+local_download_suffix = 'download.php?submit=Download&version=v%(version_major_minor)s&type=source&os=all&downloadFile='
+source_urls = ['https://www.paraview.org/paraview-downloads/%s' % local_download_suffix]
+sources = ["%(name)s-v%(version)s.tar.gz"]
+patches = ['ParaView-5.11.1-remove_glew_init_warning.patch']
+checksums = [
+    {'ParaView-v5.12.0.tar.gz': '2cc5733608fd508e2da8fc5d4ee693523d350dc1e1f89f9a89a78dc63107f70e'},
+    {'ParaView-5.11.1-remove_glew_init_warning.patch':
+     'dd86134f3a5b2c1b834224c69665dd31f99ef7d367688fe77dbaada212758710'},
+]
+
+builddependencies = [('CMake', '3.27.6')]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('Boost', '1.83.0'),
+    ('XZ', '5.4.4'),
+    ('HDF5', '1.14.3'),
+    ('netCDF', '4.9.2'),
+    ('libdrm', '2.4.117'),
+    ('Mesa', '23.1.9'),
+    ('Qt6', '6.6.3'),
+    ('zlib', '1.2.13'),
+    ('FFmpeg', '6.0'),
+    ('Szip', '2.1.1'),
+]
+
+_copts = [
+    # Basic configuration
+    # Embedded docs not supported with Qt6 https://gitlab.kitware.com/paraview/paraview/-/issues/19742
+    '-DPARAVIEW_ENABLE_EMBEDDED_DOCUMENTATION=OFF',
+    '-DCMAKE_AUTOMOC=OFF',  # err Qt6?
+    '-DPARAVIEW_INSTALL_DEVELOPMENT_FILES=ON',
+    '-DPARAVIEW_BUILD_SHARED_LIBS=ON',
+    '-DPARAVIEW_USE_MPI=ON',
+    '-DPARAVIEW_ENABLE_FFMPEG=ON',
+    '-DPARAVIEW_USE_PYTHON=ON',
+    '-DPython3_ROOT_DIR=$EBROOTPYTHON',
+    # Useful input formats
+    '-DPARAVIEW_ENABLE_XDMF2=ON',
+    '-DPARAVIEW_ENABLE_XDMF3=ON',
+    # EGL, X and Mesa
+    '-DOPENGL_glu_LIBRARY=$EBROOTLIBGLU/lib/libGLU.%s' % SHLIB_EXT,
+    '-DOPENGL_INCLUDE_DIR=$EBROOTMESA/include',
+    '-DEGL_INCLUDE_DIR=$EBROOTLIBGLVND/include',
+    '-DEGL_LIBRARY=$EBROOTLIBGLVND/lib/libEGL.%s' % SHLIB_EXT,
+    '-DEGL_opengl_LIBRARY=$EBROOTLIBGLVND/libOpenGL.%s' % SHLIB_EXT,
+    '-DVTK_OPENGL_HAS_EGL=ON',
+    '-DVTK_USE_X=ON',
+    '-DVTK_OPENGL_HAS_OSMESA=OFF']
+configopts = ' '.join(_copts)
+
+sanity_check_paths = {
+    'files': ['bin/paraview', 'bin/pvserver', 'bin/pvpython'],
+    'dirs': ['include/paraview-%(version_major_minor)s', 'lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ['python -c "import paraview"']
+
+modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.12.0-intel-2023b.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.12.0-intel-2023b.eb
@@ -1,0 +1,73 @@
+easyblock = 'CMakeMake'
+
+name = 'ParaView'
+version = '5.12.0'
+
+homepage = 'https://www.paraview.org'
+description = "ParaView is a scientific parallel visualizer."
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+local_download_suffix = 'download.php?submit=Download&version=v%(version_major_minor)s&type=source&os=all&downloadFile='
+source_urls = ['https://www.paraview.org/paraview-downloads/%s' % local_download_suffix]
+sources = ["%(name)s-v%(version)s.tar.gz"]
+patches = ['ParaView-5.11.1-remove_glew_init_warning.patch']
+checksums = [
+    {'ParaView-v5.12.0.tar.gz': '2cc5733608fd508e2da8fc5d4ee693523d350dc1e1f89f9a89a78dc63107f70e'},
+    {'ParaView-5.11.1-remove_glew_init_warning.patch':
+     'dd86134f3a5b2c1b834224c69665dd31f99ef7d367688fe77dbaada212758710'},
+]
+
+builddependencies = [('CMake', '3.27.6')]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('Boost', '1.83.0'),
+    ('XZ', '5.4.4'),
+    ('HDF5', '1.14.4.3'),
+    ('netCDF', '4.9.2'),
+    ('libdrm', '2.4.117'),
+    ('Mesa', '23.1.9'),
+    ('Qt6', '6.6.3'),
+    ('zlib', '1.2.13'),
+    ('FFmpeg', '6.0'),
+    ('Szip', '2.1.1'),
+]
+
+_copts = [
+    # Basic configuration
+    # Embedded docs not supported with Qt6 https://gitlab.kitware.com/paraview/paraview/-/issues/19742
+    '-DPARAVIEW_ENABLE_EMBEDDED_DOCUMENTATION=OFF',
+    '-DCMAKE_AUTOMOC=OFF',  # err Qt6?
+    '-DPARAVIEW_INSTALL_DEVELOPMENT_FILES=ON',
+    '-DPARAVIEW_BUILD_SHARED_LIBS=ON',
+    '-DPARAVIEW_USE_MPI=ON',
+    '-DPARAVIEW_ENABLE_FFMPEG=ON',
+    '-DPARAVIEW_USE_PYTHON=ON',
+    '-DPython3_ROOT_DIR=$EBROOTPYTHON',
+    # Useful input formats
+    '-DPARAVIEW_ENABLE_XDMF2=ON',
+    '-DPARAVIEW_ENABLE_XDMF3=ON',
+    # EGL, X and Mesa
+    '-DOPENGL_glu_LIBRARY=$EBROOTLIBGLU/lib/libGLU.%s' % SHLIB_EXT,
+    '-DOPENGL_INCLUDE_DIR=$EBROOTMESA/include',
+    '-DEGL_INCLUDE_DIR=$EBROOTLIBGLVND/include',
+    '-DEGL_LIBRARY=$EBROOTLIBGLVND/lib/libEGL.%s' % SHLIB_EXT,
+    '-DEGL_opengl_LIBRARY=$EBROOTLIBGLVND/libOpenGL.%s' % SHLIB_EXT,
+    '-DVTK_OPENGL_HAS_EGL=ON',
+    '-DVTK_USE_X=ON',
+    '-DVTK_OPENGL_HAS_OSMESA=OFF']
+configopts = ' '.join(_copts)
+
+sanity_check_paths = {
+    'files': ['bin/paraview', 'bin/pvserver', 'bin/pvpython'],
+    'dirs': ['include/paraview-%(version_major_minor)s', 'lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ['python -c "import paraview"']
+
+modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/PyTables/PyTables-3.9.2-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/p/PyTables/PyTables-3.9.2-foss-2023b-b.eb
@@ -1,0 +1,77 @@
+# http://www.pytables.org/usersguide/installation.html
+# updated: Denis Kristak (INUITS)
+
+easyblock = 'PythonBundle'
+
+name = 'PyTables'
+version = '3.9.2'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://www.pytables.org'
+description = """PyTables is a package for managing hierarchical datasets and designed to efficiently and easily cope
+ with extremely large amounts of data. PyTables is built on top of the HDF5 library, using the Python language and the
+ NumPy package. It features an object-oriented interface that, combined with C extensions for the performance-critical
+ parts of the code (generated using Cython), makes it a fast, yet extremely easy to use tool for interactively browsing,
+ processing and searching very large amounts of data. One important feature of PyTables is that it optimizes memory and 
+ disk resources so that data takes much less space (specially if on-flight compression is used) than other solutions 
+ such as relational or object oriented databases."""
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+toolchainopts = {'usempi': True}
+
+builddependencies = [
+    ('pkgconf', '2.0.3'),
+    ('CMake', '3.27.6'),
+    ('Ninja', '1.11.1'),
+    ('scikit-build', '0.17.6'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),  # provides numexpr
+    ('HDF5', '1.14.3'),
+    ('LZO', '2.10'),
+    ('Blosc', '1.21.5'),
+    ('Blosc2', '2.13.2'),
+    ('py-cpuinfo', '9.0.0'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('ndindex', '1.8', {
+        'checksums': ['5fc87ebc784605f01dd5367374cb40e8da8f2c30988968990066c5098a7eebe8'],
+    }),
+    # need to align version of blosc2 Python package with version of C Blosc2 used,
+    # see https://github.com/Blosc/python-blosc2/blob/main/RELEASE_NOTES.md
+    ('blosc2', '2.5.1', {
+        'checksums': ['47d5df50e7286edf81e629ece35f87f13f55c13c5e8545832188c420c75d1659'],
+        'preinstallopts': """sed -i 's/version=/cmake_args=["-DUSE_SYSTEM_BLOSC2=YES"], version=/g' setup.py && """,
+    }),
+    ('tables', version, {
+        'patches': [
+            'PyTables-3.8.0_fix-libs.patch',
+            'PyTables-3.9.2_fix-find-blosc2-dep.patch',
+        ],
+        'checksums': [
+            {'tables-3.9.2.tar.gz': 'd470263c2e50c4b7c8635a0d99ac1ff2f9e704c24d71e5fa33c4529e7d0ad9c3'},
+            {'PyTables-3.8.0_fix-libs.patch': '7a1e6fa1f9169e52293e2b433a4302fa13c5d31e7709cd4fe0e087199b9e3f8a'},
+            {'PyTables-3.9.2_fix-find-blosc2-dep.patch':
+             'e2149f43da12d9ba26cca4c838f6e8a4694adab75c0f055b186674a017e41a55'},
+        ],
+    }),
+]
+
+local_bins = ['pt2to3', 'ptdump', 'ptrepack', 'pttree']
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in local_bins],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+options = {'modulename': 'tables'}
+
+sanity_check_commands = ["%s --help" % x for x in local_bins]
+
+sanity_pip_check = True
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/p/PyTables/PyTables-3.9.2-intel-2023b.eb
+++ b/easybuild/easyconfigs/p/PyTables/PyTables-3.9.2-intel-2023b.eb
@@ -1,0 +1,76 @@
+# http://www.pytables.org/usersguide/installation.html
+# updated: Denis Kristak (INUITS)
+
+easyblock = 'PythonBundle'
+
+name = 'PyTables'
+version = '3.9.2'
+
+homepage = 'https://www.pytables.org'
+description = """PyTables is a package for managing hierarchical datasets and designed to efficiently and easily cope
+ with extremely large amounts of data. PyTables is built on top of the HDF5 library, using the Python language and the
+ NumPy package. It features an object-oriented interface that, combined with C extensions for the performance-critical
+ parts of the code (generated using Cython), makes it a fast, yet extremely easy to use tool for interactively browsing,
+ processing and searching very large amounts of data. One important feature of PyTables is that it optimizes memory and 
+ disk resources so that data takes much less space (specially if on-flight compression is used) than other solutions 
+ such as relational or object oriented databases."""
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+toolchainopts = {'usempi': True}
+
+builddependencies = [
+    ('pkgconf', '2.0.3'),
+    ('CMake', '3.27.6'),
+    ('Ninja', '1.11.1'),
+    ('scikit-build', '0.17.6'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),  # provides numexpr
+    ('HDF5', '1.14.3'),
+    ('LZO', '2.10'),
+    ('Blosc', '1.21.5'),
+    ('Blosc2', '2.13.2'),
+    ('py-cpuinfo', '9.0.0'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('ndindex', '1.8', {
+        'checksums': ['5fc87ebc784605f01dd5367374cb40e8da8f2c30988968990066c5098a7eebe8'],
+    }),
+    # need to align version of blosc2 Python package with version of C Blosc2 used,
+    # see https://github.com/Blosc/python-blosc2/blob/main/RELEASE_NOTES.md
+    ('blosc2', '2.5.1', {
+        'checksums': ['47d5df50e7286edf81e629ece35f87f13f55c13c5e8545832188c420c75d1659'],
+        'preinstallopts': """sed -i 's/version=/cmake_args=["-DUSE_SYSTEM_BLOSC2=YES"], version=/g' setup.py && """,
+    }),
+    ('tables', version, {
+        'patches': [
+            'PyTables-3.8.0_fix-libs.patch',
+            'PyTables-3.9.2_fix-find-blosc2-dep.patch',
+        ],
+        'checksums': [
+            {'tables-3.9.2.tar.gz': 'd470263c2e50c4b7c8635a0d99ac1ff2f9e704c24d71e5fa33c4529e7d0ad9c3'},
+            {'PyTables-3.8.0_fix-libs.patch': '7a1e6fa1f9169e52293e2b433a4302fa13c5d31e7709cd4fe0e087199b9e3f8a'},
+            {'PyTables-3.9.2_fix-find-blosc2-dep.patch':
+             'e2149f43da12d9ba26cca4c838f6e8a4694adab75c0f055b186674a017e41a55'},
+        ],
+    }),
+]
+
+local_bins = ['pt2to3', 'ptdump', 'ptrepack', 'pttree']
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in local_bins],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+options = {'modulename': 'tables'}
+
+sanity_check_commands = ["%s --help" % x for x in local_bins]
+
+sanity_pip_check = True
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.1.2-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.1.2-foss-2023b-b.eb
@@ -1,0 +1,186 @@
+name = 'PyTorch'
+version = '2.1.2'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://pytorch.org/'
+description = """Tensors and Dynamic neural networks in Python with strong GPU acceleration.
+PyTorch is a deep learning framework that puts Python first."""
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+
+source_urls = [GITHUB_RELEASE]
+sources = ['%(namelower)s-v%(version)s.tar.gz']
+patches = [
+    'PyTorch-1.7.0_disable-dev-shm-test.patch',
+    'PyTorch-1.11.1_skip-test_init_from_local_shards.patch',
+    'PyTorch-1.12.1_add-hypothesis-suppression.patch',
+    'PyTorch-1.12.1_fix-test_cpp_extensions_jit.patch',
+    'PyTorch-1.12.1_fix-TestTorch.test_to.patch',
+    'PyTorch-1.12.1_skip-test_round_robin.patch',
+    'PyTorch-1.13.1_fix-gcc-12-warning-in-fbgemm.patch',
+    'PyTorch-1.13.1_fix-protobuf-dependency.patch',
+    'PyTorch-1.13.1_fix-warning-in-test-cpp-api.patch',
+    'PyTorch-1.13.1_skip-failing-singular-grad-test.patch',
+    'PyTorch-1.13.1_skip-tests-without-fbgemm.patch',
+    'PyTorch-2.0.1_avoid-test_quantization-failures.patch',
+    'PyTorch-2.0.1_fix-skip-decorators.patch',
+    'PyTorch-2.0.1_fix-ub-in-inductor-codegen.patch',
+    'PyTorch-2.0.1_fix-vsx-loadu.patch',
+    'PyTorch-2.0.1_no-cuda-stubs-rpath.patch',
+    'PyTorch-2.0.1_skip-failing-gradtest.patch',
+    'PyTorch-2.0.1_skip-test_shuffle_reproducibility.patch',
+    'PyTorch-2.0.1_skip-tests-skipped-in-subprocess.patch',
+    'PyTorch-2.1.0_disable-gcc12-warning.patch',
+    'PyTorch-2.1.0_fix-bufferoverflow-in-oneDNN.patch',
+    'PyTorch-2.1.0_fix-test_numpy_torch_operators.patch',
+    'PyTorch-2.1.0_fix-validationError-output-test.patch',
+    'PyTorch-2.1.0_fix-vsx-vector-shift-functions.patch',
+    'PyTorch-2.1.0_increase-tolerance-functorch-test_vmapvjpvjp.patch',
+    'PyTorch-2.1.0_remove-sparse-csr-nnz-overflow-test.patch',
+    'PyTorch-2.1.0_remove-test-requiring-online-access.patch',
+    'PyTorch-2.1.0_skip-diff-test-on-ppc.patch',
+    'PyTorch-2.1.0_skip-dynamo-test_predispatch.patch',
+    'PyTorch-2.1.0_skip-test_jvp_linalg_det_singular.patch',
+    'PyTorch-2.1.0_skip-test_linear_fp32-without-MKL.patch',
+    'PyTorch-2.1.0_skip-test_wrap_bad.patch',
+    'PyTorch-2.1.2_fix-test_extension_backend-without-vectorization.patch',
+    'PyTorch-2.1.2_fix-test_memory_profiler.patch',
+    'PyTorch-2.1.2_fix-test_torchinductor-rounding.patch',
+    'PyTorch-2.1.2_fix-vsx-vector-abs.patch',
+    'PyTorch-2.1.2_fix-vsx-vector-div.patch',
+    'PyTorch-2.1.2_skip-cpu_repro-test-without-vectorization.patch',
+    'PyTorch-2.1.2_skip-memory-leak-test.patch',
+    'PyTorch-2.1.2_workaround_dynamo_failure_without_nnpack.patch',
+]
+checksums = [
+    {'pytorch-v2.1.2.tar.gz': '85effbcce037bffa290aea775c9a4bad5f769cb229583450c40055501ee1acd7'},
+    {'PyTorch-1.7.0_disable-dev-shm-test.patch': '622cb1eaeadc06e13128a862d9946bcc1f1edd3d02b259c56a9aecc4d5406b8a'},
+    {'PyTorch-1.11.1_skip-test_init_from_local_shards.patch':
+     '4aeb1b0bc863d4801b0095cbce69f8794066748f0df27c6aaaf729c5ecba04b7'},
+    {'PyTorch-1.12.1_add-hypothesis-suppression.patch':
+     'e71ffb94ebe69f580fa70e0de84017058325fdff944866d6bd03463626edc32c'},
+    {'PyTorch-1.12.1_fix-test_cpp_extensions_jit.patch':
+     '1efc9850c431d702e9117d4766277d3f88c5c8b3870997c9974971bce7f2ab83'},
+    {'PyTorch-1.12.1_fix-TestTorch.test_to.patch': '75f27987c3f25c501e719bd2b1c70a029ae0ee28514a97fe447516aee02b1535'},
+    {'PyTorch-1.12.1_skip-test_round_robin.patch': '63d4849b78605aa088fdff695637d9473ea60dee603a3ff7f788690d70c55349'},
+    {'PyTorch-1.13.1_fix-gcc-12-warning-in-fbgemm.patch':
+     '5c7be91a6096083a0b1315efe0001537499c600f1f569953c6a2c7f4cc1d0910'},
+    {'PyTorch-1.13.1_fix-protobuf-dependency.patch':
+     '8bd755a0cab7233a243bc65ca57c9630dfccdc9bf8c9792f0de4e07a644fcb00'},
+    {'PyTorch-1.13.1_fix-warning-in-test-cpp-api.patch':
+     'bdde0f2105215c95a54de64ec4b1a4520528510663174fef6d5b900eb1db3937'},
+    {'PyTorch-1.13.1_skip-failing-singular-grad-test.patch':
+     '72688a57b2bb617665ad1a1d5e362c5111ae912c10936bb38a089c0204729f48'},
+    {'PyTorch-1.13.1_skip-tests-without-fbgemm.patch':
+     '481e595f673baf8ae58b41697a6792b83048b0264aa79b422f48cd8c22948bb7'},
+    {'PyTorch-2.0.1_avoid-test_quantization-failures.patch':
+     '02e3f47e4ed1d7d6077e26f1ae50073dc2b20426269930b505f4aefe5d2f33cd'},
+    {'PyTorch-2.0.1_fix-skip-decorators.patch': '2039012cef45446065e1a2097839fe20bb29fe3c1dcc926c3695ebf29832e920'},
+    {'PyTorch-2.0.1_fix-ub-in-inductor-codegen.patch':
+     '1b37194f55ae678f3657b8728dfb896c18ffe8babe90987ce468c4fa9274f357'},
+    {'PyTorch-2.0.1_fix-vsx-loadu.patch': 'a0ffa61da2d47c6acd09aaf6d4791e527d8919a6f4f1aa7ed38454cdcadb1f72'},
+    {'PyTorch-2.0.1_no-cuda-stubs-rpath.patch': '8902e58a762240f24cdbf0182e99ccdfc2a93492869352fcb4ca0ec7e407f83a'},
+    {'PyTorch-2.0.1_skip-failing-gradtest.patch': '8030bdec6ba49b057ab232d19a7f1a5e542e47e2ec340653a246ec9ed59f8bc1'},
+    {'PyTorch-2.0.1_skip-test_shuffle_reproducibility.patch':
+     '7047862abc1abaff62954da59700f36d4f39fcf83167a638183b1b7f8fec78ae'},
+    {'PyTorch-2.0.1_skip-tests-skipped-in-subprocess.patch':
+     '166c134573a95230e39b9ea09ece3ad8072f39d370c9a88fb2a1e24f6aaac2b5'},
+    {'PyTorch-2.1.0_disable-gcc12-warning.patch': 'c858b8db0010f41005dc06f9a50768d0d3dc2d2d499ccbdd5faf8a518869a421'},
+    {'PyTorch-2.1.0_fix-bufferoverflow-in-oneDNN.patch':
+     'b15b1291a3c37bf6a4982cfbb3483f693acb46a67bc0912b383fd98baf540ccf'},
+    {'PyTorch-2.1.0_fix-test_numpy_torch_operators.patch':
+     '84bb51a719abc677031a7a3dfe4382ff098b0cbd8b39b8bed2a7fa03f80ac1e9'},
+    {'PyTorch-2.1.0_fix-validationError-output-test.patch':
+     '7eba0942afb121ed92fac30d1529447d892a89eb3d53c565f8e9d480e95f692b'},
+    {'PyTorch-2.1.0_fix-vsx-vector-shift-functions.patch':
+     '3793b4b878be1abe7791efcbd534774b87862cfe7dc4774ca8729b6cabb39e7e'},
+    {'PyTorch-2.1.0_increase-tolerance-functorch-test_vmapvjpvjp.patch':
+     'aef38adf1210d0c5455e91d7c7a9d9e5caad3ae568301e0ba9fc204309438e7b'},
+    {'PyTorch-2.1.0_remove-sparse-csr-nnz-overflow-test.patch':
+     '0ac36411e76506b3354c85a8a1260987f66af947ee52ffc64230aee1fa02ea8b'},
+    {'PyTorch-2.1.0_remove-test-requiring-online-access.patch':
+     '35184b8c5a1b10f79e511cc25db3b8a5585a5d58b5d1aa25dd3d250200b14fd7'},
+    {'PyTorch-2.1.0_skip-diff-test-on-ppc.patch': '394157dbe565ffcbc1821cd63d05930957412156cc01e949ef3d3524176a1dda'},
+    {'PyTorch-2.1.0_skip-dynamo-test_predispatch.patch':
+     '6298daf9ddaa8542850eee9ea005f28594ab65b1f87af43d8aeca1579a8c4354'},
+    {'PyTorch-2.1.0_skip-test_jvp_linalg_det_singular.patch':
+     '5229ca88a71db7667a90ddc0b809b2c817698bd6e9c5aaabd73d3173cf9b99fe'},
+    {'PyTorch-2.1.0_skip-test_linear_fp32-without-MKL.patch':
+     '5dcc79883b6e3ec0a281a8e110db5e0a5880de843bb05653589891f16473ead5'},
+    {'PyTorch-2.1.0_skip-test_wrap_bad.patch': 'b8583125ee94e553b6f77c4ab4bfa812b89416175dc7e9b7390919f3b485cb63'},
+    {'PyTorch-2.1.2_fix-test_extension_backend-without-vectorization.patch':
+     'cd1455495886a7d6b2d30d48736eb0103fded21e2e36de6baac719b9c52a1c92'},
+    {'PyTorch-2.1.2_fix-test_memory_profiler.patch':
+     '30b0c9355636c0ab3dedae02399789053825dc3835b4d7dac6e696767772b1ce'},
+    {'PyTorch-2.1.2_fix-test_torchinductor-rounding.patch':
+     'a0ef99192ee2ad1509c78a8377023d5be2b5fddb16f84063b7c9a0b53d979090'},
+    {'PyTorch-2.1.2_fix-vsx-vector-abs.patch': 'd67d32407faed7dc1dbab4bba0e2f7de36c3db04560ced35c94caf8d84ade886'},
+    {'PyTorch-2.1.2_fix-vsx-vector-div.patch': '11f497a6892eb49b249a15320e4218e0d7ac8ae4ce67de39e4a018a064ca1acc'},
+    {'PyTorch-2.1.2_skip-cpu_repro-test-without-vectorization.patch':
+     '7ace835af60c58d9e0754a34c19d4b9a0c3a531f19e5d0eba8e2e49206eaa7eb'},
+    {'PyTorch-2.1.2_skip-memory-leak-test.patch': '8d9841208e8a00a498295018aead380c360cf56e500ef23ca740adb5b36de142'},
+    {'PyTorch-2.1.2_workaround_dynamo_failure_without_nnpack.patch':
+     'fb96eefabf394617bbb3fbd3a7a7c1aa5991b3836edc2e5d2a30e708bfe49ba1'},
+]
+
+osdependencies = [OS_PKG_IBVERBS_DEV]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('hypothesis', '6.90.0'),
+    # For tests
+    ('pytest-flakefinder', '1.1.0'),
+    ('pytest-rerunfailures', '14.0'),
+    ('pytest-shard', '0.1.2'),
+]
+
+dependencies = [
+    ('Ninja', '1.11.1'),  # Required for JIT compilation of C++ extensions
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('protobuf', '25.3'),
+    ('protobuf-python', '4.25.3'),
+    ('pybind11', '2.11.1'),
+    ('SciPy-bundle', '2023.12'),
+    ('PyYAML', '6.0.1'),
+    ('MPFR', '4.2.1'),
+    ('GMP', '6.3.0'),
+    ('numactl', '2.0.16'),
+    ('FFmpeg', '6.0'),
+    ('Pillow', '10.2.0'),
+    ('expecttest', '0.2.1'),
+    ('networkx', '3.2.1'),
+    ('sympy', '1.12'),
+    ('Z3', '4.13.0',),
+]
+
+use_pip = True
+buildcmd = '%(python)s setup.py build'  # Run the (long) build in the build step
+
+excluded_tests = {
+    '': [
+        # This test seems to take too long on NVIDIA Ampere at least.
+        'distributed/test_distributed_spawn',
+        # Broken on CUDA 11.6/11.7: https://github.com/pytorch/pytorch/issues/75375
+        'distributions/test_constraints',
+        # no xdoctest
+        'doctests',
+        # failing on broadwell
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17712
+        'test_native_mha',
+        # intermittent failures on various systems
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17712
+        'distributed/rpc/test_tensorpipe_agent',
+    ]
+}
+
+runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
+
+# Especially test_quantization has a few corner cases that are triggered by the random input values,
+# those cannot be easily avoided, see https://github.com/pytorch/pytorch/issues/107030
+# So allow a low number of tests to fail as the tests "usually" succeed
+max_failed_tests = 2
+
+tests = ['PyTorch-check-cpp-extension.py']
+
+moduleclass = 'ai'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.1.2-intel-2023b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.1.2-intel-2023b.eb
@@ -1,0 +1,185 @@
+name = 'PyTorch'
+version = '2.1.2'
+
+homepage = 'https://pytorch.org/'
+description = """Tensors and Dynamic neural networks in Python with strong GPU acceleration.
+PyTorch is a deep learning framework that puts Python first."""
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+
+source_urls = [GITHUB_RELEASE]
+sources = ['%(namelower)s-v%(version)s.tar.gz']
+patches = [
+    'PyTorch-1.7.0_disable-dev-shm-test.patch',
+    'PyTorch-1.11.1_skip-test_init_from_local_shards.patch',
+    'PyTorch-1.12.1_add-hypothesis-suppression.patch',
+    'PyTorch-1.12.1_fix-test_cpp_extensions_jit.patch',
+    'PyTorch-1.12.1_fix-TestTorch.test_to.patch',
+    'PyTorch-1.12.1_skip-test_round_robin.patch',
+    'PyTorch-1.13.1_fix-gcc-12-warning-in-fbgemm.patch',
+    'PyTorch-1.13.1_fix-protobuf-dependency.patch',
+    'PyTorch-1.13.1_fix-warning-in-test-cpp-api.patch',
+    'PyTorch-1.13.1_skip-failing-singular-grad-test.patch',
+    'PyTorch-1.13.1_skip-tests-without-fbgemm.patch',
+    'PyTorch-2.0.1_avoid-test_quantization-failures.patch',
+    'PyTorch-2.0.1_fix-skip-decorators.patch',
+    'PyTorch-2.0.1_fix-ub-in-inductor-codegen.patch',
+    'PyTorch-2.0.1_fix-vsx-loadu.patch',
+    'PyTorch-2.0.1_no-cuda-stubs-rpath.patch',
+    'PyTorch-2.0.1_skip-failing-gradtest.patch',
+    'PyTorch-2.0.1_skip-test_shuffle_reproducibility.patch',
+    'PyTorch-2.0.1_skip-tests-skipped-in-subprocess.patch',
+    'PyTorch-2.1.0_disable-gcc12-warning.patch',
+    'PyTorch-2.1.0_fix-bufferoverflow-in-oneDNN.patch',
+    'PyTorch-2.1.0_fix-test_numpy_torch_operators.patch',
+    'PyTorch-2.1.0_fix-validationError-output-test.patch',
+    'PyTorch-2.1.0_fix-vsx-vector-shift-functions.patch',
+    'PyTorch-2.1.0_increase-tolerance-functorch-test_vmapvjpvjp.patch',
+    'PyTorch-2.1.0_remove-sparse-csr-nnz-overflow-test.patch',
+    'PyTorch-2.1.0_remove-test-requiring-online-access.patch',
+    'PyTorch-2.1.0_skip-diff-test-on-ppc.patch',
+    'PyTorch-2.1.0_skip-dynamo-test_predispatch.patch',
+    'PyTorch-2.1.0_skip-test_jvp_linalg_det_singular.patch',
+    'PyTorch-2.1.0_skip-test_linear_fp32-without-MKL.patch',
+    'PyTorch-2.1.0_skip-test_wrap_bad.patch',
+    'PyTorch-2.1.2_fix-test_extension_backend-without-vectorization.patch',
+    'PyTorch-2.1.2_fix-test_memory_profiler.patch',
+    'PyTorch-2.1.2_fix-test_torchinductor-rounding.patch',
+    'PyTorch-2.1.2_fix-vsx-vector-abs.patch',
+    'PyTorch-2.1.2_fix-vsx-vector-div.patch',
+    'PyTorch-2.1.2_skip-cpu_repro-test-without-vectorization.patch',
+    'PyTorch-2.1.2_skip-memory-leak-test.patch',
+    'PyTorch-2.1.2_workaround_dynamo_failure_without_nnpack.patch',
+]
+checksums = [
+    {'pytorch-v2.1.2.tar.gz': '85effbcce037bffa290aea775c9a4bad5f769cb229583450c40055501ee1acd7'},
+    {'PyTorch-1.7.0_disable-dev-shm-test.patch': '622cb1eaeadc06e13128a862d9946bcc1f1edd3d02b259c56a9aecc4d5406b8a'},
+    {'PyTorch-1.11.1_skip-test_init_from_local_shards.patch':
+     '4aeb1b0bc863d4801b0095cbce69f8794066748f0df27c6aaaf729c5ecba04b7'},
+    {'PyTorch-1.12.1_add-hypothesis-suppression.patch':
+     'e71ffb94ebe69f580fa70e0de84017058325fdff944866d6bd03463626edc32c'},
+    {'PyTorch-1.12.1_fix-test_cpp_extensions_jit.patch':
+     '1efc9850c431d702e9117d4766277d3f88c5c8b3870997c9974971bce7f2ab83'},
+    {'PyTorch-1.12.1_fix-TestTorch.test_to.patch': '75f27987c3f25c501e719bd2b1c70a029ae0ee28514a97fe447516aee02b1535'},
+    {'PyTorch-1.12.1_skip-test_round_robin.patch': '63d4849b78605aa088fdff695637d9473ea60dee603a3ff7f788690d70c55349'},
+    {'PyTorch-1.13.1_fix-gcc-12-warning-in-fbgemm.patch':
+     '5c7be91a6096083a0b1315efe0001537499c600f1f569953c6a2c7f4cc1d0910'},
+    {'PyTorch-1.13.1_fix-protobuf-dependency.patch':
+     '8bd755a0cab7233a243bc65ca57c9630dfccdc9bf8c9792f0de4e07a644fcb00'},
+    {'PyTorch-1.13.1_fix-warning-in-test-cpp-api.patch':
+     'bdde0f2105215c95a54de64ec4b1a4520528510663174fef6d5b900eb1db3937'},
+    {'PyTorch-1.13.1_skip-failing-singular-grad-test.patch':
+     '72688a57b2bb617665ad1a1d5e362c5111ae912c10936bb38a089c0204729f48'},
+    {'PyTorch-1.13.1_skip-tests-without-fbgemm.patch':
+     '481e595f673baf8ae58b41697a6792b83048b0264aa79b422f48cd8c22948bb7'},
+    {'PyTorch-2.0.1_avoid-test_quantization-failures.patch':
+     '02e3f47e4ed1d7d6077e26f1ae50073dc2b20426269930b505f4aefe5d2f33cd'},
+    {'PyTorch-2.0.1_fix-skip-decorators.patch': '2039012cef45446065e1a2097839fe20bb29fe3c1dcc926c3695ebf29832e920'},
+    {'PyTorch-2.0.1_fix-ub-in-inductor-codegen.patch':
+     '1b37194f55ae678f3657b8728dfb896c18ffe8babe90987ce468c4fa9274f357'},
+    {'PyTorch-2.0.1_fix-vsx-loadu.patch': 'a0ffa61da2d47c6acd09aaf6d4791e527d8919a6f4f1aa7ed38454cdcadb1f72'},
+    {'PyTorch-2.0.1_no-cuda-stubs-rpath.patch': '8902e58a762240f24cdbf0182e99ccdfc2a93492869352fcb4ca0ec7e407f83a'},
+    {'PyTorch-2.0.1_skip-failing-gradtest.patch': '8030bdec6ba49b057ab232d19a7f1a5e542e47e2ec340653a246ec9ed59f8bc1'},
+    {'PyTorch-2.0.1_skip-test_shuffle_reproducibility.patch':
+     '7047862abc1abaff62954da59700f36d4f39fcf83167a638183b1b7f8fec78ae'},
+    {'PyTorch-2.0.1_skip-tests-skipped-in-subprocess.patch':
+     '166c134573a95230e39b9ea09ece3ad8072f39d370c9a88fb2a1e24f6aaac2b5'},
+    {'PyTorch-2.1.0_disable-gcc12-warning.patch': 'c858b8db0010f41005dc06f9a50768d0d3dc2d2d499ccbdd5faf8a518869a421'},
+    {'PyTorch-2.1.0_fix-bufferoverflow-in-oneDNN.patch':
+     'b15b1291a3c37bf6a4982cfbb3483f693acb46a67bc0912b383fd98baf540ccf'},
+    {'PyTorch-2.1.0_fix-test_numpy_torch_operators.patch':
+     '84bb51a719abc677031a7a3dfe4382ff098b0cbd8b39b8bed2a7fa03f80ac1e9'},
+    {'PyTorch-2.1.0_fix-validationError-output-test.patch':
+     '7eba0942afb121ed92fac30d1529447d892a89eb3d53c565f8e9d480e95f692b'},
+    {'PyTorch-2.1.0_fix-vsx-vector-shift-functions.patch':
+     '3793b4b878be1abe7791efcbd534774b87862cfe7dc4774ca8729b6cabb39e7e'},
+    {'PyTorch-2.1.0_increase-tolerance-functorch-test_vmapvjpvjp.patch':
+     'aef38adf1210d0c5455e91d7c7a9d9e5caad3ae568301e0ba9fc204309438e7b'},
+    {'PyTorch-2.1.0_remove-sparse-csr-nnz-overflow-test.patch':
+     '0ac36411e76506b3354c85a8a1260987f66af947ee52ffc64230aee1fa02ea8b'},
+    {'PyTorch-2.1.0_remove-test-requiring-online-access.patch':
+     '35184b8c5a1b10f79e511cc25db3b8a5585a5d58b5d1aa25dd3d250200b14fd7'},
+    {'PyTorch-2.1.0_skip-diff-test-on-ppc.patch': '394157dbe565ffcbc1821cd63d05930957412156cc01e949ef3d3524176a1dda'},
+    {'PyTorch-2.1.0_skip-dynamo-test_predispatch.patch':
+     '6298daf9ddaa8542850eee9ea005f28594ab65b1f87af43d8aeca1579a8c4354'},
+    {'PyTorch-2.1.0_skip-test_jvp_linalg_det_singular.patch':
+     '5229ca88a71db7667a90ddc0b809b2c817698bd6e9c5aaabd73d3173cf9b99fe'},
+    {'PyTorch-2.1.0_skip-test_linear_fp32-without-MKL.patch':
+     '5dcc79883b6e3ec0a281a8e110db5e0a5880de843bb05653589891f16473ead5'},
+    {'PyTorch-2.1.0_skip-test_wrap_bad.patch': 'b8583125ee94e553b6f77c4ab4bfa812b89416175dc7e9b7390919f3b485cb63'},
+    {'PyTorch-2.1.2_fix-test_extension_backend-without-vectorization.patch':
+     'cd1455495886a7d6b2d30d48736eb0103fded21e2e36de6baac719b9c52a1c92'},
+    {'PyTorch-2.1.2_fix-test_memory_profiler.patch':
+     '30b0c9355636c0ab3dedae02399789053825dc3835b4d7dac6e696767772b1ce'},
+    {'PyTorch-2.1.2_fix-test_torchinductor-rounding.patch':
+     'a0ef99192ee2ad1509c78a8377023d5be2b5fddb16f84063b7c9a0b53d979090'},
+    {'PyTorch-2.1.2_fix-vsx-vector-abs.patch': 'd67d32407faed7dc1dbab4bba0e2f7de36c3db04560ced35c94caf8d84ade886'},
+    {'PyTorch-2.1.2_fix-vsx-vector-div.patch': '11f497a6892eb49b249a15320e4218e0d7ac8ae4ce67de39e4a018a064ca1acc'},
+    {'PyTorch-2.1.2_skip-cpu_repro-test-without-vectorization.patch':
+     '7ace835af60c58d9e0754a34c19d4b9a0c3a531f19e5d0eba8e2e49206eaa7eb'},
+    {'PyTorch-2.1.2_skip-memory-leak-test.patch': '8d9841208e8a00a498295018aead380c360cf56e500ef23ca740adb5b36de142'},
+    {'PyTorch-2.1.2_workaround_dynamo_failure_without_nnpack.patch':
+     'fb96eefabf394617bbb3fbd3a7a7c1aa5991b3836edc2e5d2a30e708bfe49ba1'},
+]
+
+osdependencies = [OS_PKG_IBVERBS_DEV]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('hypothesis', '6.90.0'),
+    # For tests
+    ('pytest-flakefinder', '1.1.0'),
+    ('pytest-rerunfailures', '14.0'),
+    ('pytest-shard', '0.1.2'),
+]
+
+dependencies = [
+    ('Ninja', '1.11.1'),  # Required for JIT compilation of C++ extensions
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('protobuf', '25.3'),
+    ('protobuf-python', '4.25.3'),
+    ('pybind11', '2.11.1'),
+    ('SciPy-bundle', '2023.12'),
+    ('PyYAML', '6.0.1'),
+    ('MPFR', '4.2.1'),
+    ('GMP', '6.3.0'),
+    ('numactl', '2.0.16'),
+    ('FFmpeg', '6.0'),
+    ('Pillow', '10.2.0'),
+    ('expecttest', '0.2.1'),
+    ('networkx', '3.2.1'),
+    ('sympy', '1.12'),
+    ('Z3', '4.13.0',),
+]
+
+use_pip = True
+buildcmd = '%(python)s setup.py build'  # Run the (long) build in the build step
+
+excluded_tests = {
+    '': [
+        # This test seems to take too long on NVIDIA Ampere at least.
+        'distributed/test_distributed_spawn',
+        # Broken on CUDA 11.6/11.7: https://github.com/pytorch/pytorch/issues/75375
+        'distributions/test_constraints',
+        # no xdoctest
+        'doctests',
+        # failing on broadwell
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17712
+        'test_native_mha',
+        # intermittent failures on various systems
+        # See https://github.com/easybuilders/easybuild-easyconfigs/issues/17712
+        'distributed/rpc/test_tensorpipe_agent',
+    ]
+}
+
+runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
+
+# Especially test_quantization has a few corner cases that are triggered by the random input values,
+# those cannot be easily avoided, see https://github.com/pytorch/pytorch/issues/107030
+# So allow a low number of tests to fail as the tests "usually" succeed
+max_failed_tests = 2
+
+tests = ['PyTorch-check-cpp-extension.py']
+
+moduleclass = 'ai'

--- a/easybuild/easyconfigs/p/parasail/parasail-2.6.2-intel-compilers-2023.2.1.eb
+++ b/easybuild/easyconfigs/p/parasail/parasail-2.6.2-intel-compilers-2023.2.1.eb
@@ -1,0 +1,26 @@
+easyblock = 'CMakeMake'
+
+name = 'parasail'
+version = '2.6.2'
+
+homepage = 'https://github.com/jeffdaily/parasail'
+description = """parasail is a SIMD C (C99) library containing implementations
+ of the Smith-Waterman (local), Needleman-Wunsch (global), and semi-global
+ pairwise sequence alignment algorithms. """
+
+toolchain = {'name': 'intel-compilers', 'version': '2023.2.1'}
+
+github_account = 'jeffdaily'
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['9057041db8e1cde76678f649420b85054650414e5de9ea84ee268756c7ea4b4b']
+
+builddependencies = [('CMake', '3.27.6')]
+
+sanity_check_paths = {
+    'files': ['bin/parasail_aligner', 'bin/parasail_stats',
+              'lib/libparasail.%s' % SHLIB_EXT, 'include/parasail.h'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/p/pystencils/pystencils-1.3.4-gfbf-2023b-b.eb
+++ b/easybuild/easyconfigs/p/pystencils/pystencils-1.3.4-gfbf-2023b-b.eb
@@ -1,0 +1,31 @@
+easyblock = 'PythonBundle'
+
+name = 'pystencils'
+version = '1.3.4'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://pycodegen.pages.i10git.cs.fau.de/pystencils'
+description = "pystencils uses sympy to define stencil operations, that can be executed on numpy arrays"
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('sympy', '1.12'),
+    ('PyYAML', '6.0.1'),
+]
+
+use_pip = True
+
+exts_list = [
+    (name, version, {
+        'checksums': ['d8c502ad27d5e270c5048558a3c8b316beef8d7ac6a8a9f72b78632a6e0ca317'],
+        # remove strict version requirement for sympy
+        'preinstallopts': """sed -i 's/"sympy[^"]*"/"sympy"/g' pyproject.toml && """,
+    }),
+]
+
+sanity_pip_check = True
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/pystencils/pystencils-1.3.4-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/p/pystencils/pystencils-1.3.4-iimkl-2023b.eb
@@ -1,0 +1,30 @@
+easyblock = 'PythonBundle'
+
+name = 'pystencils'
+version = '1.3.4'
+
+homepage = 'https://pycodegen.pages.i10git.cs.fau.de/pystencils'
+description = "pystencils uses sympy to define stencil operations, that can be executed on numpy arrays"
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('sympy', '1.12'),
+    ('PyYAML', '6.0.1'),
+]
+
+use_pip = True
+
+exts_list = [
+    (name, version, {
+        'checksums': ['d8c502ad27d5e270c5048558a3c8b316beef8d7ac6a8a9f72b78632a6e0ca317'],
+        # remove strict version requirement for sympy
+        'preinstallopts': """sed -i 's/"sympy[^"]*"/"sympy"/g' pyproject.toml && """,
+    }),
+]
+
+sanity_pip_check = True
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/python-parasail/python-parasail-1.3.4-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/p/python-parasail/python-parasail-1.3.4-foss-2023b-b.eb
@@ -1,0 +1,33 @@
+easyblock = 'PythonPackage'
+
+name = 'python-parasail'
+version = '1.3.4'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://github.com/jeffdaily/parasail-python'
+description = "Python Bindings for the Parasail C Library"
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+
+sources = ['parasail-%(version)s.tar.gz']
+checksums = ['d6a7035dfae3ef5aafdd7e6915711214c22b572ea059fa69d9d7ecbfb9b61b0f']
+
+builddependencies = [
+    ('parasail', '2.6.2'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+# make sure setup.py finds the parasail library
+preinstallopts = "ln -s $EBROOTPARASAIL/lib/libparasail.so parasail/libparasail.%s && " % SHLIB_EXT
+
+options = {'modulename': 'parasail'}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/p/python-parasail/python-parasail-1.3.4-intel-2023b.eb
+++ b/easybuild/easyconfigs/p/python-parasail/python-parasail-1.3.4-intel-2023b.eb
@@ -1,0 +1,32 @@
+easyblock = 'PythonPackage'
+
+name = 'python-parasail'
+version = '1.3.4'
+
+homepage = 'https://github.com/jeffdaily/parasail-python'
+description = "Python Bindings for the Parasail C Library"
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+
+sources = ['parasail-%(version)s.tar.gz']
+checksums = ['d6a7035dfae3ef5aafdd7e6915711214c22b572ea059fa69d9d7ecbfb9b61b0f']
+
+builddependencies = [
+    ('parasail', '2.6.2'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+# make sure setup.py finds the parasail library
+preinstallopts = "ln -s $EBROOTPARASAIL/lib/libparasail.so parasail/libparasail.%s && " % SHLIB_EXT
+
+options = {'modulename': 'parasail'}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/q/QCG-PilotJob/QCG-PilotJob-0.13.1-gfbf-2023b-b.eb
+++ b/easybuild/easyconfigs/q/QCG-PilotJob/QCG-PilotJob-0.13.1-gfbf-2023b-b.eb
@@ -1,0 +1,74 @@
+easyblock = 'PythonBundle'
+
+name = 'QCG-PilotJob'
+version = '0.13.1'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://qcg-pilotjob.readthedocs.org'
+description = """A python service for easy execution of many tasks inside a single allocation."""
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('PyZMQ', '25.1.2'),
+    ('Kaleido', '0.2.1'),
+    ('statsmodels', '0.14.1'),
+    ('plotly.py', '5.18.0'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('patsy', '0.5.6', {
+        'checksums': ['95c6d47a7222535f84bff7f63d7303f2e297747a598db89cf5c67f0c0c7d2cdb'],
+    }),
+    ('plotly_express', '0.4.1', {
+        'checksums': ['ff73a41ce02fb43d1d8e8fa131ef3e6589857349ca216b941b8f3f862bce0278'],
+    }),
+    ('prompt_toolkit', '3.0.43', {
+        'checksums': ['3527b7af26106cbc65a040bcc84839a3566ec1b051bb0bfe953631e704b0ff7d'],
+    }),
+    ('trove-classifiers', '2024.1.8', {
+        'patches': ['trove-classifiers-2024.1.8_fix_setup.patch'],
+        'checksums': [
+            {'trove-classifiers-2024.1.8.tar.gz': '6e36caf430ff6485c4b57a4c6b364a13f6a898d16b9417c6c37467e59c14b05a'},
+            {'trove-classifiers-2024.1.8_fix_setup.patch':
+             '90ef5954a558ece2e3d1bc0a9732224b397b8803f9cb8d8915cf2cf4b59498bc'},
+        ],
+    }),
+    ('hatchling', '1.21.0', {
+        'checksums': ['5c086772357a50723b825fd5da5278ac7e3697cdf7797d07541a6c90b6ff754c'],
+    }),
+    ('hatch_vcs', '0.4.0', {
+        'checksums': ['093810748fe01db0d451fabcf2c1ac2688caefd232d4ede967090b1c1b07d9f7'],
+    }),
+    ('setuptools-scm', '8.0.4', {
+        'checksums': ['b5f43ff6800669595193fd09891564ee9d1d7dcb196cab4b2506d53a2e1c95c7'],
+    }),
+    ('termcolor', '2.4.0', {
+        'checksums': ['aab9e56047c8ac41ed798fa36d892a37aca6b3e9159f3e0c24bc64a9b3ac7b7a'],
+    }),
+    ('qcg-pilotjob', version, {
+        'modulename': 'qcg.pilotjob',
+        'patches': ['QCG-PilotJob-0.12.3_rename_zmq.patch'],
+        'checksums': [
+            {'qcg-pilotjob-0.13.1.tar.gz': '6aff74436edde78e8f584066a732298731e8ce1190f7fe69edfaab64a3ecc29d'},
+            {'QCG-PilotJob-0.12.3_rename_zmq.patch':
+             '51cba1bfe1dcd33180dffe65941acdfa70823d6cae4b81182fd16a7debf907cd'},
+        ],
+    }),
+    ('qcg-pilotjob-cmds', version, {
+        'modulename': 'qcg.pilotjob.cmds',
+        'checksums': ['dc7d4a30b65f2194cf68ec876401581647f683d766215a4fef32b438ec4cbffe'],
+    }),
+    ('qcg-pilotjob-executor-api', version, {
+        'modulename': 'qcg.pilotjob.api',
+        'checksums': ['9d7303199bcce1de35d480f96bc2da93b5259a5cac31476c486f790ccbdeebdf'],
+    }),
+]
+
+sanity_pip_check = True
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/q/QCG-PilotJob/QCG-PilotJob-0.13.1-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/q/QCG-PilotJob/QCG-PilotJob-0.13.1-iimkl-2023b.eb
@@ -1,0 +1,73 @@
+easyblock = 'PythonBundle'
+
+name = 'QCG-PilotJob'
+version = '0.13.1'
+
+homepage = 'https://qcg-pilotjob.readthedocs.org'
+description = """A python service for easy execution of many tasks inside a single allocation."""
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('PyZMQ', '25.1.2'),
+    ('Kaleido', '0.2.1'),
+    ('statsmodels', '0.14.1'),
+    ('plotly.py', '5.18.0'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('patsy', '0.5.6', {
+        'checksums': ['95c6d47a7222535f84bff7f63d7303f2e297747a598db89cf5c67f0c0c7d2cdb'],
+    }),
+    ('plotly_express', '0.4.1', {
+        'checksums': ['ff73a41ce02fb43d1d8e8fa131ef3e6589857349ca216b941b8f3f862bce0278'],
+    }),
+    ('prompt_toolkit', '3.0.43', {
+        'checksums': ['3527b7af26106cbc65a040bcc84839a3566ec1b051bb0bfe953631e704b0ff7d'],
+    }),
+    ('trove-classifiers', '2024.1.8', {
+        'patches': ['trove-classifiers-2024.1.8_fix_setup.patch'],
+        'checksums': [
+            {'trove-classifiers-2024.1.8.tar.gz': '6e36caf430ff6485c4b57a4c6b364a13f6a898d16b9417c6c37467e59c14b05a'},
+            {'trove-classifiers-2024.1.8_fix_setup.patch':
+             '90ef5954a558ece2e3d1bc0a9732224b397b8803f9cb8d8915cf2cf4b59498bc'},
+        ],
+    }),
+    ('hatchling', '1.21.0', {
+        'checksums': ['5c086772357a50723b825fd5da5278ac7e3697cdf7797d07541a6c90b6ff754c'],
+    }),
+    ('hatch_vcs', '0.4.0', {
+        'checksums': ['093810748fe01db0d451fabcf2c1ac2688caefd232d4ede967090b1c1b07d9f7'],
+    }),
+    ('setuptools-scm', '8.0.4', {
+        'checksums': ['b5f43ff6800669595193fd09891564ee9d1d7dcb196cab4b2506d53a2e1c95c7'],
+    }),
+    ('termcolor', '2.4.0', {
+        'checksums': ['aab9e56047c8ac41ed798fa36d892a37aca6b3e9159f3e0c24bc64a9b3ac7b7a'],
+    }),
+    ('qcg-pilotjob', version, {
+        'modulename': 'qcg.pilotjob',
+        'patches': ['QCG-PilotJob-0.12.3_rename_zmq.patch'],
+        'checksums': [
+            {'qcg-pilotjob-0.13.1.tar.gz': '6aff74436edde78e8f584066a732298731e8ce1190f7fe69edfaab64a3ecc29d'},
+            {'QCG-PilotJob-0.12.3_rename_zmq.patch':
+             '51cba1bfe1dcd33180dffe65941acdfa70823d6cae4b81182fd16a7debf907cd'},
+        ],
+    }),
+    ('qcg-pilotjob-cmds', version, {
+        'modulename': 'qcg.pilotjob.cmds',
+        'checksums': ['dc7d4a30b65f2194cf68ec876401581647f683d766215a4fef32b438ec4cbffe'],
+    }),
+    ('qcg-pilotjob-executor-api', version, {
+        'modulename': 'qcg.pilotjob.api',
+        'checksums': ['9d7303199bcce1de35d480f96bc2da93b5259a5cac31476c486f790ccbdeebdf'],
+    }),
+]
+
+sanity_pip_check = True
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2023.12-gfbf-2023b.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2023.12-gfbf-2023b.eb
@@ -1,0 +1,105 @@
+easyblock = 'PythonBundle'
+
+name = 'SciPy-bundle'
+version = '2023.12'
+
+homepage = 'https://python.org/'
+description = "Bundle of Python packages for scientific software"
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+toolchainopts = {'pic': True, 'lowopt': True}
+
+builddependencies = [
+    ('hypothesis', '6.90.0'),
+    ('UnZip', '6.0'),
+    # scipy >= 1.9.0 uses Meson/Ninja
+    ('Meson', '1.2.3'),
+    ('meson-python', '0.15.0'),
+    ('Ninja', '1.11.1'),
+    ('pkgconf', '2.0.3'),   # required by scipy
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('pybind11', '2.11.1'),  # required by scipy
+]
+
+use_pip = True
+
+# order is important!
+exts_list = [
+    ('numpy', '1.26.2', {
+        'easyblock': 'PythonPackage',  # pip install builds numpy v1.26.x via spin/meson/ninja
+        'patches': [
+            'numpy-1.22.3_disable-broken-override-test.patch',
+            ('numpy-1.25.1_fix-duplicate-avx512-symbols.patch', 'numpy/core/src/npysort/x86-simd-sort'),
+            'numpy-1.25.1_fix-undefined-avx512-reference.patch',
+            'numpy-1.25.1_fix-test_features.patch',
+        ],
+        'checksums': [
+            {'numpy-1.26.2.tar.gz': 'f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea'},
+            {'numpy-1.22.3_disable-broken-override-test.patch':
+             '9c589bb073b28b25ff45eb3c63c57966aa508dd8b318d0b885b6295271e4983c'},
+            {'numpy-1.25.1_fix-duplicate-avx512-symbols.patch':
+             '8e32087c279b7193ae3507953480601200c9eff021819f3001d78c232c5852e6'},
+            {'numpy-1.25.1_fix-undefined-avx512-reference.patch':
+             'c4b66da93bf36071663f122de1ae668386cc6ab0154d21fa3e14ed7ddfe2a72c'},
+            {'numpy-1.25.1_fix-test_features.patch':
+             '1c05ee5d105fe2f824416dd6dd5c64ed0c1cd710a002b4e6dbfafff19203adc5'},
+        ],
+    }),
+    ('ply', '3.11', {
+        'checksums': ['00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3'],
+    }),
+    ('gast', '0.5.4', {
+        'checksums': ['9c270fe5f4b130969b54174de7db4e764b09b4f7f67ccfc32480e29f78348d97'],
+    }),
+    ('beniget', '0.4.1', {
+        'checksums': ['75554b3b8ad0553ce2f607627dad3d95c60c441189875b98e097528f8e23ac0c'],
+    }),
+    ('pythran', '0.14.0', {
+        'checksums': ['42f3473946205964844eff7f750e2541afb2006d53475d708f5ff2d048db89bd'],
+    }),
+    ('versioneer', '0.29', {
+        'checksums': ['5ab283b9857211d61b53318b7c792cf68e798e765ee17c27ade9f6c924235731'],
+    }),
+    ('scipy', '1.12.0', {
+        'enable_slow_tests': True,
+        'ignore_test_result': False,
+        'patches': [
+            'scipy-1.11.1_disable-tests.patch',
+            'scipy-1.11.1_xfail-aarch64_test_maxiter_worsening.patch',
+        ],
+        'checksums': [
+            {'scipy-1.12.0.tar.gz': '4bf5abab8a36d20193c698b0f1fc282c1d083c94723902c447e5d2f1780936a3'},
+            {'scipy-1.11.1_disable-tests.patch': '906bfb03397d94882ccdc1b93bc2c8e854e0e060c2d107c83042992394e6a4af'},
+            {'scipy-1.11.1_xfail-aarch64_test_maxiter_worsening.patch':
+             '918c8e6fa8215d459126f267764c961bde729ea4a116c7f6287cddfdc58ffcea'},
+        ],
+    }),
+    ('numexpr', '2.8.7', {
+        'checksums': ['596eeb3bbfebc912f4b6eaaf842b61ba722cebdb8bc42dfefa657d3a74953849'],
+    }),
+    ('Bottleneck', '1.3.7', {
+        'checksums': ['e1467e373ad469da340ed0ff283214d6531cc08bfdca2083361a3aa6470681f8'],
+    }),
+    ('tzdata', '2023.3', {
+        'checksums': ['11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a'],
+    }),
+    ('pandas', '2.1.3', {
+        'preinstallopts': "export PANDAS_CI=0 && ",
+        'checksums': ['22929f84bca106921917eb73c1521317ddd0a4c71b395bcf767a106e3494209f'],
+    }),
+    ('mpmath', '1.3.0', {
+        'checksums': ['7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f'],
+    }),
+    ('deap', '1.4.1', {
+        'modulename': 'deap.base',
+        'checksums': ['cc01de9892dfa7d1bc9803dab28892fead177f0182c81db47360a240ead778ff'],
+    }),
+]
+
+sanity_pip_check = True
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2023.12-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2023.12-iimkl-2023b.eb
@@ -1,0 +1,117 @@
+easyblock = 'PythonBundle'
+
+name = 'SciPy-bundle'
+version = '2023.12'
+
+homepage = 'https://python.org/'
+description = "Bundle of Python packages for scientific software"
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+toolchainopts = {
+    'pic': True, 'lowopt': True, 'strict': True,
+    'oneapi': True, 'optarch': False,  # prevents -xHost
+}
+
+builddependencies = [
+    ('hypothesis', '6.90.0'),
+    ('UnZip', '6.0'),
+    # scipy >= 1.9.0 uses Meson/Ninja
+    ('Meson', '1.2.3'),
+    ('meson-python', '0.15.0'),
+    ('Ninja', '1.11.1'),
+    ('pkgconf', '2.0.3'),   # required by scipy
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('pybind11', '2.11.1'),  # required by scipy
+]
+
+use_pip = True
+
+# order is important!
+exts_list = [
+    ('numpy', '1.26.2', {
+        'easyblock': 'PythonPackage',  # pip install builds numpy v1.26.x via spin/meson/ninja
+        'patches': [
+            'numpy-1.25.1_disable_fortran_callback_test.patch',
+            'numpy-1.25.1_disable-broken-test_long_long_map.patch',
+            'numpy-1.26.2_fix_selected_kind_for_ifort.patch',
+            'numpy-1.25.1_disable-broken-fortran-docstring-test.patch',
+            'numpy-1.25.1_fix-test_features.patch',
+        ],
+        'checksums': [
+            {'numpy-1.26.2.tar.gz': 'f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea'},
+            {'numpy-1.25.1_disable_fortran_callback_test.patch':
+             '3c02bd9973b7082fde9f9d18edfeb05798226ccb5731a56f5677269200c345cf'},
+            {'numpy-1.25.1_disable-broken-test_long_long_map.patch':
+             'fa0fb0a16c4f1339a974c1c84b79df21dc9bfdc14e3e68f6aebaf5e30bad3fe9'},
+            {'numpy-1.26.2_fix_selected_kind_for_ifort.patch':
+             '3622bacbe4063373cc0b1c0aa0ffe3d30dfe132f6a763b15b45cc6387cbd51d7'},
+            {'numpy-1.25.1_disable-broken-fortran-docstring-test.patch':
+             '8a4d36e3b3a9c9bf43df6e5214f3883234a069b80c5c1027a7c84bd5cb133457'},
+            {'numpy-1.25.1_fix-test_features.patch':
+             '1c05ee5d105fe2f824416dd6dd5c64ed0c1cd710a002b4e6dbfafff19203adc5'},
+        ],
+    }),
+    ('ply', '3.11', {
+        'checksums': ['00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3'],
+    }),
+    ('gast', '0.5.4', {
+        'checksums': ['9c270fe5f4b130969b54174de7db4e764b09b4f7f67ccfc32480e29f78348d97'],
+    }),
+    ('beniget', '0.4.1', {
+        'checksums': ['75554b3b8ad0553ce2f607627dad3d95c60c441189875b98e097528f8e23ac0c'],
+    }),
+    ('pythran', '0.14.0', {
+        'checksums': ['42f3473946205964844eff7f750e2541afb2006d53475d708f5ff2d048db89bd'],
+    }),
+    ('versioneer', '0.29', {
+        'checksums': ['5ab283b9857211d61b53318b7c792cf68e798e765ee17c27ade9f6c924235731'],
+    }),
+    ('scipy', '1.12.0', {
+        'enable_slow_tests': True,
+        'ignore_test_result': False,
+        'patches': [
+            'scipy-1.11.1_disable-tests.patch',
+            'scipy-1.11.1_xfail-aarch64_test_maxiter_worsening.patch',
+            'scipy-1.11.4_disable-test_branch_cut.patch',  # intel might need -assume=minus0
+            'scipy-1.12.0_disable-tests-iimkl.patch',
+        ],
+        'checksums': [
+            {'scipy-1.12.0.tar.gz': '4bf5abab8a36d20193c698b0f1fc282c1d083c94723902c447e5d2f1780936a3'},
+            {'scipy-1.11.1_disable-tests.patch': '906bfb03397d94882ccdc1b93bc2c8e854e0e060c2d107c83042992394e6a4af'},
+            {'scipy-1.11.1_xfail-aarch64_test_maxiter_worsening.patch':
+             '918c8e6fa8215d459126f267764c961bde729ea4a116c7f6287cddfdc58ffcea'},
+            {'scipy-1.11.4_disable-test_branch_cut.patch':
+             '3433d284e4074ee8a5b10bfc65c729214bc75670c36d8b7a983bb5ccddc5cf61'},
+            {'scipy-1.12.0_disable-tests-iimkl.patch':
+             'edf575be62b77bb8984e87e75f69a0799d719fc8b5c801c79e4f9592e1c8203f'},
+        ],
+    }),
+    ('numexpr', '2.8.7', {
+        'checksums': ['596eeb3bbfebc912f4b6eaaf842b61ba722cebdb8bc42dfefa657d3a74953849'],
+    }),
+    ('Bottleneck', '1.3.7', {
+        'checksums': ['e1467e373ad469da340ed0ff283214d6531cc08bfdca2083361a3aa6470681f8'],
+    }),
+    ('tzdata', '2023.3', {
+        'checksums': ['11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a'],
+    }),
+    ('pandas', '2.1.3', {
+        'preinstallopts': "export PANDAS_CI=0 && ",
+        'checksums': ['22929f84bca106921917eb73c1521317ddd0a4c71b395bcf767a106e3494209f'],
+    }),
+    ('mpmath', '1.3.0', {
+        'checksums': ['7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f'],
+    }),
+    ('deap', '1.4.1', {
+        'modulename': 'deap.base',
+        'checksums': ['cc01de9892dfa7d1bc9803dab28892fead177f0182c81db47360a240ead778ff'],
+    }),
+]
+
+sanity_pip_check = True
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-1.3.2-gfbf-2023b-b.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-1.3.2-gfbf-2023b-b.eb
@@ -1,0 +1,34 @@
+easyblock = 'PythonBundle'
+
+name = 'scikit-learn'
+version = '1.3.2'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://scikit-learn.org/stable/index.html'
+description = """Scikit-learn integrates machine learning algorithms in the tightly-knit scientific Python world,
+building upon numpy, scipy, and matplotlib. As a machine-learning module,
+it provides versatile tools for data mining and analysis in any field of science and engineering.
+It strives to be simple and efficient, accessible to everybody, and reusable in various contexts."""
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    (name, version, {
+        'modulename': 'sklearn',
+        'checksums': ['a2f54c76accc15a34bfb9066e6c7a56c1e7235dda5762b990792330b52ccfb05'],
+    }),
+    ('sklearn', '0.0', {
+        'checksums': ['e23001573aa194b834122d2b9562459bf5ae494a2d59ca6b8aa22c85a44c0e31'],
+    }),
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-1.3.2-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-1.3.2-iimkl-2023b.eb
@@ -1,0 +1,33 @@
+easyblock = 'PythonBundle'
+
+name = 'scikit-learn'
+version = '1.3.2'
+
+homepage = 'https://scikit-learn.org/stable/index.html'
+description = """Scikit-learn integrates machine learning algorithms in the tightly-knit scientific Python world,
+building upon numpy, scipy, and matplotlib. As a machine-learning module,
+it provides versatile tools for data mining and analysis in any field of science and engineering.
+It strives to be simple and efficient, accessible to everybody, and reusable in various contexts."""
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    (name, version, {
+        'modulename': 'sklearn',
+        'checksums': ['a2f54c76accc15a34bfb9066e6c7a56c1e7235dda5762b990792330b52ccfb05'],
+    }),
+    ('sklearn', '0.0', {
+        'checksums': ['e23001573aa194b834122d2b9562459bf5ae494a2d59ca6b8aa22c85a44c0e31'],
+    }),
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-1.4.0-gfbf-2023b-b.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-1.4.0-gfbf-2023b-b.eb
@@ -1,0 +1,35 @@
+easyblock = 'PythonBundle'
+
+name = 'scikit-learn'
+version = '1.4.0'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://scikit-learn.org/stable/index.html'
+description = """Scikit-learn integrates machine learning algorithms in the tightly-knit scientific Python world,
+building upon numpy, scipy, and matplotlib. As a machine-learning module,
+it provides versatile tools for data mining and analysis in any field of science and engineering.
+It strives to be simple and efficient, accessible to everybody, and reusable in various contexts."""
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+use_pip = True
+
+exts_list = [
+    (name, version, {
+        'modulename': 'sklearn',
+        'checksums': ['d4373c984eba20e393216edd51a3e3eede56cbe93d4247516d205643c3b93121'],
+    }),
+    ('sklearn', '0.0', {
+        'checksums': ['e23001573aa194b834122d2b9562459bf5ae494a2d59ca6b8aa22c85a44c0e31'],
+    }),
+]
+
+sanity_pip_check = True
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-1.4.0-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-1.4.0-iimkl-2023b.eb
@@ -1,0 +1,34 @@
+easyblock = 'PythonBundle'
+
+name = 'scikit-learn'
+version = '1.4.0'
+
+homepage = 'https://scikit-learn.org/stable/index.html'
+description = """Scikit-learn integrates machine learning algorithms in the tightly-knit scientific Python world,
+building upon numpy, scipy, and matplotlib. As a machine-learning module,
+it provides versatile tools for data mining and analysis in any field of science and engineering.
+It strives to be simple and efficient, accessible to everybody, and reusable in various contexts."""
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+use_pip = True
+
+exts_list = [
+    (name, version, {
+        'modulename': 'sklearn',
+        'checksums': ['d4373c984eba20e393216edd51a3e3eede56cbe93d4247516d205643c3b93121'],
+    }),
+    ('sklearn', '0.0', {
+        'checksums': ['e23001573aa194b834122d2b9562459bf5ae494a2d59ca6b8aa22c85a44c0e31'],
+    }),
+]
+
+sanity_pip_check = True
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/s/spglib-python/spglib-python-2.5.0-gfbf-2023b-b.eb
+++ b/easybuild/easyconfigs/s/spglib-python/spglib-python-2.5.0-gfbf-2023b-b.eb
@@ -1,0 +1,38 @@
+easyblock = 'PythonBundle'
+
+name = 'spglib-python'
+version = '2.5.0'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://pypi.python.org/pypi/spglib'
+description = """Spglib for Python.
+
+Spglib is a library for finding and handling crystal symmetries written in C.
+"""
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+builddependencies = [
+    ('scikit-build-core', '0.9.3')
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+use_pip = True
+
+sanity_pip_check = True
+
+exts_list = [
+    ('pyproject_metadata', '0.8.0', {
+        'checksums': ['376d5a00764ac29440a54579f88e66b7d9cb7e629d35c35a1c7248bfebc9b455'],
+    }),
+    ('spglib', version, {
+        'checksums': ['f8bb638897be91b9dbd4c085d9fde1f69048f5949e20f3832cb9438e57418d4b'],
+    }),
+]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/s/spglib-python/spglib-python-2.5.0-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/s/spglib-python/spglib-python-2.5.0-iimkl-2023b.eb
@@ -1,0 +1,37 @@
+easyblock = 'PythonBundle'
+
+name = 'spglib-python'
+version = '2.5.0'
+
+homepage = 'https://pypi.python.org/pypi/spglib'
+description = """Spglib for Python.
+
+Spglib is a library for finding and handling crystal symmetries written in C.
+"""
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+
+builddependencies = [
+    ('scikit-build-core', '0.9.3')
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+use_pip = True
+
+sanity_pip_check = True
+
+exts_list = [
+    ('pyproject_metadata', '0.8.0', {
+        'checksums': ['376d5a00764ac29440a54579f88e66b7d9cb7e629d35c35a1c7248bfebc9b455'],
+    }),
+    ('spglib', version, {
+        'checksums': ['f8bb638897be91b9dbd4c085d9fde1f69048f5949e20f3832cb9438e57418d4b'],
+    }),
+]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/s/statsmodels/statsmodels-0.14.1-gfbf-2023b-b.eb
+++ b/easybuild/easyconfigs/s/statsmodels/statsmodels-0.14.1-gfbf-2023b-b.eb
@@ -1,0 +1,34 @@
+easyblock = 'PythonBundle'
+
+name = 'statsmodels'
+version = '0.14.1'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://www.statsmodels.org/'
+description = """Statsmodels is a Python module that allows users to explore data, estimate statistical models,
+and perform statistical tests."""
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('patsy', '0.5.6', {
+        'checksums': ['95c6d47a7222535f84bff7f63d7303f2e297747a598db89cf5c67f0c0c7d2cdb'],
+    }),
+    (name, version, {
+        'patches': ['statsmodels-0.14.1_fix_setup.patch'],
+        'checksums': [
+            {'statsmodels-0.14.1.tar.gz': '2260efdc1ef89f39c670a0bd8151b1d0843567781bcafec6cda0534eb47a94f6'},
+            {'statsmodels-0.14.1_fix_setup.patch': '27ea0e82b9cd1162490eb2bea9606b6ca79ed559bd7e793bbd073ec09c8b0f53'},
+        ],
+    }),
+]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/s/statsmodels/statsmodels-0.14.1-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/s/statsmodels/statsmodels-0.14.1-iimkl-2023b.eb
@@ -1,0 +1,33 @@
+easyblock = 'PythonBundle'
+
+name = 'statsmodels'
+version = '0.14.1'
+
+homepage = 'https://www.statsmodels.org/'
+description = """Statsmodels is a Python module that allows users to explore data, estimate statistical models,
+and perform statistical tests."""
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('patsy', '0.5.6', {
+        'checksums': ['95c6d47a7222535f84bff7f63d7303f2e297747a598db89cf5c67f0c0c7d2cdb'],
+    }),
+    (name, version, {
+        'patches': ['statsmodels-0.14.1_fix_setup.patch'],
+        'checksums': [
+            {'statsmodels-0.14.1.tar.gz': '2260efdc1ef89f39c670a0bd8151b1d0843567781bcafec6cda0534eb47a94f6'},
+            {'statsmodels-0.14.1_fix_setup.patch': '27ea0e82b9cd1162490eb2bea9606b6ca79ed559bd7e793bbd073ec09c8b0f53'},
+        ],
+    }),
+]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/s/sympy/sympy-1.12-gfbf-2023b-b.eb
+++ b/easybuild/easyconfigs/s/sympy/sympy-1.12-gfbf-2023b-b.eb
@@ -1,0 +1,23 @@
+name = 'sympy'
+version = '1.12'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://sympy.org/'
+description = """SymPy is a Python library for symbolic mathematics. It aims to
+ become a full-featured computer algebra system (CAS) while keeping the code as
+ simple as possible in order to be comprehensible and easily extensible. SymPy
+ is written entirely in Python and does not require any external libraries."""
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['ebf595c8dac3e0fdc4152c51878b498396ec7f30e7a914d6071e674d49420fb8']
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('gmpy2', '2.1.5'),
+]
+
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/s/sympy/sympy-1.12-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/s/sympy/sympy-1.12-iimkl-2023b.eb
@@ -1,0 +1,22 @@
+name = 'sympy'
+version = '1.12'
+
+homepage = 'https://sympy.org/'
+description = """SymPy is a Python library for symbolic mathematics. It aims to
+ become a full-featured computer algebra system (CAS) while keeping the code as
+ simple as possible in order to be comprehensible and easily extensible. SymPy
+ is written entirely in Python and does not require any external libraries."""
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['ebf595c8dac3e0fdc4152c51878b498396ec7f30e7a914d6071e674d49420fb8']
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('gmpy2', '2.1.5'),
+]
+
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/v/VTK/VTK-9.3.0-foss-2023b-b.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-9.3.0-foss-2023b-b.eb
@@ -1,0 +1,93 @@
+##
+# Authors::
+# * Fotis Georgatos <fotis@cern.ch>
+# * Robert Mijakovic <robert.mijakovic@lxp.lu>
+##
+
+easyblock = 'CMakeNinja'
+
+name = 'VTK'
+version = '9.3.0'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://www.vtk.org'
+description = """The Visualization Toolkit (VTK) is an open-source, freely available software system for
+ 3D computer graphics, image processing and visualization. VTK consists of a C++ class library and several
+ interpreted interface layers including Tcl/Tk, Java, and Python. VTK supports a wide variety of visualization
+ algorithms including: scalar, vector, tensor, texture, and volumetric methods; and advanced modeling techniques
+ such as: implicit modeling, polygon reduction, mesh smoothing, cutting, contouring, and Delaunay triangulation."""
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://www.vtk.org/files/release/%(version_major_minor)s']
+sources = [
+    SOURCE_TAR_GZ,
+    '%(name)sData-%(version)s.tar.gz',
+]
+patches = [('vtk-version.egg-info', '.')]
+checksums = [
+    {'VTK-9.3.0.tar.gz': 'fdc7b9295225b34e4fdddc49cd06e66e94260cb00efee456e0f66568c9681be9'},
+    {'VTKData-9.3.0.tar.gz': 'f82142dd327e995c9536c1003e1370bb4092c96f23edb8119d16d2411ef35dc3'},
+    {'vtk-version.egg-info': '787b82415ae7a4a1f815b4db0e25f7abc809a05fc85d7d219627f3a7e5d3867b'},
+]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('Ninja', '1.11.1'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('XZ', '5.4.4'),
+    ('libGLU', '9.0.3'),
+    ('X11', '20231019'),
+]
+
+separate_build_dir = True
+
+# OpenGL
+configopts = "-DOPENGL_glu_LIBRARY=$EBROOTLIBGLU/lib/libGLU.%s " % SHLIB_EXT
+configopts += "-DOPENGL_gl_LIBRARY=$EBROOTMESA/lib/libGL.%s " % SHLIB_EXT
+configopts += "-DOPENGL_INCLUDE_DIR=$EBROOTMESA/include "
+# Python
+configopts += "-DVTK_WRAP_PYTHON=ON -DVTK_PYTHON_VERSION=3 -DVTK_PYTHON_OPTIONAL_LINK=OFF "
+configopts += "-DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python3 "
+configopts += "-DPython3_INCLUDE_DIR=$EBROOTPYTHON/include/python%(pyshortver)s "
+configopts += "-DPython3_LIBRARY=$EBROOTPYTHON/lib/libpython%(pyshortver)s.so "
+# Other
+configopts += "-DVTK_USE_MPI=ON "
+configopts += "-DCMAKE_INSTALL_LIBDIR=lib"
+
+preinstallopts = "export PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH && "
+
+# Install a egg-info file so VTK is more python friendly, required for mayavi
+local_egg_info_src = '%(builddir)s/VTK-%(version)s/vtk-version.egg-info'
+local_egg_info_dest = '%(installdir)s/lib/python%(pyshortver)s/site-packages/vtk-%(version)s.egg-info'
+postinstallcmds = [
+    'sed "s/#VTK_VERSION#/%%(version)s/" %s > %s' % (local_egg_info_src, local_egg_info_dest),
+]
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+local_vtk_exec = ['vtk%s-%%(version_major_minor)s' % x
+                  for x in ['WrapJava', 'ParseJava', 'WrapPythonInit', 'WrapPython', 'WrapHierarchy']]
+local_vtk_exec += ['vtkpython']
+local_vtk_libs = ['CommonCore', 'IONetCDF', 'ParallelCore', 'RenderingOpenGL2']
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in local_vtk_exec] + ['include/vtk-%(version_major_minor)s/vtkMPI.h'] +
+             ['lib/libvtk%s-%%(version_major_minor)s.%s' % (x, SHLIB_EXT) for x in local_vtk_libs],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/', 'include/vtk-%(version_major_minor)s'],
+}
+
+sanity_check_commands = [
+    "python -c 'import %(namelower)s'",
+    "python -c 'import pkg_resources; pkg_resources.get_distribution(\"vtk\")'",
+    # make sure that VTK Python libraries link to libpython (controlled via DVTK_PYTHON_OPTIONAL_LINK=OFF),
+    # see https://gitlab.kitware.com/vtk/vtk/-/issues/17881
+    "ldd $EBROOTVTK/lib/libvtkPythonContext2D-%%(version_major_minor)s.%s | grep /libpython" % SHLIB_EXT,
+]
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/v/VTK/VTK-9.3.0-intel-2023b.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-9.3.0-intel-2023b.eb
@@ -1,0 +1,92 @@
+##
+# Authors::
+# * Fotis Georgatos <fotis@cern.ch>
+# * Robert Mijakovic <robert.mijakovic@lxp.lu>
+##
+
+easyblock = 'CMakeNinja'
+
+name = 'VTK'
+version = '9.3.0'
+
+homepage = 'https://www.vtk.org'
+description = """The Visualization Toolkit (VTK) is an open-source, freely available software system for
+ 3D computer graphics, image processing and visualization. VTK consists of a C++ class library and several
+ interpreted interface layers including Tcl/Tk, Java, and Python. VTK supports a wide variety of visualization
+ algorithms including: scalar, vector, tensor, texture, and volumetric methods; and advanced modeling techniques
+ such as: implicit modeling, polygon reduction, mesh smoothing, cutting, contouring, and Delaunay triangulation."""
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://www.vtk.org/files/release/%(version_major_minor)s']
+sources = [
+    SOURCE_TAR_GZ,
+    '%(name)sData-%(version)s.tar.gz',
+]
+patches = [('vtk-version.egg-info', '.')]
+checksums = [
+    {'VTK-9.3.0.tar.gz': 'fdc7b9295225b34e4fdddc49cd06e66e94260cb00efee456e0f66568c9681be9'},
+    {'VTKData-9.3.0.tar.gz': 'f82142dd327e995c9536c1003e1370bb4092c96f23edb8119d16d2411ef35dc3'},
+    {'vtk-version.egg-info': '787b82415ae7a4a1f815b4db0e25f7abc809a05fc85d7d219627f3a7e5d3867b'},
+]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('Ninja', '1.11.1'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+    ('XZ', '5.4.4'),
+    ('libGLU', '9.0.3'),
+    ('X11', '20231019'),
+]
+
+separate_build_dir = True
+
+# OpenGL
+configopts = "-DOPENGL_glu_LIBRARY=$EBROOTLIBGLU/lib/libGLU.%s " % SHLIB_EXT
+configopts += "-DOPENGL_gl_LIBRARY=$EBROOTMESA/lib/libGL.%s " % SHLIB_EXT
+configopts += "-DOPENGL_INCLUDE_DIR=$EBROOTMESA/include "
+# Python
+configopts += "-DVTK_WRAP_PYTHON=ON -DVTK_PYTHON_VERSION=3 -DVTK_PYTHON_OPTIONAL_LINK=OFF "
+configopts += "-DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python3 "
+configopts += "-DPython3_INCLUDE_DIR=$EBROOTPYTHON/include/python%(pyshortver)s "
+configopts += "-DPython3_LIBRARY=$EBROOTPYTHON/lib/libpython%(pyshortver)s.so "
+# Other
+configopts += "-DVTK_USE_MPI=ON "
+configopts += "-DCMAKE_INSTALL_LIBDIR=lib"
+
+preinstallopts = "export PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH && "
+
+# Install a egg-info file so VTK is more python friendly, required for mayavi
+local_egg_info_src = '%(builddir)s/VTK-%(version)s/vtk-version.egg-info'
+local_egg_info_dest = '%(installdir)s/lib/python%(pyshortver)s/site-packages/vtk-%(version)s.egg-info'
+postinstallcmds = [
+    'sed "s/#VTK_VERSION#/%%(version)s/" %s > %s' % (local_egg_info_src, local_egg_info_dest),
+]
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+local_vtk_exec = ['vtk%s-%%(version_major_minor)s' % x
+                  for x in ['WrapJava', 'ParseJava', 'WrapPythonInit', 'WrapPython', 'WrapHierarchy']]
+local_vtk_exec += ['vtkpython']
+local_vtk_libs = ['CommonCore', 'IONetCDF', 'ParallelCore', 'RenderingOpenGL2']
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in local_vtk_exec] + ['include/vtk-%(version_major_minor)s/vtkMPI.h'] +
+             ['lib/libvtk%s-%%(version_major_minor)s.%s' % (l, SHLIB_EXT) for l in local_vtk_libs],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/', 'include/vtk-%(version_major_minor)s'],
+}
+
+sanity_check_commands = [
+    "python -c 'import %(namelower)s'",
+    "python -c 'import pkg_resources; pkg_resources.get_distribution(\"vtk\")'",
+    # make sure that VTK Python libraries link to libpython (controlled via DVTK_PYTHON_OPTIONAL_LINK=OFF),
+    # see https://gitlab.kitware.com/vtk/vtk/-/issues/17881
+    "ldd $EBROOTVTK/lib/libvtkPythonContext2D-%%(version_major_minor)s.%s | grep /libpython" % SHLIB_EXT,
+]
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/x/xarray/xarray-2024.5.0-gfbf-2023b-b.eb
+++ b/easybuild/easyconfigs/x/xarray/xarray-2024.5.0-gfbf-2023b-b.eb
@@ -1,0 +1,29 @@
+easyblock = 'PythonBundle'
+
+name = 'xarray'
+version = '2024.5.0'
+versionsuffix = '-b'  # alternative version of SciPy-bundle dependency
+
+homepage = 'https://github.com/pydata/xarray'
+description = """xarray (formerly xray) is an open source project and Python package that aims to bring
+ the labeled data power of pandas to the physical sciences, by providing N-dimensional variants of the
+ core pandas data structures."""
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    (name, version, {
+        'preinstallopts': """sed -i 's/^dynamic = .*version.*/version = "%(version)s"/g' pyproject.toml && """,
+        'checksums': ['e0eb1cb265f265126795f388ed9591f3c752f2aca491f6c0576711fd15b708f2'],
+    }),
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/x/xarray/xarray-2024.5.0-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/x/xarray/xarray-2024.5.0-iimkl-2023b.eb
@@ -1,0 +1,28 @@
+easyblock = 'PythonBundle'
+
+name = 'xarray'
+version = '2024.5.0'
+
+homepage = 'https://github.com/pydata/xarray'
+description = """xarray (formerly xray) is an open source project and Python package that aims to bring
+ the labeled data power of pandas to the physical sciences, by providing N-dimensional variants of the
+ core pandas data structures."""
+
+toolchain = {'name': 'iimkl', 'version': '2023b'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.12'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    (name, version, {
+        'preinstallopts': """sed -i 's/^dynamic = .*version.*/version = "%(version)s"/g' pyproject.toml && """,
+        'checksums': ['e0eb1cb265f265126795f388ed9591f3c752f2aca491f6c0576711fd15b708f2'],
+    }),
+]
+
+moduleclass = 'data'


### PR DESCRIPTION
Unlike version `2023.11`, `SciPy-bundle-2023.12` works for both `gfbg/2023b` and `iimkl/2023b`

I found a couple of dependent softwares that didn't have their intel counterpart so I provided them.

Also, I figured that the foss versions should have the version of the `SciPy-bundle` dep bumped to match, but I wouldn't want to bother existing installations, so I provide alternatives using `versionsuffix = '-b'`
