### PR TITLE
fix Python detection in HepMC3

### DIFF
--- a/easybuild/easyconfigs/h/HepMC3/HepMC3-3.2.5-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/h/HepMC3/HepMC3-3.2.5-GCC-11.3.0.eb
@@ -25,7 +25,7 @@ dependencies = [
 preconfigopts = "mv %(builddir)s/%(name)s-%(version)s/cmake/{Modules,.modules.old} &&"
 
 configopts = '-DHEPMC3_ENABLE_ROOTIO=OFF -Dmomentum=GEV -Dlength=MM '
-configopts += '-DHEPMC3_ENABLE_PYTHON=ON -DHEPMC3_PYTHON_VERSIONS=3.10 '
+configopts += '-DHEPMC3_ENABLE_PYTHON=ON -DHEPMC3_PYTHON_VERSIONS=%(pyshortver)s '
 configopts += '-DHEPMC3_Python_SITEARCH310=%(installdir)s/lib/python%(pyshortver)s/site-packages'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/h/HepMC3/HepMC3-3.2.5-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/h/HepMC3/HepMC3-3.2.5-GCC-11.3.0.eb
@@ -21,8 +21,11 @@ dependencies = [
     ('Python', '3.10.4')
 ]
 
+# hide old CMake modules in favour of the ones provided by CMake dependency
+preconfigopts = "mv %(builddir)s/%(name)s-%(version)s/cmake/{Modules,.modules.old} &&"
+
 configopts = '-DHEPMC3_ENABLE_ROOTIO=OFF -Dmomentum=GEV -Dlength=MM '
-configopts += '-DHEPMC3_ENABLE_PYTHON=ON '
+configopts += '-DHEPMC3_ENABLE_PYTHON=ON -DHEPMC3_PYTHON_VERSIONS=3.10 '
 configopts += '-DHEPMC3_Python_SITEARCH310=%(installdir)s/lib/python%(pyshortver)s/site-packages'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/h/HepMC3/HepMC3-3.2.6-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/h/HepMC3/HepMC3-3.2.6-GCC-12.3.0.eb
@@ -25,7 +25,7 @@ dependencies = [
 preconfigopts = "mv %(builddir)s/%(name)s-%(version)s/cmake/{Modules,.modules.old} &&"
 
 configopts = '-DHEPMC3_ENABLE_ROOTIO=OFF -Dmomentum=GEV -Dlength=MM '
-configopts += '-DHEPMC3_ENABLE_PYTHON=ON -DHEPMC3_PYTHON_VERSIONS=3.11 '
+configopts += '-DHEPMC3_ENABLE_PYTHON=ON -DHEPMC3_PYTHON_VERSIONS=%(pyshortver)s '
 configopts += '-DHEPMC3_Python_SITEARCH311=%(installdir)s/lib/python%(pyshortver)s/site-packages'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/h/HepMC3/HepMC3-3.2.6-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/h/HepMC3/HepMC3-3.2.6-GCC-12.3.0.eb
@@ -21,8 +21,11 @@ dependencies = [
     ('Python', '3.11.3')
 ]
 
+# hide old CMake modules in favour of the ones provided by CMake dependency
+preconfigopts = "mv %(builddir)s/%(name)s-%(version)s/cmake/{Modules,.modules.old} &&"
+
 configopts = '-DHEPMC3_ENABLE_ROOTIO=OFF -Dmomentum=GEV -Dlength=MM '
-configopts += '-DHEPMC3_ENABLE_PYTHON=ON '
+configopts += '-DHEPMC3_ENABLE_PYTHON=ON -DHEPMC3_PYTHON_VERSIONS=3.11 '
 configopts += '-DHEPMC3_Python_SITEARCH311=%(installdir)s/lib/python%(pyshortver)s/site-packages'
 
 sanity_check_paths = {


### PR DESCRIPTION
Installation fails because cmake detects the Python interpreter from the host system instead of the one loaded as dependency of HepMC3:

```
-- HepMC3 python: Python verson 3.X found in /user/brussel/101/vsc10122/.local/venv/eb.py36/bin/python3. Python bindings generation is possible.
-- HepMC3 python: For this platforrm CMAKE_SHARED_LIBRARY_PREFIX=lib, CMAKE_SHARED_LIBRARY_SUFFIX=.so
-- HepMC3 python: For this platforrm CMAKE_IMPORT_LIBRARY_PREFIX=, CMAKE_IMPORT_LIBRARY_SUFFIX=
-- HepMC3 python: Tweak HEPMC3_Python_SITEARCH36 option to set the installation path for the python36 bindings.
-- HepMC3 python: HEPMC3_Python_SITEARCH36 defaults to /user/brussel/101/vsc10122/.local/venv/eb.py36/lib64/python3.6/site-packages
-- HepMC3 python: WARNING: The installation path of the python modules is HEPMC3_Python_SITEARCH=/user/brussel/101/vsc10122/.local/venv/eb.py36/lib64/python3.6/site-packages.
-- HepMC3 python: WARNING: The installation path of the python modules is outside of the global instalation path CMAKE_INSTALL_PREFIX=/user/brussel/101/vsc10122/easybuild/install/zen2/software/HepMC3/3.2.6-GCC-12.3.0.
-- HepMC3 python: WARNING: You can use the HEPMC3_Python_SITEARCH36 variable to set the desired installation path for the Python36 modules.
```

Fortunately EasyBuild is more rigorous than CMake and errors out instead of just printing a warning:
```
ERROR: Installation of HepMC3-3.2.6-GCC-12.3.0.eb failed: "Python path errors:\nPython executable path '/user/brussel/101/vsc10122/.local/venv/eb.py36/bin/python' is outside EBROOTPYTHON (/rhea/scratch/brussel/vo/000/bvo00005/vsc10122/easybuild/install/zen2/software/Python/3.11.3-GCCcore-12.3.0)"
```

