### PR TITLE
add `*.eb_bak_*`, `*.out`, `.venv/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,15 @@
 .pydevproject
 .project
 LICENSE_HEADER
+*.eb.bak_*
 *.pyc
 *.pyo
 *.nja
+*.out
 build/
 dist/
 *egg-info/
+.venv/
 *.swp
 *.ropeproject/
 eb-*.log


### PR DESCRIPTION
Such paths should never be committed:
 - `.eb_bak` files are remnants after `eb --inject-checksums`
 - `.out` files are log remnants after `eb --job`
 - `.venv/` are probably created for ad-hoc testing