### PR TITLE
migrate easyconfig for NEURON v8.2.6 to use custom easyblock for NEURON

### DIFF
--- a/easybuild/easyconfigs/n/NEURON/NEURON-8.2.6-foss-2023a.eb
+++ b/easybuild/easyconfigs/n/NEURON/NEURON-8.2.6-foss-2023a.eb
@@ -1,5 +1,3 @@
-easyblock = 'CMakeMake'
-
 name = 'NEURON'
 version = '8.2.6'
 
@@ -22,20 +20,5 @@ dependencies = [
     ('Python', '3.11.3'),
     ('SciPy-bundle', '2023.07'),
 ]
-
-# turn off gui
-configopts = '-DNRN_ENABLE_INTERVIEWS=OFF'
-
-sanity_check_paths = {
-    'files': ['bin/nrnpyenv.sh', 'bin/nrniv', 'lib/libnrniv.so'],
-    'dirs': ['lib/python/%(namelower)s'],
-}
-
-sanity_check_commands = [
-    'export PYTHONPATH=%(installdir)s/lib/python:$PYTHONPATH && '
-    "python -c 'import neuron; neuron.test()'"
-]
-
-modextrapaths = {'PYTHONPATH': 'lib/python'}
 
 moduleclass = 'bio'


### PR DESCRIPTION
Depends on: https://github.com/easybuilders/easybuild-easyblocks/pull/3618

Tests in easyblock PR