### PR TITLE
Update easyconfigs.py - add 'alt_location' to exts patches

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1569,7 +1569,7 @@ def template_easyconfig_test(self, spec):
             if isinstance(ext_patch, (tuple, list)):
                 ext_patch['name'] = ext_patch[0]
             elif isinstance(ext_patch, dict) and ext_patch['alt_location']:
-                    specdir = os.path.join(basedir, letter_dir_for(ext_patch['alt_location']), ext_patch['alt_location'])
+                specdir = os.path.join(basedir, letter_dir_for(ext_patch['alt_location']), ext_patch['alt_location'])
             else:
                 ext_patch['name'] = ext_patch
 

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1567,7 +1567,11 @@ def template_easyconfig_test(self, spec):
 
         for idx, ext_patch in enumerate(ext.get('patches', [])):
             if isinstance(ext_patch, (tuple, list)):
-                ext_patch = ext_patch[0]
+                ext_patch['name'] = ext_patch[0]
+            elif isinstance(ext_patch, dict) and ext_patch['alt_location']:
+                    specdir = os.path.join(basedir, letter_dir_for(ext_patch['alt_location']), ext_patch['alt_location'])
+            else:
+                ext_patch['name'] = ext_patch
 
             # only check actual patch files, not other files being copied via the patch functionality
             ext_patch_full = os.path.join(specdir, ext_patch['name'])


### PR DESCRIPTION
For now when you add 'alt_location' to the patch in exts_list it fails.
See https://github.com/easybuilders/easybuild-easyconfigs/pull/21141/files# and https://github.com/easybuilders/easybuild-easyconfigs/actions/runs/10453456099/job/28943965086?pr=21141