### PR TITLE
Change source_urls for Boost from boostorg.jfrog.io to archives.boost.io

### DIFF
--- a/easybuild/easyconfigs/b/Boost.MPI/Boost.MPI-1.76.0-gompi-2021a.eb
+++ b/easybuild/easyconfigs/b/Boost.MPI/Boost.MPI-1.76.0-gompi-2021a.eb
@@ -9,7 +9,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'gompi', 'version': '2021a'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['7bd7ddceec1a1dfdcbdb3e609b60d01739c38390a5f956385a12f3122049f0ca']
 

--- a/easybuild/easyconfigs/b/Boost.MPI/Boost.MPI-1.77.0-gompi-2021b.eb
+++ b/easybuild/easyconfigs/b/Boost.MPI/Boost.MPI-1.77.0-gompi-2021b.eb
@@ -9,7 +9,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'gompi', 'version': '2021b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['5347464af5b14ac54bb945dc68f1dd7c56f0dad7262816b956138fc53bcc0131']
 

--- a/easybuild/easyconfigs/b/Boost.MPI/Boost.MPI-1.79.0-gompi-2022a.eb
+++ b/easybuild/easyconfigs/b/Boost.MPI/Boost.MPI-1.79.0-gompi-2022a.eb
@@ -9,7 +9,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'gompi', 'version': '2022a'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['273f1be93238a068aba4f9735a4a2b003019af067b9c183ed227780b8f36062c']
 

--- a/easybuild/easyconfigs/b/Boost.MPI/Boost.MPI-1.79.0-gompi-2022b.eb
+++ b/easybuild/easyconfigs/b/Boost.MPI/Boost.MPI-1.79.0-gompi-2022b.eb
@@ -9,7 +9,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'gompi', 'version': '2022b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['273f1be93238a068aba4f9735a4a2b003019af067b9c183ed227780b8f36062c']
 

--- a/easybuild/easyconfigs/b/Boost.MPI/Boost.MPI-1.81.0-gompi-2022b.eb
+++ b/easybuild/easyconfigs/b/Boost.MPI/Boost.MPI-1.81.0-gompi-2022b.eb
@@ -9,7 +9,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'gompi', 'version': '2022b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['205666dea9f6a7cfed87c7a6dfbeb52a2c1b9de55712c9c1a87735d7181452b6']
 

--- a/easybuild/easyconfigs/b/Boost.MPI/Boost.MPI-1.82.0-gompi-2023a.eb
+++ b/easybuild/easyconfigs/b/Boost.MPI/Boost.MPI-1.82.0-gompi-2023a.eb
@@ -9,7 +9,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'gompi', 'version': '2023a'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['66a469b6e608a51f8347236f4912e27dc5c60c60d7d53ae9bfe4683316c6f04c']
 

--- a/easybuild/easyconfigs/b/Boost.MPI/Boost.MPI-1.83.0-gompi-2023b.eb
+++ b/easybuild/easyconfigs/b/Boost.MPI/Boost.MPI-1.83.0-gompi-2023b.eb
@@ -9,7 +9,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'gompi', 'version': '2023b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['c0685b68dd44cc46574cce86c4e17c0f611b15e195be9848dfd0769a0a207628']
 

