### PR TITLE
MFiX/24.4.1-intel-2023b

### DIFF
--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
@@ -37,19 +37,21 @@ configopts = '-DENABLE_MPI=1'
 
 separate_build_dir = False
 
-test_cmd = ' && '.join([
-    'cd tutorials/dem/mixer_3d',
-    '%(builddir)s/%(namelower)s-%(version)s/mfixsolver_dmp -f mixer_dem_3d.mfx',
-])
-
 postinstallcmds = [
     'mkdir -p %(installdir)s/bin',
     'mv %(installdir)s/mfixsolver_dmp %(installdir)s/bin/mfixsolver_dmp',
 ]
 
+test_cmd = ' && '.join([
+    'cd tutorials/dem/mixer_3d',
+    '%(builddir)s/%(namelower)s-%(version)s/mfixsolver_dmp -f mixer_dem_3d.mfx',
+])
+
 sanity_check_paths = {
     'files': ['bin/mfixsolver_dmp'],
     'dirs': [],
 }
+
+sanity_check_commands = [('mfixsolver_dmp --help')]
 
 moduleclass = 'cae'

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
@@ -28,28 +28,23 @@ builddependencies = [
 ]
 
 configopts = ' '.join([
-    '-DCMAKE_BUILD_TYPE=RelWithDebInfo',
     '-DENABLE_MPI=1',
     '-DCMAKE_Fortran_COMPILER=mpiifort',
     '-DCMAKE_C_COMPILER=mpiicc',
     '-DCMAKE_CXX_COMPILER=mpiicpc',
-    '-DCMAKE_Fortran_FLAGS="-O2 -Wall -fcheck=all"',
+    '-DCMAKE_Fortran_FLAGS="-O2 -Wall"',
 ])
 
 separate_build_dir = False
 
 test_cmd = ' && '.join([
     'cd tutorials/dem/mixer_3d',
-    '%(installdir)s/mfixsolver_dmp -f mixer_dem_3d.mfx',
+    '%(builddir)s/%(namelower)s-%(version)s/mfixsolver_dmp -f mixer_dem_3d.mfx',
 ])
 
 sanity_check_paths = {
     'files': ['mfixsolver_dmp'],
     'dirs': [],
 }
