### PR TITLE
use proper dependency for libnsl in git-annex

### DIFF
--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.2.0.eb
@@ -16,6 +16,7 @@ dependencies = [
     ('GHC', '9.2.2', '-x86_64', SYSTEM),
     ('Stack', '2.11.1', '-x86_64', SYSTEM),
     ('git', '2.38.1', '-nodocs'),
+    ('libnsl', '2.0.0'),
 ]
 
 sources = [{

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.3.0.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('GHC', '9.4.6', '-x86_64', SYSTEM),
     ('Stack', '2.13.1', '-x86_64', SYSTEM),
     ('git', '2.41.0', '-nodocs'),
+    ('libnsl', '2.0.1' ),
 ]
 
 sources = [{

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.3.0.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('GHC', '9.4.6', '-x86_64', SYSTEM),
     ('Stack', '2.13.1', '-x86_64', SYSTEM),
     ('git', '2.41.0', '-nodocs'),
-    ('libnsl', '2.0.1' ),
+    ('libnsl', '2.0.1'),
 ]
 
 sources = [{

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20240731-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20240731-GCCcore-13.3.0.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('GHC', '9.10.1', '-x86_64', SYSTEM),
     ('Stack', '3.1.1', '-x86_64', SYSTEM),
     ('git', '2.45.1'),
+    ('libnsl', '2.0.1'),
 ]
 
 sources = [{

--- a/easybuild/easyconfigs/l/libnsl/libnsl-2.0.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libnsl/libnsl-2.0.1-GCCcore-13.3.0.eb
@@ -17,7 +17,7 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('libtirpc', '1.3.3'),
+    ('libtirpc', '1.3.5'),
 ]
 
 # Provide a symlink for libnsl.so.1, which used to be part of glibc.

--- a/easybuild/easyconfigs/l/libnsl/libnsl-2.0.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libnsl/libnsl-2.0.1-GCCcore-13.3.0.eb
@@ -1,0 +1,33 @@
+easyblock = 'ConfigureMake'
+
+name = 'libnsl'
+version = '2.0.1'
+
+homepage = 'https://github.com/thkukuk/libnsl'
+description = """The libnsl package contains the public client interface for NIS(YP)."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://github.com/thkukuk/%(name)s/releases/download/v%(version)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['5c9e470b232a7acd3433491ac5221b4832f0c71318618dc6aa04dd05ffcd8fd9']
+
+builddependencies = [
+    ('binutils', '2.42'),
+]
+
+dependencies = [
+    ('libtirpc', '1.3.3'),
+]
+
+# Provide a symlink for libnsl.so.1, which used to be part of glibc.
+# This new version of libnsl should be backwards compatible.
+postinstallcmds = ['ln -s libnsl.so %(installdir)s/lib/libnsl.so.1']
+
+sanity_check_paths = {
+    'files': ['include/rpcsvc/yp.h', 'lib/libnsl.a',
+              'lib/libnsl.%s' % SHLIB_EXT, 'lib/libnsl.%s.1' % SHLIB_EXT],
+    'dirs': ['include']
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/libtirpc/libtirpc-1.3.5-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libtirpc/libtirpc-1.3.5-GCCcore-13.3.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'libtirpc'
+version = '1.3.5'
+
+homepage = 'https://sourceforge.net/projects/libtirpc/'
+description = "Libtirpc is a port of Suns Transport-Independent RPC library to Linux."
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCE_TAR_BZ2]
+checksums = ['1e0b0c7231c5fa122e06c0609a76723664d068b0dba3b8219b63e6340b347860']
+
+configopts = '--enable-static --enable-shared --disable-gssapi'
+
+builddependencies = [
+    ('binutils', '2.42')
+]
+
+sanity_check_paths = {
+    'files': ['lib/libtirpc.%s' % (x,) for x in ['a', SHLIB_EXT]],
+    'dirs': ['include/tirpc', 'lib'],
+}
+
+modextrapaths = {'CPATH': 'include/tirpc'}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libtirpc/libtirpc-1.3.5-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libtirpc/libtirpc-1.3.5-GCCcore-13.3.0.eb
@@ -10,7 +10,7 @@ toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
 
 source_urls = [SOURCEFORGE_SOURCE]
 sources = [SOURCE_TAR_BZ2]
-checksums = ['1e0b0c7231c5fa122e06c0609a76723664d068b0dba3b8219b63e6340b347860']
+checksums = ['9b31370e5a38d3391bf37edfa22498e28fe2142467ae6be7a17c9068ec0bf12f']
 
 configopts = '--enable-static --enable-shared --disable-gssapi'
 


### PR DESCRIPTION
Hey,
when we updated some of our nodes to Rocky9, I noticed, that in the installation of git-annex, libnsl is a system-requirement, although it doesn't have to be. It is already in the GCCcore toolchain. In order to be more system-independent, I suggest using the EB-version of libnsl to build git-annex.