### PR TITLE
Adding DOLFINx for 2024a

### DIFF
--- a/easybuild/easyconfigs/d/DOLFINx/DOLFINx-0.9.0.post1-foss-2024a.eb
+++ b/easybuild/easyconfigs/d/DOLFINx/DOLFINx-0.9.0.post1-foss-2024a.eb
@@ -1,0 +1,65 @@
+easyblock = 'CMakePythonPackage'
+
+name = 'DOLFINx'
+version = '0.9.0.post1'
+
+homepage = 'https://github.com/FEniCS/dolfinx'
+description = """DOLFINx is the computational environment of [FEniCSx](https://fenicsproject.org/),
+and implements the FEniCS Problem Solving Environment in C++ and Python. DOLFINx is a new version of
+DOLFIN and is actively developed. Documentation can be viewed at https://docs.fenicsproject.org."""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+source_urls = ['https://github.com/FEniCS/dolfinx/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['2bba19954eeb8a048493327037723b9bad9d945f74b71b1c5680faf47c6dbab5']
+
+builddependencies = [
+    ('pkgconf', '2.2.0'),
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+    ('scikit-build-core', '0.11.0'),
+]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('spdlog', '1.12.0'),
+    ('pugixml', '1.15'),
+    ('Boost', '1.85.0'),
+    ('PETSc', '3.22.4'),
+    ('SLEPc', '3.22.2'),
+    ('ParMETIS', '4.0.3'),
+    ('HDF5', '1.14.5'),
+    ('SCOTCH', '7.0.6'),
+    ('KaHIP', '3.18'),
+    ('Basix', '0.9.0'),
+    ('FFCx', '0.9.0')
+]
+
+start_dir = 'cpp'
+parallel = 8
+
+preconfigopts = 'Basix_DIR=$EBROOTBASIX/lib/python3.12/site-packages/basix/lib/cmake/basix'
+
+sanity_check_paths = {
+    'files': ['include/dolfinx.h', 'lib64/dolfinx/dolfinx.conf', 'lib64/libdolfinx.so'],
+    'dirs': ['include/dolfinx', 'lib/cmake/dolfinx']
+}
+
+exts_defaultclass = 'PythonPackage'
+exts_list = [('fenics-dolfinx', version, {
+    'modulename': 'dolfinx',
+    'nosource': True,
+    'download_dep_fail': True,
+    'use_pip': True,
+    'sanity_pip_check': True,
+    'preinstallopts': 'DOLFINX_DIR=%(installdir)s',
+    'start_dir': '../python',
+})]
+
+modextrapaths = {
+    'DOLFINX_DIR': '.',
+    'CMAKE_PREFIX_PATH': 'lib64/cmake/%(namelower)s',
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/f/FFCx/FFCx-0.9.0-gfbf-2024a.eb
+++ b/easybuild/easyconfigs/f/FFCx/FFCx-0.9.0-gfbf-2024a.eb
@@ -1,0 +1,35 @@
+easyblock = 'PythonPackage'
+
+name = 'FFCx'
+version = '0.9.0'
+
+homepage = 'https://github.com/FEniCS/ffcx'
+
+description = """
+FFCx is a new version of the FEniCS Form Compiler. It is being actively developed and is compatible with DOLFINx.
+"""
+
+toolchain = {'name': 'gfbf', 'version': '2024a'}
+
+source_urls = ['https://github.com/FEniCS/ffcx/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['afa517272a3d2249f513cb711c50b77cf8368dd0b8f5ea4b759142229204a448']
+
+builddependencies = [
+    ('CMake', '3.29.3'),
+    ('scikit-build-core', '0.11.0'),
+]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('SciPy-bundle', '2024.05'),
+    ('pybind11', '2.12.0'),
+    ('Basix', '0.9.0'),
+    ('UFL', '2024.2.0'),
+]
+
+use_pip = True
+sanity_pip_check = True
+download_dep_fail = True
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/k/KaHIP/KaHIP-3.18-gompi-2024a.eb
+++ b/easybuild/easyconfigs/k/KaHIP/KaHIP-3.18-gompi-2024a.eb
@@ -1,0 +1,28 @@
+easyblock = 'CMakeMake'
+
+name = 'KaHIP'
+version = '3.18'
+
+homepage = 'https://kahip.github.io/'
+description = """The graph partitioning framework KaHIP -- Karlsruhe High Quality Partitioning."""
+
+toolchain = {'name': 'gompi', 'version': '2024a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/KaHIP/KaHIP/archive/refs/tags']
+sources = ['v%(version)s.tar.gz']
+checksums = ['e5003fa324362255d837899186cd0c3e42d376664f0d555e7e7a1d51334817c9']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+]
+
+sanity_check_paths = {
+    'files': ["lib/libkahip_static.a", "lib/libkahip.%s" % SHLIB_EXT] +
+             ["lib/libparhip_interface_static.a", "lib/libparhip_interface.%s" % SHLIB_EXT] +
+             ["include/%s" % x for x in ["kaHIP_interface.h", "parhip_interface.h"]],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/ParMETIS/ParMETIS-4.0.3-gompi-2024a.eb
+++ b/easybuild/easyconfigs/p/ParMETIS/ParMETIS-4.0.3-gompi-2024a.eb
@@ -1,0 +1,29 @@
+##
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+##
+name = 'ParMETIS'
+version = '4.0.3'
+
+homepage = 'https://karypis.github.io/glaros/projects/gp.html'
+description = """ParMETIS is an MPI-based parallel library that implements a variety of algorithms for partitioning
+ unstructured graphs, meshes, and for computing fill-reducing orderings of sparse matrices. ParMETIS extends the
+ functionality provided by METIS and includes routines that are especially suited for parallel AMR computations and
+ large scale numerical simulations. The algorithms implemented in ParMETIS are based on the parallel multilevel k-way
+ graph-partitioning, adaptive repartitioning, and parallel multi-constrained partitioning schemes."""
+
+toolchain = {'name': 'gompi', 'version': '2024a'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = [
+    'https://karypis.github.io/glaros/files/sw/parmetis',
+    'https://karypis.github.io/glaros/files/sw/parmetis/OLD',
+]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['f2d9a231b7cf97f1fee6e8c9663113ebf6c240d407d3c118c55b3633d6be6e5f']
+
+builddependencies = [('CMake', '3.29.3')]
+
+# Build static and shared libraries
+configopts = ['', '-DSHARED=1']
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/s/SLEPc/SLEPc-3.22.2-foss-2024a.eb
+++ b/easybuild/easyconfigs/s/SLEPc/SLEPc-3.22.2-foss-2024a.eb
@@ -1,0 +1,21 @@
+name = 'SLEPc'
+version = '3.22.2'
+
+homepage = 'https://slepc.upv.es'
+description = """SLEPc (Scalable Library for Eigenvalue Problem Computations) is a software library for the solution
+ of large scale sparse eigenvalue problems on parallel computers. It is an extension of PETSc and can be used for
+ either standard or generalized eigenproblems, with real or complex arithmetic. It can also be used for computing a
+ partial SVD of a large, sparse, rectangular matrix, and to solve quadratic eigenvalue problems."""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['https://slepc.upv.es/download/distrib']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['b60e58b2fa5eb7db05ce5e3a585811b43b1cc7cf89c32266e37b05f0cefd8899']
+
+dependencies = [('PETSc', '3.22.4')]
+
+petsc_arch = 'installed-arch-linux2-c-opt'
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/SuperLU_DIST/SuperLU_DIST-9.1.0-foss-2024a.eb
+++ b/easybuild/easyconfigs/s/SuperLU_DIST/SuperLU_DIST-9.1.0-foss-2024a.eb
@@ -1,0 +1,44 @@
+easyblock = "EB_SuperLU"
+
+name = 'SuperLU_DIST'
+version = '9.1.0'
+
+homepage = 'https://crd-legacy.lbl.gov/~xiaoye/SuperLU/'
+description = """SuperLU is a general purpose library for the direct solution of large, sparse, nonsymmetric systems
+ of linear equations on high performance machines."""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+toolchainopts = {'pic': True, 'openmp': True}
+
+github_account = 'xiaoyeli'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ["v%(version)s.tar.gz"]
+checksums = ['1cb2c6dc7e8231b2ec30c1266e55e440ffca9f55527771d8df28f900dd179f9d']
+
+builddependencies = [('CMake', '3.29.3')]
+
+dependencies = [
+    ('ParMETIS', '4.0.3'),
+]
+
+configopts = '-DTPL_PARMETIS_INCLUDE_DIRS="${EBROOTPARMETIS}/include" '
+configopts += '-DTPL_PARMETIS_LIBRARIES="${EBROOTPARMETIS}/lib/libparmetis.a;${EBROOTPARMETIS}/lib/libmetis.a" '
+
+# Some tests run longer than default 1500s timeout on fairly big machine (36 cores).
+# Include only first four tests, which should be fairly small to run
+pretestopts = 'export ARGS="$ARGS --tests-regex pdtest_[21]x1_[13]_2_8_20_SP" && '
+
+# remove broken symlink to libsuperlu.a
+postinstallcmds = [
+    "if [ -f %(installdir)s/lib64/libsuperlu.a ]; then rm %(installdir)s/lib64/libsuperlu.a; fi",
+    # This second one can be removed when https://github.com/easybuilders/easybuild-framework/pull/4435 is merged
+    # (i.e. in EasyBuild 5.0)
+    "if [ -f %(installdir)s/lib/libsuperlu.a ]; then rm %(installdir)s/lib/libsuperlu.a; fi"
+]
+
+sanity_check_paths = {
+    'files': ['lib64/libsuperlu_dist.a'],
+    'dirs': ['include']
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/spdlog/spdlog-1.12.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/s/spdlog/spdlog-1.12.0-GCCcore-13.3.0.eb
@@ -12,6 +12,8 @@ source_urls = ['https://github.com/gabime/%(name)s/archive/refs/tags/']
 sources = ['v%(version)s.tar.gz']
 checksums = ['4dccf2d10f410c1e2feaff89966bfc49a1abb29ef6f08246335b110e001e09a9']
 
+configopts = '-DCMAKE_POSITION_INDEPENDENT_CODE=ON'
+
 builddependencies = [
     ('binutils', '2.42'),
     ('CMake', '3.29.3'),

--- a/easybuild/easyconfigs/u/UFL/UFL-2024.2.0-gfbf-2024a.eb
+++ b/easybuild/easyconfigs/u/UFL/UFL-2024.2.0-gfbf-2024a.eb
@@ -1,0 +1,34 @@
+easyblock = 'PythonPackage'
+
+name = 'UFL'
+version = '2024.2.0'
+
+homepage = 'https://fenics.readthedocs.io/projects/ufl'
+
+description = """
+The Unified Form Language (UFL) is a domain specific language for
+declaration of finite element discretizations of variational forms.
+"""
+
+toolchain = {'name': 'gfbf', 'version': '2024a'}
+
+source_urls = ['https://github.com/FEniCS/ufl/archive/refs/tags/']
+sources = ['%(version)s.tar.gz']
+checksums = ['d9353d23ccbdd9887f8d6edab74c04fe06d818da972072081dbf0c25bc86f5a7']
+
+builddependencies = [
+    ('CMake', '3.29.3'),
+    ('scikit-build-core', '0.11.0'),
+]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('SciPy-bundle', '2024.05'),
+    ('pybind11', '2.12.0'),
+]
+
+use_pip = True
+sanity_pip_check = True
+download_dep_fail = True
+
+moduleclass = 'numlib'


### PR DESCRIPTION
This PR adds new or updated easyconfigs for building `DOLFINx` with `foss/2024a`. Here are the list of included dependencies:
- `Basix/0.9.0-gfbf-2024a` (from PR #22697)
- `DOLFINx-0.9.0.post1-foss-2024a.eb`
- `FFCx-0.9.0-gfbf-2024a.eb`
- `KaHIP-3.18-gompi-2024a.eb
- `ParMETIS-4.0.3-gompi-2024a.eb`
- `SLEPc-3.22.2-foss-2024a.eb`
- `SuperLU_DIST-9.1.0-foss-2024a.eb`
- `UFL-2024.2.0-gfbf-2024a.eb`

I also have to mention that this PR is inspired by PR #22422.