### PR TITLE
ensure that configure step of Zoltan uses an up-to-date `config.guess`

### DIFF
--- a/easybuild/easyconfigs/z/Zoltan/Zoltan-3.901-foss-2023a.eb
+++ b/easybuild/easyconfigs/z/Zoltan/Zoltan-3.901-foss-2023a.eb
@@ -22,6 +22,7 @@ dependencies = [
 ]
 
 preconfigopts = 'mkdir build && cd build &&'
+# use full path to make sure that the easyblock finds the configure command and obtains an updated config.guess
 configure_cmd = '%(start_dir)s/configure'
 configopts = ' '.join([
     '--enable-gzip',

--- a/easybuild/easyconfigs/z/Zoltan/Zoltan-3.901-foss-2023a.eb
+++ b/easybuild/easyconfigs/z/Zoltan/Zoltan-3.901-foss-2023a.eb
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 preconfigopts = 'mkdir build && cd build &&'
-configure_cmd = '../configure'
+configure_cmd = '%(start_dir)s/configure'
 configopts = ' '.join([
     '--enable-gzip',
     '--with-scotch',


### PR DESCRIPTION
A Zoltan build for EESSI on a Neoverse v1 node resulted in:
```
configure: error: cannot guess build type; you must specify one
```
(see https://github.com/EESSI/software-layer/pull/1113#issuecomment-2957964386)

Zoltan includes a very old `config.guess` (https://github.com/sandialabs/Zoltan/blob/v3.901/config/config.guess). Although EasyBuild should obtain a new version of this file, that's not being done here due to building in a subdirectory and using `configure_cmd = ../configure`:
```
preconfigopts = 'mkdir build && cd build &&'
configure_cmd = '../configure'
```

The `../configure` leads to `os.path.exists(configure_command)`  being False for this check, as that's being run in the root of the source dir: https://github.com/easybuilders/easybuild-easyblocks/blob/develop/easybuild/easyblocks/generic/configuremake.py#L314.

By using an absolute path to the configure script, the script is found and `self.determine_build_and_host_type()` will be called, which solves the issue.