### PR TITLE
 {perf}[GCCcore/13.3.0,gompi/2024a] Add Score-P 8.4, OTF2 3.0.3, OPARI2 2.0.8, CubeLib 4.8.2, CubeWriter 4.8.2, PAPI 7.1.0, PDT 3.25.2, SIONlib 1.7.7, UCX-CUDA 1.16.0

### DIFF
--- a/easybuild/easyconfigs/c/CubeLib/CubeLib-4.8.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/c/CubeLib/CubeLib-4.8.2-GCCcore-13.3.0.eb
@@ -1,0 +1,52 @@
+# Copyright 2019-2024 Juelich Supercomputing Centre, Germany
+# Copyright 2023-2024 TU Dresden, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Alexander Grund <alexander.grund@tu-dresden.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'CubeLib'
+version = '4.8.2'
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+description = """
+ Cube, which is used as performance report explorer for Scalasca and Score-P,
+ is a generic tool for displaying a multi-dimensional performance space
+ consisting of the dimensions (i) performance metric, (ii) call path, and
+ (iii) system resource. Each dimension can be represented as a tree, where
+ non-leaf nodes of the tree can be collapsed or expanded to achieve the
+ desired level of granularity.
+
+ This module provides the Cube general purpose C++ library component and
+ command-line tools.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://apps.fz-juelich.de/scalasca/releases/cube/%(version_major_minor)s/dist']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['d6fdef57b1bc9594f1450ba46cf08f431dd0d4ae595c47e2f3454e17e4ae74f4']
+
+builddependencies = [
+    # use same binutils version that was used when building GCCcore
+    ('binutils', '2.42'),
+    ('pkgconf', '2.2.0'),
+]
+dependencies = [
+    ('zlib', '1.3.1'),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubelib-config',
+              'lib/libcube4.a', 'lib/libcube4.%s' % SHLIB_EXT],
+    'dirs': ['include/cubelib'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.8.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.8.2-GCCcore-13.3.0.eb
@@ -1,0 +1,52 @@
+# Copyright:: Copyright 2019-2024 Juelich Supercomputing Centre, Germany
+#             Copyright 2023-2024 TU Dresden, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Alexander Grund <alexander.grund@tu-dresden.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'CubeWriter'
+version = '4.8.2'
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+description = """
+ Cube, which is used as performance report explorer for Scalasca and Score-P,
+ is a generic tool for displaying a multi-dimensional performance space
+ consisting of the dimensions (i) performance metric, (ii) call path, and
+ (iii) system resource. Each dimension can be represented as a tree, where
+ non-leaf nodes of the tree can be collapsed or expanded to achieve the
+ desired level of granularity.
+
+ This module provides the Cube high-performance C writer library component.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://apps.fz-juelich.de/scalasca/releases/cube/%(version_major_minor)s/dist']
+sources = ['cubew-%(version)s.tar.gz']
+checksums = ['4f3bcf0622c2429b8972b5eb3f14d79ec89b8161e3c1cc5862ceda417d7975d2']
+
+builddependencies = [
+    # use same binutils version that was used when building GCCcore
+    ('binutils', '2.42'),
+    ('pkgconf', '2.2.0'),
+]
+
+dependencies = [
+    ('zlib', '1.3.1'),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubew-config',
+              'lib/libcube4w.a', 'lib/libcube4w.%s' % SHLIB_EXT],
+    'dirs': ['include/cubew'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.8-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.8-GCCcore-13.3.0.eb
@@ -1,0 +1,45 @@
+# #
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+# Markus Geimer <m.geimer@fz-juelich.de>
+# Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+# #
+
+easyblock = 'ConfigureMake'
+
+name = 'OPARI2'
+version = '2.0.8'
+
+homepage = 'https://www.score-p.org'
+description = """
+ OPARI2, the successor of Forschungszentrum Juelich's OPARI, is a
+ source-to-source instrumentation tool for OpenMP and hybrid codes.
+ It surrounds OpenMP directives and runtime library calls with calls
+ to the POMP2 measurement interface.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/%(namelower)s/tags/%(namelower)s-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['196e59a2a625e6c795a6124c61e784bad142f9f38df0b4fa4d435ba9b9c19721']
+
+builddependencies = [
+    ('binutils', '2.42'),
+]
+
+
+sanity_check_paths = {
+    'files': ['bin/opari2', 'include/opari2/pomp2_lib.h'],
+    'dirs': [],
+}
+
+sanity_check_commands = ['opari2-config --help']
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-GCCcore-13.3.0.eb
@@ -1,0 +1,55 @@
+# #
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+# Markus Geimer <m.geimer@fz-juelich.de>
+# Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+# #
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'OTF2'
+version = '3.0.3'
+
+homepage = 'https://www.score-p.org'
+description = """
+ The Open Trace Format 2 is a highly scalable, memory efficient event trace
+ data format plus support library. It is the new standard trace format for
+ Scalasca, Vampir, and TAU and is open for other tools.
+
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/%(namelower)s/tags/%(namelower)s-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+patches = ['otf2-3.0.3-update-py-compile.patch']
+checksums = [
+    '18a3905f7917340387e3edc8e5766f31ab1af41f4ecc5665da6c769ca21c4ee8',  # otf2-3.0.3.tar.gz
+    '5b1dad8788642eaa97bc03003c9329380340ba10649e556a30ce541165cf8da4',  # otf2-3.0.3-update-py-compile.patch
+]
+
+builddependencies = [
+    ('binutils', '2.42'),
+]
+dependencies = [
+    # SIONlib container support (optional):
+    ('SIONlib', '1.7.7', '-tools'),
+]
+
+configopts = '--enable-shared'
+
+
+sanity_check_paths = {
+    'files': ['bin/otf2-config', 'include/otf2/otf2.h',
+              'lib/libotf2.a', 'lib/libotf2.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+sanity_check_commands = ['%(namelower)s-config --help']
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-GCCcore-13.3.0.eb
@@ -39,17 +39,22 @@ builddependencies = [
 dependencies = [
     # SIONlib container support (optional):
     ('SIONlib', '1.7.7', '-tools'),
+    # OTF2 Python bindings
+    ('Python', '3.12.3'),
+    ('Python-bundle-PyPI', '2024.06'),
 ]
 
+local_pyshortver = '3.12'
 configopts = '--enable-shared'
 
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_pyshortver]}
 
 sanity_check_paths = {
     'files': ['bin/otf2-config', 'include/otf2/otf2.h',
               'lib/libotf2.a', 'lib/libotf2.%s' % SHLIB_EXT],
     'dirs': [],
 }
-
-sanity_check_commands = ['%(namelower)s-config --help']
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python -c "import %(namelower)s"']
 
 moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/otf2-3.0.3-update-py-compile.patch
+++ b/easybuild/easyconfigs/o/OTF2/otf2-3.0.3-update-py-compile.patch
@@ -1,0 +1,252 @@
+This patch updates the py-compile file used by OTF2 during the install process
+to fix the removal of the imp module in Python 3.12 which was long deprecated.
+With this, OTF2 can be installed with Python 3.12, which would previously fail
+with a module not found error.
+
+--- build-config/py-compile	2023-02-12 17:32:31.274132086 +0100
++++ ../../otf2/build-config/py-compile	2024-08-22 17:44:59.939242651 +0200
+@@ -1,7 +1,7 @@
+ #!/bin/sh
+ # py-compile - Compile a Python program
+ 
+-scriptversion=2011-06-08.12; # UTC
++scriptversion=2023-03-30.00; # UTC
+ 
+ # Copyright (C) 2000-2013 Free Software Foundation, Inc.
+ 
+@@ -27,7 +27,7 @@
+ # bugs to <bug-automake@gnu.org> or send patches to
+ # <automake-patches@gnu.org>.
+ 
+-if [ -z "$PYTHON" ]; then
++if test -z "$PYTHON"; then
+   PYTHON=python
+ fi
+ 
+@@ -79,13 +79,20 @@
+       ;;
+     -h|--help)
+       cat <<\EOF
+-Usage: py-compile [--help] [--version] [--basedir DIR] [--destdir DIR] [--silent] FILES..."
++Usage: py-compile [options] FILES...
+ 
+ Byte compile some python scripts FILES.  Use --destdir to specify any
+ leading directory path to the FILES that you don't want to include in the
+ byte compiled file.  Specify --basedir for any additional path information you
+ do want to be shown in the byte compiled file.
+ 
++Options:
++  --basedir DIR   Prefix all FILES with DIR, and include in error messages.
++  --destdir DIR   Prefix all FILES with DIR before compiling.
++  -v, --version   Display version information.
++  -h, --help      This help screen.
++  --silent        Operate silently.
++
+ Example:
+   py-compile --destdir /tmp/pkg-root --basedir /usr/share/test test.py test2.py
+ 
+@@ -114,87 +121,165 @@
+   shift
+ done
+ 
+-files=$*
+-if test -z "$files"; then
+-    usage_error "no files given"
++if test $# -eq 0; then
++  usage_error "no files given"
+ fi
+ 
+ # if basedir was given, then it should be prepended to filenames before
+ # byte compilation.
+-if [ -z "$basedir" ]; then
+-    pathtrans="path = file"
++if test -z "$basedir"; then
++  pathtrans="path = file"
+ else
+-    pathtrans="path = os.path.join('$basedir', file)"
++  pathtrans="path = os.path.join('$basedir', file)"
+ fi
+ 
+ # if destdir was given, then it needs to be prepended to the filename to
+ # byte compile but not go into the compiled file.
+-if [ -z "$destdir" ]; then
+-    filetrans="filepath = path"
++if test -z "$destdir"; then
++  filetrans="filepath = path"
+ else
+-    filetrans="filepath = os.path.normpath('$destdir' + os.sep + path)"
++  filetrans="filepath = os.path.normpath('$destdir' + os.sep + path)"
++fi
++
++python_major=`$PYTHON -c 'import sys; print(sys.version_info[0])'`
++if test -z "$python_major"; then
++  usage_error "could not determine $PYTHON major version"
+ fi
+ 
++case $python_major in
++[01])
++  usage_error "python version 0.x and 1.x not supported"
++  ;;
++esac
++
++python_minor=`$PYTHON -c 'import sys; print(sys.version_info[1])'`
++
++# NB: When adding support for newer versions, prefer copying & adding new cases
++# rather than try to keep things merged with shell variables.
++
++# First byte compile (no optimization) all the modules.
++# This works for all currently known Python versions.
+ $PYTHON -c "
+-import sys, os, py_compile, imp
++import sys, os, py_compile
++
++try:
++    import importlib
++except ImportError:
++    importlib = None
++
++# importlib.util.cache_from_source was added in 3.4
++if (
++        hasattr(importlib, 'util')
++        and hasattr(importlib.util, 'cache_from_source')
++):
++    destpath = importlib.util.cache_from_source
++else:
++    destpath = lambda filepath: filepath + 'c'
+ 
+-files = '''$files'''
+ silent = $silent
+ blu = '''$blu'''
+ std = '''$std'''
+ 
+ if not silent:
+-    sys.stdout.write('Byte-compiling python modules...')
+-for file in files.split():
++    sys.stdout.write('Byte-compiling python modules...\n')
++for file in sys.argv[1:]:
+     $pathtrans
+     $filetrans
+-    if not os.path.exists(filepath) or not (len(filepath) >= 3
+-                                            and filepath[-3:] == '.py'):
+-	    continue
++    if (
++            not os.path.exists(filepath)
++            or not (len(filepath) >= 3 and filepath[-3:] == '.py')
++     ):
++        continue
+     if not silent:
+-        sys.stdout.write(' ' + file)
++        sys.stdout.write(file + ' ')
+         sys.stdout.flush()
+     else:
+-        sys.stdout.write('  PYTHON   {}{}{}\n'.format(blu, filepath + 'c', std))
+-    if hasattr(imp, 'get_tag'):
+-        py_compile.compile(filepath, imp.cache_from_source(filepath), path)
+-    else:
+-        py_compile.compile(filepath, filepath + 'c', path)
++        sys.stdout.write('  PYCACHE  {}{}{}\n'.format(blu, destpath(filepath), std))
++    py_compile.compile(filepath, destpath(filepath), path)
+ if not silent:
+-    sys.stdout.write('\n')" || exit $?
++    sys.stdout.write('\n')" "$@" || exit $?
+ 
+-# this will fail for python < 1.5, but that doesn't matter ...
++# Then byte compile w/optimization all the modules.
+ $PYTHON -O -c "
+-import sys, os, py_compile, imp
++import sys, os, py_compile
++
++try:
++    import importlib
++except ImportError:
++    importlib = None
++
++# importlib.util.cache_from_source was added in 3.4
++if (
++        hasattr(importlib, 'util')
++        and hasattr(importlib.util, 'cache_from_source')
++):
++    destpath = importlib.util.cache_from_source
++else:
++    destpath = lambda filepath: filepath + 'o'
+ 
+-# pypy does not use .pyo optimization
+-if hasattr(sys, 'pypy_translation_info'):
++# pypy2 does not use .pyo optimization
++if sys.version_info.major <= 2 and hasattr(sys, 'pypy_translation_info'):
+     sys.exit(0)
+ 
+-files = '''$files'''
+ silent = $silent
+ blu = '''$blu'''
+ std = '''$std'''
+ 
+ if not silent:
+-    sys.stdout.write('Byte-compiling python modules (optimized versions)...')
+-for file in files.split():
++    sys.stdout.write('Byte-compiling python modules (optimized versions) ...\n')
++for file in sys.argv[1:]:
+     $pathtrans
+     $filetrans
+-    if not os.path.exists(filepath) or not (len(filepath) >= 3
+-                                            and filepath[-3:] == '.py'):
+-	    continue
++    if (
++            not os.path.exists(filepath)
++            or not (len(filepath) >= 3 and filepath[-3:] == '.py')
++    ):
++        continue
+     if not silent:
+-        sys.stdout.write(' ' + file)
++        sys.stdout.write(file + ' ')
+         sys.stdout.flush()
+     else:
+-        sys.stdout.write('  PYTHON   {}{}{}\n'.format(blu, filepath + 'o', std))
+-    if hasattr(imp, 'get_tag'):
+-        py_compile.compile(filepath, imp.cache_from_source(filepath, False), path)
++        sys.stdout.write('  PYCACHE  {}{}{}\n'.format(blu, destpath(filepath), std))
++    py_compile.compile(filepath, destpath(filepath), path)
++if not silent:
++    sys.stdout.write('\n')" "$@" 2>/dev/null || exit $?
++
++# Then byte compile w/more optimization.
++# Only do this for Python 3.5+, see https://bugs.gnu.org/38043 for background.
++case $python_major.$python_minor in
++2.*|3.[0-4])
++  ;;
++*)
++  $PYTHON -OO -c "
++import sys, os, py_compile, importlib
++
++destpath = importlib.util.cache_from_source
++
++silent = $silent
++blu = '''$blu'''
++std = '''$std'''
++
++if not silent:
++    sys.stdout.write('Byte-compiling python modules (more optimized versions)'
++                     ' ...\n')
++for file in sys.argv[1:]:
++    $pathtrans
++    $filetrans
++    if (
++            not os.path.exists(filepath)
++            or not (len(filepath) >= 3 and filepath[-3:] == '.py')
++    ):
++        continue
++    if not silent:
++        sys.stdout.write(file + ' ')
++        sys.stdout.flush()
+     else:
+-        py_compile.compile(filepath, filepath + 'o', path)
++        sys.stdout.write('  PYCACHE  {}{}{}\n'.format(blu, destpath(filepath), std))
++    py_compile.compile(filepath, destpath(filepath), path)
+ if not silent:
+-    sys.stdout.write('\n')" 2>/dev/null || :
++    sys.stdout.write('\n')" "$@" 2>/dev/null || exit $?
++  ;;
++esac
+ 
+ # Local Variables:
+ # mode: shell-script

