### PR TITLE
fix setuptools issue by sticking to a single version in ReFrame 4.3.3 easyconfig

### DIFF
--- a/easybuild/easyconfigs/r/ReFrame/ReFrame-4.3.3.eb
+++ b/easybuild/easyconfigs/r/ReFrame/ReFrame-4.3.3.eb
@@ -32,6 +32,10 @@ exts_list = [
         'preinstallopts': "export PATH=%(installdir)s/bin:$PATH && "
                           # use PyYAML 6.0.1 to solve Cython 3 incompatibility issues
                           "sed -i 's@PyYAML==6.0@PyYAML==6.0.1@' requirements.txt && "
+                          # use the same setuptools version n the requirements.txt of the docs
+                          # to prevent jsonschema from installating the latest setuptools as well
+                          "echo \"setuptools==59.6.0; python_version == '3.6'\" >> docs/requirements.txt && "
+                          "echo \"setuptools==67.8.0; python_version >= '3.7'\" >> docs/requirements.txt && "
                           "./bootstrap.sh +docs +pygelf && cp -r external %(installdir)s && "
                           "PYTHONPATH=%(builddir)s/reframe/reframe-%(version)s/external:$PYTHONPATH ",
         'source_tmpl': 'v%(version)s.tar.gz',


### PR DESCRIPTION
I was trying to install ReFrame 4.3.3 in EESSI, in the same way (same easyconfig, same EB version) as we had done before, but it's now failing because of:

```
ImportError: cannot import name 'splat' from 'jaraco.functools' (/cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/usr/lib/python3.11/site-packages/jaraco/functools.py)
```

This is probably related to https://github.com/pypa/setuptools/issues/4665, and it's caused by the ReFrame bootstrap.sh doing two `pip install`s with https://github.com/reframe-hpc/reframe/blob/v4.3.3/requirements.txt and https://github.com/reframe-hpc/reframe/blob/v4.3.3/docs/requirements.txt. The first already installs `setuptools`, but the latter has jsonschema, which has a `setuptools>= 40.6.0` requirement (https://github.com/python-jsonschema/jsonschema/blob/v3.2.0/pyproject.toml). Together with the `--upgrade` flag used by `bootstrap.sh`, this results in another `setuptools` version being installed, and basically the latest one that's available at that time (and the current one apparently has this `jaraco.functools` issue).

The fix in this PR ensures that both requirements file use the same fixed version of setuptools.