### PR TITLE
use latest version (0.2.5) of archspec for LAMMPS 2Aug2023 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/a/archspec/archspec-0.2.5-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/a/archspec/archspec-0.2.5-GCCcore-12.3.0.eb
@@ -1,0 +1,27 @@
+easyblock = 'PythonPackage'
+
+name = 'archspec'
+version = '0.2.5'
+
+homepage = 'https://github.com/archspec/archspec'
+description = "A library for detecting, labeling, and reasoning about microarchitectures"
+
+toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['5bec8dfc5366ff299071200466dc9572d56db4e43abca3c66bdd62bc2b731a2a']
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('poetry', '1.5.1'),
+]
+
+dependencies = [('Python', '3.11.3')]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+sanity_check_commands = ["python -c 'from archspec.cpu import host; print(host())'"]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-2Aug2023_update2-foss-2023a-kokkos-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-2Aug2023_update2-foss-2023a-kokkos-CUDA-12.1.1.eb
@@ -36,7 +36,7 @@ checksums = [
 builddependencies = [
     ('CMake', '3.26.3'),
     ('pkgconf', '1.9.5'),
-    ('archspec', '0.2.1'),
+    ('archspec', '0.2.5'),
 ]
 dependencies = [
     ('CUDA', '12.1.1', '', SYSTEM),

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb
@@ -35,7 +35,7 @@ checksums = [
 builddependencies = [
     ('CMake', '3.26.3'),
     ('pkgconf', '1.9.5'),
-    ('archspec', '0.2.1'),
+    ('archspec', '0.2.5'),
 ]
 dependencies = [
     ('Python', '3.11.3'),


### PR DESCRIPTION
Version 0.2.1 does not support newer CPUs like Sapphire Rapids, so I'm bumping the version of archspec (which is only used as build dependency) to the latest one. LAMMPS 2Aug2023 and newer do support Sapphire Rapids, but with the current archspec version it detects Sapphire Lake as Icelake and hence uses `ICX` for the Kokkos architecture.