### PR TITLE
Fix missing space in missing-patch CI error

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1524,19 +1524,19 @@ def verify_patch(specdir, patch_spec, checksum_idx, patch_checksums, extension_n
                                                                                               type(patch_spec)))
 
     patch_path = os.path.join(patch_dir, patch_name)
-    patch_descr = "patch file " + patch_name
-    if extension_name:
-        patch_descr += " of extension " + extension_name
-
     # only check actual patch files, not other files being copied via the patch functionality
     if patch_path.endswith('.patch'):
+        patch_descr = f"patch file {patch_name}"
+        if extension_name:
+            patch_descr += f" of extension {extension_name}"
+
         if not os.path.isfile(patch_path):
-            return [patch_descr + "is missing"]
+            return [f"{patch_descr} is missing"]
 
         if checksum_idx < len(patch_checksums):
             checksum = patch_checksums[checksum_idx]
             if not verify_checksum(patch_path, checksum):
-                return ["Invalid checksum for %s: %s" % (patch_descr, checksum)]
+                return [f"Invalid checksum for {patch_descr}: {checksum}"]
 
     return []  # No error
 


### PR DESCRIPTION
` [patch_descr + "is missing"]` has a missing space.

Convert to f-strings and move `patch_descr` closer to its usage