### PR TITLE
Upgrade WCSLIB version in DP3-6.0-foss-2023b.eb 

### DIFF
--- a/easybuild/easyconfigs/d/DP3/DP3-6.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/d/DP3/DP3-6.0-foss-2023b.eb
@@ -33,10 +33,10 @@ builddependencies = [
     ('CMake', '3.27.6'),
 ]
 dependencies = [
-    ('casacore', '3.5.0'),
+    ('casacore', '3.6.1'),
     ('Boost', '1.83.0'),
     ('CFITSIO', '4.3.1'),
-    ('WCSLIB', '7.11'),
+    ('WCSLIB', '8.3'),
     ('GSL', '2.7'),
     ('HDF5', '1.14.3'),
     ('Python', '3.11.5'),


### PR DESCRIPTION
Version 7.11 of WCSLIB is no longer available for downloading
This PR requires #21527 and #21540 to work.