--- a/easybuild/easyconfigs/p/PAPI/PAPI-7.1.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/p/PAPI/PAPI-7.1.0-GCCcore-13.3.0.eb
@@ -1,0 +1,53 @@
+##
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+# Updated:   Alexander Grund <alexander.grund@tu-dresden.de>
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'PAPI'
+version = '7.1.0'
+
+homepage = 'https://icl.cs.utk.edu/projects/papi/'
+description = """
+ PAPI provides the tool designer and application engineer with a consistent
+ interface and methodology for use of the performance counter hardware found
+ in most major microprocessors. PAPI enables software engineers to see, in near
+ real time, the relation between software performance and processor events.
+ In addition Component PAPI provides access to a collection of components
+ that expose performance measurement opportunites across the hardware and
+ software stack.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://icl.utk.edu/projects/papi/downloads']
+sources = [SOURCELOWER_TAR_GZ]
+patches = ['%(name)s-%(version)s_add_initial_riscv_support.patch']
+checksums = [
+    '5818afb6dba3ece57f51e65897db5062f8e3464e6ed294b654ebf34c3991bc4f',
+    {'PAPI-7.1.0_add_initial_riscv_support.patch': '6c7d0d63ccf2b8c46f2ed736fbd4c58303038fb2a45315aed94c026b773af35a'}
+]
+
+builddependencies = [
+    ('binutils', '2.42'),
+]
+
+start_dir = 'src'
+
+configopts = "--with-components=rapl "  # for energy measurements
+
+# There is also "fulltest" that is a superset of "test" but hangs on some processors
+# indefinitely with a defunct `make` process. So use only "test".
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ["bin/papi_%s" % x
+              for x in ["avail", "clockres", "command_line", "component_avail",
+                        "cost", "decode", "error_codes", "event_chooser",
+                        "mem_info", "multiplex_cost", "native_avail",
+                        "version", "xml_event_info"]],
+    'dirs': [],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/p/PDT/PDT-3.25.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/p/PDT/PDT-3.25.2-GCCcore-13.3.0.eb
@@ -1,0 +1,40 @@
+# #
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2013-2019 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+# Markus Geimer <m.geimer@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+# #
+
+name = 'PDT'
+version = '3.25.2'
+
+homepage = 'https://www.cs.uoregon.edu/research/pdt/'
+description = """
+ Program Database Toolkit (PDT) is a framework for analyzing source code
+ written in several programming languages and for making rich program
+ knowledge accessible to developers of static and dynamic analysis tools.
+ PDT implements a standard program representation, the program database
+ (PDB), that can be accessed in a uniform way through a class library
+ supporting common PDB operations.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['http://tau.uoregon.edu/pdt_releases/']
+sources = ['pdtoolkit-%(version)s.tar.gz']
+# Might now be available as direct download although e.g. http://tau.uoregon.edu/pdt.tgz may work
+download_instructions = ("Download from https://www.cs.uoregon.edu/research/pdt/downloads.php " +
+                         "and rename to " + sources[0])
+checksums = ['01c2d403bc6672b2b264a182c325806541066c5ed5713878eb598f5506428cbe']
+
+builddependencies = [
+    ('binutils', '2.42'),
+]
+
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.7-GCCcore-13.3.0-tools.eb
+++ b/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.7-GCCcore-13.3.0-tools.eb
@@ -1,0 +1,51 @@
+# #
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2016-2019 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+# Modified 2017 by Andreas Henkel <henkel@uni-mainz.de>
+# License::   3-clause BSD
+# #
+
+easyblock = 'ConfigureMake'
+
+name = 'SIONlib'
+version = '1.7.7'
+# Provide a stripped-down version with renamed symbols for tools,
+# see description for further details
+versionsuffix = '-tools'
+
+homepage = 'https://www.fz-juelich.de/ias/jsc/EN/Expertise/Support/Software/SIONlib/_node.html'
+description = """
+ SIONlib is a scalable I/O library for parallel access to task-local files.
+ The library not only supports writing and reading binary data to or from
+ several thousands of processors into a single or a small number of physical
+ files, but also provides global open and close functions to access SIONlib
+ files in parallel. This package provides a stripped-down installation of
+ SIONlib for use with performance tools (e.g., Score-P), with renamed symbols
+ to avoid conflicts when an application using SIONlib itself is linked against
+ a tool requiring a different SIONlib version.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://apps.fz-juelich.de/jsc/%(namelower)s/download.php?version=%(version)sl']
+sources = ['%(namelower)s-%(version)sl.tar.gz']
+checksums = ['3b5072d8a32a9e9858d85dfe4dc01e7cfdbf54cdaa60660e760b634ee08d8a4c']
+
+builddependencies = [
+    ('binutils', '2.42'),
+]
+
+configopts = '--disable-cxx --disable-fortran --disable-ompi '
+
+# Comment it out if you have Xeon Phi:
+configopts += '--disable-mic '
+
+sanity_check_paths = {
+    'files': ['bin/sionconfig'] +
+             ['lib/lib%s_64.a' % x for x in ['lsioncom', 'lsiongen', 'lsionser']],
+    'dirs': []
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-gompi-2024a-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-gompi-2024a-CUDA-12.6.0.eb
@@ -1,0 +1,57 @@
+# Copyright 2013-2020 Juelich Supercomputing Centre, Germany
+# Copyright 2020-2024 TU Dresden, Germany
+# Authors::
+# * Bernd Mohr <b.mohr@fz-juelich.de>
+# * Markus Geimer <m.geimer@fz-juelich.de>
+# * Alexander Grund <alexander.grund@tu-dresden.de>
+# * Robert Mijakovic <robert.mijakovic@lxp.lu>
+# License::   3-clause BSD
+
+name = 'Score-P'
+version = '8.4'
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = 'https://www.score-p.org'
+description = """
+ The Score-P measurement infrastructure is a highly scalable and easy-to-use
+ tool suite for profiling, event tracing, and online analysis of HPC
+ applications.
+"""
+
+toolchain = {'name': 'gompi', 'version': '2024a'}
+
+source_urls = ['https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources = ['scorep-%(version)s.tar.gz']
+checksums = ['7bbde9a0721d27cc6205baf13c1626833bcfbabb1f33b325a2d67976290f7f8a']
+
+dependencies = [
+    ('CUDA', '12.6.0', '', SYSTEM),
+    ('UCX-CUDA', '1.16.0', versionsuffix),
+    ('CubeLib', '4.8.2'),
+    ('CubeWriter', '4.8.2'),
+    ('libunwind', '1.8.1'),
+    ('OPARI2', '2.0.8'),
+    ('OTF2', '3.0.3'),
+    # Hardware counter support (optional):
+    ('PAPI', '7.1.0'),
+    # PDT source-to-source instrumentation support (optional):
+    ('PDT', '3.25.2'),
+]
+
+configopts = '--enable-shared'
+
+local_adapters = [
+    'compiler_event', 'cuda_mgmt', 'compiler_mgmt', 'mpi_event', 'mpi_mgmt', 'opari2_mgmt', 'user_event', 'user_mgmt'
+]
+sanity_check_paths = {
+    'files':
+        ['bin/scorep', 'include/scorep/SCOREP_User.h'] +
+        ['lib/libscorep_adapter_%s.%s' % (a, e) for a in local_adapters for e in ('a', SHLIB_EXT)],
+    'dirs': [],
+}
+sanity_check_commands = ['scorep-config --help']
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-gompi-2024a.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-gompi-2024a.eb
@@ -1,0 +1,55 @@
+# Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Copyright 2020-2024 TU Dresden, Germany
+# Authors::
+# * Bernd Mohr <b.mohr@fz-juelich.de>
+# * Markus Geimer <m.geimer@fz-juelich.de>
+# * Alexander Grund <alexander.grund@tu-dresden.de>
+# * Robert Mijakovic <robert.mijakovic@lxp.lu>
+# * Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+
+name = 'Score-P'
+version = '8.4'
+
+homepage = 'https://www.score-p.org'
+description = """
+ The Score-P measurement infrastructure is a highly scalable and easy-to-use
+ tool suite for profiling, event tracing, and online analysis of HPC
+ applications.
+"""
+
+toolchain = {'name': 'gompi', 'version': '2024a'}
+
+source_urls = ['https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources = ['scorep-%(version)s.tar.gz']
+checksums = ['7bbde9a0721d27cc6205baf13c1626833bcfbabb1f33b325a2d67976290f7f8a']
+
+dependencies = [
+    ('CubeLib', '4.8.2'),
+    ('CubeWriter', '4.8.2'),
+    ('libunwind', '1.8.1'),
+    ('OPARI2', '2.0.8'),
+    ('OTF2', '3.0.3'),
+    # Hardware counter support (optional):
+    ('PAPI', '7.1.0'),
+    # PDT source-to-source instrumentation support (optional):
+    ('PDT', '3.25.2'),
+]
+
+configopts = '--enable-shared'
+
+local_adapters = [
+    'compiler_event', 'compiler_mgmt', 'mpi_event', 'mpi_mgmt', 'opari2_mgmt', 'user_event', 'user_mgmt'
+]
+sanity_check_paths = {
+    'files':
+        ['bin/scorep', 'include/scorep/SCOREP_User.h'] +
+        ['lib/libscorep_adapter_%s.%s' % (a, e) for a in local_adapters for e in ('a', SHLIB_EXT)],
+    'dirs': [],
+}
+sanity_check_commands = ['scorep-config --help']
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/u/UCX-CUDA/UCX-CUDA-1.16.0-GCCcore-13.3.0-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/u/UCX-CUDA/UCX-CUDA-1.16.0-GCCcore-13.3.0-CUDA-12.6.0.eb
@@ -1,0 +1,41 @@
+easyblock = 'EB_UCX_Plugins'
+
+name = 'UCX-CUDA'
+version = '1.16.0'
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = 'http://www.openucx.org/'
+description = """Unified Communication X
+An open-source production grade communication framework for data centric
+and high-performance applications
+
+This module adds the UCX CUDA support.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
+sources = [{'filename': 'ucx-%(version)s.tar.gz', 'alt_location': 'UCX'}]
+patches = ['%(name)s-1.16.0_link_against_existing_UCX_libs.patch']
+checksums = [
+    {'ucx-1.16.0.tar.gz': 'f73770d3b583c91aba5fb07557e655ead0786e057018bfe42f0ebe8716e9d28c'},
+    {'UCX-CUDA-1.16.0_link_against_existing_UCX_libs.patch':
+     'aa5bab38c188276958dd6829da4929ed9ff0b67cd55665b4459521cf3fbbe46d'},
+]
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('Autotools', '20231222'),
+    ('pkgconf', '2.2.0'),
+]
+
+dependencies = [
+    ('zlib', '1.3.1'),
+    ('UCX', version),
+    ('CUDA', '12.6.0', '', SYSTEM),
+    ('GDRCopy', '2.4.1'),
+]
+
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/u/UCX-CUDA/UCX-CUDA-1.16.0_link_against_existing_UCX_libs.patch
+++ b/easybuild/easyconfigs/u/UCX-CUDA/UCX-CUDA-1.16.0_link_against_existing_UCX_libs.patch
@@ -1,0 +1,93 @@
+diff --git a/configure.ac b/configure.ac
+index 8d8da54..2765fe0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -30,13 +30,13 @@ valgrind_libpath=""
+ AC_USE_SYSTEM_EXTENSIONS
+ AC_CONFIG_HEADERS([config.h])
+ 
+-AC_CHECK_PROG(GITBIN, git, yes)
+-AS_IF([test x"${GITBIN}" = x"yes"],
+-      [# remove preceding "refs/heads/" (11 characters) for symbolic ref
+-       AC_SUBST(SCM_BRANCH,  esyscmd([sh -c 'git symbolic-ref --quiet   HEAD | sed "s/^.\{11\}//"']))
+-       AC_SUBST(SCM_VERSION, esyscmd([sh -c 'git rev-parse    --short=7 HEAD']))],
+-      [AC_SUBST(SCM_BRANCH,  "<unknown>")
+-       AC_SUBST(SCM_VERSION, "0000000")])
++#AC_CHECK_PROG(GITBIN, git, yes)
++#AS_IF([test x"${GITBIN}" = x"yes"],
++#      [# remove preceding "refs/heads/" (11 characters) for symbolic ref
++#       AC_SUBST(SCM_BRANCH,  esyscmd([sh -c 'git symbolic-ref --quiet   HEAD | sed "s/^.\{11\}//"']))
++#       AC_SUBST(SCM_VERSION, esyscmd([sh -c 'git rev-parse    --short=7 HEAD']))],
++#      [AC_SUBST(SCM_BRANCH,  "<unknown>")
++#       AC_SUBST(SCM_VERSION, "0000000")])
+ 
+ AH_TOP([
+ #ifndef UCX_CONFIG_H
+diff --git a/src/ucm/cuda/Makefile.am b/src/ucm/cuda/Makefile.am
+index 00bd224..22e719f 100644
+--- a/src/ucm/cuda/Makefile.am
++++ b/src/ucm/cuda/Makefile.am
+@@ -9,7 +9,7 @@ if HAVE_CUDA
+ module_LTLIBRARIES      = libucm_cuda.la
+ libucm_cuda_la_CPPFLAGS = $(BASE_CPPFLAGS) $(CUDA_CPPFLAGS)
+ libucm_cuda_la_CFLAGS   = $(BASE_CFLAGS) $(CUDA_CFLAGS)
+-libucm_cuda_la_LIBADD   = ../libucm.la $(CUDA_LIBS) $(CUDART_LIBS)
++libucm_cuda_la_LIBADD   = -lucm $(CUDA_LIBS) $(CUDART_LIBS)
+ libucm_cuda_la_LDFLAGS  = $(UCM_MODULE_LDFLAGS) \
+                           $(patsubst %, -Xlinker %, $(CUDA_LDFLAGS)) \
+                           -version-info $(SOVERSION)
+diff --git a/src/ucm/rocm/Makefile.am b/src/ucm/rocm/Makefile.am
+index f9e183f..dcd1587 100644
+--- a/src/ucm/rocm/Makefile.am
++++ b/src/ucm/rocm/Makefile.am
+@@ -10,7 +10,7 @@ if HAVE_ROCM
+ module_LTLIBRARIES      = libucm_rocm.la
+ libucm_rocm_la_CPPFLAGS = $(BASE_CPPFLAGS) $(ROCM_CPPFLAGS)
+ libucm_rocm_la_CFLAGS   = $(BASE_CFLAGS) $(ROCM_CFLAGS)
+-libucm_rocm_la_LIBADD   = ../libucm.la
++libucm_rocm_la_LIBADD   = -lucm
+ libucm_rocm_la_LDFLAGS  = $(UCM_MODULE_LDFLAGS) \
+                           $(ROCM_LDFLAGS) $(ROCM_LIBS) -version-info $(SOVERSION) \
+                           $(patsubst %, -Xlinker %, -L$(ROCM_ROOT)/lib -rpath $(ROCM_ROOT)/hip/lib -rpath $(ROCM_ROOT)/lib) \
+diff --git a/src/uct/cuda/Makefile.am b/src/uct/cuda/Makefile.am
+index 00899ab..dcee6b0 100644
+--- a/src/uct/cuda/Makefile.am
++++ b/src/uct/cuda/Makefile.am
+@@ -11,8 +11,8 @@ module_LTLIBRARIES      = libuct_cuda.la
+ libuct_cuda_la_CPPFLAGS = $(BASE_CPPFLAGS) $(CUDA_CPPFLAGS)
+ libuct_cuda_la_CFLAGS   = $(BASE_CFLAGS) $(CUDA_CFLAGS)
+ libuct_cuda_la_LDFLAGS  = $(CUDA_LDFLAGS) -version-info $(SOVERSION)
+-libuct_cuda_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
+-                          $(top_builddir)/src/uct/libuct.la \
++libuct_cuda_la_LIBADD   = -lucs \
++                          -luct \
+                           $(CUDA_LIBS) $(CUDART_LIBS) $(NVML_LIBS)
+ 
+ noinst_HEADERS = \
+diff --git a/src/uct/cuda/gdr_copy/Makefile.am b/src/uct/cuda/gdr_copy/Makefile.am
+index 47602c7..601cb9f 100644
+--- a/src/uct/cuda/gdr_copy/Makefile.am
++++ b/src/uct/cuda/gdr_copy/Makefile.am
+@@ -9,7 +9,7 @@ module_LTLIBRARIES              = libuct_cuda_gdrcopy.la
+ libuct_cuda_gdrcopy_la_CPPFLAGS = $(BASE_CPPFLAGS) $(GDR_COPY_CPPFLAGS)
+ libuct_cuda_gdrcopy_la_CFLAGS   = $(BASE_CFLAGS)
+ libuct_cuda_gdrcopy_la_LDFLAGS  = $(GDR_COPY_LDFLAGS) -version-info $(SOVERSION)
+-libuct_cuda_gdrcopy_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
++libuct_cuda_gdrcopy_la_LIBADD   = -lucs \
+                                   $(top_builddir)/src/uct/cuda/libuct_cuda.la \
+                                   $(GDR_COPY_LIBS)
+ 
+diff --git a/src/uct/rocm/Makefile.am b/src/uct/rocm/Makefile.am
+index c7abce1..257e33f 100644
+--- a/src/uct/rocm/Makefile.am
++++ b/src/uct/rocm/Makefile.am
+@@ -8,8 +8,7 @@ if HAVE_ROCM
+ module_LTLIBRARIES      = libuct_rocm.la
+ libuct_rocm_la_CPPFLAGS = $(BASE_CPPFLAGS) $(ROCM_CPPFLAGS)
+ libuct_rocm_la_CFLAGS   = $(BASE_CFLAGS)
+-libuct_rocm_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
+-                          $(top_builddir)/src/uct/libuct.la
++libuct_rocm_la_LIBADD   = -lucs -luct
+ libuct_rocm_la_LDFLAGS  = $(ROCM_LDFLAGS) $(ROCM_LIBS) -version-info $(SOVERSION) \
+                           $(patsubst %, -Xlinker %, -L$(ROCM_ROOT)/lib -rpath $(ROCM_ROOT)/hip/lib -rpath $(ROCM_ROOT)/lib) \
+                           $(patsubst %, -Xlinker %, --enable-new-dtags) \


### PR DESCRIPTION
Add Score-P 8.4 and dependencies to GCCcore/13.3.0  / gompi/2024a. 

---

For OTF2, a patch updates the py-compile file used to fix the
removal of the `imp` module in Python 3.12. This prevents install failures.

The patch was generated using the Score-P developers [afs-dev](https://perftools.pages.jsc.fz-juelich.de/utils/afs-dev/) 07 and [perftools-dev](https://perftools.pages.jsc.fz-juelich.de/utils/perftools-dev/) 10. Therefore, the patch is a bit bigger than needed.

---

Requires https://github.com/easybuilders/easybuild-easyconfigs/pull/21138 for UCX-CUDA and Score-P 8.4 with CUDA support. 