### PR TITLE
use all same checksums of libxc v6.2.2 in its easyconfigs

### DIFF
--- a/easybuild/easyconfigs/l/libxc/libxc-6.2.2-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-6.2.2-GCC-12.3.0.eb
@@ -11,8 +11,11 @@ toolchain = {'name': 'GCC', 'version': '12.3.0'}
 
 source_urls = ['https://gitlab.com/libxc/libxc/-/archive/%(version)s/']
 sources = [SOURCE_TAR_GZ]
-checksums = [('a0f6f1bba7ba5c0c85b2bfe65aca1591025f509a7f11471b4cd651a79491b045',
-              '3b0523924579cf494cafc6fea92945257f35692b004217d3dfd3ea7ca780e8dc')]
+checksums = [
+    ('a0f6f1bba7ba5c0c85b2bfe65aca1591025f509a7f11471b4cd651a79491b045',
+     '3b0523924579cf494cafc6fea92945257f35692b004217d3dfd3ea7ca780e8dc',
+     'd1b65ef74615a1e539d87a0e6662f04baf3a2316706b4e2e686da3193b26b20f'),
+]
 
 builddependencies = [
     ('CMake', '3.26.3'),

--- a/easybuild/easyconfigs/l/libxc/libxc-6.2.2-GCC-13.2.0-nofhc.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-6.2.2-GCC-13.2.0-nofhc.eb
@@ -12,8 +12,11 @@ toolchain = {'name': 'GCC', 'version': '13.2.0'}
 
 source_urls = ['https://gitlab.com/libxc/libxc/-/archive/%(version)s/']
 sources = [SOURCE_TAR_GZ]
-checksums = [('a0f6f1bba7ba5c0c85b2bfe65aca1591025f509a7f11471b4cd651a79491b045',
-              '3b0523924579cf494cafc6fea92945257f35692b004217d3dfd3ea7ca780e8dc')]
+checksums = [
+    ('a0f6f1bba7ba5c0c85b2bfe65aca1591025f509a7f11471b4cd651a79491b045',
+     '3b0523924579cf494cafc6fea92945257f35692b004217d3dfd3ea7ca780e8dc',
+     'd1b65ef74615a1e539d87a0e6662f04baf3a2316706b4e2e686da3193b26b20f'),
+]
 
 builddependencies = [
     ('CMake', '3.27.6'),

--- a/easybuild/easyconfigs/l/libxc/libxc-6.2.2-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-6.2.2-GCC-13.2.0.eb
@@ -11,9 +11,11 @@ toolchain = {'name': 'GCC', 'version': '13.2.0'}
 
 source_urls = ['https://gitlab.com/libxc/libxc/-/archive/%(version)s/']
 sources = [SOURCE_TAR_GZ]
-checksums = [('a0f6f1bba7ba5c0c85b2bfe65aca1591025f509a7f11471b4cd651a79491b045',
-              '3b0523924579cf494cafc6fea92945257f35692b004217d3dfd3ea7ca780e8dc',
-              'd1b65ef74615a1e539d87a0e6662f04baf3a2316706b4e2e686da3193b26b20f',)]
+checksums = [
+    ('a0f6f1bba7ba5c0c85b2bfe65aca1591025f509a7f11471b4cd651a79491b045',
+     '3b0523924579cf494cafc6fea92945257f35692b004217d3dfd3ea7ca780e8dc',
+     'd1b65ef74615a1e539d87a0e6662f04baf3a2316706b4e2e686da3193b26b20f'),
+]
 
 builddependencies = [
     ('CMake', '3.27.6'),

--- a/easybuild/easyconfigs/l/libxc/libxc-6.2.2-intel-compilers-2023.1.0.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-6.2.2-intel-compilers-2023.1.0.eb
@@ -11,8 +11,11 @@ toolchain = {'name': 'intel-compilers', 'version': '2023.1.0'}
 
 source_urls = ['https://gitlab.com/libxc/libxc/-/archive/%(version)s/']
 sources = [SOURCE_TAR_GZ]
-checksums = [('a0f6f1bba7ba5c0c85b2bfe65aca1591025f509a7f11471b4cd651a79491b045',
-              '3b0523924579cf494cafc6fea92945257f35692b004217d3dfd3ea7ca780e8dc')]
+checksums = [
+    ('a0f6f1bba7ba5c0c85b2bfe65aca1591025f509a7f11471b4cd651a79491b045',
+     '3b0523924579cf494cafc6fea92945257f35692b004217d3dfd3ea7ca780e8dc',
+     'd1b65ef74615a1e539d87a0e6662f04baf3a2316706b4e2e686da3193b26b20f'),
+]
 
 builddependencies = [
     ('CMake', '3.26.3'),

--- a/easybuild/easyconfigs/l/libxc/libxc-6.2.2-intel-compilers-2023.2.1.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-6.2.2-intel-compilers-2023.2.1.eb
@@ -11,8 +11,11 @@ toolchain = {'name': 'intel-compilers', 'version': '2023.2.1'}
 
 source_urls = ['https://gitlab.com/libxc/libxc/-/archive/%(version)s/']
 sources = [SOURCE_TAR_GZ]
-checksums = [('a0f6f1bba7ba5c0c85b2bfe65aca1591025f509a7f11471b4cd651a79491b045',
-              '3b0523924579cf494cafc6fea92945257f35692b004217d3dfd3ea7ca780e8dc')]
+checksums = [
+    ('a0f6f1bba7ba5c0c85b2bfe65aca1591025f509a7f11471b4cd651a79491b045',
+     '3b0523924579cf494cafc6fea92945257f35692b004217d3dfd3ea7ca780e8dc',
+     'd1b65ef74615a1e539d87a0e6662f04baf3a2316706b4e2e686da3193b26b20f'),
+]
 
 builddependencies = [
     ('CMake', '3.27.6'),


### PR DESCRIPTION
Update all easyconfigs of libxc 6.2.2 with the checksums already in `libxc-6.2.2-GCC-13.3.0.eb`