### PR TITLE
Add missing cairo dependency for python-igraph v0.10.6

### DIFF
--- a/easybuild/easyconfigs/p/python-igraph/python-igraph-0.10.6-foss-2022b.eb
+++ b/easybuild/easyconfigs/p/python-igraph/python-igraph-0.10.6-foss-2022b.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('Clang', '16.0.4'),
     ('libxml2', '2.10.3'),
     ('zlib', '1.2.12'),
+    ('cairo', '1.17.4'),
 ]
 
 use_pip = True


### PR DESCRIPTION
Seems on some systems (generoso) it picked system cairo - so it did not fail 
Link with a problem: https://github.com/easybuilders/easybuild-easyconfigs/pull/21141#issuecomment-2298833068
resolves https://github.com/vscentrum/vsc-software-stack/issues/357

fix for failing sanity check:
```
AttributeError: Plotting not available; please install pycairo or cairocffi
```