### PR TITLE
Fix tagbot concurrency group

### DIFF
--- a/.github/workflows/tagbot.yml
+++ b/.github/workflows/tagbot.yml
@@ -2,7 +2,7 @@ name: Tagbot
 on: [pull_request_target]
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Can't use github.ref when using pull_request_target, since that value also points to base ref.

Currently workflows are getting cancelled by other PRs due to this. 