### PR TITLE
Add openCARP v17.0 and dependencies

### DIFF
--- a/easybuild/easyconfigs/g/gengetopt/gengetopt-2.23-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/gengetopt/gengetopt-2.23-GCCcore-13.3.0.eb
@@ -1,0 +1,27 @@
+easyblock = 'ConfigureMake'
+
+name = 'gengetopt'
+version = '2.23'
+
+homepage = 'https://www.gnu.org/software/gengetopt/gengetopt.html'
+description = "Gengetopt is a tool to write command line option parsing code for C programs."
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_XZ]
+checksums = ['b941aec9011864978dd7fdeb052b1943535824169d2aa2b0e7eae9ab807584ac']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('makeinfo', '7.1'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/gengetopt'],
+    'dirs': ['share'],
+}
+
+sanity_check_commands = ["gengetopt --help"]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/o/openCARP/openCARP-17.0-foss-2024a.eb
+++ b/easybuild/easyconfigs/o/openCARP/openCARP-17.0-foss-2024a.eb
@@ -11,10 +11,8 @@ toolchainopts = {'openmp': True, 'usempi': True}
 
 source_urls = ['https://git.opencarp.org/openCARP/openCARP/-/archive/v%(version)s/']
 sources = ['openCARP-v%(version)s.tar.gz']
