### PR TITLE
{lib}[GlobalArrays/5.8.2-intel-2024] fix for linear algebra 

### DIFF
--- a/easybuild/easyconfigs/g/GlobalArrays/GlobalArrays-5.8.2-intel-2024a.eb
+++ b/easybuild/easyconfigs/g/GlobalArrays/GlobalArrays-5.8.2-intel-2024a.eb
@@ -13,9 +13,9 @@ source_urls = ['https://github.com/%(name)s/ga/releases/download/']
 sources = ['v%(version)s/ga-%(version)s.tar.gz']
 checksums = ['51599e4abfe36f05cecfaffa33be19efbe9e9fa42d035fd3f866469b663c22a2']
 
-configopts = ' --with-mpi --enable-i8'
-configopts += ' --with-blas8="-L$MKLROOT/lib/intel64 -lmkl_sequential -lmkl_intel_ilp64"'
-configopts += ' --with-scalapack="-L$MKLROOT/lib/intel64 -lmkl_scalapack_ilp64 -lmkl_intel_ilp64 '
+configopts = ' --with-mpi'
+configopts += ' --with-blas8="-L$MKLROOT/lib/intel64 -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl" '
+configopts += ' --with-scalapack8="-L$MKLROOT/lib/intel64 -lmkl_scalapack_ilp64 -lmkl_intel_ilp64 '
 configopts += '-lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_ilp64 -lpthread -lm -ldl"'
 
 # select armci network as (Comex) MPI-1 two-sided


### PR DESCRIPTION
The existing module is setting size=8 for the BLAS library and size=4 for the ScaLapack library.   
This is not going to work when the Global Arrays library is used by NWChem.   
This fix use size=8 both for MKL BLAS  and ScaLapack.  