### PR TITLE
Create OpenFOAM-v2406-64b-foss-2020a.eb

### DIFF
--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2406-64b-foss-2020a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2406-64b-foss-2020a.eb
@@ -1,0 +1,47 @@
+name = 'OpenFOAM'
+version = 'v2406-64b'
+
+homepage = 'https://www.openfoam.com/'
+description = """OpenFOAM is a free, open source CFD software package.
+ OpenFOAM has an extensive range of features to solve anything from complex fluid flows
+ involving chemical reactions, turbulence and heat transfer,
+ to solid dynamics and electromagnetics."""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+toolchainopts = {'cstd': 'c++14', 'vectorize': False, 'i8':True}
+
+source_urls = ['https://sourceforge.net/projects/openfoam/files/%(version)s/']
+sources = [SOURCE_TGZ]
+patches = [
+    ('OpenFOAM-v2406-cleanup.patch', 1),
+    ('OpenFOAM-v2212-wmake-OpenMPI.patch', 1),
+]
+checksums = [
+    {'OpenFOAM-v2406-64b.tgz': '3bf6c0bf8167764a02c3327ac4a69acf86124f5fa417ab2ca385077462ff2dc0'},
+    {'OpenFOAM-v2406-cleanup.patch': '3abff48a517fb63719ad57fa32af746bc379a1e80c72d3e5852aa17cd13cf03e'},
+    {'OpenFOAM-v2212-wmake-OpenMPI.patch': '4f5110e98df1f057dc4b478a004e4ae2dc5cc763899f0d3ceb6773315c5c8ba9'},
+]
+
+builddependencies = [
+    ('Bison', '3.5.3'),
+    ('CMake', '3.16.4'),
+    ('flex', '2.6.4'),
+]
+
+
+dependencies = [
+    ('libreadline', '8.0'),
+    ('ncurses', '6.2'),
+    # OpenFOAM requires 64 bit METIS using 32 bit indexes (array indexes)
+    ('METIS', '5.1.0'),
+    ('SCOTCH', '6.0.9'),
+    ('KaHIP', '3.14'),
+    ('CGAL', '4.14.3','-Python-3.8.2'),
+    ('GMP', '6.2.0'),
+    ('MPFR', '4.0.2'),
+    ('ParaView', '5.8.0','-Python-3.8.2-mpi'),
+    ('gnuplot', '5.2.8'),
+]
+
+
+moduleclass = 'cae'


### PR DESCRIPTION
 In this commit, the INT size is set to 64b
 setting the flag i8 to True, aswel as setting $WM_LABEL_SIZE=64 in $WM_PROJECT_DIR/etc/bashrc and cshrc.