### PR TITLE
{tools}[GCCcore/13.2.0] datalad v1.1.0, git-annex v10.20240531, libnsl v2.0.1

### DIFF
--- a/easybuild/easyconfigs/d/datalad/datalad-1.1.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/d/datalad/datalad-1.1.0-GCCcore-13.2.0.eb
@@ -1,0 +1,84 @@
+easyblock = 'PythonBundle'
+
+name = 'datalad'
+version = "1.1.0"
+
+homepage = 'https://www.datalad.org/'
+description = "DataLad is a free and open source distributed data management system that keeps track of your data, \
+creates structure, ensures reproducibility, supports collaboration, \
+and integrates with widely used data infrastructure."
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+toolchainopts = {'pic': True}
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('hatchling', '1.18.0'),
+    ('poetry', '1.6.1')
+]
+
+dependencies = [
+    ('git-annex', '10.20240531'),
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('tqdm', '4.66.2'),
+    ('PLY', '3.11'),
+    ('scikit-build', '0.17.6'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('humanize', '4.9.0', {
+        'checksums': ['582a265c931c683a7e9b8ed9559089dea7edcf6cc95be39a3cbc2c5d5ac2bcfa'],
+    }),
+    ('fasteners', '0.19', {
+        'checksums': ['b4f37c3ac52d8a445af3a66bce57b33b5e90b97c696b7b984f530cf8f0ded09c'],
+    }),
+    ('patool', '2.3.0', {
+        'modulename': 'patoolib',
+        'checksums': ['498e294fd8c7d50889d65019d431c6867bf3fb1fec5ea2d39d1d39d1215002f8'],
+    }),
+    ('annexremote', '1.6.5', {
+        'checksums': ['ad0ccdd84a8771ad58922d172ee68b225ece77bf464abe4d24ff91a4896a423e'],
+    }),
+    ('looseversion', '1.3.0', {
+        'checksums': ['ebde65f3f6bb9531a81016c6fef3eb95a61181adc47b7f949e9c0ea47911669e'],
+    }),
+    ('botocore', '1.34.121', {
+        'checksums': ['1a8f94b917c47dfd84a0b531ab607dc53570efb0d073d8686600f2d2be985323'],
+    }),
+    ('jmespath', '1.0.1', {
+        'checksums': ['90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe'],
+    }),
+    ('s3transfer', '0.10.2', {
+        'checksums': ['0711534e9356d3cc692fdde846b4a1e4b0cb6519971860796e6bc4c7aea00ef6'],
+    }),
+    ('boto3', '1.34.121', {
+        'checksums': ['ec89f3e0b0dc959c418df29e14d3748c0b05ab7acf7c0b90c839e9f340a659fa'],
+    }),
+    ('python_gitlab', '4.5.0', {
+        'modulename': 'gitlab',
+        'checksums': ['0a106174949819912b9abb4232e39059f83f613177fdb1787097eb84481c64b2'],
+    }),
+    ('iso8601', '2.1.0', {
+        'checksums': ['6b1d3829ee8921c4301998c909f7829fa9ed3cbdac0d3b16af2d743aed1ba8df'],
+    }),
+    (name, version, {
+        'checksums': ['3403232696ae0e6cbcec56d7cccfac1be8b5d98f66f235e4751dd44fd9f5e8eb'],
+    }),
+]
+
+sanity_pip_check = True
+
+sanity_check_paths = {
+    'files': ['bin/datalad'],
+    'dirs': [],
+}
+
+sanity_check_commands = [
+    "datalad --help",
+    "datalad --version",
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20240531-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20240531-GCCcore-13.2.0.eb
@@ -1,0 +1,49 @@
+easyblock = 'MakeCp'
+
+name = 'git-annex'
+version = '10.20240531'
+
+homepage = 'https://git-annex.branchable.com'
+description = """git-annex allows managing large files with git, without storing the file contents in git. It can sync,
+backup, and archive your data, offline and online. Checksums and encryption keep your data safe and secure. Bring the
+power and distributed nature of git to bear on your large files with git-annex."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+builddependencies = [
+    ('binutils', '2.40')
+]
+
+dependencies = [
+    ('GHC', '9.10.1', '-x86_64', SYSTEM),
+    ('Stack', '3.1.1', '-x86_64', SYSTEM),
+    ('git', '2.42.0'),
+    ('libnsl', '2.0.1'),
+]
+
+sources = [{
+    'git_config': {'url': 'git://git-annex.branchable.com',
+                   'repo_name': '%(name)s',
+                   'tag': '%(version)s',
+                   'clone_into': '%(name)s-%(version)s',
+                   },
+    'filename': '%(name)s-%(version)s.tar.gz',
+}]
+
+checksums = [None]
+
+prebuildopts = "export STACK_ROOT=$(mktemp -d) && stack setup && stack build && "
+buildopts = "install-bins BUILDER=stack PREFIX=%(builddir)s"
+
+files_to_copy = [
+    (['git-annex', 'git-annex-shell'], 'bin'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/git-annex', 'bin/git-annex-shell'],
+    'dirs': [],
+}
+
+sanity_check_commands = ['git-annex version']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/l/libnsl/libnsl-2.0.1-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/l/libnsl/libnsl-2.0.1-GCCcore-13.2.0.eb
@@ -1,0 +1,33 @@
+easyblock = 'ConfigureMake'
+
+name = 'libnsl'
+version = '2.0.1'
+
+homepage = 'https://github.com/thkukuk/libnsl'
+description = """The libnsl package contains the public client interface for NIS(YP)."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+source_urls = ['https://github.com/thkukuk/%(name)s/releases/download/v%(version)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['5c9e470b232a7acd3433491ac5221b4832f0c71318618dc6aa04dd05ffcd8fd9']
+
+builddependencies = [
+    ('binutils', '2.40'),
+]
+
+dependencies = [
+    ('libtirpc', '1.3.4'),
+]
+
+# Provide a symlink for libnsl.so.1, which used to be part of glibc.
+# This new version of libnsl should be backwards compatible.
+postinstallcmds = ['ln -s libnsl.so %(installdir)s/lib/libnsl.so.1']
+
+sanity_check_paths = {
+    'files': ['include/rpcsvc/yp.h', 'lib/libnsl.a',
+              'lib/libnsl.%s' % SHLIB_EXT, 'lib/libnsl.%s.1' % SHLIB_EXT],
+    'dirs': ['include']
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Hey,
for completeness, I also built datalad-1.1.0 for the 2023b stack, as this was one version that was missing.