### PR TITLE
add patch to fix support for non-x86_64 architectures for MEGAHIT 1.2.9

### DIFF
--- a/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.2.9-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.2.9-GCCcore-11.3.0.eb
@@ -11,7 +11,12 @@ toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 
 source_urls = ['https://github.com/voutcn/%(namelower)s/archive/']
 sources = ['v%(version)s.tar.gz']
-checksums = ['09026eb07cc4e2d24f58b0a13f7a826ae8bb73da735a47cb1cbe6e4693118852']
+patches = ['MEGAHIT-1.2.9_support-non-x86_64-architectures.patch']
+checksums = [
+    {'v1.2.9.tar.gz': '09026eb07cc4e2d24f58b0a13f7a826ae8bb73da735a47cb1cbe6e4693118852'},
+    {'MEGAHIT-1.2.9_support-non-x86_64-architectures.patch':
+     '0b346d653f44b82b78514853f65f0ac8bdbd4cbcda44cad61c261aa2eb92fbdb'},
+]
 
 builddependencies = [
     ('binutils', '2.38'),

--- a/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.2.9-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.2.9-GCCcore-12.2.0.eb
@@ -11,7 +11,12 @@ toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 
 source_urls = ['https://github.com/voutcn/%(namelower)s/archive/']
 sources = ['v%(version)s.tar.gz']
-checksums = ['09026eb07cc4e2d24f58b0a13f7a826ae8bb73da735a47cb1cbe6e4693118852']
+patches = ['MEGAHIT-1.2.9_support-non-x86_64-architectures.patch']
+checksums = [
+    {'v1.2.9.tar.gz': '09026eb07cc4e2d24f58b0a13f7a826ae8bb73da735a47cb1cbe6e4693118852'},
+    {'MEGAHIT-1.2.9_support-non-x86_64-architectures.patch':
+     '0b346d653f44b82b78514853f65f0ac8bdbd4cbcda44cad61c261aa2eb92fbdb'},
+]
 
 builddependencies = [
     ('binutils', '2.39'),

--- a/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.2.9-GCCcore-12.3.0-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.2.9-GCCcore-12.3.0-Python-2.7.18.eb
@@ -12,7 +12,12 @@ toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 
 source_urls = ['https://github.com/voutcn/%(namelower)s/archive/']
 sources = ['v%(version)s.tar.gz']
-checksums = ['09026eb07cc4e2d24f58b0a13f7a826ae8bb73da735a47cb1cbe6e4693118852']
+patches = ['MEGAHIT-1.2.9_support-non-x86_64-architectures.patch']
+checksums = [
+    {'v1.2.9.tar.gz': '09026eb07cc4e2d24f58b0a13f7a826ae8bb73da735a47cb1cbe6e4693118852'},
+    {'MEGAHIT-1.2.9_support-non-x86_64-architectures.patch':
+     '0b346d653f44b82b78514853f65f0ac8bdbd4cbcda44cad61c261aa2eb92fbdb'},
+]
 
 builddependencies = [
     ('binutils', '2.40'),

--- a/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.2.9-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.2.9-GCCcore-12.3.0.eb
@@ -11,7 +11,12 @@ toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 
 source_urls = ['https://github.com/voutcn/%(namelower)s/archive/']
 sources = ['v%(version)s.tar.gz']
-checksums = ['09026eb07cc4e2d24f58b0a13f7a826ae8bb73da735a47cb1cbe6e4693118852']
+patches = ['MEGAHIT-1.2.9_support-non-x86_64-architectures.patch']
+checksums = [
+    {'v1.2.9.tar.gz': '09026eb07cc4e2d24f58b0a13f7a826ae8bb73da735a47cb1cbe6e4693118852'},
+    {'MEGAHIT-1.2.9_support-non-x86_64-architectures.patch':
+     '0b346d653f44b82b78514853f65f0ac8bdbd4cbcda44cad61c261aa2eb92fbdb'},
+]
 
 builddependencies = [
     ('binutils', '2.40'),

--- a/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.2.9-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.2.9-GCCcore-13.3.0.eb
@@ -11,7 +11,12 @@ toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
 
 source_urls = ['https://github.com/voutcn/%(namelower)s/archive/']
 sources = ['v%(version)s.tar.gz']
-checksums = ['09026eb07cc4e2d24f58b0a13f7a826ae8bb73da735a47cb1cbe6e4693118852']
+patches = ['MEGAHIT-1.2.9_support-non-x86_64-architectures.patch']
+checksums = [
+    {'v1.2.9.tar.gz': '09026eb07cc4e2d24f58b0a13f7a826ae8bb73da735a47cb1cbe6e4693118852'},
+    {'MEGAHIT-1.2.9_support-non-x86_64-architectures.patch':
+     '0b346d653f44b82b78514853f65f0ac8bdbd4cbcda44cad61c261aa2eb92fbdb'},
+]
 
 builddependencies = [
     ('binutils', '2.42'),

--- a/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.2.9_support-non-x86_64-architectures.patch
+++ b/easybuild/easyconfigs/m/MEGAHIT/MEGAHIT-1.2.9_support-non-x86_64-architectures.patch
@@ -1,0 +1,73 @@
+From 4687e4f7284eff8806dbae5eb0b8df976fdfa2b8 Mon Sep 17 00:00:00 2001
+From: Martin Tzvetanov Grigorov <mgrigorov@apache.org>
+Date: Wed, 27 Mar 2024 15:07:02 +0200
+Subject: [PATCH] Add support for non-x86_64 architectures (e.g. Linux ARM64)
+
+Fixes https://github.com/voutcn/megahit/issues/320
+Based on: https://github.com/voutcn/megahit/pull/329
+
+Preserves the x86_64 specifics when building on x86_64 machine
+
+Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>
+---
+ CMakeLists.txt           | 8 ++++++--
+ src/kmlib/kmrns.h        | 2 ++
+ src/utils/cpu_dispatch.h | 6 ++++++
+ 3 files changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 172a03d..d21b2d3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -73,8 +73,12 @@ add_executable(megahit_core_popcnt ${OTHER_SOURCE} ${ASMBL_SOURCE} ${IDBA_SOURCE
+         ${CX1_SOURCE} ${TOOLKIT_SOURCE})
+ add_executable(megahit_core_no_hw_accel ${OTHER_SOURCE} ${ASMBL_SOURCE} ${IDBA_SOURCE} ${SDBG_SOURCE} ${LCASM_SOURCE}
+         ${SEQ_SOURCE} ${CX1_SOURCE} ${TOOLKIT_SOURCE})
+-set_target_properties(megahit_core PROPERTIES COMPILE_FLAGS "-mbmi2 -DUSE_BMI2 -mpopcnt")
+-set_target_properties(megahit_core_popcnt PROPERTIES COMPILE_FLAGS "-mpopcnt")
++
++if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(amd64)|(AMD64)")
++    set_target_properties(megahit_core PROPERTIES COMPILE_FLAGS "-mbmi2 -DUSE_BMI2 -mpopcnt")
++    set_target_properties(megahit_core_popcnt PROPERTIES COMPILE_FLAGS "-mpopcnt")
++endif ()
++
+ 
+ if (STATIC_BUILD)
+     # TODO dirty
+diff --git a/src/kmlib/kmrns.h b/src/kmlib/kmrns.h
+index 9f2e9dd..0352858 100644
+--- a/src/kmlib/kmrns.h
++++ b/src/kmlib/kmrns.h
+@@ -8,7 +8,9 @@
+ #include <stdint.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#if defined(__x86_64__)
+ #include <x86intrin.h>
++#endif
+ #include <vector>
+ 
+ namespace kmlib {
+diff --git a/src/utils/cpu_dispatch.h b/src/utils/cpu_dispatch.h
+index ec01bb6..44ba1e2 100644
+--- a/src/utils/cpu_dispatch.h
++++ b/src/utils/cpu_dispatch.h
+@@ -5,6 +5,7 @@
+ #ifndef MEGAHIT_CPU_DISPATCH_H
+ #define MEGAHIT_CPU_DISPATCH_H
+ 
++#if defined(__x86_64__)
+ inline bool HasPopcnt() {
+   unsigned eax, ebx, ecx, edx;
+ #ifdef _MSC_VER
+@@ -32,5 +33,10 @@ inline bool HasBmi2() {
+ #endif
+   return ebx >> 8U & 1U;
+ }
++#else
++inline bool HasPopcnt() { return false; }
++inline bool HasBmi2() { return false; }
++#endif
++
+ 
+ #endif  // MEGAHIT_CPU_DISPATCH_H


### PR DESCRIPTION
Building on for instance Arm fails, see https://github.com/EESSI/software-layer/pull/1117#issuecomment-2959836864. This patch is taken from https://github.com/voutcn/megahit/pull/368.