### PR TITLE
clean up easyconfigs so they don't explicitly enable `keepsymlinks`, since it's now enabled by default

### DIFF
--- a/easybuild/easyconfigs/a/ADF/ADF-2019.303-intelmpi.eb
+++ b/easybuild/easyconfigs/a/ADF/ADF-2019.303-intelmpi.eb
@@ -15,8 +15,6 @@ checksums = ['62f73d2bc37bfc7891c1b10e83abccae317f7751f2a7b88976b24d16ef2b771a']
 download_instructions = f"""{name} requires manual download from {homepage}
 Required downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['atomicdata', 'bin', 'examples'],

--- a/easybuild/easyconfigs/a/AMS/AMS-2020.102-iimpi-2020b-intelmpi.eb
+++ b/easybuild/easyconfigs/a/AMS/AMS-2020.102-iimpi-2020b-intelmpi.eb
@@ -19,8 +19,6 @@ Required download: {' '.join(sources)}"""
 
 dependencies = [('libGLU', '9.0.1')]
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['atomicdata', 'bin', 'examples'],

--- a/easybuild/easyconfigs/a/AMS/AMS-2022.102-iimpi-2021b-intelmpi.eb
+++ b/easybuild/easyconfigs/a/AMS/AMS-2022.102-iimpi-2021b-intelmpi.eb
@@ -19,8 +19,6 @@ Required download: {' '.join(sources)}"""
 
 dependencies = [('libGLU', '9.0.2')]
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['atomicdata', 'bin', 'examples'],

--- a/easybuild/easyconfigs/a/AMS/AMS-2023.101-iimpi-2022a-intelmpi.eb
+++ b/easybuild/easyconfigs/a/AMS/AMS-2023.101-iimpi-2022a-intelmpi.eb
@@ -20,8 +20,6 @@ Required download: {' '.join(sources)}"""
 
 dependencies = [('libGLU', '9.0.2')]
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['atomicdata', 'bin', 'examples'],

