### PR TITLE
{perf}[iimpi/2024a] Add Score-P 8.4 (w/ CUDA 12.6.0)

### DIFF
--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-iimpi-2024a-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-iimpi-2024a-CUDA-12.6.0.eb
@@ -27,6 +27,9 @@ sources = ['scorep-%(version)s.tar.gz']
 checksums = ['7bbde9a0721d27cc6205baf13c1626833bcfbabb1f33b325a2d67976290f7f8a']
 
 dependencies = [
+    # Explicitly add binutils dependency for EasyBlock to set libbfd paths.
+    # Score-P requires libbfd for resolving addresses to line numbers.
+    ('binutils', '2.42'),
     ('CUDA', '12.6.0', '', SYSTEM),
     ('UCX-CUDA', '1.16.0', versionsuffix),
     ('CubeLib', '4.8.2'),

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-iimpi-2024a-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-iimpi-2024a-CUDA-12.6.0.eb
@@ -1,0 +1,66 @@
+# Copyright 2013-2025 Juelich Supercomputing Centre, Germany
+# Copyright 2020-2024 TU Dresden, Germany
+# Authors::
+# * Bernd Mohr <b.mohr@fz-juelich.de>
+# * Markus Geimer <m.geimer@fz-juelich.de>
+# * Alexander Grund <alexander.grund@tu-dresden.de>
+# * Robert Mijakovic <robert.mijakovic@lxp.lu>
+# * Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+
+name = 'Score-P'
+version = '8.4'
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = 'https://www.score-p.org'
+description = """
+ The Score-P measurement infrastructure is a highly scalable and easy-to-use
+ tool suite for profiling, event tracing, and online analysis of HPC
+ applications.
+"""
+
+toolchain = {'name': 'iimpi', 'version': '2024a'}
+toolchainopts = {'oneapi': True}
+
+source_urls = ['https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources = ['scorep-%(version)s.tar.gz']
+checksums = ['7bbde9a0721d27cc6205baf13c1626833bcfbabb1f33b325a2d67976290f7f8a']
+
+dependencies = [
+    ('CUDA', '12.6.0', '', SYSTEM),
+    ('UCX-CUDA', '1.16.0', versionsuffix),
+    ('CubeLib', '4.8.2'),
+    ('CubeWriter', '4.8.2'),
+    ('libunwind', '1.8.1'),
+    ('OPARI2', '2.0.8'),
+    ('OTF2', '3.0.3'),
+    # Hardware counter support (optional):
+    ('PAPI', '7.1.0'),
+    # PDT source-to-source instrumentation support (optional):
+    ('PDT', '3.25.2'),
+]
+
+# NVIDIA does not officially suppport the oneAPI based Intel compilers.
+# However, one might still run NVIDIA GPU accelerated code, e.g. via SYCL.
+# Since the Score-P EasyBlock adds '--enable-cuda' when CUDA is passed
+# as a dependency, 'configure' will abort if the compiler is not supported.
+# To work around this, set 'NVCC_PREPEND_FLAGS' to allow the oneAPI Intel
+# compilers to pass.
+preconfigopts = 'NVCC_PREPEND_FLAGS="-allow-unsupported-compiler"'
+configopts = '--enable-shared'
+
+local_adapters = [
+    'compiler_event', 'cuda_mgmt', 'compiler_mgmt', 'mpi_event', 'mpi_mgmt', 'opari2_mgmt', 'user_event', 'user_mgmt'
+]
+sanity_check_paths = {
+    'files':
+        ['bin/scorep', 'include/scorep/SCOREP_User.h'] +
+        ['lib/libscorep_adapter_%s.%s' % (a, e) for a in local_adapters for e in ('a', SHLIB_EXT)],
+    'dirs': [],
+}
+sanity_check_commands = ['scorep-config --help']
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-iimpi-2024a.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-iimpi-2024a.eb
@@ -26,6 +26,9 @@ sources = ['scorep-%(version)s.tar.gz']
 checksums = ['7bbde9a0721d27cc6205baf13c1626833bcfbabb1f33b325a2d67976290f7f8a']
 
 dependencies = [
+    # Explicitly add binutils dependency for EasyBlock to set libbfd paths.
+    # Score-P requires libbfd for resolving addresses to line numbers.
+    ('binutils', '2.42'),
     ('CubeLib', '4.8.2'),
     ('CubeWriter', '4.8.2'),
     ('libunwind', '1.8.1'),

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-iimpi-2024a.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-iimpi-2024a.eb
@@ -1,0 +1,56 @@
+# Copyright 2013-2025 Juelich Supercomputing Centre, Germany
+# Copyright 2020-2024 TU Dresden, Germany
+# Authors::
+# * Bernd Mohr <b.mohr@fz-juelich.de>
+# * Markus Geimer <m.geimer@fz-juelich.de>
+# * Alexander Grund <alexander.grund@tu-dresden.de>
+# * Robert Mijakovic <robert.mijakovic@lxp.lu>
+# * Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+
+name = 'Score-P'
+version = '8.4'
+
+homepage = 'https://www.score-p.org'
+description = """
+ The Score-P measurement infrastructure is a highly scalable and easy-to-use
+ tool suite for profiling, event tracing, and online analysis of HPC
+ applications.
+"""
+
+toolchain = {'name': 'iimpi', 'version': '2024a'}
+toolchainopts = {'oneapi': True}
+
+source_urls = ['https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources = ['scorep-%(version)s.tar.gz']
+checksums = ['7bbde9a0721d27cc6205baf13c1626833bcfbabb1f33b325a2d67976290f7f8a']
+
+dependencies = [
+    ('CubeLib', '4.8.2'),
+    ('CubeWriter', '4.8.2'),
+    ('libunwind', '1.8.1'),
+    ('OPARI2', '2.0.8'),
+    ('OTF2', '3.0.3'),
+    # Hardware counter support (optional):
+    ('PAPI', '7.1.0'),
+    # PDT source-to-source instrumentation support (optional):
+    ('PDT', '3.25.2'),
+]
+
+configopts = '--enable-shared'
+
+local_adapters = [
+    'compiler_event', 'compiler_mgmt', 'mpi_event', 'mpi_mgmt', 'opari2_mgmt', 'user_event', 'user_mgmt'
+]
+sanity_check_paths = {
+    'files':
+        ['bin/scorep', 'include/scorep/SCOREP_User.h'] +
+        ['lib/libscorep_adapter_%s.%s' % (a, e) for a in local_adapters for e in ('a', SHLIB_EXT)],
+    'dirs': [],
+}
+sanity_check_commands = ['scorep-config --help']
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'


### PR DESCRIPTION
Add Intel variant of Score-P 8.4 built for oneAPI compilers with and without CUDA support.

Depends:
- [x] https://github.com/easybuilders/easybuild-easyblocks/pull/3548

Due to dependency targeting `5.0.x`, this PR also targets `5.0.x`. See: https://github.com/easybuilders/easybuild-easyblocks/pull/3548#issuecomment-2582289086