### PR TITLE
{phys}[GCCcore/13.2.0,GCCcore/13.3.0] LIME v1.3.2

### DIFF
--- a/easybuild/easyconfigs/l/LIME/LIME-1.3.2-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/l/LIME/LIME-1.3.2-GCCcore-13.2.0.eb
@@ -1,0 +1,53 @@
+easyblock = 'ConfigureMake'
+
+name = "LIME"
+version = "1.3.2"
+
+homepage = "http://usqcd-software.github.io/c-lime/"
+description = """LIME (which can stand for Lattice QCD Interchange Message Encapsulation or more generally,
+Large Internet Message Encapsulation) is a simple packaging scheme for combining records containing ASCII
+and/or binary data. Its ancestors are the Unix cpio and tar formats and the Microsoft Corporation DIME
+(Direct Internet Message Encapsulation) format. It is simpler and allows record sizes up to $2^{63}$ bytes,
+making chunking unnecessary for the foreseeable future. Unlike tar and cpio, the records are not associated
+with Unix files. They are identified only by a record-type (LIME type) character string, analogous to the
+familiar MIME application type. The LIME software package consists of a C-language API for creating, reading,
+writing, and manipulating LIME files and a small set of utilities for examining, packing and unpacking LIME files."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+builddependencies = [
+    ('binutils', '2.40')
+]
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://usqcd-software.github.io/downloads/c-lime/']
+
+checksums = ['db5c07a72a152244f94a84c8bcc7395ec6fa084b8979ca1c8788b99a2870c881']
+
+buildopts = "all"
+
+sanity_check_paths = {
+    'files': [
+        "bin/lime_pack",
+        "bin/lime_unpack",
+        "bin/lime_contents",
+        "bin/lime_extract_record",
+        "bin/lime_extract_type",
+        "lib/liblime.a",
+        "include/dcap-overload.h",
+        "include/lime_binary_header.h",
+        "include/lime_config.h",
+        "include/lime_config_internal.h",
+        "include/lime_defs.h",
+        "include/lime_fixed_types.h",
+        "include/lime_fseeko.h",
+        "include/lime.h",
+        "include/lime_header.h",
+        "include/lime_reader.h",
+        "include/lime_utils.h",
+        "include/lime_writer.h",
+    ],
+    'dirs': [],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/l/LIME/LIME-1.3.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LIME/LIME-1.3.2-GCCcore-13.3.0.eb
@@ -16,7 +16,7 @@ writing, and manipulating LIME files and a small set of utilities for examining,
 toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
 
 builddependencies = [
-    ('binutils', '2.40')
+    ('binutils', '2.42')
 ]
 
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/l/LIME/LIME-1.3.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LIME/LIME-1.3.2-GCCcore-13.3.0.eb
@@ -1,0 +1,53 @@
+easyblock = 'ConfigureMake'
+
+name = "LIME"
+version = "1.3.2"
+
+homepage = "http://usqcd-software.github.io/c-lime/"
+description = """LIME (which can stand for Lattice QCD Interchange Message Encapsulation or more generally,
+Large Internet Message Encapsulation) is a simple packaging scheme for combining records containing ASCII
+and/or binary data. Its ancestors are the Unix cpio and tar formats and the Microsoft Corporation DIME
+(Direct Internet Message Encapsulation) format. It is simpler and allows record sizes up to $2^{63}$ bytes,
+making chunking unnecessary for the foreseeable future. Unlike tar and cpio, the records are not associated
+with Unix files. They are identified only by a record-type (LIME type) character string, analogous to the
+familiar MIME application type. The LIME software package consists of a C-language API for creating, reading,
+writing, and manipulating LIME files and a small set of utilities for examining, packing and unpacking LIME files."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+builddependencies = [
+    ('binutils', '2.40')
+]
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://usqcd-software.github.io/downloads/c-lime/']
+
+checksums = ['db5c07a72a152244f94a84c8bcc7395ec6fa084b8979ca1c8788b99a2870c881']
+
+buildopts = "all"
+
+sanity_check_paths = {
+    'files': [
+        "bin/lime_pack",
+        "bin/lime_unpack",
+        "bin/lime_contents",
+        "bin/lime_extract_record",
+        "bin/lime_extract_type",
+        "lib/liblime.a",
+        "include/dcap-overload.h",
+        "include/lime_binary_header.h",
+        "include/lime_config.h",
+        "include/lime_config_internal.h",
+        "include/lime_defs.h",
+        "include/lime_fixed_types.h",
+        "include/lime_fseeko.h",
+        "include/lime.h",
+        "include/lime_header.h",
+        "include/lime_reader.h",
+        "include/lime_utils.h",
+        "include/lime_writer.h",
+    ],
+    'dirs': [],
+}
+
+moduleclass = 'phys'


### PR DESCRIPTION
This is just to add LIME, as in #21630, but for newer GCCcore versions. @jfgrimm, could you have a look at this, as it is the same, except for the toolchain version?