### PR TITLE
{vis}[GCCcore/13.3.0] ATK-2.38.0, Gdk-Pixbuf-2.42.11

### DIFF
--- a/easybuild/easyconfigs/a/ATK/ATK-2.38.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/a/ATK/ATK-2.38.0-GCCcore-13.3.0.eb
@@ -1,0 +1,39 @@
+easyblock = 'MesonNinja'
+
+name = 'ATK'
+version = '2.38.0'
+
+homepage = 'https://developer.gnome.org/atk/'
+description = """
+ ATK provides the set of accessibility interfaces that are implemented by other
+ toolkits and applications. Using the ATK interfaces, accessibility tools have
+ full access to view and control running applications.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['ac4de2a4ef4bd5665052952fe169657e65e895c5057dffb3c2a810f6191a0c36']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('Meson', '1.4.0'),
+    ('Ninja', '1.12.1'),
+    ('pkgconf', '2.2.0'),
+    ('GObject-Introspection', '1.80.1'),
+]
+
+dependencies = [
+    ('GLib', '2.80.4'),
+]
+
+configopts = "--buildtype=release --default-library=both "
+configopts += "-Dintrospection=true "
+
+sanity_check_paths = {
+    'files': ['lib/libatk-1.0.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.42.11-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.42.11-GCCcore-13.3.0.eb
@@ -1,0 +1,46 @@
+easyblock = 'MesonNinja'
+
+name = 'Gdk-Pixbuf'
+version = '2.42.11'
+
+homepage = 'https://docs.gtk.org/gdk-pixbuf/'
+description = """
+ The Gdk Pixbuf is a toolkit for image loading and pixel buffer manipulation.
+ It is used by GTK+ 2 and GTK+ 3 to load and manipulate images. In the past it
+ was distributed as part of GTK+ 2 but it was split off into a separate package
+ in preparation for the change to GTK+ 3.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['49dcb402388708647e8c321d56b6fb30f21e51e515d0c5a942268d23052a2f00']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('Meson', '1.4.0'),
+    ('Ninja', '1.12.1'),
+    ('pkgconf', '2.2.0'),
+    ('GObject-Introspection', '1.80.1'),
+]
+
+dependencies = [
+    ('GLib', '2.80.4'),
+    ('libjpeg-turbo', '3.0.1'),
+    ('libpng', '1.6.43'),
+    ('LibTIFF', '4.6.0'),
+    ('X11', '20240607'),
+]
+
+configopts = "--buildtype=release --default-library=both "
+configopts += "-Dgio_sniffing=false -Dintrospection=enabled -Dman=false"
+
+sanity_check_paths = {
+    'files': ['lib/libgdk_pixbuf-%(version_major)s.0.a', 'lib/libgdk_pixbuf-%%(version_major)s.0.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'include/gdk-pixbuf-%(version_major)s.0', 'lib/gdk-pixbuf-%(version_major)s.0', 'share'],
+}
+
+sanity_check_commands = ["gdk-pixbuf-pixdata --help"]
+
+moduleclass = 'vis'


### PR DESCRIPTION
Added ATK and Gdk-Pixbuf after the GObject-Introspection fix (part of the SW stage at JSC)