### PR TITLE
dcm2niix for 2024a

### DIFF
--- a/easybuild/easyconfigs/c/CharLS/CharLS-2.4.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/c/CharLS/CharLS-2.4.2-GCCcore-13.3.0.eb
@@ -1,0 +1,30 @@
+easyblock = 'CMakeMake'
+
+name = 'CharLS'
+version = '2.4.2'
+
+homepage = 'https://github.com/team-charls/charls'
+description = """CharLS is a C++ implementation of the JPEG-LS standard for lossless and near-lossless image
+compression and decompression. JPEG-LS is a low-complexity image compression standard that matches JPEG 2000
+compression ratios."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/team-charls/charls/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['d1c2c35664976f1e43fec7764d72755e6a50a80f38eca70fcc7553cad4fe19d9']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+]
+
+configopts = '-DBUILD_SHARED_LIBS=ON '
+
+sanity_check_paths = {
+    'files': ['lib/libcharls.%s' % SHLIB_EXT],
+    'dirs': ['include'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/d/dcm2niix/dcm2niix-1.0.20241211-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/d/dcm2niix/dcm2niix-1.0.20241211-GCCcore-13.3.0.eb
@@ -1,0 +1,37 @@
+easyblock = 'CMakeMake'
+
+name = 'dcm2niix'
+version = '1.0.20241211'
+
+homepage = 'https://github.com/rordenlab/dcm2niix'
+description = """dcm2niix is designed to convert neuroimaging data from the DICOM format to the NIfTI format."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/rordenlab/dcm2niix/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['3c7643ac6a1cd9517209eb06f430ad5e2b39583e6a35364f015e5ec3380f9ee2']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+]
+
+dependencies = [
+    ('zlib', '1.3.1'),
+    ('pigz', '2.8'),
+    ('OpenJPEG', '2.5.2'),
+    ('CharLS', '2.4.2'),
+]
+
+configopts = '-DUSE_JPEGLS=ON -DUSE_OPENJPEG=ON -DOpenJPEG_DIR=$EBROOTOPENJPEG '
+
+sanity_check_paths = {
+    'files': ['bin/dcm2niix'],
+    'dirs': [''],
+}
+
+sanity_check_commands = ['dcm2niix -h']
+
+moduleclass = 'bio'


### PR DESCRIPTION
The version of `dcm2niix` is bumped up to the latest (as of this day) and we aim for the 2024a toolchain.