### PR TITLE
Upgrade WCSLIB version in EveryBeam-0.5.2-foss-2023b.eb

### DIFF
--- a/easybuild/easyconfigs/e/EveryBeam/EveryBeam-0.5.2-foss-2023b.eb
+++ b/easybuild/easyconfigs/e/EveryBeam/EveryBeam-0.5.2-foss-2023b.eb
@@ -33,7 +33,7 @@ dependencies = [
     ('casacore', '3.5.0'),
     ('Boost', '1.83.0'),
     ('CFITSIO', '4.3.1'),
-    ('WCSLIB', '7.11'),
+    ('WCSLIB', '8.3'),
     ('GSL', '2.7'),
     ('HDF5', '1.14.3'),
     ('Python', '3.11.5'),


### PR DESCRIPTION
Version 7.11 of WCSLIB is no longer available for downloading