### PR TITLE
ensure `Infernal` is built with MPI support, and drop toolchain to gompi

### DIFF
--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2020b.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2020b.eb
@@ -20,7 +20,7 @@ homepage = 'http://eddylab.org/infernal/'
 description = """Infernal ("INFERence of RNA ALignment") is for searching DNA sequence databases
  for RNA structure and sequence similarities."""
 
-toolchain = {'name': 'foss', 'version': '2020b'}
+toolchain = {'name': 'gompi', 'version': '2020b'}
 toolchainopts = {'pic': True}
 
 source_urls = ['http://eddylab.org/%(namelower)s']

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2020b.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2020b.eb
@@ -20,12 +20,15 @@ homepage = 'http://eddylab.org/infernal/'
 description = """Infernal ("INFERence of RNA ALignment") is for searching DNA sequence databases
  for RNA structure and sequence similarities."""
 
-toolchain = {'name': 'foss', 'version': '2021b'}
+toolchain = {'name': 'foss', 'version': '2020b'}
 toolchainopts = {'pic': True}
 
 source_urls = ['http://eddylab.org/%(namelower)s']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['f9493c7dee9fbf25f6405706818883d24b9f5e455121a0662c96c8f0307f95fc']
+
+# MPI is disabled by default
+configopts = '--enable-mpi'
 
 local_bins = ['align', 'build', 'calibrate', 'convert', 'emit', 'fetch', 'press', 'scan', 'search', 'stat']
 

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2021a.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2021a.eb
@@ -21,7 +21,7 @@ homepage = 'http://eddylab.org/infernal/'
 description = """Infernal ("INFERence of RNA ALignment") is for searching DNA sequence databases
  for RNA structure and sequence similarities."""
 
-toolchain = {'name': 'foss', 'version': '2021a'}
+toolchain = {'name': 'gompi', 'version': '2021a'}
 toolchainopts = {'pic': True}
 
 source_urls = ['http://eddylab.org/%(namelower)s']

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2021a.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2021a.eb
@@ -3,8 +3,9 @@
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>
-# License::   MIT/GPL
+# License::   BSD
 # Updated:: Denis Kristak (INUITS)
+# Updated:: Sebastien Moretti (SIB)
 # $Id$
 #
 # This work implements a part of the HPCBIOS project and is a component of the policy:
@@ -20,12 +21,15 @@ homepage = 'http://eddylab.org/infernal/'
 description = """Infernal ("INFERence of RNA ALignment") is for searching DNA sequence databases
  for RNA structure and sequence similarities."""
 
-toolchain = {'name': 'foss', 'version': '2020b'}
+toolchain = {'name': 'foss', 'version': '2021a'}
 toolchainopts = {'pic': True}
 
 source_urls = ['http://eddylab.org/%(namelower)s']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['f9493c7dee9fbf25f6405706818883d24b9f5e455121a0662c96c8f0307f95fc']
+
+# MPI is disabled by default
+configopts = '--enable-mpi'
 
 local_bins = ['align', 'build', 'calibrate', 'convert', 'emit', 'fetch', 'press', 'scan', 'search', 'stat']
 

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2021b.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2021b.eb
@@ -20,7 +20,7 @@ homepage = 'http://eddylab.org/infernal/'
 description = """Infernal ("INFERence of RNA ALignment") is for searching DNA sequence databases
  for RNA structure and sequence similarities."""
 
-toolchain = {'name': 'foss', 'version': '2021b'}
+toolchain = {'name': 'gompi', 'version': '2021b'}
 toolchainopts = {'pic': True}
 
 source_urls = ['http://eddylab.org/%(namelower)s']

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2021b.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2021b.eb
@@ -20,12 +20,15 @@ homepage = 'http://eddylab.org/infernal/'
 description = """Infernal ("INFERence of RNA ALignment") is for searching DNA sequence databases
  for RNA structure and sequence similarities."""
 
-toolchain = {'name': 'foss', 'version': '2022a'}
+toolchain = {'name': 'foss', 'version': '2021b'}
 toolchainopts = {'pic': True}
 
 source_urls = ['http://eddylab.org/%(namelower)s']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['f9493c7dee9fbf25f6405706818883d24b9f5e455121a0662c96c8f0307f95fc']
+
+# MPI is disabled by default
+configopts = '--enable-mpi'
 
 local_bins = ['align', 'build', 'calibrate', 'convert', 'emit', 'fetch', 'press', 'scan', 'search', 'stat']
 

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2022a.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2022a.eb
@@ -20,7 +20,7 @@ homepage = 'http://eddylab.org/infernal/'
 description = """Infernal ("INFERence of RNA ALignment") is for searching DNA sequence databases
  for RNA structure and sequence similarities."""
 
