### PR TITLE
use reproducible archives on easyconfigs with sources from git repos without a .git dir

### DIFF
--- a/easybuild/easyconfigs/a/AlphaPulldown/AlphaPulldown-2.0.0-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/a/AlphaPulldown/AlphaPulldown-2.0.0-foss-2023a-CUDA-12.1.1.eb
@@ -89,17 +89,16 @@ exts_list = [
         'preinstallopts': "sed -i 's/[>=]=.*//g;s/tensorflow-cpu/tensorflow/g' setup.cfg && ",
         'runtest': '%s pytest -s %s ' % (local_testinstall_PATH, " ".join('test/test_%s.py' % x for x in local_tests)),
         'sources': [{
-            'filename': '%(name)s-%(version)s.tar.gz',
+            'filename': SOURCE_TAR_XZ,
             'git_config': {
                 'url': 'https://github.com/KosinskiLab',
                 'repo_name': 'AlphaPulldown',
-                'tag': version, 'recursive': True
+                'tag': version,
+                'recursive': True
             }
         }],
         'testinstall': True,
-        # This needs to be [None], at least until EB v5 is out
-        # 'checksums': ['e338195987e003f3caadb06bda0ca56dece87e358738143ea72662f9ad69b1d4'],
-        'checksums': [None],
+        'checksums': ['a48df359e80444bf9874991f4eba6d2c57b99c523da76d024f5110a2f083ccc3'],
     }),
 ]
 

