### PR TITLE
account for crates for easyconfigs using Cargo-based easyblock when determining checksums for patches

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1459,6 +1459,9 @@ def template_easyconfig_test(self, spec):
     ]
     failing_checks.extend("Old URL '%s' found" % old_url for old_url in old_urls if old_url in ec.rawtxt)
 
+    # Note the use of app.cfg which might contain sources populated by e.g. the Cargo easyblock
+    sources, patches, checksums = app.cfg['sources'], app.cfg['patches'], app.cfg['checksums']
+
     # make sure binutils is included as a (build) dep if toolchain is GCCcore
     if ec['toolchain']['name'] == 'GCCcore':
         # easyblocks without a build step
@@ -1475,7 +1478,7 @@ def template_easyconfig_test(self, spec):
             requires_binutils &= bool(ec['name'] not in binutils_complete_dependencies)
 
         # if no sources/extensions/components are specified, it's just a bundle (nothing is being compiled)
-        requires_binutils &= bool(ec['sources'] or ec['exts_list'] or ec.get('components'))
+        requires_binutils &= bool(sources or ec['exts_list'] or ec.get('components'))
 
         if requires_binutils:
             # dependencies() returns both build and runtime dependencies
@@ -1506,13 +1509,13 @@ def template_easyconfig_test(self, spec):
                 if openssl_osdep:
                     failing_checks.append("OpenSSL should not be listed as OS dependency")
 
-    src_cnt = len(ec['sources'])
-    patch_checksums = ec['checksums'][src_cnt:]
+    src_cnt = len(sources)
+    patch_checksums = checksums[src_cnt:]
 
     # make sure all patch files are available
     specdir = os.path.dirname(spec)
     basedir = os.path.dirname(os.path.dirname(specdir))
-    for idx, patch in enumerate(ec['patches']):
+    for idx, patch in enumerate(patches):
         patch_dir = specdir
         if isinstance(patch, str):
             patch_name = patch
@@ -1535,7 +1538,7 @@ def template_easyconfig_test(self, spec):
 
     # make sure 'source' step is not being skipped,
     # since that implies not verifying the checksum
-    if ec['checksums'] and ('source' in ec['skipsteps']):
+    if checksums and ('source' in ec['skipsteps']):
         failing_checks.append("'source' step should not be skipped, since that implies not verifying checksums")
 
     for ext in ec.get_ref('exts_list'):


### PR DESCRIPTION
Fix for failing CI

> easybuild.tools.build_log.EasyBuildError: "Missing checksum for DeltaLake-0.15.1_remove-obsolete-pyarrow-hotfix.patch in {'addr2line-0.21.0.tar.gz': '8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb'}"

This problem arose due to the change in https://github.com/easybuilders/easybuild-easyblocks/pull/3448, where `self.cfg = self.cfg.copy()` was added to the Cargo constructor before `self.cfg['sources']` (was equal to the input `ec` instance) is being changed.

Closes #21416 which addresses the issue in a more specific way. This PR is more generic.