### PR TITLE
{compiler}[system/system] NVHPC-24.11-CUDA-12.6.0

### DIFF
--- a/easybuild/easyconfigs/n/NVHPC/NVHPC-24.11-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/n/NVHPC/NVHPC-24.11-CUDA-12.6.0.eb
@@ -1,0 +1,73 @@
+name = 'NVHPC'
+version = '24.11'
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = 'https://developer.nvidia.com/hpc-sdk/'
+description = """C, C++ and Fortran compilers included with the NVIDIA HPC SDK (previously: PGI)"""
+
+toolchain = SYSTEM
+
+local_tarball_tmpl = 'nvhpc_2024_%%(version_major)s%%(version_minor)s_Linux_%s_cuda_multi.tar.gz'
+# By downloading, you accept the HPC SDK Software License Agreement
+# https://docs.nvidia.com/hpc-sdk/eula/index.html
+# accept_eula = True
+source_urls = ['https://developer.download.nvidia.com/hpc-sdk/%(version)s/']
+sources = [local_tarball_tmpl % '%(arch)s']
+checksums = [
+    {
+        local_tarball_tmpl % 'aarch64':
+            'f2f64e5dec5e90dad5e12a31a992172b0aa19abf872ef1c54a1a437c7008eefb',
+        local_tarball_tmpl % 'x86_64':
+            '0c27d66ed0e2d3007d30ac904922a9abf96475197dc0f4dcc6316d235a1dc0c3',
+    }
+]
+
+local_gccver = '13.3.0'
+dependencies = [
+    ('GCCcore', local_gccver),
+    ('binutils', '2.42', '', ('GCCcore', local_gccver)),
+    # This is necessary to avoid cases where just libnuma.so.1 is present in the system and -lnuma fails
+    ('numactl', '2.0.18', '', ('GCCcore', local_gccver)),
+    ('CUDA', '12.6.0', '', SYSTEM),
+]
+
+module_add_cuda = False
+
+# specify default CUDA version that should be used by NVHPC
+# should match one of the CUDA versions that are included with this NVHPC version
+# (see install_components/Linux_x86_64/$version/cuda/) where $version is the NVHPC version
+# this version can be tweaked from the EasyBuild command line with
+# --try-amend=default_cuda_version="11.0" (for example)
+default_cuda_version = '%(cudaver)s'
+
+# NVHPC EasyBlock supports some features, which can be set via CLI or this easyconfig.
+# The following list gives examples for the easyconfig
+#
+# NVHPC needs CUDA to work. Two options are available: 1) Use NVHPC-bundled CUDA, 2) use system CUDA
+# 1) Bundled CUDA
+#    If no easybuild dependency to CUDA is present, the bundled CUDA is taken. A version needs to be specified with
+#      default_cuda_version = "11.0"
+#    in this easyconfig file; alternatively, it can be specified through the command line during installation with
+#      --try-amend=default_cuda_version="10.2"
+# 2) CUDA provided via EasyBuild
+#    Use CUDA as a dependency, for example
+#      dependencies = [('CUDA', '11.5.0')]
+#    The parameter default_cuda_version still can be set as above.
+#    If not set, it will be deduced from the CUDA module (via $EBVERSIONCUDA)
+#
+# Define a NVHPC-default Compute Capability
+#   cuda_compute_capabilities = "8.0"
+# Can also be specified on the EasyBuild command line via --cuda-compute-capabilities=8.0
+# Only single values supported, not lists of values!
+#
+# Options to add/remove things to/from environment module (defaults shown)
+#   module_byo_compilers = False  # Remove compilers from PATH (Bring-your-own compilers)
+#   module_nvhpc_own_mpi = False  # Add NVHPC's own pre-compiled OpenMPI
+#   module_add_math_libs = False  # Add NVHPC's math libraries (which should be there from CUDA anyway)
+#   module_add_profilers = False  # Add NVHPC's NVIDIA Profilers
+#   module_add_nccl = False       # Add NVHPC's NCCL library
+#   module_add_nvshmem = False    # Add NVHPC's NVSHMEM library
+#   module_add_cuda = False       # Add NVHPC's bundled CUDA
+
+# this bundle serves as a compiler-only toolchain, so it should be marked as compiler (important for HMNS)
+moduleclass = 'compiler'


### PR DESCRIPTION
Basic version bump from 24.9.

Fixes I've noticed:
- OpenMPI 5 can once again build without the configure flag workaround
- Fixes in the OpenACC profiling interface
- Fixes in the OpenMP Tools Interface (and OpenMP runtime)

----

The release notes also include a mention which might affect EasyBuild in a future version:

> In a future release, the HPC SDK tar package file name will be extended to include the release number, in addition to the version. Automations that download and install the HPC SDK from the tar file package may need to be updated. 