### PR TITLE
add optional patch file for OpenMPI 4.1.5 to disable OPAL path NFS test

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.5_disable_opal_path_nfs_test.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.5_disable_opal_path_nfs_test.patch
@@ -1,0 +1,21 @@
+Disable opal_path_nfs test in OpenMPI 4.1.5 as this test can easily fail on some systems,
+when NFS mounts are used. Generally, this test is flaky, which may prevent users
+from installing OpenMPI for no apparent reason.
+
+--- a/test/util/Makefile.am
++++ b/test/util/Makefile.am
+@@ -39,8 +39,7 @@
+ check_PROGRAMS = \
+ 	opal_bit_ops \
+-	opal_path_nfs \
+ 	bipartite_graph
+
+ TESTS = \
+ 	$(check_PROGRAMS)
+
+@@ -82,5 +81,0 @@
+-opal_path_nfs_SOURCES = opal_path_nfs.c
+-opal_path_nfs_LDADD = \
+-        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+-        $(top_builddir)/test/support/libsupport.a
+-opal_path_nfs_DEPENDENCIES = $(opal_path_nfs_LDADD)


### PR DESCRIPTION
Similarly to the patch for 5.0.3, I've added one for 4.1.5. 