-toolchain = {'name': 'foss', 'version': '2022a'}
+toolchain = {'name': 'gompi', 'version': '2022a'}
 toolchainopts = {'pic': True}
 
 source_urls = ['http://eddylab.org/%(namelower)s']

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2022a.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2022a.eb
@@ -14,18 +14,21 @@
 easyblock = 'ConfigureMake'
 
 name = 'Infernal'
-version = "1.1.5"
+version = "1.1.4"
 
 homepage = 'http://eddylab.org/infernal/'
 description = """Infernal ("INFERence of RNA ALignment") is for searching DNA sequence databases
  for RNA structure and sequence similarities."""
 
-toolchain = {'name': 'foss', 'version': '2023a'}
+toolchain = {'name': 'foss', 'version': '2022a'}
 toolchainopts = {'pic': True}
 
 source_urls = ['http://eddylab.org/%(namelower)s']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['ad4ddae02f924ca7c85bc8c4a79c9f875af8df96aeb726702fa985cbe752497f']
+checksums = ['f9493c7dee9fbf25f6405706818883d24b9f5e455121a0662c96c8f0307f95fc']
+
+# MPI is disabled by default
+configopts = '--enable-mpi'
 
 local_bins = ['align', 'build', 'calibrate', 'convert', 'emit', 'fetch', 'press', 'scan', 'search', 'stat']
 

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2022b.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2022b.eb
@@ -27,6 +27,9 @@ source_urls = ['http://eddylab.org/%(namelower)s']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['f9493c7dee9fbf25f6405706818883d24b9f5e455121a0662c96c8f0307f95fc']
 
+# MPI is disabled by default
+configopts = '--enable-mpi'
+
 local_bins = ['align', 'build', 'calibrate', 'convert', 'emit', 'fetch', 'press', 'scan', 'search', 'stat']
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2022b.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1.4-gompi-2022b.eb
@@ -20,7 +20,7 @@ homepage = 'http://eddylab.org/infernal/'
 description = """Infernal ("INFERence of RNA ALignment") is for searching DNA sequence databases
  for RNA structure and sequence similarities."""
 
-toolchain = {'name': 'foss', 'version': '2022b'}
+toolchain = {'name': 'gompi', 'version': '2022b'}
 toolchainopts = {'pic': True}
 
 source_urls = ['http://eddylab.org/%(namelower)s']

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1.5-gompi-2023a.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1.5-gompi-2023a.eb
@@ -3,9 +3,8 @@
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>
-# License::   BSD
+# License::   MIT/GPL
 # Updated:: Denis Kristak (INUITS)
-# Updated:: Sebastien Moretti (SIB)
 # $Id$
 #
 # This work implements a part of the HPCBIOS project and is a component of the policy:
@@ -15,18 +14,21 @@
 easyblock = 'ConfigureMake'
 
 name = 'Infernal'
-version = "1.1.4"
+version = "1.1.5"
 
 homepage = 'http://eddylab.org/infernal/'
 description = """Infernal ("INFERence of RNA ALignment") is for searching DNA sequence databases
  for RNA structure and sequence similarities."""
 
-toolchain = {'name': 'foss', 'version': '2021a'}
+toolchain = {'name': 'foss', 'version': '2023a'}
 toolchainopts = {'pic': True}
 
 source_urls = ['http://eddylab.org/%(namelower)s']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['f9493c7dee9fbf25f6405706818883d24b9f5e455121a0662c96c8f0307f95fc']
+checksums = ['ad4ddae02f924ca7c85bc8c4a79c9f875af8df96aeb726702fa985cbe752497f']
+
+# MPI is disabled by default
+configopts = '--enable-mpi'
 
 local_bins = ['align', 'build', 'calibrate', 'convert', 'emit', 'fetch', 'press', 'scan', 'search', 'stat']
 

--- a/easybuild/easyconfigs/i/Infernal/Infernal-1.1.5-gompi-2023a.eb
+++ b/easybuild/easyconfigs/i/Infernal/Infernal-1.1.5-gompi-2023a.eb
@@ -20,7 +20,7 @@ homepage = 'http://eddylab.org/infernal/'
 description = """Infernal ("INFERence of RNA ALignment") is for searching DNA sequence databases
  for RNA structure and sequence similarities."""
 
-toolchain = {'name': 'foss', 'version': '2023a'}
+toolchain = {'name': 'gompi', 'version': '2023a'}
 toolchainopts = {'pic': True}
 
 source_urls = ['http://eddylab.org/%(namelower)s']


### PR DESCRIPTION
to enable MPI support in `Infernal` we either need to add `usempi` to the `toolchainopts` (so that `$CC=$MPICC` etc.) , or explicitly configure with `--enable-mpi`.
It also doesn't depend on BLAS/LAPACK, so should be dropped to `gompi` instead of `foss`