### PR TITLE
{compiler}[SYSTEM,GCCcore/13.3.0] LLVM 19.1.1

### DIFF
--- a/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8_envintest.patch
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8_envintest.patch
@@ -1,0 +1,16 @@
+Related to https://github.com/llvm/llvm-project/issues/109949
+Normally run.py does not carry over LD_LIBRARY_PATH, which can cause some tests to fail on system where
+libatomic is not present on a standard system path.
+--- libcxx/utils/run.py.orig
++++ libcxx/utils/run.py
+@@ -55,6 +55,10 @@
+             v = v + os.pathsep + os.environ[k]
+         env[k] = v
+ 
++    if any(isTestExe(exe) for exe in commandLine):
++        for var in ['LD_LIBRARY_PATH', ]:
++            env[var] = os.pathsep.join(filter(None, [os.environ.get(var, ''), env.get(var, '')]))
++
+     if platform.system() == "Windows":
+         # Pass some extra variables through on Windows:
+         # COMSPEC is needed for running subprocesses via std::system().

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0-minimal.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0-minimal.eb
@@ -64,7 +64,7 @@ python_bindings = False
 skip_all_tests = False
 skip_sanitizer_tests = False
 test_suite_max_failed = 0
-test_suite_timeout_single = 5*60
+test_suite_timeout_single = 5 * 60
 # test_suite_timeout_total = 10*3600
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0-minimal.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0-minimal.eb
@@ -12,9 +12,6 @@ description = """The LLVM Core libraries provide a modern source- and target-ind
  to use LLVM as an optimizer and code generator."""
 
 toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