--- a/easybuild/easyconfigs/a/AMS/AMS-2023.104-iimpi-2022b-intelmpi.eb
+++ b/easybuild/easyconfigs/a/AMS/AMS-2023.104-iimpi-2022b-intelmpi.eb
@@ -20,8 +20,6 @@ Required download: {' '.join(sources)}"""
 
 dependencies = [('libGLU', '9.0.2')]
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['atomicdata', 'bin', 'examples'],

--- a/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.41-foss-2021b.eb
+++ b/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.41-foss-2021b.eb
@@ -23,8 +23,6 @@ checksums = ['3b868c820d59dd38372417efc31e9be3fbdca8cf0a6b39f13fb2b822607d6194']
 prebuildopts = 'unset LIBS && '
 # builds all variants and copies executables to bin directory
 buildopts = ' all && make install'
-# actually used variant is linked to via symlinks
-keepsymlinks = True
 
 files_to_copy = ['bin']
 

--- a/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.41-foss-2023a.eb
+++ b/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.41-foss-2023a.eb
@@ -24,8 +24,6 @@ checksums = ['3b868c820d59dd38372417efc31e9be3fbdca8cf0a6b39f13fb2b822607d6194']
 prebuildopts = 'unset LIBS && '
 # builds all variants and copies executables to bin directory
 buildopts = ' all && make install'
-# actually used variant is linked to via symlinks
-keepsymlinks = True
 
 files_to_copy = ['bin']
 

--- a/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.41-foss-2023b.eb
+++ b/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.41-foss-2023b.eb
@@ -24,8 +24,6 @@ checksums = ['3b868c820d59dd38372417efc31e9be3fbdca8cf0a6b39f13fb2b822607d6194']
 prebuildopts = 'unset LIBS && '
 # builds all variants and copies executables to bin directory
 buildopts = ' all && make install'
-# actually used variant is linked to via symlinks
-keepsymlinks = True
 
 files_to_copy = ['bin']
 

--- a/easybuild/easyconfigs/c/CellRanger-ARC/CellRanger-ARC-1.0.1.eb
+++ b/easybuild/easyconfigs/c/CellRanger-ARC/CellRanger-ARC-1.0.1.eb
@@ -23,8 +23,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-multiome-atac-gex/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ["bin/cellranger-arc"],
     'dirs': ["bin/rna", "bin/tenkit"],

--- a/easybuild/easyconfigs/c/CellRanger-ARC/CellRanger-ARC-2.0.0.eb
+++ b/easybuild/easyconfigs/c/CellRanger-ARC/CellRanger-ARC-2.0.0.eb
@@ -23,8 +23,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-multiome-atac-gex/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ["bin/cellranger-arc"],
     'dirs': ["bin/rna", "bin/tenkit"],

--- a/easybuild/easyconfigs/c/CellRanger-ARC/CellRanger-ARC-2.0.1.eb
+++ b/easybuild/easyconfigs/c/CellRanger-ARC/CellRanger-ARC-2.0.1.eb
@@ -23,8 +23,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-multiome-atac-gex/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ["bin/cellranger-arc"],
     'dirs': ["bin/rna", "bin/tenkit"],

--- a/easybuild/easyconfigs/c/CellRanger-ARC/CellRanger-ARC-2.0.2.eb
+++ b/easybuild/easyconfigs/c/CellRanger-ARC/CellRanger-ARC-2.0.2.eb
@@ -25,8 +25,6 @@ https://www.10xgenomics.com/support/software/cell-ranger-arc/downloads
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['02a02457938dcf8dcb418b6c65effac06b210282d167437bfa8b2f10023dacae']
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ["bin/cellranger-arc"],
     'dirs': ["bin/rna", "bin/tenkit"],

--- a/easybuild/easyconfigs/c/CellRanger-ATAC/CellRanger-ATAC-1.2.0.eb
+++ b/easybuild/easyconfigs/c/CellRanger-ATAC/CellRanger-ATAC-1.2.0.eb
@@ -19,8 +19,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-atac/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 modextrapaths = {"PATH": ""}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/c/CellRanger-ATAC/CellRanger-ATAC-2.0.0.eb
+++ b/easybuild/easyconfigs/c/CellRanger-ATAC/CellRanger-ATAC-2.0.0.eb
@@ -19,8 +19,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-atac/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ['bin/cellranger-atac', 'cellranger-atac'],
     'dirs': ['bin/atac', 'lib'],

--- a/easybuild/easyconfigs/c/CellRanger-ATAC/CellRanger-ATAC-2.1.0.eb
+++ b/easybuild/easyconfigs/c/CellRanger-ATAC/CellRanger-ATAC-2.1.0.eb
@@ -19,8 +19,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-atac/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ['bin/cellranger-atac', 'cellranger-atac'],
     'dirs': ['bin/atac', 'lib'],

--- a/easybuild/easyconfigs/c/CellRanger/CellRanger-4.0.0.eb
+++ b/easybuild/easyconfigs/c/CellRanger/CellRanger-4.0.0.eb
@@ -19,8 +19,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ["bin/cellranger"],
     'dirs': ["bin/rna", "bin/tenkit"],

--- a/easybuild/easyconfigs/c/CellRanger/CellRanger-5.0.0.eb
+++ b/easybuild/easyconfigs/c/CellRanger/CellRanger-5.0.0.eb
@@ -19,8 +19,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ["bin/cellranger"],
     'dirs': ["bin/rna", "bin/tenkit"],

--- a/easybuild/easyconfigs/c/CellRanger/CellRanger-5.0.1.eb
+++ b/easybuild/easyconfigs/c/CellRanger/CellRanger-5.0.1.eb
@@ -19,8 +19,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ["bin/cellranger"],
     'dirs': ["bin/rna", "bin/tenkit"],

--- a/easybuild/easyconfigs/c/CellRanger/CellRanger-6.0.0.eb
+++ b/easybuild/easyconfigs/c/CellRanger/CellRanger-6.0.0.eb
@@ -19,8 +19,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ["bin/cellranger"],
     'dirs': ["bin/rna", "bin/tenkit"],

--- a/easybuild/easyconfigs/c/CellRanger/CellRanger-6.0.1.eb
+++ b/easybuild/easyconfigs/c/CellRanger/CellRanger-6.0.1.eb
@@ -19,8 +19,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ["bin/cellranger"],
     'dirs': ["bin/rna", "bin/tenkit"],

--- a/easybuild/easyconfigs/c/CellRanger/CellRanger-6.0.2.eb
+++ b/easybuild/easyconfigs/c/CellRanger/CellRanger-6.0.2.eb
@@ -19,8 +19,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ["bin/cellranger"],
     'dirs': ["bin/rna", "bin/tenkit"],

--- a/easybuild/easyconfigs/c/CellRanger/CellRanger-6.1.2.eb
+++ b/easybuild/easyconfigs/c/CellRanger/CellRanger-6.1.2.eb
@@ -19,8 +19,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ["bin/cellranger"],
     'dirs': ["bin/rna", "bin/tenkit"],

--- a/easybuild/easyconfigs/c/CellRanger/CellRanger-7.0.0.eb
+++ b/easybuild/easyconfigs/c/CellRanger/CellRanger-7.0.0.eb
@@ -19,8 +19,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ['bin/cellranger'],
     'dirs': ['bin/rna', 'bin/tenkit'],

--- a/easybuild/easyconfigs/c/CellRanger/CellRanger-7.1.0.eb
+++ b/easybuild/easyconfigs/c/CellRanger/CellRanger-7.1.0.eb
@@ -19,8 +19,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ['bin/cellranger'],
     'dirs': ['bin/rna', 'bin/tenkit'],

--- a/easybuild/easyconfigs/c/CellRanger/CellRanger-7.2.0.eb
+++ b/easybuild/easyconfigs/c/CellRanger/CellRanger-7.2.0.eb
@@ -19,8 +19,6 @@ download_instructions = f"{name} requires manual download from "
 download_instructions += "https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest"
 download_instructions += f"\nRequired downloads: {' '.join(sources)}"""
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ['bin/cellranger'],
     'dirs': ['bin/rna', 'bin/tenkit'],

