### PR TITLE
Adding easyconfig medaka-2.0.1-foss-2023a.eb

### DIFF
--- a/easybuild/easyconfigs/m/medaka/medaka-2.0.1-foss-2023a.eb
+++ b/easybuild/easyconfigs/m/medaka/medaka-2.0.1-foss-2023a.eb
@@ -1,0 +1,76 @@
+easyblock = 'PythonBundle'
+
+name = 'medaka'
+version = '2.0.1'
+
+homepage = 'https://github.com/nanoporetech/medaka'
+description = "medaka is a tool to create a consensus sequence from nanopore sequencing data."
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+toolchainopts = {'pic': True}
+
+builddependencies = [('Autotools', '20220317')]
+
+_minimap_ver = '2.26'
+dependencies = [
+    ('Python', '3.11.3'),
+    ('Python-bundle-PyPI', '2023.06'),  # includes cffi
+    ('PyTorch', '2.1.2'),
+    ('Pysam', '0.22.0'),
+    ('SAMtools', '1.18'),
+    ('minimap2', _minimap_ver),
+    ('HTSlib', '1.18'),  # for tabix, bgzip
+    ('Racon', '1.5.0'),
+    ('edlib', '1.3.9'),
+    ('pyspoa', '0.2.1'),
+    ('python-parasail', '1.3.4'),
+    ('ont-fast5-api', '4.1.2'),
+    ('WhatsHap', '2.2'),
+    ('intervaltree-python', '3.1.0'),
+    ('BCFtools', '1.18'),
+    ('libdeflate', '1.18'),
+    ('tqdm', '4.66.1'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+local_sed_commands = [
+    "sed -i 's/torch.*/torch/g' requirements.txt pyproject.toml",
+    # ont-mappy/ont-parasail on PyPI are just pre-built wheels for mappy/(python-)parasail
+    "sed -i 's/ont-mappy/mappy/g;s/ont-parasail/parasail/g' requirements.txt",
+]
+
+exts_list = [
+    ('mappy', _minimap_ver, {
+        'checksums': ['e53fbe9a3ea8762a64b8103f4f779c9fb16d418eaa0a731f45cebc83867a9b71'],
+    }),
+    ('wurlitzer', '3.1.1', {
+        'source_tmpl': SOURCE_PY3_WHL,
+        'checksums': ['0b2749c2cde3ef640bf314a9f94b24d929fe1ca476974719a6909dfc568c3aac'],
+    }),
+    # medaka >= 1.12.0 requires h5py ~=3.10.0
+    ('h5py', '3.10.0', {
+        'checksums': ['d93adc48ceeb33347eb24a634fb787efc7ae4644e6ea4ba733d099605045c049'],
+    }),
+    ('pyabpoa', '1.5.3', {
+        'checksums': ['94714bb5c6be9f5ca35b66a5c63490237ebff2498ff93b82a842a9512b0bbc08'],
+    }),
+    (name, version, {
+        'checksums': ['7b7a0dc558f19d10fe8eb588f709a179ef5204a53aad5cfdfbd5c57039193a9f'],
+        # Some requirements are too strict.
+        'preinstallopts': " && ".join(local_sed_commands) + " && WITHDEFLATE=1 ",
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/medaka', 'bin/medaka_consensus', 'bin/medaka_version_report'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [
+    "medaka --help",
+    "medaka_version_report",
+]
+
+moduleclass = 'bio'


### PR DESCRIPTION
Medaka v2 now relies on PyTorch instead of TensorFlow and also needs tqdm.

Building with WITHDEFLATE=1 since otherwise the medaka import sanity check fails because libmedaka.abi3.so is missing certain libdeflate-related symbols. Libdeflate is also supposed to help the BAM file IO (https://github.com/nanoporetech/medaka/releases/tag/v1.6.0).