### PR TITLE
{devel, tools, lib}[GCCcore/13.3.0] ConcurrentVersionsSystem-1.11.23, DBus-1.15.8, ecBuild-3.8.5, FLAC-1.4.3, flatbuffers-24.3.25, flatbuffers-python-24.3.25 

### DIFF
--- a/easybuild/easyconfigs/c/ConcurrentVersionsSystem/ConcurrentVersionsSystem-1.11.23-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/c/ConcurrentVersionsSystem/ConcurrentVersionsSystem-1.11.23-GCCcore-13.3.0.eb
@@ -15,7 +15,7 @@ Source Configuration Management (SCM).
 
 toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
 
-source_urls = [' http://ftp.gnu.org/non-gnu/cvs/source/stable/%(version)s/']
+source_urls = [' https://ftp.gnu.org/non-gnu/cvs/source/stable/%(version)s/']
 sources = ['cvs-%(version)s.tar.bz2']
 patches = [
     'CVS-1.11.23-zlib-1.patch',

--- a/easybuild/easyconfigs/c/ConcurrentVersionsSystem/ConcurrentVersionsSystem-1.11.23-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/c/ConcurrentVersionsSystem/ConcurrentVersionsSystem-1.11.23-GCCcore-13.3.0.eb
@@ -1,0 +1,45 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'ConcurrentVersionsSystem'
+version = '1.11.23'
+
+homepage = 'https://savannah.nongnu.org/projects/cvs'
+description = """CVS is a version control system, an important component of
+Source Configuration Management (SCM).
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = [' http://ftp.gnu.org/non-gnu/cvs/source/stable/%(version)s/']
+sources = ['cvs-%(version)s.tar.bz2']
+patches = [
+    'CVS-1.11.23-zlib-1.patch',
+    'CVS-1.11.23-getline.patch',
+]
+checksums = [
+    '400f51b59d85116e79b844f2d5dbbad4759442a789b401a94aa5052c3d7a4aa9',  # cvs-1.11.23.tar.bz2
+    # CVS-1.11.23-zlib-1.patch
+    '3c0ee6509c4622778c093316437a5b047c51820e11cee3ed3a405c2a590a9ff4',
+    # CVS-1.11.23-getline.patch
+    '6a1aa65acfbb41b7639adc70248d908981f172c2529bb52d84359713f9541874',
+]
+
+builddependencies = [
+    ('binutils', '2.42')
+]
+
+dependencies = [
+    ('zlib', '1.3.1')
+]
+
+sanity_check_paths = {
+    'files': ['bin/cvs', 'bin/cvsbug', 'bin/rcs2log'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/d/DBus/DBus-1.15.8-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/d/DBus/DBus-1.15.8-GCCcore-13.3.0.eb
@@ -1,0 +1,45 @@
+easyblock = 'CMakeMake'
+
+name = 'DBus'
+version = '1.15.8'
+
+homepage = 'https://dbus.freedesktop.org/'
+
+description = """
+ D-Bus is a message bus system, a simple way for applications to talk
+ to one another.  In addition to interprocess communication, D-Bus helps
+ coordinate process lifecycle; it makes it simple and reliable to code
+ a "single instance" application or daemon, and to launch applications
+ and daemons on demand when their services are needed.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://dbus.freedesktop.org/releases/dbus']
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['84fc597e6ec82f05dc18a7d12c17046f95bad7be99fc03c15bc254c4701ed204']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+    ('pkgconf', '2.2.0'),
+]
+
+dependencies = [
+    ('expat', '2.6.2'),
+]
+
+configopts = '-DENABLE_SYSTEMD=OFF '
+# disable documentation
+configopts += '-DDBUS_ENABLE_XML_DOCS=OFF -DDBUS_ENABLE_QTHELP_DOCS=OFF -DDBUS_ENABLE_DOXYGEN_DOCS=OFF '
+
+sanity_check_paths = {
+    'files': ['bin/dbus-%s' % x for x in
+              ['cleanup-sockets', 'daemon', 'launch', 'monitor',
+               'run-session', 'send', 'uuidgen']] +
+             ['lib/libdbus-1.%s' % SHLIB_EXT],
+    'dirs': ['include', 'share'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/e/ecBuild/ecBuild-3.8.5-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/e/ecBuild/ecBuild-3.8.5-GCCcore-13.3.0.eb
@@ -1,0 +1,37 @@
+easyblock = 'Tarball'
+
+name = 'ecBuild'
+version = '3.8.5'
+
+homepage = 'https://ecbuild.readthedocs.io/'
+
+description = """
+A CMake-based build system, consisting of a collection of CMake macros and
+functions that ease the managing of software build systems """
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+github_account = 'ecmwf'
+sources = [
+    {
+        'source_urls': [GITHUB_SOURCE],
+        'filename': '%(version)s.tar.gz',
+        'extract_cmd': 'tar -xzf %s --strip-components=1',
+    },
+]
+checksums = ['aa0c44cab0fffec4c0b3542e91ebcc736b3d41b68a068d30c023ec0df5f93425']
+
+builddependencies = [('binutils', '2.42')]
+
+buildininstalldir = True
+
+skipsteps = ['install']
+
+sanity_check_paths = {
+    'files': ['bin/ecbuild', 'cmake/ecbuild-config.cmake'],
+    'dirs': ['bin', 'lib', 'share', 'cmake'],
+}
+
+sanity_check_commands = ['ecbuild --help']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/f/FLAC/FLAC-1.4.3-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/f/FLAC/FLAC-1.4.3-GCCcore-13.3.0.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'FLAC'
+version = '1.4.3'
+
+homepage = 'https://xiph.org/flac/'
+description = """FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning
+that audio is compressed in FLAC without any loss in quality."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://ftp.osuosl.org/pub/xiph/releases/flac/']
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['6c58e69cd22348f441b861092b825e591d0b822e106de6eb0ee4d05d27205b70']
+
+builddependencies = [('binutils', '2.42')]
+
+dependencies = [('libogg', '1.3.5')]
+
+configopts = '--enable-static --enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/flac', 'lib/libFLAC.a', 'lib/libFLAC++.a',
+              'lib/libFLAC.%s' % SHLIB_EXT, 'lib/libFLAC++.%s' % SHLIB_EXT],
+    'dirs': ['include/FLAC', 'include/FLAC++'],
+}
+
+sanity_check_commands = ["flac --help"]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/f/flatbuffers-python/flatbuffers-python-24.3.25-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/f/flatbuffers-python/flatbuffers-python-24.3.25-GCCcore-13.3.0.eb
@@ -1,0 +1,27 @@
+easyblock = 'PythonPackage'
+
+name = 'flatbuffers-python'
+version = '24.3.25'
+
+homepage = 'https://github.com/google/flatbuffers/'
+description = """Python Flatbuffers runtime library."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://pypi.python.org/packages/source/f/flatbuffers']
+sources = [{'download_filename': 'flatbuffers-%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
+checksums = ['de2ec5b203f21441716617f38443e0a8ebf3d25bf0d9c0bb0ce68fa00ad546a4']
+
+dependencies = [
+    ('binutils', '2.42'),
+    ('Python', '3.12.3'),
+]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+preinstallopts = 'VERSION=%(version)s '
+options = {'modulename': 'flatbuffers'}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/f/flatbuffers/flatbuffers-24.3.25-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/f/flatbuffers/flatbuffers-24.3.25-GCCcore-13.3.0.eb
@@ -1,0 +1,33 @@
+##
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+##
+easyblock = 'CMakeNinja'
+
+name = 'flatbuffers'
+version = '24.3.25'
+
+homepage = 'https://github.com/google/flatbuffers/'
+description = """FlatBuffers: Memory Efficient Serialization Library"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/google/flatbuffers/archive/v%(version)s/']
+sources = [SOURCE_TAR_GZ]
+checksums = ['4157c5cacdb59737c5d627e47ac26b140e9ee28b1102f812b36068aab728c1ed']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+    ('Ninja', '1.12.1'),
+    ('Python', '3.12.3'),
+]
+
+configopts = '-DFLATBUFFERS_ENABLE_PCH=ON '
+
+sanity_check_paths = {
+    'files': ['include/flatbuffers/flatbuffers.h', 'bin/flatc', 'lib/libflatbuffers.a'],
+    'dirs': ['lib/cmake'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/libogg/libogg-1.3.5-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libogg/libogg-1.3.5-GCCcore-13.3.0.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'libogg'
+version = '1.3.5'
+
+homepage = 'https://xiph.org/ogg/'
+description = """Ogg is a multimedia container format, and the native file and stream format for the Xiph.org
+multimedia codecs."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://ftp.osuosl.org/pub/xiph/releases/ogg/']
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['c4d91be36fc8e54deae7575241e03f4211eb102afb3fc0775fbbc1b740016705']
+
+builddependencies = [('binutils', '2.42')]
+
+configopts = '--enable-static --enable-shared'
+
+sanity_check_paths = {
+    'files': ['lib/libogg.a', 'lib/libogg.%s' % SHLIB_EXT],
+    'dirs': ['include/ogg'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
These packages are used in the new SW stage at JSC and were more or less version bumps from earlier toolchains