### PR TITLE
patch LASTZ escaping in Makefile to fix issues when using rpath wrappers

### DIFF
--- a/easybuild/easyconfigs/l/LASTZ/LASTZ-1.04.22-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/l/LASTZ/LASTZ-1.04.22-GCC-12.3.0.eb
@@ -13,7 +13,11 @@ toolchain = {'name': 'GCC', 'version': '12.3.0'}
 
 source_urls = [GITHUB_LOWER_SOURCE]
 sources = ['%(version)s.tar.gz']
-checksums = ['4c829603ba4aed7ddf64255b528cd88850e4557382fca29580d3576c25c5054a']
+patches = ['%(name)s-1.04.22_avoid-escaping.patch']
+checksums = [
+    {'1.04.22.tar.gz': '4c829603ba4aed7ddf64255b528cd88850e4557382fca29580d3576c25c5054a'},
+    {'LASTZ-1.04.22_avoid-escaping.patch': 'be3a9a5378cdf1ac44db4bb09a3c03b67401e227b970903be1a116366553355e'},
+]
 
 skipsteps = ['configure']
 

--- a/easybuild/easyconfigs/l/LASTZ/LASTZ-1.04.22_avoid-escaping.patch
+++ b/easybuild/easyconfigs/l/LASTZ/LASTZ-1.04.22_avoid-escaping.patch
@@ -1,0 +1,59 @@
+From 1aec3dc99b781f3466a1f5a1501cc41d69ead231 Mon Sep 17 00:00:00 2001
+From: jfgrimm <jasper.grimm@york.ac.uk>
+Date: Fri, 6 Sep 2024 16:32:11 +0100
+Subject: [PATCH] avoid requiring score type to be escaped at compile-time
+Avoid issues when using compiler wrappers (which mess with the escaping in the Makefile)
+---
+ src/Makefile        |  4 ++--
+ src/dna_utilities.h | 14 ++++++++++----
+ 2 files changed, 12 insertions(+), 6 deletions(-)
+
+diff --git a/src/Makefile b/src/Makefile
+index 1908774..cd7a55a 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -91,10 +91,10 @@ incFiles = lastz.h infer_scores.h \
+            utilities.h dna_utilities.h sequences.h capsule.h
+ 
+ %.o: %.c version.mak ${incFiles}
+-	${CC} -c ${CFLAGS} -Dscore_type=\'I\' $< -o $@
++	${CC} -c ${CFLAGS} -Dscore_type=I $< -o $@
+ 
+ %_D.o: %.c version.mak ${incFiles}
+-	${CC} -c ${CFLAGS} -Dscore_type=\'D\' $< -o $@
++	${CC} -c ${CFLAGS} -Dscore_type=D $< -o $@
+ 
+ %_32.o: %.c version.mak ${incFiles}
+ 	${CC} -c ${CFLAGS} ${flagsFor32} $< -o $@
+diff --git a/src/dna_utilities.h b/src/dna_utilities.h
+index f3a0ce2..b0d41cb 100644
+--- a/src/dna_utilities.h
++++ b/src/dna_utilities.h
+@@ -35,9 +35,7 @@ global int dna_utilities_dbgShowQToBest;
+ // score values--
+ //	Scores used for sequence comparisons are normally signed 32-bit integers,
+ //	but the programmer can override this at compile time by defining score_type
+-//	as one of 'F', 'D', or 'I'.  Note that some effort must be taken to get
+-//	the apostrophes into the definition from the compiler command line, such as
+-//	-Dscore_type=\'F\' .
++//	as one of: F, D, or I, by compiling with e.g. -Dscore_type=F
+ //
+ //----------
+ //
+@@ -66,7 +64,15 @@ global int dna_utilities_dbgShowQToBest;
+ //----------
+ 
+ #if defined(score_type)
+-#define scoreType score_type
++#if score_type == I
++#define scoreType 'I'
++#elif score_type == F
++#define scoreType 'F'
++#elif score_type == D
++#define scoreType 'D'
++#else
++#error ***** undecipherable score type definition *****
++#endif
+ #else
+ #define scoreType 'I'
+ #endif


### PR DESCRIPTION
otherwise, you get errors like:
```
gcc -c -O3 -Wfatal-errors -Wall -Wextra -Werror -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DVERSION_MAJOR="\"1"\" -DVERSION_MINOR="\"04"\" -DVERSION_SUBMINOR="\"22"\" -DREVISION_DATE="\"20220807"\" -DSUBVERSION_REV="\""\" -Dscore_type=\'I\' lastz.c -o lastz.o
In file included from lastz.c:133:
dna_utilities.h:72:9: note: '#pragma message: score_type=`I`'
   72 | #pragma message PRINT_MACRO_AT_COMPILE_TIME(score_type)
      |         ^~~~~~~
dna_utilities.h:80:9: note: '#pragma message: scoreType=`I`'
   80 | #pragma message PRINT_MACRO_AT_COMPILE_TIME(scoreType)
      |         ^~~~~~~
dna_utilities.h:89:2: error: #error ***** undecipherable score type definition *****
   89 | #error ***** undecipherable score type definition *****
      |  ^~~~~
compilation terminated due to -Wfatal-errors.
make: *** [Makefile:94: lastz.o] Error 1
```