### PR TITLE
Reframe 462

### DIFF
--- a/easybuild/easyconfigs/r/ReFrame/ReFrame-4.6.2-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/r/ReFrame/ReFrame-4.6.2-GCCcore-12.3.0.eb
@@ -11,9 +11,9 @@ toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 # Note that for ReFrame's CPU autodetect to work
 # the system also needs to provide (new enough versions of) these dependencies
 dependencies = [
-    ('Python', '3.11.5'),
+    ('Python', '3.11.3'),
     ('libxslt', '1.1.38'),
-    ('libxml2', '2.11.5'), 
+    ('libxml2', '2.11.4'), 
 ]
 
 use_pip = True

--- a/easybuild/easyconfigs/r/ReFrame/ReFrame-4.6.2-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/r/ReFrame/ReFrame-4.6.2-GCCcore-13.2.0.eb
@@ -1,0 +1,71 @@
+easyblock = 'PythonBundle'
+
+name = 'ReFrame'
+version = '4.6.2'
+
+homepage = 'https://github.com/reframe-hpc/reframe'
+description = '''ReFrame is a framework for writing regression tests for HPC systems.'''
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('libxslt', '1.1.38'),
+    ('libxml2', '2.11.4'), 
+]
+
+use_pip = True
+
+exts_list = [
+    # ReFrame's bootstrap script is intended to run with zero dependencies. It downloads all python deps for ReFrame
+    # into a %(installdir)/external directory. ReFrame's main executable (reframe) adds this dir to python's sys.path
+    # so that ReFrame (and only ReFrame) will find & use all of these dependencies.
+    # In EasyBuild, we should adhere to this installation method because a) it is how ReFrame is meant to be used and
+    # b) it isolates all of ReFrame dependencies from any other python code you run. Thus, there is no chance that
+    # a test will pick up on any python deps from ReFrame itself.
+    # For this to work, we need to disable download_dep_fail and sanity_pip_check, as both are _expected_ to fail
+    # for this setup.
+    ('reframe', version, {
+        # Deps are downloaded to %(installdir)/external, which won't polute the PYTHONPATH, so is ok
+        'download_dep_fail': False,
+        # ReFrame uses its custom sys.path to find necessary packages, they are not on PYTYHONPATH
+        # Thus, the regular pip sanity check is expected to fail, even if ReFrame would run just fine 
+        'sanity_pip_check': False,
+        # Set modulename to False, as to skip the sanity_check-step from extension.py (python -c "import reframe")
+        # This step would fail, since the regular python interpreter wouldn't find the additional packages in
+        # %(installdir)/external. That's fine, as ReFrame should never be imported directly, only through the
+        # reframe command.
+        'modulename': False,
+        'preinstallopts': "export PATH=%(installdir)s/bin:$PATH && "
+                          "./bootstrap.sh +docs +pygelf && cp -r external %(installdir)s && ",
+        'source_tmpl': 'v%(version)s.tar.gz',
+        'source_urls': ['https://github.com/reframe-hpc/reframe/archive/'],
+        'checksums': ['d3343815ee3d2c330b91a1cdb924ba184119ed7d9fc88a4a754b939a4259df82'],
+    }),
+]
+
+postinstallcmds = [
+    "cp -a tools examples %(installdir)s",
+    "mkdir -p %(installdir)s/share && cp -a share/completions %(installdir)s/share/completions",
+    r"sed -i 's@/\(python[0-9.]*\)$@/\1 -S@g' %(installdir)s/bin/reframe",
+]
+
+sanity_check_paths = {
+    'files': ['bin/reframe',
+              'share/completions/reframe.bash',
+              'share/completions/reframe.fish',
+              'share/completions/reframe.tcsh'],
+    'dirs': ['external', 'lib', 'tools', 'examples']
+}
+
+sanity_check_commands = ['reframe -V']
+
+sanity_pip_check = True
+
+# Since this is at the GCCcore toolchain level, make sure ReFrame is configured to purge modules before running
+# any tests by default
+modextravars = {
+    'RFM_PURGE_ENVIRONMENT': '1',
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/r/ReFrame/ReFrame-4.6.2.eb
+++ b/easybuild/easyconfigs/r/ReFrame/ReFrame-4.6.2.eb
@@ -6,15 +6,18 @@ version = '4.6.2'
 homepage = 'https://github.com/reframe-hpc/reframe'
 description = '''ReFrame is a framework for writing regression tests for HPC systems.'''
 
-toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+toolchain = SYSTEM
 
-# Note that for ReFrame's CPU autodetect to work
-# the system also needs to provide (new enough versions of) these dependencies
-dependencies = [
-    ('Python', '3.11.5'),
-    ('libxslt', '1.1.38'),
-    ('libxml2', '2.11.5'), 
+allow_system_deps = [('Python', SYS_PYTHON_VERSION)]
+
+osdependencies = [
+    ('libxml2'),
+    ('libxslt'),
 ]
+
+# Listed as python_requires in https://github.com/reframe-hpc/reframe/blob/v4.6.2/setup.cfg
+req_py_majver = 3
+req_py_minver = 6
 
 use_pip = True
 

--- a/easybuild/easyconfigs/r/ReFrame/ReFrame-4.6.2.eb
+++ b/easybuild/easyconfigs/r/ReFrame/ReFrame-4.6.2.eb
@@ -67,10 +67,4 @@ sanity_check_commands = ['reframe -V']
 
 sanity_pip_check = True
 
-# Since this is at the GCCcore toolchain level, make sure ReFrame is configured to purge modules before running
-# any tests by default
-modextravars = {
-    'RFM_PURGE_ENVIRONMENT': '1',
-}
-
 moduleclass = 'devel'


### PR DESCRIPTION
I had a close look at https://github.com/easybuilders/easybuild-easyconfigs/pull/20911 and https://github.com/easybuilders/easybuild-easyconfigs/pull/21189 and discussed a bit on the maintainers chat how to proceed with ReFrame: do we put it at a toolchain level, or not.

Consensus was that if there is good reason, we can do both. This PR adds both options. It also

- Correctly lists dependencies (as `osdependencies` in case of the `SYSTEM` toolchain, and regular `dependencies` in case of the `GCCcore` toolchain
- It does not include `binutils as build dep. Was there in https://github.com/easybuilders/easybuild-easyconfigs/pull/20911but doesn't make sense imho, since nothing is compiled for this installation.
- It does not include `req_py_majver` and `req_py_minver` for the configs at `GCCcore` level, as these only apply to the `SYSTEM` toolchain
- It does not include all ReFrame deps in `exts_list`, but rather, depends on ReFrame to install all in the `%(installdir)/external` directory. This is how ReFrame's was _designed_ to work. The bootstrap install requires no build dependencies at all. At runtime, the `reframe` command adds the `%(installdir)/external` to the `sys.path` before executing the rest of the ReFrame code. From this moment onward, as soon as `reframe` finds a reframe test that includes a `import reframe`, that import works, since all the deps are on the `sys.path`. These deps are NOT on the `PYTHONPATH` on purpose: this way, `reframe` can run in an isolated manner, without affecting how other code (e.g. code from the tests) run.
- We set `RFM_PURGE_ENVIRONMENT` by default for the ReFrame versions at `GCCcore` toolchain level. This is a sensible default, since the toolchain will now be loaded when the `reframe` command is run, and one wants to unload it when running a test. Note that this behavior can still be overwritten in a local ReFrame config file, it merely gives a reasonable default for this type of installation.
- We disable all kind of standard python-package sanity checks from EasyBuild, as they are _expected_ to fail for ReFrame's setup. First, `download_dep_fail` is disabled, since we intentionally let ReFrame's bootstrap script download all dependencies. Second, `sanity_pip_check` is disabled, since this pip check will rely on the dependencies being on `PYTHONPATH` (and they are not, they are included in the `sys.path` as part of the `reframe` command). Third, we set `modulename` to `False` so that no `python -c "import reframe"` is done as part of the `sanity_check`. This is expected to fail, as it would require the dependencies to be on the `PYTHONPATH`.
- Removed all manual additions to `PYTHONPATH`
- No longer manually copy `hpctestlib`. It is now installed by default by ReFrame's installation method. See https://github.com/reframe-hpc/reframe/releases/tag/v4.3.4
- https://github.com/easybuilders/easybuild-easyconfigs/pull/21189 sets `BASH_COMPLETION_USER_DIR` as environment variable, but that is not needed. The `share` directory is automatically added by EasyBuild to `XDG_DATA_DIRS`. This seems to be enough, at least my auto-complete for `reframe` arguments seemed to work just fine without setting `BASH_COMPLETION_USER_DIR`.