### PR TITLE
{devel,lib}{GCCcore/13.3.0} Add GOTCHA v1.0.7, Check v0.15.2

### DIFF
--- a/easybuild/easyconfigs/c/Check/Check-0.15.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/c/Check/Check-0.15.2-GCCcore-13.3.0.eb
@@ -1,0 +1,37 @@
+easyblock = 'ConfigureMake'
+
+name = 'Check'
+version = '0.15.2'
+
+homepage = 'https://libcheck.github.io/check/'
+description = """
+Check is a unit testing framework for C. It features a simple interface for
+defining unit tests, putting little in the way of the developer. Tests are
+run in a separate address space, so both assertion failures and code errors
+that cause segmentation faults or other signals can be caught. Test results
+are reportable in the following: Subunit, TAP, XML, and a generic logging
+format."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+github_account = 'libcheck'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['%(version)s.tar.gz']
+checksums = ['998d355294bb94072f40584272cf4424571c396c631620ce463f6ea97aa67d2e']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('Autotools', '20231222'),
+    ('pkgconf', '2.2.0'),
+]
+
+preconfigopts = "autoreconf -f -i && "
+configopts = "--disable-build-docs"
+
+sanity_check_paths = {
+    'files': ['bin/checkmk', 'lib/libcheck.a', 'lib/libcheck.%s' % SHLIB_EXT],
+    'dirs': ['include', 'share']
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/g/GOTCHA/GOTCHA-1.0.7-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/GOTCHA/GOTCHA-1.0.7-GCCcore-13.3.0.eb
@@ -1,0 +1,37 @@
+easyblock = "CMakeMake"
+
+name = "GOTCHA"
+version = "1.0.7"
+
+homepage = "https://gotcha.readthedocs.io/en/latest/"
+description = """Gotcha is a library that wraps functions. Tools can use gotcha to install hooks into other
+libraries, for example putting a wrapper function around libc's malloc. It is similar to LD_PRELOAD, but
+operates via a programmable API. This enables easy methods of accomplishing tasks like code instrumentation
+or wholesale replacement of mechanisms in programs without disrupting their source code."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/LLNL/GOTCHA/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['1ecc1917a46ba0a63b75f0668b280e447afcb7623ad171caa35c596355d986f7']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+    ('Check', '0.15.2')
+]
+
+configopts = [
+    "-DGOTCHA_ENABLE_TESTS=ON",
+    "-DDEPENDENCIES_PREINSTALLED=ON"
+]
+
+sanity_check_paths = {
+    'files': [('lib/libgotcha.%s' % SHLIB_EXT, 'lib64/libgotcha.%s' % SHLIB_EXT),
+              'lib/cmake/gotcha/gotcha-config.cmake',
+              'include/gotcha/gotcha.h'],
+    'dirs': []
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Add GOTCHA, a library which helps to wrap function calls. This will get relevant for tools like Score-P.
The build itself is straight-forward, but parallel builds need to be disabled due to issues when enabling tests. 
This is not a huge problem though, as the library builds quickly (~20 seconds on my machine).