### PR TITLE
Add missing extension curly brackets and parentheses

### DIFF
--- a/contrib/easyconfig-templates/2022a/PythonBundle-minimal.eb.tmpl
+++ b/contrib/easyconfig-templates/2022a/PythonBundle-minimal.eb.tmpl
@@ -24,8 +24,10 @@ exts_list = [
     }),
     ('ext2-name-from-pypi', 'ext2_version', {
         'modulename': 'import_name',
+    }),
     ('wheel-name-from-pipy', 'ext3_version', {
         'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
+    }),
     ('name-lower', 'version', {
         'use_pip_extras': 'extra',
     }),

--- a/contrib/easyconfig-templates/2022a/PythonBundle-scipy.eb.tmpl
+++ b/contrib/easyconfig-templates/2022a/PythonBundle-scipy.eb.tmpl
@@ -21,8 +21,10 @@ exts_list = [
     }),
     ('ext2-name-from-pypi', 'ext2_version', {
         'modulename': 'import_name',
+    }),
     ('wheel-name-from-pipy', 'ext3_version', {
         'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
+    }),
     ('name-lower', 'version', {
         'use_pip_extras': 'extra',
     }),

--- a/contrib/easyconfig-templates/2023a/PythonBundle-minimal.eb.tmpl
+++ b/contrib/easyconfig-templates/2023a/PythonBundle-minimal.eb.tmpl
@@ -24,8 +24,10 @@ exts_list = [
     }),
     ('ext2-name-from-pypi', 'ext2_version', {
         'modulename': 'import_name',
+    }),
     ('wheel-name-from-pipy', 'ext3_version', {
         'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
+    }),
     ('name-lower', 'version', {
         'use_pip_extras': 'extra',
     }),

--- a/contrib/easyconfig-templates/2023a/PythonBundle-scipy.eb.tmpl
+++ b/contrib/easyconfig-templates/2023a/PythonBundle-scipy.eb.tmpl
@@ -21,8 +21,10 @@ exts_list = [
     }),
     ('ext2-name-from-pypi', 'ext2_version', {
         'modulename': 'import_name',
+    }),
     ('wheel-name-from-pipy', 'ext3_version', {
         'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
+    }),
     ('name-lower', 'version', {
         'use_pip_extras': 'extra',
     }),

--- a/contrib/easyconfig-templates/2024a/PythonBundle-minimal.eb.tmpl
+++ b/contrib/easyconfig-templates/2024a/PythonBundle-minimal.eb.tmpl
@@ -24,8 +24,10 @@ exts_list = [
     }),
     ('ext2-name-from-pypi', 'ext2_version', {
         'modulename': 'import_name',
+    }),
     ('wheel-name-from-pipy', 'ext3_version', {
         'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
+    }),
     ('name-lower', 'version', {
         'use_pip_extras': 'extra',
     }),

--- a/contrib/easyconfig-templates/2024a/PythonBundle-scipy.eb.tmpl
+++ b/contrib/easyconfig-templates/2024a/PythonBundle-scipy.eb.tmpl
@@ -21,8 +21,10 @@ exts_list = [
     }),
     ('ext2-name-from-pypi', 'ext2_version', {
         'modulename': 'import_name',
+    }),
     ('wheel-name-from-pipy', 'ext3_version', {
         'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
+    }),
     ('name-lower', 'version', {
         'use_pip_extras': 'extra',
     }),


### PR DESCRIPTION
The extensions examples for some of the `PythonBundle` templates are missing `})`.