### PR TITLE
add new checksum for sources of Stellarscope v1.4.1

### DIFF
--- a/easybuild/easyconfigs/s/Stellarscope/Stellarscope-1.4.1-foss-2023a.eb
+++ b/easybuild/easyconfigs/s/Stellarscope/Stellarscope-1.4.1-foss-2023a.eb
@@ -22,8 +22,11 @@ dependencies = [
 exts_list = [
     (name, version, {
         'source_urls': ['https://github.com/nixonlab/stellarscope/archive/'],
-        'sources': [{'download_filename': '%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
-        'checksums': ['64aa3fa30e9ee1d4857572a0f491fd4983c15a5b5906edf9a3b7cacda780b99c'],
+        'sources': [{'download_filename': '%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}],
+        'checksums': [
+            ('64aa3fa30e9ee1d4857572a0f491fd4983c15a5b5906edf9a3b7cacda780b99c',
+             '5f3e899ca0bd39dae9748fc7438ca494ec3e128b33e2340cab97ba270affa71d'),
+        ],
     }),
 ]
 


### PR DESCRIPTION
New tarball with same name and minor differences in the source code:
```
diff -r -u stellarscope-1.4.1.a/stellarscope/_version.py stellarscope-1.4.1.b/stellarscope/_version.py
--- stellarscope-1.4.1.a/stellarscope/_version.py       2024-09-25 17:08:59.000000000 +0200
+++ stellarscope-1.4.1.b/stellarscope/_version.py       2024-09-25 17:08:59.000000000 +0200
@@ -25,7 +25,7 @@
     # setup.py/versioneer.py will grep for the variable names, so they must
     # each be defined on a line of their own. _version.py will just call
     # get_keywords().
-    git_refnames = " (HEAD -> main, tag: 1.4.1)"
+    git_refnames = " (tag: 1.4.1)"
     git_full = "af8902ac72e03f23603c55bdf2920c89228a6493"
     git_date = "2024-09-25 11:08:59 -0400"
     keywords = {"refnames": git_refnames, "full": git_full, "date": git_date}
```