### PR TITLE
{bio}[gompi/2022a] DaliLite 5 & DSSP 4.5

### DIFF
--- a/easybuild/easyconfigs/d/DSSP/DSSP-4.5.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/d/DSSP/DSSP-4.5.0-GCCcore-11.3.0.eb
@@ -1,0 +1,32 @@
+easyblock = 'CMakeMake'
+
+name = 'DSSP'
+version = '4.5.0'
+
+homepage = 'https://github.com/PDB-REDO/dssp/'
+description = """The DSSP program was designed by Wolfgang Kabsch and Chris
+Sander to standardize secondary structure assignment.  DSSP is a database of
+secondary structure assignments (and much more) for all protein entries in
+the Protein Data Bank (PDB).  DSSP is also the program that calculates DSSP
+entries from PDB entries."""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = ['https://github.com/PDB-REDO/dssp/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+checksums = [
+    'd8cb1b3b173cb176f19b67459ad37fee203fb942951d2284dd4e8130a76f471d',
+]
+
+dependencies = [
+    ('libcifpp', '8.0.0'),
+]
+
+builddependencies = [('CMake', '3.23.1')]
+
+sanity_check_paths = {
+    'files': ['bin/mkdssp'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/d/DaliLite/DaliLite-5.0-gompi-2022a.eb
+++ b/easybuild/easyconfigs/d/DaliLite/DaliLite-5.0-gompi-2022a.eb
@@ -1,0 +1,58 @@
+easyblock = 'MakeCp'
+
+name = 'DaliLite'
+version = '5.0'
+
+homepage = 'http://ekhidna2.biocenter.helsinki.fi/dali/'
+description = """DaliLite is a light version of the software run by the Dali server. The web
+server has search and data visualization options which are not included in this
+package. DaliLite supports data import (import.pl) to convert PDB entries to
+Dali's internal data format and pairwise comparison (dali.pl) to structurally
+align a list of query structures to a list of target structures."""
+
+toolchain = {'name': 'gompi', 'version': '2022a'}
+
+source_urls = ['http://ekhidna2.biocenter.helsinki.fi/dali']
+sources = [{'filename': SOURCE_TAR_GZ, 'download_filename': '%(name)s.v%(version_major)s.tar.gz'}]
+checksums = [
+    '888869cdd536dea6591bcde32ea5b01f262beee2b4fcb0b5bafeaed151d63526',
+]
+
+dependencies = [
+    ('Perl', '5.34.1'),
+    ('BLAST+', '2.13.0'),
+    ('DSSP', '4.5.0'),
+]
+
+# Build, replace dsscmbi with mkdssp for updated compiler
+build_cmd  = ' cd %(builddir)s/%(name)s.v%(version_major)s/bin && '
+build_cmd += ' sed -i "s/\$MPIDALI_BIN\/dsspcmbi/mkdssp --output-format=dssp/" mpidali.pm &&'
+build_cmd += ' make clean && '
+build_cmd += ' make OPENMPI_PATH=$EBROOTOPENMPI/bin '
+
+# Installation
+_bin_files = ['dsspcmbi', 'filter95fitz', 'fssp', 'pipe', 'pipedccp', 'puu', 'puutos',
+              'selfdccp', 'serialcompare']
+_perl_scripts = ['applymatrix.pl', 'dali.pl', 'dat2fasta.pl', 'dccp2dalicon.pl', 'fsspfilter.pl', 
+                 'fsspselect.pl', 'htmljs.pl', 'import.pl', 'pipe96-free.pl', 'pipe96.pl', 'sortdccp.pl']
+_perl_mods = ['FSSP.pm', 'mpidali.pm', 'upgma.pm', 'walk.pm']
+
+files_to_copy = [
+    (['bin/%s' % x for x in _bin_files + _perl_scripts], 'bin'),
+    (['bin/%s' % x for x in _perl_mods], 'lib/perl5/site_perl/%(perlver)s/'),
+]
+
+# Fix perl scritps
+fix_perl_shebang_for = ['bin/%s' % x for x in _perl_scripts]
+postinstallcmds = ['chmod 755 %(installdir)s/bin/*.pl']
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in _bin_files + _perl_scripts],
+    'dirs': ['lib/perl5/site_perl/%(perlver)s/'],
+}
+
+modextrapaths = {
+    'PERL5LIB': 'lib/perl5/site_perl/%(perlver)s/'
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/l/libcifpp/libcifpp-8.0.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/l/libcifpp/libcifpp-8.0.0-GCCcore-11.3.0.eb
@@ -1,0 +1,37 @@
+easyblock = 'CMakeMake'
+
+name = 'libcifpp'
+version = '8.0.0'
+
+homepage = 'https://github.com/PDB-REDO/libcifpp'
+
+description = """As the name implies, this library was originally written to
+work with mmCIF files using C++ as programming language.  The design of this
+library leanes heavily on the structure of CIF files.  These files can be
+thought of as a text dump of a relational databank with, often but not
+always, a very strict schema describing the data.  These schema's are called
+dictionaries."""
+
+toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
+
+source_urls = ['https://github.com/PDB-REDO/libcifpp/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+checksums = [
+    '526f9c670984c65f55972d8a7f6f9ebeaede63628eeabef7e48759981db008d4',
+]
+
+dependencies = [
+    ('Eigen', '3.4.0'),
+    ('zlib', '1.2.12'),
+]
+
+builddependencies = [
+    ('CMake', '3.23.1'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['include', 'lib'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
An update of DaliLite. DSSP 4.5 and required library libcifpp were also added so that DaliLite can use DSSP as indicated in [the document](http://ekhidna2.biocenter.helsinki.fi/dali/README.v5.html).