### PR TITLE
remove `-m64` compiler flag for non-x86-64 CPU architectures in SIONlib 1.7.7 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.7-GCCcore-11.2.0-tools.eb
+++ b/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.7-GCCcore-11.2.0-tools.eb
@@ -39,6 +39,10 @@ builddependencies = [
     ('binutils', '2.37'),
 ]
 
+# remove -m64 flag from PFLAG variable in Makefiles for CPU architectures that don't support it
+if ARCH != 'x86_64':
+    preconfigopts = 'sed -i "s|PFLAG  = -m\\$(PREC)|PFLAG  = |" mf/Makefile.defs.linux-gomp* && '
+
 configopts = '--disable-cxx --disable-fortran --disable-ompi '
 
 # Comment it out if you have Xeon Phi:

--- a/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.7-GCCcore-11.3.0-tools.eb
+++ b/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.7-GCCcore-11.3.0-tools.eb
@@ -39,6 +39,10 @@ builddependencies = [
     ('binutils', '2.38'),
 ]
 
+# remove -m64 flag from PFLAG variable in Makefiles for CPU architectures that don't support it
+if ARCH != 'x86_64':
+    preconfigopts = 'sed -i "s|PFLAG  = -m\\$(PREC)|PFLAG  = |" mf/Makefile.defs.linux-gomp* && '
+
 configopts = '--disable-cxx --disable-fortran --disable-ompi '
 
 # Comment it out if you have Xeon Phi:

--- a/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.7-GCCcore-12.2.0-tools.eb
+++ b/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.7-GCCcore-12.2.0-tools.eb
@@ -39,6 +39,10 @@ builddependencies = [
     ('binutils', '2.39'),
 ]
 
+# remove -m64 flag from PFLAG variable in Makefiles for CPU architectures that don't support it
+if ARCH != 'x86_64':
+    preconfigopts = 'sed -i "s|PFLAG  = -m\\$(PREC)|PFLAG  = |" mf/Makefile.defs.linux-gomp* && '
+
 configopts = '--disable-cxx --disable-fortran --disable-ompi '
 
 # Comment it out if you have Xeon Phi:

--- a/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.7-GCCcore-12.3.0-tools.eb
+++ b/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.7-GCCcore-12.3.0-tools.eb
@@ -39,6 +39,10 @@ builddependencies = [
     ('binutils', '2.40'),
 ]
 
+# remove -m64 flag from PFLAG variable in Makefiles for CPU architectures that don't support it
+if ARCH != 'x86_64':
+    preconfigopts = 'sed -i "s|PFLAG  = -m\\$(PREC)|PFLAG  = |" mf/Makefile.defs.linux-gomp* && '
+
 configopts = '--disable-cxx --disable-fortran --disable-ompi '
 
 # Comment it out if you have Xeon Phi:

--- a/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.7-GCCcore-13.2.0-tools.eb
+++ b/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.7-GCCcore-13.2.0-tools.eb
@@ -39,6 +39,10 @@ builddependencies = [
     ('binutils', '2.40'),
 ]
 
+# remove -m64 flag from PFLAG variable in Makefiles for CPU architectures that don't support it
+if ARCH != 'x86_64':
+    preconfigopts = 'sed -i "s|PFLAG  = -m\\$(PREC)|PFLAG  = |" mf/Makefile.defs.linux-gomp* && '
+
 configopts = '--disable-cxx --disable-fortran --disable-ompi '
 
 # Comment it out if you have Xeon Phi:

--- a/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.7-GCCcore-13.3.0-tools.eb
+++ b/easybuild/easyconfigs/s/SIONlib/SIONlib-1.7.7-GCCcore-13.3.0-tools.eb
@@ -39,6 +39,10 @@ builddependencies = [
     ('binutils', '2.42'),
 ]
 
+# remove -m64 flag from PFLAG variable in Makefiles for CPU architectures that don't support it
+if ARCH != 'x86_64':
+    preconfigopts = 'sed -i "s|PFLAG  = -m\\$(PREC)|PFLAG  = |" mf/Makefile.defs.linux-gomp* && '
+
 configopts = '--disable-cxx --disable-fortran --disable-ompi '
 
 # Comment it out if you have Xeon Phi:


### PR DESCRIPTION
This flag is not supported for (many) other CPU architectures, e.g. on Arm64 it will throw errors like:
```
gcc: error: unrecognized command-line option -m64
```

It may even be fine to remove it for x86-64 as well, since it only seems to be useful when cross-compiling for a 64-bit machine on a 32-bit machine?