### PR TITLE
adding easyconfigs: McStas-3.5.24-foss-2023a.eb

### DIFF
--- a/easybuild/easyconfigs/m/McStas/McStas-3.5.24-foss-2023a.eb
+++ b/easybuild/easyconfigs/m/McStas/McStas-3.5.24-foss-2023a.eb
@@ -1,0 +1,42 @@
+# Author: Erik B Knudsen
+# United Neux
+
+easyblock = 'CMakeMake'
+
+name = 'McStas'
+version = '3.5.24'
+
+homepage = 'https://mcstas.org'
+description = "McStas is a Monte Carlo ray tracing neutron instrumentaton and experiment simulation packages."
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+github_account = 'mccode-dev'
+source_urls = ["https://github.com/mccode-dev/McCode/archive/refs/tags/"]
+sources = ['v%(version)s.tar.gz']
+checksums = ['b1958a24b6b7e06e65ff3fc302da6d306412fdaee15ac77fadf841e1521b773a']
+
+builddependencies = [
+    ('CMake', '3.26.3'),
+]
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('SciPy-bundle','2023.07'),
+    ('PyYAML','6.0')
+]
+
+configopts = '-DBUILD_MCSTAS=ON -DENSURE_NCRYSTAL=off -DMCVERSION=%(version)s -DBUILD_TOOLS=off -DBUILD_MCXRUN=on'
+
+sanity_check_paths = {
+    'files': ["%(namelower)s/%(version)s/bin/mcstas"],
+    'dirs': [f"%(namelower)s/%(version)s/{dd}" for dd in ['samples','share','optics']]
+}
+
+sanity_check_commands = [
+    "mcstas -v"
+]
+
+modextravars = {'MCSTAS' : "%(installdir)s/%(namelower)s/%(version)s"}
+
+moduleclass = 'phys'


### PR DESCRIPTION
McStas is a neutron ray tracing package for Monte Carlo simulation of neutron scattering experiments and instrumentation.

It works by describing the geometry in a domain specific language. The description is then transformed by a lex/yacc-based code generator into a c-program, which in turn may be compiled into an executable.
Code-generation to a large part consists of concatenating pieces of code from various file, which is why the installed software library contains a set of .c and .h-files. This is by design.