### PR TITLE
{devel,tools,lib,compiler}[system/system,GCCcore/14.2.0] Add pkgconf 2.3.0, XZ 5.6.3, ncurses 6.5, libxml 2.13.4, AOCC 5.0.0

### DIFF
--- a/easybuild/easyconfigs/a/AOCC/AOCC-5.0.0-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/a/AOCC/AOCC-5.0.0-GCCcore-14.2.0.eb
@@ -1,0 +1,24 @@
+name = 'AOCC'
+version = '5.0.0'
+
+homepage = 'https://developer.amd.com/amd-aocc/'
+description = "AMD Optimized C/C++ & Fortran compilers (AOCC) based on LLVM 13.0"
+
+# Clang also depends on libstdc++ during runtime, but this dependency is
+# already specified as the toolchain.
+toolchain = {'name': 'GCCcore', 'version': '14.2.0'}
+
+source_urls = ['https://download.amd.com/developer/eula/aocc/aocc-5-0/']
+sources = ['aocc-compiler-%(version)s.tar']
+checksums = ['966fac2d2c759e9de6e969c10ada7a7b306c113f7f1e07ea376829ec86380daa']
+
+clangversion = '17.0.6'
+
+dependencies = [
+    ('binutils', '2.42'),
+    ('ncurses', '6.5'),
+    ('zlib', '1.3.1'),
+    ('libxml2', '2.13.4'),
+]
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.13.4-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.13.4-GCCcore-14.2.0.eb
@@ -1,0 +1,27 @@
+name = 'libxml2'
+version = '2.13.4'
+
+homepage = 'http://xmlsoft.org/'
+
+description = """
+ Libxml2 is the XML C parser and toolchain developed for the Gnome project
+ (but usable outside of the Gnome platform).
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '14.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://download.gnome.org/sources/libxml2/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650']
+
+builddependencies = [
+    ('binutils', '2.42'),
+]
+
+dependencies = [
+    ('XZ', '5.6.3'),
+    ('zlib', '1.3.1'),
+]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.5-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.5-GCCcore-14.2.0.eb
@@ -1,0 +1,53 @@
+easyblock = 'ConfigureMake'
+
+name = 'ncurses'
+version = '6.5'
+
+homepage = 'https://www.gnu.org/software/ncurses/'
+description = """
+ The Ncurses (new curses) library is a free software emulation of curses in
+ System V Release 4.0, and more. It uses Terminfo format, supports pads and
+ color and multiple highlights and forms characters and function-key mapping,
+ and has all the other SYSV-curses enhancements over BSD Curses.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '14.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('pkgconf', '2.3.0'),
+]
+
+local_common_configopts = "--with-shared --enable-overwrite --without-ada --enable-symlinks --with-versioned-syms "
+local_common_configopts += "--enable-pc-files --with-pkg-config-libdir=%(installdir)s/lib/pkgconfig "
+configopts = [
+    # build ncurses: serial build in default paths with shared libraries
+    local_common_configopts + "--disable-widec",
+    # build ncursesw: serial with UTF-8
+    local_common_configopts + "--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/",
+]
+
+# Symlink libtinfo to libncurses
+# libncurses with this configopts has all the symbols from libtinfo, but some packages look for libtinfo specifically
+postinstallcmds = ['cd %(installdir)s/lib && for l in libncurses{.,_,w}*; do ln -s "${l}" "${l/ncurses/tinfo}"; done']
+
+_target_suffix = ['', 'w']  # '': ncurses, 'w': ncursesw
+_lib_suffix = ['%s%s' % (x, y) for x in _target_suffix for y in ['.a', '_g.a', '.' + SHLIB_EXT]]
+_lib_names = ['form', 'menu', 'ncurses', 'panel', 'tinfo']
+_pc_names = ['form', 'menu', 'ncurses++', 'ncurses', 'panel']
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
+                                     "reset", "tabs", "tic", "toe", "tput", "tset"]] +
+             ['lib/lib%s%s' % (x, y) for x in _lib_names for y in _lib_suffix] +
+             ['lib/libncurses++%s.a' % x for x in _target_suffix] +
+             ['lib/pkgconfig/%s%s.pc' % (x, y) for x in _pc_names for y in _target_suffix],
+    'dirs': ['include', 'include/ncursesw'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/pkgconf/pkgconf-2.3.0-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/p/pkgconf/pkgconf-2.3.0-GCCcore-14.2.0.eb
@@ -1,0 +1,31 @@
+easyblock = 'ConfigureMake'
+
+name = 'pkgconf'
+version = '2.3.0'
+
+homepage = 'https://github.com/pkgconf/pkgconf'
+
+description = """pkgconf is a program which helps to configure compiler and linker flags for development libraries.
+ It is similar to pkg-config from freedesktop.org."""
+
+toolchain = {'name': 'GCCcore', 'version': '14.2.0'}
+
+source_urls = ['https://distfiles.ariadne.space/pkgconf/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a2df680578e85f609f2fa67bd3d0fc0dc71b4bf084fc49119de84cd6ed28e723']
+
+builddependencies = [('binutils', '2.42')]
+
+postinstallcmds = ["cd %(installdir)s/bin && ln -s pkgconf pkg-config"]
+
+sanity_check_paths = {
+    'files': ['bin/pkg-config', 'bin/pkgconf'],
+    'dirs': [],
+}
+
+sanity_check_commands = [
+    "pkg-config --help",
+    "pkgconf --help",
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/pkgconf/pkgconf-2.3.0.eb
+++ b/easybuild/easyconfigs/p/pkgconf/pkgconf-2.3.0.eb
@@ -1,0 +1,33 @@
+easyblock = 'ConfigureMake'
+
+name = 'pkgconf'
+version = '2.3.0'
+
+homepage = 'https://github.com/pkgconf/pkgconf'
+
+description = """pkgconf is a program which helps to configure compiler and linker flags for development libraries.
+ It is similar to pkg-config from freedesktop.org."""
+
+toolchain = SYSTEM
+
+source_urls = ['https://distfiles.ariadne.space/pkgconf/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a2df680578e85f609f2fa67bd3d0fc0dc71b4bf084fc49119de84cd6ed28e723']
+
+# add pkgconfig directories in the system to list of default search paths
+preconfigopts = 'EB_SYS_PC_PATH=":$(find /usr -xdev -type d -name "pkgconfig" -printf %p: 2>/dev/null)";'
+configopts = '--with-pkg-config-dir="%(installdir)s/lib/pkgconfig:%(installdir)s/share/pkgconfig${EB_SYS_PC_PATH%:}"'
+
+postinstallcmds = ["cd %(installdir)s/bin && ln -s pkgconf pkg-config"]
+
+sanity_check_paths = {
+    'files': ['bin/pkg-config', 'bin/pkgconf'],
+    'dirs': [],
+}
+
+sanity_check_commands = [
+    "pkg-config --help",
+    "pkgconf --help",
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/x/XZ/XZ-5.6.3-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.6.3-GCCcore-14.2.0.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'XZ'
+version = '5.6.3'
+
+homepage = 'https://tukaani.org/xz/'
+description = "xz: XZ utilities"
+
+toolchain = {'name': 'GCCcore', 'version': '14.2.0'}
+
+source_urls = ['https://tukaani.org/xz/']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['a95a49147b2dbb5487517acc0adcd77f9c2032cf00664eeae352405357d14a6c']
+
+builddependencies = [
+    # use gettext built with system toolchain as build dep to avoid cyclic dependency (XZ -> gettext -> libxml2 -> XZ)
+    ('gettext', '0.22.5', '', SYSTEM),
+    ('binutils', '2.42'),
+]
+
+# may become useful in non-x86 archs
+# configopts = ' --disable-assembler '
+
+sanity_check_paths = {
+    'files': ['bin/lzmainfo', 'bin/unxz', 'bin/xz'],
+    'dirs': []
+}
+
+sanity_check_commands = [
+    "xz --help",
+    "unxz --help",
+]
+
+moduleclass = 'tools'


### PR DESCRIPTION
Add AOCC 5.0.0 and required dependencies to GCCcore 14.2.0. I chose the newest toolchain, as there's #21343 for GCCcore/13.3.0 already.

Requires https://github.com/easybuilders/easybuild-easyblocks/pull/3480 for compilers to work correctly.