### PR TITLE
Replace deprecated `usepolly` with `use_polly` in LLVM easyconfigs

### DIFF
--- a/easybuild/easyconfigs/l/LLVM/LLVM-11.1.0-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-11.1.0-GCCcore-10.3.0.eb
@@ -44,7 +44,7 @@ build_bolt = False
 build_openmp = False
 build_openmp_offload = False
 build_openmp_tools = False
-usepolly = False
+use_polly = False
 
 python_bindings = False
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-12.0.1-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-12.0.1-GCCcore-10.3.0.eb
@@ -47,7 +47,7 @@ build_bolt = False
 build_openmp = False
 build_openmp_offload = False
 build_openmp_tools = False
-usepolly = False
+use_polly = False
 
 python_bindings = False
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-12.0.1-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-12.0.1-GCCcore-11.2.0.eb
@@ -44,7 +44,7 @@ build_bolt = False
 build_openmp = False
 build_openmp_offload = False
 build_openmp_tools = False
-usepolly = False
+use_polly = False
 
 python_bindings = False
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-14.0.3-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-14.0.3-GCCcore-11.3.0.eb
@@ -49,7 +49,7 @@ build_bolt = False
 build_openmp = False
 build_openmp_offload = False
 build_openmp_tools = False
-usepolly = False
+use_polly = False
 
 python_bindings = False
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-14.0.6-GCCcore-12.2.0-llvmlite.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-14.0.6-GCCcore-12.2.0-llvmlite.eb
@@ -58,7 +58,7 @@ build_bolt = False
 build_openmp = False
 build_openmp_offload = False
 build_openmp_tools = False
-usepolly = False
+use_polly = False
 
 python_bindings = False
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-14.0.6-GCCcore-12.3.0-llvmlite.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-14.0.6-GCCcore-12.3.0-llvmlite.eb
@@ -60,7 +60,7 @@ build_bolt = False
 build_openmp = False
 build_openmp_offload = False
 build_openmp_tools = False
-usepolly = False
+use_polly = False
 
 python_bindings = False
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-14.0.6-GCCcore-13.2.0-llvmlite.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-14.0.6-GCCcore-13.2.0-llvmlite.eb
@@ -60,7 +60,7 @@ build_bolt = False
 build_openmp = False
 build_openmp_offload = False
 build_openmp_tools = False
-usepolly = False
+use_polly = False
 
 python_bindings = False
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-14.0.6-GCCcore-13.3.0-llvmlite.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-14.0.6-GCCcore-13.3.0-llvmlite.eb
@@ -60,7 +60,7 @@ build_bolt = False
 build_openmp = False
 build_openmp_offload = False
 build_openmp_tools = False
-usepolly = False
+use_polly = False
 
 python_bindings = False
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-15.0.5-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-15.0.5-GCCcore-12.2.0.eb
@@ -46,7 +46,7 @@ build_bolt = False
 build_openmp = False
 build_openmp_offload = False
 build_openmp_tools = False
-usepolly = False
+use_polly = False
 
 python_bindings = False
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-16.0.6-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-16.0.6-GCCcore-12.3.0.eb
@@ -46,7 +46,7 @@ build_bolt = False
 build_openmp = False
 build_openmp_offload = False
 build_openmp_tools = False
-usepolly = False
+use_polly = False
 
 python_bindings = False
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-16.0.6-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-16.0.6-GCCcore-13.2.0.eb
@@ -46,7 +46,7 @@ build_bolt = False
 build_openmp = False
 build_openmp_offload = False
 build_openmp_tools = False
-usepolly = False
+use_polly = False
 
 python_bindings = False
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0-minimal.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0-minimal.eb
@@ -47,7 +47,7 @@ build_bolt = False
 build_openmp = False
 build_openmp_offload = False
 build_openmp_tools = False
-usepolly = False
+use_polly = False
 
 python_bindings = False
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
@@ -63,7 +63,7 @@ build_bolt = True
 build_openmp = True
 build_openmp_offload = True
 build_openmp_tools = True
-usepolly = True
+use_polly = True
 
 python_bindings = True
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.7-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.7-GCCcore-13.3.0.eb
@@ -64,7 +64,7 @@ build_bolt = True
 build_openmp = True
 build_openmp_tools = True
 build_openmp_offload = True
-usepolly = True
+use_polly = True
 
 python_bindings = True
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-20.1.4-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-20.1.4-GCCcore-13.3.0.eb
@@ -64,7 +64,7 @@ build_bolt = True
 build_openmp = True
 build_openmp_tools = True
 build_openmp_offload = True
-usepolly = True
+use_polly = True
 
 python_bindings = True
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-20.1.5-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-20.1.5-GCCcore-13.2.0.eb
@@ -61,7 +61,7 @@ build_bolt = True
 build_openmp = True
 build_openmp_tools = True
 build_openmp_offload = True
-usepolly = True
+use_polly = True
 
 python_bindings = True
 

--- a/easybuild/easyconfigs/l/LLVM/LLVM-20.1.5-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-20.1.5-GCCcore-13.3.0.eb
@@ -64,7 +64,7 @@ build_bolt = True
 build_openmp = True
 build_openmp_tools = True
 build_openmp_offload = True
-usepolly = True
+use_polly = True
 
 python_bindings = True
 


### PR DESCRIPTION
requires: 
- [x] https://github.com/easybuilders/easybuild-easyblocks/pull/3812

(created using `eb --new-pr`)
