### PR TITLE
{tools, lib, devel, bio}[GCCcore/13.3.0, gfbf/2024a] ccache-4.10.2, PROJ-9.4.1, protobuf-28.0, protobuf-python-5.28.0, pytest-flakefinder-1.1.0, RDFlib-7.0.0, RapidJSON-1.1.0-20240815, Seaborn-0.13.2

### DIFF
--- a/easybuild/easyconfigs/c/ccache/ccache-4.10.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/c/ccache/ccache-4.10.2-GCCcore-13.3.0.eb
@@ -1,0 +1,49 @@
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+
+easyblock = 'CMakeNinja'
+
+name = 'ccache'
+version = '4.10.2'
+
+homepage = 'https://ccache.dev/'
+description = """Ccache (or “ccache”) is a compiler cache. It speeds up recompilation by
+caching previous compilations and detecting when the same compilation is being done again"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = [GITHUB_RELEASE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['108100960bb7e64573ea925af2ee7611701241abb36ce0aae3354528403a7d87']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+    ('Ninja', '1.12.1'),
+    ('zstd', '1.5.6'),
+    ('pkgconf', '2.2.0'),
+]
+
+dependencies = [
+    ('hiredis', '1.2.0'),
+]
+
+# use BFD linker rather than default ld.gold (required on CentOS 8)
+preconfigopts = 'LDFLAGS="-fuse-ld=bfd"'
+configopts = ' '.join([
+    '-DENABLE_DOCUMENTATION=OFF',
+    '-DENABLE_IPO=ON',
+    # Link most libraries statically
+    '-DSTATIC_LINK=ON',
+    # Disable downloading dependencies
+    '-DZSTD_FROM_INTERNET=OFF -DHIREDIS_FROM_INTERNET=OFF',
+])
+
+sanity_check_paths = {
+    'files': ['bin/ccache'],
+    'dirs': []
+}
+sanity_check_commands = ['ccache --help']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/PROJ/PROJ-9.4.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-9.4.1-GCCcore-13.3.0.eb
@@ -1,0 +1,49 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2014-2015 The Cyprus Institute
+# Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>
+# License:: MIT/GPL
+#
+##
+easyblock = 'CMakeMake'
+
+name = 'PROJ'
+version = '9.4.1'
+
+homepage = 'https://proj.org'
+description = """Program proj is a standard Unix filter function which converts
+geographic longitude and latitude coordinates into cartesian coordinates"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://download.osgeo.org/proj/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['ffe20170ee2b952207adf8a195e2141eab12cda181e49fdeb54425d98c7171d7']
+
+builddependencies = [
+    ('pkgconf', '2.2.0'),
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+    ('googletest', '1.15.2'),
+]
+
+dependencies = [
+    ('SQLite', '3.45.3'),
+    ('LibTIFF', '4.6.0'),
+    ('cURL', '8.7.1'),
+    ('XZ', '5.4.5'),
+    ('nlohmann_json', '3.11.3'),
+]
+
+# build twice, once for static, once for shared libraries
+configopts = ['', '-DBUILD_SHARED_LIBS=OFF']
+
+sanity_check_paths = {
+    'files': ['bin/cct', 'bin/cs2cs', 'bin/geod', 'bin/gie', 'bin/proj', 'bin/projinfo',
+              'lib/libproj.a', 'lib/libproj.%s' % SHLIB_EXT],
+    'dirs': ['include'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/protobuf-python/protobuf-python-5.28.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/p/protobuf-python/protobuf-python-5.28.0-GCCcore-13.3.0.eb
@@ -1,0 +1,35 @@
+easyblock = 'PythonPackage'
+
+name = 'protobuf-python'
+version = '5.28.0'
+
+homepage = 'https://github.com/google/protobuf/'
+description = "Python Protocol Buffers runtime library."
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://pypi.python.org/packages/source/p/protobuf']
+sources = ['protobuf-%(version)s.tar.gz']
+checksums = ['dde74af0fa774fa98892209992295adbfb91da3fa98c8f67a88afe8f5a349add']
+
+builddependencies = [('binutils', '2.42')]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('protobuf', version[2:]),  # Major version is only used for the Python bindings
+]
+
+download_dep_fail = True
+sanity_pip_check = True
+use_pip = True
+
+options = {'modulename': 'google.protobuf'}
+
+# Make sure protobuf is installed as a regular folder or it will not be found if
+# other google packages are installed in other site-packages folders
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/google/protobuf'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/protobuf/protobuf-28.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/p/protobuf/protobuf-28.0-GCCcore-13.3.0.eb
@@ -1,0 +1,35 @@
+easyblock = 'CMakeMake'
+
+name = 'protobuf'
+version = '28.0'
+
+homepage = 'https://github.com/protocolbuffers/protobuf'
+description = """Protocol Buffers (a.k.a., protobuf) are Google's
+language-neutral, platform-neutral, extensible mechanism for
+serializing structured data."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+github_account = 'protocolbuffers'
+source_urls = [GITHUB_RELEASE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['13e7749c30bc24af6ee93e092422f9dc08491c7097efa69461f88eb5f61805ce']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+]
+dependencies = [
+    ('Abseil', '20240722.0'),
+]
+
+srcdir = '.'
+
+configopts = '-Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_SHARED_LIBS=ON -Dprotobuf_ABSL_PROVIDER="package" '
+
+sanity_check_paths = {
+    'files': ['bin/protoc', 'lib/libprotobuf.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/pytest-flakefinder/pytest-flakefinder-1.1.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/p/pytest-flakefinder/pytest-flakefinder-1.1.0-GCCcore-13.3.0.eb
@@ -1,0 +1,24 @@
+easyblock = 'PythonPackage'
+
+name = 'pytest-flakefinder'
+version = '1.1.0'
+
+homepage = 'https://github.com/dropbox/pytest-flakefinder'
+description = "Runs tests multiple times to expose flakiness."
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+builddependencies = [('binutils', '2.42')]
+dependencies = [
+    ('Python', '3.12.3'),
+    ('Python-bundle-PyPI', '2024.06'),
+]
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['e2412a1920bdb8e7908783b20b3d57e9dad590cc39a93e8596ffdd493b403e0e']
+
+use_pip = True
+sanity_pip_check = True
+download_dep_fail = True
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/r/RDFlib/RDFlib-7.0.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/r/RDFlib/RDFlib-7.0.0-GCCcore-13.3.0.eb
@@ -1,0 +1,35 @@
+easyblock = 'PythonBundle'
+
+name = 'RDFlib'
+version = '7.0.0'
+
+homepage = 'https://github.com/RDFLib/rdflib'
+description = """RDFLib is a Python library for working with RDF, a simple yet powerful language
+ for representing information."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('poetry', '1.8.3'),
+]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('Python-bundle-PyPI', '2024.06'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('isodate', '0.6.1', {
+        'checksums': ['48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9'],
+    }),
+    ('rdflib', version, {
+        'checksums': ['9995eb8569428059b8c1affd26b25eac510d64f5043d9ce8c84e0d0036e995ae'],
+    }),
+]
+
+sanity_pip_check = True
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/r/RapidJSON/RapidJSON-1.1.0-20240815-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/r/RapidJSON/RapidJSON-1.1.0-20240815-GCCcore-13.3.0.eb
@@ -1,0 +1,31 @@
+easyblock = 'CMakeMake'
+
+name = 'RapidJSON'
+# no new release since Aug'16 so using latest commit;
+# see also https://github.com/Tencent/rapidjson/issues/2202
+version = '1.1.0-20240815'
+local_commit = '7c73dd7'
+
+homepage = 'https://rapidjson.org'
+description = "A fast JSON parser/generator for C++ with both SAX/DOM style API"
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://github.com/Tencent/%(namelower)s/archive/']
+sources = [{'download_filename': '%s.tar.gz' % local_commit, 'filename': 'v%(version)s.tar.gz'}]
+checksums = ['91138ebc9c980e554e6bcf9d13537f9eebf42710e0b956fdca46181ad645f94d']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+]
+
+# strip out hardcoded use of -march=native, EasyBuild should be in control of this
+preconfigopts = "sed -i 's/-march=native//g' ../rapidjson-*/CMakeLists.txt && "
+
+sanity_check_paths = {
+    'files': ['lib/pkgconfig/%(name)s.pc'],
+    'dirs': ['include/%(namelower)s', 'lib/cmake', 'share'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/s/Seaborn/Seaborn-0.13.2-gfbf-2024a.eb
+++ b/easybuild/easyconfigs/s/Seaborn/Seaborn-0.13.2-gfbf-2024a.eb
@@ -1,0 +1,24 @@
+easyblock = 'PythonPackage'
+
+name = 'Seaborn'
+version = '0.13.2'
+
+homepage = 'https://seaborn.pydata.org/'
+description = """ Seaborn is a Python visualization library based on matplotlib.
+ It provides a high-level interface for drawing attractive statistical graphics. """
+
+toolchain = {'name': 'gfbf', 'version': '2024a'}
+
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7']
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('matplotlib', '3.9.2'),
+]
+
+use_pip = True
+download_dep_fail = True
+sanity_pip_check = True
+
+moduleclass = 'bio'


### PR DESCRIPTION
Added a few more packages from the new SW stage at JSC to GCCcore 13.3.0 and gfbf 2024a.