### PR TITLE
{lib, tools}[gompi/2024a] dtcmp-1.1.5, libcircle-0.3, lwgrp-1.0.6, maeparser-1.3.1, mpifileutils-0.11.1

### DIFF
--- a/easybuild/easyconfigs/d/dtcmp/dtcmp-1.1.5-gompi-2024a.eb
+++ b/easybuild/easyconfigs/d/dtcmp/dtcmp-1.1.5-gompi-2024a.eb
@@ -1,0 +1,39 @@
+#
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+#
+easyblock = 'ConfigureMake'
+
+name = 'dtcmp'
+version = '1.1.5'
+
+homepage = 'https://github.com/LLNL/dtcmp'
+description = """The Datatype Comparison (DTCMP) Library provides pre-defined and user-defined
+comparison operations to compare the values of two items which can be arbitrary MPI datatypes.
+Using these comparison operations, the library provides various routines for manipulating data,
+which may be distributed over the processes of an MPI communicator."""
+
+toolchain = {'name': 'gompi', 'version': '2024a'}
+
+github_account = 'LLNL'
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['5c3d672fcf1be81e9afb65ef3f860a7dfe0f1bd79360ac63848acfe4d44439c9']
+
+builddependencies = [
+    ('Autotools', '20231222'),
+    ('pkgconf', '2.2.0'),
+]
+
+dependencies = [
+    ('lwgrp', '1.0.6'),
+]
+
+preconfigopts = './autogen.sh && '
+configopts = '--with-lwgrp=$EBROOTLWGRP'
+
+sanity_check_paths = {
+    'files': ['include/%(name)s.h', 'lib/lib%%(name)s.%s' % SHLIB_EXT, 'share/%(name)s/README.md'],
+    'dirs': []
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libcircle/libcircle-0.3-gompi-2024a.eb
+++ b/easybuild/easyconfigs/l/libcircle/libcircle-0.3-gompi-2024a.eb
@@ -1,0 +1,38 @@
+##
+# Authors:
+# * Petar Forai <petar.forai@gmi.oeaw.ac.at>
+# * Robert Mijakovic <robert.mijakovic@lxp.lu>
+##
+easyblock = 'ConfigureMake'
+
+name = 'libcircle'
+version = '0.3'
+
+homepage = 'https://github.com/hpc/libcircle/'
+
+description = """
+ An API to provide an efficient distributed queue on a cluster. libcircle is an
+ API for distributing embarrassingly parallel workloads using self-stabilization.
+"""
+
+toolchain = {'name': 'gompi', 'version': '2024a'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+github_account = 'hpc'
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['fd8bc6e4dcc6fdec9d2a3d1c78a4060948ae4f11f0b278792610d6c05d53e14c']
+
+builddependencies = [
+    ('Autotools', '20231222'),
+    ('pkgconf', '2.2.0'),
+]
+
+preconfigopts = './autogen.sh && '
+
+sanity_check_paths = {
+    'files': ['include/%(name)s.h', 'lib/%(name)s.a', 'lib/%%(name)s.%s' % SHLIB_EXT],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/lwgrp/lwgrp-1.0.6-gompi-2024a.eb
+++ b/easybuild/easyconfigs/l/lwgrp/lwgrp-1.0.6-gompi-2024a.eb
@@ -1,0 +1,36 @@
+#
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+#
+easyblock = 'ConfigureMake'
+
+name = 'lwgrp'
+version = '1.0.6'
+
+homepage = 'https://github.com/LLNL/lwgrp'
+description = """The light-weight group library defines data structures and collective operations to
+group MPI processes as an ordered set.  Such groups are useful as substitutes for MPI communicators
+when the overhead of communicator creation is too costly.  For example, certain sorting algorithms
+recursively divide processes into subgroups as the sort algorithm progresses.  These groups may be
+different with each invocation, so that it is inefficient to create and destroy communicators during
+the sort routine."""
+
+toolchain = {'name': 'gompi', 'version': '2024a'}
+
+github_account = 'LLNL'
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['108e622441028b7f88223244c9117d5de18a91fd7c246bfa48802b5c585557d0']
+
+builddependencies = [
+    ('Autotools', '20231222'),
+    ('pkgconf', '2.2.0'),
+]
+
+preconfigopts = './autogen.sh && '
+
+sanity_check_paths = {
+    'files': ['include/%(name)s.h', 'lib/lib%%(name)s.%s' % SHLIB_EXT],
+    'dirs': ['share/%(name)s'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/m/maeparser/maeparser-1.3.1-gompi-2024a.eb
+++ b/easybuild/easyconfigs/m/maeparser/maeparser-1.3.1-gompi-2024a.eb
@@ -1,0 +1,26 @@
+easyblock = 'CMakeMake'
+
+name = 'maeparser'
+version = '1.3.1'
+
+homepage = 'https://github.com/schrodinger/maeparser'
+description = "maeparser is a parser for Schrodinger Maestro files."
+
+toolchain = {'name': 'gompi', 'version': '2024a'}
+
+source_urls = ['https://github.com/schrodinger/maeparser/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['a8d80f67d1b9be6e23b9651cb747f4a3200132e7d878a285119c86bf44568e36']
+
+builddependencies = [
+    ('CMake', '3.29.3'),
+]
+
+dependencies = [('Boost', '1.85.0')]
+
+sanity_check_paths = {
+    'files': ['lib/libmaeparser.%s' % SHLIB_EXT],
+    'dirs': ['include/maeparser', 'lib/cmake'],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/mpifileutils/mpifileutils-0.11.1-gompi-2024a.eb
+++ b/easybuild/easyconfigs/m/mpifileutils/mpifileutils-0.11.1-gompi-2024a.eb
@@ -1,0 +1,45 @@
+easyblock = 'CMakeMake'
+
+name = 'mpifileutils'
+version = "0.11.1"
+
+homepage = 'https://hpc.github.io/mpifileutils/'
+
+description = """
+ MPI-Based File Utilities For Distributed Systems
+"""
+
+toolchain = {'name': 'gompi', 'version': '2024a'}
+
+github_account = 'hpc'
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['e2cba53309b5b3ee581b6ff82e4e66f54628370cce694c34224ed947fece32d4']
+
+builddependencies = [
+    ('CMake', '3.29.3'),
+]
+
+dependencies = [
+    ('attr', '2.5.2'),
+    ('bzip2', '1.0.8'),
+    ('lwgrp', '1.0.6'),
+    ('dtcmp', '1.1.5'),
+    ('libarchive', '3.7.4'),
+    ('libcircle', '0.3'),
+]
+
+_binaries = [
+    'dbcast', 'dbz2', 'dchmod', 'dcmp', 'dcp', 'ddup', 'dfind',
+    'dreln', 'drm', 'dstripe', 'dsync', 'dtar', 'dwalk'
+]
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in _binaries] +
+             ['include/mfu.h', 'lib/libmfu.%s' % SHLIB_EXT],
+    'dirs': []
+}
+
+sanity_check_commands = ['%s --help 2>&1 | grep Usage' % x for x in _binaries]
+
+moduleclass = 'tools'


### PR DESCRIPTION
This PR adds some files to the gompi-2024a toolchain from the new SW stage at JSC.