### PR TITLE
[system/system] Add Intel 2025.0.0 compilers

### DIFF
--- a/easybuild/easyconfigs/i/intel-compilers/intel-compilers-2025.0.0.eb
+++ b/easybuild/easyconfigs/i/intel-compilers/intel-compilers-2025.0.0.eb
@@ -1,0 +1,37 @@
+name = 'intel-compilers'
+version = '2025.0.0'
+
+homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/hpc-toolkit.html'
+description = "Intel C, C++ & Fortran compilers"
+
+toolchain = SYSTEM
+
+# see https://software.intel.com/content/www/us/en/develop/articles/oneapi-standalone-components.html
+sources = [
+    {
+        'source_urls': [
+            'https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ac92f2bb-4818-4e53-a432-f8b34d502f23/'
+        ],
+        'filename': 'intel-dpcpp-cpp-compiler-%(version)s.740_offline.sh',
+    },
+    {
+        'source_urls': [
+            'https://registrationcenter-download.intel.com/akdlm/IRC_NAS/69f79888-2d6c-4b20-999e-e99d72af68d4/'
+        ],
+        'filename': 'intel-fortran-compiler-%(version)s.723_offline.sh',
+    },
+]
+checksums = [
+    {'intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh':
+     '04fadf63789acee731895e631db63f65a98b8279db3d0f48bdf0d81e6103bdd8'},
+    {'intel-fortran-compiler-2025.0.0.723_offline.sh':
+     '2be6d607ce84f35921228595b118fbc516d28587cbc4e6dcf6b7219e5cd1a9a9'},
+]
+
+local_gccver = '14.2.0'
+dependencies = [
+    ('GCCcore', local_gccver),
+    ('binutils', '2.42', '', ('GCCcore', local_gccver)),
+]
+
+moduleclass = 'compiler'


### PR DESCRIPTION
Add the newly released Intel oneAPI compilers for GCCcore 14.2.0. Basically just a version bump. 

The most notable change from the patch notes:
> Intel® Fortran Compiler Classic (ifort) is now discontinued in oneAPI 2025 release.

Requires https://github.com/easybuilders/easybuild-easyblocks/pull/3495