### PR TITLE
add new checksum for tantan v50 tarball

### DIFF
--- a/easybuild/easyconfigs/t/tantan/tantan-50-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/t/tantan/tantan-50-GCC-12.3.0.eb
@@ -10,7 +10,10 @@ toolchain = {'name': 'GCC', 'version': '12.3.0'}
 
 source_urls = ['https://gitlab.com/mcfrith/tantan/-/archive/%(version)s/']
 sources = ['tantan-%(version)s.tar.gz']
-checksums = ['a239e9fb3c059ed9eb4c25a29b3c44a2ef1c1b492a9780874f429de7ae8b5407']
+checksums = [
+    ('a239e9fb3c059ed9eb4c25a29b3c44a2ef1c1b492a9780874f429de7ae8b5407',
+     'ee2238693862e60b9e744fac0586f1e583ae8fc87149df704ddb70dc283d08ee'),
+]
 
 skipsteps = ['configure']
 


### PR DESCRIPTION
New tarball with same name and minor differences in the source code:
```
diff -r -u tantan-50.a/src/Makefile tantan-50.b/src/Makefile
--- tantan-50.a/src/Makefile    2024-07-29 08:49:17.000000000 +0200
+++ tantan-50.b/src/Makefile    2024-07-29 08:49:17.000000000 +0200
@@ -10,7 +10,7 @@
        rm -f ../bin/tantan

 VERSION1 = git describe --dirty
-VERSION2 = echo ' (HEAD -> main, tag: 50) ' | sed -e 's/.*tag: *//' -e 's/[,) ].*//'
+VERSION2 = echo ' (tag: 50) ' | sed -e 's/.*tag: *//' -e 's/[,) ].*//'

 VERSION = \"`test -e ../.git && $(VERSION1) || $(VERSION2)`\"
```