### PR TITLE
Fix confliction platformdirs dependency in Pylint-3.2.5-GCCcore-13.2.0

### DIFF
--- a/easybuild/easyconfigs/p/Pylint/Pylint-3.2.5-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/p/Pylint/Pylint-3.2.5-GCCcore-13.2.0.eb
@@ -18,20 +18,13 @@ builddependencies = [
 
 dependencies = [
     ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('dill', '0.3.8'),
 ]
 
 use_pip = True
 
 exts_list = [
-    ('dill', '0.3.8', {
-        'checksums': ['3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca'],
-    }),
-    ('platformdirs', '4.2.2', {
-        'checksums': ['38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3'],
-    }),
-    ('tomlkit', '0.12.5', {
-        'checksums': ['eef34fba39834d4d6b73c9ba7f3e4d1c417a4e56f89a7e96e090dd0d24b8fb3c'],
-    }),
     ('astroid', '3.2.2', {
         'checksums': ['8ead48e31b92b2e217b6c9733a21afafe479d52d6e164dd25fb1a770c7c3cf94'],
     }),


### PR DESCRIPTION
The PyLint EasyConfig installs a different version of the `platformdirs` package than available in e.g. Python-bundle-PyPI which leads to conflicts later on.
Depend on that to pull in the right version