### PR TITLE
POV_Ray updates for PyMOL

### DIFF
--- a/easybuild/easyconfigs/p/POV-Ray/POV-Ray-3.7.0.10-GCC-12.2.0.eb
+++ b/easybuild/easyconfigs/p/POV-Ray/POV-Ray-3.7.0.10-GCC-12.2.0.eb
@@ -1,0 +1,64 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'POV-Ray'
+version = '3.7.0.10'
+
+homepage = 'https://www.povray.org/'
+description = """The Persistence of Vision Raytracer, or POV-Ray, is a ray tracing program
+ which generates images from a text-based scene description, and is available for a variety
+ of computer platforms. POV-Ray is a high-quality, Free Software tool for creating stunning
+ three-dimensional graphics. The source code is available for those wanting to do their own ports."""
+
+toolchain = {'name': 'GCC', 'version': '12.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/POV-Ray/povray/archive/']
+sources = ['v%(version)s.tar.gz']
+patches = ['POV-Ray-3.7.0.7_dont-touch-home.patch']
+checksums = [
+    '7bee83d9296b98b7956eb94210cf30aa5c1bbeada8ef6b93bb52228bbc83abff',  # v3.7.0.10.tar.gz
+    '45103afca808e279dcdee80194c65e2a760c76d011d351392a46e817b0b655f7',  # POV-Ray-3.7.0.7_dont-touch-home.patch
+]
+
+builddependencies = [
+    ('Autotools', '20220317'),
+]
+
+dependencies = [
+    ('Boost', '1.81.0'),
+    ('zlib', '1.2.12'),
+    ('libpng', '1.6.38'),
+    ('libjpeg-turbo', '2.1.4'),
+    ('X11', '20221110'),
+    ('LibTIFF', '4.4.0'),
+    ('SDL2', '2.26.3'),
+    ('OpenEXR', '3.1.5'),
+]
+
+preconfigopts = "cd unix && sed -i 's/^automake/automake --add-missing; automake/g' prebuild.sh && "
+preconfigopts += " ./prebuild.sh && cd .. && "
+configopts = "COMPILED_BY='EasyBuild' "
+configopts += "--with-boost=$EBROOTBOOST --with-zlib=$EBROOTZLIB --with-libpng=$EBROOTLIBPNG "
+configopts += "--with-libtiff=$EBROOTLIBTIFF --with-libjpeg=$EBROOTLIBJPEGMINTURBO --with-libsdl=$EBROOTSDL2 "
+# configopts += " --with-libmkl=DIR " ## upstream needs to fix this, still in BETA
+
+runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['bin/povray'],
+    'dirs': ['etc/povray/%(version_major_minor)s', 'share']
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/POV-Ray/POV-Ray-3.7.0.10-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/p/POV-Ray/POV-Ray-3.7.0.10-GCC-13.2.0.eb
@@ -1,0 +1,64 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'POV-Ray'
+version = '3.7.0.10'
+
+homepage = 'https://www.povray.org/'
+description = """The Persistence of Vision Raytracer, or POV-Ray, is a ray tracing program
+ which generates images from a text-based scene description, and is available for a variety
+ of computer platforms. POV-Ray is a high-quality, Free Software tool for creating stunning
+ three-dimensional graphics. The source code is available for those wanting to do their own ports."""
+
+toolchain = {'name': 'GCC', 'version': '13.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/POV-Ray/povray/archive/']
+sources = ['v%(version)s.tar.gz']
+patches = ['POV-Ray-3.7.0.7_dont-touch-home.patch']
+checksums = [
+    '7bee83d9296b98b7956eb94210cf30aa5c1bbeada8ef6b93bb52228bbc83abff',  # v3.7.0.10.tar.gz
+    '45103afca808e279dcdee80194c65e2a760c76d011d351392a46e817b0b655f7',  # POV-Ray-3.7.0.7_dont-touch-home.patch
+]
+
+builddependencies = [
+    ('Autotools', '20220317'),
+]
+
+dependencies = [
+    ('Boost', '1.83.0'),
+    ('zlib', '1.2.13'),
+    ('libpng', '1.6.40'),
+    ('libjpeg-turbo', '3.0.1'),
+    ('X11', '20231019'),
+    ('LibTIFF', '4.6.0'),
+    ('SDL2', '2.28.5'),
+    ('OpenEXR', '3.2.0'),
+]
+
+preconfigopts = "cd unix && sed -i 's/^automake/automake --add-missing; automake/g' prebuild.sh && "
+preconfigopts += " ./prebuild.sh && cd .. && "
+configopts = "COMPILED_BY='EasyBuild' "
+configopts += "--with-boost=$EBROOTBOOST --with-zlib=$EBROOTZLIB --with-libpng=$EBROOTLIBPNG "
+configopts += "--with-libtiff=$EBROOTLIBTIFF --with-libjpeg=$EBROOTLIBJPEGMINTURBO --with-libsdl=$EBROOTSDL2 "
+# configopts += " --with-libmkl=DIR " ## upstream needs to fix this, still in BETA
+
+runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['bin/povray'],
+    'dirs': ['etc/povray/%(version_major_minor)s', 'share']
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/POV-Ray/PyQt-builder-1.15.4-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/p/POV-Ray/PyQt-builder-1.15.4-GCCcore-13.2.0.eb
@@ -1,0 +1,37 @@
+# Thomas Hoffmann, EMBL Heidelberg, structures-it@embl.de, 2024/01
+easyblock = 'PythonBundle'
+
+name = 'PyQt-builder'
+version = '1.15.4'
+
+homepage = 'http://www.example.com'
+description = """PyQt-builder is the PEP 517 compliant build system for PyQt and projects that   
+extend PyQt. It extends the SIP build system and uses Qt’s qmake to perform the 
+actual compilation and installation of extension modules.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+builddependencies = [('binutils', '2.40')]
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SIP', '6.8.6'),
+]
+
+
+exts_list = [
+    (name, version, {
+        'modulename': 'pyqtbuild',
+        'checksums': ['39f8c75db17d9ce17cb6bbf3df1650b5cebc1ea4e5bd73843d21cc96612b2ae1'],
+    }),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/'],
+}
+
+moduleclass = 'lang'


### PR DESCRIPTION
These updates are likely needed for PyMOL updates --> https://github.com/easybuilders/easybuild-easyconfigs/pull/21222

outputs from local computer:

```
eb --robot POV-Ray-3.7.0.10-GCC-13.2.0.eb --force
== Temporary log file in case of crash /tmp/eb-rttjagvj/easybuild-t29ja72b.log
== resolving dependencies ...
== processing EasyBuild easyconfig /home/admin/easybuild/software/EasyBuild/4.9.2/easybuild/easyconfigs/p/POV-Ray/POV-Ray-3.7.0.10-GCC-13.2.0.eb
== building and installing POV-Ray/3.7.0.10-GCC-13.2.0...
== fetching files...
== ... (took 4 secs)
== creating build dir, resetting environment...
== unpacking...
== patching...
== preparing...
== configuring...
== ... (took 15 secs)
== building...
== ... (took 44 secs)
== testing...
== ... (took 1 secs)
== installing...
== ... (took 17 secs)
== taking care of extensions...
== restore after iterating...
== postprocessing...
== sanity checking...
== cleaning up...
== creating module...
== permissions...
== packaging...
== COMPLETED: Installation ended successfully (took 1 min 26 secs)
== Results of the build can be found in the log file(s) /home/admin/easybuild/software/POV-Ray/3.7.0.10-GCC-13.2.0/easybuild/easybuild-POV-Ray-3.7.0.10-20240821.190153.log
== Build succeeded for 1 out of 1
== Temporary log file(s) /tmp/eb-rttjagvj/easybuild-t29ja72b.log* have been removed.
== Temporary directory /tmp/eb-rttjagvj has been removed.
```


```
eb --robot POV-Ray-3.7.0.10-GCC-12.2.0.eb --force
== Temporary log file in case of crash /tmp/eb-78jztm5q/easybuild-4qoz_y83.log
== resolving dependencies ...
== processing EasyBuild easyconfig /home/admin/easybuild/software/EasyBuild/4.9.2/easybuild/easyconfigs/p/POV-Ray/POV-Ray-3.7.0.10-GCC-12.2.0.eb
== building and installing POV-Ray/3.7.0.10-GCC-12.2.0...
== fetching files...
== creating build dir, resetting environment...
== unpacking...
== patching...
== preparing...
== configuring...
== ... (took 15 secs)
== building...
== ... (took 47 secs)
== testing...
== ... (took 1 secs)
== installing...
== ... (took 18 secs)
== taking care of extensions...
== restore after iterating...
== postprocessing...
== sanity checking...
== cleaning up...
== creating module...
== permissions...
== packaging...
== COMPLETED: Installation ended successfully (took 1 min 24 secs)
== Results of the build can be found in the log file(s) /home/admin/easybuild/software/POV-Ray/3.7.0.10-GCC-12.2.0/easybuild/easybuild-POV-Ray-3.7.0.10-20240821.190545.log
== Build succeeded for 1 out of 1
== Temporary log file(s) /tmp/eb-78jztm5q/easybuild-4qoz_y83.log* have been removed.
== Temporary directory /tmp/eb-78jztm5q has been removed.
```