### PR TITLE
{vis}[GCCcore/13.3.0] Update dependencies of Graphviz 12.2.0

### DIFF
--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-12.2.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-12.2.0-GCCcore-13.3.0.eb
@@ -29,10 +29,11 @@ builddependencies = [
     ('flex', '2.6.4'),
     ('SWIG', '4.2.1'),
     ('pkgconf', '2.2.0'),
+    ('groff', '1.23.0'),
 ]
 
 dependencies = [
-    ('Java', '21.0.2', '', SYSTEM),
+    ('Java', '17', '', SYSTEM),
     ('Python', '3.12.3'),
     ('FriBidi', '1.0.15'),
     ('Gdk-Pixbuf', '2.42.11'),

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-12.2.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-12.2.0-GCCcore-13.3.0.eb
@@ -33,7 +33,7 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('Java', '17', '', SYSTEM),
+    ('Java', '21', '', SYSTEM),
     ('Python', '3.12.3'),
     ('FriBidi', '1.0.15'),
     ('Gdk-Pixbuf', '2.42.11'),


### PR DESCRIPTION
- Switch Java version to Java 21 to be consistent with remaining toolchain
- Add groff as a build dependency to avoid system version being used, which can cause libstdc++ issues (see below).

```console
# Shell for the command: 'qmake -o cmd/gvedit/qMakefile cmd/gvedit/gvedit.pro &&  make  -j 8'
# Use command history, exit to stop
eb-shell> qmake -o cmd/gvedit/qMakefile cmd/gvedit/gvedit.pro &&  make  -j 8
make  all-recursive
make[1]: Entering directory '/data/EasyBuild-develop/build/Graphviz/12.2.0/GCCcore-13.3.0/graphviz-12.2.0'
Making all in libltdl
make[2]: Entering directory '/data/EasyBuild-develop/build/Graphviz/12.2.0/GCCcore-13.3.0/graphviz-12.2.0/libltdl'
make  all-am
make[3]: Entering directory '/data/EasyBuild-develop/build/Graphviz/12.2.0/GCCcore-13.3.0/graphviz-12.2.0/libltdl'
make[3]: Leaving directory '/data/EasyBuild-develop/build/Graphviz/12.2.0/GCCcore-13.3.0/graphviz-12.2.0/libltdl'
make[2]: Leaving directory '/data/EasyBuild-develop/build/Graphviz/12.2.0/GCCcore-13.3.0/graphviz-12.2.0/libltdl'
Making all in lib
make[2]: Entering directory '/data/EasyBuild-develop/build/Graphviz/12.2.0/GCCcore-13.3.0/graphviz-12.2.0/lib'
Making all in util
make[3]: Entering directory '/data/EasyBuild-develop/build/Graphviz/12.2.0/GCCcore-13.3.0/graphviz-12.2.0/lib/util'
make[3]: Nothing to be done for 'all'.
make[3]: Leaving directory '/data/EasyBuild-develop/build/Graphviz/12.2.0/GCCcore-13.3.0/graphviz-12.2.0/lib/util'
Making all in cdt
make[3]: Entering directory '/data/EasyBuild-develop/build/Graphviz/12.2.0/GCCcore-13.3.0/graphviz-12.2.0/lib/cdt'
rm -f cdt.3.pdf; pdffile=cdt.3.pdf; psfile=${pdffile%pdf}ps; \
groff -Tps -man cdt.3 > $psfile || { rm -f $psfile; exit 1; }; \
ps2pdf $psfile && rm -f $psfile || { rm -f $psfile; exit 1; }
  CCLD     libcdt.la
  CCLD     libcdt_C.la
grops: /data/EasyBuild-develop/software/GCCcore/13.3.0/lib64/libstdc++.so.6: version `CXXABI_1.3.15' not found (required by grops)
make[3]: *** [Makefile:1063: cdt.3.pdf] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: Leaving directory '/data/EasyBuild-develop/build/Graphviz/12.2.0/GCCcore-13.3.0/graphviz-12.2.0/lib/cdt'
make[2]: *** [Makefile:541: all-recursive] Error 1
make[2]: Leaving directory '/data/EasyBuild-develop/build/Graphviz/12.2.0/GCCcore-13.3.0/graphviz-12.2.0/lib'
make[1]: *** [Makefile:754: all-recursive] Error 1
make[1]: Leaving directory '/data/EasyBuild-develop/build/Graphviz/12.2.0/GCCcore-13.3.0/graphviz-12.2.0'
make: *** [Makefile:585: all] Error 2
eb-shell> which grops
/usr/bin/grops
```