### PR TITLE
Expand templates in checksum keys

### DIFF
--- a/easybuild/easyconfigs/c/CFITSIO/CFITSIO-4.3.1-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/c/CFITSIO/CFITSIO-4.3.1-GCCcore-13.2.0.eb
@@ -16,8 +16,8 @@ source_urls = ['https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/']
 sources = [SOURCELOWER_TAR_GZ]
 patches = ['%(name)s-3.48_install_test_data.patch']
 checksums = [
-    {SOURCELOWER_TAR_GZ: '47a7c8ee05687be1e1d8eeeb94fb88f060fbf3cd8a4df52ccb88d5eb0f5062be'},
-    {'%(name)s-3.48_install_test_data.patch': 'dbf16f857f133468fc1e6a793c6e89fca66d54796593e03606f2722a2a980c0c'},
+    {'cfitsio-4.3.1.tar.gz': '47a7c8ee05687be1e1d8eeeb94fb88f060fbf3cd8a4df52ccb88d5eb0f5062be'},
+    {'CFITSIO-3.48_install_test_data.patch': 'dbf16f857f133468fc1e6a793c6e89fca66d54796593e03606f2722a2a980c0c'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/c/CellBender/CellBender-0.2.1-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/c/CellBender/CellBender-0.2.1-foss-2021a-CUDA-11.3.1.eb
@@ -38,7 +38,7 @@ exts_list = [
         'sources': ['v%(version)s.tar.gz'],
         'patches': ['CellBender-0.2.1-sphinxremoval.patch'],
         'checksums': [
-            {'v%(version)s.tar.gz':
+            {'0.2.1.tar.gz':
              '309f6245585d9741ba7099690a10a8f496756c4827d100100130be589b797ba4'},
             {'CellBender-0.2.1-sphinxremoval.patch':
              '0f6a342bac16f4ee80cd05d43923b4cc60d71999ea1bb5c80a75edb7290bbdec'},

--- a/easybuild/easyconfigs/c/CellBender/CellBender-0.2.1-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/c/CellBender/CellBender-0.2.1-foss-2021a-CUDA-11.3.1.eb
@@ -38,7 +38,7 @@ exts_list = [
         'sources': ['v%(version)s.tar.gz'],
         'patches': ['CellBender-0.2.1-sphinxremoval.patch'],
         'checksums': [
-            {'0.2.1.tar.gz':
+            {'v0.2.1.tar.gz':
              '309f6245585d9741ba7099690a10a8f496756c4827d100100130be589b797ba4'},
             {'CellBender-0.2.1-sphinxremoval.patch':
              '0f6a342bac16f4ee80cd05d43923b4cc60d71999ea1bb5c80a75edb7290bbdec'},

--- a/easybuild/easyconfigs/d/duplex-tools/duplex-tools-0.3.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/d/duplex-tools/duplex-tools-0.3.1-foss-2022a.eb
@@ -40,10 +40,10 @@ exts_list = [
     ('lib-pod5', '0.1.5', {
         'source_tmpl': 'lib_pod5-%%(version)s-cp310-cp310-manylinux_2_17_%s.manylinux2014_%s.whl' % (ARCH, ARCH),
         'checksums': [{
-            'lib_pod5-%(version)s-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl': (
+            'lib_pod5-0.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl': (
                 '4e8993327268784bb0e1320595411f545d2019cf4952b04d63be584cf7208480'
             ),
-            'lib_pod5-%(version)s-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl': (
+            'lib_pod5-0.1.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl': (
                 '125f19ad83c299d0d6c67d18ce8e43da4e12bf12cf7141ab7d60fba7574239bd'
             ),
         }],

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2023.05.001-foss-2023a.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2023.05.001-foss-2023a.eb
@@ -22,11 +22,11 @@ patches = [
     '%(name)s-%(version)s_fix_AVX512_support.patch',
 ]
 checksums = [
-    {'%(namelower)s-new_release_%(version)s.tar.gz':
+    {'elpa-new_release_2023.05.001.tar.gz':
      '7e07ca287ab07c0a73d97df71d5a5431c847b8e4d5c759aae99e12672e6decf3'},
-    {'%(name)s-%(version)s_fix_hardcoded_perl_path.patch':
+    {'ELPA-2023.05.001_fix_hardcoded_perl_path.patch':
      '0548105065777a2ed07dde306636251c4f96e555a801647564de37d1ddd7b0b5'},
-    {'%(name)s-%(version)s_fix_AVX512_support.patch':
+    {'ELPA-2023.05.001_fix_AVX512_support.patch':
      'ecf08b64fe1da432a218040fa45d4ecfbb3269d58cb018b12da5a2d854bf96be'},
 ]
 

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2023.05.001-intel-2023a.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2023.05.001-intel-2023a.eb
@@ -22,11 +22,11 @@ patches = [
     '%(name)s-%(version)s_fix_AVX512_support.patch',
 ]
 checksums = [
-    {'%(namelower)s-new_release_%(version)s.tar.gz':
+    {'elpa-new_release_2023.05.001.tar.gz':
      '7e07ca287ab07c0a73d97df71d5a5431c847b8e4d5c759aae99e12672e6decf3'},
-    {'%(name)s-%(version)s_fix_hardcoded_perl_path.patch':
+    {'ELPA-2023.05.001_fix_hardcoded_perl_path.patch':
      '0548105065777a2ed07dde306636251c4f96e555a801647564de37d1ddd7b0b5'},
-    {'%(name)s-%(version)s_fix_AVX512_support.patch':
+    {'ELPA-2023.05.001_fix_AVX512_support.patch':
      'ecf08b64fe1da432a218040fa45d4ecfbb3269d58cb018b12da5a2d854bf96be'},
 ]
 

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2023.11.001-foss-2023b.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2023.11.001-foss-2023b.eb
@@ -22,11 +22,11 @@ patches = [
     '%(name)s-2023.05.001_fix_AVX512_support.patch',
 ]
 checksums = [
-    {'%(namelower)s-new_release_%(version)s.tar.gz':
+    {'elpa-new_release_2023.11.001.tar.gz':
      'b8dd04e238dac23c1e910e8862370b1779b239eae4b871c9966bee578d40c750'},
-    {'%(name)s-2023.05.001_fix_hardcoded_perl_path.patch':
+    {'ELPA-2023.05.001_fix_hardcoded_perl_path.patch':
      '0548105065777a2ed07dde306636251c4f96e555a801647564de37d1ddd7b0b5'},
-    {'%(name)s-2023.05.001_fix_AVX512_support.patch':
+    {'ELPA-2023.05.001_fix_AVX512_support.patch':
      'ecf08b64fe1da432a218040fa45d4ecfbb3269d58cb018b12da5a2d854bf96be'},
 ]
 

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2023.11.001-intel-2023b.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2023.11.001-intel-2023b.eb
@@ -22,11 +22,11 @@ patches = [
     '%(name)s-2023.05.001_fix_AVX512_support.patch',
 ]
 checksums = [
-    {'%(namelower)s-new_release_%(version)s.tar.gz':
+    {'elpa-new_release_2023.11.001.tar.gz':
      'b8dd04e238dac23c1e910e8862370b1779b239eae4b871c9966bee578d40c750'},
-    {'%(name)s-2023.05.001_fix_hardcoded_perl_path.patch':
+    {'ELPA-2023.05.001_fix_hardcoded_perl_path.patch':
      '0548105065777a2ed07dde306636251c4f96e555a801647564de37d1ddd7b0b5'},
-    {'%(name)s-2023.05.001_fix_AVX512_support.patch':
+    {'ELPA-2023.05.001_fix_AVX512_support.patch':
      'ecf08b64fe1da432a218040fa45d4ecfbb3269d58cb018b12da5a2d854bf96be'},
 ]
 

--- a/easybuild/easyconfigs/g/Gurobi/Gurobi-11.0.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/Gurobi/Gurobi-11.0.0-GCCcore-12.3.0.eb
@@ -36,9 +36,9 @@ exts_list = [
     ('gurobipy', '11.0.0', {
         'sources': ['gurobipy-%(version)s-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_%(arch)s.whl'],
         'checksums': [{
-            'gurobipy-%(version)s-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_aarch64.whl':
+            'gurobipy-11.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_aarch64.whl':
                 '096f63ca02fbe810bae25311be598c9d8c5874362e85eac46ef0a4fdb3eaf96b',
-            'gurobipy-%(version)s-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl':
+            'gurobipy-11.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl':
                 'a98abda1cb45f548fff17370eb30cc6e187d04edc5d9984a68d194491598a993',
         }],
     }),

--- a/easybuild/easyconfigs/g/Gurobi/Gurobi-11.0.2-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/Gurobi/Gurobi-11.0.2-GCCcore-12.3.0.eb
@@ -38,9 +38,9 @@ exts_list = [
     ('gurobipy', version, {
         'sources': ['gurobipy-%(version)s-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_%(arch)s.whl'],
         'checksums': [{
-            'gurobipy-%(version)s-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_aarch64.whl':
+            'gurobipy-11.0.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_aarch64.whl':
                 '871e818026c8f288d7440fcd4b842becdf1006f43495fc4f6e3ec6d9b8ba3d7a',
-            'gurobipy-%(version)s-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl':
+            'gurobipy-11.0.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl':
                 '86265b7a9a8f3e531c1bbee6e61c1e7d0b68264e976795b4cf7aec68b9e66eb8',
         }],
     }),

--- a/easybuild/easyconfigs/l/LLVM/LLVM-16.0.6-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-16.0.6-GCCcore-12.3.0.eb
@@ -20,9 +20,9 @@ sources = [
     'third-party-%(version)s.src.tar.xz',
 ]
 checksums = [
-    {'llvm-%(version)s.src.tar.xz': 'e91db44d1b3bb1c33fcea9a7d1f2423b883eaa9163d3d56ca2aa6d2f0711bc29'},
-    {'cmake-%(version)s.src.tar.xz': '39d342a4161095d2f28fb1253e4585978ac50521117da666e2b1f6f28b62f514'},
-    {'third-party-%(version)s.src.tar.xz': '15f5b9aeeba938530af977d5f9205612737a091a7f0f6c8075df8723b7713f70'},
+    {'llvm-16.0.6.src.tar.xz': 'e91db44d1b3bb1c33fcea9a7d1f2423b883eaa9163d3d56ca2aa6d2f0711bc29'},
+    {'cmake-16.0.6.src.tar.xz': '39d342a4161095d2f28fb1253e4585978ac50521117da666e2b1f6f28b62f514'},
+    {'third-party-16.0.6.src.tar.xz': '15f5b9aeeba938530af977d5f9205612737a091a7f0f6c8075df8723b7713f70'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.2-gompi-2024a.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.2-gompi-2024a.eb
@@ -14,7 +14,7 @@ sources = ['v%(version)s.tar.gz']
 patches = ['%(name)s-%(version_major_minor)s.0_skip-nasa-test.patch']
 checksums = [
     {'v4.9.2.tar.gz': 'bc104d101278c68b303359b3dc4192f81592ae8640f1aee486921138f7f88cb7'},
-    {'%(name)s-%(version_major_minor)s.0_skip-nasa-test.patch':
+    {'netCDF-4.9.2.0_skip-nasa-test.patch':
      '19d99e03c048b037dc01f03f5b8ddc910ebaceb076d0f050540d348f26dfcd2a'},
 ]
 

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.2-gompi-2024a.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.2-gompi-2024a.eb
@@ -14,7 +14,7 @@ sources = ['v%(version)s.tar.gz']
 patches = ['%(name)s-%(version_major_minor)s.0_skip-nasa-test.patch']
 checksums = [
     {'v4.9.2.tar.gz': 'bc104d101278c68b303359b3dc4192f81592ae8640f1aee486921138f7f88cb7'},
-    {'netCDF-4.9.2.0_skip-nasa-test.patch':
+    {'netCDF-4.9.0_skip-nasa-test.patch':
      '19d99e03c048b037dc01f03f5b8ddc910ebaceb076d0f050540d348f26dfcd2a'},
 ]
 

--- a/easybuild/easyconfigs/o/OpenCV/OpenCV-4.8.1-foss-2023a-CUDA-12.1.1-contrib.eb
+++ b/easybuild/easyconfigs/o/OpenCV/OpenCV-4.8.1-foss-2023a-CUDA-12.1.1-contrib.eb
@@ -36,8 +36,8 @@ sources = [
 patches = [('opencv_contrib_python.egg-info', '..')]
 
 checksums = [
-    {'%(namelower)s-%(version)s.tar.gz': '62f650467a60a38794d681ae7e66e3e8cfba38f445e0bf87867e2f2cdc8be9d5'},
-    {'%(namelower)s_contrib-%(version)s.tar.gz': '0c082a0b29b3118f2a0a1856b403bb098643af7b994a0080f402a12159a99c6e'},
+    {'opencv-4.8.1.tar.gz': '62f650467a60a38794d681ae7e66e3e8cfba38f445e0bf87867e2f2cdc8be9d5'},
+    {'opencv_contrib-4.8.1.tar.gz': '0c082a0b29b3118f2a0a1856b403bb098643af7b994a0080f402a12159a99c6e'},
     {'ippicv_2021.8_lnx_intel64_20230330_general.tgz':
      '7cfe0fb0e15ea8f3d2d971c19df2d14382469943d4efa85e48bf358930daa85d'},
     {'opencv_contrib_python.egg-info': '08eb95c735d4ff82e35e3df56c2e7e75501cc263a8efcb9348d04e6322a4b034'},

--- a/easybuild/easyconfigs/o/OpenCV/OpenCV-4.8.1-foss-2023a-contrib.eb
+++ b/easybuild/easyconfigs/o/OpenCV/OpenCV-4.8.1-foss-2023a-contrib.eb
@@ -33,8 +33,8 @@ sources = [
 ]
 patches = [('opencv_contrib_python.egg-info', '..')]
 checksums = [
-    {'%(namelower)s-%(version)s.tar.gz': '62f650467a60a38794d681ae7e66e3e8cfba38f445e0bf87867e2f2cdc8be9d5'},
-    {'%(namelower)s_contrib-%(version)s.tar.gz': '0c082a0b29b3118f2a0a1856b403bb098643af7b994a0080f402a12159a99c6e'},
+    {'opencv-4.8.1.tar.gz': '62f650467a60a38794d681ae7e66e3e8cfba38f445e0bf87867e2f2cdc8be9d5'},
+    {'opencv_contrib-4.8.1.tar.gz': '0c082a0b29b3118f2a0a1856b403bb098643af7b994a0080f402a12159a99c6e'},
     {'ippicv_2021.8_lnx_intel64_20230330_general.tgz':
      '7cfe0fb0e15ea8f3d2d971c19df2d14382469943d4efa85e48bf358930daa85d'},
     {'opencv_contrib_python.egg-info': '08eb95c735d4ff82e35e3df56c2e7e75501cc263a8efcb9348d04e6322a4b034'},

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-11-foss-2022a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-11-foss-2022a.eb
@@ -14,8 +14,8 @@ source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version_major)s/archive']
 sources = ['version-%(version)s.tar.gz']
 patches = ['OpenFOAM-11-ThirdParty.patch']
 checksums = [
-    {'version-%(version)s.tar.gz': 'ebc0f86ead699abba61290ba8aac5b730aa93256e675d1d93a5d5f116d51e0c0'},
-    {'OpenFOAM-%(version)s-ThirdParty.patch': '7c526be93a0e241584c849cdcda682c23d1a87f23b1a06eae2fa8372a2cab415'},
+    {'version-11.tar.gz': 'ebc0f86ead699abba61290ba8aac5b730aa93256e675d1d93a5d5f116d51e0c0'},
+    {'OpenFOAM-11-ThirdParty.patch': '7c526be93a0e241584c849cdcda682c23d1a87f23b1a06eae2fa8372a2cab415'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-11-foss-2023a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-11-foss-2023a.eb
@@ -14,8 +14,8 @@ source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version_major)s/archive']
 sources = ['version-%(version)s.tar.gz']
 patches = ['OpenFOAM-11-ThirdParty.patch']
 checksums = [
-    {'version-%(version)s.tar.gz': 'ebc0f86ead699abba61290ba8aac5b730aa93256e675d1d93a5d5f116d51e0c0'},
-    {'OpenFOAM-%(version)s-ThirdParty.patch': '7c526be93a0e241584c849cdcda682c23d1a87f23b1a06eae2fa8372a2cab415'},
+    {'version-11.tar.gz': 'ebc0f86ead699abba61290ba8aac5b730aa93256e675d1d93a5d5f116d51e0c0'},
+    {'OpenFOAM-11-ThirdParty.patch': '7c526be93a0e241584c849cdcda682c23d1a87f23b1a06eae2fa8372a2cab415'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb
@@ -2056,22 +2056,6 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/W/WS/WSNYDER'],
         'checksums': ['3973ebdc44682c9c15c776f66e8be242cb4ff1dd52caf43ff446b74d4dccca06'],
     }),
-    ('Sys::Info::Driver::Linux::Device::CPU', '0.7905', {
-        'source_tmpl': 'Sys-Info-Driver-Linux-%(version)s.tar.gz',
-        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BU/BURAK'],
-        'patches': [
-            ('Perl-bundle-5.36.1-debian-release.patch'),
-            ('Perl-bundle-5.36.1-pod.patch'),
-        ],
-        'checksums': [
-            {'Sys-Info-Driver-Linux-%(version)s.tar.gz':
-             '899c329bd3508ec5849ad0e5dadfa7c3679bbacaea9dda12404a7893032e8b7b'},
-            {'Perl-bundle-5.36.1-debian-release.patch':
-             '18b8d876db5b3abe7e5a1bb8c6abf8b5fef481b56294472fcf9f96f974c56c48'},
-            {'Perl-bundle-5.36.1-pod.patch':
-             '7c70bd91a06c256a8d85845e011e53a1a9d4f8a250d9f06bd06f5004596f271a'},
-        ],
-    }),
     ('Sys::Info', '0.7811', {
         'source_tmpl': 'Sys-Info-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BU/BURAK'],

--- a/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb
@@ -2125,7 +2125,7 @@ exts_list = [
             ('Perl-bundle-5.36.1-pod.patch'),
         ],
         'checksums': [
-            {'Sys-Info-Driver-Linux-%(version)s.tar.gz':
+            {'Sys-Info-Driver-Linux-0.7905.tar.gz':
              '899c329bd3508ec5849ad0e5dadfa7c3679bbacaea9dda12404a7893032e8b7b'},
             {'Perl-bundle-5.36.1-debian-release.patch':
              '18b8d876db5b3abe7e5a1bb8c6abf8b5fef481b56294472fcf9f96f974c56c48'},

--- a/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb
@@ -2056,6 +2056,22 @@ exts_list = [
         'source_urls': ['https://cpan.metacpan.org/authors/id/W/WS/WSNYDER'],
         'checksums': ['3973ebdc44682c9c15c776f66e8be242cb4ff1dd52caf43ff446b74d4dccca06'],
     }),
+    ('Sys::Info::Driver::Linux', '0.7905', {
+        'source_tmpl': 'Sys-Info-Driver-Linux-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BU/BURAK'],
+        'patches': [
+            ('Perl-bundle-5.36.1-debian-release.patch'),
+            ('Perl-bundle-5.36.1-pod.patch'),
+        ],
+        'checksums': [
+            {'Sys-Info-Driver-Linux-0.7905.tar.gz':
+             '899c329bd3508ec5849ad0e5dadfa7c3679bbacaea9dda12404a7893032e8b7b'},
+            {'Perl-bundle-5.36.1-debian-release.patch':
+             '18b8d876db5b3abe7e5a1bb8c6abf8b5fef481b56294472fcf9f96f974c56c48'},
+            {'Perl-bundle-5.36.1-pod.patch':
+             '7c70bd91a06c256a8d85845e011e53a1a9d4f8a250d9f06bd06f5004596f271a'},
+        ],
+    }),
     ('Sys::Info', '0.7811', {
         'source_tmpl': 'Sys-Info-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BU/BURAK'],
@@ -2100,22 +2116,6 @@ exts_list = [
         'source_tmpl': 'Sys-Info-Driver-Unknown-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BU/BURAK'],
         'checksums': ['02408843c8e36ea3d507e9f33fee48d6908543829ebe320f13d1bfe76af31e09'],
-    }),
-    ('Sys::Info::Driver::Linux', '0.7905', {
-        'source_tmpl': 'Sys-Info-Driver-Linux-%(version)s.tar.gz',
-        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BU/BURAK'],
-        'patches': [
-            ('Perl-bundle-5.36.1-debian-release.patch'),
-            ('Perl-bundle-5.36.1-pod.patch'),
-        ],
-        'checksums': [
-            {'Sys-Info-Driver-Linux-0.7905.tar.gz':
-             '899c329bd3508ec5849ad0e5dadfa7c3679bbacaea9dda12404a7893032e8b7b'},
-            {'Perl-bundle-5.36.1-debian-release.patch':
-             '18b8d876db5b3abe7e5a1bb8c6abf8b5fef481b56294472fcf9f96f974c56c48'},
-            {'Perl-bundle-5.36.1-pod.patch':
-             '7c70bd91a06c256a8d85845e011e53a1a9d4f8a250d9f06bd06f5004596f271a'},
-        ],
     }),
     ('Unix::Processors', '2.046', {
         'source_tmpl': 'Unix-Processors-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/p/pyiron/pyiron-0.5.1-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/pyiron/pyiron-0.5.1-foss-2023a.eb
@@ -94,7 +94,7 @@ exts_list = [
         'patches': ['pyiron-0.5.1_fix-pylammpsmpi.patch'],
         'source_urls': ['https://github.com/pyiron/pylammpsmpi/archive/refs/tags/'],
         'checksums': [
-            {'%(name)s-%(version)s.tar.gz': 'bd5af29a935dacbee743c3cc0bcc799e24e7c2483801f56cb9092a79f016f2ed'},
+            {'pylammpsmpi-0.2.10.tar.gz': 'bd5af29a935dacbee743c3cc0bcc799e24e7c2483801f56cb9092a79f016f2ed'},
             {'pyiron-0.5.1_fix-pylammpsmpi.patch':
              'd7cacf8eb73cb43e47526bfa3f98157073c01cd88918f191f87d7e75ab4c7c30'},
         ],

--- a/easybuild/easyconfigs/p/pytesseract/pytesseract-0.3.10-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/p/pytesseract/pytesseract-0.3.10-GCCcore-11.3.0.eb
@@ -20,7 +20,7 @@ toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 sources = [SOURCELOWER_TAR_GZ]
 patches = ['pytesseract-0.3.10_relax-packaging-version-requirements.patch']
 checksums = [
-    {SOURCELOWER_TAR_GZ: 'f1c3a8b0f07fd01a1085d451f5b8315be6eec1d5577a6796d46dc7a62bd4120f'},
+    {'pytesseract-0.3.10.tar.gz': 'f1c3a8b0f07fd01a1085d451f5b8315be6eec1d5577a6796d46dc7a62bd4120f'},
     {'pytesseract-0.3.10_relax-packaging-version-requirements.patch':
      '17bcf10055dd421572654b8da3a7899115c0eb50ec32bb6ab58371d16530f8c6'},
 ]

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.2-foss-2023a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.2-foss-2023a.eb
@@ -27,8 +27,8 @@ sources = [
     },
 ]
 checksums = [
-    {'q-e-qe-%(version)s.tar.gz': 'b348a4a7348b66a73545d9ca317a2645755c98d343c1cfe8def475ad030808c0'},
-    {'qe-gipaw-%(version)s.tar.gz': '3375e6e8242b9d0a1ebf9ff9ac1111f4cc5c95d3f654bc2534c396b3b4e59a2f'},
+    {'q-e-qe-7.2.tar.gz': 'b348a4a7348b66a73545d9ca317a2645755c98d343c1cfe8def475ad030808c0'},
+    {'qe-gipaw-7.2.tar.gz': '3375e6e8242b9d0a1ebf9ff9ac1111f4cc5c95d3f654bc2534c396b3b4e59a2f'},
     {'wannier90-3.1.0.tar.gz': '40651a9832eb93dec20a8360dd535262c261c34e13c41b6755fa6915c936b254'},
 ]
 

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-foss-2023a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-foss-2023a.eb
@@ -30,8 +30,8 @@ sources = [
     },
 ]
 checksums = [
-    {'q-e-qe-%(version)s.tar.gz': 'edc2a0f3315c69966df4f82ec86ab9f682187bc9430ef6d2bacad5f27f08972c'},
-    {'qe-gipaw-%(version)s.tar.gz': 'a24d328ec068043d36fdf69fe4f8d1904d7befeba7962cb85be059ea0fe6f026'},
+    {'q-e-qe-7.3.tar.gz': 'edc2a0f3315c69966df4f82ec86ab9f682187bc9430ef6d2bacad5f27f08972c'},
+    {'qe-gipaw-7.3.tar.gz': 'a24d328ec068043d36fdf69fe4f8d1904d7befeba7962cb85be059ea0fe6f026'},
     {'wannier90-3.1.0.tar.gz': '40651a9832eb93dec20a8360dd535262c261c34e13c41b6755fa6915c936b254'},
 ]
 

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-intel-2023a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3-intel-2023a.eb
@@ -30,8 +30,8 @@ sources = [
     },
 ]
 checksums = [
-    {'q-e-qe-%(version)s.tar.gz': 'edc2a0f3315c69966df4f82ec86ab9f682187bc9430ef6d2bacad5f27f08972c'},
-    {'qe-gipaw-%(version)s.tar.gz': 'a24d328ec068043d36fdf69fe4f8d1904d7befeba7962cb85be059ea0fe6f026'},
+    {'q-e-qe-7.3.tar.gz': 'edc2a0f3315c69966df4f82ec86ab9f682187bc9430ef6d2bacad5f27f08972c'},
+    {'qe-gipaw-7.3.tar.gz': 'a24d328ec068043d36fdf69fe4f8d1904d7befeba7962cb85be059ea0fe6f026'},
     {'wannier90-3.1.0.tar.gz': '40651a9832eb93dec20a8360dd535262c261c34e13c41b6755fa6915c936b254'},
 ]
 

--- a/easybuild/easyconfigs/r/Ray-project/Ray-project-2.9.1-foss-2023a.eb
+++ b/easybuild/easyconfigs/r/Ray-project/Ray-project-2.9.1-foss-2023a.eb
@@ -47,10 +47,10 @@ exts_list = [
     ('Ray', version, {
         'source_tmpl': '%(namelower)s-%(version)s-cp311-cp311-manylinux2014_%(arch)s.whl',
         'checksums': [{
-            '%(namelower)s-%(version)s-cp311-cp311-manylinux2014_x86_64.whl': (
+            'ray-2.9.1-cp311-cp311-manylinux2014_x86_64.whl': (
                 'fabc520990c1b98dde592813d62737e5e817460e0ac359f32ba029ace292cbe2'
             ),
-            '%(namelower)s-%(version)s-cp311-cp311-manylinux2014_aarch64.whl': (
+            'ray-2.9.1-cp311-cp311-manylinux2014_aarch64.whl': (
                 '1907649d69efdc1b9ffbc03db086f6d768216cb73908ebd4038ac5030effef9e'
             ),
         }],

--- a/easybuild/easyconfigs/s/STAR/STAR-2.7.11a-GCC-12.2.0.eb
+++ b/easybuild/easyconfigs/s/STAR/STAR-2.7.11a-GCC-12.2.0.eb
@@ -20,8 +20,8 @@ source_urls = [GITHUB_SOURCE]
 sources = ['%(version)s.tar.gz']
 patches = ['STAR-%(version)s_use-external-htslib.patch']
 checksums = [
-    {'%(version)s.tar.gz': '542457b1a4fee73f27a581b1776e9f73ad2b4d7e790388b6dc71147bd039f99a'},
-    {'STAR-%(version)s_use-external-htslib.patch': '2fdc3ed9372d983f77d861d6f16a60a553598358dce9ff8216f96eb20e63ce4e'},
+    {'2.7.11a.tar.gz': '542457b1a4fee73f27a581b1776e9f73ad2b4d7e790388b6dc71147bd039f99a'},
+    {'STAR-2.7.11a_use-external-htslib.patch': '2fdc3ed9372d983f77d861d6f16a60a553598358dce9ff8216f96eb20e63ce4e'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/s/STAR/STAR-2.7.11a-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/s/STAR/STAR-2.7.11a-GCC-12.3.0.eb
@@ -20,8 +20,8 @@ source_urls = [GITHUB_SOURCE]
 sources = ['%(version)s.tar.gz']
 patches = ['STAR-%(version)s_use-external-htslib.patch']
 checksums = [
-    {'%(version)s.tar.gz': '542457b1a4fee73f27a581b1776e9f73ad2b4d7e790388b6dc71147bd039f99a'},
-    {'STAR-%(version)s_use-external-htslib.patch': '2fdc3ed9372d983f77d861d6f16a60a553598358dce9ff8216f96eb20e63ce4e'},
+    {'2.7.11a.tar.gz': '542457b1a4fee73f27a581b1776e9f73ad2b4d7e790388b6dc71147bd039f99a'},
+    {'STAR-2.7.11a_use-external-htslib.patch': '2fdc3ed9372d983f77d861d6f16a60a553598358dce9ff8216f96eb20e63ce4e'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/w/wget/wget-1.21.4-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/w/wget/wget-1.21.4-GCCcore-12.2.0.eb
@@ -13,7 +13,7 @@ toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = [
-    {SOURCE_TAR_GZ: '81542f5cefb8faacc39bbbc6c82ded80e3e4a88505ae72ea51df27525bcde04c'},
+    {'wget-1.21.4.tar.gz': '81542f5cefb8faacc39bbbc6c82ded80e3e4a88505ae72ea51df27525bcde04c'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/w/wget/wget-1.21.4-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/w/wget/wget-1.21.4-GCCcore-13.2.0.eb
@@ -13,7 +13,7 @@ toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = [
-    {SOURCE_TAR_GZ: '81542f5cefb8faacc39bbbc6c82ded80e3e4a88505ae72ea51df27525bcde04c'},
+    {'wget-1.21.4.tar.gz': '81542f5cefb8faacc39bbbc6c82ded80e3e4a88505ae72ea51df27525bcde04c'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/w/wget/wget-1.24.5-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/w/wget/wget-1.24.5-GCCcore-12.3.0.eb
@@ -13,7 +13,7 @@ toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = [
-    {SOURCE_TAR_GZ: 'fa2dc35bab5184ecbc46a9ef83def2aaaa3f4c9f3c97d4bd19dcb07d4da637de'},
+    {'wget-1.21.4.tar.gz': 'fa2dc35bab5184ecbc46a9ef83def2aaaa3f4c9f3c97d4bd19dcb07d4da637de'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/w/wget/wget-1.24.5-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/w/wget/wget-1.24.5-GCCcore-12.3.0.eb
@@ -13,7 +13,7 @@ toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = [
-    {'wget-1.21.4.tar.gz': 'fa2dc35bab5184ecbc46a9ef83def2aaaa3f4c9f3c97d4bd19dcb07d4da637de'},
+    {'wget-1.24.5.tar.gz': 'fa2dc35bab5184ecbc46a9ef83def2aaaa3f4c9f3c97d4bd19dcb07d4da637de'},
 ]
 
 builddependencies = [


### PR DESCRIPTION
There are more cases for things that do nested dicts with arch specific binary source tarballs. I started changing those as well, but there were a lot and it seems to work anyway, so i'm not sure if we should "fix" those as well.
They are all cases where a normal --inject-checksums wouldn't work (due to multiple source variants).

edit: fixes #22090