### PR TITLE
Update workflows to 24.04 + update actions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,12 +10,12 @@ concurrency:
 
 jobs:
   python-linting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python: [3.6, '3.11']
+        python: ['3.6.15', '3.11']
         modules_tool: [Lmod-7.8.22, Lmod-8.6.8]
         module_syntax: [Lua, Tcl]
         # exclude some configurations: only test Tcl module syntax with Lmod 8.x and Python 3.6
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python: [3.6, '3.11']
+        python: ['3.6.15', '3.11']
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -22,9 +22,15 @@ jobs:
             module_syntax: Tcl
       fail-fast: false
     steps:
+    - name: Check disk usage
+      run: df -h
+
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0 # Required for git merge-base to work
+
+    - name: Check disk usage2
+      run: df -h
 
     - name: Cache source files in /tmp/sources
       id: cache-sources
@@ -33,11 +39,17 @@ jobs:
         path: /tmp/sources
         key: eb-sourcepath
 
+    - name: Check disk usage
+      run: df -h
+
     - name: set up Python
       uses: actions/setup-python@v5
       with:
         python-version: ${{matrix.python}}
         architecture: x64
+
+    - name: Check disk usage
+      run: df -h
 
     - name: install OS & Python packages
       run: |
@@ -56,6 +68,9 @@ jobs:
         # required for test_dep_graph
         pip install pep8 python-graph-core python-graph-dot
 
+    - name: Check disk usage
+      run: df -h
+
     - name: install EasyBuild framework
       run: |
           cd $HOME
@@ -73,6 +88,9 @@ jobs:
           cd easybuild-easyblocks; git log -n 1; cd -
           pip install $PWD/easybuild-easyblocks
 
+    - name: Check disk usage
+      run: df -h
+
     - name: install modules tool
       run: |
           cd $HOME
@@ -87,6 +105,9 @@ jobs:
           echo $MOD_INIT > mod_init
           echo $PATH > path
           if [ ! -z $MODULESHOME ]; then echo $MODULESHOME > moduleshome; fi
+
+    - name: Check disk usage
+      run: df -h
 
     - name: run test suite
       env:
@@ -150,6 +171,10 @@ jobs:
           # try installing M4 with system toolchain (requires ConfigureMake easyblock + easyconfig)
           # use /tmp/sources because that has cached downloads (see cache step above)
           eb --prefix /tmp/$USER/$GITHUB_SHA --sourcepath /tmp/sources M4-1.4.18.eb
+
+    - name: Check disk usage
+      run: df -h
+
 
   test-sdist:
     runs-on: ubuntu-24.04

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   test-suite:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python: [3.6, '3.11']
@@ -22,19 +22,19 @@ jobs:
             module_syntax: Tcl
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0 # Required for git merge-base to work
 
     - name: Cache source files in /tmp/sources
       id: cache-sources
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: /tmp/sources
         key: eb-sourcepath
 
     - name: set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{matrix.python}}
         architecture: x64
@@ -152,15 +152,15 @@ jobs:
           eb --prefix /tmp/$USER/$GITHUB_SHA --sourcepath /tmp/sources M4-1.4.18.eb
 
   test-sdist:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python: [3.6, '3.11']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{matrix.python}}
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python: ['3.6.15', '3.11']
+        python: ['3.8', '3.11']
         modules_tool: [Lmod-7.8.22, Lmod-8.6.8]
         module_syntax: [Lua, Tcl]
         # exclude some configurations: only test Tcl module syntax with Lmod 8.x and Python 3.6
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python: ['3.6.15', '3.11']
+        python: ['3.8', '3.11']
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Update to ubuntu 24.04 and latest stable actions. 

Lets see if this has any impact of the warnings/errors we are seeing with unit-tests CI currently.