### PR TITLE
{vis}[GCCcore/13.3.0] Graphviz v12.2.0-minimal 

### DIFF
--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-12.2.0-GCCcore-13.3.0-minimal.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-12.2.0-GCCcore-13.3.0-minimal.eb
@@ -1,0 +1,87 @@
+easyblock = 'ConfigureMake'
+
+name = 'Graphviz'
+version = '12.2.0'
+versionsuffix = '-minimal'
+local_pyver_major = '3'
+
+homepage = 'https://www.graphviz.org/'
+description = """Graphviz is open source graph visualization software. Graph visualization
+ is a way of representing structural information as diagrams of
+ abstract graphs and networks. It has important applications in networking,
+ bioinformatics,  software engineering, database and web design, machine learning,
+ and in visual interfaces for other technical domains."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://gitlab.com/graphviz/graphviz/-/archive/%(version)s']
+patches = ['%(name)s-8.1.0_skip-install-data-hook.patch']
+sources = [SOURCELOWER_TAR_GZ]
+
+checksums = [
+    {'graphviz-12.2.0.tar.gz': '0063e501fa4642b55f4daf82820b2778bfb7dafa651a862ae5c9810efb8e2311'},
+    {'Graphviz-8.1.0_skip-install-data-hook.patch': '834666f1b5a8eff35f30899419e322739d71a2936408b27c8ffb4423a99a38e1'},
+]
+
+builddependencies = [
+    ('Autotools', '20231222'),
+    ('binutils', '2.42'),
+    ('Bison', '3.8.2'),
+    ('flex', '2.6.4'),
+    ('SWIG', '4.2.1'),
+    ('pkgconf', '2.2.0'),
+    ('groff', '1.23.0'),
+]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('libgd', '2.3.3'),
+    ('zlib', '1.3.1'),
+    ('bzip2', '1.0.8'),
+    ('libjpeg-turbo', '3.0.1'),
+    ('expat', '2.6.2'),
+]
+
+preconfigopts = './autogen.sh NOCONFIG && '
+
+_copts = [
+    '--enable-python%s=yes' % local_pyver_major,
+    '--enable-guile=no --enable-lua=no --enable-ocaml=no',
+    '--enable-r=no --enable-ruby=no --enable-php=no',
+    '--enable-java=no',
+    '--enable-ghostscript=no'
+    # Disable GUI-related options
+    '--without-x --without-qt --without-gtk --without-glut --enable-tcl=no'
+    # Use ltdl from libtool in EB
+    '--enable-ltdl --without-included-ltdl --disable-ltdl-install',
+    '--with-ltdl-include=$EBROOTLIBTOOL/include --with-ltdl-lib=$EBROOTLIBTOOL/lib',
+    '--with-expatincludedir=$EBROOTEXPAT/include --with-expatlibdir=$EBROOTEXPAT/lib',
+    '--with-zincludedir=$EBROOTZLIB/include --with-zlibdir=$EBROOTZLIB/lib',
+]
+
+configopts = ' '.join(_copts)
+
+postinstallcmds = ['%(installdir)s/bin/dot -c']  # Writes plugin configuration
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['acyclic', 'bcomps', 'ccomps', 'cluster', 'diffimg', 'dijkstra', 'dot',
+                                     'dot_builtins', 'edgepaint', 'gc', 'gml2gv', 'graphml2gv', 'gv2gml',
+                                     'gvcolor', 'gvgen', 'gvmap', 'gvmap.sh', 'gvpack', 'gvpr', 'gxl2gv',
+                                     'neato', 'mm2gv', 'nop', 'prune', 'sccmap', 'tred', 'unflatten']] +
+             ['lib/%s.%s' % (x, SHLIB_EXT) for x in ['libcdt', 'libcgraph', 'libgvc', 'libgvpr',
+                                                     'libpathplan', 'libxdot']],
+    'dirs': ['include', 'lib/graphviz', 'lib/graphviz/python%s' % local_pyver_major,
+             'lib/pkgconfig', 'share']
+}
+
+sanity_check_commands = [
+    ("test ! -d $EBROOTTCL/lib/*/graphviz", ''),
+    ("test ! -d $EBROOTTCL/lib64/*/graphviz", ''),
+    ('python', '-c "import gv"'),
+]
+
+modextrapaths = {
+    'PYTHONPATH': 'lib/graphviz/python%s' % local_pyver_major,
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-12.2.0-GCCcore-13.3.0-minimal.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-12.2.0-GCCcore-13.3.0-minimal.eb
@@ -49,9 +49,9 @@ _copts = [
     '--enable-guile=no --enable-lua=no --enable-ocaml=no',
     '--enable-r=no --enable-ruby=no --enable-php=no',
     '--enable-java=no',
-    '--enable-ghostscript=no'
+    '--enable-ghostscript=no',
     # Disable GUI-related options
-    '--without-x --without-qt --without-gtk --without-glut --enable-tcl=no'
+    '--without-x --without-qt --without-gtk --without-glut --enable-tcl=no',
     # Use ltdl from libtool in EB
     '--enable-ltdl --without-included-ltdl --disable-ltdl-install',
     '--with-ltdl-include=$EBROOTLIBTOOL/include --with-ltdl-lib=$EBROOTLIBTOOL/lib',


### PR DESCRIPTION
This adds a variant of the `Graphviz` package without the GUI and Java dependencies which pull many different dependencies.
This is helpful for tools such as [MUST](https://itc.rwth-aachen.de/must/) which require the `dot` command to draw graphs but nothing else of the Graphviz package. In particular, it might be of use in #22836.

The following dependencies are removed: `Java`, `FriBidi`, `Gdk-Pixbuf`, `Ghostscript`, `GTS`, `Pango`, `Perl`, `Qt6`, `Tcl`.

The version suffix is to be discussed, of course. :slightly_smiling_face: