### PR TITLE
{bio}[GCC/13.2.0] MetaGeneMark-2 for 2023b

### DIFF
--- a/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
@@ -53,6 +53,6 @@ sanity_check_paths = {
     'dirs': ['include']
 }
 
-sanity_check_commands = ['perl bin/run_mgm.pl | grep seq']
+sanity_check_commands = ['perl %(installdir)s/bin/run_mgm.pl | grep seq']
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
@@ -1,0 +1,53 @@
+easyblock = 'MakeCp'
+
+name = 'MetaGeneMark-2'
+version = '1.06'
+
+homepage = 'https://github.com/gatech-genemark/MetaGeneMark-2'
+description = """MetaGeneMark-2 is an unsupervised metagenomic gene finder. It improves on MetaGeneMark by adding models for better gene start prediction, as well as automatic selection of genetic code (4 or 11). The models for gene start prediction are based in part on the work done for GeneMarkS-2; they include Shine-Dalgarno RBS, non-Shine-Dalgarno (or non-canonical) RBS, and bacterial and archaeal promoter models (for use in cases of leaderless transcription).
+"""
+
+toolchain = {'name': 'GCC', 'version': '13.2.0'}
+
+sources = [{
+    'filename': '%(name)s-%(version)s.tar.gz',
+    'git_config': {
+        'url': 'https://github.com/gatech-genemark',
+        'repo_name': '%(name)s',
+        'commit': 'a455a8b48ebc6f681b81202c0760d7830f015fe5',
+    }
+}]
+patches = ['MetaGeneMark-2-fix_Makefile.patch']
+checksums = [
+    {'MetaGeneMark-2-1.06.tar.gz': '9565a8174485b0fcad6a369551464abd5dfbff1770ed8aba2b872eedfa4b8374'},
+    {'MetaGeneMark-2-fix_Makefile.patch': '6f0fe0fefc053833f394e6ce47fe17596fda552a34e21901fd24d1f60a2d10d0'},
+]
+
+dependencies = [
+    ('Perl', '5.38.0'),
+    ('Boost', '1.83.0'),
+]
+
+build_cmd = ' && '.join([
+    'cd src',
+    'make -f Makefile.ubuntu'
+])
+
+parallel = 4
+
+fix_perl_shebang_for = ['bin/run_mgm.pl']
+
+files_to_copy = [
+    (['src/gmhmmp2', 'src/run_mgm.pl'], 'bin'),
+    (['src/*.h', 'src/*.hpp'], 'include'),
+    (['src/mgm2_11.mod', 'src/mgm2_4.mod'], 'lib'),         # stupid hack
+]
+
+sanity_check_paths = {
+    'files': ['bin/gmhmmp2'],
+    'dirs': ['include']
+}
+
+sanity_check_commands = ['perl bin/run_mgm.pl | grep seq']
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
@@ -38,8 +38,6 @@ build_cmd = ' && '.join([
     'make -f Makefile.ubuntu'
 ])
 
-parallel = 4
-
 fix_perl_shebang_for = ['bin/run_mgm.pl']
 
 files_to_copy = [

--- a/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
@@ -4,7 +4,7 @@ name = 'MetaGeneMark-2'
 version = '1.06'
 
 homepage = 'https://github.com/gatech-genemark/MetaGeneMark-2'
-description = """MetaGeneMark-2 is an unsupervised metagenomic gene finder. 
+description = """MetaGeneMark-2 is an unsupervised metagenomic gene finder.
 It improves on MetaGeneMark by adding models for better gene start prediction,
 as well as automatic selection of genetic code (4 or 11). The models for gene
 start prediction are based in part on the work done for GeneMarkS-2; they include

--- a/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
@@ -48,11 +48,18 @@ files_to_copy = [
     (['src/mgm2_11.mod', 'src/mgm2_4.mod'], 'lib'),
 ]
 
+postinstallcmds = [
+    'chmod a+rx %(installdir)s/bin/run_mgm.pl',
+]
+
 sanity_check_paths = {
     'files': ['bin/gmhmmp2'],
     'dirs': ['include']
 }
 
-sanity_check_commands = ['perl %(installdir)s/bin/run_mgm.pl | grep seq']
+sanity_check_commands = [
+    'run_mgm.pl | grep seq',
+    'gmhmmp2 --help 2>&1 | grep seq',
+]
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
@@ -23,6 +23,7 @@ sources = [{
     }
 }]
 patches = ['MetaGeneMark-2-fix_Makefile.patch']
+checksums = [
     {'MetaGeneMark-2-1.06.tar.xz': '0098b905c1b96b2916abdfeb05702e3f7db35c45a4f92d623da295c9cbae3be8'},
     {'MetaGeneMark-2-fix_Makefile.patch': '6f0fe0fefc053833f394e6ce47fe17596fda552a34e21901fd24d1f60a2d10d0'},
 ]

--- a/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
@@ -15,7 +15,7 @@ archaeal promoter models (for use in cases of leaderless transcription).
 toolchain = {'name': 'GCC', 'version': '13.2.0'}
 
 sources = [{
-    'filename': '%(name)s-%(version)s.tar.gz',
+    'filename': '%(name)s-%(version)s.tar.xz',
     'git_config': {
         'url': 'https://github.com/gatech-genemark',
         'repo_name': '%(name)s',
@@ -23,8 +23,7 @@ sources = [{
     }
 }]
 patches = ['MetaGeneMark-2-fix_Makefile.patch']
-checksums = [
-    {'MetaGeneMark-2-1.06.tar.gz': '9565a8174485b0fcad6a369551464abd5dfbff1770ed8aba2b872eedfa4b8374'},
+    {'MetaGeneMark-2-1.06.tar.xz': '0098b905c1b96b2916abdfeb05702e3f7db35c45a4f92d623da295c9cbae3be8'},
     {'MetaGeneMark-2-fix_Makefile.patch': '6f0fe0fefc053833f394e6ce47fe17596fda552a34e21901fd24d1f60a2d10d0'},
 ]
 

--- a/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-1.06-GCC-13.2.0.eb
@@ -4,7 +4,12 @@ name = 'MetaGeneMark-2'
 version = '1.06'
 
 homepage = 'https://github.com/gatech-genemark/MetaGeneMark-2'
-description = """MetaGeneMark-2 is an unsupervised metagenomic gene finder. It improves on MetaGeneMark by adding models for better gene start prediction, as well as automatic selection of genetic code (4 or 11). The models for gene start prediction are based in part on the work done for GeneMarkS-2; they include Shine-Dalgarno RBS, non-Shine-Dalgarno (or non-canonical) RBS, and bacterial and archaeal promoter models (for use in cases of leaderless transcription).
+description = """MetaGeneMark-2 is an unsupervised metagenomic gene finder. 
+It improves on MetaGeneMark by adding models for better gene start prediction,
+as well as automatic selection of genetic code (4 or 11). The models for gene
+start prediction are based in part on the work done for GeneMarkS-2; they include
+Shine-Dalgarno RBS, non-Shine-Dalgarno (or non-canonical) RBS, and bacterial and
+archaeal promoter models (for use in cases of leaderless transcription).
 """
 
 toolchain = {'name': 'GCC', 'version': '13.2.0'}
@@ -40,7 +45,7 @@ fix_perl_shebang_for = ['bin/run_mgm.pl']
 files_to_copy = [
     (['src/gmhmmp2', 'src/run_mgm.pl'], 'bin'),
     (['src/*.h', 'src/*.hpp'], 'include'),
-    (['src/mgm2_11.mod', 'src/mgm2_4.mod'], 'lib'),         # stupid hack
+    (['src/mgm2_11.mod', 'src/mgm2_4.mod'], 'lib'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-fix_Makefile.patch
+++ b/easybuild/easyconfigs/m/MetaGeneMark-2/MetaGeneMark-2-fix_Makefile.patch
@@ -1,0 +1,38 @@
+# Author: Ehsan Moravveji (VSC, KU Leuven)
+# Purpose: Fix caveats of Makefile.ubuntu
+
+diff -ruN MetaGeneMark-2-orig/src/Makefile.ubuntu MetaGeneMark-2/src/Makefile.ubuntu
+--- MetaGeneMark-2-orig/src/Makefile.ubuntu	2025-03-11 13:34:45.480535000 +0100
++++ MetaGeneMark-2/src/Makefile.ubuntu	2025-03-11 14:44:41.794798000 +0100
+@@ -12,24 +12,25 @@
+ VER=1.06
+ 
+ CXX = g++
+-CXXFLAGS = -O2 -Wall -I. -I/usr/include/boost/
+-LIBS = -L/usr/lib/ -lboost_program_options -lboost_iostreams 
++CXXFLAGS = -O2 -Wall -I. -I$(EBROOTBOOST)/include/
++LIBS = -L$(EBROOTBOOST)/lib/ -lboost_program_options -lboost_iostreams 
+ LDFLAGS = -lm  -lstdc++  -static
+ 
+ SRCS = main.cpp \
+ 	data_2.cpp model_2.cpp parameter_parser_2.cpp parameters_2.cpp \
+ 	pset_2.cpp sequence_file_2.cpp sequence_map_2.cpp settings_2.cpp \
+-	evidence_2.cpp site_2.cpp output_2.cpp
++	evidence_2.cpp site_2.cpp multi_shift_site.cpp output_2.cpp
+ 
+ OBJS = main.o \
+ 	data_2.o model_2.o parameter_parser_2.o parameters_2.o \
+ 	pset_2.o sequence_file_2.o sequence_map_2.o settings_2.o \
+-	evidence_2.o site_2.o output_2.o
++	evidence_2.o site_2.o multi_shift_site.o output_2.o
+ 
+ HDRS = common_2.h \
+ 	data_2.h index_2.h logfile_2.h memory_mapped_file_2.h model_2.h \
+-	parameter_parser_2.h parameters_2.h pset_2.h exit.h\
+-	sequence_file_2.h sequence_map_2.h settings_2.h evidence_2.h site_2.h output_2.h
++	parameter_parser_2.h parameters_2.h pset_2.h exit.h \
++	sequence_file_2.h sequence_map_2.h settings_2.h evidence_2.h site_2.h \
++	multi_shift_site.hpp output_2.h
+ 
+ .cpp.o:
+ 	$(CXX) -c -o $@ $(CXXFLAGS) $< 


### PR DESCRIPTION
This PR adds a new module, MetaGeneMark-2. The installation on (Skylake, Cascadelake, Icelake and Sapphire Rapids) Intel architectures on Rocky 8.9 Linux works out fine.