### PR TITLE
use source tarballs from GitHub for recent libdap easyconfigs

### DIFF
--- a/easybuild/easyconfigs/l/libdap/libdap-3.20.11-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/l/libdap/libdap-3.20.11-GCCcore-11.3.0.eb
@@ -9,9 +9,9 @@ description = """A C++ SDK which contains an implementation of DAP 2.0 and
 
 toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 
-source_urls = ['https://www.opendap.org/pub/source/']
-sources = [SOURCE_TAR_GZ]
-checksums = ['850debf6ee6991350bf31051308093bee35ddd2121e4002be7e130a319de1415']
+source_urls = ['https://github.com/OPENDAP/libdap4/archive/refs/tags/']
+sources = ['%(version)s.tar.gz']
+checksums = ['319e9771d037b6c796f04e6a96bb27db1706bc5931ca149c78347c623a747771']
 
 builddependencies = [
     ('binutils', '2.38'),

--- a/easybuild/easyconfigs/l/libdap/libdap-3.20.11-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/l/libdap/libdap-3.20.11-GCCcore-11.3.0.eb
@@ -17,6 +17,7 @@ builddependencies = [
     ('binutils', '2.38'),
     ('Bison', '3.8.2'),
     ('flex', '2.6.4'),
+    ('Autotools', '20220317'),
 ]
 
 dependencies = [
@@ -27,6 +28,7 @@ dependencies = [
     ('util-linux', '2.38'),
 ]
 
+preconfigopts = "autoreconf -fi && "
 configopts = 'TIRPC_LIBS="-ltirpc"'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libdap/libdap-3.20.11-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/libdap/libdap-3.20.11-GCCcore-12.3.0.eb
@@ -17,6 +17,7 @@ builddependencies = [
     ('binutils', '2.40'),
     ('Bison', '3.8.2'),
     ('flex', '2.6.4'),
+    ('Autotools', '20220317'),
 ]
 
 dependencies = [
@@ -27,6 +28,7 @@ dependencies = [
     ('util-linux', '2.39'),
 ]
 
+preconfigopts = "autoreconf -fi && "
 configopts = 'TIRPC_LIBS="-ltirpc"'
 
 

--- a/easybuild/easyconfigs/l/libdap/libdap-3.20.11-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/libdap/libdap-3.20.11-GCCcore-12.3.0.eb
@@ -9,9 +9,9 @@ description = """A C++ SDK which contains an implementation of DAP 2.0 and
 
 toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 
-source_urls = ['https://www.opendap.org/pub/source/']
-sources = [SOURCE_TAR_GZ]
-checksums = ['850debf6ee6991350bf31051308093bee35ddd2121e4002be7e130a319de1415']
+source_urls = ['https://github.com/OPENDAP/libdap4/archive/refs/tags/']
+sources = ['%(version)s.tar.gz']
+checksums = ['319e9771d037b6c796f04e6a96bb27db1706bc5931ca149c78347c623a747771']
 
 builddependencies = [
     ('binutils', '2.40'),

--- a/easybuild/easyconfigs/l/libdap/libdap-3.20.7-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/libdap/libdap-3.20.7-GCCcore-10.3.0.eb
@@ -17,6 +17,7 @@ builddependencies = [
     ('binutils', '2.36.1'),
     ('Bison', '3.7.6'),
     ('flex', '2.6.4'),
+    ('Autotools', '20220317'),
 ]
 
 dependencies = [
@@ -27,6 +28,7 @@ dependencies = [
     ('util-linux', '2.36'),
 ]
 
+preconfigopts = "autoreconf -fi && "
 configopts = 'TIRPC_LIBS="-ltirpc"'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libdap/libdap-3.20.7-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/libdap/libdap-3.20.7-GCCcore-10.3.0.eb
@@ -9,9 +9,9 @@ description = """A C++ SDK which contains an implementation of DAP 2.0 and
 
 toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
 
-source_urls = ['https://www.opendap.org/pub/source/']
-sources = [SOURCE_TAR_GZ]
-checksums = ['6856813d0b29e70a36e8a53e9cf20ad680d21d615952263e9c6586704539e78c']
+source_urls = ['https://github.com/OPENDAP/libdap4/archive/refs/tags/']
+sources = ['%(version)s.tar.gz']
+checksums = ['f6e907ea7a9f878965a3af2a858423450dde389d851fc67a33b0096b8b9b6085']
 
 builddependencies = [
     ('binutils', '2.36.1'),

--- a/easybuild/easyconfigs/l/libdap/libdap-3.20.7-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/libdap/libdap-3.20.7-GCCcore-10.3.0.eb
@@ -17,7 +17,7 @@ builddependencies = [
     ('binutils', '2.36.1'),
     ('Bison', '3.7.6'),
     ('flex', '2.6.4'),
-    ('Autotools', '20220317'),
+    ('Autotools', '20210128'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/l/libdap/libdap-3.20.8-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/l/libdap/libdap-3.20.8-GCCcore-11.2.0.eb
@@ -17,7 +17,7 @@ builddependencies = [
     ('binutils', '2.37'),
     ('Bison', '3.7.6'),
     ('flex', '2.6.4'),
-    ('Autotools', '20220317'),
+    ('Autotools', '20210726'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/l/libdap/libdap-3.20.8-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/l/libdap/libdap-3.20.8-GCCcore-11.2.0.eb
@@ -17,6 +17,7 @@ builddependencies = [
     ('binutils', '2.37'),
     ('Bison', '3.7.6'),
     ('flex', '2.6.4'),
+    ('Autotools', '20220317'),
 ]
 
 dependencies = [
@@ -27,6 +28,7 @@ dependencies = [
     ('util-linux', '2.37'),
 ]
 
+preconfigopts = "autoreconf -fi && "
 configopts = 'TIRPC_LIBS="-ltirpc"'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libdap/libdap-3.20.8-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/l/libdap/libdap-3.20.8-GCCcore-11.2.0.eb
@@ -9,9 +9,9 @@ description = """A C++ SDK which contains an implementation of DAP 2.0 and
 
 toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
 
-source_urls = ['https://www.opendap.org/pub/source/']
-sources = [SOURCE_TAR_GZ]
-checksums = ['65eb5c8f693cf74d58eece5eaa2e7c3c65f368926b1bffab0cf5b207757b94eb']
+source_urls = ['https://github.com/OPENDAP/libdap4/archive/refs/tags/']
+sources = ['%(version)s.tar.gz']
+checksums = ['e59b48f48bb37b36dcf9618043881e1d4150abd9b2ea3fa7474647c4ad622ccc']
 
 builddependencies = [
     ('binutils', '2.37'),


### PR DESCRIPTION
It looks like the source tarballs have been removed from the original source URL (https://www.opendap.org/pub/source/). 