### PR TITLE
{compiler}[GCCcore/13.3.0] LLVM 18.1.8 (new)

### DIFF
--- a/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
@@ -24,11 +24,13 @@ sources = [
 patches = [
     'LLVM-18.1.8_envintest.patch',
     'LLVM-18.1.8_libomptarget_tests.patch',
+    'LLVM-19.1.7_clang_rpathwrap_test.patch',
 ]
 checksums = [
     {'llvm-project-18.1.8.src.tar.xz': '0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a'},
     {'LLVM-18.1.8_envintest.patch': '8e25dfab8a29a860717b4bd2d8cdd0e795433766d7fffbda32d06a2bde47058d'},
     {'LLVM-18.1.8_libomptarget_tests.patch': '858669446358d24936e2c85fa2bdc0b9e77427dc4a6f2aaa9c6d8e28638041c8'},
+    {'LLVM-19.1.7_clang_rpathwrap_test.patch': '5ee6a87ec8ff1c8b736ffe0513aa2098bd2b83a1ffc647a1ad2cf966f567e8a1'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
@@ -76,4 +76,8 @@ test_suite_max_failed = 150  # Could increase depending on build targets
 test_suite_timeout_single = 5 * 60
 # test_suite_timeout_total = 10*3600
 
+# LLVM will produce .mod files for its flang installation at the 3rd stage of the build via Clang+Flang
+# These should not be checked for sanity, as we want to build LLVM on top of GCCcore to be used as a new toolchain
+skip_mod_files_sanity_check = True
+
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
@@ -72,7 +72,7 @@ python_bindings = True
 skip_all_tests = False
 skip_sanitizer_tests = False
 test_suite_max_failed = 150  # Could increase depending on build targets
-test_suite_timeout_single = 5*60
+test_suite_timeout_single = 5 * 60
 # test_suite_timeout_total = 10*3600
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
@@ -61,6 +61,7 @@ build_lld = True
 build_lldb = True
 build_bolt = True
 build_openmp = True
+build_openmp_offload = True
 build_openmp_tools = True
 usepolly = True
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
@@ -27,11 +27,10 @@ patches = [
     'LLVM-18.1.8_libomptarget_tests.patch',
 ]
 checksums = [
-    '0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a',
-    None,
-    None
+    {'llvm-project-18.1.8.src.tar.xz': '0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a'},
+    {'LLVM-18.1.8_envintest.patch': '8e25dfab8a29a860717b4bd2d8cdd0e795433766d7fffbda32d06a2bde47058d'},
+    {'LLVM-18.1.8_libomptarget_tests.patch': '858669446358d24936e2c85fa2bdc0b9e77427dc4a6f2aaa9c6d8e28638041c8'},
 ]
-checksums = ['0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a']
 
 builddependencies = [
     ('binutils', '2.42'),

--- a/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
@@ -1,6 +1,5 @@
 name = 'LLVM'
 version = '18.1.8'
-versionsuffix = '-minimal'
 
 local_gcc_version = '13.3.0'
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
@@ -1,0 +1,78 @@
+name = 'LLVM'
+version = '18.1.8'
+versionsuffix = '-minimal'
+
+local_gcc_version = '13.3.0'
+
+homepage = "https://llvm.org/"
+description = """The LLVM Core libraries provide a modern source- and target-independent
+ optimizer, along with code generation support for many popular CPUs
+ (as well as some less common ones!) These libraries are built around a well
+ specified code representation known as the LLVM intermediate representation
+ ("LLVM IR"). The LLVM Core libraries are well documented, and it is
+ particularly easy to invent your own language (or port an existing compiler)
+ to use LLVM as an optimizer and code generator."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {
+    'pic': True,
+}
+
+source_urls = ['https://github.com/llvm/llvm-project/releases/download/llvmorg-%(version)s/']
+sources = [
+    'llvm-project-%(version)s.src.tar.xz',
+]
+patches = [
+    'LLVM-18.1.8_envintest.patch',
+    'LLVM-18.1.8_libomptarget_tests.patch',
+]
+checksums = [
+    '0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a',
+    None,
+    None
+]
+checksums = ['0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('Python', '3.12.3'),
+    ('CMake', '3.29.3'),
+    ('psutil', '6.0.0'),  # Needed to enable test timeout in lit
+    ('lit', '18.1.8'),
+    ('git', '2.45.1'),
+]
+
+dependencies = [
+    ('libxml2', '2.12.7'),
+    ('ncurses', '6.5'),
+    ('zlib', '1.3.1'),
+    ('Z3', '4.13.0'),
+]
+
+build_shared_libs = True
+
+minimal = False
+
+bootstrap = True
+full_llvm = False
+build_clang_extras = True
+build_runtimes = True
+build_lld = True
+build_lldb = True
+build_bolt = True
+build_openmp = True
+build_openmp_tools = True
+usepolly = True
+
+python_bindings = True
+
+# build_targets = ['all']
+# disable_werror = True
+
+skip_all_tests = False
+skip_sanitizer_tests = False
+test_suite_max_failed = 150  # Could increase depending on build targets
+test_suite_timeout_single = 5*60
+# test_suite_timeout_total = 10*3600
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8_envintest.patch
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8_envintest.patch
@@ -1,0 +1,16 @@
+Related to https://github.com/llvm/llvm-project/issues/109949
+Normally run.py does not carry over LD_LIBRARY_PATH, which can cause some tests to fail on system where
+libatomic is not present on a standard system path.
+--- libcxx/utils/run.py.orig
++++ libcxx/utils/run.py
+@@ -55,6 +55,10 @@
+             v = v + os.pathsep + os.environ[k]
+         env[k] = v
+ 
++    if any(isTestExe(exe) for exe in commandLine):
++        for var in ['LD_LIBRARY_PATH', ]:
++            env[var] = os.pathsep.join(filter(None, [os.environ.get(var, ''), env.get(var, '')]))
++
+     if platform.system() == "Windows":
+         # Pass some extra variables through on Windows:
+         # COMSPEC is needed for running subprocesses via std::system().

--- a/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8_libomptarget_tests.patch
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8_libomptarget_tests.patch
@@ -1,0 +1,49 @@
+# Patch to fix bug in libomptarget testing.
+# Related to:
+# - https://github.com/easybuilders/easybuild-easyblocks/pull/3373#issuecomment-2404623211
+# - https://github.com/llvm/llvm-project/issues/90333
+diff --git a/openmp/libomptarget/test/lit.cfg b/openmp/libomptarget/test/lit.cfg
+index d912b622c05b..ad378300bc80 100644
+--- a/openmp/libomptarget/test/lit.cfg
++++ b/openmp/libomptarget/test/lit.cfg
+@@ -286,18 +286,24 @@ for libomptarget_target in config.libomptarget_all_targets:
+         config.substitutions.append(("%libomptarget-run-fail-" + \
+             libomptarget_target, \
+             "%not --crash %t"))
++
++        if '-unknown-' in config.host_triple and '-pc-' in libomptarget_target:
++            _libomptarget_target = libomptarget_target.replace('-pc-', '-unknown-')
++        else:
++            _libomptarget_target = libomptarget_target
++
+         config.substitutions.append(("%clangxx-" + libomptarget_target, \
+                                      "%clangxx %openmp_flags %cuda_flags %flags %flags_clang -fopenmp-targets=" +\
+-                                     remove_suffix_if_present(libomptarget_target)))
++                                     remove_suffix_if_present(_libomptarget_target)))
+         config.substitutions.append(("%clangxxx-force-usm-" + libomptarget_target, \
+                                      "%clangxx %openmp_flags -fopenmp-force-usm  %cuda_flags %flags %flags_clang -fopenmp-targets=" +\
+-                                     remove_suffix_if_present(libomptarget_target)))
++                                     remove_suffix_if_present(_libomptarget_target)))
+         config.substitutions.append(("%clang-" + libomptarget_target, \
+                                      "%clang %openmp_flags %cuda_flags %flags %flags_clang -fopenmp-targets=" +\
+-                                     remove_suffix_if_present(libomptarget_target)))
++                                     remove_suffix_if_present(_libomptarget_target)))
+         config.substitutions.append(("%flang-" + libomptarget_target, \
+                                      "%flang %openmp_flags %flags %flags_flang -fopenmp-targets=" +\
+-                                     remove_suffix_if_present(libomptarget_target)))
++                                     remove_suffix_if_present(_libomptarget_target)))
+         config.substitutions.append(("%fcheck-" + libomptarget_target, \
+             config.libomptarget_filecheck + " %s"))
+     else:
+diff --git a/openmp/libomptarget/test/lit.site.cfg.in b/openmp/libomptarget/test/lit.site.cfg.in
+index 7c75aaa18fa7..15189c156986 100644
+--- a/openmp/libomptarget/test/lit.site.cfg.in
++++ b/openmp/libomptarget/test/lit.site.cfg.in
+@@ -19,6 +19,7 @@ config.omp_header_directory = "@LIBOMPTARGET_OPENMP_HEADER_FOLDER@"
+ config.omp_host_rtl_directory = "@LIBOMPTARGET_OPENMP_HOST_RTL_FOLDER@"
+ config.llvm_lib_directory = "@LIBOMPTARGET_LLVM_LIBRARY_DIR@"
+ config.operating_system = "@CMAKE_SYSTEM_NAME@"
++config.host_triple = "@LLVM_HOST_TRIPLE@"
+ config.libomptarget_all_targets = "@LIBOMPTARGET_ALL_TARGETS@".split()
+ config.libomptarget_current_target = "@CURRENT_TARGET@"
+ config.libomptarget_filecheck = "@OPENMP_FILECHECK_EXECUTABLE@"

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.7_clang_rpathwrap_test.patch
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.7_clang_rpathwrap_test.patch
@@ -1,0 +1,17 @@
+Properly building the runtimes with rpath wrappers causes the test suite to also use the wrappers.
+In clang this will cause a bunch of warning due to linking flags used at compile time (-Wl,rpath=...)
+that are turned into errors by `-Werror`.
+`-Wno-unused-command-line-argument` also needs to be added in order to avoid the error.
+diff --git a/libcxx/utils/libcxx/test/dsl.py b/libcxx/utils/libcxx/test/dsl.py
+index 7ff4be0ee7cf..0788eada1dfa 100644
+--- a/libcxx/utils/libcxx/test/dsl.py
++++ b/libcxx/utils/libcxx/test/dsl.py
+@@ -214,7 +214,7 @@ def tryCompileFlag(config, flag):
+     # fmt: off
+     with _makeConfigTest(config) as test:
+         out, err, exitCode, timeoutInfo, _ = _executeWithFakeConfig(test, [
+-            "%{{cxx}} -xc++ {} -Werror -fsyntax-only %{{flags}} %{{compile_flags}} {}".format(os.devnull, flag)
++            "%{{cxx}} -xc++ {} -Werror -Wno-unused-command-line-argument -fsyntax-only %{{flags}} %{{compile_flags}} {}".format(os.devnull, flag)
+         ])
+         return exitCode, out, err
+     # fmt: on


### PR DESCRIPTION
EC files to compile LLVMcore (clang + flang-new + optional projects) for `18.1.8` with GCCcore 13.3.0 as a base

-  [x] Requires EB from PR (https://github.com/easybuilders/easybuild-easyblocks/pull/3373)
-  Splitted from https://github.com/easybuilders/easybuild-easyconfigs/pull/20902
