### PR TITLE
Fix Perl-bundle-CPAN `IO::Socket::SSL` failing tests

### DIFF
--- a/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb
@@ -683,9 +683,15 @@ exts_list = [
         ],
     }),
     ('IO::Socket::SSL', '2.083', {
+        # Patch to fix OCSP stapling tests failing https://github.com/noxxi/p5-io-socket-ssl/issues/169
+        'patches': ['Perl-bundle-CPAN-IO-Socket-SSL-OCSP.patch'],
         'source_tmpl': 'IO-Socket-SSL-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SU/SULLR'],
-        'checksums': ['904ef28765440a97d8a9a0df597f8c3d7f3cb0a053d1b082c10bed03bc802069'],
+        'checksums': [
+            {'IO-Socket-SSL-2.083.tar.gz': '904ef28765440a97d8a9a0df597f8c3d7f3cb0a053d1b082c10bed03bc802069'},
+            {'Perl-bundle-CPAN-IO-Socket-SSL-OCSP.patch':
+             'c4d5e80d3681494f1a8e8d69b488df25e214ef2ce892a93f2b4381995f0d0478'},
+        ],
     }),
     ('Fennec::Lite', '0.004', {
         'source_tmpl': 'Fennec-Lite-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.38.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.38.0-GCCcore-13.2.0.eb
@@ -684,9 +684,15 @@ exts_list = [
         ],
     }),
     ('IO::Socket::SSL', '2.083', {
+        # Patch to fix OCSP stapling tests failing https://github.com/noxxi/p5-io-socket-ssl/issues/169
+        'patches': ['Perl-bundle-CPAN-IO-Socket-SSL-OCSP.patch'],
         'source_tmpl': 'IO-Socket-SSL-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SU/SULLR'],
-        'checksums': ['904ef28765440a97d8a9a0df597f8c3d7f3cb0a053d1b082c10bed03bc802069'],
+        'checksums': [
+            {'IO-Socket-SSL-2.083.tar.gz': '904ef28765440a97d8a9a0df597f8c3d7f3cb0a053d1b082c10bed03bc802069'},
+            {'Perl-bundle-CPAN-IO-Socket-SSL-OCSP.patch':
+             'c4d5e80d3681494f1a8e8d69b488df25e214ef2ce892a93f2b4381995f0d0478'},
+        ],
     }),
     ('Fennec::Lite', '0.004', {
         'source_tmpl': 'Fennec-Lite-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.38.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.38.2-GCCcore-13.3.0.eb
@@ -690,9 +690,15 @@ exts_list = [
         'checksums': ['9d7be8a56d1bedda05c425306cc504ba134307e0c09bda4a788c98744ebcd95d'],
     }),
     ('IO::Socket::SSL', '2.087', {
+        # Patch to fix OCSP stapling tests failing https://github.com/noxxi/p5-io-socket-ssl/issues/169
+        'patches': ['Perl-bundle-CPAN-IO-Socket-SSL-OCSP.patch'],
         'source_tmpl': 'IO-Socket-SSL-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SU/SULLR'],
-        'checksums': ['936a46c58312df272313fedb4bb39faea7481629c163d83a8cdd283a0e28c578'],
+        'checksums': [
+            {'IO-Socket-SSL-2.087.tar.gz': '936a46c58312df272313fedb4bb39faea7481629c163d83a8cdd283a0e28c578'},
+            {'Perl-bundle-CPAN-IO-Socket-SSL-OCSP.patch':
+             'c4d5e80d3681494f1a8e8d69b488df25e214ef2ce892a93f2b4381995f0d0478'},
+        ],
     }),
     ('Fennec::Lite', '0.004', {
         'source_tmpl': 'Fennec-Lite-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.40.0-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.40.0-GCCcore-14.2.0.eb
@@ -695,9 +695,15 @@ exts_list = [
         'checksums': ['9d7be8a56d1bedda05c425306cc504ba134307e0c09bda4a788c98744ebcd95d'],
     }),
     ('IO::Socket::SSL', '2.089', {
+        # Patch to fix OCSP stapling tests failing https://github.com/noxxi/p5-io-socket-ssl/issues/169
+        'patches': ['Perl-bundle-CPAN-IO-Socket-SSL-OCSP.patch'],
         'source_tmpl': 'IO-Socket-SSL-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/S/SU/SULLR'],
-        'checksums': ['f683112c1642967e9149f51ad553eccd017833b2f22eb23a9055609d2e3a14d1'],
+        'checksums': [
+            {'IO-Socket-SSL-2.089.tar.gz': 'f683112c1642967e9149f51ad553eccd017833b2f22eb23a9055609d2e3a14d1'},
+            {'Perl-bundle-CPAN-IO-Socket-SSL-OCSP.patch':
+             'c4d5e80d3681494f1a8e8d69b488df25e214ef2ce892a93f2b4381995f0d0478'},
+        ],
     }),
     ('Fennec::Lite', '0.004', {
         'source_tmpl': 'Fennec-Lite-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-IO-Socket-SSL-OCSP.patch
+++ b/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-IO-Socket-SSL-OCSP.patch
@@ -1,0 +1,20 @@
+Fix failing OCSP stapling test of `IO::Socket:SSL` extension after the www.chksum.de server disabled OCSP support.
+See: https://github.com/noxxi/p5-io-socket-ssl/issues/169
+https://github.com/noxxi/p5-io-socket-ssl/commit/58ad1d1672516d246f7536961c6ab320ffde1b8a
+This fix is included only from the 2.090 release of IO-Socket-SSL.
+
+--- a/t/external/fingerprint.pl
++++ b/t/external/fingerprint.pl
+@@ -8,10 +8,10 @@
+ # --- BEGIN-FINGERPRINTS ----
+ my $fingerprints= [
+   {
+-    _ => 'this should give us OCSP stapling',
++    _ => 'this should give us OCSP stapling - before LetsEncrypt had disabled OCSP support',
+     fingerprint => 'sha1$pub$39d64bbaea90c6035e25ff990ba4ce565350bac5',
+     host => 'www.chksum.de',
+-    ocsp => {
++    _disabled_ocsp => {
+               staple => 1
+             },
+     port => 443


### PR DESCRIPTION
The OCSP stapling tests run by the `IO::Socket::SSL` extension of `Perl-bundle-CPAN` started failing due to a change of behavior of the server contacted by these tests (see https://github.com/noxxi/p5-io-socket-ssl/issues/169).
A patch derived from https://github.com/noxxi/p5-io-socket-ssl/commit/58ad1d1672516d246f7536961c6ab320ffde1b8a is applied to avoid this issue.