-#patches = ['openCARP-8.2_build-info.patch']
 checksums = [
     '6439b6b8e6a265cd6cfe39f59507418739d936de6f6e059b2d0f468df816d26e',  # openCARP-v8.2.tar.gz
-    # '23c8754c749acc5f0f58ac3780ef7e202cefbcc8092e02e832ac2ff540367365',  # openCARP-8.2_build-info.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/openCARP/openCARP-17.0-foss-2024a.eb
+++ b/easybuild/easyconfigs/o/openCARP/openCARP-17.0-foss-2024a.eb
@@ -12,7 +12,7 @@ toolchainopts = {'openmp': True, 'usempi': True}
 source_urls = ['https://git.opencarp.org/openCARP/openCARP/-/archive/v%(version)s/']
 sources = ['openCARP-v%(version)s.tar.gz']
 checksums = [
-    '6439b6b8e6a265cd6cfe39f59507418739d936de6f6e059b2d0f468df816d26e',  # openCARP-v8.2.tar.gz
+    '6439b6b8e6a265cd6cfe39f59507418739d936de6f6e059b2d0f468df816d26e',  # openCARP-v17.0.tar.gz
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/openCARP/openCARP-17.0-foss-2024a.eb
+++ b/easybuild/easyconfigs/o/openCARP/openCARP-17.0-foss-2024a.eb
@@ -1,0 +1,38 @@
+easyblock = 'CMakeMakeCp'
+
+name = 'openCARP'
+version = '17.0'
+
+homepage = 'https://opencarp.org'
+description = "openCARP is an open cardiac electrophysiology simulator for in-silico experiments."
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = ['https://git.opencarp.org/openCARP/openCARP/-/archive/v%(version)s/']
+sources = ['openCARP-v%(version)s.tar.gz']
+#patches = ['openCARP-8.2_build-info.patch']
+checksums = [
+    '6439b6b8e6a265cd6cfe39f59507418739d936de6f6e059b2d0f468df816d26e',  # openCARP-v8.2.tar.gz
+    # '23c8754c749acc5f0f58ac3780ef7e202cefbcc8092e02e832ac2ff540367365',  # openCARP-8.2_build-info.patch
+]
+
+builddependencies = [
+    ('CMake', '3.29.3'),
+    ('gengetopt', '2.23'),
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('PETSc', '3.22.3'),
+    ('zlib', '1.3.1'),
+]
+
+files_to_copy = ['bin']
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['bench', 'igbapd', 'igbextract', 'igbhead', 'igbops', 'mesher', 'openCARP']],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/o/openCARP/openCARP-17.0-foss-2024a.eb
+++ b/easybuild/easyconfigs/o/openCARP/openCARP-17.0-foss-2024a.eb
@@ -1,4 +1,4 @@
-easyblock = 'CMakeMakeCp'
+easyblock = 'CMakeMake'
 
 name = 'openCARP'
 version = '17.0'
@@ -26,7 +26,8 @@ dependencies = [
     ('zlib', '1.3.1'),
 ]
 
-files_to_copy = ['bin']
+# Avoids non relevant post install operations
+configopts = "-DSPACK_BUILD=ON "
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['bench', 'igbapd', 'igbextract', 'igbhead', 'igbops', 'mesher', 'openCARP']],

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.22.3-foss-2024a.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.22.3-foss-2024a.eb
@@ -1,0 +1,45 @@
+##
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+# Author:    Jasper Grimm (UoY)
+##
+name = 'PETSc'
+version = '3.22.3'
+
+homepage = 'https://www.mcs.anl.gov/petsc'
+description = """PETSc, pronounced PET-see (the S is silent), is a suite of data structures and routines for the
+ scalable (parallel) solution of scientific applications modeled by partial differential equations."""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+toolchainopts = {'openmp': True, 'usempi': True, 'pic': True}
+
+source_urls = [
+    'https://web.cels.anl.gov/projects/petsc/download/release-snapshots',
+]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['88c0d465a3bd688cb17ebf06a17c06d6e9cc457fa6b9643d217389424e6bd795']
+
+builddependencies = [('CMake', '3.29.3')]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('SciPy-bundle', '2024.05'),
+    ('Boost', '1.85.0'),
+    ('METIS', '5.1.0'),
+    ('SCOTCH', '7.0.6'),
+    ('MUMPS', '5.7.2', '-metis'),
+    ('SuiteSparse', '7.8.2', '-METIS-5.1.0'),
+    ('Hypre', '2.32.0'),
+    ('ParMETIS', '4.0.3'),
+    ('SuperLU_DIST', '8.2.1'),
+    ('mpi4py', '4.0.1'),
+]
+
+configopts = '--LIBS="$LIBS -lrt" --with-mpi4py=0 '
+
+shared_libs = 1
+
+# only required when building PETSc in a SLURM job environment
+# configopts += '--with-batch=1 --known-mpi-shared-libraries=1 --known-64-bit-blas-indices=0 '
+# prebuildopts = "srun ./conftest-arch-linux2-c-opt && ./reconfigure-arch-linux2-c-opt.py && "
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/p/ParMETIS/ParMETIS-4.0.3-gompi-2024a.eb
+++ b/easybuild/easyconfigs/p/ParMETIS/ParMETIS-4.0.3-gompi-2024a.eb
@@ -1,0 +1,29 @@
+##
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+##
+name = 'ParMETIS'
+version = '4.0.3'
+
+homepage = 'https://karypis.github.io/glaros/projects/gp.html'
+description = """ParMETIS is an MPI-based parallel library that implements a variety of algorithms for partitioning
+ unstructured graphs, meshes, and for computing fill-reducing orderings of sparse matrices. ParMETIS extends the
+ functionality provided by METIS and includes routines that are especially suited for parallel AMR computations and
+ large scale numerical simulations. The algorithms implemented in ParMETIS are based on the parallel multilevel k-way
+ graph-partitioning, adaptive repartitioning, and parallel multi-constrained partitioning schemes."""
+
+toolchain = {'name': 'gompi', 'version': '2024a'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = [
+    'https://karypis.github.io/glaros/files/sw/parmetis',
+    'https://karypis.github.io/glaros/files/sw/parmetis/OLD',
+]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['f2d9a231b7cf97f1fee6e8c9663113ebf6c240d407d3c118c55b3633d6be6e5f']
+
+builddependencies = [('CMake', '3.29.3')]
+
+# Build static and shared libraries
+configopts = ['', '-DSHARED=1']
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.2-GCCcore-13.3.0.eb
@@ -1,0 +1,36 @@
+# pkgconf should be used in preference to pkg-config
+# This is included for use only in software that fails to build when using pkgconf
+easyblock = 'ConfigureMake'
+
+name = 'pkg-config'
+version = '0.29.2'
+
+homepage = 'https://www.freedesktop.org/wiki/Software/pkg-config/'
+
+description = """
+ pkg-config is a helper tool used when compiling applications and libraries.
+ It helps you insert the correct compiler options on the command line so an
+ application can use gcc -o test test.c `pkg-config --libs --cflags glib-2.0`
+ for instance, rather than hard-coding values on where to find glib (or other
+ libraries).
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591']
+
+builddependencies = [('binutils', '2.42')]
+
+# don't use PAX, it might break.
+tar_config_opts = True
+
+configopts = " --with-internal-glib"
+
+sanity_check_paths = {
+    'files': ['bin/pkg-config'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/s/SuperLU_DIST/SuperLU_DIST-8.2.1-foss-2024a.eb
+++ b/easybuild/easyconfigs/s/SuperLU_DIST/SuperLU_DIST-8.2.1-foss-2024a.eb
@@ -1,0 +1,44 @@
+easyblock = "EB_SuperLU"
+
+name = 'SuperLU_DIST'
+version = '8.2.1'
+
+homepage = 'https://crd-legacy.lbl.gov/~xiaoye/SuperLU/'
+description = """SuperLU is a general purpose library for the direct solution of large, sparse, nonsymmetric systems
+ of linear equations on high performance machines."""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+toolchainopts = {'pic': True, 'openmp': True}
+
+github_account = 'xiaoyeli'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ["v%(version)s.tar.gz"]
+checksums = ['b77d065cafa6bc1a1dcc15bf23fd854f54b05762b165badcffc195835ad2bddf']
+
+builddependencies = [('CMake', '3.29.3')]
+
+dependencies = [
+    ('ParMETIS', '4.0.3'),
+]
+
+configopts = '-DTPL_PARMETIS_INCLUDE_DIRS="${EBROOTPARMETIS}/include" '
+configopts += '-DTPL_PARMETIS_LIBRARIES="${EBROOTPARMETIS}/lib/libparmetis.a;${EBROOTPARMETIS}/lib/libmetis.a" '
+
+# Some tests run longer than default 1500s timeout on fairly big machine (36 cores).
+# Include only first four tests, which should be fairly small to run
+pretestopts = 'export ARGS="$ARGS --tests-regex pdtest_[21]x1_[13]_2_8_20_SP" && '
+
+# remove broken symlink to libsuperlu.a
+postinstallcmds = [
+    "if [ -f %(installdir)s/lib64/libsuperlu.a ]; then rm %(installdir)s/lib64/libsuperlu.a; fi",
+    # This second one can be removed when https://github.com/easybuilders/easybuild-framework/pull/4435 is merged
+    # (i.e. in EasyBuild 5.0)
+    "if [ -f %(installdir)s/lib/libsuperlu.a ]; then rm %(installdir)s/lib/libsuperlu.a; fi"
+]
+
+sanity_check_paths = {
+    'files': ['lib64/libsuperlu_dist.a'],
+    'dirs': ['include']
+}
+
+moduleclass = 'numlib'


### PR DESCRIPTION
- Add new version for openCARP (17.0), using foss-2024a
- Update dependencies not available with foss-2024a yet: gengetopt-2.23, PETSc-3.22.3, ParMETIS-4.0.3, pkg-config-0.29.2, SuperLU_DIST-8.2.1