### PR TITLE
take into list of crates for easyconfigs using Cargo-based easyblock when determining checksums for patches

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -40,6 +40,7 @@ from unittest import TestCase, TestLoader, main, skip
 import easybuild.main as eb_main
 import easybuild.tools.options as eboptions
 from easybuild.base import fancylogger
+from easybuild.easyblocks.generic.cargo import Cargo
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
 from easybuild.framework.easyblock import EasyBlock
@@ -1507,6 +1508,12 @@ def template_easyconfig_test(self, spec):
                     failing_checks.append("OpenSSL should not be listed as OS dependency")
 
     src_cnt = len(ec['sources'])
+
+    # if easyblock derives from Cargo easyblock we need to take into account list of crates,
+    # which get added to list of sources, to correctly determine number of checksums for sources (incl. crates)
+    if isinstance(app, Cargo):
+        src_cnt += len(ec.get('crates', []))
+
     patch_checksums = ec['checksums'][src_cnt:]
 
     # make sure all patch files are available


### PR DESCRIPTION
for for failing CI:
```
ERROR: test__parse_easyconfig_DeltaLake-0.15.1-gfbf-2023a.eb (test.easyconfigs.easyconfigs.EasyConfigTest)
Test for easyconfig DeltaLake-0.15.1-gfbf-2023a.eb
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/easybuild/tools/filetools.py", line 1274, in verify_checksum
    checksum = checksum[filename]
KeyError: 'DeltaLake-0.15.1_remove-obsolete-pyarrow-hotfix.patch'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/easybuild-easyconfigs/easybuild-easyconfigs/test/easyconfigs/easyconfigs.py", line 1693, in innertest
    template_easyconfig_test(self, spec_path)
  File "/home/runner/work/easybuild-easyconfigs/easybuild-easyconfigs/test/easyconfigs/easyconfigs.py", line 1533, in template_easyconfig_test
    if not verify_checksum(patch_full, checksum):
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/easybuild/tools/filetools.py", line 1276, in verify_checksum
    raise EasyBuildError("Missing checksum for %s in %s", filename, checksum)
easybuild.tools.build_log.EasyBuildError: "Missing checksum for DeltaLake-0.15.1_remove-obsolete-pyarrow-hotfix.patch in {'addr2line-0.21.0.tar.gz': '8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb'}"
```

This problem arose due to the change in https://github.com/easybuilders/easybuild-easyblocks/pull/3448, where `self.cfg = self.cfg.copy()` was added to the `Cargo` constructor before `self.cfg['sources']` is being changed...

The checksum for `DeltaLake-0.15.1_remove-obsolete-pyarrow-hotfix.patch` is already there in `DeltaLake-0.15.1-gfbf-2023a.eb`