--- a/easybuild/easyconfigs/b/Boost.Python-NumPy/Boost.Python-NumPy-1.79.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/b/Boost.Python-NumPy/Boost.Python-NumPy-1.79.0-foss-2022a.eb
@@ -10,7 +10,7 @@ description = """Boost.Python is a C++ library which enables seamless interopera
 toolchain = {'name': 'foss', 'version': '2022a'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['273f1be93238a068aba4f9735a4a2b003019af067b9c183ed227780b8f36062c']
 

--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.71.0-gompi-2019b.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.71.0-gompi-2019b.eb
@@ -10,7 +10,7 @@ description = """Boost.Python is a C++ library which enables seamless interopera
 toolchain = {'name': 'gompi', 'version': '2019b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 patches = ['Boost-%(version)s_fix-Python3.patch']
 checksums = [

--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.71.0-gompic-2019b.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.71.0-gompic-2019b.eb
@@ -10,7 +10,7 @@ description = """Boost.Python is a C++ library which enables seamless interopera
 toolchain = {'name': 'gompic', 'version': '2019b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 patches = ['Boost-%(version)s_fix-Python3.patch']
 checksums = [

--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.71.0-iimpi-2019b.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.71.0-iimpi-2019b.eb
@@ -10,7 +10,7 @@ description = """Boost.Python is a C++ library which enables seamless interopera
 toolchain = {'name': 'iimpi', 'version': '2019b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 patches = ['Boost-%(version)s_fix-Python3.patch']
 checksums = [

--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.71.0-iimpic-2019b.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.71.0-iimpic-2019b.eb
@@ -10,7 +10,7 @@ description = """Boost.Python is a C++ library which enables seamless interopera
 toolchain = {'name': 'iimpic', 'version': '2019b'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 patches = ['Boost-%(version)s_fix-Python3.patch']
 checksums = [

--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.72.0-gompi-2020a.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.72.0-gompi-2020a.eb
@@ -10,7 +10,7 @@ description = """Boost.Python is a C++ library which enables seamless interopera
 toolchain = {'name': 'gompi', 'version': '2020a'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 patches = ['Boost-1.71.0_fix-Python3.patch']
 checksums = [

--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.72.0-gompic-2020a.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.72.0-gompic-2020a.eb
@@ -10,7 +10,7 @@ description = """Boost.Python is a C++ library which enables seamless interopera
 toolchain = {'name': 'gompic', 'version': '2020a'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 patches = ['Boost-1.71.0_fix-Python3.patch']
 checksums = [

--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.72.0-iimpi-2020a.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.72.0-iimpi-2020a.eb
@@ -10,7 +10,7 @@ description = """Boost.Python is a C++ library which enables seamless interopera
 toolchain = {'name': 'iimpi', 'version': '2020a'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 patches = ['Boost-1.71.0_fix-Python3.patch']
 checksums = [

--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.74.0-GCC-10.2.0.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.74.0-GCC-10.2.0.eb
@@ -10,7 +10,7 @@ description = """Boost.Python is a C++ library which enables seamless interopera
 toolchain = {'name': 'GCC', 'version': '10.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 patches = ['Boost-1.71.0_fix-Python3.patch']
 checksums = [

--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.76.0-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.76.0-GCC-10.3.0.eb
@@ -10,7 +10,7 @@ description = """Boost.Python is a C++ library which enables seamless interopera
 toolchain = {'name': 'GCC', 'version': '10.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 patches = ['Boost-1.71.0_fix-Python3.patch']
 checksums = [

--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.77.0-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.77.0-GCC-11.2.0.eb
@@ -10,7 +10,7 @@ description = """Boost.Python is a C++ library which enables seamless interopera
 toolchain = {'name': 'GCC', 'version': '11.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['5347464af5b14ac54bb945dc68f1dd7c56f0dad7262816b956138fc53bcc0131']
 

--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.79.0-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.79.0-GCC-11.3.0.eb
@@ -10,7 +10,7 @@ description = """Boost.Python is a C++ library which enables seamless interopera
 toolchain = {'name': 'GCC', 'version': '11.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['273f1be93238a068aba4f9735a4a2b003019af067b9c183ed227780b8f36062c']
 

--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.82.0-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.82.0-GCC-12.3.0.eb
@@ -10,7 +10,7 @@ description = """Boost.Python is a C++ library which enables seamless interopera
 toolchain = {'name': 'GCC', 'version': '12.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_1_82_0.tar.gz']
 checksums = ['66a469b6e608a51f8347236f4912e27dc5c60c60d7d53ae9bfe4683316c6f04c']
 

--- a/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.83.0-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/b/Boost.Python/Boost.Python-1.83.0-GCC-13.2.0.eb
@@ -10,7 +10,7 @@ description = """Boost.Python is a C++ library which enables seamless interopera
 toolchain = {'name': 'GCC', 'version': '13.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['boost_1_83_0.tar.gz']
 checksums = ['c0685b68dd44cc46574cce86c4e17c0f611b15e195be9848dfd0769a0a207628']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.71.0-gompi-2019b.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.71.0-gompi-2019b.eb
@@ -7,7 +7,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'gompi', 'version': '2019b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['96b34f7468f26a141f6020efb813f1a2f3dfb9797ecf76a7d7cbd843cc95f5bd']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.71.0-gompic-2019b.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.71.0-gompic-2019b.eb
@@ -7,7 +7,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'gompic', 'version': '2019b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['96b34f7468f26a141f6020efb813f1a2f3dfb9797ecf76a7d7cbd843cc95f5bd']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.71.0-iimpi-2019b.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.71.0-iimpi-2019b.eb
@@ -7,7 +7,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'iimpi', 'version': '2019b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['96b34f7468f26a141f6020efb813f1a2f3dfb9797ecf76a7d7cbd843cc95f5bd']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.71.0-iimpic-2019b.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.71.0-iimpic-2019b.eb
@@ -7,7 +7,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'iimpic', 'version': '2019b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['96b34f7468f26a141f6020efb813f1a2f3dfb9797ecf76a7d7cbd843cc95f5bd']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.72.0-GCCcore-9.3.0-no_mpi.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.72.0-GCCcore-9.3.0-no_mpi.eb
@@ -8,7 +8,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['c66e88d5786f2ca4dbebb14e06b566fb642a1a6947ad8cc9091f9f445134143f']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.72.0-gompi-2020a.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.72.0-gompi-2020a.eb
@@ -7,7 +7,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'gompi', 'version': '2020a'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['c66e88d5786f2ca4dbebb14e06b566fb642a1a6947ad8cc9091f9f445134143f']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.72.0-gompic-2020a.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.72.0-gompic-2020a.eb
@@ -7,7 +7,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'gompic', 'version': '2020a'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['c66e88d5786f2ca4dbebb14e06b566fb642a1a6947ad8cc9091f9f445134143f']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.72.0-iimpi-2020a.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.72.0-iimpi-2020a.eb
@@ -7,7 +7,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'iimpi', 'version': '2020a'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['c66e88d5786f2ca4dbebb14e06b566fb642a1a6947ad8cc9091f9f445134143f']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.74.0-GCC-10.2.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.74.0-GCC-10.2.0.eb
@@ -10,7 +10,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'GCC', 'version': '10.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 patches = ['Boost-%(version)s-library_version_type_serialization.patch']
 checksums = [

--- a/easybuild/easyconfigs/b/Boost/Boost-1.74.0-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.74.0-GCC-12.3.0.eb
@@ -10,7 +10,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'GCC', 'version': '12.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 patches = ['Boost-%(version)s-library_version_type_serialization.patch']
 checksums = [

--- a/easybuild/easyconfigs/b/Boost/Boost-1.74.0-iccifort-2020.4.304.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.74.0-iccifort-2020.4.304.eb
@@ -8,7 +8,7 @@ toolchain = {'name': 'iccifort', 'version': '2020.4.304'}
 # add C++ compiler option as workaround for "error: no instance of constructor .* matches the argument list" errors
 toolchainopts = {'pic': True, 'extra_cxxflags': '-DBOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT=1'}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 patches = ['Boost-%(version)s-library_version_type_serialization.patch']
 checksums = [

--- a/easybuild/easyconfigs/b/Boost/Boost-1.75.0-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.75.0-GCC-11.2.0.eb
@@ -7,7 +7,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'GCC', 'version': '11.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['aeb26f80e80945e82ee93e5939baebdca47b9dee80a07d3144be1e1a6a66dd6a']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.75.0-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.75.0-GCC-12.3.0.eb
@@ -7,7 +7,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'GCC', 'version': '12.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['aeb26f80e80945e82ee93e5939baebdca47b9dee80a07d3144be1e1a6a66dd6a']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.76.0-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.76.0-GCC-10.3.0.eb
@@ -10,7 +10,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'GCC', 'version': '10.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['7bd7ddceec1a1dfdcbdb3e609b60d01739c38390a5f956385a12f3122049f0ca']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.76.0-intel-compilers-2021.2.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.76.0-intel-compilers-2021.2.0.eb
@@ -7,7 +7,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'intel-compilers', 'version': '2021.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['7bd7ddceec1a1dfdcbdb3e609b60d01739c38390a5f956385a12f3122049f0ca']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.77.0-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.77.0-GCC-11.2.0.eb
@@ -10,7 +10,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'GCC', 'version': '11.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['5347464af5b14ac54bb945dc68f1dd7c56f0dad7262816b956138fc53bcc0131']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.77.0-intel-compilers-2021.4.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.77.0-intel-compilers-2021.4.0.eb
@@ -7,7 +7,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'intel-compilers', 'version': '2021.4.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['5347464af5b14ac54bb945dc68f1dd7c56f0dad7262816b956138fc53bcc0131']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.79.0-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.79.0-GCC-11.2.0.eb
@@ -12,7 +12,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'GCC', 'version': '11.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['273f1be93238a068aba4f9735a4a2b003019af067b9c183ed227780b8f36062c']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.79.0-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.79.0-GCC-11.3.0.eb
@@ -10,7 +10,7 @@ description = """Boost provides free peer-reviewed portable C++ source libraries
 toolchain = {'name': 'GCC', 'version': '11.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 checksums = ['273f1be93238a068aba4f9735a4a2b003019af067b9c183ed227780b8f36062c']
 


### PR DESCRIPTION
Update all `source_urls` in Boost related easybuilds so that they point to the new archive website. Checksum does not seem to change.

Tested locally for 2023b and 2022b.

fix #22152