### PR TITLE
Adding fMRIPrep/25.0.0, Nilearn/0.10.4, Nibabel/5.2.1 and Nipype/1.9.2 for 2024a

### DIFF
--- a/easybuild/easyconfigs/f/fMRIPrep/fMRIPrep-25.0.0-gfbf-2024a.eb
+++ b/easybuild/easyconfigs/f/fMRIPrep/fMRIPrep-25.0.0-gfbf-2024a.eb
@@ -1,0 +1,222 @@
+# Author: Ehsan Moravveji (VSC, KU Leuven)
+
+easyblock = 'PythonBundle'
+
+name = 'fMRIPrep'
+version = '25.0.0'
+
+homepage = 'https://pypi.org/project/fmriprep/'
+description = """fMRIPrep is an analysis-agnostic tool that addresses the challenge of robust and
+reproducible preprocessing for task-based and resting fMRI data. fMRIPrep automatically adapts a
+best-in-breed workflow to the idiosyncrasies of virtually any dataset, ensuring high-quality
+preprocessing without manual intervention. fMRIPrep robustly produces high-quality results on diverse
+fMRI data. Additionally, fMRIPrep introduces less uncontrolled spatial smoothness than observed with
+commonly used preprocessing tools. fMRIPrep equips neuroscientists with an easy-to-use and transparent
+preprocessing workflow, which can help ensure the validity of inference and the interpretability of results."""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+builddependencies = [
+    ('hatchling', '1.24.2'),
+    ('PDM', '2.18.2'),
+]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('SciPy-bundle', '2024.05'),
+    ('matplotlib', '3.9.2'),
+    ('Seaborn', '0.13.2'),
+    ('scikit-learn', '1.5.2'),
+    ('scikit-image', '0.25.0'),
+    ('h5py', '3.12.1'),
+    ('PyYAML', '6.0.2'),
+    ('tqdm', '4.66.5'),
+    ('SQLAlchemy', '2.0.36'),
+    ('zlib', '1.3.1'),
+    ('NiBabel', '5.2.1'),  # latest version compatible with tedana
+    ('Nipype', '1.9.2'),   # also includes 'acres'
+    ('Nilearn', '0.10.4'), # latest version compatible with tedana
+]
+
+# Keep the package order!
+# tedana is compatible with Nilearn/0.10.4 and bokeh/3.5.2
+exts_list = [
+    ('tzlocal', '5.3.1', {
+        'checksums': ['cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd'],
+    }),
+    ('APScheduler', '3.11.0', {
+        'modulename': 'apscheduler',
+        'sources': ['%(namelower)s-%(version)s.tar.gz'],
+        'checksums': ['4c622d250b0955a65d5d0eb91c33e6d43fd879834bf541e0a18661ae60460133'],
+    }),
+    ('types-python-dateutil', '2.9.0.20240316', {
+        'modulename': False,
+        'checksums': ['5d2f2e240b86905e40944dd787db6da9263f0deabef1076ddaed797351ec0202'],
+    }),
+    ('arrow', '1.3.0', {
+        'checksums': ['d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85'],
+    }),
+    ('sniffio', '1.3.1', {
+        'checksums': ['f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc'],
+    }),
+    ('anyio', '4.9.0', {
+        'checksums': ['673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028'],
+    }),
+    ('h11', '0.14.0', {
+        'checksums': ['8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d'],
+    }),
+    ('httpcore', '1.0.7', {
+        'checksums': ['8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c'],
+    }),
+    ('httpx', '0.27.2', {
+        'checksums': ['f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2'],
+    }),
+    ('jwcrypto', '1.5.6', {
+        'checksums': ['771a87762a0c081ae6166958a954f80848820b2ab066937dc8b8379d65b1b039'],
+    }),
+    ('fief-client', '0.20.0', {
+        'modulename': 'fief_client',
+        'sources': ['fief_client-%(version)s.tar.gz'],
+        'checksums': ['dbfb906d03c4a5402ceac5c843aa4708535fb6f5d5c1c4e263ec06fbbbc434d7'],
+    }),
+    ('prometheus-client', '0.21.1', {
+        'modulename': 'prometheus_client',
+        'sources': 'prometheus_client-%(version)s.tar.gz',
+        'checksums': ['252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb'],
+    }),
+    ('py-cpuinfo', '9.0.0', {
+        'modulename': 'cpuinfo',
+        'checksums': ['3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690'],
+    }),
+    ('nvidia-ml-py', '12.570.86', {
+        'modulename': 'pynvml',
+        'sources': 'nvidia_ml_py-%(version)s.tar.gz',
+        'checksums': ['0508d4a0c7b6d015cf574530b95a62ed4fc89da3b8b47e1aefe6777db170ec8b'],
+    }),
+    ('pynvml', '12.0.0', {
+        'modulename': 'pynvml_utils',
+        'checksums': ['299ce2451a6a17e6822d6faee750103e25b415f06f59abb8db65d30f794166f5'],
+    }),
+    ('prompt-toolkit', '3.0.50', {
+        'modulename': 'prompt_toolkit',
+        'source_tmpl': 'prompt_toolkit-%(version)s-py3-none-any.whl',
+        'checksums': ['9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198'],
+    }),
+    ('questionary', '2.1.0', {
+        'checksums': ['6302cdd645b19667d8f6e6634774e9538bfcd1aad9be287e743d96cacaf95587'],
+    }),
+    ('typer', '0.15.2', {
+        'checksums': ['ab2fab47533a813c49fe1f16b1a370fd5819099c00b119e0633df65f22144ba5'],
+    }),
+    ('codecarbon', '2.8.3', {
+        'checksums': ['037dd5afa1c5f60154f893ecd1631e0c849786edcfc9ff34a7ef467707891269'],
+    }),
+    ('looseversion', '1.3.0', {
+        'checksums': ['ebde65f3f6bb9531a81016c6fef3eb95a61181adc47b7f949e9c0ea47911669e'],
+    }),
+    ('nireports', '25.0.1', {
+        'checksums': ['4fa885e9b552be0e2fbbad18d38fb28ddce396dc570491b758855d2223364707'],
+    }),
+    ('nitime', '0.11', {
+        'checksums': ['e087bc7ee93d08a767ffae13b027cdd8da36754d7a202a4145661eaeaa85d3fd'],
+    }),
+    ('nitransforms', '24.1.1', {
+        'checksums': ['536956c580ee03e3e93043208da9eafc920b5934c7e7e0c4c7d759fca0963633'],
+    }),
+    ('svgutils', '0.3.4', {
+        'checksums': ['9ef48f44cb1d460a7747dd02694200fda25eb9faf6dea392118def2695e0e053'],
+    }),
+    ('niworkflows', '1.13.0', {
+        'checksums': ['b31c3d6fead012e142bf5eaeb9ca8fc0a1b57d38e48ebd93218a276fe19c2c87'],
+    }),
+    ('bidsschematools', '1.0.4', {
+        'checksums': ['7443c98ab732ed10d16b543b96052181f8f67b0568d6bb14bb50359a74a2eafc'],
+    }),
+    ('bids-validator', '1.14.7.post0', {
+        'modulename': 'bids_validator',
+        'sources': 'bids_validator-%(version)s.tar.gz',
+        'checksums': ['e6005a500b75f8a961593fb67d46085107dadb116f59a5c3b524aa0697945b66'],
+    }),
+    ('interface-meta', '1.3.0', {
+        'modulename': 'interface_meta',
+        'sources': 'interface_meta-%(version)s.tar.gz',
+        'checksums': ['8a4493f8bdb73fb9655dcd5115bc897e207319e36c8835f39c516a2d7e9d79a1'],
+    }),
+    ('wrapt', '1.17.2', {
+        'checksums': ['41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3'],
+    }),
+    ('latexcodec', '3.0.0', {
+        'checksums': ['917dc5fe242762cc19d963e6548b42d63a118028cdd3361d62397e3b638b6bc5'],
+    }),
+    ('pybtex', '0.24.0', {
+        'checksums': ['818eae35b61733e5c007c3fcd2cfb75ed1bc8b4173c1f70b56cc4c0802d34755'],
+    }),
+    ('pybtex-docutils', '1.0.3', {
+        'checksums': ['3a7ebdf92b593e00e8c1c538aa9a20bca5d92d84231124715acc964d51d93c6b'],
+    }),
+    ('formulaic', '1.1.1', {
+        'checksums': ['ddf80e4bef976dd99698aa27512015276c7b86c314b601ae6fd360c7741b7231'],
+    }),
+    ('frozendict', '2.4.6', {
+        'checksums': ['df7cd16470fbd26fc4969a208efadc46319334eb97def1ddf48919b351192b8e'],
+    }),
+    ('num2words', '0.5.14', {
+        'checksums': ['b066ec18e56b6616a3b38086b5747daafbaa8868b226a36127e0451c0cf379c6'],
+    }),
+    ('universal-pathlib', '0.2.6', {
+        'modulename': 'upath',
+        'sources': 'universal_pathlib-%(version)s.tar.gz',
+        'checksums': ['50817aaeaa9f4163cb1e76f5bdf84207fa05ce728b23fd779479b3462e5430ac'],
+    }),
+    ('pybids', '0.19.0', {
+        'modulename': 'bids',
+        'checksums': ['5b6315e137af5883f17031e76745930c0a3d256edd413ab2efc49c8842100333'],
+    }),
+    ('migas', '0.4.0', {
+        'checksums': ['069481021e86fb9a84b9977f2f5adb9c77c5220787065859b9510cf80e7095f5'],
+    }),
+    ('sdcflows', '2.12.0', {
+        'checksums': ['14c19618516b06a041f06f03f1d3184bc28a02a5023cddea7f6fb1fe278ba47f'],
+    }),
+    ('indexed-gzip', '1.9.4', {
+        'modulename': 'indexed_gzip',
+        'source_tmpl': 'indexed_gzip-1.9.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl',
+        'checksums': ['8fe763dd78676d78fef2f14b93e7ed9411b67ba195a887235239a52a4053e564'],
+    }),
+    ('smriprep', '0.17.0', {
+        'checksums': ['0fff231d10fb46f84d73b9a53f16f7a38fbbb0408975379b7b8e2db4247d11b8'],
+    }),
+    ('mapca', '0.0.5', {
+        'checksums': ['948fd1f7a8ab2a41e4fe67694a36a626b7fc23f549bc0dcc0129bdc4535d2c8e'],
+    }),
+    ('pybtex', '0.24.0', {
+        'checksums': ['818eae35b61733e5c007c3fcd2cfb75ed1bc8b4173c1f70b56cc4c0802d34755'],
+    }),
+    ('pybtex-apa-style', '1.3', {
+        'modulename': 'formatting',
+        'checksums': ['38a6d11e8f40f259b1d0a6974b6dbae93edbe009c247d83de14c26bdd965afb2'],
+    }),
+    ('robustica', '0.1.4', {
+        'checksums': ['2ec0a10d8815a016c8319ffe4b460914044efd47cf4186e4ded2d3b96ca91aa9'],
+    }),
+    ('bokeh', '3.5.2', {
+        'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
+        'checksums': ['2be7bc1484a961c496294c8725c47f21129191cb6b3fa45f953cc97ae075bc4b'],
+    }),
+    ('tedana', '24.0.2', {
+        'checksums': ['e4d50bf62982f967201bc1ae6a60acf60a7a0df0021124f690e41857abfaf246'],
+    }),
+    ('templateflow', '24.2.2', {
+        'checksums': ['6b5ec6a566b4e21d0db8588fef1aa8c491c542e05d9433054100445a4c2c9cd0'],
+    }),
+    ('transforms3d', '0.4.2', {
+        'checksums': ['e8b5df30eaedbee556e81c6938e55aab5365894e47d0a17615d7db7fd2393680'],
+    }),
+    ('fmriprep', version, {
+        'modulename': '%(namelower)s',
+        'source_urls': ['https://pypi.python.org/packages/source/%(nameletterlower)s/%(namelower)s'],
+        'checksums': ['33cc87b3cc2cc658ac78cbce28148583ae4ee7d9fe04a81dcf6eff671ab58e18'],
+    }),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/n/NiBabel/NiBabel-5.2.1-gfbf-2024a.eb
+++ b/easybuild/easyconfigs/n/NiBabel/NiBabel-5.2.1-gfbf-2024a.eb
@@ -1,0 +1,48 @@
+easyblock = 'PythonBundle'
+
+name = 'NiBabel'
+version = '5.2.1'
+
+homepage = 'https://nipy.github.io/nibabel'
+description = """NiBabel provides read/write access to some common medical and neuroimaging file formats,
+ including: ANALYZE (plain, SPM99, SPM2 and later), GIFTI, NIfTI1, NIfTI2, MINC1, MINC2, MGH and ECAT
+ as well as Philips PAR/REC. We can read and write Freesurfer geometry, and read Freesurfer morphometry and
+ annotation files. There is some very limited support for DICOM. NiBabel is the successor of PyNIfTI."""
+
+toolchain = {'name': 'gfbf', 'version': '2024a'}
+
+builddependencies = [
+    ('hatchling', '1.24.2'),
+]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('SciPy-bundle', '2024.05'),
+    ('Pillow', '10.4.0'),
+    ('pydicom', '3.0.1'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('bz2file', '0.98', {
+        'checksums': ['64c1f811e31556ba9931953c8ec7b397488726c63e09a4c67004f43bdd28da88'],
+    }),
+    ('nibabel', version, {
+        'checksums': ['b6c80b2e728e4bc2b65f1142d9b8d2287a9102a8bf8477e115ef0d8334559975'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/nib-dicomfs', 'bin/nib-diff', 'bin/nib-ls', 'bin/nib-nifti-dx', 'bin/parrec2nii'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [
+    "nib-diff --help",
+    "parrec2nii --help",
+]
+
+sanity_pip_check = True
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/n/Nilearn/Nilearn-0.10.4-gfbf-2024a.eb
+++ b/easybuild/easyconfigs/n/Nilearn/Nilearn-0.10.4-gfbf-2024a.eb
@@ -1,0 +1,29 @@
+easyblock = 'PythonBundle'
+
+name = 'Nilearn'
+version = '0.10.4'
+
+homepage = 'https://nilearn.github.io/'
+description = """Nilearn is a Python module for fast and easy statistical learning on NeuroImaging data."""
+
+toolchain = {'name': 'gfbf', 'version': '2024a'}
+
+builddependencies = [
+    ('hatchling', '1.24.2'),
+]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('SciPy-bundle', '2024.05'),
+    ('lxml', '5.3.0'),
+    ('NiBabel', '5.2.1'),
+    ('scikit-learn', '1.5.2'),
+]
+
+exts_list = [
+    ('nilearn', version, {
+        'checksums': ['9450bd56a776d997b324f45dd18bf96e89bd8d80160974fcc759333fbaea35c2'],
+    }),
+]
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/n/Nipype/Nipype-1.9.2-gfbf-2024a.eb
+++ b/easybuild/easyconfigs/n/Nipype/Nipype-1.9.2-gfbf-2024a.eb
@@ -1,0 +1,89 @@
+easyblock = 'PythonBundle'
+
+name = 'Nipype'
+version = '1.9.2'
+
+homepage = 'https://nipype.readthedocs.io'
+description = """Nipype is a Python project that provides a uniform interface to existing neuroimaging software and
+ facilitates interaction between these packages within a single workflow."""
+
+toolchain = {'name': 'gfbf', 'version': '2024a'}
+
+builddependencies = [
+    ('hatchling', '1.24.2'),
+    ('PDM', '2.18.2'),
+]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('lxml', '5.3.0'),
+    ('networkx', '3.4.2'),
+    ('pydot', '3.0.3'),
+    ('NiBabel', '5.2.1'),
+    ('pytest-xdist', '3.6.1'),
+    ('poetry', '1.8.3'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('traits', '6.3.2', {
+        'checksums': ['4520ef4a675181f38be4a5bab1b1d5472691597fe2cfe4faf91023e89407e2c6'],
+    }),
+    ('pydotplus', '2.0.2', {
+        'checksums': ['91e85e9ee9b85d2391ead7d635e3d9c7f5f44fd60a60e59b13e2403fa66505c4'],
+    }),
+    ('funcsigs', '1.0.2', {
+        'checksums': ['a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50'],
+    }),
+    ('isodate', '0.6.1', {
+        'checksums': ['48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9'],
+    }),
+    ('rdflib', '6.3.2', {
+        'source_urls': ['https://github.com/RDFLib/rdflib/releases/download/%(version)s/'],
+        'checksums': ['72af591ff704f4caacea7ecc0c5a9056b8553e0489dd4f35a9bc52dbd41522e0'],
+    }),
+    ('prov', '2.0.1', {
+        'checksums': ['0e238c1405d1a55c72bd39b3b6d73d6f7abfd9d0a7fab2ec0693a19a29a5617f'],
+    }),
+    ('ci-info', '0.3.0', {
+        'checksums': ['1fd50cbd401f29adffeeb18b0489e232d16ac1a7458ac6bc316deab6ae535fb0'],
+    }),
+    ('etelemetry', '0.3.1', {
+        'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
+        'checksums': ['a64f09bcd55cbfa5684e4d9fb6d1d6a018ab99d2ea28e638435c4c26e6814a6b'],
+    }),
+    ('looseversion', '1.3.0', {
+        'checksums': ['ebde65f3f6bb9531a81016c6fef3eb95a61181adc47b7f949e9c0ea47911669e'],
+    }),
+    ('acres', '0.3.0', {
+        'patches': ['acres-0.3.0-fix-pdm-version.patch'],
+        'source_urls': ['https://github.com/nipreps/acres/archive/refs/tags/'],
+        'sources': ['%(version)s.tar.gz'],
+        'checksums': [
+            {'0.3.0.tar.gz': 'd6b6854aa4d31e80025d67e9ee5de18b86214960a65ca96c64b9d1ffee67cd54'},
+            {'acres-0.3.0-fix-pdm-version.patch': 'b26a3ca6d51027b15be18a451a0be5da06f0187cb269050fc38767d19c767f5b'},
+        ],
+    }),
+    ('puremagic', '1.28', {
+        'checksums': ['195893fc129657f611b86b959aab337207d6df7f25372209269ed9e303c1a8c0'],
+    }),
+    ('nipype', version, {
+        'patches': ['Nipype-1.9.2-scm-version-info.patch'],
+        'checksums': [
+            {'nipype-1.9.2.tar.gz': 'a503bd41b658f084d104252fd728ef75f1a1998026feab98b1639989654e0343'},
+            {'Nipype-1.9.2-scm-version-info.patch': '6399bcc8fdbfd103e388a6387017b1e1ec3e72a55c1598531473cba09b1e0311'},
+        ],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/nipypecli'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["python -c 'import nipype.interfaces'"]
+
+sanity_pip_check = True
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/n/Nipype/Nipype-1.9.2-scm-version-info.patch
+++ b/easybuild/easyconfigs/n/Nipype/Nipype-1.9.2-scm-version-info.patch
@@ -1,0 +1,15 @@
+# Author: Ehsan Moravveji (VSC, KU Leuven)
+# Purpose: to prevent the following error message:
+#          "pdm.backend.exceptions.ConfigError: 
+#           Cannot find the version from SCM or SCM isn't detected."
+
+diff -ruN nipype-1.9.2-orig/pyproject.toml nipype-1.9.2/pyproject.toml
+--- nipype-1.9.2-orig/pyproject.toml	2025-03-07 13:15:12.132810000 +0100
++++ nipype-1.9.2/pyproject.toml	2025-03-07 13:17:04.736965000 +0100
+@@ -25,3 +25,6 @@
+ env = "PYTHONHASHSEED=0"
+ filterwarnings = ["ignore::DeprecationWarning"]
+ junit_family = "xunit2"
++
++[tool.setuptools_scm]
++write_to = 'nipype/_version.py'

--- a/easybuild/easyconfigs/n/Nipype/acres-0.3.0-fix-pdm-version.patch
+++ b/easybuild/easyconfigs/n/Nipype/acres-0.3.0-fix-pdm-version.patch
@@ -1,0 +1,30 @@
+# Author: Ehsan Moravveji (VSC, KU Leuven)
+# Purpose: The PDM-compatible version information was missing
+
+diff -ruN acres-0.3.0-orig/pyproject.toml acres-0.3.0/pyproject.toml
+--- acres-0.3.0-orig/pyproject.toml	2025-03-07 15:25:17.725252000 +0100
++++ acres-0.3.0/pyproject.toml	2025-03-12 14:32:25.292661000 +0100
+@@ -1,5 +1,6 @@
+ [project]
+ name = "acres"
++version = "0.3.0"
+ description = "Access resources on your terms"
+ authors = [
+   {name = "The NiPreps Developers", email = "nipreps@gmail.com"}
+@@ -20,7 +21,6 @@
+   "Programming Language :: Python :: 3.12",
+   "Programming Language :: Python :: 3.13",
+ ]
+-dynamic = ["version"]
+ 
+ [build-system]
+ requires = ["pdm-backend"]
+@@ -28,6 +28,8 @@
+ 
+ [tool.pdm]
+ distribution = true
++backend = 'pdm.backend'
++fallback_version = '0.3.0'
+ 
+ [tool.pdm.build]
+ source-includes = [


### PR DESCRIPTION
Remarks:
- to resolve the versions of dependencies of `fMRIPrep`, some of dependencies had to be built with slightly older versions that the latest ones