### PR TITLE
disable keepsymlinks in libStatGen

### DIFF
--- a/easybuild/easyconfigs/l/libStatGen/libStatGen-1.0.15-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/l/libStatGen/libStatGen-1.0.15-GCCcore-10.2.0.eb
@@ -21,6 +21,7 @@ dependencies = [('zlib', '1.2.11')]
 
 runtest = 'test'
 
+keepsymlinks = False
 files_to_copy = [
     (['libStatGen.a'], 'lib'),
     ('include'),

--- a/easybuild/easyconfigs/l/libStatGen/libStatGen-1.0.15-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/libStatGen/libStatGen-1.0.15-GCCcore-12.3.0.eb
@@ -9,6 +9,7 @@ description = "Useful set of classes for creating statistical genetic programs."
 
 toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 
+github_account = 'statgen'
 source_urls = [GITHUB_SOURCE]
 sources = [{'download_filename': 'ff4f2fc.tar.gz', 'filename': SOURCELOWER_TAR_GZ}]
 checksums = ['68acb15b6c85f07b0dbf3f8b7a2a99a88fc97d3e29e80bebab82bd2a8e09121e']
@@ -20,8 +21,9 @@ dependencies = [
     ('zlib', '1.2.13'),
 ]
 
-github_account = 'statgen'
 runtest = 'test'
+
+keepsymlinks = False
 files_to_copy = [
     (['%(name)s.a'], 'lib'),
     'include',


### PR DESCRIPTION
> ERROR: Installation of libStatGen-1.0.15-GCCcore-12.3.0.eb failed: "Sanity check failed: no file found at 'include/VcfFile.h' in /user/brussel/101/vsc10122/easybuild/install/zen2/software/libStatGen/1.0.15-GCCcore-12.3.0\nno file found at 'include/SamFile.h' in /user/brussel/101/vsc10122/easybuild/install/zen2/software/libStatGen/1.0.15-GCCcore-12.3.0\nno file found at 'include/BamIndex.h' in /user/brussel/101/vsc10122/easybuild/install/zen2/software/libStatGen/1.0.15-GCCcore-12.3.0\nno file found at 'include/Cigar.h' in /user/brussel/101/vsc10122/easybuild/install/zen2/software/libStatGen/1.0.15-GCCcore-12.3.0"
