### PR TITLE
{lang, lib, devel}[GCCcore/13.3.0] byacc-2.0.20240109, Guile-2.0.14, giflib-5.2.1, libgit2-1.8.1, libmatheval-1.1.11, libopus-1.5.2, libsndfile-1.2.2, libspatialindex-2.0.0, libvorbis-1.3.7, libwebp-1.4.0, libxslt-1.1.42

### DIFF
--- a/easybuild/easyconfigs/b/byacc/byacc-2.0.20240109-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/b/byacc/byacc-2.0.20240109-GCCcore-13.3.0.eb
@@ -20,3 +20,5 @@ sanity_check_paths = {
     'files': ["bin/yacc"],
     'dirs': []
 }
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/b/byacc/byacc-2.0.20240109-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/b/byacc/byacc-2.0.20240109-GCCcore-13.3.0.eb
@@ -1,0 +1,22 @@
+easyblock = 'ConfigureMake'
+
+name = 'byacc'
+version = '2.0.20240109'
+
+homepage = 'http://invisible-island.net/byacc/byacc.html'
+description = """Berkeley Yacc (byacc) is generally conceded to be the best yacc variant available.
+ In contrast to bison, it is written to avoid dependencies upon a particular compiler.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://invisible-island.net/archives/byacc/current/']
+sources = ['byacc.tar.gz']
+checksums = ['e5e0c069fb15d454918568f77e90a60221373dd206a3d3c2da1e7daba3bae9ea']
+
+builddependencies = [('binutils', '2.42')]
+
+sanity_check_paths = {
+    'files': ["bin/yacc"],
+    'dirs': []
+}

--- a/easybuild/easyconfigs/g/Guile/Guile-2.0.14-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/Guile/Guile-2.0.14-GCCcore-13.3.0.eb
@@ -1,0 +1,41 @@
+easyblock = 'ConfigureMake'
+
+name = 'Guile'
+version = '2.0.14'
+
+homepage = 'http://www.gnu.org/software/guile'
+description = """Guile is the GNU Ubiquitous Intelligent Language for Extensions, the official extension language for 
+the GNU operating system.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['8aeb2f353881282fe01694cce76bb72f7ffdd296a12c7a1a39255c27b0dfe5f1']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('pkgconf', '2.2.0'),
+]
+
+dependencies = [
+    ('gc', '8.2.6'),
+    ('GMP', '6.3.0'),
+    ('libffi', '3.4.5'),
+    ('libunistring', '1.2'),
+    ('libtool', '2.4.7'),
+    ('libreadline', '8.2'),
+    ('XZ', '5.4.5'),
+]
+
+configopts = " --enable-error-on-warning=no"
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["guile", 'guile-config', 'guile-snarf', 'guile-tools']] +
+             ["lib/libguile-%(version_major_minor)s.a",
+              "include/guile/%(version_major_minor)s/libguile.h"],
+    'dirs': []
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/g/giflib/giflib-5.2.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/giflib/giflib-5.2.1-GCCcore-13.3.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'giflib'
+version = '5.2.1'
+
+homepage = 'http://giflib.sourceforge.net/'
+description = """giflib is a library for reading and writing gif images.
+It is API and ABI compatible with libungif which was in wide use while
+the LZW compression algorithm was patented."""
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['31da5562f44c5f15d63340a09a4fd62b48c45620cd302f77a6d9acf0077879bd']
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+builddependencies = [('binutils', '2.42')]
+
+skipsteps = ['configure']
+
+installopts = 'PREFIX=%(installdir)s'
+
+sanity_check_paths = {
+    'files': ['bin/giftool'],
+    'dirs': []
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libgit2/libgit2-1.8.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libgit2/libgit2-1.8.1-GCCcore-13.3.0.eb
@@ -1,0 +1,34 @@
+easyblock = 'CMakeMake'
+
+name = 'libgit2'
+version = '1.8.1'
+
+homepage = 'https://libgit2.org/'
+description = """libgit2 is a portable, pure C implementation of the Git core methods provided as a re-entrant
+linkable library with a solid API, allowing you to write native speed custom Git applications in any language
+which supports C bindings."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = [GITHUB_SOURCE]
+sources = [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
+checksums = ['8c1eaf0cf07cba0e9021920bfba9502140220786ed5d8a8ec6c7ad9174522f8e']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+    ('pkgconf', '2.2.0'),
+]
+dependencies = [
+    ('PCRE2', '10.43'),
+    ('OpenSSL', '3', '', SYSTEM),
+]
+
+configopts = '-DREGEX_BACKEND=pcre2'
+
+sanity_check_paths = {
+    'files': ['include/git2.h', 'lib64/%%(name)s.%s' % SHLIB_EXT, 'lib64/pkgconfig/%(name)s.pc'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/libmatheval/003-guile2.0.patch
+++ b/easybuild/easyconfigs/l/libmatheval/003-guile2.0.patch
@@ -1,0 +1,402 @@
+Description: Increase precision of floating point tests
+ guile-2.0 has increased the precision of the floating point maths returns,
+ so the test suite needs to allow for the correct values to be returned
+ with higher precision. Thanks to Dave Pigott <dave.pigott@linaro.org>
+ Also adapt the configure script to build against guile-2.0 - patch from
+ Hilo Bengen <bengen@debian.org>.
+ .
+ libmatheval (1.1.11+dfsg-1.1) unstable; urgency=low
+ .
+   * Non-maintainer upload.
+   * Migrate to guile-2.0 - patch from Hilo Bengen,
+     extended to support higher precision of return values
+     by guile-2.0. (Closes: #746013)
+Author: Neil Williams <codehelp@debian.org>
+Bug-Debian: https://bugs.debian.org/746013
+
+---
+
+--- libmatheval-1.1.11+dfsg.orig/configure.in
++++ libmatheval-1.1.11+dfsg/configure.in
+@@ -60,10 +60,11 @@ dnl Checks for library functions.
+ AC_CHECK_FUNCS([bzero memset], [break])
+ 
+ dnl Additional Guile feature checks.
++CFLAGS="$CFLAGS $GUILE_CFLAGS"
+ AC_CHECK_TYPE([scm_t_bits], [AC_DEFINE([HAVE_SCM_T_BITS], [1], [Define to 1 if you have the `scm_t_bits' type.])], [], [#include <libguile.h>])
+-AC_CHECK_LIB([guile], [scm_c_define_gsubr], [AC_DEFINE([HAVE_SCM_C_DEFINE_GSUBR], [1], [Define to 1 if you have the `scm_c_define_gsubr' function.])], [], [$GUILE_LDFLAGS])
+-AC_CHECK_LIB([guile], [scm_make_gsubr], [AC_DEFINE([HAVE_SCM_MAKE_GSUBR], [1], [Define to 1 if you have the `scm_make_gsubr' function.])], [], [$GUILE_LDFLAGS])
+-AC_CHECK_LIB([guile], [scm_num2dbl], [AC_DEFINE([HAVE_SCM_NUM2DBL], [1], [Define to 1 if you have the `scm_num2dbl' function.])], [], [$GUILE_LDFLAGS])
++AC_CHECK_LIB([guile-2.0], [scm_c_define_gsubr], [AC_DEFINE([HAVE_SCM_C_DEFINE_GSUBR], [1], [Define to 1 if you have the `scm_c_define_gsubr' function.])], [], [$GUILE_LDFLAGS])
++AC_CHECK_LIB([guile-2.0], [scm_make_gsubr], [AC_DEFINE([HAVE_SCM_MAKE_GSUBR], [1], [Define to 1 if you have the `scm_make_gsubr' function.])], [], [$GUILE_LDFLAGS])
++AC_CHECK_LIB([guile-2.0], [scm_num2dbl], [AC_DEFINE([HAVE_SCM_NUM2DBL], [1], [Define to 1 if you have the `scm_num2dbl' function.])], [], [$GUILE_LDFLAGS])
+ 
+ AC_CONFIG_FILES([Makefile doc/Makefile lib/Makefile])
+ AC_OUTPUT(libmatheval.pc)
+--- libmatheval-1.1.11+dfsg.orig/tests/basics.at
++++ libmatheval-1.1.11+dfsg/tests/basics.at
+@@ -62,7 +62,7 @@ AT_DATA([basics.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh basics.scm], [ignore], [10.0], [ignore])
++AT_CHECK([matheval.sh basics.scm], [ignore], [10.000000000000002], [ignore])
+ 
+ AT_DATA([basics.scm],
+ [[
+@@ -70,7 +70,7 @@ AT_DATA([basics.scm],
+ (display (evaluator-evaluate-x f 0.7))
+ ]])
+ 
+-AT_CHECK([matheval.sh basics.scm], [ignore], [0.220966666722528], [ignore])
++AT_CHECK([matheval.sh basics.scm], [ignore], [0.22096666672252796], [ignore])
+ 
+ AT_DATA([basics.scm],
+ [[
+@@ -78,7 +78,7 @@ AT_DATA([basics.scm],
+ (display (evaluator-evaluate-x-y f 0.4 -0.7))
+ ]])
+ 
+-AT_CHECK([matheval.sh basics.scm], [ignore], [-1.14962406520749], [ignore])
++AT_CHECK([matheval.sh basics.scm], [ignore], [-1.1496240652074883], [ignore])
+ 
+ AT_DATA([basics.scm],
+ [[
+@@ -86,7 +86,7 @@ AT_DATA([basics.scm],
+ (display (evaluator-evaluate-x-y-z f 11.2 0.41 -0.66))
+ ]])
+ 
+-AT_CHECK([matheval.sh basics.scm], [ignore], [3.99876152571934], [ignore])
++AT_CHECK([matheval.sh basics.scm], [ignore], [3.9987615257193383], [ignore])
+ 
+ AT_DATA([basics.scm],
+ [[
+--- libmatheval-1.1.11+dfsg.orig/tests/constants.at
++++ libmatheval-1.1.11+dfsg/tests/constants.at
+@@ -29,7 +29,7 @@ AT_DATA([constant.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh constant.scm], [ignore], [2.71828182845905], [ignore])
++AT_CHECK([matheval.sh constant.scm], [ignore], [2.718281828459045], [ignore])
+ 
+ AT_DATA([constant.scm],
+ [[
+@@ -37,7 +37,7 @@ AT_DATA([constant.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh constant.scm], [ignore], [1.44269504088896], [ignore])
++AT_CHECK([matheval.sh constant.scm], [ignore], [1.4426950408889634], [ignore])
+ 
+ AT_DATA([constant.scm],
+ [[
+@@ -45,7 +45,7 @@ AT_DATA([constant.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh constant.scm], [ignore], [0.434294481903252], [ignore])
++AT_CHECK([matheval.sh constant.scm], [ignore], [0.4342944819032518], [ignore])
+ 
+ AT_DATA([constant.scm],
+ [[
+@@ -53,7 +53,7 @@ AT_DATA([constant.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh constant.scm], [ignore], [0.693147180559945], [ignore])
++AT_CHECK([matheval.sh constant.scm], [ignore], [0.6931471805599453], [ignore])
+ 
+ AT_DATA([constant.scm],
+ [[
+@@ -61,7 +61,7 @@ AT_DATA([constant.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh constant.scm], [ignore], [2.30258509299405], [ignore])
++AT_CHECK([matheval.sh constant.scm], [ignore], [2.302585092994046], [ignore])
+ 
+ AT_DATA([constant.scm],
+ [[
+@@ -69,7 +69,7 @@ AT_DATA([constant.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh constant.scm], [ignore], [3.14159265358979], [ignore])
++AT_CHECK([matheval.sh constant.scm], [ignore], [3.141592653589793], [ignore])
+ 
+ AT_DATA([constant.scm],
+ [[
+@@ -77,7 +77,7 @@ AT_DATA([constant.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh constant.scm], [ignore], [1.5707963267949], [ignore])
++AT_CHECK([matheval.sh constant.scm], [ignore], [1.5707963267948966], [ignore])
+ 
+ AT_DATA([constant.scm],
+ [[
+@@ -85,7 +85,7 @@ AT_DATA([constant.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh constant.scm], [ignore], [0.785398163397448], [ignore])
++AT_CHECK([matheval.sh constant.scm], [ignore], [0.7853981633974483], [ignore])
+ 
+ AT_DATA([constant.scm],
+ [[
+@@ -93,7 +93,7 @@ AT_DATA([constant.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh constant.scm], [ignore], [0.318309886183791], [ignore])
++AT_CHECK([matheval.sh constant.scm], [ignore], [0.3183098861837907], [ignore])
+ 
+ AT_DATA([constant.scm],
+ [[
+@@ -101,7 +101,7 @@ AT_DATA([constant.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh constant.scm], [ignore], [0.636619772367581], [ignore])
++AT_CHECK([matheval.sh constant.scm], [ignore], [0.6366197723675814], [ignore])
+ 
+ AT_DATA([constant.scm],
+ [[
+@@ -109,7 +109,7 @@ AT_DATA([constant.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh constant.scm], [ignore], [1.12837916709551], [ignore])
++AT_CHECK([matheval.sh constant.scm], [ignore], [1.1283791670955126], [ignore])
+ 
+ AT_DATA([constant.scm],
+ [[
+@@ -117,7 +117,7 @@ AT_DATA([constant.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh constant.scm], [ignore], [1.4142135623731], [ignore])
++AT_CHECK([matheval.sh constant.scm], [ignore], [1.4142135623730951], [ignore])
+ 
+ AT_DATA([constant.scm],
+ [[
+@@ -125,7 +125,7 @@ AT_DATA([constant.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh constant.scm], [ignore], [0.707106781186548], [ignore])
++AT_CHECK([matheval.sh constant.scm], [ignore], [0.7071067811865476], [ignore])
+ 
+ AT_DATA([constant.scm],
+ [[
+@@ -133,7 +133,7 @@ AT_DATA([constant.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh constant.scm], [ignore], [10.0], [ignore])
++AT_CHECK([matheval.sh constant.scm], [ignore], [10.000000000000002], [ignore])
+ 
+ AT_DATA([constant.scm],
+ [[
+--- libmatheval-1.1.11+dfsg.orig/tests/functions.at
++++ libmatheval-1.1.11+dfsg/tests/functions.at
+@@ -29,7 +29,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [2.71828182845905], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [2.718281828459045], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -80,7 +80,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [0.841470984807897], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [0.8414709848078965], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -97,7 +97,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [0.54030230586814], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [0.5403023058681398], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -114,7 +114,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [1.5574077246549], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [1.5574077246549023], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -131,7 +131,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [0.642092615934331], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [0.6420926159343306], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -148,7 +148,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [1.85081571768093], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [1.8508157176809255], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -165,7 +165,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [1.18839510577812], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [1.1883951057781212], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -182,7 +182,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [1.5707963267949], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [1.5707963267948966], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -216,7 +216,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [0.785398163397448], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [0.7853981633974483], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -233,7 +233,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [0.785398163397448], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [0.7853981633974483], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -267,7 +267,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [1.5707963267949], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [1.5707963267948966], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -284,7 +284,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [1.1752011936438], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [1.1752011936438014], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -301,7 +301,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [1.54308063481524], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [1.5430806348152437], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -318,7 +318,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [0.761594155955765], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [0.7615941559557649], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -335,7 +335,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [1.31303528549933], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [1.3130352854993315], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -352,7 +352,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [0.648054273663885], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [0.6480542736638855], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -368,7 +368,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [0.850918128239322], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [0.8509181282393216], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -385,7 +385,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [0.881373587019543], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [0.8813735870195429], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -419,7 +419,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 0.5))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [0.549306144334055], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [0.5493061443340549], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -436,7 +436,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 2))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [0.549306144334055], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [0.5493061443340549], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+@@ -470,7 +470,7 @@ AT_DATA([function.scm],
+ (display (evaluator-evaluate-x f 1))
+ ]])
+ 
+-AT_CHECK([matheval.sh function.scm], [ignore], [0.881373587019543], [ignore])
++AT_CHECK([matheval.sh function.scm], [ignore], [0.8813735870195429], [ignore])
+ 
+ AT_DATA([function.scm],
+ [[
+--- libmatheval-1.1.11+dfsg.orig/tests/numbers.at
++++ libmatheval-1.1.11+dfsg/tests/numbers.at
+@@ -53,6 +53,6 @@ AT_DATA([number.scm],
+ (display (evaluator-evaluate-x f 0))
+ ]])
+ 
+-AT_CHECK([matheval.sh number.scm], [ignore], [0.644394014977254], [ignore])
++AT_CHECK([matheval.sh number.scm], [ignore], [0.6443940149772542], [ignore])
+ 
+ AT_CLEANUP

--- a/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-GCCcore-13.3.0.eb
@@ -1,0 +1,45 @@
+easyblock = 'ConfigureMake'
+
+name = 'libmatheval'
+version = '1.1.11'  # still the latest version available on the ftp mirror
+
+homepage = 'http://www.gnu.org/software/libmatheval/'
+description = """GNU libmatheval is a library (callable from C and Fortran) to parse
+ and evaluate symbolic expressions input as text.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    '003-guile2.0.patch',
+    'libmatheval-1.1.11_fix-matheval-test.patch'
+]
+checksums = [
+    {'libmatheval-1.1.11.tar.gz': '474852d6715ddc3b6969e28de5e1a5fbaff9e8ece6aebb9dc1cc63e9e88e89ab'},
+    {'003-guile2.0.patch': 'd0ad39d54800153cbaa26c01448f040d405f09e9fd57e1357eab170a274a9b5c'},
+    {'libmatheval-1.1.11_fix-matheval-test.patch': '2888ee1ba32bb864b655e53e13b06eafc23b598faed80b90585d41c98e2ae073'},
+]
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('flex', '2.6.4'),
+    ('Bison', '3.8.2'),
+    ('byacc', '2.0.20240109'),
+    # guile 2.2.X, 3.0.7 removed scm_num2dbl (among others), which are needed for libmatheval (at least for 1.1.11)
+    ('Guile', '2.0.14')
+]
+
+configopts = '--with-pic '
+
+# fix for guile-config being broken because shebang line contains full path to bin/guile
+configopts += 'GUILE_CONFIG="$EBROOTGUILE/bin/guile -e main -s $EBROOTGUILE/bin/guile-config"'
+
+sanity_check_paths = {
+    'files': ['lib/libmatheval.a', 'include/matheval.h'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-GCCcore-13.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'libmatheval'
 version = '1.1.11'  # still the latest version available on the ftp mirror
 
-homepage = 'http://www.gnu.org/software/libmatheval/'
+homepage = 'https://www.gnu.org/software/libmatheval/'
 description = """GNU libmatheval is a library (callable from C and Fortran) to parse
  and evaluate symbolic expressions input as text.
 """

--- a/easybuild/easyconfigs/l/libopus/libopus-1.5.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libopus/libopus-1.5.2-GCCcore-13.3.0.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'libopus'
+version = '1.5.2'
+
+homepage = 'https://www.opus-codec.org/'
+description = """Opus is a totally open, royalty-free, highly versatile audio codec. Opus is unmatched for interactive
+ speech and music transmission over the Internet, but is also intended for storage and streaming applications. It is
+ standardized by the Internet Engineering Task Force (IETF) as RFC 6716 which incorporated technology from Skype’s
+ SILK codec and Xiph.Org’s CELT codec."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://downloads.xiph.org/releases/opus/']
+sources = ['opus-%(version)s.tar.gz']
+checksums = ['65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('pkgconf', '2.2.0'),
+]
+
+configopts = '--enable-static --enable-shared'
+
+sanity_check_paths = {
+    'files': ['lib/libopus.a', 'lib/libopus.%s' % SHLIB_EXT],
+    'dirs': ['include/opus'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libsndfile/libsndfile-1.2.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libsndfile/libsndfile-1.2.2-GCCcore-13.3.0.eb
@@ -1,0 +1,39 @@
+easyblock = 'CMakeMake'
+
+name = 'libsndfile'
+version = '1.2.2'
+
+homepage = 'http://www.mega-nerd.com/libsndfile'
+description = """Libsndfile is a C library for reading and writing files containing sampled sound
+ (such as MS Windows WAV and the Apple/SGI AIFF format) through one standard library interface."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://github.com/%(name)s/%(name)s/releases/download/%(version)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['3799ca9924d3125038880367bf1468e53a1b7e3686a934f098b7e1d286cdb80e']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('pkgconf', '2.2.0'),
+    ('CMake', '3.29.3'),
+]
+dependencies = [
+    ('FLAC', '1.4.3'),
+    ('libvorbis', '1.3.7'),
+    ('libopus', '1.5.2'),
+    ('LAME', '3.100'),
+]
+
+configopts = [
+    '',
+    '-DBUILD_SHARED_LIBS=ON',
+]
+
+
+sanity_check_paths = {
+    'files': ['include/sndfile.h', 'include/sndfile.hh', 'lib/%(name)s.a', 'lib/%(name)s.so'],
+    'dirs': ['bin'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libspatialindex/libspatialindex-2.0.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libspatialindex/libspatialindex-2.0.0-GCCcore-13.3.0.eb
@@ -1,0 +1,25 @@
+easyblock = 'CMakeMake'
+
+name = 'libspatialindex'
+version = '2.0.0'
+
+homepage = 'https://libspatialindex.org'
+description = "C++ implementation of R*-tree, an MVR-tree and a TPR-tree with C API"
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://github.com/%(name)s/%(name)s/releases/download/%(version)s/']
+sources = ['spatialindex-src-%(version)s.tar.gz']
+checksums = ['f1d5a369681fa6ac3301a54db412ccf3180fc17163ebc3252f32c752f77345de']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/%s.%s' % (name, SHLIB_EXT)],
+    'dirs': ['include/spatialindex'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libvorbis/libvorbis-1.3.7-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libvorbis/libvorbis-1.3.7-GCCcore-13.3.0.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'libvorbis'
+version = '1.3.7'
+
+homepage = 'https://xiph.org/vorbis/'
+description = """Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed
+audio format"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://ftp.osuosl.org/pub/xiph/releases/vorbis/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['b33cc4934322bcbf6efcbacf49e3ca01aadbea4114ec9589d1b1e9d20f72954b']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('pkgconf', '2.2.0'),
+]
+
+dependencies = [('libogg', '1.3.5')]
+
+configopts = '--enable-static --enable-shared'
+
+sanity_check_paths = {
+    'files': ['lib/libvorbis.a', 'lib/libvorbis.%s' % SHLIB_EXT],
+    'dirs': ['include/vorbis'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libwebp/libwebp-1.4.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libwebp/libwebp-1.4.0-GCCcore-13.3.0.eb
@@ -1,0 +1,45 @@
+easyblock = 'ConfigureMake'
+
+name = 'libwebp'
+version = '1.4.0'
+
+homepage = 'https://developers.google.com/speed/webp/'
+description = """WebP is a modern image format that provides superior
+lossless and lossy compression for images on the web. Using WebP,
+webmasters and web developers can create smaller, richer images that
+make the web faster."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://storage.googleapis.com/downloads.webmproject.org/releases/webp']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['61f873ec69e3be1b99535634340d5bde750b2e4447caa1db9f61be3fd49ab1e5']
+
+builddependencies = [
+    ('binutils', '2.42'),
+]
+dependencies = [
+    ('libjpeg-turbo', '3.0.1'),
+    ('libpng', '1.6.43'),
+    ('LibTIFF', '4.6.0'),
+    ('giflib', '5.2.1'),
+]
+
+configopts = '--enable-libwebpmux'
+
+local_headers, local_libs = (
+    ['decode.h', 'demux.h', 'encode.h', 'mux.h', 'mux_types.h', 'types.h'],
+    ['webp', 'webpdemux', 'webpmux']
+)
+
+sanity_check_paths = {
+    'files': (
+        ['include/webp/%s' % h for h in local_headers] +
+        ['lib/lib%s.a' % s for s in local_libs] +
+        ['lib/lib%s.%s' % (s, SHLIB_EXT) for s in local_libs]
+    ),
+    'dirs': ['lib/']
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxslt/libxslt-1.1.42-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libxslt/libxslt-1.1.42-GCCcore-13.3.0.eb
@@ -1,0 +1,36 @@
+easyblock = 'ConfigureMake'
+
+name = 'libxslt'
+version = '1.1.42'
+
+homepage = 'http://xmlsoft.org/'
+description = """Libxslt is the XSLT C library developed for the GNOME project
+ (but usable outside of the Gnome platform)."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://download.gnome.org/sources/libxslt/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['85ca62cac0d41fc77d3f6033da9df6fd73d20ea2fc18b0a3609ffb4110e1baeb']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('pkgconf', '2.2.0'),
+]
+
+dependencies = [
+    ('zlib', '1.3.1'),
+    ('libxml2', '2.12.7'),
+]
+
+# Make sure it doesn't pick up OS installed libgcrypt or Python
+# enable building static libs
+configopts = '--with-crypto=no --with-python=no --enable-static=yes '
+
+sanity_check_paths = {
+    'files': ['bin/xsltproc', 'include/libxslt/xslt.h', 'lib/%%(name)s.%s' % SHLIB_EXT, 'lib/%(name)s.a',
+              'lib/libexslt.%s' % SHLIB_EXT, 'lib/libexslt.a'],
+    'dirs': ['include/libxslt', 'include/libexslt'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
These packages are used in the new SW stage at JSC and were more or less version bumps from earlier toolchains. 

Needs `libogg` and `FLAC` from
- #21286 