### PR TITLE
unset `$BUILD_VERSION` set by `torchvision` easyblock in `preinstallopts` for `torchaudio` in easyconfigs for `PyTorch-bundle` 2.1.2

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a-CUDA-12.1.1.eb
@@ -101,7 +101,7 @@ exts_list = [
         ),
         'testinstall': True,
     }),
-    ('torchaudio', version, {
+    ('torchaudio', '2.1.2', {
         'installopts': "--no-use-pep517 -v",
         'patches': [
             'torchaudio-2.1.2_use-external-sox.patch',

--- a/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a-CUDA-12.1.1.eb
@@ -102,13 +102,12 @@ exts_list = [
         'testinstall': True,
     }),
     ('torchaudio', version, {
-        'preinstallopts': "unset BUILD_VERSION && ",
         'installopts': "--no-use-pep517 -v",
         'patches': [
             'torchaudio-2.1.2_use-external-sox.patch',
             'torchaudio-2.1.2_transform_test_tol.patch',
         ],
-        'preinstallopts': ('rm -r third_party/{sox,ffmpeg/multi};'  # runs twice when testinstall
+        'preinstallopts': ('unset BUILD_VERSION && rm -r third_party/{sox,ffmpeg/multi};'  # runs twice when testinstall
                            ' USE_CUDA=1 USE_OPENMP=1 USE_FFMPEG=1 FFMPEG_ROOT="$EBROOTFFMPEG"'),
         'source_urls': ['https://github.com/pytorch/audio/archive'],
         'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],

--- a/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a-CUDA-12.1.1.eb
@@ -101,7 +101,8 @@ exts_list = [
         ),
         'testinstall': True,
     }),
-    ('torchaudio', '2.1.2', {
+    ('torchaudio', version, {
+        'preinstallopts': "unset BUILD_VERSION && ",
         'installopts': "--no-use-pep517 -v",
         'patches': [
             'torchaudio-2.1.2_use-external-sox.patch',

--- a/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a.eb
@@ -98,7 +98,7 @@ exts_list = [
         ),
         'testinstall': True,
     }),
-    ('torchaudio', version, {
+    ('torchaudio', '2.1.2', {
         'installopts': "--no-use-pep517 -v",
         'patches': [
             'torchaudio-2.1.2_use-external-sox.patch',

--- a/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a.eb
@@ -99,7 +99,6 @@ exts_list = [
         'testinstall': True,
     }),
     ('torchaudio', version, {
-        'preinstallopts': "unset BUILD_VERSION && ",
         'installopts': "--no-use-pep517 -v",
         'patches': [
             'torchaudio-2.1.2_use-external-sox.patch',

--- a/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a.eb
@@ -98,7 +98,8 @@ exts_list = [
         ),
         'testinstall': True,
     }),
-    ('torchaudio', '2.1.2', {
+    ('torchaudio', version, {
+        'preinstallopts': "unset BUILD_VERSION && ",
         'installopts': "--no-use-pep517 -v",
         'patches': [
             'torchaudio-2.1.2_use-external-sox.patch',

--- a/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a.eb
@@ -105,7 +105,7 @@ exts_list = [
             'torchaudio-2.1.2_use-external-sox.patch',
             'torchaudio-2.1.2_transform_test_tol.patch',
         ],
-        'preinstallopts': ('rm -r third_party/{sox,ffmpeg/multi};'  # runs twice when testinstall
+        'preinstallopts': ('unset BUILD_VERSION && rm -r third_party/{sox,ffmpeg/multi};'  # runs twice when testinstall
                            ' USE_CUDA=0 USE_OPENMP=1 USE_FFMPEG=1 FFMPEG_ROOT="$EBROOTFFMPEG"'),
         'source_urls': ['https://github.com/pytorch/audio/archive'],
         'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],


### PR DESCRIPTION
There is problem with version of torchaudio - it has `version` instead of `2.1.2` in easyconfig, but it not get right version.
See: https://github.com/easybuilders/easybuild-framework/issues/4706