### PR TITLE
add build dependency on git to Scalene

### DIFF
--- a/easybuild/easyconfigs/s/Scalene/Scalene-1.5.13-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/s/Scalene/Scalene-1.5.13-GCCcore-11.2.0.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
 
 builddependencies = [
     ('binutils', '2.37'),
+    ('git', '2.33.1', '-nodocs'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/s/Scalene/Scalene-1.5.20-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/s/Scalene/Scalene-1.5.20-GCCcore-11.3.0.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 
 builddependencies = [
     ('binutils', '2.38'),
+    ('git', '2.36.0', '-nodocs'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/s/Scalene/Scalene-1.5.26-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/s/Scalene/Scalene-1.5.26-GCCcore-12.2.0.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 
 builddependencies = [
     ('binutils', '2.39'),
+    ('git', '2.38.1', '-nodocs'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/s/Scalene/Scalene-1.5.26-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/s/Scalene/Scalene-1.5.26-GCCcore-12.3.0.eb
@@ -13,6 +13,7 @@ toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 builddependencies = [
     ('binutils', '2.40'),
     ('poetry', '1.5.1'),
+    ('git', '2.41.0', '-nodocs'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/s/Scalene/Scalene-1.5.35-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/s/Scalene/Scalene-1.5.35-GCCcore-13.2.0.eb
@@ -13,6 +13,7 @@ toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 builddependencies = [
     ('binutils', '2.40'),
     ('poetry', '1.6.1'),
+    ('git', '2.42.0'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/s/Scalene/Scalene-1.5.51-gfbf-2024a.eb
+++ b/easybuild/easyconfigs/s/Scalene/Scalene-1.5.51-gfbf-2024a.eb
@@ -13,6 +13,7 @@ toolchain = {'name': 'gfbf', 'version': '2024a'}
 builddependencies = [
     ('binutils', '2.42'),
     ('poetry', '1.8.3'),
+    ('git', '2.45.1'),
 ]
 
 dependencies = [


### PR DESCRIPTION
Scalene downloads some vendored packages with `git` at build time:
```
== 2025-03-13 14:03:00,251 run.py:598 INFO Output of '/user/brussel/101/vsc10122/easybuild/install/zen2/software/Python/3.11.3-GCCcore-12.3.0/bin/python ...' shell command (stdout + stderr):
Processing /rhea/scratch/brussel/vo/000/bvo00005/vsc10122/easybuild/install/zen2/build/Scalene/1.5.26/GCCcore-12.3.0/Scalene/scalene-1.5.26
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      /user/brussel/101/vsc10122/easybuild/install/zen2/software/Python/3.11.3-GCCcore-12.3.0/lib/python3.11/site-packages/setuptools/__init__.py:84: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
      !!

              ********************************************************************************
              Requirements should be satisfied by a PEP 517 installer.
              If you are using pip, you can try `pip install --use-pep517`.
              ********************************************************************************

      !!
        dist.fetch_build_eggs(dist.setup_requires)
      running egg_info
      make vendor-deps
      rm -fr vendor/
      mkdir -p vendor && cd vendor && git clone https://github.com/emeryberger/Heap-Layers
      Cloning into 'Heap-Layers'...
      /usr/libexec/git-core/git-remote-https: symbol lookup error: /lib64/libk5crypto.so.3: undefined symbol: EVP_KDF_ctrl, version OPENSSL_1_1_1b
      make: *** [GNUmakefile:57: vendor/Heap-Layers] Error 128
      error: command '/usr/bin/make' failed with exit code 2
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```