### PR TITLE
update action/cache

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Cache source files in /tmp/sources
       id: cache-sources
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: /tmp/sources
         key: eb-sourcepath


### PR DESCRIPTION
https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/

> Starting February 1st, 2025, Actions’ cache storage will move to a new architecture, resulting in the deprecation of v1-v2 of [actions/cache](https://github.com/actions/cache). Attempting to use a version of the action after the announced deprecation date will result in a workflow failure. Please note: if you are pinned to a specific version or SHA of the action, your workflows will also fail after February 1st. We strongly encourage you to update your workflows to begin using v3 or v4 of actions/cache as soon as possible.