--- a/easybuild/easyconfigs/a/AlphaPulldown/AlphaPulldown-2.0.0b4-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/a/AlphaPulldown/AlphaPulldown-2.0.0b4-foss-2022a-CUDA-11.7.0.eb
@@ -69,7 +69,7 @@ exts_list = [
     }),
     (name, version, {
         'sources': [{
-            'filename': SOURCE_TAR_GZ,
+            'filename': SOURCE_TAR_XZ,
             'git_config': {
                 'url': 'https://github.com/KosinskiLab',
                 'repo_name': 'AlphaPulldown',
@@ -79,8 +79,10 @@ exts_list = [
         }],
         'patches': ['AlphaPulldown-2.0.0b2_fix-import-protein_letters_3to1.patch'],
         'checksums': [
-            None,
-            'd41247cd12f6ef8579adbc893f6c1af5fba051167ee838449974365f4bdccf06',
+            {'AlphaPulldown-2.0.0b4.tar.xz':
+             '574eee097be4fee3e7f022b5935ac29b858ad9de32edd4bc1ca0439047f9b2f5'},
+            {'AlphaPulldown-2.0.0b2_fix-import-protein_letters_3to1.patch':
+             'd41247cd12f6ef8579adbc893f6c1af5fba051167ee838449974365f4bdccf06'},
         ],
         # remove strict version requirements for Python dependencies
         'preinstallopts': "sed -i 's/[>=]=.*//g' setup.cfg && ",

--- a/easybuild/easyconfigs/a/AlphaPulldown/AlphaPulldown-2.0.0b4-foss-2022a.eb
+++ b/easybuild/easyconfigs/a/AlphaPulldown/AlphaPulldown-2.0.0b4-foss-2022a.eb
@@ -67,7 +67,7 @@ exts_list = [
     }),
     (name, version, {
         'sources': [{
-            'filename': SOURCE_TAR_GZ,
+            'filename': SOURCE_TAR_XZ,
             'git_config': {
                 'url': 'https://github.com/KosinskiLab',
                 'repo_name': 'AlphaPulldown',
@@ -77,8 +77,10 @@ exts_list = [
         }],
         'patches': ['AlphaPulldown-2.0.0b2_fix-import-protein_letters_3to1.patch'],
         'checksums': [
-            None,
-            'd41247cd12f6ef8579adbc893f6c1af5fba051167ee838449974365f4bdccf06',
+            {'AlphaPulldown-2.0.0b4.tar.xz':
+             '574eee097be4fee3e7f022b5935ac29b858ad9de32edd4bc1ca0439047f9b2f5'},
+            {'AlphaPulldown-2.0.0b2_fix-import-protein_letters_3to1.patch':
+             'd41247cd12f6ef8579adbc893f6c1af5fba051167ee838449974365f4bdccf06'},
         ],
         # remove strict version requirements for Python dependencies
         'preinstallopts': "sed -i 's/[>=]=.*//g' setup.cfg && ",

--- a/easybuild/easyconfigs/c/CREST/CREST-3.0.1-gfbf-2022b.eb
+++ b/easybuild/easyconfigs/c/CREST/CREST-3.0.1-gfbf-2022b.eb
@@ -15,7 +15,7 @@ toolchain = {'name': 'gfbf', 'version': '2022b'}
 toolchainopts = {'opt': True}
 
 sources = [{
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/crest-lab',
         'repo_name': 'crest',
@@ -23,7 +23,7 @@ sources = [{
         'recursive': True,
     },
 }]
-checksums = [None]
+checksums = ['271c446730cd82856eb05692daa3184079d91f1f5bb12930ed801e2cf037a3bd']
 
 builddependencies = [('CMake', '3.24.3')]
 

--- a/easybuild/easyconfigs/c/CREST/CREST-3.0.2-foss-2023a.eb
+++ b/easybuild/easyconfigs/c/CREST/CREST-3.0.2-foss-2023a.eb
@@ -15,7 +15,7 @@ toolchain = {'name': 'foss', 'version': '2023a'}
 toolchainopts = {'opt': True}
 
 sources = [{
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/crest-lab',
         'repo_name': 'crest',
@@ -23,7 +23,7 @@ sources = [{
         'recursive': True,
     },
 }]
-checksums = [None]
+checksums = ['e54cce51b748a95ac65fac239796df382977cb30cba0940cc83a0ba3a6cd05db']
 
 builddependencies = [('CMake', '3.26.3')]
 

--- a/easybuild/easyconfigs/c/CREST/CREST-3.0.2-gfbf-2023b.eb
+++ b/easybuild/easyconfigs/c/CREST/CREST-3.0.2-gfbf-2023b.eb
@@ -15,7 +15,7 @@ toolchain = {'name': 'gfbf', 'version': '2023b'}
 toolchainopts = {'opt': True}
 
 sources = [{
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/crest-lab',
         'repo_name': 'crest',
@@ -23,7 +23,7 @@ sources = [{
         'recursive': True,
     },
 }]
-checksums = [None]
+checksums = ['e54cce51b748a95ac65fac239796df382977cb30cba0940cc83a0ba3a6cd05db']
 
 builddependencies = [('CMake', '3.27.6')]
 

--- a/easybuild/easyconfigs/c/CloudCompare/CloudCompare-2.12.4-foss-2021b.eb
+++ b/easybuild/easyconfigs/c/CloudCompare/CloudCompare-2.12.4-foss-2021b.eb
@@ -13,7 +13,7 @@ source_urls = [GITHUB_SOURCE]
 sources = [
     'v%(version)s.tar.gz',
     {
-        'filename': 'CCCoreLib-20220714.tar.gz',
+        'filename': 'CCCoreLib-20220714.tar.xz',
         'git_config': {
             'url': 'https://github.com/CloudCompare',
             'repo_name': 'CCCoreLib',
@@ -23,8 +23,10 @@ sources = [
     },
 ]
 checksums = [
-    '31c1f4f91efbdb74619cebb36f57f999d6f1a57bb6f87b13e60d21e670c38f68',
-    None,
+    {'v2.12.4.tar.gz':
+     '31c1f4f91efbdb74619cebb36f57f999d6f1a57bb6f87b13e60d21e670c38f68'},
+    {'CCCoreLib-20220714.tar.xz':
+     'dc42727a687f5f88a0e567fbe9bd885862934a6e783aa058023e34d2be669623'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/c/Cluster-Buster/Cluster-Buster-20200507-GCC-12.2.0.eb
+++ b/easybuild/easyconfigs/c/Cluster-Buster/Cluster-Buster-20200507-GCC-12.2.0.eb
@@ -15,9 +15,9 @@ sources = [{
         'repo_name': '%(namelower)s',
         'commit': 'ac1d33cffff0c276216450ebced471595cf01488',
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
-checksums = [None]
+checksums = ['b02b939ce55aae582953822de7ea5db87bcd06783f1ff3fe5eab6a7a62f6652b']
 
 files_to_copy = [(['cbust'], 'bin')]
 

--- a/easybuild/easyconfigs/d/DGL/DGL-0.9.1-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/d/DGL/DGL-0.9.1-foss-2021a-CUDA-11.3.1.eb
@@ -19,7 +19,7 @@ source_urls = [GITHUB_LOWER_SOURCE]
 sources = [
     {
         'download_filename': '%(version)s.tar.gz',
-        'filename': '%(namelower)s-%(version)s.tar.gz',
+        'filename': SOURCELOWER_TAR_GZ,
     },
     {
         'source_urls': ['https://github.com/KarypisLab/METIS/archive'],
@@ -118,7 +118,11 @@ exts_default_options = {
 
 exts_list = [
     ('dgl', version, {
-        'source_tmpl': '%(namelower)s-%(version)s.tar.gz',
+        'source_urls': [GITHUB_LOWER_SOURCE],
+        'sources': {
+            'download_filename': '%(version)s.tar.gz',
+            'filename': SOURCELOWER_TAR_GZ,
+        },
         'start_dir': 'python',
         'installopts': '--use-feature=in-tree-build ',
         'checksums': ['8d26ebb7ed976665bbf5bbd1792d8e6efb13a8fa16e5eb1efed75e07fb982e04'],

--- a/easybuild/easyconfigs/d/DGL/DGL-0.9.1-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/d/DGL/DGL-0.9.1-foss-2021a-CUDA-11.3.1.eb
@@ -34,7 +34,7 @@ sources = [
         'extract_cmd': "tar -C %(namelower)s-%(version)s/third_party/METIS/GKlib --strip-components=1 -xf %s",
     },
     {
-        'filename': 'tensorpipe-20230206.tar.gz',
+        'filename': 'tensorpipe-20230206.tar.xz',
         'git_config': {
             'url': 'https://github.com/pytorch',
             'repo_name': 'tensorpipe',
@@ -65,7 +65,7 @@ checksums = [
     '8d26ebb7ed976665bbf5bbd1792d8e6efb13a8fa16e5eb1efed75e07fb982e04',  # dgl-0.9.1.tar.gz
     'cedf0b32d32a8496bac7eb078b2b8260fb00ddb8d50c27e4082968a01bc33331',  # metis-5.1.1-DistDGL-v0.5.tar.gz
     '52aa0d383d42360f4faa0ae9537ba2ca348eeab4db5f2dfd6343192d0ff4b833',  # GKlib-METIS-v5.1.1-DistDGL-0.5.tar.gz
-    None,  # tensorpipe-20230206.tar.gz
+    '85203179f7970f4274a9f90452616ec534b1f54a87040fc98786d035efb429e4',  # tensorpipe-20230206.tar.xz
     'b02aca5d2325e9128ed9d46785b8e72366f758b873b95001f905f22afcf31bbf',  # thrust-1.17.0.tar.gz
     '16fd4860ae3196bc3eb08bf5754fa2a9697951ddae36dc9721e6614388893618',  # cub-1.17.0.tar.gz
     # DGL-0.9.1_use_externals_instead_of_submodules.patch'

--- a/easybuild/easyconfigs/d/DP3/DP3-6.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/d/DP3/DP3-6.0-foss-2022a.eb
@@ -8,7 +8,7 @@ description = """DP3: streaming processing pipeline for radio interferometric da
 toolchain = {'name': 'foss', 'version': '2022a'}
 
 sources = [{
-    'filename': '%(name)s-v%(version)s.tar.gz',
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://git.astron.nl/RD',
         'repo_name': '%(name)s',
@@ -17,7 +17,7 @@ sources = [{
         'recursive': True,
     },
 }]
-checksums = [None]
+checksums = ['9ca678e9608a401a1dda4676e8d28f1000212ad51553a284bbc8842de37a713c']
 
 builddependencies = [
     ('CMake', '3.24.3'),

--- a/easybuild/easyconfigs/d/DP3/DP3-6.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/d/DP3/DP3-6.0-foss-2023b.eb
@@ -10,7 +10,7 @@ toolchain = {'name': 'foss', 'version': '2023b'}
 
 sources = [
     {
-        'filename': '%(name)s-v%(version)s.tar.gz',
+        'filename': SOURCE_TAR_XZ,
         # Repo uses git submodules, which are not included in the release tarballs.
         # Thus, we let EasyBuild download directly from the git repository.
         'git_config': {
@@ -24,9 +24,10 @@ sources = [
 ]
 patches = ['DP3-6.0_fix-for-xsimd-error-on-neoverse-v1.patch']
 checksums = [
-    None,  # checksum for git clone source is non-deterministic
-    # DP3-6.0_fix-for-xsimd-error-on-neoverse-v1.patch
-    '7f5069388846c9c715013d5a3a267a6d8e266520445a6427e63e9d52d3046c9d',
+    {'DP3-6.0.tar.xz':
+     '9ca678e9608a401a1dda4676e8d28f1000212ad51553a284bbc8842de37a713c'},
+    {'DP3-6.0_fix-for-xsimd-error-on-neoverse-v1.patch':
+     '7f5069388846c9c715013d5a3a267a6d8e266520445a6427e63e9d52d3046c9d'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/d/DP3/DP3-6.2-foss-2023b.eb
+++ b/easybuild/easyconfigs/d/DP3/DP3-6.2-foss-2023b.eb
@@ -10,7 +10,7 @@ toolchain = {'name': 'foss', 'version': '2023b'}
 
 sources = [
     {
-        'filename': '%(name)s-v%(version)s.tar.gz',
+        'filename': SOURCE_TAR_XZ,
         # Repo uses git submodules, which are not included in the release tarballs.
         # Thus, we let EasyBuild download directly from the git repository.
         'git_config': {
@@ -24,9 +24,10 @@ sources = [
 ]
 patches = ['DP3-6.2_fix-for-xsimd-error-on-neoverse-v1.patch']
 checksums = [
-    None,  # checksum for git clone source is non-deterministic
-    # DP3-6.2_fix-for-xsimd-error-on-neoverse-v1.patch
-    '51209661ee657151d94778916d4f295b9d767f6bbd13720fc5054a2a24f740dc',
+    {'DP3-6.2.tar.xz':
+     '6f5f46dff4317a2e7e667dc963e3bd28dccfc8d7556b2f1a45ec54bda8a77a0a'},
+    {'DP3-6.2_fix-for-xsimd-error-on-neoverse-v1.patch':
+     '51209661ee657151d94778916d4f295b9d767f6bbd13720fc5054a2a24f740dc'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/d/Dalton/Dalton-2020.0-foss-2021a.eb
+++ b/easybuild/easyconfigs/d/Dalton/Dalton-2020.0-foss-2021a.eb
@@ -14,7 +14,7 @@ toolchain = {'name': 'foss', 'version': '2021a'}
 toolchainopts = {'usempi': True, 'openmp': True}
 
 sources = [{
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://gitlab.com/dalton',
         'repo_name': 'dalton',
@@ -31,7 +31,7 @@ patches = [
     '%(name)s-%(version)s_disable_failing_tests.patch',
 ]
 checksums = [
-    None,  # Dalton-2020.0.tar.gz
+    'a67f8d7ed5a06777638e7e2a778daca6bcdcec617c14700e51c5bb57716b4d89',  # Dalton-2020.0.tar.xz
     '3159b03a488d6f5ee23d468be02ea62eacd08cbdf68cd64ef4e5a0d469a6718b',  # Dalton-2016-fix-cmake-install.patch
     # Dalton-2020.0_use-EB-install-for-dalton-script.patch
     'f38b434d2af609b667b341192d8f0d7e37ee1e0461cc68c780b049c7027bfcf5',

--- a/easybuild/easyconfigs/d/Dalton/Dalton-2020.1-foss-2022b.eb
+++ b/easybuild/easyconfigs/d/Dalton/Dalton-2020.1-foss-2022b.eb
@@ -19,7 +19,7 @@ toolchain = {'name': 'foss', 'version': '2022b'}
 toolchainopts = {'usempi': True, 'openmp': True}
 
 sources = [{
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://gitlab.com/dalton',
         'repo_name': 'dalton',
@@ -37,7 +37,7 @@ patches = [
 ]
 
 checksums = [
-    None,  # Dalton-2020.0.tar.gz
+    '68c1a8119195d58a5f0ce1cf455a669af750966674946ac682eca391e5880be2',  # Dalton-2020.1.tar.xz
     '3159b03a488d6f5ee23d468be02ea62eacd08cbdf68cd64ef4e5a0d469a6718b',  # Dalton-2016-fix-cmake-install.patch
     # Dalton-2020.0_use-EB-install-for-dalton-script.patch
     'f38b434d2af609b667b341192d8f0d7e37ee1e0461cc68c780b049c7027bfcf5',

--- a/easybuild/easyconfigs/d/dorado/dorado-0.1.1-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/d/dorado/dorado-0.1.1-foss-2022a-CUDA-11.7.0.eb
@@ -18,9 +18,9 @@ sources = [{
         'tag': 'v%(version)s',
         'recursive': True,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
-checksums = [None]
+checksums = ['99aba3685a24b8f6004bd68c8e35d59b027a55c52bd32423e3e2f361ec297548']
 
 builddependencies = [
     ('binutils', '2.38'),

--- a/easybuild/easyconfigs/d/dorado/dorado-0.3.0-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/d/dorado/dorado-0.3.0-foss-2022a-CUDA-11.7.0.eb
@@ -18,9 +18,9 @@ sources = [{
         'tag': 'v%(version)s',
         'recursive': True,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
-checksums = [None]
+checksums = ['e01968f81051a10cb28cead93c8f6ab1950292abadcd86fc86f214a7f6a4dd32']
 
 builddependencies = [
     ('binutils', '2.38'),

--- a/easybuild/easyconfigs/d/dorado/dorado-0.3.1-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/d/dorado/dorado-0.3.1-foss-2022a-CUDA-11.7.0.eb
@@ -18,9 +18,9 @@ sources = [{
         'tag': 'v%(version)s',
         'recursive': True,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
-checksums = [None]
+checksums = ['13c71adb8f48e796eff2e5418eda8e347fc9eefc842e0bb65b44455a046e0279']
 
 builddependencies = [
     ('binutils', '2.38'),

--- a/easybuild/easyconfigs/d/dorado/dorado-0.5.1-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/d/dorado/dorado-0.5.1-foss-2022a-CUDA-11.7.0.eb
@@ -20,9 +20,9 @@ sources = [{
         'tag': 'v%(version)s',
         'recursive': True,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
-checksums = [None]
+checksums = ['f5399902e93b5d294fd4a0459515ae9eddabe8651ea63f141590237509dfacb1']
 
 builddependencies = [
     ('binutils', '2.38'),

--- a/easybuild/easyconfigs/d/dorado/dorado-0.5.3-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/d/dorado/dorado-0.5.3-foss-2022a-CUDA-11.7.0.eb
@@ -20,9 +20,9 @@ sources = [{
         'tag': 'v%(version)s',
         'recursive': True,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
-checksums = [None]
+checksums = ['f42798a58662d29b3c7825a845cf939e6a444c0db22f2ab4c9e62683b26384e8']
 
 builddependencies = [
     ('binutils', '2.38'),

--- a/easybuild/easyconfigs/d/dorado/dorado-0.6.1-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/d/dorado/dorado-0.6.1-foss-2023a-CUDA-12.1.1.eb
@@ -18,12 +18,14 @@ sources = [{
         'tag': 'v%(version)s',
         'recursive': True,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
 patches = ['dorado-0.6.1_include-fstream.patch']
 checksums = [
-    None,
-    'a7692a2d67422d808b3b81f3a297b7b89299ab0091e5d01f0b8a9aee9b942377',
+    {'dorado-0.6.1.tar.xz':
+     'f05e1a079bca9cb2d43f3b5d29b2bf3df85fb943469522f0b2151406218c5c5e'},
+    {'dorado-0.6.1_include-fstream.patch':
+     'a7692a2d67422d808b3b81f3a297b7b89299ab0091e5d01f0b8a9aee9b942377'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/d/dorado/dorado-0.7.3-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/d/dorado/dorado-0.7.3-foss-2023a-CUDA-12.1.1.eb
@@ -18,7 +18,7 @@ sources = [{
         'tag': 'v%(version)s',
         'recursive': True,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
 patches = [
     '%(name)s-%(version)s_include-fstream.patch',
@@ -26,9 +26,12 @@ patches = [
 ]
 
 checksums = [
-    None,
-    'a32cbd34185bcc5ae3d552a072e396825aa7184187cd11c70a4380618387a530',
-    '2a250d606c0ae17f47d99981309fa204a1394ddd81851a1d530dcd0aea2306ac',
+    {'dorado-0.7.3.tar.xz':
+     'edf60da5290c346fcda8069c2c7deb70227e1ee927e70ee08ded06d3157adfa1'},
+    {'dorado-0.7.3_include-fstream.patch':
+     'a32cbd34185bcc5ae3d552a072e396825aa7184187cd11c70a4380618387a530'},
+    {'dorado-0.7.3_dont_install_external_libraries.patch':
+     '2a250d606c0ae17f47d99981309fa204a1394ddd81851a1d530dcd0aea2306ac'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/d/dorado/dorado-0.8.0-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/d/dorado/dorado-0.8.0-foss-2023a-CUDA-12.1.1.eb
@@ -18,15 +18,17 @@ sources = [{
         'tag': 'v%(version)s',
         'recursive': True,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
 patches = [
     '%(name)s-%(version)s_dont_install_external_libraries.patch',
 ]
 
 checksums = [
-    None,
-    '28942b7057af00c574a5e70d33a58b4036fd09ae0b041f45b67581c8dda832b1',
+    {'dorado-0.8.0.tar.xz':
+     '8d44463853d6c06506011ec26eaea68b708be903ab3b31779b4dc2454247c6b3'},
+    {'dorado-0.8.0_dont_install_external_libraries.patch':
+     '28942b7057af00c574a5e70d33a58b4036fd09ae0b041f45b67581c8dda832b1'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/d/dorado/dorado-0.8.3-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/d/dorado/dorado-0.8.3-foss-2023a-CUDA-12.1.1.eb
@@ -18,14 +18,16 @@ sources = [{
         'tag': 'v%(version)s',
         'recursive': True,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
 patches = [
     '%(name)s-0.8.0_dont_install_external_libraries.patch',
 ]
 checksums = [
-    None,
-    '28942b7057af00c574a5e70d33a58b4036fd09ae0b041f45b67581c8dda832b1',
+    {'dorado-0.8.3.tar.xz':
+     'b33b259bf7cb6c7df8012b79c5373c588477d116bb59f563003e9453832c9532'},
+    {'dorado-0.8.0_dont_install_external_libraries.patch':
+     '28942b7057af00c574a5e70d33a58b4036fd09ae0b041f45b67581c8dda832b1'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/d/dorado/dorado-0.9.0-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/d/dorado/dorado-0.9.0-foss-2023a-CUDA-12.1.1.eb
@@ -18,14 +18,16 @@ sources = [{
         'tag': 'v%(version)s',
         'recursive': True,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
 patches = [
     '%(name)s-0.8.0_dont_install_external_libraries.patch',
 ]
 checksums = [
-    None,
-    '28942b7057af00c574a5e70d33a58b4036fd09ae0b041f45b67581c8dda832b1',
+    {'dorado-0.9.0.tar.xz':
+     'f08ccbd047d16e20e1fbd71f3449c9b82cbe264aa07a0d0f9a637f957587d99a'},
+    {'dorado-0.8.0_dont_install_external_libraries.patch':
+     '28942b7057af00c574a5e70d33a58b4036fd09ae0b041f45b67581c8dda832b1'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/d/dorado/dorado-0.9.1-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/d/dorado/dorado-0.9.1-foss-2023a-CUDA-12.1.1.eb
@@ -18,14 +18,16 @@ sources = [{
         'tag': 'v%(version)s',
         'recursive': True,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
 patches = [
     '%(name)s-0.8.0_dont_install_external_libraries.patch',
 ]
 checksums = [
-    None,
-    '28942b7057af00c574a5e70d33a58b4036fd09ae0b041f45b67581c8dda832b1',
+    {'dorado-0.9.1.tar.xz':
+     '95fcbc822b0f31e0f670cafbd234ea639233e978d2fad745b0546b344974dff0'},
+    {'dorado-0.8.0_dont_install_external_libraries.patch':
+     '28942b7057af00c574a5e70d33a58b4036fd09ae0b041f45b67581c8dda832b1'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/e/EVidenceModeler/EVidenceModeler-2.1.0-foss-2023a.eb
+++ b/easybuild/easyconfigs/e/EVidenceModeler/EVidenceModeler-2.1.0-foss-2023a.eb
@@ -10,7 +10,7 @@ combining diverse evidence types into a single automated gene structure annotati
 toolchain = {'name': 'foss', 'version': '2023a'}
 
 sources = [{
-    'filename': '%(name)s-v%(version)s.tar.gz',
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/EVidenceModeler',
         'repo_name': '%(name)s',
@@ -20,9 +20,10 @@ sources = [{
 }]
 patches = ['EVidenceModeler-2.0.0_set-correct-CFlags-for-ParaFly.patch']
 checksums = [
-    None,  # EVidenceModeler-v2.1.0.tar.gz
-    '619fc54db10fad3638daa177373c19c9ba4b69dcb80585822bfa9b2500f57d13',
-    # EVidenceModeler-2.0.0_set-correct-CFlags-for-ParaFly.patch
+    {'EVidenceModeler-2.1.0.tar.xz':
+     'a20ebcf82266fb9c75c9fae8d939f25441e39e0d3d7e2275e544cd27dd49c2bf'},
+    {'EVidenceModeler-2.0.0_set-correct-CFlags-for-ParaFly.patch':
+     '619fc54db10fad3638daa177373c19c9ba4b69dcb80585822bfa9b2500f57d13'},
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-0.5.0.0beta1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-0.5.0.0beta1.eb
@@ -12,7 +12,7 @@ toolchain = SYSTEM
 
 sources = [
     {
-        'filename': 'easybuild-framework-v%s.tar.xz' % version[2:],
+        'filename': 'easybuild-framework-v%s.tar.gz' % version[2:],
         'git_config': {
             'url': 'https://github.com/easybuilders',
             'repo_name': 'easybuild-framework',
@@ -21,7 +21,7 @@ sources = [
         },
     },
     {
-        'filename': 'easybuild-easyblocks-v%s.tar.xz' % version[2:],
+        'filename': 'easybuild-easyblocks-v%s.tar.gz' % version[2:],
         'git_config': {
             'url': 'https://github.com/easybuilders',
             'repo_name': 'easybuild-easyblocks',
@@ -30,7 +30,7 @@ sources = [
         },
     },
     {
-        'filename': 'easybuild-easyconfigs-v%s.tar.xz' % version[2:],
+        'filename': 'easybuild-easyconfigs-v%s.tar.gz' % version[2:],
         'git_config': {
             'url': 'https://github.com/easybuilders',
             'repo_name': 'easybuild-easyconfigs',
@@ -40,12 +40,9 @@ sources = [
     },
 ]
 checksums = [
-    {'easybuild-framework-v5.0.0beta1.tar.xz':
-     '72447ff69b1873d96685be082017d8812350731f49e96ceb995a1f1f177cbe67'},
-    {'easybuild-easyblocks-v5.0.0beta1.tar.xz':
-     'fb6bdce5bf7c8fda2c9ebabd8520c642bb39822cbc07de84ee1eca090893cd0f'},
-    {'easybuild-easyconfigs-v5.0.0beta1.tar.xz':
-     '8c8b3d928204cdf2a502abd23125ddeaa6cfa5a30a52a0380548d0bd218ef4a3'},
+    None,
+    None,
+    None,
 ]
 
 # EasyBuild is a (set of) Python packages, so it depends on Python

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-0.5.0.0beta1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-0.5.0.0beta1.eb
@@ -12,7 +12,7 @@ toolchain = SYSTEM
 
 sources = [
     {
-        'filename': 'easybuild-framework-v%s.tar.gz' % version[2:],
+        'filename': 'easybuild-framework-v%s.tar.xz' % version[2:],
         'git_config': {
             'url': 'https://github.com/easybuilders',
             'repo_name': 'easybuild-framework',
@@ -21,7 +21,7 @@ sources = [
         },
     },
     {
-        'filename': 'easybuild-easyblocks-v%s.tar.gz' % version[2:],
+        'filename': 'easybuild-easyblocks-v%s.tar.xz' % version[2:],
         'git_config': {
             'url': 'https://github.com/easybuilders',
             'repo_name': 'easybuild-easyblocks',
@@ -30,7 +30,7 @@ sources = [
         },
     },
     {
-        'filename': 'easybuild-easyconfigs-v%s.tar.gz' % version[2:],
+        'filename': 'easybuild-easyconfigs-v%s.tar.xz' % version[2:],
         'git_config': {
             'url': 'https://github.com/easybuilders',
             'repo_name': 'easybuild-easyconfigs',
@@ -40,9 +40,12 @@ sources = [
     },
 ]
 checksums = [
-    None,
-    None,
-    None,
+    {'easybuild-framework-v5.0.0beta1.tar.xz':
+     '72447ff69b1873d96685be082017d8812350731f49e96ceb995a1f1f177cbe67'},
+    {'easybuild-easyblocks-v5.0.0beta1.tar.xz':
+     'fb6bdce5bf7c8fda2c9ebabd8520c642bb39822cbc07de84ee1eca090893cd0f'},
+    {'easybuild-easyconfigs-v5.0.0beta1.tar.xz':
+     '8c8b3d928204cdf2a502abd23125ddeaa6cfa5a30a52a0380548d0bd218ef4a3'},
 ]
 
 # EasyBuild is a (set of) Python packages, so it depends on Python

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-0.5.0.0beta2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-0.5.0.0beta2.eb
@@ -12,7 +12,7 @@ toolchain = SYSTEM
 
 sources = [
     {
-        'filename': 'easybuild-framework-v%s.tar.gz' % version[2:],
+        'filename': 'easybuild-framework-v%s.tar.xz' % version[2:],
         'git_config': {
             'url': 'https://github.com/easybuilders',
             'repo_name': 'easybuild-framework',
@@ -21,7 +21,7 @@ sources = [
         },
     },
     {
-        'filename': 'easybuild-easyblocks-v%s.tar.gz' % version[2:],
+        'filename': 'easybuild-easyblocks-v%s.tar.xz' % version[2:],
         'git_config': {
             'url': 'https://github.com/easybuilders',
             'repo_name': 'easybuild-easyblocks',
@@ -30,7 +30,7 @@ sources = [
         },
     },
     {
-        'filename': 'easybuild-easyconfigs-v%s.tar.gz' % version[2:],
+        'filename': 'easybuild-easyconfigs-v%s.tar.xz' % version[2:],
         'git_config': {
             'url': 'https://github.com/easybuilders',
             'repo_name': 'easybuild-easyconfigs',
@@ -40,9 +40,12 @@ sources = [
     },
 ]
 checksums = [
-    None,
-    None,
-    None,
+    {'easybuild-framework-v5.0.0beta2.tar.xz':
+     'a259df76cc691b10bfe800630456d3c005cda4f5f5707a988e5a3ddebc05ebc4'},
+    {'easybuild-easyblocks-v5.0.0beta2.tar.xz':
+     'dd033a7a8bf283542efb75ec9a88dc070dafa3d1a0fb9d5708130daecf352f20'},
+    {'easybuild-easyconfigs-v5.0.0beta2.tar.xz':
+     '334939460850364f43eee4e25c2397860b1e5f0c07f1ffe78b4ad0e21c57ff1b'},
 ]
 
 # EasyBuild is a (set of) Python packages, so it depends on Python

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-0.5.0.0beta2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-0.5.0.0beta2.eb
@@ -12,7 +12,7 @@ toolchain = SYSTEM
 
 sources = [
     {
-        'filename': 'easybuild-framework-v%s.tar.xz' % version[2:],
+        'filename': 'easybuild-framework-v%s.tar.gz' % version[2:],
         'git_config': {
             'url': 'https://github.com/easybuilders',
             'repo_name': 'easybuild-framework',
@@ -21,7 +21,7 @@ sources = [
         },
     },
     {
-        'filename': 'easybuild-easyblocks-v%s.tar.xz' % version[2:],
+        'filename': 'easybuild-easyblocks-v%s.tar.gz' % version[2:],
         'git_config': {
             'url': 'https://github.com/easybuilders',
             'repo_name': 'easybuild-easyblocks',
@@ -30,7 +30,7 @@ sources = [
         },
     },
     {
-        'filename': 'easybuild-easyconfigs-v%s.tar.xz' % version[2:],
+        'filename': 'easybuild-easyconfigs-v%s.tar.gz' % version[2:],
         'git_config': {
             'url': 'https://github.com/easybuilders',
             'repo_name': 'easybuild-easyconfigs',
@@ -40,12 +40,9 @@ sources = [
     },
 ]
 checksums = [
-    {'easybuild-framework-v5.0.0beta2.tar.xz':
-     'a259df76cc691b10bfe800630456d3c005cda4f5f5707a988e5a3ddebc05ebc4'},
-    {'easybuild-easyblocks-v5.0.0beta2.tar.xz':
-     'dd033a7a8bf283542efb75ec9a88dc070dafa3d1a0fb9d5708130daecf352f20'},
-    {'easybuild-easyconfigs-v5.0.0beta2.tar.xz':
-     '334939460850364f43eee4e25c2397860b1e5f0c07f1ffe78b4ad0e21c57ff1b'},
+    None,
+    None,
+    None,
 ]
 
 # EasyBuild is a (set of) Python packages, so it depends on Python

--- a/easybuild/easyconfigs/e/EveryBeam/EveryBeam-0.5.2-foss-2022a.eb
+++ b/easybuild/easyconfigs/e/EveryBeam/EveryBeam-0.5.2-foss-2022a.eb
@@ -9,7 +9,7 @@ such as LOFAR (and LOBES), SKA (OSKAR), MWA, JVLA, etc."""
 toolchain = {'name': 'foss', 'version': '2022a'}
 
 sources = [{
-    'filename': '%(name)s-v%(version)s.tar.gz',
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://git.astron.nl/RD',
         'repo_name': '%(name)s',
@@ -18,7 +18,7 @@ sources = [{
         'recursive': True,
     },
 }]
-checksums = [None]
+checksums = ['032d6ea0c040c60338f0404b3c260041aa1d67e382738540420968d039b2267d']
 
 builddependencies = [
     ('CMake', '3.24.3'),

--- a/easybuild/easyconfigs/e/EveryBeam/EveryBeam-0.5.2-foss-2023b.eb
+++ b/easybuild/easyconfigs/e/EveryBeam/EveryBeam-0.5.2-foss-2023b.eb
@@ -11,7 +11,7 @@ toolchain = {'name': 'foss', 'version': '2023b'}
 
 sources = [
     {
-        'filename': '%(name)s-v%(version)s.tar.gz',
+        'filename': SOURCE_TAR_XZ,
         # Repo uses git submodules, which are not included in the release tarballs.
         # Thus, we let EasyBuild download directly from the git repository.
         'git_config': {
@@ -23,7 +23,7 @@ sources = [
         }
     },
 ]
-checksums = [None]
+checksums = ['032d6ea0c040c60338f0404b3c260041aa1d67e382738540420968d039b2267d']
 
 builddependencies = [
     ('CMake', '3.27.6'),

--- a/easybuild/easyconfigs/e/EveryBeam/EveryBeam-0.6.1-foss-2023b.eb
+++ b/easybuild/easyconfigs/e/EveryBeam/EveryBeam-0.6.1-foss-2023b.eb
@@ -11,7 +11,7 @@ toolchain = {'name': 'foss', 'version': '2023b'}
 
 sources = [
     {
-        'filename': '%(name)s-v%(version)s.tar.gz',
+        'filename': SOURCE_TAR_XZ,
         # Repo uses git submodules, which are not included in the release tarballs.
         # Thus, we let EasyBuild download directly from the git repository.
         'git_config': {
@@ -27,8 +27,10 @@ patches = [
     'EveryBeam-0.5.4_python_metadata.patch'
 ]
 checksums = [
-    None,  # checksum for git clone source is non-deterministic
-    '63c42e85d1b63cbf5887d10ec158be9b69e2c63cf3b209e9c1944f46c01810ac'  # EveryBeam-0.5.4_python_metadata.patch
+    {'EveryBeam-0.6.1.tar.xz':
+     '441190d4c08dae5082c8bdf6acace6bb4c16aef0653e0729bedc6a4b08a4ef04'},
+    {'EveryBeam-0.5.4_python_metadata.patch':
+     '63c42e85d1b63cbf5887d10ec158be9b69e2c63cf3b209e9c1944f46c01810ac'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/f/FreeBarcodes/FreeBarcodes-3.0.a5-foss-2021b.eb
+++ b/easybuild/easyconfigs/f/FreeBarcodes/FreeBarcodes-3.0.a5-foss-2021b.eb
@@ -40,14 +40,14 @@ exts_list = [
     }),
     (name, version, {
         'sources': [{
-            'filename': '%(name)s-%(version)s.tar.gz',
+            'filename': SOURCE_TAR_XZ,
             'git_config': {
                 'url': 'https://github.com/hawkjo/',
                 'repo_name': 'freebarcodes',
                 'commit': 'a684c11',
             },
         }],
-        'checksums': [None],
+        'checksums': ['8007b1f6f35f0d9f63b74c657977b390abca1d48b0e0624a095a67d1ecf1bb72'],
     }),
 ]
 

--- a/easybuild/easyconfigs/g/GLM-AED/GLM-AED-3.3.0a5-gompi-2021b.eb
+++ b/easybuild/easyconfigs/g/GLM-AED/GLM-AED-3.3.0a5-gompi-2021b.eb
@@ -15,7 +15,7 @@ reservoirs, upto the scale of the Great Lakes."""
 toolchain = {'name': 'gompi', 'version': '2021b'}
 
 sources = [{
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/AquaticEcoDynamics',
         'repo_name': '%(namelower)s',
@@ -25,8 +25,10 @@ sources = [{
 }]
 patches = ['GLM-AED-3.3.0a5_disable-deb-pkg.patch']
 checksums = [
-    None,  # can't add proper SHA256 checksum, because source tarball is created locally after recursive 'git clone'
-    'b5c1a0c0d1c5a47068ad38ec54def75373ea0bb04f6fa43c0d0a0f7f960e26c6',  # GLM-AED-3.3.0a5_disable-deb-pkg.patch
+    {'GLM-AED-3.3.0a5.tar.xz':
+     '0c3ec958d71293a559d28d58b7c00ebb782b3f03b09eac87537fe189dc811534'},
+    {'GLM-AED-3.3.0a5_disable-deb-pkg.patch':
+     'b5c1a0c0d1c5a47068ad38ec54def75373ea0bb04f6fa43c0d0a0f7f960e26c6'},
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/g/GenomeWorks/GenomeWorks-2021.02.2-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/g/GenomeWorks/GenomeWorks-2021.02.2-fosscuda-2020b.eb
@@ -63,8 +63,8 @@ exts_list = [
         'checksums': ['d8e9609d6c580a16a1224a3dc8965789e03ebc4c3e5ffd05ada54a2fed5dcacd'],
     }),
     ('genomeworks', version, {
-        'sources': ['GenomeWorks-%(version)s.tar.xz'],
-        'checksums': ['ac3946d7172853efe3260339e7edc430bbbd585ed490c7f1ad9f7644446a5ae6'],
+        'sources': sources,
+        'checksums': checksums,
         'start_dir': 'pygenomeworks',
         'preinstallopts': local_genomeworks_preinstallopts,
     }),

--- a/easybuild/easyconfigs/g/GenomeWorks/GenomeWorks-2021.02.2-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/g/GenomeWorks/GenomeWorks-2021.02.2-fosscuda-2020b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'fosscuda', 'version': '2020b'}
 toolchainopts = {'pic': True}
 
 sources = [{
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/clara-parabricks',
         'repo_name': name,
@@ -20,8 +20,7 @@ sources = [{
         'recursive': True,
     },
 }]
-# no checksum for source tarball because it's created locally via 'git clone'
-checksums = [None]
+checksums = ['ac3946d7172853efe3260339e7edc430bbbd585ed490c7f1ad9f7644446a5ae6']
 
 builddependencies = [
     ('CMake', '3.18.4'),
@@ -64,9 +63,8 @@ exts_list = [
         'checksums': ['d8e9609d6c580a16a1224a3dc8965789e03ebc4c3e5ffd05ada54a2fed5dcacd'],
     }),
     ('genomeworks', version, {
-        'sources': ['GenomeWorks-%(version)s.tar.gz'],
-        # no checksum for source tarball because it's created locally via 'git clone'
-        'checksums': [None],
+        'sources': ['GenomeWorks-%(version)s.tar.xz'],
+        'checksums': ['ac3946d7172853efe3260339e7edc430bbbd585ed490c7f1ad9f7644446a5ae6'],
         'start_dir': 'pygenomeworks',
         'preinstallopts': local_genomeworks_preinstallopts,
     }),

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.2.0.eb
@@ -10,6 +10,17 @@ power and distributed nature of git to bear on your large files with git-annex."
 
 toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 
+sources = [{
+    'git_config': {
+        'url': 'git://git-annex.branchable.com',
+        'repo_name': '%(name)s',
+        'tag': '%(version)s',
+        'clone_into': '%(name)s-%(version)s',
+    },
+    'filename': SOURCE_TAR_XZ,
+}]
+checksums = ['675d15ae480f23373ed7df79e20dc40895bb3d4a1d1e71aa813ca7549249be72']
+
 builddependencies = [('binutils', '2.39')]
 
 dependencies = [
@@ -18,17 +29,6 @@ dependencies = [
     ('git', '2.38.1', '-nodocs'),
     ('libnsl', '2.0.0'),
 ]
-
-sources = [{
-    'git_config': {'url': 'git://git-annex.branchable.com',
-                   'repo_name': '%(name)s',
-                   'tag': '%(version)s',
-                   'clone_into': '%(name)s-%(version)s',
-                   },
-    'filename': '%(name)s-%(version)s.tar.gz',
-}]
-
-checksums = [None]
 
 prebuildopts = "export STACK_ROOT=$(mktemp -d) && stack setup && stack build && "
 buildopts = "install-bins BUILDER=stack PREFIX=%(builddir)s"

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.3.0.eb
@@ -10,6 +10,17 @@ power and distributed nature of git to bear on your large files with git-annex."
 
 toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 
+sources = [{
+    'git_config': {
+        'url': 'git://git-annex.branchable.com',
+        'repo_name': '%(name)s',
+        'tag': '%(version)s',
+        'clone_into': '%(name)s-%(version)s',
+    },
+    'filename': SOURCE_TAR_XZ,
+}]
+checksums = ['675d15ae480f23373ed7df79e20dc40895bb3d4a1d1e71aa813ca7549249be72']
+
 builddependencies = [
     ('binutils', '2.40')
 ]
@@ -20,17 +31,6 @@ dependencies = [
     ('git', '2.41.0', '-nodocs'),
     ('libnsl', '2.0.1'),
 ]
-
-sources = [{
-    'git_config': {'url': 'git://git-annex.branchable.com',
-                   'repo_name': '%(name)s',
-                   'tag': '%(version)s',
-                   'clone_into': '%(name)s-%(version)s',
-                   },
-    'filename': '%(name)s-%(version)s.tar.gz',
-}]
-
-checksums = [None]
 
 prebuildopts = "export STACK_ROOT=$(mktemp -d) && stack setup && stack build && "
 buildopts = "install-bins BUILDER=stack PREFIX=%(builddir)s"

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20240531-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20240531-GCCcore-13.2.0.eb
@@ -10,6 +10,17 @@ power and distributed nature of git to bear on your large files with git-annex."
 
 toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 
+sources = [{
+    'git_config': {
+        'url': 'git://git-annex.branchable.com',
+        'repo_name': '%(name)s',
+        'tag': '%(version)s',
+        'clone_into': '%(name)s-%(version)s',
+    },
+    'filename': SOURCE_TAR_XZ,
+}]
+checksums = ['2b07e80a29e2403d5abe0c4c6cdaa1f30f3ae651cc50fc0b857dd792f7171c5d']
+
 builddependencies = [
     ('binutils', '2.40')
 ]
@@ -20,17 +31,6 @@ dependencies = [
     ('git', '2.42.0'),
     ('libnsl', '2.0.1'),
 ]
-
-sources = [{
-    'git_config': {'url': 'git://git-annex.branchable.com',
-                   'repo_name': '%(name)s',
-                   'tag': '%(version)s',
-                   'clone_into': '%(name)s-%(version)s',
-                   },
-    'filename': '%(name)s-%(version)s.tar.gz',
-}]
-
-checksums = [None]
 
 prebuildopts = "export STACK_ROOT=$(mktemp -d) && stack setup && stack build && "
 buildopts = "install-bins BUILDER=stack PREFIX=%(builddir)s"

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20240731-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20240731-GCCcore-13.3.0.eb
@@ -10,6 +10,17 @@ power and distributed nature of git to bear on your large files with git-annex."
 
 toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
 
+sources = [{
+    'git_config': {
+        'url': 'git://git-annex.branchable.com',
+        'repo_name': '%(name)s',
+        'tag': '%(version)s',
+        'clone_into': '%(name)s-%(version)s',
+    },
+    'filename': SOURCE_TAR_XZ,
+}]
+checksums = ['7ff4a4332e14adb7d5d3b4650302f65a4664b3951cdb533b4ae6a7132f3f7683']
+
 builddependencies = [
     ('binutils', '2.42')
 ]
@@ -20,17 +31,6 @@ dependencies = [
     ('git', '2.45.1'),
     ('libnsl', '2.0.1'),
 ]
-
-sources = [{
-    'git_config': {'url': 'git://git-annex.branchable.com',
-                   'repo_name': '%(name)s',
-                   'tag': '%(version)s',
-                   'clone_into': '%(name)s-%(version)s',
-                   },
-    'filename': '%(name)s-%(version)s.tar.gz',
-}]
-
-checksums = [None]
 
 prebuildopts = "export STACK_ROOT=$(mktemp -d) && stack setup && stack build && "
 buildopts = "install-bins BUILDER=stack PREFIX=%(builddir)s"

--- a/easybuild/easyconfigs/i/IDG/IDG-1.2.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/i/IDG/IDG-1.2.0-foss-2023b.eb
@@ -17,7 +17,7 @@ toolchain = {'name': 'foss', 'version': '2023b'}
 
 sources = [
     {
-        'filename': '%(name)s-v%(version)s.tar.gz',
+        'filename': SOURCE_TAR_XZ,
         # Repo uses git submodules, which are not included in the release tarballs.
         # Thus, we let EasyBuild download directly from the git repository.
         'git_config': {
@@ -31,9 +31,10 @@ sources = [
 ]
 patches = ['IDG-1.2.0_fix-for-xsimd-error-on-neoverse-v1.patch']
 checksums = [
-    None,  # checksum for git clone source is non-deterministic
-    # IDG-1.2.0_fix-for-xsimd-error-on-neoverse-v1.patch
-    '3811028d7757cd7085501bf3209f8eb526eafb67caf2950110a25a7a072df3c1',
+    {'IDG-1.2.0.tar.xz':
+     'f153cad857ad7171aa976927b1ab2ad3c7c7f7368c33268cf33ca83957eb870f'},
+    {'IDG-1.2.0_fix-for-xsimd-error-on-neoverse-v1.patch':
+     '3811028d7757cd7085501bf3209f8eb526eafb67caf2950110a25a7a072df3c1'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/j/JupyterHub/JupyterHub-3.0.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/j/JupyterHub/JupyterHub-3.0.0-GCCcore-11.3.0.eb
@@ -68,14 +68,14 @@ exts_list = [
     }),
     ('batchspawner', '1.2.0-%s' % local_batchspawner_commit, {
         'sources': {
-            'filename': 'main.tar.gz',
+            'filename': SOURCE_TAR_XZ,
             'git_config': {
                 'url': 'https://github.com/jupyterhub/',
                 'repo_name': 'batchspawner',
                 'commit': local_batchspawner_commit,
             }
         },
-        'checksums': [None],
+        'checksums': ['e1a39fd4b31e402ac17e36941680807627ddbd1ddf38bc6518ae578b2ac64dd7'],
     }),
     ('jupyterhub-systemdspawner', '0.16', {
         'modulename': 'systemdspawner',

--- a/easybuild/easyconfigs/j/JupyterHub/JupyterHub-4.0.1-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/j/JupyterHub/JupyterHub-4.0.1-GCCcore-12.2.0.eb
@@ -67,14 +67,14 @@ exts_list = [
     }),
     ('batchspawner', '1.2.0-%s' % local_batchspawner_commit, {
         'sources': {
-            'filename': 'main.tar.gz',
+            'filename': SOURCE_TAR_XZ,
             'git_config': {
                 'url': 'https://github.com/jupyterhub/',
                 'repo_name': 'batchspawner',
                 'commit': local_batchspawner_commit,
             }
         },
-        'checksums': [None],
+        'checksums': ['e1a39fd4b31e402ac17e36941680807627ddbd1ddf38bc6518ae578b2ac64dd7'],
     }),
     ('jupyterhub-systemdspawner', '1.0.1', {
         'modulename': 'systemdspawner',

--- a/easybuild/easyconfigs/k/kineto/kineto-0.4.0-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/k/kineto/kineto-0.4.0-GCC-11.3.0.eb
@@ -16,9 +16,9 @@ sources = [{
         'tag': 'v%(version)s',
         'recursive': True,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
-checksums = [None]
+checksums = ['5f1c744d57fdc40878b0ff87400097b04ed3027757bcccf6d4f8ceecc8e29855']
 
 builddependencies = [
     ('CMake', '3.24.3'),

--- a/easybuild/easyconfigs/k/kineto/kineto-0.4.0-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/k/kineto/kineto-0.4.0-GCC-12.3.0.eb
@@ -16,9 +16,9 @@ sources = [{
         'tag': 'v%(version)s',
         'recursive': True,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
-checksums = [None]
+checksums = ['5f1c744d57fdc40878b0ff87400097b04ed3027757bcccf6d4f8ceecc8e29855']
 
 builddependencies = [
     ('CMake', '3.26.3'),

--- a/easybuild/easyconfigs/m/MetalWalls/MetalWalls-21.06.1-foss-2023a.eb
+++ b/easybuild/easyconfigs/m/MetalWalls/MetalWalls-21.06.1-foss-2023a.eb
@@ -11,21 +11,15 @@ toolchainopts = {'usempi': True}
 
 sources = [
     {
-        "filename": "metalwalls-%(version)s.tar.gz",
+        "filename": SOURCE_TAR_XZ,
         "git_config": {
             "url": "https://gitlab.com/ampere2",
             "repo_name": "metalwalls",
             "tag": '%(version)s',
-
         },
     },
 ]
-checksums = [
-    #     # Holding off checksum checks untill 5.0.x
-    #     # https://github.com/easybuilders/easybuild-framework/pull/4248
-    # '8852bf5bd3591868cc2af6be378ac4dbfcd209d53acc176536038dbe69892b3d',
-    None
-]
+checksums = ['e2c2723ce72bb96fd6485a4bf0631093689f6766d9514301a59cf796f6a51e44']
 
 builddependencies = [
     ("Python", "3.11.3"),

--- a/easybuild/easyconfigs/m/ModelTest-NG/ModelTest-NG-0.1.7-gompi-2021b.eb
+++ b/easybuild/easyconfigs/m/ModelTest-NG/ModelTest-NG-0.1.7-gompi-2021b.eb
@@ -12,7 +12,7 @@ ModelTest-NG supersedes jModelTest and ProtTest in one single tool, with graphic
 toolchain = {'name': 'gompi', 'version': '2021b'}
 
 sources = [{
-    'filename': 'v%(version)s.tar.gz',
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'recursive': True,
         'url': 'https://github.com/ddarriba',
@@ -20,7 +20,7 @@ sources = [{
         'tag': 'v%(version)s',
     }
 }]
-checksums = [None]
+checksums = ['800ab765c6bb58d41d8931e8d9ea218fe59acdef43ed8c686e452c3cce417373']
 
 builddependencies = [('CMake', '3.22.1')]
 

--- a/easybuild/easyconfigs/m/mdust/mdust-20150102-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/m/mdust/mdust-20150102-GCC-10.3.0.eb
@@ -9,14 +9,14 @@ description = "mdust from DFCI Gene Indices Software Tools (archived for a histo
 toolchain = {'name': 'GCC', 'version': '10.3.0'}
 
 sources = [{
-    'filename': 'mdust.tar.gz',
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/lh3',
         'repo_name': 'mdust',
         'commit': '3e3fed8',
     },
 }]
-checksums = [None]
+checksums = ['399ad93dacea84f64805e4bf5005f2860dbd688973aea8b9c792ecafee28dcc1']
 
 files_to_copy = [(['mdust'], 'bin')]
 

--- a/easybuild/easyconfigs/n/NECI/NECI-20220711-foss-2022a.eb
+++ b/easybuild/easyconfigs/n/NECI/NECI-20220711-foss-2022a.eb
@@ -17,12 +17,14 @@ sources = [{
         'recursive': True,
         'commit': _commit,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
 patches = ['NECI-20220711_fix-cmake-print-summary.patch']
 checksums = [
-    None,
-    'e189f1b3991b28502dbd8285a04784e7e422d0a9e01e3f28025d0458b479af2d',
+    {'NECI-20220711.tar.xz':
+     'cea5e4fccec03163d71093c864515404a934d825fe61955d21d55c9424891077'},
+    {'NECI-20220711_fix-cmake-print-summary.patch':
+     'e189f1b3991b28502dbd8285a04784e7e422d0a9e01e3f28025d0458b479af2d'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/n/NECI/NECI-20230620-foss-2022b.eb
+++ b/easybuild/easyconfigs/n/NECI/NECI-20230620-foss-2022b.eb
@@ -17,9 +17,9 @@ sources = [{
         'recursive': True,
         'commit': _commit,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
-checksums = [None]
+checksums = ['b6f0e9a7cc0ce483f4fe60ae17a430288f4876832f861007b67c0a2a44cbaee9']
 
 builddependencies = [
     ('CMake', '3.24.3'),

--- a/easybuild/easyconfigs/n/NECI/NECI-20230620-foss-2023a.eb
+++ b/easybuild/easyconfigs/n/NECI/NECI-20230620-foss-2023a.eb
@@ -17,12 +17,14 @@ sources = [{
         'recursive': True,
         'commit': _commit,
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
 patches = ['NECI-20230620_segfault.patch']
 checksums = [
-    None,
-    'f0b5f62e115a1e07d6b90bc66ee9957a5f5d686bef65beba9c2be4bd8f29f0e4',
+    {'NECI-20230620.tar.xz':
+     'b6f0e9a7cc0ce483f4fe60ae17a430288f4876832f861007b67c0a2a44cbaee9'},
+    {'NECI-20230620_segfault.patch':
+     'f0b5f62e115a1e07d6b90bc66ee9957a5f5d686bef65beba9c2be4bd8f29f0e4'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/n/NewHybrids/NewHybrids-1.1_Beta3-GCC-10.2.0.eb
+++ b/easybuild/easyconfigs/n/NewHybrids/NewHybrids-1.1_Beta3-GCC-10.2.0.eb
@@ -13,7 +13,7 @@ individuals fall into each of a set of user-defined hybrid categories."""
 toolchain = {'name': 'GCC', 'version': '10.2.0'}
 
 sources = [{
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/eriqande',
         'repo_name': 'newhybrids',
@@ -21,7 +21,7 @@ sources = [{
         'recursive': True,
     }
 }]
-checksums = [None]
+checksums = ['cdb3f922bfb63a740ac0e56af77b15cf83a111e40dec3a12bb9d4bc0464c8520']
 
 extract_sources = True
 

--- a/easybuild/easyconfigs/o/OpenFOAM-Extend/OpenFOAM-Extend-4.1-20210705-foss-2023a-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM-Extend/OpenFOAM-Extend-4.1-20210705-foss-2023a-Python-2.7.18.eb
@@ -15,7 +15,7 @@ toolchain = {'name': 'foss', 'version': '2023a'}
 toolchainopts = {'usempi': True}
 
 sources = [{
-    'filename': '%%(name)s-%%(version)s-%s.tar.gz' % local_commit,
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://git.code.sf.net/p/foam-extend/',
         'repo_name': 'foam-extend-4.1',
@@ -30,9 +30,7 @@ patches = [
     'OpenFOAM-Extend-4.1-20210705_fix-private-PackedList.patch',
 ]
 checksums = [
-    # no checksum for OpenFOAM-Extend-4.1-20200408-f2c557.tar.gz since it's created from git repo,
-    # and hence resuluting tarball won't be exactly the same on all systems
-    None,
+    '2177a4fb98f40190f1d4bb41bd1e6f768c676e83fe382c04924a8975c4ea0e02',  # OpenFOAM-Extend-4.1-20210705.tar.xz
     '737c76fe42e7f6a1789edb79fea1134f8fa7765db74f153fbe5201f049fa528c',  # OpenFOAM-Extend-3.2-ParMGridGen.patch
     '1532c7f1243c7e9045f84db4f3f6ddf29636c6261ed55f843fd3ee70670036ff',  # OpenFOAM-Extend-3.1_build-qa.patch
     'e71a77b6f39653f9a0d4b0ce6691433c742df74f23402782c69a8b736c98eb7a',  # OpenFOAM-Extend-4.1_comp-mpi.patch

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.8.1-foss-2020b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.8.1-foss-2020b.eb
@@ -8,7 +8,7 @@ PyTorch is a deep learning framework that puts Python first."""
 toolchain = {'name': 'foss', 'version': '2020b'}
 
 sources = [{
-    'filename': '%(name)s-%(version)s.tar.gz',
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/pytorch',
         'repo_name': 'pytorch',
@@ -31,7 +31,7 @@ patches = [
     'PyTorch-1.8.1_skip-complex-grad-check-on-ppc.patch',
 ]
 checksums = [
-    None,  # can't add proper SHA256 checksum, because source tarball is created locally after recursive 'git clone'
+    '2a45d5c0344dc71ec998b5a86f62826dd0c5ac6b9a9084ce6dfb606ea2442c50',  # PyTorch-1.8.1.tar.xz
     # PyTorch-1.6.0_fix-test-dataloader-fixed-affinity.patch
     'a4208a46cd2098744daaba96cebb96cd91166f8fc616924315e05974bad80c67',
     'b899aa94d9e60f11ee75a706563312ccefa9cf432756c470caa8e623991c8f18',  # PyTorch-1.7.0_avoid-nan-in-test-torch.patch

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.8.1-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.8.1-fosscuda-2020b.eb
@@ -8,7 +8,7 @@ PyTorch is a deep learning framework that puts Python first."""
 toolchain = {'name': 'fosscuda', 'version': '2020b'}
 
 sources = [{
-    'filename': '%(name)s-%(version)s.tar.gz',
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/pytorch',
         'repo_name': 'pytorch',
@@ -40,7 +40,7 @@ patches = [
     'PyTorch-1.8.1_fix_test_collect_shards.patch',
 ]
 checksums = [
-    None,  # can't add proper SHA256 checksum, because source tarball is created locally after recursive 'git clone'
+    '2a45d5c0344dc71ec998b5a86f62826dd0c5ac6b9a9084ce6dfb606ea2442c50',  # PyTorch-1.8.1.tar.xz
     # PyTorch-1.6.0_fix-test-dataloader-fixed-affinity.patch
     'a4208a46cd2098744daaba96cebb96cd91166f8fc616924315e05974bad80c67',
     'b899aa94d9e60f11ee75a706563312ccefa9cf432756c470caa8e623991c8f18',  # PyTorch-1.7.0_avoid-nan-in-test-torch.patch

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.9.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.9.0-foss-2020b.eb
@@ -8,7 +8,7 @@ PyTorch is a deep learning framework that puts Python first."""
 toolchain = {'name': 'foss', 'version': '2020b'}
 
 sources = [{
-    'filename': '%(name)s-%(version)s.tar.gz',
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/pytorch',
         'repo_name': 'pytorch',
@@ -32,7 +32,7 @@ patches = [
     'PyTorch-1.9.0_skip-lstm-serialization-test.patch',
 ]
 checksums = [
-    None,  # can't add proper SHA256 checksum, because source tarball is created locally after recursive 'git clone'
+    '6f9bc441bc7a3627dd9eba55121734ce69e17622da8b2b34b9fad2a50d277ff6',  # PyTorch-1.9.0.tar.xz
     # PyTorch-1.6.0_fix-test-dataloader-fixed-affinity.patch
     'a4208a46cd2098744daaba96cebb96cd91166f8fc616924315e05974bad80c67',
     'b899aa94d9e60f11ee75a706563312ccefa9cf432756c470caa8e623991c8f18',  # PyTorch-1.7.0_avoid-nan-in-test-torch.patch

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.9.0-fosscuda-2020b-imkl.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.9.0-fosscuda-2020b-imkl.eb
@@ -9,7 +9,7 @@ PyTorch is a deep learning framework that puts Python first."""
 toolchain = {'name': 'fosscuda', 'version': '2020b'}
 
 sources = [{
-    'filename': '%(name)s-%(version)s.tar.gz',
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/pytorch',
         'repo_name': 'pytorch',
@@ -42,7 +42,7 @@ patches = [
     'PyTorch-1.9.0_skip-nccl-error-tests.patch',
 ]
 checksums = [
-    None,  # can't add proper SHA256 checksum, because source tarball is created locally after recursive 'git clone'
+    '6f9bc441bc7a3627dd9eba55121734ce69e17622da8b2b34b9fad2a50d277ff6',  # PyTorch-1.9.0.tar.xz
     # PyTorch-1.6.0_fix-test-dataloader-fixed-affinity.patch
     'a4208a46cd2098744daaba96cebb96cd91166f8fc616924315e05974bad80c67',
     'b899aa94d9e60f11ee75a706563312ccefa9cf432756c470caa8e623991c8f18',  # PyTorch-1.7.0_avoid-nan-in-test-torch.patch

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.9.0-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.9.0-fosscuda-2020b.eb
@@ -8,7 +8,7 @@ PyTorch is a deep learning framework that puts Python first."""
 toolchain = {'name': 'fosscuda', 'version': '2020b'}
 
 sources = [{
-    'filename': '%(name)s-%(version)s.tar.gz',
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/pytorch',
         'repo_name': 'pytorch',
@@ -41,7 +41,7 @@ patches = [
     'PyTorch-1.9.0_skip-nccl-error-tests.patch',
 ]
 checksums = [
-    None,  # can't add proper SHA256 checksum, because source tarball is created locally after recursive 'git clone'
+    '6f9bc441bc7a3627dd9eba55121734ce69e17622da8b2b34b9fad2a50d277ff6',  # PyTorch-1.9.0.tar.xz
     # PyTorch-1.6.0_fix-test-dataloader-fixed-affinity.patch
     'a4208a46cd2098744daaba96cebb96cd91166f8fc616924315e05974bad80c67',
     'b899aa94d9e60f11ee75a706563312ccefa9cf432756c470caa8e623991c8f18',  # PyTorch-1.7.0_avoid-nan-in-test-torch.patch

--- a/easybuild/easyconfigs/p/purge_dups/purge_dups-1.2.5-foss-2021b.eb
+++ b/easybuild/easyconfigs/p/purge_dups/purge_dups-1.2.5-foss-2021b.eb
@@ -45,9 +45,9 @@ exts_list = [
                 'repo_name': 'runner',
                 'commit': '73a4d11',
             },
-            'filename': 'runner-%(version)s.tar.gz',
+            'filename': SOURCE_TAR_XZ,
         }],
-        'checksums': [None],
+        'checksums': ['f1b51cafac42f09490f542987a6f6194b1f4f155bca2858bfd21c3b00bd903b9'],
         'preinstallopts': "sed -i 's/0.0.0/%(version)s/g' setup.py && "
     }),
 ]

--- a/easybuild/easyconfigs/p/purge_dups/purge_dups-1.2.6-foss-2023b.eb
+++ b/easybuild/easyconfigs/p/purge_dups/purge_dups-1.2.6-foss-2023b.eb
@@ -58,9 +58,9 @@ exts_list = [
                 'repo_name': 'runner',
                 'commit': '73a4d11',
             },
-            'filename': 'runner-%(version)s.tar.gz',
+            'filename': SOURCE_TAR_XZ,
         }],
-        'checksums': [None],
+        'checksums': ['f1b51cafac42f09490f542987a6f6194b1f4f155bca2858bfd21c3b00bd903b9'],
     }),
 ]
 

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3.1-foss-2023a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3.1-foss-2023a.eb
@@ -28,7 +28,6 @@ local_qe_gipaw_hash = "79d3a03b7bdc4325e66f3fad02a24c6e6e3e5806"
 local_qmcpack_hash = "f72ab25fa4ea755c1b4b230ae8074b47d5509c70"
 local_w90_hash = "1d6b187374a2d50b509e5e79e2cab01a79ff7ce1"
 
-
 sources = [
     {
         "filename": "q-e-qe-%(version)s.tar.gz",
@@ -36,7 +35,7 @@ sources = [
         "source_urls": ["https://gitlab.com/QEF/q-e/-/archive/qe-%(version)s"],
     },
     {
-        "filename": "lapack-%s.tar.gz" % local_lapack_hash,
+        "filename": f"lapack-{local_lapack_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/Reference-LAPACK",
             "repo_name": "lapack",
@@ -44,7 +43,7 @@ sources = [
         },
     },
     {
-        "filename": "mbd-%s.tar.gz" % local_mbd_hash,
+        "filename": f"mbd-{local_mbd_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/libmbd",
             "repo_name": "libmbd",
@@ -53,7 +52,7 @@ sources = [
         },
     },
     {
-        "filename": "devxlib-%s.tar.gz" % local_devxlib_hash,
+        "filename": f"devxlib-{local_devxlib_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://gitlab.com/max-centre/components",
             "repo_name": "devicexlib",
@@ -62,7 +61,7 @@ sources = [
         },
     },
     {
-        "filename": "d3q-%s.tar.gz" % local_d3q_hash,
+        "filename": f"d3q-{local_d3q_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/anharmonic",
             "repo_name": "d3q",
@@ -70,7 +69,7 @@ sources = [
         },
     },
     {
-        "filename": "fox-%s.tar.gz" % local_fox_hash,
+        "filename": f"fox-{local_fox_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/pietrodelugas",
             "repo_name": "fox",
@@ -78,7 +77,7 @@ sources = [
         },
     },
     {
-        "filename": "qe-gipaw-%s.tar.gz" % local_qe_gipaw_hash,
+        "filename": f"qe-gipaw-{local_qe_gipaw_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/dceresoli",
             "repo_name": "qe-gipaw",
@@ -86,7 +85,7 @@ sources = [
         },
     },
     {
-        "filename": "pw2qmcpack-%s.tar.gz" % local_qmcpack_hash,
+        "filename": f"pw2qmcpack-{local_qmcpack_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/QMCPACK",
             "repo_name": "pw2qmcpack",
@@ -94,7 +93,7 @@ sources = [
         },
     },
     {
-        "filename": "wannier90-%s.tar.gz" % local_w90_hash,
+        "filename": f"wannier90-{local_w90_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/wannier-developers",
             "repo_name": "wannier90",
@@ -102,22 +101,25 @@ sources = [
         },
     },
 ]
-# Holding off checksum checks untill 5.0.x
-# https://github.com/easybuilders/easybuild-framework/pull/4248
-# checksums = [
-#     {'q-e-qe-7.3.1.tar.gz': '2c58b8fadfe4177de5a8b69eba447db5e623420b070dea6fd26c1533b081d844'},
-#     {'lapack-%s.tar.gz' % local_lapack_hash: 'c05532ae0e5fe35f473206dda12970da5f2e2214620487d71837ddcf0ea6b21d'},
-#     {'mbd-%s.tar.gz' % local_mbd_hash: 'a180682c00bb890c9b1e26a98addbd68e32f970c06439acf7582415f4c589800'},
-#     {'devxlib-%s.tar.gz' % local_devxlib_hash: '76da8fe5a2050f58efdc92fa8831efec25c19190df7f4e5e39c173a5fbae83b4'},
-#     {'d3q-%s.tar.gz' % local_d3q_hash: '43e50753a56af05d181b859d3e29d842fb3fc4352f00cb7fe229a435a1f20c31'},
-#     {'fox-%s.tar.gz' % local_fox_hash: '99b6a899a3f947d7763aa318e86f9f08db684568bfdcd293f3318bee9d7f1948'},
-#     {'qe-gipaw-%s.tar.gz' % local_qe_gipaw_hash: '9ac8314363d29cc2f1ce85abd8f26c1a3ae311d54f6e6034d656442dd101c928'},
-#     {'pw2qmcpack-%s.tar.gz' % local_qmcpack_hash: 'a8136da8429fc49ab560ef7356cd6f0a2714dfbb137baff7961f46dfe32061eb'},
-#     {'wannier90-%s.tar.gz' % local_w90_hash: 'f989497790ec9777bdc159945bbf42156edb7268011f972874dec67dd4f58658'},
-# ]
 checksums = [
-    '2c58b8fadfe4177de5a8b69eba447db5e623420b070dea6fd26c1533b081d844',
-    None, None, None, None, None, None, None, None
+    {'q-e-qe-7.3.1.tar.gz':
+     '2c58b8fadfe4177de5a8b69eba447db5e623420b070dea6fd26c1533b081d844'},
+    {'lapack-12d82539.tar.xz':
+     '88aea5bca5e730e99fda0a5b9d677d6036c7dd82874e0deaed5cccef1f880111'},
+    {'mbd-82005cbb.tar.xz':
+     'bbcf6ee38cc46d59dc364eff1fbe18258a15ef1a393f2720a25e483ef188a62d'},
+    {'devxlib-a6b89ef7.tar.xz':
+     '0a9b7e5350f44017a2390c85176d1683c6ecec0e4b716a59d727f7650f16e807'},
+    {'d3q-de471835.tar.xz':
+     '7ba995ecb64578b27acb0f64a9408c7eafa52aa0994f299454a2bbc502ff8474'},
+    {'fox-3453648e.tar.xz':
+     'c8c55cdf9eb2709aebac86a58f936480ee66438dffd3d65c6a35ca7771c031b3'},
+    {'qe-gipaw-79d3a03b.tar.xz':
+     'ce71b9bd1bde3f5261c68eb794ad19b843aaa8c7a5df9cb73a3132c54b306eda'},
+    {'pw2qmcpack-f72ab25f.tar.xz':
+     'bc9513c4901ec2469d56b8a6b66f56878cb13e3bc7fbcdc5dba0ca6dad880ab9'},
+    {'wannier90-1d6b1873.tar.xz':
+     '351531aaf3434a9aac92d39ee40df5eb949aa27d14fcb93518bf08444478cd2a'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3.1-foss-2024a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3.1-foss-2024a.eb
@@ -95,7 +95,7 @@ sources = [
         },
     },
     {
-            "filename": f"wannier90-{local_w90_hash[:8]}.tar.xz",
+        "filename": f"wannier90-{local_w90_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/wannier-developers",
             "repo_name": "wannier90",

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3.1-foss-2024a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3.1-foss-2024a.eb
@@ -37,7 +37,7 @@ sources = [
         "source_urls": ["https://gitlab.com/QEF/q-e/-/archive/qe-%(version)s"],
     },
     {
-        "filename": "lapack-%s.tar.gz" % local_lapack_hash,
+        "filename": f"lapack-{local_lapack_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/Reference-LAPACK",
             "repo_name": "lapack",
@@ -45,7 +45,7 @@ sources = [
         },
     },
     {
-        "filename": "mbd-%s.tar.gz" % local_mbd_hash,
+        "filename": f"mbd-{local_mbd_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/libmbd",
             "repo_name": "libmbd",
@@ -54,7 +54,7 @@ sources = [
         },
     },
     {
-        "filename": "devxlib-%s.tar.gz" % local_devxlib_hash,
+        "filename": f"devxlib-{local_devxlib_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://gitlab.com/max-centre/components",
             "repo_name": "devicexlib",
@@ -63,7 +63,7 @@ sources = [
         },
     },
     {
-        "filename": "d3q-%s.tar.gz" % local_d3q_hash,
+        "filename": f"d3q-{local_d3q_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/anharmonic",
             "repo_name": "d3q",
@@ -71,7 +71,7 @@ sources = [
         },
     },
     {
-        "filename": "fox-%s.tar.gz" % local_fox_hash,
+        "filename": f"fox-{local_fox_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/pietrodelugas",
             "repo_name": "fox",
@@ -79,7 +79,7 @@ sources = [
         },
     },
     {
-        "filename": "qe-gipaw-%s.tar.gz" % local_qe_gipaw_hash,
+        "filename": f"qe-gipaw-{local_qe_gipaw_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/dceresoli",
             "repo_name": "qe-gipaw",
@@ -87,7 +87,7 @@ sources = [
         },
     },
     {
-        "filename": "pw2qmcpack-%s.tar.gz" % local_qmcpack_hash,
+        "filename": f"pw2qmcpack-{local_qmcpack_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/QMCPACK",
             "repo_name": "pw2qmcpack",
@@ -95,7 +95,7 @@ sources = [
         },
     },
     {
-        "filename": "wannier90-%s.tar.gz" % local_w90_hash,
+            "filename": f"wannier90-{local_w90_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/wannier-developers",
             "repo_name": "wannier90",
@@ -103,22 +103,25 @@ sources = [
         },
     },
 ]
-# Holding off checksum checks untill 5.0.x
-# https://github.com/easybuilders/easybuild-framework/pull/4248
-# checksums = [
-#     {'q-e-qe-7.3.1.tar.gz': '2c58b8fadfe4177de5a8b69eba447db5e623420b070dea6fd26c1533b081d844'},
-#     {'lapack-%s.tar.gz' % local_lapack_hash: 'c05532ae0e5fe35f473206dda12970da5f2e2214620487d71837ddcf0ea6b21d'},
-#     {'mbd-%s.tar.gz' % local_mbd_hash: 'a180682c00bb890c9b1e26a98addbd68e32f970c06439acf7582415f4c589800'},
-#     {'devxlib-%s.tar.gz' % local_devxlib_hash: '76da8fe5a2050f58efdc92fa8831efec25c19190df7f4e5e39c173a5fbae83b4'},
-#     {'d3q-%s.tar.gz' % local_d3q_hash: '43e50753a56af05d181b859d3e29d842fb3fc4352f00cb7fe229a435a1f20c31'},
-#     {'fox-%s.tar.gz' % local_fox_hash: '99b6a899a3f947d7763aa318e86f9f08db684568bfdcd293f3318bee9d7f1948'},
-#     {'qe-gipaw-%s.tar.gz' % local_qe_gipaw_hash: '9ac8314363d29cc2f1ce85abd8f26c1a3ae311d54f6e6034d656442dd101c928'},
-#     {'pw2qmcpack-%s.tar.gz' % local_qmcpack_hash: 'a8136da8429fc49ab560ef7356cd6f0a2714dfbb137baff7961f46dfe32061eb'},
-#     {'wannier90-%s.tar.gz' % local_w90_hash: 'f989497790ec9777bdc159945bbf42156edb7268011f972874dec67dd4f58658'},
-# ]
 checksums = [
-    '2c58b8fadfe4177de5a8b69eba447db5e623420b070dea6fd26c1533b081d844',
-    None, None, None, None, None, None, None, None
+    {'q-e-qe-7.3.1.tar.gz':
+     '2c58b8fadfe4177de5a8b69eba447db5e623420b070dea6fd26c1533b081d844'},
+    {'lapack-12d82539.tar.xz':
+     '88aea5bca5e730e99fda0a5b9d677d6036c7dd82874e0deaed5cccef1f880111'},
+    {'mbd-82005cbb.tar.xz':
+     'bbcf6ee38cc46d59dc364eff1fbe18258a15ef1a393f2720a25e483ef188a62d'},
+    {'devxlib-a6b89ef7.tar.xz':
+     '0a9b7e5350f44017a2390c85176d1683c6ecec0e4b716a59d727f7650f16e807'},
+    {'d3q-de471835.tar.xz':
+     '7ba995ecb64578b27acb0f64a9408c7eafa52aa0994f299454a2bbc502ff8474'},
+    {'fox-3453648e.tar.xz':
+     'c8c55cdf9eb2709aebac86a58f936480ee66438dffd3d65c6a35ca7771c031b3'},
+    {'qe-gipaw-79d3a03b.tar.xz':
+     'ce71b9bd1bde3f5261c68eb794ad19b843aaa8c7a5df9cb73a3132c54b306eda'},
+    {'pw2qmcpack-f72ab25f.tar.xz':
+     'bc9513c4901ec2469d56b8a6b66f56878cb13e3bc7fbcdc5dba0ca6dad880ab9'},
+    {'wannier90-1d6b1873.tar.xz':
+     '351531aaf3434a9aac92d39ee40df5eb949aa27d14fcb93518bf08444478cd2a'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3.1-intel-2023a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.3.1-intel-2023a.eb
@@ -33,7 +33,7 @@ sources = [
         'source_urls': ['https://gitlab.com/QEF/q-e/-/archive/qe-%(version)s']
     },
     {
-        "filename": "lapack-%s.tar.gz" % local_lapack_hash,
+        "filename": f"lapack-{local_lapack_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/Reference-LAPACK",
             "repo_name": "lapack",
@@ -41,7 +41,7 @@ sources = [
         },
     },
     {
-        "filename": "mbd-%s.tar.gz" % local_mbd_hash,
+        "filename": f"mbd-{local_mbd_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/libmbd",
             "repo_name": "libmbd",
@@ -50,7 +50,7 @@ sources = [
         },
     },
     {
-        "filename": "devxlib-%s.tar.gz" % local_devxlib_hash,
+        "filename": f"devxlib-{local_devxlib_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://gitlab.com/max-centre/components",
             "repo_name": "devicexlib",
@@ -59,7 +59,7 @@ sources = [
         },
     },
     {
-        "filename": "d3q-%s.tar.gz" % local_d3q_hash,
+        "filename": f"d3q-{local_d3q_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/anharmonic",
             "repo_name": "d3q",
@@ -67,7 +67,7 @@ sources = [
         },
     },
     {
-        "filename": "fox-%s.tar.gz" % local_fox_hash,
+        "filename": f"fox-{local_fox_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/pietrodelugas",
             "repo_name": "fox",
@@ -75,7 +75,7 @@ sources = [
         },
     },
     {
-        "filename": "qe-gipaw-%s.tar.gz" % local_qe_gipaw_hash,
+        "filename": f"qe-gipaw-{local_qe_gipaw_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/dceresoli",
             "repo_name": "qe-gipaw",
@@ -83,7 +83,7 @@ sources = [
         },
     },
     {
-        "filename": "pw2qmcpack-%s.tar.gz" % local_qmcpack_hash,
+        "filename": f"pw2qmcpack-{local_qmcpack_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/QMCPACK",
             "repo_name": "pw2qmcpack",
@@ -91,7 +91,7 @@ sources = [
         },
     },
     {
-        "filename": "wannier90-%s.tar.gz" % local_w90_hash,
+        "filename": f"wannier90-{local_w90_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/wannier-developers",
             "repo_name": "wannier90",
@@ -99,22 +99,25 @@ sources = [
         },
     },
 ]
-# Holding off checksum checks untill 5.0.x
-# https://github.com/easybuilders/easybuild-framework/pull/4248
-# checksums = [
-#     {'q-e-qe-7.3.1.tar.gz': '2c58b8fadfe4177de5a8b69eba447db5e623420b070dea6fd26c1533b081d844'},
-#     {'lapack-%s.tar.gz' % local_lapack_hash: 'c05532ae0e5fe35f473206dda12970da5f2e2214620487d71837ddcf0ea6b21d'},
-#     {'mbd-%s.tar.gz' % local_mbd_hash: 'a180682c00bb890c9b1e26a98addbd68e32f970c06439acf7582415f4c589800'},
-#     {'devxlib-%s.tar.gz' % local_devxlib_hash: '76da8fe5a2050f58efdc92fa8831efec25c19190df7f4e5e39c173a5fbae83b4'},
-#     {'d3q-%s.tar.gz' % local_d3q_hash: '43e50753a56af05d181b859d3e29d842fb3fc4352f00cb7fe229a435a1f20c31'},
-#     {'fox-%s.tar.gz' % local_fox_hash: '99b6a899a3f947d7763aa318e86f9f08db684568bfdcd293f3318bee9d7f1948'},
-#     {'qe-gipaw-%s.tar.gz' % local_qe_gipaw_hash: '9ac8314363d29cc2f1ce85abd8f26c1a3ae311d54f6e6034d656442dd101c928'},
-#     {'pw2qmcpack-%s.tar.gz' % local_qmcpack_hash: 'a8136da8429fc49ab560ef7356cd6f0a2714dfbb137baff7961f46dfe32061eb'},
-#     {'wannier90-%s.tar.gz' % local_w90_hash: 'f989497790ec9777bdc159945bbf42156edb7268011f972874dec67dd4f58658'},
-# ]
 checksums = [
-    '2c58b8fadfe4177de5a8b69eba447db5e623420b070dea6fd26c1533b081d844',
-    None, None, None, None, None, None, None, None
+    {'q-e-qe-7.3.1.tar.gz':
+     '2c58b8fadfe4177de5a8b69eba447db5e623420b070dea6fd26c1533b081d844'},
+    {'lapack-12d82539.tar.xz':
+     '88aea5bca5e730e99fda0a5b9d677d6036c7dd82874e0deaed5cccef1f880111'},
+    {'mbd-82005cbb.tar.xz':
+     'bbcf6ee38cc46d59dc364eff1fbe18258a15ef1a393f2720a25e483ef188a62d'},
+    {'devxlib-a6b89ef7.tar.xz':
+     '0a9b7e5350f44017a2390c85176d1683c6ecec0e4b716a59d727f7650f16e807'},
+    {'d3q-de471835.tar.xz':
+     '7ba995ecb64578b27acb0f64a9408c7eafa52aa0994f299454a2bbc502ff8474'},
+    {'fox-3453648e.tar.xz':
+     'c8c55cdf9eb2709aebac86a58f936480ee66438dffd3d65c6a35ca7771c031b3'},
+    {'qe-gipaw-75b01b69.tar.xz':
+     'e556a4936dae88ab6fb1e631bb907bb14c2cf5cec9ca64485ede5f94f251d731'},
+    {'pw2qmcpack-f72ab25f.tar.xz':
+     'bc9513c4901ec2469d56b8a6b66f56878cb13e3bc7fbcdc5dba0ca6dad880ab9'},
+    {'wannier90-1d6b1873.tar.xz':
+     '351531aaf3434a9aac92d39ee40df5eb949aa27d14fcb93518bf08444478cd2a'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.4-foss-2024a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.4-foss-2024a.eb
@@ -35,7 +35,7 @@ sources = [
         "source_urls": ["https://gitlab.com/QEF/q-e/-/archive/qe-%(version)s"],
     },
     {
-        "filename": "lapack-%s.tar.gz" % local_lapack_hash,
+        "filename": f"lapack-{local_lapack_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/Reference-LAPACK",
             "repo_name": "lapack",
@@ -43,7 +43,7 @@ sources = [
         },
     },
     {
-        "filename": "mbd-%s.tar.gz" % local_mbd_hash,
+        "filename": f"mbd-{local_mbd_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/libmbd",
             "repo_name": "libmbd",
@@ -52,7 +52,7 @@ sources = [
         },
     },
     {
-        "filename": "devxlib-%s.tar.gz" % local_devxlib_hash,
+        "filename": f"devxlib-{local_devxlib_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://gitlab.com/max-centre/components",
             "repo_name": "devicexlib",
@@ -61,7 +61,7 @@ sources = [
         },
     },
     {
-        "filename": "d3q-%s.tar.gz" % local_d3q_hash,
+        "filename": f"d3q-{local_d3q_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/anharmonic",
             "repo_name": "d3q",
@@ -69,7 +69,7 @@ sources = [
         },
     },
     {
-        "filename": "fox-%s.tar.gz" % local_fox_hash,
+        "filename": f"fox-{local_fox_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/pietrodelugas",
             "repo_name": "fox",
@@ -77,7 +77,7 @@ sources = [
         },
     },
     {
-        "filename": "qe-gipaw-%s.tar.gz" % local_qe_gipaw_hash,
+        "filename": f"qe-gipaw-{local_qe_gipaw_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/dceresoli",
             "repo_name": "qe-gipaw",
@@ -85,7 +85,7 @@ sources = [
         },
     },
     {
-        "filename": "pw2qmcpack-%s.tar.gz" % local_qmcpack_hash,
+        "filename": f"pw2qmcpack-{local_qmcpack_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/QMCPACK",
             "repo_name": "pw2qmcpack",
@@ -93,7 +93,7 @@ sources = [
         },
     },
     {
-        "filename": "wannier90-%s.tar.gz" % local_w90_hash,
+        "filename": f"wannier90-{local_w90_hash[:8]}.tar.xz",
         "git_config": {
             "url": "https://github.com/wannier-developers",
             "repo_name": "wannier90",
@@ -102,22 +102,33 @@ sources = [
     },
 ]
 patches = [
-    {
-        'name': 'QuantumESPRESSO-7.4-d3q.patch',
-        'sourcepath': '../'  # Needed as patches are normally applied to the first `finalpath` directory
-    },
-
-    {
-        'name': 'QuantumESPRESSO-7.4-parallel-symmetrization.patch',
-    },
+    # sourcepath needed for patches applied outside the first `finalpath` directory
+    {'name': 'QuantumESPRESSO-7.4-d3q.patch', 'sourcepath': '../'},
+    {'name': 'QuantumESPRESSO-7.4-parallel-symmetrization.patch'},
 ]
-# Holding off git clone checksum checks untill 5.0.x
-# See https://github.com/easybuilders/easybuild-framework/pull/4248
 checksums = [
-    'b15dcfe25f4fbf15ccd34c1194021e90996393478226e601d876f7dea481d104',
-    None, None, None, None, None, None, None, None,
-    '1f1686365fbf0cc56f634e072a92b3d336fe454348e514d0b4136d447f0d4923',
-    'e11ac954fa2289a3b453e86871a819a78972e94681f08425ec35dc51a908f7d2',
+    {'q-e-qe-7.4.tar.gz':
+     'b15dcfe25f4fbf15ccd34c1194021e90996393478226e601d876f7dea481d104'},
+    {'lapack-12d82539.tar.xz':
+     '88aea5bca5e730e99fda0a5b9d677d6036c7dd82874e0deaed5cccef1f880111'},
+    {'mbd-89a3cc19.tar.xz':
+     'd026bf0e9334874670a23cd854f445baac003d4f099afa46bab667bc67abb450'},
+    {'devxlib-a6b89ef7.tar.xz':
+     '0a9b7e5350f44017a2390c85176d1683c6ecec0e4b716a59d727f7650f16e807'},
+    {'d3q-808acbaf.tar.xz':
+     '8e42c946c33b90094ad16c3fd545f00a6801958880dfc5e5274759126a4b193c'},
+    {'fox-3453648e.tar.xz':
+     'c8c55cdf9eb2709aebac86a58f936480ee66438dffd3d65c6a35ca7771c031b3'},
+    {'qe-gipaw-9b2ae1a4.tar.xz':
+     '29e6edfda8ee71c12683b1dfce4a29c5fff8aa9046b0a8085441dce01d084475'},
+    {'pw2qmcpack-f72ab25f.tar.xz':
+     'bc9513c4901ec2469d56b8a6b66f56878cb13e3bc7fbcdc5dba0ca6dad880ab9'},
+    {'wannier90-1d6b1873.tar.xz':
+     '351531aaf3434a9aac92d39ee40df5eb949aa27d14fcb93518bf08444478cd2a'},
+    {'QuantumESPRESSO-7.4-d3q.patch':
+     '1f1686365fbf0cc56f634e072a92b3d336fe454348e514d0b4136d447f0d4923'},
+    {'QuantumESPRESSO-7.4-parallel-symmetrization.patch':
+     'e11ac954fa2289a3b453e86871a819a78972e94681f08425ec35dc51a908f7d2'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/s/SISSO++/SISSO++-1.1-foss-2021b.eb
+++ b/easybuild/easyconfigs/s/SISSO++/SISSO++-1.1-foss-2021b.eb
@@ -17,12 +17,14 @@ sources = [{
         'recursive': True,
         'commit': 'v%(version)s',
     },
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
 }]
 patches = ['SISSO++-1.1_cmake-mpi-fix.patch']
 checksums = [
-    None,  # SISSO++-1.1.tar.gz
-    '614f13ef34dc1d1b2fe0e9868cdcf576a0dacb336759f5295115131d15e9c35a',
+    {'SISSO++-1.1.tar.xz':
+     '16fa3e6b34c56108340eba062bdcd1cc84eeb80897652844e11c5b95745a4924'},
+    {'SISSO++-1.1_cmake-mpi-fix.patch':
+     '614f13ef34dc1d1b2fe0e9868cdcf576a0dacb336759f5295115131d15e9c35a'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/s/STRique/STRique-0.4.2-foss-2021b.eb
+++ b/easybuild/easyconfigs/s/STRique/STRique-0.4.2-foss-2021b.eb
@@ -56,14 +56,14 @@ exts_list = [
         ],
         'preconfigopts': local_preconfigopts,
         'sources': [{
-            'filename': '%(name)s-%(version)s.tar.gz',
+            'filename': SOURCE_TAR_XZ,
             'git_config': {
                 'url': 'https://github.com/giesselmann',
                 'repo_name': 'STRique', 'commit': '585273215abff7956f5d6277601f0a6be2211a96',
                 'recursive': True
             }
         }],
-        'checksums': [None],
+        'checksums': ['f5064d9e279d97cfe4aacfbcc92b2549fbf5e722b74f32bbe9811d01d74889ce'],
     }),
 ]
 

--- a/easybuild/easyconfigs/s/Sambamba/Sambamba-0.8.0-GCC-10.2.0.eb
+++ b/easybuild/easyconfigs/s/Sambamba/Sambamba-0.8.0-GCC-10.2.0.eb
@@ -13,7 +13,7 @@ toolchain = {'name': 'GCC', 'version': '10.2.0'}
 
 source_urls = ['https://github.com/biod/sambamba/archive/']
 sources = [{
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/biod',
         'repo_name': 'sambamba',
@@ -21,7 +21,7 @@ sources = [{
         'recursive': True,
     }
 }]
-checksums = [None]
+checksums = ['4a00d072ffc1d077fd8cd54294eea5ae0e890eedbaaa5b16b54fffa758caafce']
 
 builddependencies = [
     ('LDC', '1.25.1'),

--- a/easybuild/easyconfigs/s/Sambamba/Sambamba-0.8.2-GCC-10.3.0.eb
+++ b/easybuild/easyconfigs/s/Sambamba/Sambamba-0.8.2-GCC-10.3.0.eb
@@ -13,7 +13,7 @@ toolchain = {'name': 'GCC', 'version': '10.3.0'}
 
 source_urls = ['https://github.com/biod/sambamba/archive/']
 sources = [{
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/biod',
         'repo_name': 'sambamba',
@@ -21,7 +21,7 @@ sources = [{
         'recursive': True,
     }
 }]
-checksums = [None]
+checksums = ['d35d980b28088bb895fb1baede5ffc344f06384ca3e1af6901f0fb83a8637029']
 
 builddependencies = [
     ('LDC', '1.26.0'),

--- a/easybuild/easyconfigs/s/SeuratData/SeuratData-20210514-foss-2020b-R-4.0.3.eb
+++ b/easybuild/easyconfigs/s/SeuratData/SeuratData-20210514-foss-2020b-R-4.0.3.eb
@@ -12,14 +12,14 @@ package and data management systems."""
 toolchain = {'name': 'foss', 'version': '2020b'}
 
 sources = [{
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/satijalab',
         'repo_name': 'seurat-data',
         'commit': local_commit,
     },
 }]
-checksums = [None]
+checksums = ['7bec7540f634b39089ba457b32784bb5236dfad0935937f8155240201ab862bd']
 
 dependencies = [('R', '4.0.3')]
 

--- a/easybuild/easyconfigs/s/SeuratWrappers/SeuratWrappers-20210528-foss-2020b-R-4.0.3.eb
+++ b/easybuild/easyconfigs/s/SeuratWrappers/SeuratWrappers-20210528-foss-2020b-R-4.0.3.eb
@@ -11,14 +11,14 @@ description = "SeuratWrappers is a collection of community-provided methods and 
 toolchain = {'name': 'foss', 'version': '2020b'}
 
 sources = [{
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/satijalab',
         'repo_name': 'seurat-wrappers',
         'commit': local_commit,
     },
 }]
-checksums = [None]
+checksums = ['01d1bfef64cd4f5b3c209a431ecc475349d4dec513318263ddb0354cd37ca47e']
 
 dependencies = [
     ('R', '4.0.3'),

--- a/easybuild/easyconfigs/s/SeuratWrappers/SeuratWrappers-20221022-foss-2022a-R-4.2.1.eb
+++ b/easybuild/easyconfigs/s/SeuratWrappers/SeuratWrappers-20221022-foss-2022a-R-4.2.1.eb
@@ -11,14 +11,14 @@ description = "SeuratWrappers is a collection of community-provided methods and 
 toolchain = {'name': 'foss', 'version': '2022a'}
 
 sources = [{
-    'filename': SOURCE_TAR_GZ,
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/satijalab',
         'repo_name': 'seurat-wrappers',
         'commit': local_commit,
     },
 }]
-checksums = [None]
+checksums = ['ccdf66ad730d75031278b0409c690c001e383dcae930d286fd9f8047a5c553aa']
 
 dependencies = [
     ('R', '4.2.1'),

--- a/easybuild/easyconfigs/s/Slideflow/Slideflow-3.0.1-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/s/Slideflow/Slideflow-3.0.1-foss-2023a-CUDA-12.1.1.eb
@@ -52,14 +52,14 @@ dependencies = [
 exts_list = [
     ('triangle', '20230923', {
         'sources': [{
-            'filename': '%(name)s-v%(version)s.tar.gz',
+            'filename': SOURCE_TAR_XZ,
             'git_config': {
                 'url': 'https://github.com/drufat',
                 'repo_name': 'triangle',
                 'tag': 'v20230923', 'recursive': True
             }
         }],
-        'checksums': [None],
+        'checksums': ['cea3495da94cfa17dd0df2316d76180d85e1ef64fe9f14054c48f4844de54d8d'],
     }),
     (name, version, {
         'patches': ['%(name)s-%(version)s_fix-opencv-dep.patch'],

--- a/easybuild/easyconfigs/t/tmap/tmap-20220502-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/t/tmap/tmap-20220502-GCC-11.2.0.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'GCC', 'version': '11.2.0'}
 
 sources = [
     {
-        'filename': SOURCE_TAR_GZ,
+        'filename': SOURCE_TAR_XZ,
         'git_config': {
             'url': 'https://github.com/reymond-group',
             'repo_name': '%(name)s',
@@ -24,8 +24,10 @@ patches = [
     'tmap-20220502_add_install.patch',
 ]
 checksums = [
-    None,  # tmap-20220502.tar.gz
-    '055f69b36ca3b4c41f1d979193eb6a0471416cf018853511db2ffe7594f35eca',  # tmap-20220502_add_install.patch
+    {'tmap-20220502.tar.xz':
+     'cf5eb8034e72af5074cc6c384ed637056701a5ec90459e7d617519758371bc18'},
+    {'tmap-20220502_add_install.patch':
+     '055f69b36ca3b4c41f1d979193eb6a0471416cf018853511db2ffe7594f35eca'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/w/WRF/WRF-4.4-foss-2022a-dmpar.eb
+++ b/easybuild/easyconfigs/w/WRF/WRF-4.4-foss-2022a-dmpar.eb
@@ -12,9 +12,8 @@ toolchain = {'name': 'foss', 'version': '2022a'}
 toolchainopts = {'opt': False}  # don't use agressive optimization, stick to -O2
 
 source_urls = ['https://github.com/wrf-model/WRF/archive/']
-# sources = ['v%(version)s.tar.gz']
 sources = [{
-    'filename': 'v4.4.tar.gz',
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/wrf-model',
         'repo_name': 'WRF',
@@ -28,8 +27,10 @@ patches = [
 ]
 # The problem: sources from git clone have different checksum every time
 checksums = [
-    None,  # v4.4.tar.gz
-    '0e37c8a7bb4d25947083bdb6d0f2a9f4fdb825c88f6cb10c59b7580fe3d129ff',  # WRF-4.4_netCDF-Fortran_separate_path.patch
+    {'WRF-4.4.tar.xz':
+     '8656d657af9fb0626ff809623f36cdd9f3332d2ee8db04df1663c46196f91f30'},
+    {'WRF-4.4_netCDF-Fortran_separate_path.patch':
+     '0e37c8a7bb4d25947083bdb6d0f2a9f4fdb825c88f6cb10c59b7580fe3d129ff'},
 ]
 
 # csh is used by WRF install scripts

--- a/easybuild/easyconfigs/w/WRF/WRF-4.4.1-foss-2022b-dmpar.eb
+++ b/easybuild/easyconfigs/w/WRF/WRF-4.4.1-foss-2022b-dmpar.eb
@@ -12,9 +12,8 @@ toolchain = {'name': 'foss', 'version': '2022b'}
 toolchainopts = {'opt': False}  # don't use agressive optimization, stick to -O2
 
 source_urls = ['https://github.com/wrf-model/WRF/archive/']
-# sources = ['v%(version)s.tar.gz']
 sources = [{
-    'filename': 'v%(version)s.tar.gz',
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/wrf-model',
         'repo_name': 'WRF',
@@ -27,8 +26,10 @@ patches = [
     'WRF-4.4_netCDF-Fortran_separate_path.patch',
 ]
 checksums = [
-    None,  # v4.4.1.tar.gz
-    '0e37c8a7bb4d25947083bdb6d0f2a9f4fdb825c88f6cb10c59b7580fe3d129ff',  # WRF-4.4_netCDF-Fortran_separate_path.patch
+    {'WRF-4.4.1.tar.xz':
+     '2e902985aa10d496a48900350e8c96e089a26dc71b9977e2afa4455051692b70'},
+    {'WRF-4.4_netCDF-Fortran_separate_path.patch':
+     '0e37c8a7bb4d25947083bdb6d0f2a9f4fdb825c88f6cb10c59b7580fe3d129ff'},
 ]
 
 # csh is used by WRF install scripts


### PR DESCRIPTION
We can use reproducible archives in all sources from git repos without `keep_git_dir`:
* rename sources to `SOURCE_TAR_XZ`
* add corresponding checksums