### PR TITLE
Use f-strings for MATLAB download instructions

### DIFF
--- a/easybuild/easyconfigs/m/MATLAB/MATLAB-2023a.eb
+++ b/easybuild/easyconfigs/m/MATLAB/MATLAB-2023a.eb
@@ -10,7 +10,7 @@ toolchain = SYSTEM
 
 sources = ['R%(version)s_Linux.iso']
 checksums = ['f18225237c2a5ff1294f19ed0c9945cfe691c3a3a62a6a8d324473d73ec92913']
-download_instructions = 'Download %s from mathworks.com' % sources[0]
+download_instructions = f'Download {sources[0]} from mathworks.com'
 
 java_options = '-Xmx2048m'
 

--- a/easybuild/easyconfigs/m/MATLAB/MATLAB-2023b.eb
+++ b/easybuild/easyconfigs/m/MATLAB/MATLAB-2023b.eb
@@ -10,7 +10,7 @@ toolchain = SYSTEM
 
 sources = ['R%s_Linux.iso' % (version)]
 checksums = ['f1cc4ae1a2e42a1d22745884aa80bf0d5d8676939ad21741ccff15fade06a881']
-download_instructions = 'Download %s from mathworks.com' % sources[0]
+download_instructions = f'Download {sources[0]} from mathworks.com'
 
 java_options = '-Xmx2048m'
 

--- a/easybuild/easyconfigs/m/MATLAB/MATLAB-2024b.eb
+++ b/easybuild/easyconfigs/m/MATLAB/MATLAB-2024b.eb
@@ -10,8 +10,7 @@ toolchain = SYSTEM
 
 sources = ['R%s_Linux.iso' % (version)]
 checksums = ['4e4499d93b4909b750ee2a6444af107cd5c1c62e75020c3e1625e946c6693573']
-
-download_instructions = 'Download %s from mathworks.com' % sources[0]
+download_instructions = f'Download {sources[0]} from mathworks.com'
 
 java_options = '-Xmx2048m'
 


### PR DESCRIPTION
This wasn't updated from the 4.9.4 target when merged into 5.0.x, lets be consistent.