### PR TITLE
Update GitHub actions workflows to use ubuntu-22.04 or ubuntu-24.04

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,10 +12,10 @@ jobs:
   python-linting:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
     - name: set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: 3.8
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,12 +10,12 @@ concurrency:
 
 jobs:
   python-linting:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - uses: actions/checkout@v4
 
     - name: set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,24 +13,24 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: ['3.9', '3.11']
+        python: ['3.7', '3.11']
         modules_tool: [Lmod-8.6.8]
         module_syntax: [Lua, Tcl]
       fail-fast: false
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0 # Required for git merge-base to work
 
     - name: Cache source files in /tmp/sources
       id: cache-sources
-      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
+      uses: actions/cache@v4
       with:
         path: /tmp/sources
         key: eb-sourcepath
 
     - name: set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      uses: actions/setup-python@v5
       with:
         python-version: ${{matrix.python}}
         architecture: x64
@@ -42,11 +42,6 @@ jobs:
         # sudo apt-get update
         # for modules tool
         sudo apt-get install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
-        # fix for lua-posix packaging issue, see https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082
-        # needed for Ubuntu 18.04, but not for Ubuntu 20.04, so skipping symlinking if posix.so already exists
-        if [ ! -e /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so ] ; then
-            sudo ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so
-        fi
         # for testing OpenMPI-system*eb we need to have Open MPI installed
         sudo apt-get install libopenmpi-dev openmpi-bin
         # required for test_dep_graph
@@ -148,15 +143,15 @@ jobs:
           eb --prefix /tmp/$USER/$GITHUB_SHA --sourcepath /tmp/sources M4-1.4.18.eb
 
   test-sdist:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: [3.6, '3.11']
+        python: [3.7, '3.11']
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - uses: actions/checkout@v4
 
     - name: set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      uses: actions/setup-python@v5
       with:
         python-version: ${{matrix.python}}
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -18,19 +18,19 @@ jobs:
         module_syntax: [Lua, Tcl]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       with:
         fetch-depth: 0 # Required for git merge-base to work
 
     - name: Cache source files in /tmp/sources
       id: cache-sources
-      uses: actions/cache@v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
       with:
         path: /tmp/sources
         key: eb-sourcepath
 
     - name: set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{matrix.python}}
         architecture: x64
@@ -148,10 +148,10 @@ jobs:
       matrix:
         python: [3.7, '3.11']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
     - name: set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{matrix.python}}
 


### PR DESCRIPTION
Rebase of https://github.com/easybuilders/easybuild-easyconfigs/pull/22459 on 5.0x

Use newer Ubuntu for linting to avoid having to update it too soon

Also test with Python 3.7 instead of 3.9 as minimum version of 5.0x is 3.6