### PR TITLE
adding Basix and few dependencies for 2024a

### DIFF
--- a/easybuild/easyconfigs/b/Basix/Basix-0.9.0-gfbf-2024a.eb
+++ b/easybuild/easyconfigs/b/Basix/Basix-0.9.0-gfbf-2024a.eb
@@ -1,0 +1,56 @@
+easyblock = 'EB_Basix'
+
+name = 'Basix'
+version = '0.9.0'
+
+homepage = 'https://github.com/FEniCS/basix'
+description = """Basix is a finite element definition and tabulation runtime library.
+Basix includes a range of built-in elements, and also allows the user to define their own custom elements.
+Basix is one of the components of FEniCSx, alongside UFL, FFCx, and DOLFINx."""
+
+toolchain = {'name': 'gfbf', 'version': '2024a'}
+
+source_urls = ['https://github.com/FEniCS/basix/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+patches = ['Basix-0.9.0-enable-distribution.patch']
+checksums = [
+    {'v0.9.0.tar.gz': '60e96b2393084729b261cb10370f0e44d12735ab3dbd1f15890dec23b9e85329'},
+    {'Basix-0.9.0-enable-distribution.patch': '902f672000ef1fa844208450568bc34d5c5f40ef3b8ae9ed3781c15579ff8f51'},
+]
+
+builddependencies = [
+    ('CMake', '3.29.3'),
+    ('PDM', '2.18.2'),
+    ('Ninja', '1.12.1'),
+    ('scikit-build-core', '0.11.0'),
+]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('Python-bundle-PyPI', '2024.06'),
+    ('SciPy-bundle', '2024.05'),
+    ('nanobind', '2.6.1'),
+]
+
+parallel = 8
+
+exts_defaultclass = 'PythonPackage'
+exts_list = [('fenics-basix', version, {
+    'modulename': 'basix',
+    'nosource': True,
+    'download_dep_fail': True,
+    'use_pip': True,
+    'sanity_pip_check': True,
+    'start_dir': 'python'
+})]
+
+sanity_check_paths = {
+    'files': [
+             'lib64/libbasix.so',
+             'lib64/cmake/basix/BasixConfig.cmake'
+             ],
+    'dirs': ['include', 'include/basix', 
+             'lib/python%(pyshortver)s/site-packages/basix',
+]}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/n/nanobind/nanobind-2.6.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/n/nanobind/nanobind-2.6.1-GCCcore-13.3.0.eb
@@ -1,0 +1,33 @@
+easyblock = 'PythonPackage'
+
+name = 'nanobind'
+version = '2.6.1'
+
+homepage = 'https://github.com/wjakob/nanobind'
+description = """nanobind is a small binding library for C++11 / C++17 / C++20 that heavily
+builds on capabilities introduced in recent versions of C++."""
+
+source_urls = ['https://github.com/wjakob/nanobind/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['519c6dd56581ad6db9aab814105c2666a0491096487cb384dd20216f80d1a291']
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+builddependencies = [
+    ('CMake', '3.29.3'),
+    ('scikit-build-core', '0.11.0'),
+]
+
+dependencies = [
+    ('binutils', '2.42'),
+    ('robin-map', '1.4.0'),
+    ('Python', '3.12.3'),
+]
+
+prebuildopts = preinstallopts = "CMAKE_ARGS='-DNB_USE_SUBMODULE_DEPS=OFF'"
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/r/robin-map/robin-map-1.4.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/r/robin-map/robin-map-1.4.0-GCCcore-13.3.0.eb
@@ -1,0 +1,24 @@
+easyblock = 'CMakeMake'
+
+name = 'robin-map'
+version = '1.4.0'
+
+homepage = 'https://github.com/Tessil/robin-map'
+description = """robin-map is a C++ implementation of a fast and memory efficient hash table.
+It is based on Robin Hood hashing with backward shift deletion."""
+
+source_urls = ['https://github.com/Tessil/robin-map/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['7930dbf9634acfc02686d87f615c0f4f33135948130b8922331c16d90a03250c']
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+dependencies = [('CMake', '3.29.3')]
+builddependencies = [('binutils', '2.42')]
+
+sanity_check_paths = {
+    'files': ['include/tsl/robin_map.h'],
+    'dirs': ['share/cmake'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/s/scikit-build-core/scikit-build-core-0.11.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/s/scikit-build-core/scikit-build-core-0.11.0-GCCcore-13.3.0.eb
@@ -1,0 +1,37 @@
+easyblock = 'PythonBundle'
+
+name = 'scikit-build-core'
+version = '0.11.0'
+
+homepage = 'https://scikit-build.readthedocs.io/en/latest/'
+description = """Scikit-build-core is a complete ground-up rewrite of scikit-build on top of
+modern packaging APIs. It provides a bridge between CMake and the Python build
+system, allowing you to make Python modules with CMake."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('hatchling', '1.24.2'),
+]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('Python-bundle-PyPI', '2024.06'),
+    ('CMake', '3.29.3'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('pyproject-metadata', '0.9.1', {
+        'sources': ['pyproject_metadata-%(version)s.tar.gz'],
+        'checksums': ['b8b2253dd1b7062b78cf949a115f02ba7fa4114aabe63fa10528e9e1a954a816'],
+    }),
+    ('scikit_build_core', version, {
+        'checksums': ['423d8b0885bf1942816c851f8ec7c1efc0a7ecad4f38ff43d5ba869a894b107b'],
+    }),
+]
+
+moduleclass = 'lib'


### PR DESCRIPTION
This PR adds `Basix` which is one of the dependencies of `DOLFINx`. This PR depends on the easyblock from [this PR](https://github.com/easybuilders/easybuild-easyblocks/pull/3684).
Furthermore, these new easyconfigs are either created or a newer version is proposed:
- `scikit-build-core/0.11.0-GCCcore-13.3.0`
- `robin-map/1.4.0-GCCcore-13.3.0`
- `nanobind/2.6.1-GCCcore-13.3.0`

I also have to admit that this PR is inspired by PR #22422.