-
-postinstallcmds = [
-    'chmod o-rwx %(installdir)s',
-]
 
 moduleclass = 'cae'

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
@@ -1,0 +1,47 @@
+# Author: Ehsan Moravveji (VSC, KU Leuven)
+
+easyblock = 'CMakeMake'
+
+name = 'MFiX'
+version = '24.3'
+
+homepage = 'https://mfix.netl.doe.gov/products/mfix/'
+description = 'The National Energy Technology Laboratory’s (NETL’s) computational fluid dynamics (CFD) code, MFiX —Multiphase Flow with Interphase eXchanges— is central to the laboratory’s multiphase flow reactor modeling efforts. This open-source software has over three decades of development history and more than 7,000 registered users worldwide. MFiX has become the standard for comparing, implementing, and evaluating multiphase flow constitutive models and has been applied to an extremely diverse range of multiphase flows applications. The successes achieved in modeling complex multiphase flow systems have led to new and improved key attributes such as drag, polydispersity, attrition, and agglomeration models, among other significant advances.'
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+toolchainopts = {'usempi': True}
+
+sources = ['%(namelower)s-%(version)s.tar.gz']
+checksums = ['d6313d02b4631a6b2eef944c158bb7b1a2eecfe7bcee9f533ce71571f1acffe8']
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('binutils', '2.40'),
+]
+
+configopts = ' '.join([
+    '-DCMAKE_BUILD_TYPE=RelWithDebInfo',
+    '-DENABLE_MPI=1',
+    '-DCMAKE_Fortran_COMPILER=mpiifort',
+    '-DCMAKE_C_COMPILER=mpiicc',
+    '-DCMAKE_CXX_COMPILER=mpiicpc',
+    '-DCMAKE_Fortran_FLAGS="-O2 -Wall -fcheck=all"',
+])
+
+separate_build_dir = False
+
+test_cmd = ' && '.join([
+    'cd tutorials/dem/mixer_3d',
+    '%(installdir)s/mfixsolver_dmp -f mixer_dem_3d.mfx',
+])
+
+sanity_check_paths = {
+   'files': ['mfixsolver_dmp'],
+   'dirs': [],
+}
+
+postinstallcmds = [
+    'chmod o-rwx %(installdir)s',
+]
+
+moduleclass = 'cae'

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
@@ -8,12 +8,12 @@ version = '24.3'
 homepage = 'https://mfix.netl.doe.gov/products/mfix/'
 description = """
 The National Energy Technology Laboratory’s (NETL’s) computational fluid dynamics (CFD) code, 
-MFiX-Multiphase Flow with Interphase eXchanges - is central to the laboratory’s multiphase flow reactor modeling efforts. 
-This open-source software has over three decades of development history and more than 7,000 registered users worldwide. 
-MFiX has become the standard for comparing, implementing, and evaluating multiphase flow constitutive models 
-and has been applied to an extremely diverse range of multiphase flows applications. The successes achieved in 
-modeling complex multiphase flow systems have led to new and improved key attributes such as drag, polydispersity, 
-attrition, and agglomeration models, among other significant advances.
+MFiX-Multiphase Flow with Interphase eXchanges - is central to the laboratory’s multiphase flow reactor 
+modeling efforts. This open-source software has over three decades of development history and more than 7,000 
+registered users worldwide.  MFiX has become the standard for comparing, implementing, and evaluating multiphase 
+flow constitutive models and has been applied to an extremely diverse range of multiphase flows applications. 
+The successes achieved in modeling complex multiphase flow systems have led to new and improved key attributes 
+such as drag, polydispersity, attrition, and agglomeration models, among other significant advances.
 """
 
 toolchain = {'name': 'intel', 'version': '2023b'}

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
@@ -17,7 +17,8 @@ such as drag, polydispersity, attrition, and agglomeration models, among other s
 """
 
 toolchain = {'name': 'intel', 'version': '2023b'}
-toolchainopts = {'usempi': True}
+toolchainopts = {'usempi': True, 'pic': True}
+toolchainopts = {'extra_fflags': '-fallow-argument-mismatch'}
 
 sources = ['%(namelower)s-%(version)s.tar.gz']
 checksums = ['d6313d02b4631a6b2eef944c158bb7b1a2eecfe7bcee9f533ce71571f1acffe8']
@@ -27,13 +28,7 @@ builddependencies = [
     ('binutils', '2.40'),
 ]
 
-configopts = ' '.join([
-    '-DENABLE_MPI=1',
-    '-DCMAKE_Fortran_COMPILER=mpiifort',
-    '-DCMAKE_C_COMPILER=mpiicc',
-    '-DCMAKE_CXX_COMPILER=mpiicpc',
-    '-DCMAKE_Fortran_FLAGS="-O2 -Wall"',
-])
+configopts = '-DENABLE_MPI=1'
 
 separate_build_dir = False
 

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
@@ -17,8 +17,11 @@ such as drag, polydispersity, attrition, and agglomeration models, among other s
 """
 
 toolchain = {'name': 'intel', 'version': '2023b'}
