### PR TITLE
Mesa-demos/9.0.0-GCCcore-13.3.0, glew/2.2.0-GCCcore-13.3.0-egl

### DIFF
--- a/easybuild/easyconfigs/g/glew/glew-2.2.0-GCCcore-13.3.0-egl.eb
+++ b/easybuild/easyconfigs/g/glew/glew-2.2.0-GCCcore-13.3.0-egl.eb
@@ -1,0 +1,47 @@
+easyblock = 'ConfigureMake'
+versionsuffix = '-egl'
+# available: -glx, -osmesa, -egl
+# GLEW does support GLX (onscreen or requiring VirtualGL), EGL (technically can do both onscreen and
+# offscreen), and OSMESA (offscreen software only).
+
+name = 'glew'
+version = '2.2.0'
+
+homepage = 'https://github.com/nigels-com/glew'
+description = """The OpenGL Extension Wrangler Library (GLEW) is a cross-platform open-source
+C/C++ extension loading library. GLEW provides efficient run-time mechanisms
+for determining which OpenGL extensions are supported on the target platform."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://github.com/nigels-com/glew/releases/download/%(name)s-%(version)s/']
+sources = ['%(name)s-%(version)s.tgz']
+patches = ['uintptr_t.patch']
+checksums = [
+    {'glew-2.2.0.tgz': 'd4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1'},
+    {'uintptr_t.patch': '30fffe5b6606ae840fd5d10d353196c8faf3b88618ab8db03bd1b50dde98a280'},
+]
+
+builddependencies = [('binutils', '2.42')]
+
+dependencies = [
+    ('Mesa', '24.1.3'),
+    ('X11', '20240607'),
+]
+
+local_system = 'SYSTEM=linux`echo %(versionsuffix)s|sed -e "s/-glx//g"`'
+buildopts = local_system
+
+skipsteps = ['configure']
+
+preinstallopts = 'GLEW_PREFIX=%(installdir)s GLEW_DEST=%(installdir)s '
+install_cmd = 'make install.all ' + local_system
+
+sanity_check_paths = {
+    'files': ['lib/libGLEW.a', 'lib/libGLEW.%s' % SHLIB_EXT] +
+             ['bin/glewinfo', 'bin/visualinfo'] +
+             ['include/GL/%s.h' % h for h in ['glew', 'glxew', 'wglew']],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/g/glew/uintptr_t.patch
+++ b/easybuild/easyconfigs/g/glew/uintptr_t.patch
@@ -1,0 +1,24 @@
+# Author: Ehsan Moravveji
+# Purpose: This patch ensures correct casting of integer to uintptr_t,
+#          otherwise, we get a lot of compiler warnings
+
+diff -ruN glew-2.2.0-orig/src/glew.c glew-2.2.0/src/glew.c
+--- glew-2.2.0-orig/src/glew.c	2025-06-04 12:30:27.320452000 +0200
++++ glew-2.2.0/src/glew.c	2025-06-04 12:38:44.034321000 +0200
+@@ -56,6 +56,7 @@
+ #endif
+ 
+ #include <stddef.h>  /* For size_t */
++#include <stdint.h>  /* For casting ints to pointers */
+ 
+ #if defined(GLEW_EGL)
+ #elif defined(GLEW_REGAL)
+@@ -17782,7 +17783,7 @@
+   r = ((glGlobalAlphaFactordSUN = (PFNGLGLOBALALPHAFACTORDSUNPROC)glewGetProcAddress((const GLubyte*)"glGlobalAlphaFactordSUN")) == NULL) || r;
+   r = ((glGlobalAlphaFactorfSUN = (PFNGLGLOBALALPHAFACTORFSUNPROC)glewGetProcAddress((const GLubyte*)"glGlobalAlphaFactorfSUN")) == NULL) || r;
+   r = ((glGlobalAlphaFactoriSUN = (PFNGLGLOBALALPHAFACTORISUNPROC)glewGetProcAddress((const GLubyte*)"glGlobalAlphaFactoriSUN")) == NULL) || r;
+-  r = ((glGlobalAlphaFactorsSUN = (PFNGLGLOBALALPHAFACTORSSUNPROC)glewGetProcAddress((const GLubyte*)"glGlobalAlphaFactorsSUN")) == NULL) || r;
++  r = ((glGlobalAlphaFactorsSUN = (PFNGLGLOBALALPHAFACTORSSUNPROC)(uintptr_t)glewGetProcAddress((const GLubyte*)"glGlobalAlphaFactorsSUN")) == NULL) || r;
+   r = ((glGlobalAlphaFactorubSUN = (PFNGLGLOBALALPHAFACTORUBSUNPROC)glewGetProcAddress((const GLubyte*)"glGlobalAlphaFactorubSUN")) == NULL) || r;
+   r = ((glGlobalAlphaFactoruiSUN = (PFNGLGLOBALALPHAFACTORUISUNPROC)glewGetProcAddress((const GLubyte*)"glGlobalAlphaFactoruiSUN")) == NULL) || r;
+   r = ((glGlobalAlphaFactorusSUN = (PFNGLGLOBALALPHAFACTORUSSUNPROC)glewGetProcAddress((const GLubyte*)"glGlobalAlphaFactorusSUN")) == NULL) || r;

--- a/easybuild/easyconfigs/m/Mesa-demos/Mesa-demos-9.0.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/m/Mesa-demos/Mesa-demos-9.0.0-GCCcore-13.3.0.eb
@@ -1,0 +1,37 @@
+easyblock = 'MesonNinja'
+
+name = 'Mesa-demos'
+version = '9.0.0'
+
+homepage = 'https://www.mesa3d.org/'
+description = "Mesa utility and demo programs, including glxinfo and eglinfo."
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+#source_urls = ['https://mesa.freedesktop.org/archive/demos/']
+source_urls = ['https://archive.mesa3d.org/demos/']
+sources = [SOURCELOWER_TAR_XZ]
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('freetype', '2.13.2'),
+    ('pkgconf', '2.2.0'),
+    ('Meson', '1.4.0'),
+    ('Ninja', '1.12.1'),
+]
+
+dependencies = [
+    ('Mesa', '24.1.3'),
+    ('glew', '2.2.0', '-egl'),
+    ('libGLU', '9.0.3'),
+    ('freeglut', '3.6.0'),
+    ('DBus', '1.15.8'),
+    ('GTK+', '3.24.23'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/eglinfo', 'bin/glxinfo'],
+    'dirs': []
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
Topping up the version of `Mesa-demos` to v9.0.0 and adding the dependency module `glew/2.2.0-GCCcore-13.3.0-egl`. Building the latter with the recent GCCcore requires a new patch file to fix compilation errors.