### PR TITLE
detect use of deprecated behavior in test runs

### DIFF
--- a/test/easyconfigs/suite.py
+++ b/test/easyconfigs/suite.py
@@ -46,7 +46,7 @@ fancylogger.disableDefaultHandlers()
 fancylogger.setLogLevelError()
 
 # make sure no deprecated behaviour is triggered
-# os.environ['EASYBUILD_DEPRECATED'] = '10000'
+os.environ['EASYBUILD_DEPRECATED'] = '10000'
 
 
 class EasyConfigsTestSuite(unittest.TestSuite):


### PR DESCRIPTION
Re-enable the option to error on any deprecated behavior.

This is more general than the test case added in https://github.com/easybuilders/easybuild-easyconfigs/pull/19375/commits/93ed7fe27632968a85826fcd83bd51671f35feed checking (only) for use of deprecated EC parameters.

I'm not fully sure which one we want:
1. `test_pr_deprecated_ec_params` catches only deprecated EC params in changed easyconfigs
2. `$EASYBUILD_DEPRECATED` catches any use of deprecated behavior

The advantage of the test method is that it reports failures for all (changed) ECs in a single error while $EASYBUILD_DEPRECATED would error and stop on the first failure. We can also be more specific in what kind of deprecated behavior we want to check for if we don't use the variable, e.g. just the EC params in changed ECs, not also in dependencies. But then I don't see how we could easily detect e.g. usage of functions deprecated in the framework.

In any case, we should either merge this PR or remove the commented line.