-toolchainopts = {
-    'pic': True,
-}
 
 source_urls = ['https://github.com/llvm/llvm-project/releases/download/llvmorg-%(version)s/']
 sources = [

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0-minimal.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0-minimal.eb
@@ -1,0 +1,73 @@
+name = 'LLVM'
+version = '19.1.1'
+versionsuffix = '-minimal'
+
+homepage = "https://llvm.org/"
+description = """The LLVM Core libraries provide a modern source- and target-independent
+ optimizer, along with code generation support for many popular CPUs
+ (as well as some less common ones!) These libraries are built around a well
+ specified code representation known as the LLVM intermediate representation
+ ("LLVM IR"). The LLVM Core libraries are well documented, and it is
+ particularly easy to invent your own language (or port an existing compiler)
+ to use LLVM as an optimizer and code generator."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {
+    'pic': True,
+}
+
+source_urls = ['https://github.com/llvm/llvm-project/releases/download/llvmorg-%(version)s/']
+sources = [
+    'llvm-project-%(version)s.src.tar.xz',
+]
+patches = [
+    'LLVM-18.1.8_envintest.patch',
+]
+checksums = [
+    {'llvm-project-19.1.1.src.tar.xz': 'd40e933e2a208ee142898f85d886423a217e991abbcd42dd8211f507c93e1266'},
+    {'LLVM-18.1.8_envintest.patch': '8e25dfab8a29a860717b4bd2d8cdd0e795433766d7fffbda32d06a2bde47058d'},
+]
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('Python', '3.12.3'),
+    ('CMake', '3.29.3'),
+    ('psutil', '6.0.0'),  # Needed to enable test timeout in lit
+    ('lit', '18.1.8'),
+    ('git', '2.45.1'),
+]
+
+dependencies = [
+    ('libxml2', '2.12.7'),
+    ('ncurses', '6.5'),
+    ('zlib', '1.3.1'),
+    ('Z3', '4.13.0'),
+]
+
+build_shared_libs = True
+
+minimal = True
+
+bootstrap = False
+full_llvm = False
+build_clang_extras = False
+build_runtimes = False
+build_lld = False
+build_lldb = False
+build_bolt = False
+build_openmp = False
+build_openmp_tools = False
+usepolly = False
+
+python_bindings = False
+
+# build_targets = ['all']
+# disable_werror = True
+
+skip_all_tests = False
+skip_sanitizer_tests = False
+test_suite_max_failed = 0
+test_suite_timeout_single = 5*60
+# test_suite_timeout_total = 10*3600
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0-minimal.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0-minimal.eb
@@ -53,6 +53,7 @@ build_lld = False
 build_lldb = False
 build_bolt = False
 build_openmp = False
+build_openmp_offload = False
 build_openmp_tools = False
 usepolly = False
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
@@ -32,6 +32,7 @@ checksums = [
 builddependencies = [
     ('binutils', '2.42'),
     ('Python', '3.12.3'),
+    ('SWIG', '4.2.1'),
     ('CMake', '3.29.3'),
     ('psutil', '6.0.0'),  # Needed to enable test timeout in lit
     ('lit', '18.1.8'),

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
@@ -69,7 +69,7 @@ python_bindings = True
 
 skip_all_tests = False
 skip_sanitizer_tests = False
-test_suite_max_failed = 30  # Could increase depending of number of targets compiled for
+test_suite_max_failed = 150  # Could increase depending of number of targets compiled for
 test_suite_timeout_single = 5*60
 # test_suite_timeout_total = 10*3600
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
@@ -28,6 +28,7 @@ checksums = [
     {'llvm-project-19.1.1.src.tar.xz': 'd40e933e2a208ee142898f85d886423a217e991abbcd42dd8211f507c93e1266'},
     {'LLVM-18.1.8_envintest.patch': '8e25dfab8a29a860717b4bd2d8cdd0e795433766d7fffbda32d06a2bde47058d'},
     {'LLVM-19.1.1_libomptarget_tests.patch': 'a6cc11a2fb79e087d6c58fa5c01e5d6c95c952453ba8c1a09a0d4d3e6d109bd2'},
+    {'LLVM-19.1.1_envintest_lldb.patch': 'fbaa2494765637996f212f2fd9073b6bd775c0938a5a87fb70e19feb183c3299'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
@@ -1,0 +1,74 @@
+name = 'LLVM'
+version = '19.1.1'
+
+local_gcc_version = '13.3.0'
+
+homepage = "https://llvm.org/"
+description = """The LLVM Core libraries provide a modern source- and target-independent
+ optimizer, along with code generation support for many popular CPUs
+ (as well as some less common ones!) These libraries are built around a well
+ specified code representation known as the LLVM intermediate representation
+ ("LLVM IR"). The LLVM Core libraries are well documented, and it is
+ particularly easy to invent your own language (or port an existing compiler)
+ to use LLVM as an optimizer and code generator."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {
+    'pic': True,
+}
+
+source_urls = ['https://github.com/llvm/llvm-project/releases/download/llvmorg-%(version)s/']
+sources = [
+    'llvm-project-%(version)s.src.tar.xz',
+]
+patches = [
+    'LLVM-18.1.8_envintest.patch',
+]
+checksums = [
+    None,
+    None
+]
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('Python', '3.12.3'),
+    ('CMake', '3.29.3'),
+    ('psutil', '6.0.0'),  # Needed to enable test timeout in lit
+    ('lit', '18.1.8'),
+    ('git', '2.45.1'),
+]
+
+dependencies = [
+    ('libxml2', '2.12.7'),
+    ('ncurses', '6.5'),
+    ('zlib', '1.3.1'),
+    ('Z3', '4.13.0'),
+]
+
+build_shared_libs = True
+
+minimal = False
+
+bootstrap = True
+full_llvm = False
+build_clang_extras = True
+build_runtimes = True
+build_lld = True
+build_lldb = True
+build_bolt = True
+build_openmp = True
+build_openmp_tools = True
+usepolly = True
+
+python_bindings = True
+
+# build_targets = ['all']
+# disable_werror = True
+
+skip_all_tests = False
+skip_sanitizer_tests = False
+test_suite_max_failed = 350  # Could increase depending on build targets
+test_suite_timeout_single = 5*60
+# test_suite_timeout_total = 10*3600
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
@@ -70,7 +70,7 @@ python_bindings = True
 skip_all_tests = False
 skip_sanitizer_tests = False
 test_suite_max_failed = 150  # Could increase depending of number of targets compiled for
