### PR TITLE
remove explicit use of `ld.gold` in recent PLUMED easyconfigs

### DIFF
--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.2-foss-2021a.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.2-foss-2021a.eb
@@ -38,11 +38,6 @@ if ARCH == 'x86_64':
     configopts += '--enable-asmjit '
 prebuildopts = 'source sourceme.sh && '
 
-# make sure that ld.gold linker is used
-# required to work around problems like "ld: BFD (GNU Binutils) 2.30 assertion fail elf.c:3564"
-# (problem with intel build but maintain consistency between easyconfigs)
-buildopts = 'LD_RO="ld.gold -r -o"'
-
 # install path for PLUMED libraries must be included in $LD_LIBRARY_PATH when Python bindings get built/installed
 preinstallopts = 'LD_LIBRARY_PATH="%(installdir)s/lib:$LD_LIBRARY_PATH" '
 

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.2-intel-2021a.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.2-intel-2021a.eb
@@ -36,11 +36,6 @@ configopts += '--enable-boost_graph --enable-boost_serialization '
 configopts += '--enable-asmjit '
 prebuildopts = 'source sourceme.sh && '
 
-# make sure that ld.gold linker is used
-# required to work around problems like "ld: BFD (GNU Binutils) 2.30 assertion fail elf.c:3564"
-# (problem with intel build but maintain consistency between easyconfigs)
-buildopts = 'LD_RO="ld.gold -r -o"'
-
 # install path for PLUMED libraries must be included in $LD_LIBRARY_PATH when Python bindings get built/installed
 preinstallopts = 'LD_LIBRARY_PATH="%(installdir)s/lib:$LD_LIBRARY_PATH" '
 

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.3-foss-2021b.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.3-foss-2021b.eb
@@ -38,11 +38,6 @@ if ARCH == 'x86_64':
     configopts += '--enable-asmjit '
 prebuildopts = 'source sourceme.sh && '
 
-# make sure that ld.gold linker is used
-# required to work around problems like "ld: BFD (GNU Binutils) 2.30 assertion fail elf.c:3564"
-# (problem with intel build but maintain consistency between easyconfigs)
-buildopts = 'LD_RO="ld.gold -r -o"'
-
 # install path for PLUMED libraries must be included in $LD_LIBRARY_PATH when Python bindings get built/installed
 preinstallopts = 'LD_LIBRARY_PATH="%(installdir)s/lib:$LD_LIBRARY_PATH" '
 

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.8.0-foss-2021b.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.8.0-foss-2021b.eb
@@ -35,11 +35,6 @@ configopts = '--exec-prefix=%(installdir)s --enable-gsl --enable-modules=all --e
 configopts += '--enable-boost_graph --enable-boost_serialization '
 prebuildopts = 'source sourceme.sh && '
 
-# make sure that ld.gold linker is used
-# required to work around problems like "ld: BFD (GNU Binutils) 2.30 assertion fail elf.c:3564"
-# (problem with intel build but maintain consistency between easyconfigs)
-buildopts = 'LD_RO="ld.gold -r -o"'
-
 # install path for PLUMED libraries must be included in $LD_LIBRARY_PATH when Python bindings get built/installed
 preinstallopts = 'LD_LIBRARY_PATH="%(installdir)s/lib:$LD_LIBRARY_PATH" '
 

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.8.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.8.1-foss-2022a.eb
@@ -35,11 +35,6 @@ configopts = '--exec-prefix=%(installdir)s --enable-gsl --enable-modules=all --e
 configopts += '--enable-boost_graph --enable-boost_serialization '
 prebuildopts = 'source sourceme.sh && '
 
-# make sure that ld.gold linker is used
-# required to work around problems like "ld: BFD (GNU Binutils) 2.30 assertion fail elf.c:3564"
-# (problem with intel build but maintain consistency between easyconfigs)
-buildopts = 'LD_RO="ld.gold -r -o"'
-
 # install path for PLUMED libraries must be included in $LD_LIBRARY_PATH when Python bindings get built/installed
 preinstallopts = 'LD_LIBRARY_PATH="%(installdir)s/lib:$LD_LIBRARY_PATH" '
 

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.9.0-foss-2022b.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.9.0-foss-2022b.eb
@@ -35,11 +35,6 @@ configopts = '--exec-prefix=%(installdir)s --enable-gsl --enable-modules=all --e
 configopts += '--enable-boost_graph --enable-boost_serialization '
 prebuildopts = 'source sourceme.sh && '
 
-# make sure that ld.gold linker is used
-# required to work around problems like "ld: BFD (GNU Binutils) 2.30 assertion fail elf.c:3564"
-# (problem with intel build but maintain consistency between easyconfigs)
-buildopts = 'LD_RO="ld.gold -r -o"'
-
 # install path for PLUMED libraries must be included in $LD_LIBRARY_PATH when Python bindings get built/installed
 preinstallopts = 'LD_LIBRARY_PATH="%(installdir)s/lib:$LD_LIBRARY_PATH" '
 

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.9.0-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.9.0-foss-2023a.eb
@@ -35,11 +35,6 @@ configopts = '--exec-prefix=%(installdir)s --enable-gsl --enable-modules=all --e
 configopts += '--enable-boost_graph --enable-boost_serialization '
 prebuildopts = 'source sourceme.sh && '
 
-# make sure that ld.gold linker is used
-# required to work around problems like "ld: BFD (GNU Binutils) 2.30 assertion fail elf.c:3564"
-# (problem with intel build but maintain consistency between easyconfigs)
-buildopts = 'LD_RO="ld.gold -r -o"'
-
 # install path for PLUMED libraries must be included in $LD_LIBRARY_PATH when Python bindings get built/installed
 preinstallopts = 'LD_LIBRARY_PATH="%(installdir)s/lib:$LD_LIBRARY_PATH" '
 

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.9.2-foss-2023b.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.9.2-foss-2023b.eb
@@ -35,11 +35,6 @@ configopts = '--exec-prefix=%(installdir)s --enable-gsl --enable-modules=all --e
 configopts += '--enable-boost_graph --enable-boost_serialization '
 prebuildopts = 'source sourceme.sh && '
 
-# make sure that ld.gold linker is used
-# required to work around problems like "ld: BFD (GNU Binutils) 2.30 assertion fail elf.c:3564"
-# (problem with intel build but maintain consistency between easyconfigs)
-buildopts = 'LD_RO="ld.gold -r -o"'
-
 # install path for PLUMED libraries must be included in $LD_LIBRARY_PATH when Python bindings get built/installed
 preinstallopts = 'LD_LIBRARY_PATH="%(installdir)s/lib:$LD_LIBRARY_PATH" '
 


### PR DESCRIPTION
This was introduced in an old version as a workaround for an issue with the intel toolchain, see: https://github.com/easybuilders/easybuild-easyconfigs/issues/7822.

I think we should remove this for several reasons:
- it was only required for intel toolchains, but there are no recent easyconfigs of PLUMED with the intel toolchain (most recent one is with intel 2021a)
- `ld.gold` is disabled by default for GCC >= 11.3.0, see https://github.com/easybuilders/easybuild-easyblocks/pull/2711
- explicitly using `ld.gold` may cause issues on systems without `ld.gold`
- most importantly, I don't think it's still required anyway, as the test build of `PLUMED-2.7.2-intel-2021a.eb` should demonstrate