### PR TITLE
Adding FLINT (+NTL), fmt, GEOS, LERC, libaio, libcerf, libcroco, libtirpc, libdap (+PCRE) for GCC(core) 13.3.0

### DIFF
--- a/easybuild/easyconfigs/f/FLINT/FLINT-3.1.2-gfbf-2024a.eb
+++ b/easybuild/easyconfigs/f/FLINT/FLINT-3.1.2-gfbf-2024a.eb
@@ -1,0 +1,45 @@
+easyblock = 'CMakeMake'
+
+name = 'FLINT'
+version = '3.1.2'
+
+homepage = 'https://www.flintlib.org/'
+
+description = """FLINT (Fast Library for Number Theory) is a C library in support of computations
+ in number theory. Operations that can be performed include conversions, arithmetic, computing GCDs,
+ factoring, solving linear systems, and evaluating special functions. In addition, FLINT provides
+ various low-level routines for fast arithmetic. FLINT is extensively documented and tested."""
+
+toolchain = {'name': 'gfbf', 'version': '2024a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://www.flintlib.org']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['fdb3a431a37464834acff3bdc145f4fe8d0f951dd5327c4c6f93f4cbac5c2700']
+
+builddependencies = [
+    ('CMake', '3.29.3'),
+    ('Python', '3.12.3'),
+]
+
+dependencies = [
+    ('GMP', '6.3.0'),
+    ('MPFR', '4.2.1'),
+    ('NTL', '11.5.1'),
+]
+
+# Make flexiblas the first to be found and used to avoid linking openblas.
+preconfigopts = 'sed -i "s/PATH_SUFFIXES openblas/PATH_SUFFIXES flexiblas openblas/g;'
+preconfigopts += 's/accelerate openblas/accelerate flexiblas openblas/g" '
+preconfigopts += '%(builddir)s/%(namelower)s-%(version)s/CMake/FindCBLAS.cmake && '
+
+configopts = '-DWITH_NTL=on -DBUILD_TESTING=yes'
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['lib/lib%%(namelower)s.%s' % SHLIB_EXT],
+    'dirs': ['include'],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/f/fmt/fmt-11.0.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/f/fmt/fmt-11.0.2-GCCcore-13.3.0.eb
@@ -1,0 +1,26 @@
+easyblock = 'CMakeMake'
+
+name = 'fmt'
+version = '11.0.2'
+
+homepage = 'http://fmtlib.net/'
+description = "fmt (formerly cppformat) is an open-source formatting library."
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/fmtlib/fmt/releases/download/%(version)s/']
+sources = ['fmt-%(version)s.zip']
+checksums = ['40fc58bebcf38c759e11a7bd8fdc163507d2423ef5058bba7f26280c5b9c5465']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/libfmt.a'],
+    'dirs': ['include/fmt', 'lib/cmake'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/g/GEOS/GEOS-3.12.2-GCC-13.3.0.eb
+++ b/easybuild/easyconfigs/g/GEOS/GEOS-3.12.2-GCC-13.3.0.eb
@@ -7,12 +7,16 @@ homepage = 'https://trac.osgeo.org/geos'
 description = """GEOS (Geometry Engine - Open Source) is a C++ port of the Java Topology Suite (JTS)"""
 
 toolchain = {'name': 'GCC', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
 
 source_urls = ['https://download.osgeo.org/geos/']
 sources = [SOURCELOWER_TAR_BZ2]
 checksums = ['34c7770bf0090ee88488af98767d08e779f124fa33437e0aabec8abd4609fec6']
 
 builddependencies = [('CMake', '3.29.3')]
+
+# Build static and shared libraries
+configopts = ['', '-DBUILD_SHARED_LIBS=OFF']
 
 sanity_check_paths = {
     'files': ['bin/geos-config', 'lib/libgeos.%s' % SHLIB_EXT, 'lib/libgeos_c.so', 'include/geos.h'],

--- a/easybuild/easyconfigs/g/GEOS/GEOS-3.12.2-GCC-13.3.0.eb
+++ b/easybuild/easyconfigs/g/GEOS/GEOS-3.12.2-GCC-13.3.0.eb
@@ -19,7 +19,8 @@ builddependencies = [('CMake', '3.29.3')]
 configopts = ['', '-DBUILD_SHARED_LIBS=OFF']
 
 sanity_check_paths = {
-    'files': ['bin/geos-config', 'lib/libgeos.%s' % SHLIB_EXT, 'lib/libgeos_c.so', 'include/geos.h'],
+    'files': ['bin/geos-config', 'lib/libgeos.%s' % SHLIB_EXT, 'lib/libgeos.a', 'lib/libgeos_c.%s' % SHLIB_EXT,
+              'include/geos.h'],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/g/GEOS/GEOS-3.12.2-GCC-13.3.0.eb
+++ b/easybuild/easyconfigs/g/GEOS/GEOS-3.12.2-GCC-13.3.0.eb
@@ -1,0 +1,22 @@
+easyblock = 'CMakeMake'
+
+name = 'GEOS'
+version = '3.12.2'
+
+homepage = 'https://trac.osgeo.org/geos'
+description = """GEOS (Geometry Engine - Open Source) is a C++ port of the Java Topology Suite (JTS)"""
+
+toolchain = {'name': 'GCC', 'version': '13.3.0'}
+
+source_urls = ['https://download.osgeo.org/geos/']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['34c7770bf0090ee88488af98767d08e779f124fa33437e0aabec8abd4609fec6']
+
+builddependencies = [('CMake', '3.29.3')]
+
+sanity_check_paths = {
+    'files': ['bin/geos-config', 'lib/libgeos.%s' % SHLIB_EXT, 'lib/libgeos_c.so', 'include/geos.h'],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LERC/LERC-4.0.0-GCCcore-13.3.0.eb
@@ -1,0 +1,45 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# Updated: Denis Kristak
+# Updated: Thomas Hoffmann (EMBL)
+easyblock = 'CMakeMake'
+
+name = 'LERC'
+version = '4.0.0'
+
+homepage = 'https://github.com/Esri/lerc'
+description = """LERC is an open-source image or raster format which supports rapid encoding and decoding
+for any pixel type (not just RGB or Byte). Users set the maximum compression error per pixel while encoding,
+so the precision of the original input image is preserved (within user defined error bounds)."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://github.com/Esri/lerc/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['91431c2b16d0e3de6cbaea188603359f87caed08259a645fd5a3805784ee30a0']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+]
+
+configopts = '-DCMAKE_INSTALL_LIBDIR=lib'
+
+postinstallcmds = [
+    # copy the LercTest source file to a LercTest subdir in the installation directory and compile it
+    # (needs to be done here instead of in the sanity check, else it won't work when RPATH linking is enabled)
+    "cd %(builddir)s/lerc-%(version)s/src/LercTest && sed -i -e 's@../LercLib/include/@@' main.cpp",
+    "mkdir %(installdir)s/LercTest",
+    "cp %(builddir)s/lerc-%(version)s/src/LercTest/main.cpp %(installdir)s/LercTest/main.cpp",
+    "cd %(installdir)s/LercTest && ${CXX} ${CXXFLAGS} main.cpp -o LercTest -I../include -L../lib -lLerc",
+]
+
+sanity_check_commands = [
+    "%(installdir)s/LercTest/LercTest",
+]
+
+sanity_check_paths = {
+    'files': ['include/Lerc_c_api.h', 'include/Lerc_types.h', 'lib/libLerc.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libaio/libaio-0.3.113-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libaio/libaio-0.3.113-GCCcore-13.3.0.eb
@@ -1,0 +1,39 @@
+easyblock = 'MakeCp'
+
+name = 'libaio'
+version = '0.3.113'
+_libversion = '1.0.2'
+
+homepage = 'https://pagure.io/libaio'
+description = "Asynchronous input/output library that uses the kernels native interface."
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://pagure.io/%(name)s/archive/%(name)s-%(version)s/']
+sources = ['%(name)s-%(version)s.tar.gz']
+checksums = ['1c561c20670c5c09cc8437a622008c0693c6a7816c1f30332da3796953b2f454']
+
+builddependencies = [('binutils', '2.42')]
+
+_soname = "libaio.%s.%s" % (SHLIB_EXT, _libversion)
+
+files_to_copy = [
+    (["src/libaio.a", "src/%s" % _soname], "lib"),
+    (["src/libaio.h"], "include"),
+]
+
+# links to the shared library with generic names
+_solinks = [
+    "libaio.%s" % SHLIB_EXT,
+    "libaio.%s.1" % SHLIB_EXT,
+]
+
+postinstallcmds = ["cd %%(installdir)s/lib && ln -s %s %s" % (_soname, l) for l in _solinks]
+
+sanity_check_paths = {
+    'files': ['lib/%s' % l for l in ['libaio.a', _soname] + _solinks] + ['include/libaio.h'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libcerf/libcerf-2.4-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libcerf/libcerf-2.4-GCCcore-13.3.0.eb
@@ -1,0 +1,32 @@
+easyblock = 'CMakeMake'
+
+name = 'libcerf'
+version = '2.4'
+
+homepage = 'https://jugit.fz-juelich.de/mlz/libcerf'
+
+description = """
+ libcerf is a self-contained numeric library that provides an efficient and
+ accurate implementation of complex error functions, along with Dawson,
+ Faddeeva, and Voigt functions.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://jugit.fz-juelich.de/mlz/libcerf/-/archive/v%(version)s/']
+sources = ['libcerf-v%(version)s.tar.gz']
+checksums = ['080b30ae564c3dabe3b89264522adaf5647ec754021572bee54929697b276cdc']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+    ('Perl', '5.38.2'),  # required for pod2html
+]
+
+sanity_check_paths = {
+    'files': ['lib/libcerf.%s' % SHLIB_EXT],
+    'dirs': []
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/l/libcroco/libcroco-0.6.13-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libcroco/libcroco-0.6.13-GCCcore-13.3.0.eb
@@ -1,0 +1,32 @@
+easyblock = 'ConfigureMake'
+
+name = 'libcroco'
+version = '0.6.13'
+
+homepage = 'https://gitlab.gnome.org/Archive/libcroco'
+description = """Libcroco is a standalone css2 parsing and manipulation library."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://download.gnome.org/sources/libcroco/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['767ec234ae7aa684695b3a735548224888132e063f92db585759b422570621d4']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('pkgconf', '2.2.0'),
+]
+
+dependencies = [
+    ('zlib', '1.3.1'),
+    ('libxml2', '2.12.7'),
+    ('GLib', '2.80.4'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/csslint-%(version_major_minor)s', 'lib/libcroco-%%(version_major_minor)s.%s' % SHLIB_EXT,
+              'lib/libcroco-%(version_major_minor)s.a'],
+    'dirs': ['include/libcroco-%(version_major_minor)s', 'share']
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libdap/libdap-3.21.0-27-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libdap/libdap-3.21.0-27-GCCcore-13.3.0.eb
@@ -1,0 +1,37 @@
+easyblock = 'ConfigureMake'
+
+name = 'libdap'
+version = '3.21.0-27'
+
+homepage = 'https://www.opendap.org/software/libdap'
+description = """A C++ SDK which contains an implementation of DAP 2.0 and
+ DAP4.0. This includes both Client- and Server-side support classes."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://www.opendap.org/pub/source/']
+sources = [SOURCE_TAR_GZ]
+checksums = ['b5b8229d3aa97fea9bba4a0b11b1ee1c6446bd5f7ad2cff591f86064f465eacf']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('Bison', '3.8.2'),
+    ('flex', '2.6.4'),
+]
+
+dependencies = [
+    ('cURL', '8.7.1'),
+    ('libxml2', '2.12.7'),
+    ('libtirpc', '1.3.5'),
+    ('PCRE', '8.45'),
+    ('util-linux', '2.40'),
+]
+
+configopts = 'TIRPC_LIBS="-ltirpc"'
+
+sanity_check_paths = {
+    'files': ['bin/getdap', 'bin/getdap4', 'bin/dap-config', 'lib/libdap.a', 'lib/libdap.%s' % SHLIB_EXT],
+    'dirs': ['include'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libtirpc/libtirpc-1.3.5-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libtirpc/libtirpc-1.3.5-GCCcore-13.3.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'libtirpc'
+version = '1.3.5'
+
+homepage = 'https://sourceforge.net/projects/libtirpc/'
+description = "Libtirpc is a port of Suns Transport-Independent RPC library to Linux."
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCE_TAR_BZ2]
+checksums = ['9b31370e5a38d3391bf37edfa22498e28fe2142467ae6be7a17c9068ec0bf12f']
+
+configopts = '--enable-static --enable-shared --disable-gssapi'
+
+builddependencies = [
+    ('binutils', '2.42')
+]
+
+sanity_check_paths = {
+    'files': ['lib/libtirpc.%s' % (x,) for x in ['a', SHLIB_EXT]],
+    'dirs': ['include/tirpc', 'lib'],
+}
+
+modextrapaths = {'CPATH': 'include/tirpc'}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/NTL/NTL-11.5.1-GCC-13.3.0.eb
+++ b/easybuild/easyconfigs/n/NTL/NTL-11.5.1-GCC-13.3.0.eb
@@ -1,0 +1,44 @@
+# contributed by Guilherme Peretti-Pezzi (CSCS)
+# updated by Alex Domingo (Vrije Universiteit Brussel)
+# updated by Åke Sandgren(Umeå University)
+# Update: Petr Král (INUITS)
+easyblock = 'ConfigureMake'
+
+name = 'NTL'
+version = '11.5.1'
+
+homepage = 'https://shoup.net/ntl/'
+
+description = """NTL is a high-performance, portable C++ library providing data structures and
+algorithms for manipulating signed, arbitrary length integers, and for vectors,
+matrices, and polynomials over the integers and over finite fields."""
+
+toolchain = {'name': 'GCC', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+github_account = 'libntl'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['ef578fa8b6c0c64edd1183c4c303b534468b58dd3eb8df8c9a5633f984888de5']
+
+builddependencies = [
+    ('Perl', '5.38.2'),
+]
+
+dependencies = [
+    ('GMP', '6.3.0'),
+]
+
+start_dir = 'src'
+
+prefix_opt = 'PREFIX='
+configopts = 'CXX="$CXX" CXXFLAGS="$CXXFLAGS" GMP_PREFIX="$EBROOTGMP" SHARED=on'
+
+runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['lib/libntl.%s' % e for e in ['a', SHLIB_EXT]],
+    'dirs': ['include/NTL', 'share/doc'],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/PCRE/PCRE-8.45-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/p/PCRE/PCRE-8.45-GCCcore-13.3.0.eb
@@ -1,0 +1,43 @@
+easyblock = 'ConfigureMake'
+
+name = 'PCRE'
+version = '8.45'
+
+homepage = 'https://www.pcre.org/'
+description = """
+ The PCRE library is a set of functions that implement regular expression
+ pattern matching using the same syntax and semantics as Perl 5.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [
+    SOURCEFORGE_SOURCE,
+    'https://ftp.%(namelower)s.org/pub/%(namelower)s/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['4e6ce03e0336e8b4a3d6c2b70b1c5e18590a5673a98186da90d4f33c23defc09']
+
+builddependencies = [
+    ('binutils', '2.42'),
+]
+dependencies = [
+    ('bzip2', '1.0.8'),
+    ('zlib', '1.3.1'),
+]
+
+configopts = "--enable-utf --enable-unicode-properties --enable-pcre16 --enable-pcre32"
+
+
+sanity_check_paths = {
+    'files': [
+        'bin/%(namelower)s-config',
+        'include/%(namelower)s.h',
+        'share/man/man3/%(namelower)s.3',
+        'lib/libpcre32.%s' % SHLIB_EXT
+    ],
+    'dirs': ['lib/pkgconfig', 'share/doc/%(namelower)s/html', 'share/man/man1'],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
These packages are used in the new SW stage at JSC and were more or less version bumps from earlier toolchains.