-test_suite_timeout_single = 5*60
+test_suite_timeout_single = 5 * 60
 # test_suite_timeout_total = 10*3600
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
@@ -23,12 +23,14 @@ patches = [
     'LLVM-18.1.8_envintest.patch',
     'LLVM-19.1.1_libomptarget_tests.patch',
     'LLVM-19.1.1_envintest_lldb.patch',
+    'LLVM-19.1.7_clang_rpathwrap_test.patch',
 ]
 checksums = [
     {'llvm-project-19.1.1.src.tar.xz': 'd40e933e2a208ee142898f85d886423a217e991abbcd42dd8211f507c93e1266'},
     {'LLVM-18.1.8_envintest.patch': '8e25dfab8a29a860717b4bd2d8cdd0e795433766d7fffbda32d06a2bde47058d'},
     {'LLVM-19.1.1_libomptarget_tests.patch': 'a6cc11a2fb79e087d6c58fa5c01e5d6c95c952453ba8c1a09a0d4d3e6d109bd2'},
     {'LLVM-19.1.1_envintest_lldb.patch': 'fbaa2494765637996f212f2fd9073b6bd775c0938a5a87fb70e19feb183c3299'},
+    {'LLVM-19.1.7_clang_rpathwrap_test.patch': '5ee6a87ec8ff1c8b736ffe0513aa2098bd2b83a1ffc647a1ad2cf966f567e8a1'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
@@ -62,6 +62,7 @@ build_lld = True
 build_lldb = True
 build_bolt = True
 build_openmp = True
+build_openmp_offload = True
 build_openmp_tools = True
 usepolly = True
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
@@ -1,8 +1,6 @@
 name = 'LLVM'
 version = '19.1.1'
 
-local_gcc_version = '13.3.0'
-
 homepage = "https://llvm.org/"
 description = """The LLVM Core libraries provide a modern source- and target-independent
  optimizer, along with code generation support for many popular CPUs
@@ -69,7 +67,7 @@ python_bindings = True
 
 skip_all_tests = False
 skip_sanitizer_tests = False
-test_suite_max_failed = 350  # Could increase depending on build targets
+test_suite_max_failed = 10
 test_suite_timeout_single = 5*60
 # test_suite_timeout_total = 10*3600
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
@@ -25,8 +25,8 @@ patches = [
     'LLVM-18.1.8_envintest.patch',
 ]
 checksums = [
-    None,
-    None
+    {'llvm-project-19.1.1.src.tar.xz': 'd40e933e2a208ee142898f85d886423a217e991abbcd42dd8211f507c93e1266'},
+    {'LLVM-18.1.8_envintest.patch': '8e25dfab8a29a860717b4bd2d8cdd0e795433766d7fffbda32d06a2bde47058d'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
@@ -67,7 +67,7 @@ python_bindings = True
 
 skip_all_tests = False
 skip_sanitizer_tests = False
-test_suite_max_failed = 10
+test_suite_max_failed = 30  # Could increase depending of number of targets compiled for
 test_suite_timeout_single = 5*60
 # test_suite_timeout_total = 10*3600
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
@@ -22,6 +22,7 @@ sources = [
 patches = [
     'LLVM-18.1.8_envintest.patch',
     'LLVM-19.1.1_libomptarget_tests.patch',
+    'LLVM-19.1.1_envintest_lldb.patch',
 ]
 checksums = [
     {'llvm-project-19.1.1.src.tar.xz': 'd40e933e2a208ee142898f85d886423a217e991abbcd42dd8211f507c93e1266'},

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1-GCCcore-13.3.0.eb
@@ -23,10 +23,12 @@ sources = [
 ]
 patches = [
     'LLVM-18.1.8_envintest.patch',
+    'LLVM-19.1.1_libomptarget_tests.patch',
 ]
 checksums = [
     {'llvm-project-19.1.1.src.tar.xz': 'd40e933e2a208ee142898f85d886423a217e991abbcd42dd8211f507c93e1266'},
     {'LLVM-18.1.8_envintest.patch': '8e25dfab8a29a860717b4bd2d8cdd0e795433766d7fffbda32d06a2bde47058d'},
+    {'LLVM-19.1.1_libomptarget_tests.patch': 'a6cc11a2fb79e087d6c58fa5c01e5d6c95c952453ba8c1a09a0d4d3e6d109bd2'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
@@ -1,0 +1,70 @@
+name = 'LLVM'
+version = '19.1.1'
+
+local_gcc_version = '13.3.0'
+
+homepage = "https://llvm.org/"
+description = """The LLVM Core libraries provide a modern source- and target-independent
+ optimizer, along with code generation support for many popular CPUs
+ (as well as some less common ones!) These libraries are built around a well
+ specified code representation known as the LLVM intermediate representation
+ ("LLVM IR"). The LLVM Core libraries are well documented, and it is
+ particularly easy to invent your own language (or port an existing compiler)
+ to use LLVM as an optimizer and code generator."""
+
+toolchain = SYSTEM
+toolchainopts = {
+    'pic': True,
+}
+
+source_urls = ['https://github.com/llvm/llvm-project/releases/download/llvmorg-%(version)s/']
+sources = [
+    'llvm-project-%(version)s.src.tar.xz',
+]
+checksums = [
+    None,
+]
+
+local_gcc_compiler = ('GCCcore', local_gcc_version)
+
+builddependencies = [
+    ('GCCcore', local_gcc_version, '', SYSTEM),
+    # ('binutils', '2.42', '', SYSTEM),
+    ('CMake', '3.29.3', '', local_gcc_compiler),
+    ('psutil', '6.0.0', '', local_gcc_compiler),  # Needed to enable test timeout in lit
+    ('Python', '3.12.3', '', local_gcc_compiler),
+    ('lit', '18.1.8', '', local_gcc_compiler),
+    ('git', '2.45.1', '', local_gcc_compiler),
+]
+
+dependencies = [
+    ('ncurses', '6.5', '', SYSTEM),
+    ('zlib', '1.3.1', '', SYSTEM),
+]
+
+build_shared_libs = True
+
+bootstrap = True
+full_llvm = True
+build_clang_extras = True
+build_runtimes = True
+build_lld = True
+build_lldb = True
+build_bolt = True
+build_openmp = True
+build_openmp_tools = True
+usepolly = True
+
+# Need to reconcile full_llvm and python_bindings as loading python will cause a conflict between system
+# ncurses/zlib and the GCC ones
+python_bindings = False
+
+# build_targets = ['all']
+# disable_werror = True
+
+skip_all_tests = False
+skip_sanitizer_tests = False
+test_suite_max_failed = 350  # Could increase depending on build targets
+test_suite_timeout_single = 5*60
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
@@ -25,8 +25,8 @@ patches = [
     'LLVM-18.1.8_envintest.patch',
 ]
 checksums = [
-    None,
-    None
+    {'llvm-project-19.1.1.src.tar.xz': 'd40e933e2a208ee142898f85d886423a217e991abbcd42dd8211f507c93e1266'},
+    {'LLVM-18.1.8_envintest.patch': '8e25dfab8a29a860717b4bd2d8cdd0e795433766d7fffbda32d06a2bde47058d'},
 ]
 
 local_gcc_compiler = ('GCCcore', local_gcc_version)

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
@@ -68,6 +68,6 @@ python_bindings = False
 skip_all_tests = False
 skip_sanitizer_tests = False
 test_suite_max_failed = 30  # Could increase depending of number of targets compiled for
-test_suite_timeout_single = 5*60
+test_suite_timeout_single = 5 * 60
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
@@ -36,6 +36,7 @@ local_gcc_compiler = ('GCCcore', local_gcc_version)
 builddependencies = [
     ('GCCcore', local_gcc_version, '', SYSTEM),
     # ('binutils', '2.42', '', SYSTEM),
+    ('SWIG', '4.2.1', '', local_gcc_compiler),
     ('CMake', '3.29.3', '', local_gcc_compiler),
     ('psutil', '6.0.0', '', local_gcc_compiler),  # Needed to enable test timeout in lit
     ('Python', '3.12.3', '', local_gcc_compiler),

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
@@ -70,7 +70,7 @@ python_bindings = False
 
 skip_all_tests = False
 skip_sanitizer_tests = False
-test_suite_max_failed = 10
+test_suite_max_failed = 30  # Could increase depending of number of targets compiled for
 test_suite_timeout_single = 5*60
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
@@ -12,9 +12,6 @@ description = """The LLVM Core libraries provide a modern source- and target-ind
  to use LLVM as an optimizer and code generator."""
 
 toolchain = SYSTEM
-toolchainopts = {
-    'pic': True,
-}
 
 source_urls = ['https://github.com/llvm/llvm-project/releases/download/llvmorg-%(version)s/']
 sources = [

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
@@ -20,11 +20,15 @@ sources = [
 patches = [
     'LLVM-18.1.8_envintest.patch',
     'LLVM-19.1.1_libomptarget_tests.patch',
+    'LLVM-19.1.1_envintest_lldb.patch',
+    'LLVM-19.1.7_clang_rpathwrap_test.patch',
 ]
 checksums = [
     {'llvm-project-19.1.1.src.tar.xz': 'd40e933e2a208ee142898f85d886423a217e991abbcd42dd8211f507c93e1266'},
     {'LLVM-18.1.8_envintest.patch': '8e25dfab8a29a860717b4bd2d8cdd0e795433766d7fffbda32d06a2bde47058d'},
     {'LLVM-19.1.1_libomptarget_tests.patch': 'a6cc11a2fb79e087d6c58fa5c01e5d6c95c952453ba8c1a09a0d4d3e6d109bd2'},
+    {'LLVM-19.1.1_envintest_lldb.patch': 'fbaa2494765637996f212f2fd9073b6bd775c0938a5a87fb70e19feb183c3299'},
+    {'LLVM-19.1.7_clang_rpathwrap_test.patch': '5ee6a87ec8ff1c8b736ffe0513aa2098bd2b83a1ffc647a1ad2cf966f567e8a1'},
 ]
 
 local_gcc_version = '13.3.0'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
@@ -23,10 +23,12 @@ sources = [
 ]
 patches = [
     'LLVM-18.1.8_envintest.patch',
+    'LLVM-19.1.1_libomptarget_tests.patch',
 ]
 checksums = [
     {'llvm-project-19.1.1.src.tar.xz': 'd40e933e2a208ee142898f85d886423a217e991abbcd42dd8211f507c93e1266'},
     {'LLVM-18.1.8_envintest.patch': '8e25dfab8a29a860717b4bd2d8cdd0e795433766d7fffbda32d06a2bde47058d'},
+    {'LLVM-19.1.1_libomptarget_tests.patch': 'a6cc11a2fb79e087d6c58fa5c01e5d6c95c952453ba8c1a09a0d4d3e6d109bd2'},
 ]
 
 local_gcc_compiler = ('GCCcore', local_gcc_version)

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
@@ -36,7 +36,6 @@ local_gcc_compiler = ('GCCcore', local_gcc_version)
 builddependencies = [
     ('GCCcore', local_gcc_version, '', SYSTEM),
     # ('binutils', '2.42', '', SYSTEM),
-    ('SWIG', '4.2.1', '', local_gcc_compiler),
     ('CMake', '3.29.3', '', local_gcc_compiler),
     ('psutil', '6.0.0', '', local_gcc_compiler),  # Needed to enable test timeout in lit
     ('Python', '3.12.3', '', local_gcc_compiler),

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
@@ -59,6 +59,7 @@ build_lld = True
 build_lldb = True
 build_bolt = True
 build_openmp = True
+build_openmp_offload = True
 build_openmp_tools = True
 usepolly = True
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
@@ -1,7 +1,6 @@
 name = 'LLVM'
 version = '19.1.1'
 
-local_gcc_version = '13.3.0'
 
 homepage = "https://llvm.org/"
 description = """The LLVM Core libraries provide a modern source- and target-independent
@@ -31,6 +30,7 @@ checksums = [
     {'LLVM-19.1.1_libomptarget_tests.patch': 'a6cc11a2fb79e087d6c58fa5c01e5d6c95c952453ba8c1a09a0d4d3e6d109bd2'},
 ]
 
+local_gcc_version = '13.3.0'
 local_gcc_compiler = ('GCCcore', local_gcc_version)
 
 builddependencies = [
@@ -71,7 +71,7 @@ python_bindings = False
 
 skip_all_tests = False
 skip_sanitizer_tests = False
-test_suite_max_failed = 350  # Could increase depending on build targets
+test_suite_max_failed = 10
 test_suite_timeout_single = 5*60
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
@@ -21,8 +21,12 @@ source_urls = ['https://github.com/llvm/llvm-project/releases/download/llvmorg-%
 sources = [
     'llvm-project-%(version)s.src.tar.xz',
 ]
+patches = [
+    'LLVM-18.1.8_envintest.patch',
+]
 checksums = [
     None,
+    None
 ]
 
 local_gcc_compiler = ('GCCcore', local_gcc_version)

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
@@ -44,7 +44,6 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('libffi', '3.4.5', '', SYSTEM),  # Ensure SYSTEM libffi is loaded at build time
     ('ncurses', '6.5', '', SYSTEM),
     ('zlib', '1.3.1', '', SYSTEM),
 ]

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1.eb
@@ -42,6 +42,7 @@ builddependencies = [
 ]
 
 dependencies = [
+    ('libffi', '3.4.5', '', SYSTEM),  # Ensure SYSTEM libffi is loaded at build time
     ('ncurses', '6.5', '', SYSTEM),
     ('zlib', '1.3.1', '', SYSTEM),
 ]

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1_envintest_lldb.patch
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1_envintest_lldb.patch
@@ -1,0 +1,44 @@
+# Ensure that the shared library path is injected into the environment for lldb-api tests even if
+# BUILD_SHARED_LIBS -> LLVM_ENABLE_SHARED_LIBS is not set
+# This is needed when building shared libraries with LLVM_BUILD_LLVM_DYLIB
+diff --git a/lldb/test/API/lit.cfg.py b/lldb/test/API/lit.cfg.py
+index 96520c7c8262..7d3fcbbc3a62 100644
+--- a/lldb/test/API/lit.cfg.py
++++ b/lldb/test/API/lit.cfg.py
+@@ -151,22 +151,21 @@ if platform.system() == "Darwin":
+         config.python_executable = python_executable
+ 
+ # Shared library build of LLVM may require LD_LIBRARY_PATH or equivalent.
+-if is_configured("shared_libs"):
+-    for shlibpath_var in find_shlibpath_var():
+-        # In stand-alone build llvm_shlib_dir specifies LLDB's lib directory while
+-        # llvm_libs_dir specifies LLVM's lib directory.
+-        shlibpath = os.path.pathsep.join(
+-            (
+-                config.llvm_shlib_dir,
+-                config.llvm_libs_dir,
+-                config.environment.get(shlibpath_var, ""),
+-            )
+-        )
+-        config.environment[shlibpath_var] = shlibpath
+-    else:
+-        lit_config.warning(
+-            "unable to inject shared library path on '{}'".format(platform.system())
++for shlibpath_var in find_shlibpath_var():
++    # In stand-alone build llvm_shlib_dir specifies LLDB's lib directory while
++    # llvm_libs_dir specifies LLVM's lib directory.
++    shlibpath = os.path.pathsep.join(
++        (
++            config.llvm_shlib_dir,
++            config.llvm_libs_dir,
++            config.environment.get(shlibpath_var, ""),
+         )
++    )
++    config.environment[shlibpath_var] = shlibpath
++else:
++    lit_config.warning(
++        "unable to inject shared library path on '{}'".format(platform.system())
++    )
+ 
+ lldb_use_simulator = lit_config.params.get("lldb-run-with-simulator", None)
+ if lldb_use_simulator:

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1_envintest_lldb.patch
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1_envintest_lldb.patch
@@ -1,11 +1,12 @@
 # Ensure that the shared library path is injected into the environment for lldb-api tests even if
 # BUILD_SHARED_LIBS -> LLVM_ENABLE_SHARED_LIBS is not set
-# This is needed when building shared libraries with LLVM_BUILD_LLVM_DYLIB
+# This is needed when building shared libraries with LLVM_BUILD_LLVM_DYLIB and if libatomic is not
+# available in a system path.
 diff --git a/lldb/test/API/lit.cfg.py b/lldb/test/API/lit.cfg.py
-index 96520c7c8262..7d3fcbbc3a62 100644
+index 96520c7c8262..4b67bb651969 100644
 --- a/lldb/test/API/lit.cfg.py
 +++ b/lldb/test/API/lit.cfg.py
-@@ -151,22 +151,21 @@ if platform.system() == "Darwin":
+@@ -151,22 +151,22 @@ if platform.system() == "Darwin":
          config.python_executable = python_executable
  
  # Shared library build of LLVM may require LD_LIBRARY_PATH or equivalent.
@@ -35,6 +36,7 @@ index 96520c7c8262..7d3fcbbc3a62 100644
          )
 +    )
 +    config.environment[shlibpath_var] = shlibpath
++    break
 +else:
 +    lit_config.warning(
 +        "unable to inject shared library path on '{}'".format(platform.system())
@@ -42,3 +44,12 @@ index 96520c7c8262..7d3fcbbc3a62 100644
  
  lldb_use_simulator = lit_config.params.get("lldb-run-with-simulator", None)
  if lldb_use_simulator:
+@@ -223,7 +223,7 @@ if is_configured("has_libcxx") and config.has_libcxx:
+ 
+ # Forward ASan-specific environment variables to tests, as a test may load an
+ # ASan-ified dylib.
+-for env_var in ("ASAN_OPTIONS", "DYLD_INSERT_LIBRARIES"):
++for env_var in ("ASAN_OPTIONS", "DYLD_INSERT_LIBRARIES", shlibpath_var):
+     if env_var in config.environment:
+         dotest_cmd += ["--inferior-env", env_var + "=" + config.environment[env_var]]
+ 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1_libomptarget_tests.patch
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.1_libomptarget_tests.patch
@@ -1,0 +1,82 @@
+# Patch to fix bug in new offload testing.
+# Related to:
+# - https://github.com/easybuilders/easybuild-easyblocks/pull/3373#issuecomment-2404623211
+# - https://github.com/llvm/llvm-project/issues/90333
+diff --git a/offload/CMakeLists.txt b/offload/CMakeLists.txt
+index 4cd97a6a5ff6..7369cdd0163d 100644
+--- a/offload/CMakeLists.txt
++++ b/offload/CMakeLists.txt
+@@ -127,6 +127,11 @@ include(LibomptargetGetDependencies)
+ # Set up testing infrastructure.
+ include(OpenMPTesting)
+ 
++set(OPENMP_TEST_FLAGS "" CACHE STRING
++  "Extra compiler flags to send to the test compiler.")
++set(OPENMP_TEST_OPENMP_FLAGS ${OPENMP_TEST_COMPILER_OPENMP_FLAGS} CACHE STRING
++  "OpenMP compiler flag to use for testing OpenMP runtime libraries.")
++
+ check_cxx_compiler_flag(-Werror=global-constructors OFFLOAD_HAVE_WERROR_CTOR)
+ 
+ # LLVM source tree is required at build time for libomptarget
+diff --git a/offload/test/lit.cfg b/offload/test/lit.cfg
+index 99d7defdb9e1..40ed3f5928cf 100644
+--- a/offload/test/lit.cfg
++++ b/offload/test/lit.cfg
+@@ -82,7 +82,7 @@ config.test_format = lit.formats.ShTest()
+ 
+ # compiler flags
+ config.test_flags = " -I " + config.test_source_root + \
+-    " -I " + config.omp_header_directory + \
++    " -I " + config.llvm_lib_directory + "/../projects/openmp/runtime/src" + \
+     " -L " + config.library_dir + \
+     " -L " + config.llvm_lib_directory
+ 
+@@ -156,7 +156,6 @@ else: # Unices
+     if config.libomptarget_current_target != "nvptx64-nvidia-cuda":
+         config.test_flags += " -nogpulib"
+     config.test_flags += " -Wl,-rpath," + config.library_dir
+-    config.test_flags += " -Wl,-rpath," + config.omp_host_rtl_directory
+     config.test_flags += " -Wl,-rpath," + config.llvm_lib_directory
+     if config.cuda_libdir:
+         config.test_flags += " -Wl,-rpath," + config.cuda_libdir
+@@ -324,18 +323,24 @@ for libomptarget_target in config.libomptarget_all_targets:
+         config.substitutions.append(("%libomptarget-run-fail-" + \
+             libomptarget_target, \
+             "%not --crash %t"))
++        
++        if '-unknown-' in config.host_triple and '-pc-' in libomptarget_target:
++            _libomptarget_target = libomptarget_target.replace('-pc-', '-unknown-')
++        else:
++            _libomptarget_target = libomptarget_target
++
+         config.substitutions.append(("%clangxx-" + libomptarget_target, \
+                                      "%clangxx %openmp_flags %cuda_flags %flags %flags_clang -fopenmp-targets=" +\
+-                                     remove_suffix_if_present(libomptarget_target)))
++                                     remove_suffix_if_present(_libomptarget_target)))
+         config.substitutions.append(("%clangxxx-force-usm-" + libomptarget_target, \
+                                      "%clangxx %openmp_flags -fopenmp-force-usm  %cuda_flags %flags %flags_clang -fopenmp-targets=" +\
+-                                     remove_suffix_if_present(libomptarget_target)))
++                                     remove_suffix_if_present(_libomptarget_target)))
+         config.substitutions.append(("%clang-" + libomptarget_target, \
+                                      "%clang %openmp_flags %cuda_flags %flags %flags_clang -fopenmp-targets=" +\
+-                                     remove_suffix_if_present(libomptarget_target)))
++                                     remove_suffix_if_present(_libomptarget_target)))
+         config.substitutions.append(("%flang-" + libomptarget_target, \
+                                      "%flang %openmp_flags %flags %flags_flang -fopenmp-targets=" +\
+-                                     remove_suffix_if_present(libomptarget_target)))
++                                     remove_suffix_if_present(_libomptarget_target)))
+         config.substitutions.append(("%fcheck-" + libomptarget_target, \
+             config.libomptarget_filecheck + " %s"))
+     else:
+diff --git a/offload/test/lit.site.cfg.in b/offload/test/lit.site.cfg.in
+index 43751970cac2..149fcf0aea92 100644
+--- a/offload/test/lit.site.cfg.in
++++ b/offload/test/lit.site.cfg.in
+@@ -20,6 +20,7 @@ config.omp_host_rtl_directory = "@LIBOMPTARGET_OPENMP_HOST_RTL_FOLDER@"
+ config.llvm_lib_directory = "@LIBOMPTARGET_LLVM_LIBRARY_DIR@"
+ config.operating_system = "@CMAKE_SYSTEM_NAME@"
+ config.libomptarget_all_targets = "@LIBOMPTARGET_ALL_TARGETS@".split()
++config.host_triple = "@LLVM_HOST_TRIPLE@"
+ config.libomptarget_current_target = "@CURRENT_TARGET@"
+ config.libomptarget_filecheck = "@OPENMP_FILECHECK_EXECUTABLE@"
+ config.libomptarget_not = "@OPENMP_NOT_EXECUTABLE@"

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.7_clang_rpathwrap_test.patch
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.7_clang_rpathwrap_test.patch
@@ -1,0 +1,17 @@
+Properly building the runtimes with rpath wrappers causes the test suite to also use the wrappers.
+In clang this will cause a bunch of warning due to linking flags used at compile time (-Wl,rpath=...)
+that are turned into errors by `-Werror`.
+`-Wno-unused-command-line-argument` also needs to be added in order to avoid the error.
+diff --git a/libcxx/utils/libcxx/test/dsl.py b/libcxx/utils/libcxx/test/dsl.py
+index 7ff4be0ee7cf..0788eada1dfa 100644
+--- a/libcxx/utils/libcxx/test/dsl.py
++++ b/libcxx/utils/libcxx/test/dsl.py
+@@ -214,7 +214,7 @@ def tryCompileFlag(config, flag):
+     # fmt: off
+     with _makeConfigTest(config) as test:
+         out, err, exitCode, timeoutInfo, _ = _executeWithFakeConfig(test, [
+-            "%{{cxx}} -xc++ {} -Werror -fsyntax-only %{{flags}} %{{compile_flags}} {}".format(os.devnull, flag)
++            "%{{cxx}} -xc++ {} -Werror -Wno-unused-command-line-argument -fsyntax-only %{{flags}} %{{compile_flags}} {}".format(os.devnull, flag)
+         ])
+         return exitCode, out, err
+     # fmt: on


### PR DESCRIPTION
Adds EC for LLVM:

- 19.1.1  SYSTEM
- 19.1.1  GCCcore-13.3.0

Depends on:

- https://github.com/easybuilders/easybuild-easyblocks/pull/3373
- https://github.com/easybuilders/easybuild-easyconfigs/pull/21617

WIP:

- [x] Pin correct number of errors that have been reduced from 18.1.8
  - [x] Need to fix `libomptarget` false error due to missing `-fopenmp` in test-suite