### PR TITLE
adding easyconfigs: ORCA-6.0.1-gompi-2023b.eb

### DIFF
--- a/easybuild/easyconfigs/o/ORCA/ORCA-6.0.1-gompi-2023b.eb
+++ b/easybuild/easyconfigs/o/ORCA/ORCA-6.0.1-gompi-2023b.eb
@@ -1,0 +1,23 @@
+name = 'ORCA'
+version = '6.0.1'
+
+homepage = 'https://orcaforum.kofo.mpg.de'
+description = """
+ORCA is a flexible, efficient and easy-to-use general purpose tool for quantum
+chemistry with specific emphasis on spectroscopic properties of open-shell
+molecules. It features a wide variety of standard quantum chemical methods
+ranging from semiempirical methods to DFT to single- and multireference
+correlated ab initio methods. It can also treat environmental and relativistic
+effects."""
+
+toolchain = {'name': 'gompi', 'version': '2023b'}
+
+download_instructions = "Shared build of ORCA: download from https://orcaforum.kofo.mpg.de"
+# mostly dynamically linked (SCALAPACK, OpenBLAS are still embedded)
+sources = ['%%(namelower)s_%s_linux_%%(orcaarch)s_shared_openmpi416.tar.xz' % version.replace('.', '_')]
+checksums = [
+    # orca_6_0_0_linux_x86-64_shared_openmpi416.tar.xz
+    '5e9b49588375e0ce5bc32767127cc725f5425917804042cdecdfd5c6b965ef61'
+]
+
+moduleclass = 'chem'


### PR DESCRIPTION
I saw avx2 only versions but needed to build this for our users.
Built successfully this one.