### PR TITLE
add FreeCAD-1.0.0pre-foss-2023b.eb with deps and patches

### DIFF
--- a/easybuild/easyconfigs/b/build/build-1.0.3-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/b/build/build-1.0.3-GCCcore-13.2.0.eb
@@ -1,0 +1,36 @@
+easyblock = 'PythonBundle'
+
+name = 'build'
+version = '1.0.3'
+
+homepage = 'https://github.com/pypa/build'
+description = """A simple, correct Python build frontend."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+builddependencies = [('binutils', '2.40')]
+
+dependencies = [
+    ('Python', '3.11.5'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('packaging', '23.2', {
+        'checksums': ['048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5'],
+    }),
+    ('pyproject_hooks', '1.0.0', {
+        'checksums': ['f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5'],
+    }),
+    (name, version, {
+        'checksums': ['538aab1b64f9828977f84bc63ae570b060a8ed1be419e7870b8b4fc5e6ea553b'],
+    }),
+]
+
+sanity_check_commands = [
+    "python3 -m build -V",
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/c/Coin/Coin-4.0.2-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/c/Coin/Coin-4.0.2-GCC-13.2.0.eb
@@ -1,0 +1,35 @@
+easyblock = 'CMakeMake'
+
+name = 'Coin'
+version = '4.0.2'
+
+homepage = 'https://coin3d.github.io'
+description = """Coin is an OpenGL-based, 3D graphics library that has its roots in the
+Open Inventor 2.1 API, which Coin still is compatible with."""
+
+toolchain = {'name': 'GCC', 'version': '13.2.0'}
+
+source_urls = ["https://github.com/coin3d/%(namelower)s/archive/refs/tags/"]
+sources = ["v%(version)s.tar.gz"]
+checksums = ['fab19ccdb5f199dae5543036738076a957a3097589b473ef496696c24eeac3d2']
+
+# Boost is a header-only dependency
+builddependencies = [
+    ('Boost', '1.83.0'),
+    ('CMake', '3.27.6'),
+]
+
+dependencies = [
+    ('X11', '20231019'),
+    ('Mesa', '23.1.9'),
+    ('libGLU', '9.0.3'),
+]
+
+configopts = "-DCOIN_BUILD_TESTS=OFF"
+
+sanity_check_paths = {
+    'files': ['lib/libCoin.%s' % SHLIB_EXT],
+    'dirs': ['lib/pkgconfig']
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/f/FreeCAD/FreeCAD-1.0.0pre-foss-2023b.eb
+++ b/easybuild/easyconfigs/f/FreeCAD/FreeCAD-1.0.0pre-foss-2023b.eb
@@ -1,0 +1,119 @@
+easyblock = 'CMakeNinja'
+
+name = 'FreeCAD'
+version = '1.0.0pre'
+
+# FreeCAD main can be built against Qt6, no official release yet
+# https://github.com/FreeCAD/FreeCAD/issues/13303#issuecomment-2039708088
+
+homepage = 'https://github.com/FreeCAD/FreeCAD'
+description = '''Your own 3D parametric modeler'''
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+
+sources = [
+    {
+        'source_urls': ['https://github.com/FreeCAD/FreeCAD/archive'],
+        'download_filename': 'b05dc2da7373c4483a3b476a0e190c02b175e80a.tar.gz',  # release/FreeCAD-1-0 branch
+        'filename': '%(name)s-%(version)s.tar.gz',
+        'extract_cmd': 'tar -xzf %s -C %(builddir)s --strip-components=1',
+    },
+    {
+        'source_urls': ['https://github.com/microsoft/GSL/archive'],
+        'download_filename': 'b39e7e4b0987859f5b19ff7686b149c916588658.tar.gz',
+        'filename': '%(name)s-%(version)s-GSL.tar.gz',
+        'extract_cmd': 'tar -xzf %s -C %(builddir)s/src/3rdParty/GSL --strip-components=1',
+    },
+    {
+        'source_urls': ['https://github.com/Ondsel-Development/OndselSolver/archive'],
+        'download_filename': '64e546fe807043d4cdc33be023e521ac0f6449e9.tar.gz',
+        'filename': '%(name)s-%(version)s-OndselSolver.tar.gz',
+        'extract_cmd': 'tar -xzf %s -C %(builddir)s/src/3rdParty/OndselSolver --strip-components=1',
+    },
+    {
+        'source_urls': ['https://github.com/google/googletest/archive'],
+        'download_filename': 'f8d7d77c06936315286eb55f8de22cd23c188571.tar.gz',
+        'filename': '%(name)s-%(version)s-googletest.tar.gz',
+        'extract_cmd': 'tar -xzf %s -C %(builddir)s/tests/lib --strip-components=1',
+    },
+]
+
+checksums = [
+    {'FreeCAD-0.22.0pre.tar.gz': 'ef119bf4b0c9b760dccae69a6d74890a2392c0b728c5780de01741bed1cef2b4'},
+    {'FreeCAD-0.22.0pre-GSL.tar.gz': 'dcd20c4eafbd5b9cfa9078a638546724390f661834dd3816622ca9875659907e'},
+    {'FreeCAD-0.22.0pre-OndselSolver.tar.gz': '66c60f09f017d107cd50e92a9e54bd235655cfbc38dd109e91bbbeb8a31634ad'},
+    {'FreeCAD-0.22.0pre-googletest.tar.gz': '7ff5db23de232a39cbb5c9f5143c355885e30ac596161a6b9fc50c4538bfbf01'},
+]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('Doxygen', '1.9.8'),
+    ('Eigen', '3.4.0'),
+    ('Ninja', '1.11.1'),
+]
+
+dependencies = [
+    ('fmt', '10.2.0'),
+    ('yaml-cpp', '0.8.0'),
+    ('Xerces-C++', '3.2.5'),
+    ('Boost', '1.83.0'),
+    ('Python', '3.11.5'),
+    ('Boost.Python', '1.83.0'),
+    ('Qt6', '6.6.3'),
+    ('PySide6', '6.6.2'),
+    ('Shiboken6', '6.6.2'),
+    ('X11', '20231019'),
+    ('VTK', '9.3.0'),
+    ('matplotlib', '3.8.2'),
+    ('med', '5.0.0'),
+    ('pivy', '0.6.9.a0'),
+    ('Mesa', '23.1.9'),
+    ('libGLU', '9.0.3'),
+    ('Coin', '4.0.2'),
+    ('Quarter', '1.2.1'),
+    ('occt', '7.8.1'),
+]
+
+build_type = 'RelWithDebInfo'
+
+configopts = ''
+configopts += ' -DENABLE_DEVELOPER_TESTS=NO'
+configopts += ' -DBUILD_TEST=NO'
+configopts += ' -DBUILD_FLAT_MESH=YES'
+configopts += ' -DBUILD_DESIGNER_PLUGIN=YES'
+configopts += ' -DBUILD_DRAWING=YES'
+configopts += ' -DFREECAD_QT_MAJOR_VERSION=6'
+configopts += ' -DFREECAD_USE_QT_FILEDIALOG=YES'
+configopts += ' -DFREECAD_USE_PYBIND11=YES'
+configopts += ' -DFREECAD_USE_EXTERNAL_PIVY=YES'
+configopts += ' -DFREECAD_USE_OCC_VARIANT="Official Version"'
+configopts += ' -DINSTALL_TO_SITEPACKAGES=NO'
+configopts += ' -DDESIGNER_PLUGIN_LOCATION=%(installdir)s/plugins'
+configopts += ' -Wno-dev'
+configopts += ' -Wdeprecated-declarations'
+
+sanity_check_paths = {
+    'files': [
+        'bin/FreeCADCmd',
+        'bin/FreeCAD',
+        'lib64/Points.so',
+        'lib64/libSMESH.so',
+        'lib64/FreeCAD.so',
+    ],
+    'dirs': ['bin', 'share/pkgconfig', 'lib64'],
+}
+
+postinstallcmds = [
+    'ln -s FreeCAD %(installdir)s/bin/freecad',
+    'ln -s FreeCADCmd %(installdir)s/bin/freecadcmd',
+]
+
+modextrapaths = {
+    'QT_PLUGIN_PATH': 'plugins',
+}
+
+sanity_check_commands = [
+    'FreeCAD -c "print(2+2)"',
+]
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/f/FreeImage/FreeImage-3.18.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/f/FreeImage/FreeImage-3.18.0-GCCcore-13.2.0.eb
@@ -1,0 +1,43 @@
+easyblock = 'ConfigureMake'
+
+name = 'FreeImage'
+version = '3.18.0'
+
+homepage = 'http://freeimage.sourceforge.net'
+description = """FreeImage is an Open Source library project for developers who would like to support popular graphics
+image formats like PNG, BMP, JPEG, TIFF and others as needed by today's multimedia applications. FreeImage is easy to
+use, fast, multithreading safe."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+toolchainopts = {'cstd': 'c++14'}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%(name)s3180.zip']
+patches = ['%(name)s-%(version)s-fix-makefile.patch']
+checksums = [
+    'f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd',  # FreeImage3180.zip
+    '3eaa1eb9562ccfd0cb95a37879bb7e3e8c745166596d75af529478181ef006a0',  # %(name)s-%(version)s-fix-makefile.patch
+]
+
+builddependencies = [('binutils', '2.40')]
+
+dependencies = [('zlib', '1.2.13')]
+
+skipsteps = ['configure']
+
+buildopts = ['', '-f Makefile.fip']
+
+installopts = [
+    "INCDIR=%(installdir)s/include INSTALLDIR=%(installdir)s/lib",
+    "-f Makefile.fip INCDIR=%(installdir)s/include INSTALLDIR=%(installdir)s/lib",
+]
+
+_incs = ['include/FreeImage%s.h' % x for x in ['', 'Plus']]
+_libs = ['lib/libfreeimage%s.%s' % (x, y) for x in ['', 'plus'] for y in ['a', SHLIB_EXT]]
+
+sanity_check_paths = {
+    'files': _incs + _libs,
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/med/med-5.0.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/m/med/med-5.0.0-foss-2023b.eb
@@ -1,0 +1,54 @@
+easyblock = 'CMakeNinja'
+
+name = 'med'
+version = '5.0.0'
+
+homepage = 'https://www.salome-platform.org'
+description = '''MED: interoperable format for data interchange between mesh based solvers'''
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+
+source_urls = ['https://files.salome-platform.org/Salome/medfile/']
+sources = [SOURCELOWER_TAR_BZ2]
+patches = ['med-5.0.0-hdf5-1.14-compat.patch']
+checksums = [
+    {'med-5.0.0.tar.bz2': '267e76d0c67ec51c10e3199484ec1508baa8d5ed845c628adf660529dce7a3d4'},
+    {'med-5.0.0-hdf5-1.14-compat.patch': '91937b08316fc5acca0709031341bb2a6fea04c0bcbaab1274be554c4723b514'},
+]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('Ninja', '1.11.1'),
+]
+
+dependencies = [
+    ('HDF5', '1.14.3'),
+    ('Python', '3.11.5'),
+    ('SWIG', '4.1.1'),
+    ('Tk', '8.6.13'),
+]
+
+configopts = ''
+configopts += ' -DMEDFILE_BUILD_PYTHON=ON'
+configopts += ' -DMEDFILE_BUILD_TESTS=OFF'
+configopts += ' -DMEDFILE_INSTALL_DOC=OFF'
+
+sanity_check_paths = {
+    'files': [
+        'lib/libmed.%s' % SHLIB_EXT,
+        'lib/libmedC.%s' % SHLIB_EXT,
+        'lib/python%(pyshortver)s/site-packages/med/medfile.py',
+        'lib/python%%(pyshortver)s/site-packages/med/_medmesh.%s' % SHLIB_EXT,
+        'include/med.h',
+        'include/medfile.h',
+        'include/medmesh.h',
+    ],
+    'dirs': [
+        'bin',
+        'include',
+        'share/cmake/medfile-%(version)s',
+        'lib/python%(pyshortver)s/site-packages',
+    ],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/med/med-5.0.0-hdf5-1.14-compat.patch
+++ b/easybuild/easyconfigs/m/med/med-5.0.0-hdf5-1.14-compat.patch
@@ -1,0 +1,128 @@
+See https://aur.archlinux.org/packages/med
+
+diff --git a/config/cmake_files/medMacros.cmake b/config/cmake_files/medMacros.cmake
+index 992103e..b60ef52 100644
+--- a/config/cmake_files/medMacros.cmake
++++ b/config/cmake_files/medMacros.cmake
+@@ -447,7 +447,7 @@ MACRO(MED_FIND_HDF5)
+     ##
+     ## Requires 1.12.x version
+     ##
+-    IF (NOT HDF_VERSION_MAJOR_REF EQUAL 1 OR NOT HDF_VERSION_MINOR_REF EQUAL 12 OR NOT HDF_VERSION_RELEASE_REF GREATER 0)
++    IF (HDF5_VERSION VERSION_LESS 1.12.1)
+         MESSAGE(FATAL_ERROR "HDF5 version is ${HDF_VERSION_REF}. Only versions >= 1.12.1 are supported.")
+     ENDIF()
+     ##
+diff --git a/src/ci/MEDfileCompatibility.c b/src/ci/MEDfileCompatibility.c
+index b0f7c59..2c1bb8e 100644
+--- a/src/ci/MEDfileCompatibility.c
++++ b/src/ci/MEDfileCompatibility.c
+@@ -116,7 +116,7 @@ MEDfileCompatibility(const char* const filename,
+ #if MED_NUM_MAJEUR != 5
+ #error "Don't forget to update the test version here when you change the major version of the library !"
+ #endif
+-#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
+ #error "Don't forget to check the compatibility version of the library, depending on the internal hdf model choice !"
+ #error "Cf. _MEDfileCreate ..."
+ #endif
+diff --git a/src/hdfi/_MEDfileCreate.c b/src/hdfi/_MEDfileCreate.c
+index 8958f57..c27967b 100644
+--- a/src/hdfi/_MEDfileCreate.c
++++ b/src/hdfi/_MEDfileCreate.c
+@@ -189,7 +189,7 @@ med_idt _MEDfileCreate(const char * const filename, const med_access_mode access
+    * Cette ligne est censée obliger HDF à ne pas utiliser un modèle interne différent de 1.10.z
+    * Un test autoconf permet de fixer un intervalle de version HDF à MED.
+    */
+-#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+    
+diff --git a/src/hdfi/_MEDfileOpen.c b/src/hdfi/_MEDfileOpen.c
+index 9ef55a0..5500776 100644
+--- a/src/hdfi/_MEDfileOpen.c
++++ b/src/hdfi/_MEDfileOpen.c
+@@ -113,7 +113,7 @@ med_idt _MEDfileOpen(const char * const filename,const med_access_mode accessmod
+        has been set in the group creation property list (see H5Pset_link_creation_order).
+   */
+ 
+-#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+ /* L'avantage de bloquer le modèle interne HDF5
+diff --git a/src/hdfi/_MEDfileOpenForImport.c b/src/hdfi/_MEDfileOpenForImport.c
+index 938c55d..497e1e3 100644
+--- a/src/hdfi/_MEDfileOpenForImport.c
++++ b/src/hdfi/_MEDfileOpenForImport.c
+@@ -53,7 +53,7 @@ med_idt  _MEDfileOpenForImport(const char * const filename,const med_access_mode
+   }
+ 
+ 
+-#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+ /* L'avantage de bloquer le modèle interne HDF5
+diff --git a/src/hdfi/_MEDmemFileOpen.c b/src/hdfi/_MEDmemFileOpen.c
+index fbf059c..516e101 100644
+--- a/src/hdfi/_MEDmemFileOpen.c
++++ b/src/hdfi/_MEDmemFileOpen.c
+@@ -439,7 +439,7 @@ med_idt _MEDmemFileOpen(const char * const filename, med_memfile * const memfile
+     goto ERROR;
+   }
+ 
+-#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+   if ( H5Pset_libver_bounds( _fapl, H5F_LIBVER_V112, H5F_LIBVER_V112 ) ) {
+@@ -506,7 +506,7 @@ med_idt _MEDmemFileOpen(const char * const filename, med_memfile * const memfile
+ 	goto ERROR;
+       }
+       _fversionMM = 100*_fmajor+10*_fminor;
+-#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+       if ( _fversionMM < 500 ) { /*100*MED_NUM_MAJEUR+10*MED_NUM_MINEUR*/
+diff --git a/src/hdfi/_MEDparFileCreate.c b/src/hdfi/_MEDparFileCreate.c
+index 2d4e164..2a8ca7d 100644
+--- a/src/hdfi/_MEDparFileCreate.c
++++ b/src/hdfi/_MEDparFileCreate.c
+@@ -64,7 +64,7 @@ med_idt _MEDparFileCreate(const char * const filename, const med_access_mode acc
+    * En HDF5-1.10.0p1 cela n'a aucun effet ! 
+    * Un test autoconf permet de fixer un intervalle de version HDF à MED.
+    */
+-#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+    
+diff --git a/src/hdfi/_MEDparFileOpen.c b/src/hdfi/_MEDparFileOpen.c
+index d072f18..a226683 100644
+--- a/src/hdfi/_MEDparFileOpen.c
++++ b/src/hdfi/_MEDparFileOpen.c
+@@ -86,7 +86,7 @@ med_idt _MEDparFileOpen(const char * const filename,const med_access_mode access
+   }
+   _fversionMM = 100*_fmajor+10*_fminor;
+ 
+-#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif 
+   if ( _fversionMM < 500 ) { /*100*MED_NUM_MAJEUR+10*MED_NUM_MINEUR*/
+diff --git a/src/misc/MEDversionedApi3C.c b/src/misc/MEDversionedApi3C.c
+index acc044f..e04078b 100644
+--- a/src/misc/MEDversionedApi3C.c
++++ b/src/misc/MEDversionedApi3C.c
+@@ -114,7 +114,7 @@ MedFuncType _MEDversionedApi3( const char * const key,
+   /*      (_fversionMM <= (100*MED_NUM_MAJEUR+10*MED_NUM_MINEUR) ) */
+   /*      ) { */
+ 
+-#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+   

--- a/easybuild/easyconfigs/o/occt/occt-7.8.1-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/o/occt/occt-7.8.1-GCCcore-13.2.0.eb
@@ -1,0 +1,51 @@
+easyblock = 'CMakeMake'
+
+name = 'occt'
+version = '7.8.1'
+local_v = version.replace('.', '_')
+
+homepage = 'https://www.opencascade.com/'
+description = """Open CASCADE Technology (OCCT) is an object-oriented C++
+class library designed for rapid production of sophisticated domain-specific
+CAD/CAM/CAE applications."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+source_urls = ['https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags']
+sources = [{'download_filename': 'V%s.tar.gz' % local_v, 'filename': SOURCE_TAR_GZ}]
+patches = ['occt-OpenCASCADEConfig-cmake.patch']
+checksums = [
+    {'occt-7.8.1.tar.gz': '7321af48c34dc253bf8aae3f0430e8cb10976961d534d8509e72516978aa82f5'},
+    {'occt-OpenCASCADEConfig-cmake.patch': 'f4b7ff289a3077c94d7c80665076af6d7c5d80da945311feca3558662e394f5d'},
+]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('Doxygen', '1.9.8'),
+    ('binutils', '2.40'),
+]
+dependencies = [
+    ('Mesa', '23.1.9'),
+    ('freetype', '2.13.2'),
+    ('Tcl', '8.6.13'),
+    ('Tk', '8.6.13'),
+    ('FreeImage', '3.18.0'),
+    ('tbb', '2021.13.0'),
+]
+
+separate_build_dir = True
+
+configopts = "-DUSE_FREEIMAGE=ON -D3RDPARTY_FREEIMAGE_DIR=$EBROOTFREEIMAGE "
+configopts += "-D3RDPARTY_TBB_DIR=$EBROOTTBB "
+configopts += "-D3RDPARTY_TCL_DIR=$EBROOTTCL "
+configopts += "-D3RDPARTY_TK_DIR=$EBROOTTK "
+configopts += "-D3RDPARTY_FREETYPE_DIR=$EBROOTFREETYPE "
+
+sanity_check_paths = {
+    'files': ['bin/DRAWEXE', 'bin/env.sh'],
+    'dirs': ['lib/cmake/opencascade'],
+}
+
+sanity_check_commands = ['DRAWEXE -h']
+
+moduleclass = 'cae'

--- a/easybuild/easyconfigs/o/occt/occt-OpenCASCADEConfig-cmake.patch
+++ b/easybuild/easyconfigs/o/occt/occt-OpenCASCADEConfig-cmake.patch
@@ -1,0 +1,14 @@
+diff --git a/adm/templates/OpenCASCADEConfig.cmake.in.orig b/adm/templates/OpenCASCADEConfig.cmake.in
+index e391ddfe8e..f66a3c115a 100644
+--- a/adm/templates/OpenCASCADEConfig.cmake.in.orig
++++ b/adm/templates/OpenCASCADEConfig.cmake.in
+@@ -30,6 +30,9 @@ endif()
+ if (OpenCASCADE_INSTALL_PREFIX MATCHES "/lib$")
+   get_filename_component (OpenCASCADE_INSTALL_PREFIX "${OpenCASCADE_INSTALL_PREFIX}" PATH)
+ endif()
++if (OpenCASCADE_INSTALL_PREFIX MATCHES "/lib64$")
++  get_filename_component (OpenCASCADE_INSTALL_PREFIX "${OpenCASCADE_INSTALL_PREFIX}" PATH)
++endif()
+ if (OpenCASCADE_INSTALL_PREFIX MATCHES "/libs/${CMAKE_ANDROID_ARCH_ABI}$")
+   get_filename_component (OpenCASCADE_INSTALL_PREFIX "${OpenCASCADE_INSTALL_PREFIX}" PATH)
+   get_filename_component (OpenCASCADE_INSTALL_PREFIX "${OpenCASCADE_INSTALL_PREFIX}" PATH)

--- a/easybuild/easyconfigs/p/PySide6/PySide6-6.6.2-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/p/PySide6/PySide6-6.6.2-GCCcore-13.2.0.eb
@@ -1,0 +1,48 @@
+easyblock = 'PythonPackage'
+
+name = 'PySide6'
+version = '6.6.2'
+
+homepage = 'https://pypi.python.org/pypi/PySide6'
+description = """PySide6 is the official Python module from the Qt for Python project,
+    which provides access to the complete Qt 6.0+ framework."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+source_urls = ['https://download.qt.io/official_releases/QtForPython/%(namelower)s/%(name)s-%(version)s-src/']
+sources = ['pyside-setup-everywhere-src-%(version)s.tar.xz']
+checksums = ['14620b694d7af4c978443016292d3d2108ba5dc105f4170e3b71eadcaf04c9f0']
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('CMake', '3.27.6'),
+    ('Clang', '17.0.6'),
+    ('Ninja', '1.11.1'),
+    ('build', '1.0.3'),
+    ('patchelf', '0.18.0'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Qt6', '6.6.3'),
+]
+
+use_pip = False
+sanity_pip_check = True
+download_dep_fail = True
+
+preconfigopts = 'export CLANG_INSTALL_DIR=$EBROOTCLANG && '
+
+prebuildopts = 'export CLANG_INSTALL_DIR=$EBROOTCLANG && '
+buildcmd = 'build --parallel=%(parallel)s'
+
+preinstallopts = 'export CLANG_INSTALL_DIR=$EBROOTCLANG && '
+install_target = 'install --parallel=%(parallel)s'
+
+options = {'modulename': 'PySide6'}
+
+postinstallcmds = [
+    'ln -s python%(pyshortver)s/site-packages/%(name)s/libpyside6.abi3.so.6.6  %(installdir)s/lib/',
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/pivy/pivy-0.6.9.a0-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/p/pivy/pivy-0.6.9.a0-GCC-13.2.0.eb
@@ -1,0 +1,54 @@
+easyblock = 'CMakePythonPackage'
+
+name = 'pivy'
+version = '0.6.9.a0'
+
+homepage = 'https://coin3d.github.io'
+description = '''Python binding for Coin.'''
+
+toolchain = {'name': 'GCC', 'version': '13.2.0'}
+
+source_urls = ['https://github.com/coin3d/%(name)s/archive/refs/tags/']
+sources = ['%(version)s.tar.gz']
+patches = [
+    'pivy-0.6.9.a0-coin-includes.patch',
+    'pivy-0.6.9.a0-swigify.patch',
+    'pivy-0.6.9.a0-python-sitearch.patch',
+]
+checksums = [
+    {'0.6.9.a0.tar.gz': '2c2da80ae216fe06394562f4a8fc081179d678f20bf6f8ec412cda470d7eeb91'},
+    {'pivy-0.6.9.a0-coin-includes.patch': 'ac720c8d3c9f540217c3135651d74bbdfe2872d3b83d45020da361be8cd25bd7'},
+    {'pivy-0.6.9.a0-swigify.patch': 'b8fe796d4a56ef0f3ad7a2dd64990d4efd84758d962fc9c98d1f256e55a0612d'},
+    {'pivy-0.6.9.a0-python-sitearch.patch': '764a79ce69a270b6c41ff935f369a850e9988716785ee1007d6695dc35fce7b4'},
+]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SWIG', '4.1.1'),
+    ('SoQt', '1.6.2'),
+]
+
+configopts = ' '.join([
+    '-DPIVY_USE_QT6=ON',
+    '-DPython_EXECUTABLE="${EBROOTPYTHON}/bin/python"',
+    '-DPIVY_Python_SITEARCH="%(installdir)s/lib/python%(pyshortver)s/site-packages"',
+    '-DDISABLE_SWIG_WARNINGS=ON',
+    '-DCMAKE_VERBOSE_MAKEFILE=ON',
+])
+
+sanity_check_paths = {
+    'files': [
+        'lib/python%(pyshortver)s/site-packages/%(name)s/coin.py',
+        'lib/python%(pyshortver)s/site-packages/%(name)s/_coin.so',
+    ],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s'],
+}
+sanity_check_commands = [
+    "python -c 'from pivy import coin; va = coin.SbVec3f([0, 0, 0]);'"
+]
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/pivy/pivy-0.6.9.a0-coin-includes.patch
+++ b/easybuild/easyconfigs/p/pivy/pivy-0.6.9.a0-coin-includes.patch
@@ -1,0 +1,58 @@
+commit 43113b4542e1ab8f3e6a198b48e90611391d5476
+Author: Louwrens van Dellen <lthvd@protonmail.com>
+Date:   Sat Sep 7 15:17:53 2024 +0200
+
+    add verbosity to cmake build
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 786eeab..651d9ea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,6 +21,20 @@ endif()
+ 
+ find_package(Python REQUIRED COMPONENTS Interpreter Development)
+ 
++if (Coin_FOUND)
++	MESSAGE(STATUS "COIN_FOUND: TRUE")
++	MESSAGE(STATUS "COIN_INCLUDE_DIR: ${Coin_INCLUDE_DIR}")
++	MESSAGE(STATUS "COIN_LIB_DIR: ${Coin_LIB_DIR}")
++	MESSAGE(STATUS "COIN_VERSION: ${Coin_VERSION}")
++endif()
++
++if (SoQt_FOUND)
++	MESSAGE(STATUS "SOQT_FOUND: True")
++	MESSAGE(STATUS "SOQT_INCLUDE_DIRS: ${SoQt_INCLUDE_DIRS}")
++	MESSAGE(STATUS "SOQT_LIB_DIRS: ${SoQt_LIBRARY_DIRS}")
++	MESSAGE(STATUS "SOQT_VERSION: ${SoQt_VERSION}")
++endif()
++
+ # SWIGIFY HEADERS
+ # doing this with the origin python functions
+ 
+
+commit 7d37be9e5efce925c96a14a71eca78966bad5b0c
+Author: Louwrens van Dellen <lthvd@protonmail.com>
+Date:   Sat Sep 7 15:16:46 2024 +0200
+
+    bugfix build failure
+
+diff --git a/interfaces/CMakeLists.txt b/interfaces/CMakeLists.txt
+index 92f9af6..168fb2e 100644
+--- a/interfaces/CMakeLists.txt
++++ b/interfaces/CMakeLists.txt
+@@ -52,6 +52,7 @@ if (SoQt_FOUND)
+     set_property(SOURCE soqt.i PROPERTY INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}")
+     set_property(SOURCE soqt.i APPEND PROPERTY INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/fake_headers")
+     set_property(SOURCE soqt.i APPEND PROPERTY INCLUDE_DIRECTORIES "${SoQt_INCLUDE_DIRS}")
++    set_property(SOURCE soqt.i APPEND PROPERTY INCLUDE_DIRECTORIES "${Coin_INCLUDE_DIR}")
+ 
+ 
+     swig_add_library(soqt
+@@ -68,6 +69,7 @@ if (SoQt_FOUND)
+ 
+     target_include_directories(soqt
+         PUBLIC
++        ${Coin_INCLUDE_DIR}
+         ${SoQt_INCLUDE_DIRS}
+         ${Qt5Gui_INCLUDE_DIRS}
+         ${Qt5Widgets_INCLUDE_DIRS}

--- a/easybuild/easyconfigs/p/pivy/pivy-0.6.9.a0-python-sitearch.patch
+++ b/easybuild/easyconfigs/p/pivy/pivy-0.6.9.a0-python-sitearch.patch
@@ -1,0 +1,55 @@
+commit bef24fc96179b126db1e03ec66ed31d34b97bba7
+Author: Louwrens van Dellen <lthvd@protonmail.com>
+Date:   Sat Sep 14 21:03:38 2024 +0200
+
+    add PIVY_Python_SITEARCH install destination
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index efe3090..fb0aa41 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,6 +21,15 @@ endif()
+ 
+ find_package(Python REQUIRED COMPONENTS Interpreter Development)
+ 
++if (NOT PIVY_Python_SITEARCH)
++    SET(PIVY_Python_SITEARCH ${Python_SITEARCH})
++endif()
++
++if (Python_FOUND)
++	MESSAGE(STATUS "Python_FOUND: TRUE")
++	MESSAGE(STATUS "PIVY_Python_SITEARCH: ${PIVY_Python_SITEARCH}")
++endif()
++
+ if (Coin_FOUND)
+ 	MESSAGE(STATUS "COIN_FOUND: TRUE")
+ 	MESSAGE(STATUS "COIN_INCLUDE_DIR: ${Coin_INCLUDE_DIR}")
+@@ -54,7 +63,7 @@ add_subdirectory(interfaces)
+ 
+ install(DIRECTORY
+     ${CMAKE_BINARY_DIR}/pivy
+-    DESTINATION ${Python_SITEARCH}
++    DESTINATION ${PIVY_Python_SITEARCH}
+     FILES_MATCHING
+     PATTERN "*.py"
+     PATTERN "*.so"
+diff --git a/interfaces/CMakeLists.txt b/interfaces/CMakeLists.txt
+index 168fb2e..75bee1a 100644
+--- a/interfaces/CMakeLists.txt
++++ b/interfaces/CMakeLists.txt
+@@ -40,7 +40,7 @@ target_include_directories(coin
+     )
+ 
+ target_link_libraries(coin PUBLIC Coin::Coin)
+-install(TARGETS coin DESTINATION ${Python_SITEARCH}/pivy)
++install(TARGETS coin DESTINATION ${PIVY_Python_SITEARCH}/pivy)
+ 
+ 
+ if (SoQt_FOUND)
+@@ -79,5 +79,5 @@ if (SoQt_FOUND)
+         )
+ 
+     target_link_libraries(soqt PUBLIC SoQt::SoQt)
+-    install(TARGETS soqt DESTINATION ${Python_SITEARCH}/pivy/gui)
++    install(TARGETS soqt DESTINATION ${PIVY_Python_SITEARCH}/pivy/gui)
+ endif()

--- a/easybuild/easyconfigs/p/pivy/pivy-0.6.9.a0-swigify.patch
+++ b/easybuild/easyconfigs/p/pivy/pivy-0.6.9.a0-swigify.patch
@@ -1,0 +1,170 @@
+commit 6f7381a409857db50d5dbb4b3b17789b7fb9ee36
+Author: Louwrens van Dellen <lthvd@protonmail.com>
+Date:   Sat Sep 14 18:40:13 2024 +0200
+
+    bugfix install_helper.py for arbitrary build dir, simplify call
+    
+    The script bugged if choosing a CMAKE_BUILD_DIR other than a subdir of
+    CMAKE_SOURCE_DIR.
+    
+    Also, make it a bit more readable.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 651d9ea..efe3090 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -38,9 +38,7 @@ endif()
+ # SWIGIFY HEADERS
+ # doing this with the origin python functions
+ 
+-execute_process(COMMAND ${Python_EXECUTABLE} -c
+-"import sys; sys.path.append('${CMAKE_SOURCE_DIR}'); \
+-import install_helpers; install_helpers.swigify('${CMAKE_SOURCE_DIR}', '${Coin_INCLUDE_DIR}');")
++execute_process(COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/install_helpers.py ${CMAKE_SOURCE_DIR} ${Coin_INCLUDE_DIR})
+ 
+ 
+ # copy the python module
+diff --git a/install_helpers.py b/install_helpers.py
+index e80388d..38155c2 100644
+--- a/install_helpers.py
++++ b/install_helpers.py
+@@ -10,63 +10,78 @@ PIVY_HEADER = """\
+ 
+ """
+ 
+-def copy_and_swigify_headers(includedir, dirname, files):
+-        """Copy the header files to the local include directories. Add an
+-        #include line at the beginning for the SWIG interface files..."""
+-
+-        for file in files:
+-            if not os.path.isfile(os.path.join(dirname, file)):
+-                continue
+-
+-            if file[-2:] == ".i":
+-                file = os.path.join(dirname, file)
+-
+-                file_i = file.split(os.path.sep)
+-                file_i = [i for i in file_i if i != ".."]
+-                file_i = os.path.join(*file_i)
+-
+-                file_h = file_i[:-2] + ".h"
+-                from_file = os.path.join(includedir, file_h)
+-
+-                file_h = file[:-2] + ".h"
+-                to_file = os.path.abspath(file_h)
+-
+-                if os.path.exists(from_file):
+-                    shutil.copyfile(from_file, to_file)
+-                    sys.stdout.write('create swigified header: ' + to_file + '\n')
+-                    fd = open(to_file, 'r+')
+-                    contents = fd.readlines()
+-
+-                    ins_line_nr = -1
+-                    for line in contents:
+-                        ins_line_nr += 1
+-                        if line.find("#include ") != -1:
+-                            break
+-
+-                    if ins_line_nr != -1:
+-                        contents.insert(ins_line_nr, PIVY_HEADER % (file_i))
+-                        fd.seek(0)
+-                        fd.writelines(contents)
+-                    else:
+-                        print("[failed]")
+-                        sys.exit(1)
+-                    fd.close
+-            # fixes for SWIG 1.3.21 and upwards
+-            # (mostly workarounding swig's preprocessor "function like macros"
+-            # preprocessor bug when no parameters are provided which then results
+-            # in no constructors being created in the wrapper)
+-            elif file[-4:] == ".fix":
+-                sys.stdout.write(' ' + os.path.join(dirname, file)[:-4])
+-                shutil.copyfile(os.path.join(dirname, file),
+-                                os.path.join(dirname, file)[:-4])
+-            # had to introduce this because windows is a piece of crap
+-            elif sys.platform == "win32" and file[-6:] == ".win32":
+-                sys.stdout.write(' ' + os.path.join(dirname, file)[:-6])
+-                shutil.copyfile(os.path.join(dirname, file),
+-                                os.path.join(dirname, file)[:-6])
+-
+-
+-def swigify(interface_dir, include_dir):
+-    dir_gen = os.walk(os.path.relpath(os.path.join(interface_dir, "Inventor")))
+-    for _dir, _, names in dir_gen:
+-        copy_and_swigify_headers(include_dir, _dir, names)
+\ No newline at end of file
++
++def swigify_header(header_file, include_file):
++    sys.stdout.write("create swigified header: " + header_file + "\n")
++
++    fd = open(header_file, "r+")
++    contents = fd.readlines()
++
++    ins_line_nr = -1
++    for line in contents:
++        ins_line_nr += 1
++        if line.find("#include ") != -1:
++            break
++
++    if ins_line_nr != -1:
++        contents.insert(ins_line_nr, PIVY_HEADER % (include_file))
++        fd.seek(0)
++        fd.writelines(contents)
++    else:
++        print("[failed]")
++        sys.exit(1)
++    fd.close
++
++
++def copy_and_swigify_header(interface_dir, include_dir, fname):
++    """Copy the header file to the local include directory. Add an
++    #include line at the beginning for the SWIG interface file..."""
++
++    if fname.endswith(".i"):  # consider ".i" files
++        fname_h = fname[:-2] + ".h"  # corresponding ".h" file
++        from_file = os.path.join(include_dir, fname_h)
++        to_file = os.path.join(interface_dir, fname_h)
++
++    elif fname.endswith(".fix"):  # just drop the suffix
++        # fixes for SWIG 1.3.21 and upwards
++        # (mostly workarounding swig's preprocessor "function like macros"
++        # preprocessor bug when no parameters are provided which then results
++        # in no constructors being created in the wrapper)
++        fname_nosuffix = fname[:-4]
++        from_file = os.path.join(interface_dir, fname)
++        to_file = os.path.join(interface_dir, fname_nosuffix)
++
++    elif sys.platform == "win32" and fname.endswith(".win32"):  # just drop the suffix
++        # had to introduce this because windows is a piece of crap
++        fname_nosuffix = fname[:-6]
++        from_file = os.path.join(interface_dir, fname)
++        to_file = os.path.join(interface_dir, fname_nosuffix)
++
++    else:  # ignore other extensions
++        return
++
++    if not os.path.isfile(os.path.join(from_file)):
++        return
++
++    # copy
++    shutil.copyfile(from_file, to_file)
++
++    # and swigify
++    if fname.endswith(".i"):  # consider ".i" files
++        swigify_header(to_file, fname)
++
++
++def swigify(interface_dir, include_dir, component="Inventor"):
++    """Prepare header files for SWIG"""
++
++    # find files within interface_dir/component
++    interface_walker = os.walk(os.path.join(interface_dir, component))
++    for dirpath, _, fnames in interface_walker:
++        for fname in fnames:
++            # only the filename relative to below interface_dir is needed
++            relative_fname = os.path.join(dirpath[1+len(interface_dir):], fname)
++            copy_and_swigify_header(interface_dir, include_dir, relative_fname)
++
++
++if __name__ == "__main__":
++    swigify(sys.argv[1], sys.argv[2])

--- a/easybuild/easyconfigs/q/Quarter/Quarter-1.2.1-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/q/Quarter/Quarter-1.2.1-GCC-13.2.0.eb
@@ -1,0 +1,38 @@
+easyblock = 'CMakeMake'
+
+name = 'Quarter'
+version = '1.2.1'
+
+homepage = 'https://github.com/coin3d/quarter/'
+description = """Quarter is a light-weight glue library that provides seamless
+ integration between Systems in Motions's Coin high-level 3D visualization
+ library and Trolltech's Qt 2D user interface library."""
+
+toolchain = {'name': 'GCC', 'version': '13.2.0'}
+
+github_account = 'coin3d'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['566ddc00a76a0d845eea25ce7710bab3e8b28de2d61a3ba22f076b7dda744558']
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+]
+
+dependencies = [
+    ('Coin', '4.0.2'),
+    ('Boost', '1.83.0'),
+    ('X11', '20231019'),
+    ('Mesa', '23.1.9'),
+    ('libGLU', '9.0.3'),
+    ('Qt6', '6.6.3'),
+]
+
+# configopts = "-DSOXT_BUILD_TESTS=OFF"
+
+sanity_check_paths = {
+    'files': ['include/Quarter/Quarter.h', 'lib/libQuarter.%s' % SHLIB_EXT],
+    'dirs': ['lib/pkgconfig']
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/s/Shiboken6/Shiboken6-6.6.2-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/s/Shiboken6/Shiboken6-6.6.2-GCCcore-13.2.0.eb
@@ -1,0 +1,80 @@
+easyblock = 'PythonBundle'
+
+name = 'Shiboken6'
+version = '6.6.2'
+
+homepage = 'https://download.qt.io/official_releases/QtForPython'
+description = 'Shiboken6 is the official Python module from the Qt for Python project.'
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+# source_urls = ['https://download.qt.io/official_releases/QtForPython/%(namelower)s/%(name)s-%(version)s-src/']
+# sources = ['pyside-setup-everywhere-src-%(version)s.tar.xz']
+# checksums = ['14620b694d7af4c978443016292d3d2108ba5dc105f4170e3b71eadcaf04c9f0']
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('CMake', '3.27.6'),
+    ('Clang', '17.0.6'),
+    ('Ninja', '1.11.1'),
+    ('build', '1.0.3'),
+    ('patchelf', '0.18.0'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Qt6', '6.6.3'),
+    ('PySide6', '6.6.2'),
+]
+
+# pip install \
+#     --index-url=https://download.qt.io/official_releases/QtForPython/ \
+#     --trusted-host download.qt.io \
+#     shiboken6 pyside6 shiboken6_generator
+# The whl package cannot automatically discover in your system the location for:
+
+# Clang installation,
+
+# Qt location (indicated by the path of the qtpaths tool) with the same version/build as the one described in the wheel,
+
+# Qt libraries with the same package version.
+
+# So using this process requires you to manually modify the variables:
+
+# CLANG_INSTALL_DIR must be set to where the libraries are,
+
+# PATH must include the location for the qtpaths tool with the same Qt
+# version as the package,
+
+# LD_LIBRARY_PATH including the Qt libraries and Clang libraries paths.
+
+use_pip = True
+sanity_pip_check = True
+
+preconfigopts = 'export CLANG_INSTALL_DIR=$EBROOTCLANG && '
+
+prebuildopts = 'export CLANG_INSTALL_DIR=$EBROOTCLANG && '
+# buildcmd = 'build --parallel=%(parallel)s'
+
+preinstallopts = 'export CLANG_INSTALL_DIR=$EBROOTCLANG && '
+# install_target = 'install --parallel=%(parallel)s'
+
+exts_list = [
+    ('shiboken6', version, {
+        'source_tmpl': '%%(name)s-%%(version)s-cp38-abi3-manylinux_2_28_%s.whl' % ARCH,
+        'source_urls': ['https://download.qt.io/official_releases/QtForPython/shiboken6/'],
+        'checksums': ['9da86622cee5e7201bafe9c5beee3c06d9168c6b8f3e2fac52c1b7df00956bff'],
+    }),
+    ('shiboken6_generator', version, {
+        'source_tmpl': '%%(name)s-%%(version)s-cp38-abi3-manylinux_2_28_%s.whl' % ARCH,
+        'source_urls': ['https://download.qt.io/official_releases/QtForPython/shiboken6-generator/'],
+        'checksums': ['bb989483e54a4ed36c296d3fe29660e96407d97718941a50b41ee7d70c490bb2'],
+    }),
+]
+
+postinstallcmds = [
+    'ln -s python%(pyshortver)s/site-packages/%(name)s/libshiboken6.abi3.so.6.6 %(installdir)s/lib/',
+    'ln -s python%(pyshortver)s/site-packages/%(name)s/Shiboken.abi3.so %(installdir)s/lib/',
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/s/SoQt/SoQt-1.6.2-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/s/SoQt/SoQt-1.6.2-GCC-13.2.0.eb
@@ -1,0 +1,81 @@
+easyblock = 'CMakeMake'
+
+name = 'SoQt'
+version = '1.6.2'
+
+homepage = 'https://coin3d.github.io/SoQt/html/'
+description = '''SoQt is a library which provides the glue between Systems in
+ Motion's Coin high-level 3D visualization library and the Qt 2D user interface
+ library.
+'''
+
+toolchain = {'name': 'GCC', 'version': '13.2.0'}
+
+sources = [
+    {
+        'source_urls': ['https://github.com/coin3d/soqt/archive'],
+        'download_filename': '17364833049d3855f5e9e0f7908eb5ba08209318.tar.gz',
+        'filename': '%(name)s-%(version)s.tar.gz',
+        'extract_cmd': 'tar -xzf %s -C %(builddir)s --strip-components=1',
+    },
+    {
+        'source_urls': ['https://github.com/coin3d/generalmsvcgeneration/archive'],
+        'download_filename': 'a61fae6a84bd57364fa07a5345eeb4b7ae030318.tar.gz',
+        'filename': '%(name)s-%(version)s-generalmsvc.tar.gz',
+        'extract_cmd': 'tar -xzf %s -C %(builddir)s/build/general --strip-components=1',
+    },
+    {
+        'source_urls': ['https://github.com/coin3d/cpack.d/archive'],
+        'download_filename': '2186a57bff8f318cdf466181b013f9e0398fb8ca.tar.gz',
+        'filename': '%(name)s-%(version)s-cpackd.tar.gz',
+        'extract_cmd': 'tar -xzf %s -C %(builddir)s/cpack.d --strip-components=1',
+    },
+    {
+        'source_urls': ['https://github.com/coin3d/soanydata/archive'],
+        'download_filename': '7ee364a6ec2b496b28e5a13a88800ad11fcbe84e.tar.gz',
+        'filename': '%(name)s-%(version)s-soanydata.tar.gz',
+        'extract_cmd': 'tar -xzf %s -C %(builddir)s/data --strip-components=1',
+    },
+    {
+        'source_urls': ['https://github.com/coin3d/sogui/archive'],
+        'download_filename': '426cd49f3e4598ff96da50e521867b9fe550fd99.tar.gz',
+        'filename': '%(name)s-%(version)s-sogui.tar.gz',
+        'extract_cmd': 'tar -xzf %s -C %(builddir)s/src/Inventor/Qt/common --strip-components=1',
+    },
+    {
+        'source_urls': ['https://github.com/coin3d/doxygen-awesome-css/archive'],
+        'download_filename': '6217657eef6aec24a0e4ecea4695031c1a622cf3.tar.gz',
+        'filename': '%(name)s-%(version)s-doxygen-awesome-css.tar.gz',
+        'extract_cmd': 'tar -xzf %s -C %(builddir)s/src/Inventor/Qt/common/docs/doxygen-awesome --strip-components=1',
+    },
+]
+checksums = [
+    {'SoQt-1.6.2.tar.gz': 'ebb2faa13b425ed9f90ebddb4c8a9285991b8cacaa999648a6891fd4a79d74e5'},
+    {'SoQt-1.6.2-generalmsvc.tar.gz': 'cef65714a1e134ada469e05ab833ad496a16bccaeed1f74078c72c592f9e1539'},
+    {'SoQt-1.6.2-cpackd.tar.gz': 'b741f7efd5c967d59375a13eb3bbc94f653ac74f7ddfaf26178c594761daf2db'},
+    {'SoQt-1.6.2-soanydata.tar.gz': '33018911f52ff6046daedfa4d94079518ab664cda7947739f60f2ffa3262905c'},
+    {'SoQt-1.6.2-sogui.tar.gz': 'ff601ffc54fc59b5f8713140603492f07f2d0a9dacf2471f0687fde1e3fab580'},
+    {'SoQt-1.6.2-doxygen-awesome-css.tar.gz': 'f2a982b3d37e861fb7a259a79580f3393ab2204a5deec57b70c30fef62649bb7'},
+]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+]
+
+dependencies = [
+    ('Coin', '4.0.2'),
+    ('Boost', '1.83.0'),
+    ('X11', '20231019'),
+    ('Mesa', '23.1.9'),
+    ('libGLU', '9.0.3'),
+    ('Qt6', '6.6.3'),
+]
+
+# configopts = '-DSOXT_BUILD_TESTS=OFF'
+
+sanity_check_paths = {
+    'files': ['lib/libSoQt.%s' % SHLIB_EXT],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/t/tbb/tbb-2021.13.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/t/tbb/tbb-2021.13.0-GCCcore-13.2.0.eb
@@ -1,0 +1,32 @@
+easyblock = 'CMakeMake'
+
+name = 'tbb'
+version = '2021.13.0'
+
+homepage = 'https://github.com/oneapi-src/oneTBB'
+description = """Intel(R) Threading Building Blocks (Intel(R) TBB) lets you easily write parallel C++ programs that
+ take full advantage of multicore performance, that are portable, composable and have future-proof scalability."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+# The following option is needed to supress the "stringop-overflow error".
+# See https://github.com/oneapi-src/oneTBB/issues/1180#issuecomment-1690958371 for details.
+toolchainopts = {'extra_cxxflags': '-Wno-error=stringop-overflow'}
+
+source_urls = ['https://github.com/oneapi-src/oneTBB/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['3ad5dd08954b39d113dc5b3f8a8dc6dc1fd5250032b7c491eb07aed5c94133e1']
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('CMake', '3.27.6'),
+]
+
+dependencies = [('hwloc', '2.9.2')]
+
+sanity_check_paths = {
+    'files': ['lib/libtbb.%s' % SHLIB_EXT, 'lib/libtbbmalloc.%s' % SHLIB_EXT],
+    'dirs': ['lib', 'include', 'share'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
FreeCAD main can be built against Qt6, but there is no official release
to date.

Dependencies

- build-1.0.3-GCCcore-13.2.0.eb
- Coin-4.0.2-GCC-13.2.0.eb
- FreeCAD-1.0.0pre-foss-2023b.eb
- FreeImage-3.18.0-GCCcore-13.2.0.eb
- med-5.0.0-foss-2023b.eb
- occt-7.8.1-GCCcore-13.2.0.eb
- PySide6-6.6.2-GCCcore-13.2.0.eb
- pivy-0.6.9.a0-GCC-13.2.0.eb
- Quarter-1.2.1-GCC-13.2.0.eb
- Shiboken6-6.6.2-GCCcore-13.2.0.eb
- SoQt-1.6.2-GCC-13.2.0.eb
- tbb-2021.13.0-GCCcore-13.2.0.eb

and patches

- med-5.0.0-hdf5-1.14-compat.patch
- occt-OpenCASCADEConfig-cmake.patch
