### PR TITLE
Ensure `Proteinortho` links against `FlexiBLAS`, and bump to `foss`

### DIFF
--- a/easybuild/easyconfigs/p/Proteinortho/Proteinortho-6.2.3-foss-2021b.eb
+++ b/easybuild/easyconfigs/p/Proteinortho/Proteinortho-6.2.3-foss-2021b.eb
@@ -6,7 +6,7 @@ version = '6.2.3'
 homepage = 'https://www.bioinf.uni-leipzig.de/Software/proteinortho'
 description = "Proteinortho is a tool to detect orthologous genes within different species."
 
-toolchain = {'name': 'gompi', 'version': '2021b'}
+toolchain = {'name': 'foss', 'version': '2021b'}
 
 source_urls = ['https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v%(version)s/']
 sources = ['proteinortho-v%(version)s.tar.gz']
@@ -20,6 +20,9 @@ dependencies = [
 ]
 
 skipsteps = ['configure']
+
+# run "make clean" first, otherwise we skip the compilation due to bundled artefacts
+prebuildopts = "make clean && sed -i 's/-llapack -lblas/-lflexiblas/g' Makefile && "
 
 preinstallopts = "mkdir -p %(installdir)s/bin && "
 installopts = "PREFIX=%(installdir)s/bin"

--- a/easybuild/easyconfigs/p/Proteinortho/Proteinortho-6.3.2-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/Proteinortho/Proteinortho-6.3.2-foss-2023a.eb
@@ -6,7 +6,7 @@ version = '6.3.2'
 homepage = 'https://www.bioinf.uni-leipzig.de/Software/proteinortho'
 description = "Proteinortho is a tool to detect orthologous genes within different species."
 
-toolchain = {'name': 'gompi', 'version': '2023a'}
+toolchain = {'name': 'foss', 'version': '2023a'}
 
 source_urls = ['https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v%(version)s/']
 sources = ['proteinortho-v%(version)s.tar.gz']
@@ -20,6 +20,9 @@ dependencies = [
 ]
 
 skipsteps = ['configure']
+
+# run "make clean" first, otherwise we skip the compilation due to bundled artefacts
+prebuildopts = "make clean && sed -i 's/-llapack -lblas/-lflexiblas/g' Makefile && "
 
 preinstallopts = "mkdir -p %(installdir)s/bin && "
 installopts = "PREFIX=%(installdir)s/bin"


### PR DESCRIPTION
Current easyconfigs missed the BLAS/LAPACK dependency. This didn't result in build failures, because the sources bundle their own lapack and pre-compiled artefacts, which are used as a fallback.

To see the difference, run an `ldd` on e.g. `bin/proteinortho_clustering` before/after the PR