--- a/easybuild/easyconfigs/c/CellRanger/CellRanger-8.0.0.eb
+++ b/easybuild/easyconfigs/c/CellRanger/CellRanger-8.0.0.eb
@@ -19,8 +19,6 @@ Download manually from https://support.10xgenomics.com/single-cell-gene-expressi
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['58b077b66b2b48966b3712a1f16a61be938237addbdf611a7a924bc99211bca6']
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ['bin/cellranger'],
     'dirs': ['bin/rna', 'bin/tenkit'],

--- a/easybuild/easyconfigs/c/CellRanger/CellRanger-8.0.1.eb
+++ b/easybuild/easyconfigs/c/CellRanger/CellRanger-8.0.1.eb
@@ -19,8 +19,6 @@ Download manually from https://support.10xgenomics.com/single-cell-gene-expressi
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['ea2a35ac0f03961bab2ea485565d60cc6709a981c833a5e6c2b13a8fef641e81']
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ['bin/cellranger'],
     'dirs': ['bin/rna', 'bin/tenkit'],

--- a/easybuild/easyconfigs/c/CellRanger/CellRanger-9.0.0.eb
+++ b/easybuild/easyconfigs/c/CellRanger/CellRanger-9.0.0.eb
@@ -19,8 +19,6 @@ Download manually from https://support.10xgenomics.com/single-cell-gene-expressi
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['d57e574630bc0871299ba0e3e3b9a770b572cd35a819c52bfd58403ccd72035d']
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ['bin/cellranger'],
     'dirs': ['bin/rna', 'bin/tenkit'],

