### PR TITLE
use top-level parameters for `use_pip` & co instead of `exts_default_options` for `PythonBundle` easyconfigs

### DIFF
--- a/easybuild/easyconfigs/c/cell2location/cell2location-0.05-alpha-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/c/cell2location/cell2location-0.05-alpha-fosscuda-2020b.eb
@@ -45,12 +45,6 @@ preinstallopts = "sed -i 's/theano/Theano-PyMC/g' setup.py && "
 
 use_pip = True
 
-exts_default_options = {
-    'download_dep_fail': True,
-    'sanity_pip_check': True,
-    'use_pip': True,
-}
-
 exts_list = [
     ('opt-einsum', '3.3.0', {
         'source_tmpl': 'opt_einsum-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/f/flit/flit-3.9.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/f/flit/flit-3.9.0-GCCcore-12.3.0.eb
@@ -17,11 +17,8 @@ dependencies = [
     ('Python', '3.11.3'),
 ]
 
-exts_default_options = {
-    'download_dep_fail': True,
-    'sanity_pip_check': True,
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
 
 exts_list = [
     ('idna', '3.4', {

--- a/easybuild/easyconfigs/f/flit/flit-3.9.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/f/flit/flit-3.9.0-GCCcore-13.2.0.eb
@@ -18,11 +18,8 @@ dependencies = [
     ('Python', '3.11.5'),
 ]
 
-exts_default_options = {
-    'download_dep_fail': True,
-    'sanity_pip_check': True,
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
 
 exts_list = [
     ('idna', '3.4', {

--- a/easybuild/easyconfigs/f/flit/flit-3.9.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/f/flit/flit-3.9.0-GCCcore-13.3.0.eb
@@ -18,11 +18,8 @@ dependencies = [
     ('Python', '3.12.3'),
 ]
 
-exts_default_options = {
-    'download_dep_fail': True,
-    'sanity_pip_check': True,
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
 
 exts_list = [
     ('idna', '3.7', {

--- a/easybuild/easyconfigs/g/GI-DocGen/GI-DocGen-2023.3-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/GI-DocGen/GI-DocGen-2023.3-GCCcore-12.3.0.eb
@@ -21,11 +21,8 @@ dependencies = [
     ('Python-bundle-PyPI', '2023.06'),
 ]
 
-exts_default_options = {
-    'download_dep_fail': True,
-    'sanity_pip_check': True,
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
 
 exts_list = [
     ('Markdown', '3.5.2', {

--- a/easybuild/easyconfigs/o/OpenStackClient/OpenStackClient-5.5.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenStackClient/OpenStackClient-5.5.0-GCCcore-10.2.0.eb
@@ -16,9 +16,9 @@ dependencies = [
 ]
 builddependencies = [('binutils', '2.35')]
 
-exts_default_options = {
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
+
 exts_list = [
     ('pbr', '5.6.0', {
         'checksums': ['42df03e7797b796625b1029c0400279c7c34fd7df24a7d7818a1abb5b38710dd'],
@@ -121,7 +121,6 @@ exts_list = [
     }),
 ]
 
-sanity_pip_check = True
 enhance_sanity_check = True
 sanity_check_commands = ['openstack -h']
 

--- a/easybuild/easyconfigs/o/OpenStackClient/OpenStackClient-5.8.0-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenStackClient/OpenStackClient-5.8.0-GCCcore-11.2.0.eb
@@ -16,9 +16,9 @@ dependencies = [
 ]
 builddependencies = [('binutils', '2.37')]
 
-exts_default_options = {
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
+
 exts_list = [
     ('pyperclip', '1.8.2', {
         'checksums': ['105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57'],
@@ -121,7 +121,6 @@ exts_list = [
     }),
 ]
 
-sanity_pip_check = True
 enhance_sanity_check = True
 sanity_check_commands = ['openstack -h']
 

--- a/easybuild/easyconfigs/o/OpenStackClient/OpenStackClient-6.0.0-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenStackClient/OpenStackClient-6.0.0-GCCcore-12.2.0.eb
@@ -15,9 +15,9 @@ dependencies = [
 ]
 builddependencies = [('binutils', '2.39')]
 
-exts_default_options = {
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
+
 exts_list = [
     ('pyperclip', '1.8.2', {
         'checksums': ['105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57'],
@@ -114,7 +114,6 @@ exts_list = [
     }),
 ]
 
-sanity_pip_check = True
 enhance_sanity_check = True
 sanity_check_commands = ['openstack -h']
 

--- a/easybuild/easyconfigs/p/PyClone/PyClone-2020.9b2-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/p/PyClone/PyClone-2020.9b2-GCCcore-10.2.0.eb
@@ -21,9 +21,8 @@ dependencies = [
     ('Python', '3.8.6'),
 ]
 
-exts_default_options = {
-    'use_pip': True
-}
+sanity_pip_check = True
+use_pip = True
 
 exts_list = [
     ('Logbook', '1.5.3', {
@@ -36,7 +35,5 @@ exts_list = [
         'checksums': ['e294e875fdd9131526ba9974ad478f213c6d982d273b4b385346e3147e672bc0'],
     }),
 ]
-
-sanity_pip_check = True
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/Python-bundle-PyPI/Python-bundle-PyPI-2023.06-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/p/Python-bundle-PyPI/Python-bundle-PyPI-2023.06-GCCcore-12.3.0.eb
@@ -26,11 +26,8 @@ dependencies = [
     ('virtualenv', '20.23.1'),
 ]
 
-exts_default_options = {
-    'download_dep_fail': True,
-    'sanity_pip_check': True,
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
 
 # order is important!
 # package versions updated 2023-06-26

--- a/easybuild/easyconfigs/p/Python-bundle-PyPI/Python-bundle-PyPI-2023.10-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/p/Python-bundle-PyPI/Python-bundle-PyPI-2023.10-GCCcore-13.2.0.eb
@@ -26,11 +26,8 @@ dependencies = [
     ('virtualenv', '20.24.6'),
 ]
 
-exts_default_options = {
-    'download_dep_fail': True,
-    'sanity_pip_check': True,
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
 
 # order is important!
 # package versions updated 2023-10-29

--- a/easybuild/easyconfigs/p/Python-bundle-PyPI/Python-bundle-PyPI-2024.06-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/p/Python-bundle-PyPI/Python-bundle-PyPI-2024.06-GCCcore-13.3.0.eb
@@ -28,11 +28,8 @@ dependencies = [
     ('virtualenv', '20.26.2'),
 ]
 
-exts_default_options = {
-    'download_dep_fail': True,
-    'sanity_pip_check': True,
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
 
 # order is important!
 # package versions updated 2024-06-14

--- a/easybuild/easyconfigs/s/setuptools-rust/setuptools-rust-1.6.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/s/setuptools-rust/setuptools-rust-1.6.0-GCCcore-12.3.0.eb
@@ -18,11 +18,8 @@ dependencies = [
     ('Python', '3.11.3'),
 ]
 
-exts_default_options = {
-    'download_dep_fail': True,
-    'sanity_pip_check': True,
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
 
 exts_list = [
     ('typing_extensions', '4.6.3', {

--- a/easybuild/easyconfigs/s/setuptools-rust/setuptools-rust-1.8.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/s/setuptools-rust/setuptools-rust-1.8.0-GCCcore-13.2.0.eb
@@ -18,11 +18,8 @@ dependencies = [
     ('Python', '3.11.5'),
 ]
 
-exts_default_options = {
-    'download_dep_fail': True,
-    'sanity_pip_check': True,
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
 
 exts_list = [
     ('typing_extensions', '4.8.0', {

--- a/easybuild/easyconfigs/s/setuptools-rust/setuptools-rust-1.9.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/s/setuptools-rust/setuptools-rust-1.9.0-GCCcore-13.3.0.eb
@@ -18,11 +18,8 @@ dependencies = [
     ('Python', '3.12.3'),
 ]
 
-exts_default_options = {
-    'download_dep_fail': True,
-    'sanity_pip_check': True,
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
 
 exts_list = [
     ('typing-extensions', '4.12.2', {

--- a/easybuild/easyconfigs/v/virtualenv/virtualenv-20.23.1-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/v/virtualenv/virtualenv-20.23.1-GCCcore-12.3.0.eb
@@ -18,11 +18,8 @@ dependencies = [
     ('Python', '3.11.3'),
 ]
 
-exts_default_options = {
-    'download_dep_fail': True,
-    'sanity_pip_check': True,
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
 
 exts_list = [
     ('distlib', '0.3.6', {

--- a/easybuild/easyconfigs/v/virtualenv/virtualenv-20.24.6-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/v/virtualenv/virtualenv-20.24.6-GCCcore-13.2.0.eb
@@ -18,11 +18,8 @@ dependencies = [
     ('Python', '3.11.5'),
 ]
 
-exts_default_options = {
-    'download_dep_fail': True,
-    'sanity_pip_check': True,
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
 
 exts_list = [
     ('distlib', '0.3.7', {

--- a/easybuild/easyconfigs/v/virtualenv/virtualenv-20.26.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/v/virtualenv/virtualenv-20.26.2-GCCcore-13.3.0.eb
@@ -18,11 +18,8 @@ dependencies = [
     ('Python', '3.12.3'),
 ]
 
-exts_default_options = {
-    'download_dep_fail': True,
-    'sanity_pip_check': True,
-    'use_pip': True,
-}
+sanity_pip_check = True
+use_pip = True
 
 exts_list = [
     ('distlib', '0.3.8', {


### PR DESCRIPTION
It is easier in the top-level and might cause confusion with https://github.com/easybuilders/easybuild-easyblocks/pull/3428