-toolchainopts = {'usempi': True, 'pic': True}
-toolchainopts = {'extra_fflags': '-fallow-argument-mismatch'}
+toolchainopts = {
+    'usempi': True, 
+    'pic': True, 
+    'extra_fflags': '-fallow-argument-mismatch'
+}
 
 sources = ['%(namelower)s-%(version)s.tar.gz']
 checksums = ['d6313d02b4631a6b2eef944c158bb7b1a2eecfe7bcee9f533ce71571f1acffe8']

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
@@ -44,8 +44,8 @@ test_cmd = ' && '.join([
 ])
 
 sanity_check_paths = {
-   'files': ['mfixsolver_dmp'],
-   'dirs': [],
+    'files': ['mfixsolver_dmp'],
+    'dirs': [],
 }
 
 postinstallcmds = [

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
@@ -18,18 +18,22 @@ such as drag, polydispersity, attrition, and agglomeration models, among other s
 
 toolchain = {'name': 'intel', 'version': '2023b'}
 toolchainopts = {
-    'usempi': True, 
-    'pic': True, 
-    'extra_fflags': '-fallow-argument-mismatch'
+    'usempi': True,
+    'pic': True,
+    'extra_fflags': '-fallow-argument-mismatch',
 }
 
 sources = ['%(namelower)s-%(version)s.tar.gz']
 checksums = ['d6313d02b4631a6b2eef944c158bb7b1a2eecfe7bcee9f533ce71571f1acffe8']
 
+download_instructions = 'Fetch the source %s after logging into %s' % (sources[0], homepage)
+
 builddependencies = [
     ('CMake', '3.27.6'),
     ('binutils', '2.40'),
 ]
+
+preconfigcmds = 'mkdir -p %(installdir)/bin'
 
 configopts = '-DENABLE_MPI=1'
 
@@ -40,8 +44,13 @@ test_cmd = ' && '.join([
     '%(builddir)s/%(namelower)s-%(version)s/mfixsolver_dmp -f mixer_dem_3d.mfx',
 ])
 
+postinstallcmds = [
+    'mkdir -p %(installdir)s/bin',
+    'mv %(installdir)s/mfixsolver_dmp %(installdir)s/bin/mfixsolver_dmp',
+]
+
 sanity_check_paths = {
-    'files': ['mfixsolver_dmp'],
+    'files': ['bin/mfixsolver_dmp'],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
@@ -6,7 +6,15 @@ name = 'MFiX'
 version = '24.3'
 
 homepage = 'https://mfix.netl.doe.gov/products/mfix/'
-description = 'The National Energy Technology Laboratory’s (NETL’s) computational fluid dynamics (CFD) code, MFiX —Multiphase Flow with Interphase eXchanges— is central to the laboratory’s multiphase flow reactor modeling efforts. This open-source software has over three decades of development history and more than 7,000 registered users worldwide. MFiX has become the standard for comparing, implementing, and evaluating multiphase flow constitutive models and has been applied to an extremely diverse range of multiphase flows applications. The successes achieved in modeling complex multiphase flow systems have led to new and improved key attributes such as drag, polydispersity, attrition, and agglomeration models, among other significant advances.'
+description = """
+The National Energy Technology Laboratory’s (NETL’s) computational fluid dynamics (CFD) code, 
+MFiX-Multiphase Flow with Interphase eXchanges - is central to the laboratory’s multiphase flow reactor modeling efforts. 
+This open-source software has over three decades of development history and more than 7,000 registered users worldwide. 
+MFiX has become the standard for comparing, implementing, and evaluating multiphase flow constitutive models 
+and has been applied to an extremely diverse range of multiphase flows applications. The successes achieved in 
+modeling complex multiphase flow systems have led to new and improved key attributes such as drag, polydispersity, 
+attrition, and agglomeration models, among other significant advances.
+"""
 
 toolchain = {'name': 'intel', 'version': '2023b'}
 toolchainopts = {'usempi': True}

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
@@ -33,8 +33,6 @@ builddependencies = [
     ('binutils', '2.40'),
 ]
 
-preconfigcmds = 'mkdir -p %(installdir)/bin'
-
 configopts = '-DENABLE_MPI=1'
 
 separate_build_dir = False

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.3-intel-2023b.eb
@@ -17,11 +17,7 @@ such as drag, polydispersity, attrition, and agglomeration models, among other s
 """
 
 toolchain = {'name': 'intel', 'version': '2023b'}
-toolchainopts = {
-    'usempi': True,
-    'pic': True,
-    'extra_fflags': '-fallow-argument-mismatch',
-}
+toolchainopts = {'usempi': True, 'pic': True}
 
 sources = ['%(namelower)s-%(version)s.tar.gz']
 checksums = ['d6313d02b4631a6b2eef944c158bb7b1a2eecfe7bcee9f533ce71571f1acffe8']

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
@@ -17,9 +17,9 @@ such as drag, polydispersity, attrition, and agglomeration models, among other s
 """
 
 citing = """
-The use of MFIX is to be acknowledged in any published paper based on computations using this software by 
-citing the MFIX theory manual. MFIX is being developed at NETL with active collaboration from ORNL and funding 
-through OIT of DOE. Some of the submodels are being developed by researchers outside of NETL. The use of such 
+The use of MFIX is to be acknowledged in any published paper based on computations using this software by
+citing the MFIX theory manual. MFIX is being developed at NETL with active collaboration from ORNL and funding
+through OIT of DOE. Some of the submodels are being developed by researchers outside of NETL. The use of such
 submodels is to be acknowledged by citing the appropriate papers of the developers of the  submodels.
 """
 

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
@@ -29,10 +29,10 @@ toolchainopts = {'usempi': True}
 # Source URLs are linked under https://mfix.netl.doe.gov/products/mfix/mfix-archive/
 # (which requires an account to access). Linked URLs found there are open.
 # source_urls = ['https://mfix.netl.doe.gov/s3/35d029c0/7e08111faa3097aa77691ac70d2770cc//source/%(namelower)s/']
+sources = ['%(namelower)s-%(version)s.tar.gz']
 download_instructions =  """
 Fetch the source %s from https://mfix.netl.doe.gov/products/mfix/mfix-archive/ after logging into %s
 """ % (sources[0], homepage)
-sources = ['%(namelower)s-%(version)s.tar.gz']
 patches = ['MFiX-24.4.1-remove-tab.patch']
 checksums = [
     'c603bc11c0ac07662b206b816c85e189ba2562fc05b31260ba296447a7def1af',  # mfix-24.4.1.tar.gz

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
@@ -28,7 +28,10 @@ toolchainopts = {'usempi': True}
 
 # Source URLs are linked under https://mfix.netl.doe.gov/products/mfix/mfix-archive/
 # (which requires an account to access). Linked URLs found there are open.
-source_urls = ['https://mfix.netl.doe.gov/s3/35d029c0/7e08111faa3097aa77691ac70d2770cc//source/%(namelower)s/']
+# source_urls = ['https://mfix.netl.doe.gov/s3/35d029c0/7e08111faa3097aa77691ac70d2770cc//source/%(namelower)s/']
+download_instructions =  """
+Fetch the source from https://mfix.netl.doe.gov/products/mfix/mfix-archive/ 
+after logging into %s""" % (sources[0], homepage)
 sources = ['%(namelower)s-%(version)s.tar.gz']
 patches = ['MFiX-24.4.1-remove-tab.patch']
 checksums = [

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
@@ -17,10 +17,10 @@ such as drag, polydispersity, attrition, and agglomeration models, among other s
 """
 
 citing = """
-The use of MFIX is to be acknowledged in any published paper based on computations using this software by 
-citing the MFIX theory manual. MFIX is being developed at NETL with active collaboration from ORNL and funding
-through OIT of DOE. Some of the submodels are being developed by researchers outside of NETL. The use of such 
-submodels is to be acknowledged by citing the appropriate papers of the developers of the  submodels.
+The use of MFIX is to be acknowledged in any published paper based on computations using this software by
+ citing the MFIX theory manual. MFIX is being developed at NETL with active collaboration from ORNL and funding
+ through OIT of DOE. Some of the submodels are being developed by researchers outside of NETL. The use of such
+ submodels is to be acknowledged by citing the appropriate papers of the developers of the  submodels.
 """
 
 toolchain = {'name': 'intel', 'version': '2023b'}
@@ -33,7 +33,7 @@ sources = ['%(namelower)s-%(version)s.tar.gz']
 patches = ['MFiX-24.4.1-remove-tab.patch']
 checksums = [
     'c603bc11c0ac07662b206b816c85e189ba2562fc05b31260ba296447a7def1af',  # mfix-24.4.1.tar.gz
-    '0ad4ab803da6ea070e2018da38fbbddcf43cef6747ae5f7da9531d51ef6161de',  # MFiX-24.4.1-remove-tab.patch 
+    '0ad4ab803da6ea070e2018da38fbbddcf43cef6747ae5f7da9531d51ef6161de',  # MFiX-24.4.1-remove-tab.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
@@ -30,8 +30,8 @@ toolchainopts = {'usempi': True}
 # (which requires an account to access). Linked URLs found there are open.
 # source_urls = ['https://mfix.netl.doe.gov/s3/35d029c0/7e08111faa3097aa77691ac70d2770cc//source/%(namelower)s/']
 download_instructions =  """
-Fetch the source from https://mfix.netl.doe.gov/products/mfix/mfix-archive/ 
-after logging into %s
+Fetch the source from https://mfix.netl.doe.gov/products/mfix/mfix-archive/
+ after logging into %s
 """ % (sources[0], homepage)
 sources = ['%(namelower)s-%(version)s.tar.gz']
 patches = ['MFiX-24.4.1-remove-tab.patch']

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
@@ -3,7 +3,7 @@
 easyblock = 'CMakeMake'
 
 name = 'MFiX'
-version = '24.3'
+version = '24.4.1'
 
 homepage = 'https://mfix.netl.doe.gov/products/mfix/'
 description = """
@@ -16,13 +16,25 @@ The successes achieved in modeling complex multiphase flow systems have led to n
 such as drag, polydispersity, attrition, and agglomeration models, among other significant advances.
 """
 
+citing = """
+The use of MFIX is to be acknowledged in any published paper based on computations using this software by 
+citing the MFIX theory manual. MFIX is being developed at NETL with active collaboration from ORNL and funding
+through OIT of DOE. Some of the submodels are being developed by researchers outside of NETL. The use of such 
+submodels is to be acknowledged by citing the appropriate papers of the developers of the  submodels.
+"""
+
 toolchain = {'name': 'intel', 'version': '2023b'}
-toolchainopts = {'usempi': True, 'pic': True}
+toolchainopts = {'usempi': True}
 
+# Source URLs are linked under https://mfix.netl.doe.gov/products/mfix/mfix-archive/
+# (which requires an account to access). Linked URLs found there are open.
+source_urls = ['https://mfix.netl.doe.gov/s3/35d029c0/cfd4465f36afd13c89f92073390d7759//source/%(namelower)s/']
 sources = ['%(namelower)s-%(version)s.tar.gz']
-checksums = ['d6313d02b4631a6b2eef944c158bb7b1a2eecfe7bcee9f533ce71571f1acffe8']
-
-download_instructions = 'Fetch the source %s after logging into %s' % (sources[0], homepage)
+patches = ['MFiX-24.4.1-remove-tab.patch']
+checksums = [
+    'c603bc11c0ac07662b206b816c85e189ba2562fc05b31260ba296447a7def1af',  # mfix-24.4.1.tar.gz
+    '0ad4ab803da6ea070e2018da38fbbddcf43cef6747ae5f7da9531d51ef6161de',  # MFiX-24.4.1-remove-tab.patch 
+]
 
 builddependencies = [
     ('CMake', '3.27.6'),
@@ -37,6 +49,8 @@ postinstallcmds = [
     'mkdir -p %(installdir)s/bin',
     'mv %(installdir)s/mfixsolver_dmp %(installdir)s/bin/mfixsolver_dmp',
 ]
+
+parallel = 4
 
 test_cmd = ' && '.join([
     'cd tutorials/dem/mixer_3d',

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
@@ -30,7 +30,7 @@ toolchainopts = {'usempi': True}
 # (which requires an account to access). Linked URLs found there are open.
 # source_urls = ['https://mfix.netl.doe.gov/s3/35d029c0/7e08111faa3097aa77691ac70d2770cc//source/%(namelower)s/']
 sources = ['%(namelower)s-%(version)s.tar.gz']
-download_instructions =  """
+download_instructions = """
 Fetch the source %s from https://mfix.netl.doe.gov/products/mfix/mfix-archive/ after logging into %s
 """ % (sources[0], homepage)
 patches = ['MFiX-24.4.1-remove-tab.patch']

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
@@ -17,10 +17,10 @@ such as drag, polydispersity, attrition, and agglomeration models, among other s
 """
 
 citing = """
-The use of MFIX is to be acknowledged in any published paper based on computations using this software by
- citing the MFIX theory manual. MFIX is being developed at NETL with active collaboration from ORNL and funding
- through OIT of DOE. Some of the submodels are being developed by researchers outside of NETL. The use of such
- submodels is to be acknowledged by citing the appropriate papers of the developers of the  submodels.
+The use of MFIX is to be acknowledged in any published paper based on computations using this software by 
+citing the MFIX theory manual. MFIX is being developed at NETL with active collaboration from ORNL and funding 
+through OIT of DOE. Some of the submodels are being developed by researchers outside of NETL. The use of such 
+submodels is to be acknowledged by citing the appropriate papers of the developers of the  submodels.
 """
 
 toolchain = {'name': 'intel', 'version': '2023b'}
@@ -30,8 +30,7 @@ toolchainopts = {'usempi': True}
 # (which requires an account to access). Linked URLs found there are open.
 # source_urls = ['https://mfix.netl.doe.gov/s3/35d029c0/7e08111faa3097aa77691ac70d2770cc//source/%(namelower)s/']
 download_instructions =  """
-Fetch the source from https://mfix.netl.doe.gov/products/mfix/mfix-archive/
- after logging into %s
+Fetch the source %s from https://mfix.netl.doe.gov/products/mfix/mfix-archive/ after logging into %s
 """ % (sources[0], homepage)
 sources = ['%(namelower)s-%(version)s.tar.gz']
 patches = ['MFiX-24.4.1-remove-tab.patch']

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
@@ -28,7 +28,7 @@ toolchainopts = {'usempi': True}
 
 # Source URLs are linked under https://mfix.netl.doe.gov/products/mfix/mfix-archive/
 # (which requires an account to access). Linked URLs found there are open.
-source_urls = ['https://mfix.netl.doe.gov/s3/35d029c0/cfd4465f36afd13c89f92073390d7759//source/%(namelower)s/']
+source_urls = ['https://mfix.netl.doe.gov/s3/35d029c0/7e08111faa3097aa77691ac70d2770cc//source/%(namelower)s/']
 sources = ['%(namelower)s-%(version)s.tar.gz']
 patches = ['MFiX-24.4.1-remove-tab.patch']
 checksums = [

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-intel-2023b.eb
@@ -31,7 +31,8 @@ toolchainopts = {'usempi': True}
 # source_urls = ['https://mfix.netl.doe.gov/s3/35d029c0/7e08111faa3097aa77691ac70d2770cc//source/%(namelower)s/']
 download_instructions =  """
 Fetch the source from https://mfix.netl.doe.gov/products/mfix/mfix-archive/ 
-after logging into %s""" % (sources[0], homepage)
+after logging into %s
+""" % (sources[0], homepage)
 sources = ['%(namelower)s-%(version)s.tar.gz']
 patches = ['MFiX-24.4.1-remove-tab.patch']
 checksums = [

--- a/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-remove-tab.patch
+++ b/easybuild/easyconfigs/m/MFiX/MFiX-24.4.1-remove-tab.patch
@@ -1,0 +1,164 @@
+# Author: Ehsan Moravveji (VSC, KU Leuven)
+# Purpose: replace the tab with spaces to fix a compilation error
+diff -ruN mfix-24.4.1-orig/model/chem/calc_arrhenius_rrates.f mfix-24.4.1/model/chem/calc_arrhenius_rrates.f
+--- mfix-24.4.1-orig/model/chem/calc_arrhenius_rrates.f	2025-03-04 13:59:49.856329000 +0100
++++ mfix-24.4.1/model/chem/calc_arrhenius_rrates.f	2025-03-04 19:12:10.534090000 +0100
+@@ -95,7 +95,7 @@
+          DO M=1, DIMENSION_M
+             DO LL = 1, DIMENSION_N_S
+                Csi(M, LL) = RO_s(IJK, M)*X_s(IJK,M,LL)/Mw_s(M,LL)  ! kmol/m3
+-	    ENDDO
++            ENDDO
+          ENDDO
+       ENDIF
+ 
+@@ -115,17 +115,17 @@
+                NN = Reaction(rr)%Species(lN)%sMap
+                IF(M .EQ. 0) THEN
+                   has_gas = .TRUE.
+-	          IF(X_g(IJK, NN) .LT. chem_min_species_fluid) THEN
++                  IF(X_g(IJK, NN) .LT. chem_min_species_fluid) THEN
+                      reactant_sufficient = .FALSE.
+                      EXIT
+-		  ENDIF
++                  ENDIF
+                ELSE
+                   has_solid = .TRUE.
+                   Tgs = max(min(TMAX, T_s(IJK,M)), TMIN)
+-	          IF(X_s(IJK, M, NN) .LT. chem_min_species_solid) THEN
++                  IF(X_s(IJK, M, NN) .LT. chem_min_species_solid) THEN
+                      reactant_sufficient = .FALSE.
+                      EXIT
+-		  ENDIF
++                  ENDIF
+                ENDIF
+             ENDIF
+          ENDDO
+@@ -141,18 +141,18 @@
+             IF(Reaction(rr)%nSpecies == 0) CYCLE RXN_LP
+             ! getting the forward rate constant
+             IF(arrhenius_coeff(rr,2)==0.0d0) THEN
+-	        k_rate = arrhenius_coeff(rr,1)* exp(-arrhenius_coeff(rr,3)*exp_factor)
++                k_rate = arrhenius_coeff(rr,1)* exp(-arrhenius_coeff(rr,3)*exp_factor)
+             ELSEIF(arrhenius_coeff(rr,2)==1.0d0) THEN
+-	        k_rate = arrhenius_coeff(rr,1) * T_g(IJK) &
+-	                   * exp(-arrhenius_coeff(rr,3)*exp_factor)
++                k_rate = arrhenius_coeff(rr,1) * T_g(IJK) &
++                         * exp(-arrhenius_coeff(rr,3)*exp_factor)
+             ELSEIF(arrhenius_coeff(rr,2)==-1.0d0) THEN
+-	        k_rate = arrhenius_coeff(rr,1) / T_g(IJK) &
+-	                   * exp(-arrhenius_coeff(rr,3)*exp_factor)
+-	    ELSE
++                k_rate = arrhenius_coeff(rr,1) / T_g(IJK) &
++                          * exp(-arrhenius_coeff(rr,3)*exp_factor)
++            ELSE
+                k_rate = arrhenius_coeff(rr,1) * T_g(IJK)**arrhenius_coeff(rr,2) &
+-	                * exp(-arrhenius_coeff(rr,3)*exp_factor)
++                        * exp(-arrhenius_coeff(rr,3)*exp_factor)
+             ENDIF
+-	        ! check if there are third body in the reaction
++            ! check if there are third body in the reaction
+             IF(has_solid .AND. (third_body_model(rr) .NE. UNDEFINED_C)) THEN
+                WRITE(ERR_MSG,"(/1X,70('*')/' From: rrates_arrhenius:',/   &
+                ' Message: Third body information is given for reaction with solid phase, ',/  &
+@@ -179,7 +179,7 @@
+                         EXIT
+                     ENDIF
+                  ENDDO
+-	     ENDIF
++             ENDIF
+             ! check for pressure-related parameters
+             IF(has_solid .AND. (press_rxn_model(rr) .NE. UNDEFINED_C)) THEN
+                WRITE(ERR_MSG,"(/1X,70('*')/' From: rrates_arrhenius:',/   &
+@@ -228,7 +228,7 @@
+                                       * exp(-arrhenius_coeff_press(rr,PP,3)*exp_factor)
+                         ELSE
+                            k_plog(LL) = k_plog(LL) + arrhenius_coeff_press(rr,PP,1) * T_g(IJK)**arrhenius_coeff_press(rr,PP,2) &
+-	                              * exp(-arrhenius_coeff_press(rr,PP,3)*exp_factor)
++                                      * exp(-arrhenius_coeff_press(rr,PP,3)*exp_factor)
+                         ENDIF
+                      ENDDO
+                   ENDDO
+@@ -256,13 +256,13 @@
+                                 * exp(-arrhenius_coeff_press(rr,1,3)*exp_factor)
+                   ELSEIF(arrhenius_coeff_press(rr,1,2)==1.0d0) THEN
+                       k_extrapre = arrhenius_coeff_press(rr,1,1) * T_g(IJK) &
+-	                          * exp(-arrhenius_coeff_press(rr,1,3)*exp_factor)
++                                  * exp(-arrhenius_coeff_press(rr,1,3)*exp_factor)
+                   ELSEIF(arrhenius_coeff_press(rr,1,2)==-1.0d0) THEN
+                       k_extrapre = arrhenius_coeff_press(rr,1,1) / T_g(IJK) &
+-	                          * exp(-arrhenius_coeff_press(rr,1,3)*exp_factor)
++                                  * exp(-arrhenius_coeff_press(rr,1,3)*exp_factor)
+                   ELSE
+                       k_extrapre = arrhenius_coeff_press(rr,1,1) * T_g(IJK)**arrhenius_coeff_press(rr,1,2) &
+-	                          * exp(-arrhenius_coeff_press(rr,1,3)*exp_factor)
++                                  * exp(-arrhenius_coeff_press(rr,1,3)*exp_factor)
+                   ENDIF
+ 
+                   IF(INDEX(press_rxn_model(rr), 'FALLOFF') .NE. 0) THEN
+@@ -312,14 +312,14 @@
+             ! check for Landau-Teller reactions
+             IF(LT_coeff(rr,1) .NE. UNDEFINED) THEN
+                IF(ANY( LT_coeff(rr,:)== UNDEFINED)) THEN
+-                  WRITE(ERR_MSG,"(/1X,70('*')/' From: rrates_arrhenius:',/   &
+-                          ' Message: 2 parameters must be givn for Landau-Teller type of reactions.',/  &
+-                           A)") trim(Reaction(rr)%ChemEq)
++                  WRITE(ERR_MSG,"(/1X,70('*')/' From: rrates_arrhenius:',/ &
++                          ' Message: 2 parameters must be givn for Landau-Teller type of reactions.',/ &
++                          ' ', A)") trim(Reaction(rr)%ChemEq)
+                   CALL log_error()
+                ENDIF
+                k_rate = arrhenius_coeff(rr,1) * T_g(IJK)**arrhenius_coeff(rr,2) * &
+                         exp(-arrhenius_coeff(rr,3)*exp_factor + &
+-			LT_coeff(rr,1)/T_g(IJK)**(1.0d0/3.0d0) + LT_coeff(rr,2)/T_g(IJK)**(2.0d0/3.0d0))
++                        LT_coeff(rr,1)/T_g(IJK)**(1.0d0/3.0d0) + LT_coeff(rr,2)/T_g(IJK)**(2.0d0/3.0d0))
+             ENDIF
+             ! check for other rate constant fitting options
+             IF(rate_fit_model(rr) .NE. UNDEFINED_C) THEN
+@@ -331,7 +331,7 @@
+                      CALL log_error()
+                   ENDIF
+                   k_rate = arrhenius_coeff(rr,1) * T_g(IJK)**arrhenius_coeff(rr,2) &
+-		           * exp(arrhenius_coeff(rr,3)/T_g(IJK)+ &
++                           * exp(arrhenius_coeff(rr,3)/T_g(IJK)+ &
+                                 rate_fit_coeff(rr,1) + &
+                                 rate_fit_coeff(rr,2)*LOG(T_g(IJK)) + &
+                                 rate_fit_coeff(rr,3)*(LOG(T_g(IJK)))**2.0d0 + &
+@@ -356,25 +356,25 @@
+                                 rate_fit_coeff(rr,4)/(T_g(IJK)**4.0d0))
+                ENDIF
+                IF(arrhenius_coeff(rr,2)==0.0d0) THEN
+-	               k_rate = k_rate
++                       k_rate = k_rate
+                ELSEIF(arrhenius_coeff(rr,2)==1.0d0) THEN
+-	               k_rate = k_rate * T_g(IJK)
++                       k_rate = k_rate * T_g(IJK)
+                ELSEIF(arrhenius_coeff(rr,2)==-1.0d0) THEN
+-	               k_rate = k_rate / T_g(IJK)
+-	            ELSE
++                       k_rate = k_rate / T_g(IJK)
++               ELSE
+                   k_rate = k_rate * T_g(IJK)**arrhenius_coeff(rr,2)
+                ENDIF
+             ENDIF
+ 
+             ! getting the rate constant for reverse reactions
+-	    ! reverse_calc is UNDEFINED_C means the reaction is forward reaction
+-	    ! reverse_calc is fromForwardRateConstant means that
+-	    !  1. the reaction is the reverse reaction
+-	    !  2. the rate constant needs to be calculated based on the forward rate constant
+-	    ! reverse_calc is fromArrheniusCoeff or defined means
+-	    !  1. the reaction is the reverse reaction
+-	    !  2. arrhenius coefficients are given for the calculation of the rate constant,
+-	    !     which has been calculated in the above calculation of k_rate
++            ! reverse_calc is UNDEFINED_C means the reaction is forward reaction
++            ! reverse_calc is fromForwardRateConstant means that
++            !  1. the reaction is the reverse reaction
++            !  2. the rate constant needs to be calculated based on the forward rate constant
++            ! reverse_calc is fromArrheniusCoeff or defined means
++            !  1. the reaction is the reverse reaction
++            !  2. arrhenius coefficients are given for the calculation of the rate constant,
++            !     which has been calculated in the above calculation of k_rate
+             IF(INDEX(reverse_calc(rr), "FROMFORWARDRATECONSTANT") .NE. 0) THEN
+                IF(has_solid) THEN
+                   WRITE(ERR_MSG,"(/1X,70('*')/' From: rrates_arrhenius:',/   &


### PR DESCRIPTION
With this PR, I share a new easyconfig for MFiX (open source alternative to Fluent).

Remarks:
- testing is done in the build folder, and the test sources/artefacts are preserved (i.e. not copied to the install folder)
- even thought the software is compiled with Intel MPI, the test is done serially, because I did not know the correct configuration for running the test case and the correct number of MPI processes needed