### PR TITLE
Move Clang easyconfigs to use LLVM easyblock

### DIFF
--- a/easybuild/easyconfigs/c/Clang/Clang-18.1.6-GCCcore-13.3.0-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-18.1.6-GCCcore-13.3.0-CUDA-12.6.0.eb
@@ -2,7 +2,6 @@ name = 'Clang'
 version = "18.1.6"
 versionsuffix = '-CUDA-%(cudaver)s'
 easyblock = 'EB_LLVM'
-bootstrap = False
 
 homepage = 'https://clang.llvm.org/'
 description = """C, C++, Objective-C compiler, based on LLVM.  Does not

--- a/easybuild/easyconfigs/c/Clang/Clang-18.1.6-GCCcore-13.3.0-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-18.1.6-GCCcore-13.3.0-CUDA-12.6.0.eb
@@ -1,5 +1,5 @@
 name = 'Clang'
-version = "18.1.8"
+version = "18.1.6"
 versionsuffix = '-CUDA-%(cudaver)s'
 easyblock = 'EB_LLVM'
 bootstrap = False

--- a/easybuild/easyconfigs/c/Clang/Clang-18.1.8-GCCcore-13.3.0-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-18.1.8-GCCcore-13.3.0-CUDA-12.6.0.eb
@@ -2,7 +2,6 @@ name = 'Clang'
 version = "18.1.8"
 versionsuffix = '-CUDA-%(cudaver)s'
 easyblock = 'EB_LLVM'
-bootstrap = False
 
 homepage = 'https://clang.llvm.org/'
 description = """C, C++, Objective-C compiler, based on LLVM.  Does not

--- a/easybuild/easyconfigs/c/Clang/Clang-19.1.0-GCCcore-13.3.0-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-19.1.0-GCCcore-13.3.0-CUDA-12.6.0.eb
@@ -1,5 +1,5 @@
 name = 'Clang'
-version = "18.1.8"
+version = "19.1.0"
 versionsuffix = '-CUDA-%(cudaver)s'
 easyblock = 'EB_LLVM'
 bootstrap = False
@@ -43,13 +43,13 @@ dependencies = [
 enable_rtti = False
 
 assertions = True
-build_clang_extras = True
-build_lld = True
-build_lldb = True
-build_runtimes = True
-build_shared_libs = True
 python_bindings = False
 skip_all_tests = True
+build_runtimes = True
+build_shared_libs = True
 use_polly = True
+build_lld = True
+build_lldb = True
+build_clang_extras = True
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/c/Clang/Clang-19.1.0-GCCcore-13.3.0-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-19.1.0-GCCcore-13.3.0-CUDA-12.6.0.eb
@@ -2,7 +2,6 @@ name = 'Clang'
 version = "19.1.0"
 versionsuffix = '-CUDA-%(cudaver)s'
 easyblock = 'EB_LLVM'
-bootstrap = False
 
 homepage = 'https://clang.llvm.org/'
 description = """C, C++, Objective-C compiler, based on LLVM.  Does not

--- a/easybuild/easyconfigs/c/Clang/Clang-20.1.0-GCCcore-13.3.0-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-20.1.0-GCCcore-13.3.0-CUDA-12.6.0.eb
@@ -1,5 +1,5 @@
 name = 'Clang'
-version = "18.1.8"
+version = "20.1.0"
 versionsuffix = '-CUDA-%(cudaver)s'
 easyblock = 'EB_LLVM'
 bootstrap = False
@@ -43,13 +43,13 @@ dependencies = [
 enable_rtti = False
 
 assertions = True
-build_clang_extras = True
-build_lld = True
-build_lldb = True
-build_runtimes = True
-build_shared_libs = True
 python_bindings = False
 skip_all_tests = True
+build_runtimes = True
+build_shared_libs = True
 use_polly = True
+build_lld = True
+build_lldb = True
+build_clang_extras = True
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/c/Clang/Clang-20.1.0-GCCcore-13.3.0-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-20.1.0-GCCcore-13.3.0-CUDA-12.6.0.eb
@@ -2,7 +2,6 @@ name = 'Clang'
 version = "20.1.0"
 versionsuffix = '-CUDA-%(cudaver)s'
 easyblock = 'EB_LLVM'
-bootstrap = False
 
 homepage = 'https://clang.llvm.org/'
 description = """C, C++, Objective-C compiler, based on LLVM.  Does not

--- a/easybuild/easyconfigs/c/Clang/Clang-21.0.0-GCCcore-13.3.0-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-21.0.0-GCCcore-13.3.0-CUDA-12.6.0.eb
@@ -1,7 +1,8 @@
 name = 'Clang'
-version = "18.1.8"
-versionsuffix = '-CUDA-%(cudaver)s'
 easyblock = 'EB_LLVM'
+version = '21.0.0'
+versionsuffix = '-CUDA-%(cudaver)s'
+local_commit = '3bd3e06' # 'a66376b0dc3b'
 bootstrap = False
 
 homepage = 'https://clang.llvm.org/'
@@ -12,10 +13,11 @@ description = """C, C++, Objective-C compiler, based on LLVM.  Does not
 # already specified as the toolchain.
 toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
 
-source_urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-%(version)s"]
-sources = [
-    'llvm-project-%(version)s.src.tar.xz',
-]
+sources = [{
+    'source_urls': ["https://github.com/llvm/llvm-project/archive"],
+    'download_filename': '%s.tar.gz' % local_commit,
+    'filename': 'llvm-project-%s.tar.gz' % version,
+}]
 
 #checksums = ['10eb1d36aabbc5d31c9d2af27844f51638d40be28975a4ab20ad13609f7da23d']
 

--- a/easybuild/easyconfigs/c/Clang/Clang-21.0.0-GCCcore-13.3.0-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-21.0.0-GCCcore-13.3.0-CUDA-12.6.0.eb
@@ -3,7 +3,6 @@ easyblock = 'EB_LLVM'
 version = '21.0.0'
 versionsuffix = '-CUDA-%(cudaver)s'
 local_commit = '3bd3e06' # 'a66376b0dc3b'
-bootstrap = False
 
 homepage = 'https://clang.llvm.org/'
 description = """C, C++, Objective-C compiler, based on LLVM.  Does not


### PR DESCRIPTION
This is intended to test https://github.com/easybuilders/easybuild-easyblocks/pull/3755

I'll reduce this to changes and move the new easyconfigs out using correct names and comments (I need a specific commit for Triton)