### PR TITLE
Improve output of styletest on failure

### DIFF
--- a/test/easyconfigs/styletests.py
+++ b/test/easyconfigs/styletests.py
@@ -53,19 +53,16 @@ class StyleTest(TestCase):
         specs = glob.glob('%s/*/*/*.eb' % easyconfigs_path)
         specs = sorted(specs)
 
-        self.mock_stderr(True)
-        self.mock_stdout(True)
-        result = check_easyconfigs_style(specs)
-        stderr, stdout = self.get_stderr(), self.get_stdout()
-        self.mock_stderr(False)
-        self.mock_stdout(False)
+        with self.mocked_stdout_stderr():
+            result = check_easyconfigs_style(specs)
+            stderr, stdout = self.get_stderr(), self.get_stdout()
 
-        error_msg = '\n'.join([
-            "There shouldn't be any code style errors (and/or warnings), found %d:" % result,
-            stdout,
-            stderr,
-        ])
-        self.assertEqual(result, 0, error_msg)
+        if result != 0:
+            self.fail('\n'.join([
+                "There shouldn't be any code style errors (and/or warnings), found %d:" % result,
+                stdout,
+                stderr,
+            ]))
 
 
 def suite(loader=None):


### PR DESCRIPTION
Just show the error on failure not e.g. "1 != 0"

The current output isn't easy to read. Example:
```
FAIL: test_style_conformance (test.easyconfigs.styletests.StyleTest)
Check the easyconfigs for style
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/easybuild/base/testing.py", line 97, in assertEqual
    super(TestCase, self).assertEqual(a, b)
  File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/unittest/case.py", line 852, in assertEqual
    assertion_func(first, second, msg=msg)
AssertionError: 1 != 0

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/easybuild-easyconfigs/easybuild-easyconfigs/test/easyconfigs/styletests.py", line 68, in test_style_conformance
    self.assertEqual(result, 0, error_msg)
  File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/easybuild/base/testing.py", line 119, in assertEqual
    raise AssertionError("%s:\nDIFF%s:\n%s" % (msg, limit, ''.join(diff[:self.ASSERT_MAX_DIFF])))
AssertionError: There shouldn't be any code style errors (and/or warnings), found 1:
/home/runner/work/easybuild-easyconfigs/easybuild-easyconfigs/easybuild/easyconfigs/u/UFL/UFL-2024.2.0-gfbf-2023b.eb:31:17: E221 multiple spaces before operator

: 1 != 0:
DIFF:
- 1
```