### PR TITLE
{numlib}[GCC-13.2.0] OpenBLAS 0.3.27 sequential with 64 bit interface

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.27-GCC-13.2.0-seq-iface64.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.27-GCC-13.2.0-seq-iface64.eb
@@ -42,9 +42,14 @@ builddependencies = [
     ('Python', '3.11.5'),
 ]
 
+# INTERFACE64=1 needs if you link OpenBLAS for fortran code compied with 64 bit integers (-i8)
+# This would be in intel library naming convention ilp64
+# The USE_OPENMP=0 and USE_THREAD=0 needs for the single threaded version
+# The USE_LOCKING=1 needs for thread safe version (if threaded software calls OpenBLAS, without it
+# OpenBLAS is not thread safe (so only single threaded software would be able to use it)
 buildopts = "INTERFACE64=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1 "
-testopts = "INTERFACE64=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1 "
-installopts = "INTERFACE64=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1 "
+testopts = buildopts
+installopts = buildopts
 
 run_lapack_tests = True
 max_failing_lapack_tests_num_errors = 150

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.27-GCC-13.2.0-seq-iface64.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.27-GCC-13.2.0-seq-iface64.eb
@@ -1,0 +1,55 @@
+name = 'OpenBLAS'
+version = '0.3.27'
+versionsuffix = '-seq-iface64'
+
+homepage = 'https://www.openblas.net/'
+description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
+
+toolchain = {'name': 'GCC', 'version': '13.2.0'}
+
+source_urls = [
+    # order matters, trying to download the large.tgz/timing.tgz LAPACK tarballs from GitHub causes trouble
+    'https://www.netlib.org/lapack/timing/',
+    'https://github.com/xianyi/OpenBLAS/archive/',
+]
+sources = ['v%(version)s.tar.gz']
+patches = [
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
+    'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch',
+    'OpenBLAS-0.3.21_fix-order-vectorization.patch',
+    'OpenBLAS-0.3.26_lapack_qr_noninittest.patch',
+    'OpenBLAS-0.3.27_fix_zscal.patch',
+    'OpenBLAS-0.3.27_riscv-drop-static-fortran-flag.patch',
+]
+checksums = [
+    {'v0.3.27.tar.gz': 'aa2d68b1564fe2b13bc292672608e9cdeeeb6dc34995512e65c3b10f4599e897'},
+    {'large.tgz': 'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1'},
+    {'timing.tgz': '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af'},
+    {'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch':
+     'e6b326fb8c4a8a6fd07741d9983c37a72c55c9ff9a4f74a80e1352ce5f975971'},
+    {'OpenBLAS-0.3.21_fix-order-vectorization.patch':
+     '08af834e5d60441fd35c128758ed9c092ba6887c829e0471ecd489079539047d'},
+    {'OpenBLAS-0.3.26_lapack_qr_noninittest.patch': '4781bf1d7b239374fd8069e15b4e2c0ef0e8efaa1a7d4c33557bd5b27e5de77c'},
+    {'OpenBLAS-0.3.27_fix_zscal.patch': '9210d7b66538dabaddbe1bfceb16f8225708856f60876ca5561b19d3599f9fd1'},
+    {'OpenBLAS-0.3.27_riscv-drop-static-fortran-flag.patch':
+     'f374e41efffd592ab1c9034df9e7abf1045ed151f4fc0fd0da618ce9826f2d4b'},
+]
+
+builddependencies = [
+    ('make', '4.4.1'),
+    # required by LAPACK test suite
+    ('Python', '3.11.5'),
+]
+
+buildopts = "INTERFACE64=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1 "
+testopts = "INTERFACE64=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1 "
+installopts = "INTERFACE64=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1 "
+
+run_lapack_tests = True
+max_failing_lapack_tests_num_errors = 150
+
+# extensive testing can be enabled by uncommenting the line below
+# runtest = 'PATH=.:$PATH lapack-timing'
+
+moduleclass = 'numlib'


### PR DESCRIPTION
needed to a fortran software that uses -i8 and forking, so a single threaded version with interface64 is needed.