### PR TITLE
{phys}[intel/2023a] Siesta 5.0.1

### DIFF
--- a/easybuild/easyconfigs/s/Siesta/Siesta-5.0.1-intel-2023a.eb
+++ b/easybuild/easyconfigs/s/Siesta/Siesta-5.0.1-intel-2023a.eb
@@ -1,0 +1,40 @@
+easyblock = 'CMakeMake'
+
+name = 'Siesta'
+version = '5.0.1'
+
+homepage = 'http://departments.icmab.es/leem/siesta'
+description = """SIESTA is both a method and its computer program implementation, to perform efficient electronic
+ structure calculations and ab initio molecular dynamics simulations of molecules and solids."""
+
+toolchain = {'name': 'intel', 'version': '2023a'}
+toolchainopts = {'usempi': True, 'precise': True}
+
+source_urls = ['https://gitlab.com/siesta-project/siesta/-/releases/%(version)s/downloads']
+sources = ['siesta-5.0.1.tar.gz']
+checksums = [
+    {'siesta-5.0.1.tar.gz': '1933cde879d921577a5e854c459531951d0afc9fd193f086a04457e9022ba9a0'},
+]
+
+builddependencies = [
+    ('CMake', '3.26.3'),
+]
+
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('netCDF-Fortran', '4.6.1'),
+    ('HDF5', '1.14.0'),
+    ('ELPA', '2023.05.001'),
+    ('libxc', '6.2.2'),
+]
+
+configopts = '-DSIESTA_WITH_MPI=ON -DLAPACK_LIBRARY="-lmkl_intel_lp64 -lmkl_sequential -lmkl_core" -DSCALAPACK_LIBRARY="-lmkl_scalapack_lp64 -lmkl_blacs_intelmpi_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core" -DSIESTA_WITH_FFTW=ON' 
+
+sanity_check_paths = {
+    'files': ["bin/siesta", "bin/mpi_driver", "bin/tbtrans", "bin/s-dftd3", "lib64/libsiesta.a"],
+    'dirs': [],
+}
+
+runtest = True
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/s/Siesta/Siesta-5.0.1-intel-2023a.eb
+++ b/easybuild/easyconfigs/s/Siesta/Siesta-5.0.1-intel-2023a.eb
@@ -28,7 +28,9 @@ dependencies = [
     ('libxc', '6.2.2'),
 ]
 
-configopts = '-DSIESTA_WITH_MPI=ON -DLAPACK_LIBRARY="-lmkl_intel_lp64 -lmkl_sequential -lmkl_core" -DSCALAPACK_LIBRARY="-lmkl_scalapack_lp64 -lmkl_blacs_intelmpi_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core" -DSIESTA_WITH_FFTW=ON' 
+configopts = '-DSIESTA_WITH_MPI=ON -DLAPACK_LIBRARY="-lmkl_intel_lp64 -lmkl_sequential -lmkl_core" '
+configopts += '-DSCALAPACK_LIBRARY="-lmkl_scalapack_lp64 -lmkl_blacs_intelmpi_lp64 -lmkl_intel_lp64 '
+configopts += ' -lmkl_sequential -lmkl_core" -DSIESTA_WITH_FFTW=ON'
 
 sanity_check_paths = {
     'files': ["bin/siesta", "bin/mpi_driver", "bin/tbtrans", "bin/s-dftd3", "lib64/libsiesta.a"],


### PR DESCRIPTION
Easyconfig file for Siesta 5.0.1 with the intel toolchain.

Based on the work here: https://github.com/easybuilders/easybuild-easyconfigs/issues/20910

It runs the tests but does not verify the results (as described here: https://docs.siesta-project.org/projects/siesta/en/latest/installation/build-manually.html#tests). If I enable the verification, some tests fail with tiny errors on some values. That's probably to be expected since, as far as I can see, the test references were obtained with GNU compilers.