### PR TITLE
{CHEM}[PyMOL 2.5 and 3.0]

### DIFF
--- a/easybuild/easyconfigs/p/PyMOL/PyMOL-2.5.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/p/PyMOL/PyMOL-2.5.0-foss-2023b.eb
@@ -1,0 +1,55 @@
+easyblock = 'PythonBundle'
+
+name = 'PyMOL'
+version = '2.5.0'
+
+homepage = 'https://github.com/schrodinger/pymol-open-source'
+description = """
+PyMOL is a Python-enhanced molecular graphics tool. It excels at 3D             
+visualization of proteins, small molecules, density, surfaces, and trajectories.
+It also includes molecular editing, ray tracing, and movies. Open Source PyMOL  
+is free to everyone!
+"""
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.11'),
+    ('PyQt5', '5.15.10'),
+    ('glew', '2.2.0', '-egl'),
+    ('libpng', '1.6.40'),
+    ('libxml2', '2.11.5'),
+    ('freetype', '2.13.2'),
+    ('GLM', '1.0.1'),
+    ('netCDF', '4.9.2'),
+    ('Tkinter', '%(pyver)s'),
+]
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+
+use_pip = False
+sanity_pip_check = True
+
+exts_list = [
+#    ('Pmw', '2.0.1', {
+#        'modulename': 'Pmw',
+#        'source_tmpl': '8bedfc8747e7757c1048bc5e11899d1163717a43.zip',
+#        'source_urls': ['https://github.com/schrodinger/pmw-patched/archive/'],
+#        'checksums': ['db1ab4ee1020023ad814bb24c74f6361fb72e1011871911f7d37bb6ecf6c79ed'],
+#    }),
+    (name, version, {
+        'buildopts':  '--use-msgpackc=no',
+        'installopts': '--use-msgpackc=no',
+        'source_tmpl': 'v%(version)s.tar.gz',
+        'source_urls': ["https://github.com/schrodinger/pymol-open-source/archive/refs/tags/"],
+        'checksums': ['aa828bf5719bd9a14510118a93182a6e0cadc03a574ba1e327e1e9780a0e80b3'],
+    }),
+]
+
+modextravars = {'PYMOL_PATH': 'lib/python%(pyshortver)s/site-packages/pymol/pymol_path'}
+
+sanity_check_paths = {
+    'files': ['bin/pymol'],
+    'dirs': ['bin', 'lib'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/PyMOL/PyMOL-3.0.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/p/PyMOL/PyMOL-3.0.0-foss-2023b.eb
@@ -1,0 +1,55 @@
+easyblock = 'PythonBundle'
+
+name = 'PyMOL'
+version = '3.0.0'
+
+homepage = 'https://github.com/schrodinger/pymol-open-source'
+description = """
+PyMOL is a Python-enhanced molecular graphics tool. It excels at 3D             
+visualization of proteins, small molecules, density, surfaces, and trajectories.
+It also includes molecular editing, ray tracing, and movies. Open Source PyMOL  
+is free to everyone!
+"""
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.11'),
+    ('PyQt5', '5.15.10'),
+    ('glew', '2.2.0', '-egl'),
+    ('libpng', '1.6.40'),
+    ('libxml2', '2.11.5'),
+    ('freetype', '2.13.2'),
+    ('GLM', '1.0.1'),
+    ('netCDF', '4.9.2'),
+    ('Tkinter', '%(pyver)s'),
+]
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+
+use_pip = False
+sanity_pip_check = True
+
+exts_list = [
+#    ('Pmw', '2.0.1', {
+#        'modulename': 'Pmw',
+#        'source_tmpl': '8bedfc8747e7757c1048bc5e11899d1163717a43.zip',
+#        'source_urls': ['https://github.com/schrodinger/pmw-patched/archive/'],
+#        'checksums': ['db1ab4ee1020023ad814bb24c74f6361fb72e1011871911f7d37bb6ecf6c79ed'],
+#    }),
+    (name, version, {
+        'buildopts':  '--use-msgpackc=no',
+        'installopts': '--use-msgpackc=no',
+        'source_tmpl': 'v%(version)s.tar.gz',
+        'source_urls': ["https://github.com/schrodinger/pymol-open-source/archive/refs/tags/"],
+        'checksums': ['45e800a02680cec62dff7a0f92283f4be7978c13a02934a43ac6bb01f67622cf'],
+    }),
+]
+
+modextravars = {'PYMOL_PATH': 'lib/python%(pyshortver)s/site-packages/pymol/pymol_path'}
+
+sanity_check_paths = {
+    'files': ['bin/pymol'],
+    'dirs': ['bin', 'lib'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/PyQt-builder/PyQt-builder-1.15.4-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/p/PyQt-builder/PyQt-builder-1.15.4-GCCcore-13.2.0.eb
@@ -1,0 +1,37 @@
+# Thomas Hoffmann, EMBL Heidelberg, structures-it@embl.de, 2024/01
+easyblock = 'PythonBundle'
+
+name = 'PyQt-builder'
+version = '1.15.4'
+
+homepage = 'http://www.example.com'
+description = """PyQt-builder is the PEP 517 compliant build system for PyQt and projects that   
+extend PyQt. It extends the SIP build system and uses Qt’s qmake to perform the 
+actual compilation and installation of extension modules.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+builddependencies = [('binutils', '2.40')]
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SIP', '6.8.6'),
+]
+
+
+exts_list = [
+    (name, version, {
+        'modulename': 'pyqtbuild',
+        'checksums': ['39f8c75db17d9ce17cb6bbf3df1650b5cebc1ea4e5bd73843d21cc96612b2ae1'],
+    }),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/'],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/PyQt5/PyQt5-5.15.10-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/p/PyQt5/PyQt5-5.15.10-GCCcore-13.2.0.eb
@@ -1,0 +1,114 @@
+# update 5.15.10, sip6: THEMBL
+easyblock = 'PythonBundle'
+
+name = 'PyQt5'
+version = '5.15.10'
+
+homepage = 'https://www.riverbankcomputing.com/software/pyqt'
+description = """PyQt5 is a set of Python bindings for v5 of the Qt application framework from The Qt Company.
+This bundle includes PyQtWebEngine, a set of Python bindings for The Qt Company’s Qt WebEngine framework."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+toolchainopts = {'cstd': 'c++11'}
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('PyQt-builder', '1.15.4'),
+]
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Qt5', '5.15.13'),
+]
+
+local_sipdir = '%(installdir)s/share/sip'
+
+local_pylibdir = '%(installdir)s/lib/python%(pyshortver)s/site-packages'
+
+local_setup_env = "export PATH=%(installdir)s/bin:$PATH && "
+local_setup_env += "export PYTHONPATH=%s:$PYTHONPATH && " % local_pylibdir
+
+
+local_sip_configopts_common = [
+    "--no-make",
+    "--jobs %(parallel)s",
+    "--qmake-setting 'QMAKE_CXXFLAGS+=$$(CFLAGS)'",
+    "--qmake-setting 'QMAKE_CFLAGS+=$$(CFLAGS)'",
+    "--qmake-setting 'QMAKE_LFLAGS+=$$(LDFLAGS)'",
+    "--api-dir %(installdir)s/qsci",
+    "--scripts-dir %(installdir)s/bin",
+    "--target-dir %s" % local_pylibdir,
+]
+
+local_pyqt5_configopts = [
+    "--confirm-license",
+    "--no-designer-plugin",
+    "--no-qml-plugin",
+] + local_sip_configopts_common
+
+local_pyqtwebengine_configopts = local_sip_configopts_common
+default_easyblock = 'PythonPackage'
+
+components = [
+    ('%s_sip' % name, '12.13.0', {
+        'source_urls': [PYPI_SOURCE],
+        'sources': [SOURCE_TAR_GZ],
+        'start_dir': '%(name)s-%(version)s',
+        'use_pip': True,
+        'checksums': ['7f321daf84b9c9dbca61b80e1ef37bdaffc0e93312edae2cd7da25b953971d91'],
+    }),
+    (name, version, {
+        'source_urls': [PYPI_SOURCE],
+        'sources': [SOURCE_TAR_GZ],
+        'easyblock': 'ConfigureMake',
+        'configure_cmd': 'sip-build',
+        'start_dir': '%(name)s-%(version)s',
+        'configure_without_installdir': True,
+        'preconfigopts': local_setup_env,
+        'configopts': ' '.join(local_pyqt5_configopts),
+        'prebuildopts': local_setup_env + "cd build && ",
+        'preinstallopts': "cd build && ",
+        'checksums': ['d46b7804b1b10a4ff91753f8113e5b5580d2b4462f3226288e2d84497334898a'],
+    }),
+    ('PyQtWebEngine', '5.15.6', {
+        'source_urls': [PYPI_SOURCE],
+        'sources': [SOURCE_TAR_GZ],
+        'easyblock': 'ConfigureMake',
+        'configure_cmd': 'sip-build',
+        'start_dir': '%(name)s-%(version)s',
+        'configure_without_installdir': True,
+        'preconfigopts': local_setup_env,
+        'configopts': ' '.join(local_pyqtwebengine_configopts),
+        'prebuildopts': local_setup_env + "cd build && ",
+        'preinstallopts': "cd build && ",
+        'checksums': ['ae241ef2a61c782939c58b52c2aea53ad99b30f3934c8358d5e0a6ebb3fd0721'],
+    })
+]
+
+postinstallcmds = [
+    'mkdir %(installdir)s/share',
+    'ln -s --relative %s/%%(name)s/bindings %s' % (local_pylibdir, local_sipdir)
+]
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in [
+        'pyrcc5', 'pyuic5', 'pylupdate5']],
+    'dirs': ['lib/python%(pyshortver)s/site-packages', 'qsci'],
+}
+
+use_pip = True
+
+sanity_pip_check = True
+
+sanity_check_commands = [
+    "python -c 'import %(name)s.QtCore'",
+    "python -c 'import %(name)s.QtWebEngineWidgets'",
+    "pyuic5 --help",
+    "pylupdate5 -version 2>&1 | grep 'pylupdate5 v%(version)s'",
+    "pyrcc5 -version 2>&1 | grep 'pyrcc5 v%(version)s'",
+]
+
+modextrapaths = {
+    'QT_INSTALL_DATA': 'qsci',
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
This is the updated version of PyMOL with updated toolchain. Several other packages needed to be updated for PyMOL to work. These were PyQt5-5.15.10-GCCcore-13.2.0.eb and PyQt-builder-1.15.4-GCCcore-13.2.0.eb