### PR TITLE
{perf} OTF2: Use toolchain Python instead of system one

### DIFF
--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0-GCCcore-11.3.0.eb
@@ -3,6 +3,7 @@
 # Copyright:: Copyright 2013-2019 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # Markus Geimer <m.geimer@fz-juelich.de>
+# Jan Andre Reuter <j.reuter@fz-juelich.de>
 # License::   3-clause BSD
 #
 # This work is based on experiences from the UNITE project
@@ -34,17 +35,21 @@ builddependencies = [
 dependencies = [
     # SIONlib container support (optional):
     ('SIONlib', '1.7.7', '-tools'),
+    # OTF2 Python bindings
+    ('Python', '3.10.4'),
 ]
 
+local_pyshortver = '3.10'
 configopts = '--enable-shared'
 
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_pyshortver]}
 
 sanity_check_paths = {
     'files': ['bin/otf2-config', 'include/otf2/otf2.h',
               'lib/libotf2.a', 'lib/libotf2.%s' % SHLIB_EXT],
     'dirs': [],
 }
-
-sanity_check_commands = ['%(namelower)s-config --help']
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python -c "import %(namelower)s"']
 
 moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0.2-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0.2-GCCcore-11.2.0.eb
@@ -3,6 +3,7 @@
 # Copyright:: Copyright 2013-2019 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # Markus Geimer <m.geimer@fz-juelich.de>
+# Jan Andre Reuter <j.reuter@fz-juelich.de>
 # License::   3-clause BSD
 #
 # This work is based on experiences from the UNITE project
@@ -34,17 +35,22 @@ builddependencies = [
 dependencies = [
     # SIONlib container support (optional):
     ('SIONlib', '1.7.7', '-tools'),
+    # OTF2 Python bindings
+    ('Python', '3.9.6'),
 ]
 
+local_pyshortver = '3.9'
 configopts = '--enable-shared'
 
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_pyshortver]}
 
 sanity_check_paths = {
     'files': ['bin/otf2-config', 'include/otf2/otf2.h',
               'lib/libotf2.a', 'lib/libotf2.%s' % SHLIB_EXT],
     'dirs': [],
 }
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python -c "import %(namelower)s"']
 
-sanity_check_commands = ['%(namelower)s-config --help']
 
 moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0.2-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0.2-GCCcore-11.3.0.eb
@@ -3,6 +3,7 @@
 # Copyright:: Copyright 2013-2019 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # Markus Geimer <m.geimer@fz-juelich.de>
+# Jan Andre Reuter <j.reuter@fz-juelich.de>
 # License::   3-clause BSD
 #
 # This work is based on experiences from the UNITE project
@@ -34,17 +35,21 @@ builddependencies = [
 dependencies = [
     # SIONlib container support (optional):
     ('SIONlib', '1.7.7', '-tools'),
+    # OTF2 Python bindings
+    ('Python', '3.10.4'),
 ]
 
+local_pyshortver = '3.10'
 configopts = '--enable-shared'
 
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_pyshortver]}
 
 sanity_check_paths = {
     'files': ['bin/otf2-config', 'include/otf2/otf2.h',
               'lib/libotf2.a', 'lib/libotf2.%s' % SHLIB_EXT],
     'dirs': [],
 }
-
-sanity_check_commands = ['%(namelower)s-config --help']
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python -c "import %(namelower)s"']
 
 moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-GCCcore-12.2.0.eb
@@ -3,6 +3,7 @@
 # Copyright:: Copyright 2013-2019 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # Markus Geimer <m.geimer@fz-juelich.de>
+# Jan Andre Reuter <j.reuter@fz-juelich.de>
 # License::   3-clause BSD
 #
 # This work is based on experiences from the UNITE project
@@ -34,17 +35,21 @@ builddependencies = [
 dependencies = [
     # SIONlib container support (optional):
     ('SIONlib', '1.7.7', '-tools'),
+    # OTF2 Python bindings
+    ('Python', '3.10.8'),
 ]
 
+local_pyshortver = '3.10'
 configopts = '--enable-shared'
 
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_pyshortver]}
 
 sanity_check_paths = {
     'files': ['bin/otf2-config', 'include/otf2/otf2.h',
               'lib/libotf2.a', 'lib/libotf2.%s' % SHLIB_EXT],
     'dirs': [],
 }
-
-sanity_check_commands = ['%(namelower)s-config --help']
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python -c "import %(namelower)s"']
 
 moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-GCCcore-12.3.0.eb
@@ -3,6 +3,7 @@
 # Copyright:: Copyright 2013-2019 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # Markus Geimer <m.geimer@fz-juelich.de>
+# Jan Andre Reuter <j.reuter@fz-juelich.de>
 # License::   3-clause BSD
 #
 # This work is based on experiences from the UNITE project
@@ -34,17 +35,22 @@ builddependencies = [
 dependencies = [
     # SIONlib container support (optional):
     ('SIONlib', '1.7.7', '-tools'),
+    # OTF2 Python bindings
+    ('Python', '3.11.3'),
+    ('Python-bundle-PyPI', '2023.06'),
 ]
 
+local_pyshortver = '3.11'
 configopts = '--enable-shared'
 
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_pyshortver]}
 
 sanity_check_paths = {
     'files': ['bin/otf2-config', 'include/otf2/otf2.h',
               'lib/libotf2.a', 'lib/libotf2.%s' % SHLIB_EXT],
     'dirs': [],
 }
-
-sanity_check_commands = ['%(namelower)s-config --help']
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python -c "import %(namelower)s"']
 
 moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-GCCcore-13.2.0.eb
@@ -3,6 +3,7 @@
 # Copyright:: Copyright 2013-2019 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
 # Markus Geimer <m.geimer@fz-juelich.de>
+# Jan Andre Reuter <j.reuter@fz-juelich.de>
 # License::   3-clause BSD
 #
 # This work is based on experiences from the UNITE project
@@ -34,17 +35,22 @@ builddependencies = [
 dependencies = [
     # SIONlib container support (optional):
     ('SIONlib', '1.7.7', '-tools'),
+    # OTF2 Python bindings
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
 ]
 
+local_pyshortver = '3.11'
 configopts = '--enable-shared'
 
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_pyshortver]}
 
 sanity_check_paths = {
     'files': ['bin/otf2-config', 'include/otf2/otf2.h',
               'lib/libotf2.a', 'lib/libotf2.%s' % SHLIB_EXT],
     'dirs': [],
 }
-
-sanity_check_commands = ['%(namelower)s-config --help']
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python -c "import %(namelower)s"']
 
 moduleclass = 'perf'


### PR DESCRIPTION
Add Python as a dependency to OTF2 versions to ensure that the toolchain Python is used. To verify, a sanity check is added which ensures that the OTF2 Python module can be loaded. As `six` is required, newer toolchains also need Python-bundle-PyPI.

Resolves #21266 