### PR TITLE
remove `exts_default_options` from TensorFlow 2.3.1

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.3.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.3.1-foss-2020a-Python-3.8.2.eb
@@ -40,9 +40,7 @@ dependencies = [
     ('zlib', '1.2.11'),
 ]
 
-exts_default_options = {
-    'sanity_pip_check': True,
-}
+sanity_pip_check = True
 use_pip = True
 
 # Dependencies created and updated using findPythonDeps.sh:

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.3.1-fosscuda-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.3.1-fosscuda-2020a-Python-3.8.2.eb
@@ -42,9 +42,7 @@ dependencies = [
     ('zlib', '1.2.11'),
 ]
 
-exts_default_options = {
-    'sanity_pip_check': True,
-}
+sanity_pip_check = True
 use_pip = True
 
 # Dependencies created and updated using findPythonDeps.sh:


### PR DESCRIPTION
This is a top-level parameter