### PR TITLE
correct extension order in R-bundle-CRAN 2024.06

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2024.06-foss-2023b.eb
+++ b/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2024.06-foss-2023b.eb
@@ -3436,6 +3436,9 @@ exts_list = [
     ('missMDA', '1.19', {
         'checksums': ['f9675884829b2fef75237c335b21991d163674320e766523c71c7a853f95e65c'],
     }),
+    ('insight', '0.20.3', {
+        'checksums': ['b60e189849cd3c368e9c2b2174e89c2dfbba3b34e84feb8a20af1bb758116bb2'],
+    }),
     ('datawizard', '0.12.2', {
         'checksums': ['fee36520440131596394878eb19f295609ef5d7997a3a5614c059f2a8d2be081'],
     }),
@@ -3444,9 +3447,6 @@ exts_list = [
     }),
     ('performance', '0.12.2', {
         'checksums': ['b55e663eb45b8e88625c704506f20c4068a1c892c5a6a94d7bd0c0e3a7ed4028'],
-    }),
-    ('insight', '0.20.3', {
-        'checksums': ['b60e189849cd3c368e9c2b2174e89c2dfbba3b34e84feb8a20af1bb758116bb2'],
     }),
 ]
 


### PR DESCRIPTION
#21260 added `insight`. #21272 added `performance`, `datwizard`, and `bayestestR`, but before `insight`.

Failure in https://github.com/easybuilders/easybuild-easyconfigs/pull/20913#issuecomment-2319486003
```
ERROR: dependency insight is not available for package datawizard
```