### PR TITLE
{vis}[GCCcore/12.3.0,GCCcore/13.3.0] Added `GraphicsMagick-1.3.45` EC for GCCcore-12.3.0 + fix for #22927

### DIFF
--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
@@ -15,11 +15,11 @@ source_urls = [
 ]
 sources = [SOURCE_TAR_XZ]
 patches = [
-    'GraphicsMagick_pkgconfig_libtiff.patch'
+    'GraphicsMagick_pkgconfig_libtiff-4.patch'
 ]
 checksums = [
     {'GraphicsMagick-1.3.45.tar.xz': 'dcea5167414f7c805557de2d7a47a9b3147bcbf617b91f5f0f4afe5e6543026b'},
-    {'GraphicsMagick_pkgconfig_libtiff.patch': '25b4c5361f30e23c809a078ac4b26e670d2b8341496323480037e2095d969294'},
+    {'GraphicsMagick_pkgconfig_libtiff-4.patch': 'b1f0f648084e45531ff55d851c8713eb081d37e737ef64223e17cc92ac23b2f7'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
@@ -19,7 +19,7 @@ patches = [
 ]
 checksums = [
     {'GraphicsMagick-1.3.45.tar.xz': 'dcea5167414f7c805557de2d7a47a9b3147bcbf617b91f5f0f4afe5e6543026b'},
-    {'GraphicsMagick_pkgconfig_libtiff-4.patch': 'b1f0f648084e45531ff55d851c8713eb081d37e737ef64223e17cc92ac23b2f7'},
+    {'GraphicsMagick_pkgconfig_libtiff-4.patch': 'fddd53421387b410377d3147845cb7774b8c2cd1769865568c304237f85b2157'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
@@ -1,0 +1,62 @@
+easyblock = 'ConfigureMake'
+
+name = 'GraphicsMagick'
+version = '1.3.45'
+
+homepage = 'http://www.graphicsmagick.org/'
+description = """GraphicsMagick is the swiss army knife of image processing."""
+
+toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [
+    SOURCEFORGE_SOURCE,
+    'ftp://ftp.graphicsmagick.org/pub/GraphicsMagick/%(version_major_minor)s/',
+]
+sources = [SOURCE_TAR_XZ]
+patches = [
+    'GraphicsMagick_pkgconfig_libtiff.patch'
+]
+checksums = [
+    {'GraphicsMagick-1.3.45.tar.xz': 'dcea5167414f7c805557de2d7a47a9b3147bcbf617b91f5f0f4afe5e6543026b'},
+    {'GraphicsMagick_pkgconfig_libtiff.patch': '25b4c5361f30e23c809a078ac4b26e670d2b8341496323480037e2095d969294'},
+]
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('Autotools', '20220317'),
+]
+
+dependencies = [
+    ('X11', '20230603'),
+    ('bzip2', '1.0.8'),
+    ('freetype', '2.13.0'),
+    ('libpng', '1.6.39'),
+    ('libjpeg-turbo', '2.1.5.1'),
+    ('LibTIFF', '4.5.0'),
+    ('libxml2', '2.11.4'),
+    ('XZ', '5.4.2'),
+    ('zlib', '1.2.13'),
+    ('Ghostscript', '10.01.2'),
+]
+
+# When building Octave, mixing rpathed shared libraries with libGraphicsMagick++.a will cause the check on the library
+# to fail due to missing symbols. The default previously was to build the static library only.
+configure_opts = '--enable-shared --enable-static'
+
+modextrapaths = {MODULE_LOAD_ENV_HEADERS: ['include/GraphicsMagick']}
+
+sanity_check_paths = {
+    'files': [
+        'bin/gm',
+        'lib/libGraphicsMagick.a',
+        'lib/libGraphicsMagick++.a',
+        'lib/libGraphicsMagickWand.a',
+        'lib/libGraphicsMagick.so',
+        'lib/libGraphicsMagick++.so',
+        'lib/libGraphicsMagickWand.so'
+    ],
+    'dirs': ['include/GraphicsMagick', 'lib/pkgconfig'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
@@ -27,11 +27,11 @@ builddependencies = [
     ('Autotools', '20220317'),
 ]
 
-dependencies = [
-    # This needs to be here to ensure pkg-config is available at sanity check time both for a full run
-    # and for a `--sanity-check-only` run
-    ('pkgconf', '1.9.5'),
+sanitycheck_dependencies = [
+    ('pkgconf', '1.9.5'),  # pkgconf is used for sanity checks
+]
 
+dependencies = [
     ('X11', '20230603'),
     ('bzip2', '1.0.8'),
     ('freetype', '2.13.0'),

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
@@ -28,7 +28,10 @@ builddependencies = [
 ]
 
 dependencies = [
+    # This needs to be here to ensure pkg-config is available at sanity check time both for a full run
+    # and for a `--sanity-check-only` run
     ('pkgconf', '1.9.5'),
+
     ('X11', '20230603'),
     ('bzip2', '1.0.8'),
     ('freetype', '2.13.0'),

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
@@ -59,4 +59,10 @@ sanity_check_paths = {
     'dirs': ['include/GraphicsMagick', 'lib/pkgconfig'],
 }
 
+sanity_check_commands = [
+    "pkg-config --cflags GraphicsMagick",
+    "pkg-config --cflags GraphicsMagick++",
+    "pkg-config --cflags GraphicsMagickWand",
+]
+
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
@@ -27,10 +27,6 @@ builddependencies = [
     ('Autotools', '20220317'),
 ]
 
-sanitycheck_dependencies = [
-    ('pkgconf', '1.9.5'),  # pkgconf is used for sanity checks
-]
-
 dependencies = [
     ('X11', '20230603'),
     ('bzip2', '1.0.8'),
@@ -64,9 +60,7 @@ sanity_check_paths = {
 }
 
 sanity_check_commands = [
-    "pkg-config --cflags GraphicsMagick",
-    "pkg-config --cflags GraphicsMagick++",
-    "pkg-config --cflags GraphicsMagickWand",
+    "grep 'libtiff-4' %(installdir)s/lib/pkgconfig/GraphicsMagick.pc",
 ]
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
@@ -15,11 +15,12 @@ source_urls = [
 ]
 sources = [SOURCE_TAR_XZ]
 patches = [
-    'GraphicsMagick_pkgconfig_libtiff-4.patch'
+    'GraphicsMagick-12.3.0_pkgconfig_libtiff-4.patch'
 ]
 checksums = [
     {'GraphicsMagick-1.3.45.tar.xz': 'dcea5167414f7c805557de2d7a47a9b3147bcbf617b91f5f0f4afe5e6543026b'},
-    {'GraphicsMagick_pkgconfig_libtiff-4.patch': 'fddd53421387b410377d3147845cb7774b8c2cd1769865568c304237f85b2157'},
+    {'GraphicsMagick-12.3.0_pkgconfig_libtiff-4.patch':
+     'f3f900bcc4797f12ff3e2df0fc9eb67c0cc4e532531e200b8d283988f298fa48'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-12.3.0.eb
@@ -28,6 +28,7 @@ builddependencies = [
 ]
 
 dependencies = [
+    ('pkgconf', '1.9.5'),
     ('X11', '20230603'),
     ('bzip2', '1.0.8'),
     ('freetype', '2.13.0'),

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
@@ -19,7 +19,7 @@ patches = [
 ]
 checksums = [
     {'GraphicsMagick-1.3.45.tar.xz': 'dcea5167414f7c805557de2d7a47a9b3147bcbf617b91f5f0f4afe5e6543026b'},
-    {'GraphicsMagick_pkgconfig_libtiff-4.patch': 'b1f0f648084e45531ff55d851c8713eb081d37e737ef64223e17cc92ac23b2f7'},
+    {'GraphicsMagick_pkgconfig_libtiff.patch': '25b4c5361f30e23c809a078ac4b26e670d2b8341496323480037e2095d969294'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
@@ -48,4 +48,10 @@ sanity_check_paths = {
     'dirs': ['include/GraphicsMagick', 'lib/pkgconfig'],
 }
 
+sanity_check_commands = [
+    "pkg-config --cflags GraphicsMagick",
+    "pkg-config --cflags GraphicsMagick++",
+    "pkg-config --cflags GraphicsMagickWand",
+]
+
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
@@ -15,11 +15,11 @@ source_urls = [
 ]
 sources = [SOURCE_TAR_XZ]
 patches = [
-    'GraphicsMagick_pkgconfig_libtiff.patch'
+    'GraphicsMagick_pkgconfig_libtiff-4.patch'
 ]
 checksums = [
     {'GraphicsMagick-1.3.45.tar.xz': 'dcea5167414f7c805557de2d7a47a9b3147bcbf617b91f5f0f4afe5e6543026b'},
-    {'GraphicsMagick_pkgconfig_libtiff.patch': '25b4c5361f30e23c809a078ac4b26e670d2b8341496323480037e2095d969294'},
+    {'GraphicsMagick_pkgconfig_libtiff-4.patch': 'fddd53421387b410377d3147845cb7774b8c2cd1769865568c304237f85b2157'},
 ]
 
 builddependencies = [
@@ -40,11 +40,22 @@ dependencies = [
     ('Ghostscript', '10.03.1'),
 ]
 
+# When building Octave, mixing rpathed shared libraries with libGraphicsMagick++.a will cause the check on the library
+# to fail due to missing symbols. The default previously was to build the static library only.
+configure_opts = '--enable-shared --enable-static'
+
 modextrapaths = {MODULE_LOAD_ENV_HEADERS: ['include/GraphicsMagick']}
 
 sanity_check_paths = {
-    'files': ['bin/gm', 'lib/libGraphicsMagick.a', 'lib/libGraphicsMagick++.a',
-              'lib/libGraphicsMagickWand.a'],
+    'files': [
+        'bin/gm',
+        'lib/libGraphicsMagick.a',
+        'lib/libGraphicsMagick++.a',
+        'lib/libGraphicsMagickWand.a',
+        'lib/libGraphicsMagick.so',
+        'lib/libGraphicsMagick++.so',
+        'lib/libGraphicsMagickWand.so'
+    ],
     'dirs': ['include/GraphicsMagick', 'lib/pkgconfig'],
 }
 

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
@@ -28,6 +28,7 @@ builddependencies = [
 ]
 
 dependencies = [
+    ('pkgconf', '2.2.0'),
     ('X11', '20240607'),
     ('bzip2', '1.0.8'),
     ('freetype', '2.13.2'),

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
@@ -27,10 +27,6 @@ builddependencies = [
     ('Autotools', '20231222'),
 ]
 
-sanitycheck_dependencies = [
-    ('pkgconf', '1.9.5'),  # pkgconf is used for sanity checks
-]
-
 dependencies = [
     ('X11', '20240607'),
     ('bzip2', '1.0.8'),
@@ -64,9 +60,7 @@ sanity_check_paths = {
 }
 
 sanity_check_commands = [
-    "pkg-config --cflags GraphicsMagick",
-    "pkg-config --cflags GraphicsMagick++",
-    "pkg-config --cflags GraphicsMagickWand",
+    "grep 'libtiff-4' %(installdir)s/lib/pkgconfig/GraphicsMagick.pc",
 ]
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
@@ -27,11 +27,11 @@ builddependencies = [
     ('Autotools', '20231222'),
 ]
 
-dependencies = [
-    # This needs to be here to ensure pkg-config is available at sanity check time both for a full run
-    # and for a `--sanity-check-only` run
-    ('pkgconf', '2.2.0'),
+sanitycheck_dependencies = [
+    ('pkgconf', '1.9.5'),  # pkgconf is used for sanity checks
+]
 
+dependencies = [
     ('X11', '20240607'),
     ('bzip2', '1.0.8'),
     ('freetype', '2.13.2'),

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
@@ -28,7 +28,10 @@ builddependencies = [
 ]
 
 dependencies = [
+    # This needs to be here to ensure pkg-config is available at sanity check time both for a full run
+    # and for a `--sanity-check-only` run
     ('pkgconf', '2.2.0'),
+
     ('X11', '20240607'),
     ('bzip2', '1.0.8'),
     ('freetype', '2.13.2'),

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
@@ -15,11 +15,12 @@ source_urls = [
 ]
 sources = [SOURCE_TAR_XZ]
 patches = [
-    'GraphicsMagick_pkgconfig_libtiff-4.patch'
+    'GraphicsMagick-12.3.0_pkgconfig_libtiff-4.patch'
 ]
 checksums = [
     {'GraphicsMagick-1.3.45.tar.xz': 'dcea5167414f7c805557de2d7a47a9b3147bcbf617b91f5f0f4afe5e6543026b'},
-    {'GraphicsMagick_pkgconfig_libtiff-4.patch': 'fddd53421387b410377d3147845cb7774b8c2cd1769865568c304237f85b2157'},
+    {'GraphicsMagick-12.3.0_pkgconfig_libtiff-4.patch':
+     'f3f900bcc4797f12ff3e2df0fc9eb67c0cc4e532531e200b8d283988f298fa48'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-1.3.45-GCCcore-13.3.0.eb
@@ -19,7 +19,7 @@ patches = [
 ]
 checksums = [
     {'GraphicsMagick-1.3.45.tar.xz': 'dcea5167414f7c805557de2d7a47a9b3147bcbf617b91f5f0f4afe5e6543026b'},
-    {'GraphicsMagick_pkgconfig_libtiff.patch': '25b4c5361f30e23c809a078ac4b26e670d2b8341496323480037e2095d969294'},
+    {'GraphicsMagick_pkgconfig_libtiff-4.patch': 'b1f0f648084e45531ff55d851c8713eb081d37e737ef64223e17cc92ac23b2f7'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-12.3.0_pkgconfig_libtiff-4.patch
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick-12.3.0_pkgconfig_libtiff-4.patch
@@ -1,5 +1,6 @@
-# Adds libtiff-4 as a dependency to pkgconfig
+# Adds `libtiff-4` as a dependency to pkgconfig (not `libtiff`)
 # See https://github.com/easybuilders/easybuild-easyconfigs/issues/22927
+# Author: Davide Grassano <davide.grassano@epfl.ch>
 --- GraphicsMagick-1.3.34/magick/GraphicsMagick.pc.in.orig	2020-01-19 19:01:31.462709217 +0100
 +++ GraphicsMagick-1.3.34/magick/GraphicsMagick.pc.in	2020-01-19 19:02:12.561387370 +0100
 @@ -9,3 +9,4 @@

--- a/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick_pkgconfig_libtiff-4.patch
+++ b/easybuild/easyconfigs/g/GraphicsMagick/GraphicsMagick_pkgconfig_libtiff-4.patch
@@ -1,0 +1,9 @@
+# Adds libtiff-4 as a dependency to pkgconfig
+# See https://github.com/easybuilders/easybuild-easyconfigs/issues/22927
+--- GraphicsMagick-1.3.34/magick/GraphicsMagick.pc.in.orig	2020-01-19 19:01:31.462709217 +0100
++++ GraphicsMagick-1.3.34/magick/GraphicsMagick.pc.in	2020-01-19 19:02:12.561387370 +0100
+@@ -9,3 +9,4 @@
+ Description: GraphicsMagick image processing library
+ Libs: -L${libdir} -lGraphicsMagick
+ Cflags: -I${includedir} @MAGICK_API_PC_CPPFLAGS@
++Requires.private: libtiff-4


### PR DESCRIPTION
New EC files for `GraphicsMagick` and `foss/2023a` with potential fix for 

- #22927 
- #22929

If from the discussion on the PR/Issue it is decided this is the proper way to go we should apply the change to enable both static and shared builds (+ sanity checks)

```
# When building Octave, mixing rpathed shared libraries with libGraphicsMagick++.a will cause the check on the library
# to fail due to missing symbols. The default previously was to build the static library only.
configure_opts = '--enable-shared --enable-static'
```

also to

GraphicsMagick-1.3.45-GCCcore-13.3.0.eb