### PR TITLE
add patch to fix dependency check in OPERA-MS

### DIFF
--- a/easybuild/easyconfigs/o/OPERA-MS/OPERA-MS-0.9.0-20240703-foss-2023a.eb
+++ b/easybuild/easyconfigs/o/OPERA-MS/OPERA-MS-0.9.0-20240703-foss-2023a.eb
@@ -12,9 +12,16 @@ description = """OPERA-MS is a hybrid metagenomic assembler which combines the
 
 toolchain = {'name': 'foss', 'version': '2023a'}
 
+buildininstalldir = True
+
 source_urls = ['https://github.com/CSB5/OPERA-MS/archive/']
 sources = [{'download_filename': '%s.tar.gz' % local_commit, 'filename': SOURCE_TAR_GZ}]
-checksums = ['72a3e16287dd1f2098adac41930d6a54779a033f5bf78c2659580afae5a7280c']
+patches = ['OPERA-MS-0.9.0-20240703_fix-perl-dependency-check.patch']
+checksums = [
+    {'OPERA-MS-0.9.0-20240703.tar.gz': '72a3e16287dd1f2098adac41930d6a54779a033f5bf78c2659580afae5a7280c'},
+    {'OPERA-MS-0.9.0-20240703_fix-perl-dependency-check.patch':
+     '463ca8ae674b266ce540206363fbc7f92629e860e23d8894fc42704906a9b975'},
+]
 
 dependencies = [
     ('Perl', '5.36.1'),

--- a/easybuild/easyconfigs/o/OPERA-MS/OPERA-MS-0.9.0-20240703_fix-perl-dependency-check.patch
+++ b/easybuild/easyconfigs/o/OPERA-MS/OPERA-MS-0.9.0-20240703_fix-perl-dependency-check.patch
@@ -1,0 +1,24 @@
+The command OPERA-MS check_dependency is executed as a sanity check. It will
+however revert an earlier created symlink to the correct perl interpreter.
+This patch makes sure the existing correct symlink is not removed.
+
+steven.vandenbrande@kuleuven.be
+--- OPERA-MS.pl.orig	2025-04-07 14:03:09.361405000 +0200
++++ OPERA-MS.pl	2025-04-07 14:03:56.109454000 +0200
+@@ -278,11 +278,11 @@
+     #check_software("$opera_ms_dir/bin", "bundler", $sofware_name, $test_command, $opera_ms_dependency) = @_;
+     
+     #For the perl verion
+-    if($stage eq "CHECK_DEPENDENCY"){
+-	my $perl_path = "$utils_dir/perl";
+-	`rm $perl_path` if(-e "$perl_path");
+-	`ln -s $^X $perl_path`;
+-    }
++    #if($stage eq "CHECK_DEPENDENCY"){
++    #	my $perl_path = "$utils_dir/perl";
++    #	`rm $perl_path` if(-e "$perl_path");
++    #	`ln -s $^X $perl_path`;
++    #}
+     $opera_ms_dependency->{"perl"} = $utils_dir;
+     
+     #OPERA-LG


### PR DESCRIPTION
- The command `OPERA-MS check_dependency` is executed as a sanity check. It will however revert an earlier created symlink to the correct perl interpreter. A patch is added to make sure the existing correct symlink is not removed.
- Some paths are hardcoded in scripts such as `tools_opera_ms/MUMmer3.23/exact-tandems` during compilation. This is why the build is now done in the installation directory (`buildininstalldir = True`)

(created using `eb --new-pr`)
