### PR TITLE
make CMake a runtime dependency of gemmi

### DIFF
--- a/easybuild/easyconfigs/g/gemmi/gemmi-0.4.5-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/g/gemmi/gemmi-0.4.5-GCCcore-10.2.0.eb
@@ -20,24 +20,25 @@ that use CIF files (we have the fastest open-source CIF parser).
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 toolchainopts = {'opt': True}
 
+github_account = 'project-gemmi'
 source_urls = [GITHUB_SOURCE]
 sources = ['v%(version)s.tar.gz']
 checksums = ['af462dbb3a2a144b1437700637e78c0365a5273dc5bffadeea80f73765ab15c7']
 
-github_account = 'project-gemmi'
-
-runtest = 'cpptest ftest ftest_grid test'
+builddependencies = [
+    ('pybind11', '2.6.0'),
+    ('binutils', '2.35')
+]
+dependencies = [
+    ('Python', '3.8.6'),
+    ('CMake', '3.18.4'),  # cmake needed to import gemmi
+]
 
 configopts = '-DUSE_PYTHON=1 '
 configopts += '-DUSE_FORTRAN=1  '
 configopts += '-DPYTHON_INSTALL_DIR=%(installdir)s/lib/python%(pyshortver)s/site-packages '
 
-builddependencies = [
-    ('pybind11', '2.6.0'),
-    ('CMake', '3.18.4'),
-    ('binutils', '2.35')
-]
-dependencies = [('Python', '3.8.6')]
+runtest = 'cpptest ftest ftest_grid test'
 
 sanity_check_paths = {
     'files': ['bin/gemmi'],

--- a/easybuild/easyconfigs/g/gemmi/gemmi-0.6.5-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/gemmi/gemmi-0.6.5-GCCcore-12.3.0.eb
@@ -18,25 +18,26 @@ that use CIF files (we have the fastest open-source CIF parser)."""
 toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 toolchainopts = {'opt': True}
 
+github_account = 'project-gemmi'
 source_urls = [GITHUB_SOURCE]
 sources = ['v%(version)s.tar.gz']
 checksums = ['9159506a16e0d22bbeeefc4d34137099318307db1b2bebf06fb2ae501571b19c']
 
-github_account = 'project-gemmi'
-
-configopts = [
-    '-DSTRIP_BINARY=ON '
-    '-DUSE_FORTRAN=1 -DBUILD_SHARED_LIBS=%s' % x for x in ['OFF', 'ON']]
-
 builddependencies = [
     ('pybind11', '2.11.1'),
     ('pybind11-stubgen', '2.5.1'),
-    ('CMake', '3.26.3'),
     ('scikit-build-core', '0.5.0'),
     ('meson-python', '0.13.2'),
     ('binutils', '2.40')
 ]
-dependencies = [('Python', '3.11.3')]
+dependencies = [
+    ('Python', '3.11.3'),
+    ('CMake', '3.26.3'),  # cmake needed to import gemmi
+]
+
+configopts = [
+    '-DSTRIP_BINARY=ON -DUSE_FORTRAN=1 -DBUILD_SHARED_LIBS=%s' % x for x in ['OFF', 'ON']
+]
 
 local_pipcmd = "mkdir %(builddir)s/pybuild &&"
 local_pipcmd += "python -m pip install -ve %(builddir)s/%(name)s-%(version)s"


### PR DESCRIPTION
CMake is needed at runtime, importing `gemmi` fails without it:

```
== 2025-03-13 14:50:12,728 build_log.py:226 ERROR EasyBuild encountered an error (at easybuild/easybuild-framework/easybuild/base/exceptions.py:126 in __init__): Sanity check failed: command "/user/brussel/101/vsc10122/easybuild/install/zen2/software/Python/3.11.3-GCCcore-12.3.0/bin/python -c "import gemmi"" failed; output:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1140, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1080, in _find_spec
  File "/user/brussel/101/vsc10122/easybuild/install/zen2/software/gemmi/0.6.5-GCCcore-12.3.0/lib/python3.11/site-packages/_gemmi_editable.py", line 49, in find_spec
    self.rebuild()
  File "/user/brussel/101/vsc10122/easybuild/install/zen2/software/gemmi/0.6.5-GCCcore-12.3.0/lib/python3.11/site-packages/_gemmi_editable.py", line 77, in rebuild
    result = subprocess.run(
             ^^^^^^^^^^^^^^^
  File "/user/brussel/101/vsc10122/easybuild/install/zen2/software/Python/3.11.3-GCCcore-12.3.0/lib/python3.11/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/user/brussel/101/vsc10122/easybuild/install/zen2/software/Python/3.11.3-GCCcore-12.3.0/lib/python3.11/subprocess.py", line 1024, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/user/brussel/101/vsc10122/easybuild/install/zen2/software/Python/3.11.3-GCCcore-12.3.0/lib/python3.11/subprocess.py", line 1917, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'cmake'
```