--- a/easybuild/easyconfigs/n/netMHCII/netMHCII-2.3.eb
+++ b/easybuild/easyconfigs/n/netMHCII/netMHCII-2.3.eb
@@ -29,8 +29,6 @@ checksums = [
 download_instructions = f"""{name} is proprietary software, but free for academics.
 It can be requested at {homepage}"""
 
-keepsymlinks = True
-
 postinstallcmds = [
     "sed -i -e 's|setenv[[:space:]]NMHOME.*|setenv NMHOME $EBROOTNETMHCII|' %(installdir)s/netMHCII-%(version)s",
     "sed -i -e 's|setenv[[:space:]]*TMPDIR.*|setenv TMPDIR $TMPDIR|' %(installdir)s/netMHCII-%(version)s",

--- a/easybuild/easyconfigs/r/RInChI/RInChI-1.00-x86_64.eb
+++ b/easybuild/easyconfigs/r/RInChI/RInChI-1.00-x86_64.eb
@@ -36,7 +36,6 @@ source_urls = ['https://www.inchi-trust.org/download/RInChI/']
 sources = ['RInChI-V%(version_major)s-%(version_minor)s.zip']
 checksums = ['e115b941185ee64e444bfbd57f1b9e80d7fd14e39bc803975843dfface2a163c']
 
-
 extract_sources = True
 
 install_cmd = 'mkdir -p %(installdir)s/bin/   && '

--- a/easybuild/easyconfigs/s/Spack/Spack-0.16.2.eb
+++ b/easybuild/easyconfigs/s/Spack/Spack-0.16.2.eb
@@ -14,8 +14,6 @@ source_urls = ['https://github.com/spack/spack/archive/']
 sources = ['v%(version)s.tar.gz']
 checksums = ['ed3e5d479732b0ba82489435b4e0f9088571604e789f7ab9bc5ce89030793350']
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ['bin/spack'],
     'dirs': ['etc/spack/defaults', 'lib/spack', 'share/spack', 'var/spack'],

--- a/easybuild/easyconfigs/s/Spack/Spack-0.17.0.eb
+++ b/easybuild/easyconfigs/s/Spack/Spack-0.17.0.eb
@@ -17,8 +17,6 @@ source_urls = ['https://github.com/spack/spack/archive/']
 sources = ['v%(version)s.tar.gz']
 checksums = ['93df99256a892ceefb153d48e2080c01d18e58e27773da2c2a469063d67cb582']
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ['bin/spack'],
     'dirs': ['etc/spack/defaults', 'lib/spack', 'share/spack', 'var/spack'],

--- a/easybuild/easyconfigs/s/Spack/Spack-0.17.2.eb
+++ b/easybuild/easyconfigs/s/Spack/Spack-0.17.2.eb
@@ -17,8 +17,6 @@ source_urls = ['https://github.com/spack/spack/archive/']
 sources = ['v%(version)s.tar.gz']
 checksums = ['3c3c0eccc5c0a1fa89223cbdfd48c71c5be8b4645f5fa4e921426062a9b32d51']
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ['bin/spack'],
     'dirs': ['etc/spack/defaults', 'lib/spack', 'share/spack', 'var/spack'],

--- a/easybuild/easyconfigs/s/Spack/Spack-0.21.2.eb
+++ b/easybuild/easyconfigs/s/Spack/Spack-0.21.2.eb
@@ -17,8 +17,6 @@ source_urls = [GITHUB_LOWER_RELEASE]
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['b1860537ba00c55fa0b2517ce9dbfe0e415600892c48e3dc4e15ee8da0f50dd3']
 
-keepsymlinks = True
-
 sanity_check_paths = {
     'files': ['bin/spack'],
     'dirs': ['etc/spack/defaults', 'lib/spack', 'share/spack', 'var/spack'],

--- a/easybuild/easyconfigs/s/SqueezeMeta/SqueezeMeta-1.5.0-foss-2021b.eb
+++ b/easybuild/easyconfigs/s/SqueezeMeta/SqueezeMeta-1.5.0-foss-2021b.eb
@@ -50,8 +50,6 @@ dependencies = [
     ('R-bundle-Bioconductor', '3.14', '-R-%(rver)s')  # provides pathview needed for SQMtools
 ]
 
-keepsymlinks = True
-
 postinstallcmds = [
     # backup patched barrnap
     "cp %(installdir)s/bin/barrnap %(builddir)s/",

--- a/easybuild/easyconfigs/s/sonic/sonic-20180202-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/s/sonic/sonic-20180202-gfbf-2023a.eb
@@ -26,8 +26,6 @@ checksums = [
     '1e767c98286e13231d01ec7ae2ec2ea9b9c0ce074d4f8034b9d92ee2854d1be9',  # sonic-20180202.patch
 ]
 
-keepsymlinks = True
-
 files_to_copy = [
     (['sonic'], 'bin'),
     (['sonic.h'], 'include'),


### PR DESCRIPTION
List of affected easyconfigs:
* a/ADF/ADF-2019.303-intelmpi.eb
* a/AMS/AMS-2020.102-iimpi-2020b-intelmpi.eb
* a/AMS/AMS-2022.102-iimpi-2021b-intelmpi.eb
* a/AMS/AMS-2023.101-iimpi-2022a-intelmpi.eb
* a/AMS/AMS-2023.104-iimpi-2022b-intelmpi.eb
* b/BEDOPS/BEDOPS-2.4.41-foss-2021b.eb
* b/BEDOPS/BEDOPS-2.4.41-foss-2023a.eb
* b/BEDOPS/BEDOPS-2.4.41-foss-2023b.eb
* c/CellRanger-ARC/CellRanger-ARC-1.0.1.eb
* c/CellRanger-ARC/CellRanger-ARC-2.0.0.eb
* c/CellRanger-ARC/CellRanger-ARC-2.0.1.eb
* c/CellRanger-ARC/CellRanger-ARC-2.0.2.eb
* c/CellRanger-ATAC/CellRanger-ATAC-1.2.0.eb
* c/CellRanger-ATAC/CellRanger-ATAC-2.0.0.eb
* c/CellRanger-ATAC/CellRanger-ATAC-2.1.0.eb
* c/CellRanger/CellRanger-4.0.0.eb
* c/CellRanger/CellRanger-5.0.0.eb
* c/CellRanger/CellRanger-5.0.1.eb
* c/CellRanger/CellRanger-6.0.0.eb
* c/CellRanger/CellRanger-6.0.1.eb
* c/CellRanger/CellRanger-6.0.2.eb
* c/CellRanger/CellRanger-6.1.2.eb
* c/CellRanger/CellRanger-7.0.0.eb
* c/CellRanger/CellRanger-7.1.0.eb
* c/CellRanger/CellRanger-7.2.0.eb
* c/CellRanger/CellRanger-8.0.0.eb
* c/CellRanger/CellRanger-8.0.1.eb
* c/CellRanger/CellRanger-9.0.0.eb
* n/netMHCII/netMHCII-2.3.eb
* s/Spack/Spack-0.16.2.eb
* s/Spack/Spack-0.17.0.eb
* s/Spack/Spack-0.17.2.eb
* s/Spack/Spack-0.21.2.eb
* s/SqueezeMeta/SqueezeMeta-1.5.0-foss-2021b.eb
* s/sonic/sonic-20180202-gfbf-2023a.eb