### PR TITLE
Add easyconfig Kaleido-0.4.2-GCCcore-13.2.0.eb

### DIFF
--- a/easybuild/easyconfigs/k/Kaleido/Kaleido-0.4.2-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/k/Kaleido/Kaleido-0.4.2-GCCcore-13.2.0.eb
@@ -1,0 +1,24 @@
+easyblock = 'PythonPackage'
+
+name = 'Kaleido'
+version = '0.4.2'
+
+homepage = 'https://github.com/plotly/Kaleido'
+description = "Fast static image export for web-based visualization libraries with zero dependencies"
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+sources = ['kaleido-%(version)s-py3-none-any.whl']
+checksums = ['cc0ecb6f8c7e33fa1a49b3f15f182b80d9c5401cabde75e272239ce540fe5d82']
+
+builddependencies = [
+    ('binutils', '2.40'),
+]
+
+dependencies = [('Python', '3.11.5')]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+moduleclass = 'vis'


### PR DESCRIPTION
Need version 0.4.2 as there is no .whl file available for RISC-V in version 0.2.1