### PR TITLE
GCCcore 12-13: update `nvptx-tools` version to fix compatibility with CUDA 12

### DIFF
--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-12.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-12.1.0.eb
@@ -28,7 +28,7 @@ sources = [
     'mpc-1.2.1.tar.gz',
     'isl-0.24.tar.bz2',
     'newlib-4.1.0.tar.gz',
-    {'download_filename': '7292758.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
+    {'download_filename': '9962793.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
 ]
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-12.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-12.1.0.eb
@@ -28,7 +28,7 @@ sources = [
     'mpc-1.2.1.tar.gz',
     'isl-0.24.tar.bz2',
     'newlib-4.1.0.tar.gz',
-    {'download_filename': '7292758.tar.gz', 'filename': 'nvptx-tools-20220412.tar.gz'},
+    {'download_filename': '7292758.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
 ]
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
@@ -47,7 +47,7 @@ checksums = [
     {'mpc-1.2.1.tar.gz': '17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459'},
     {'isl-0.24.tar.bz2': 'fcf78dd9656c10eb8cf9fbd5f59a0b6b01386205fe1934b3b287a0a1898145c0'},
     {'newlib-4.1.0.tar.gz': 'f296e372f51324224d387cc116dc37a6bd397198756746f93a2b02e9a5d40154'},
-    {'nvptx-tools-20220412.tar.gz': '20e3c1eeae7f375c36455b6036c4801de16b854910ff54268bbd3346f3685080'},
+    {'nvptx-tools-20240419.tar.gz': 'a4f65efe0ba960d75a18741faf2b93dbf51c2492a53b734d590ce5da4bd3f237'},
     {'GCCcore-6.2.0-fix-find-isl.patch': '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68'},
     {'GCCcore-9.3.0_gmp-c99.patch': '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e'},
     {'GCCcore-12.1.0_allow-pragma-wself-init.patch':

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-12.2.0.eb
@@ -28,7 +28,7 @@ sources = [
     'mpc-1.2.1.tar.gz',
     'isl-0.24.tar.bz2',
     'newlib-4.1.0.tar.gz',
-    {'download_filename': '472b6e7.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
+    {'download_filename': '9962793.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
 ]
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-12.2.0.eb
@@ -28,7 +28,7 @@ sources = [
     'mpc-1.2.1.tar.gz',
     'isl-0.24.tar.bz2',
     'newlib-4.1.0.tar.gz',
-    {'download_filename': '472b6e7.tar.gz', 'filename': 'nvptx-tools-20220610.tar.gz'},
+    {'download_filename': '472b6e7.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
 ]
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
@@ -48,7 +48,7 @@ checksums = [
     {'mpc-1.2.1.tar.gz': '17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459'},
     {'isl-0.24.tar.bz2': 'fcf78dd9656c10eb8cf9fbd5f59a0b6b01386205fe1934b3b287a0a1898145c0'},
     {'newlib-4.1.0.tar.gz': 'f296e372f51324224d387cc116dc37a6bd397198756746f93a2b02e9a5d40154'},
-    {'nvptx-tools-20220610.tar.gz': '53e7973af841935490b8a7b9e4d1331f775589b54e21f9921f18589183fb9997'},
+    {'nvptx-tools-20240419.tar.gz': 'a4f65efe0ba960d75a18741faf2b93dbf51c2492a53b734d590ce5da4bd3f237'},
     {'GCCcore-6.2.0-fix-find-isl.patch': '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68'},
     {'GCCcore-9.3.0_gmp-c99.patch': '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e'},
     {'GCCcore-12.1.0_allow-pragma-wself-init.patch':

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-12.3.0.eb
@@ -28,7 +28,7 @@ sources = [
     'mpc-1.3.1.tar.gz',
     'isl-0.26.tar.bz2',
     'newlib-4.3.0.20230120.tar.gz',
-    {'download_filename': '93e0090.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
+    {'download_filename': '9962793.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
 ]
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-12.3.0.eb
@@ -28,7 +28,7 @@ sources = [
     'mpc-1.3.1.tar.gz',
     'isl-0.26.tar.bz2',
     'newlib-4.3.0.20230120.tar.gz',
-    {'download_filename': '93e0090.tar.gz', 'filename': 'nvptx-tools-20230122.tar.gz'},
+    {'download_filename': '93e0090.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
 ]
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
@@ -46,7 +46,7 @@ checksums = [
     {'mpc-1.3.1.tar.gz': 'ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8'},
     {'isl-0.26.tar.bz2': '5eac8664e9d67be6bd0bee5085d6840b8baf738c06814df47eaf4166d9776436'},
     {'newlib-4.3.0.20230120.tar.gz': '83a62a99af59e38eb9b0c58ed092ee24d700fff43a22c03e433955113ef35150'},
-    {'nvptx-tools-20230122.tar.gz': 'af05fac26e9a83d337758a5495dc35f7a7bbfd90cd09f4a5d3242d059f235e08'},
+    {'nvptx-tools-20240419.tar.gz': 'a4f65efe0ba960d75a18741faf2b93dbf51c2492a53b734d590ce5da4bd3f237'},
     {'GCCcore-6.2.0-fix-find-isl.patch': '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68'},
     {'GCCcore-9.3.0_gmp-c99.patch': '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e'},
     {'GCCcore-12.1.0_fix-double-destruct.patch': '2e09c125318b6c15ec60f1807d77fb7d1f32b64a4e5d1c9a3da89ba2ca738d35'},

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-13.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-13.1.0.eb
@@ -28,7 +28,7 @@ sources = [
     'mpc-1.3.1.tar.gz',
     'isl-0.26.tar.bz2',
     'newlib-4.3.0.20230120.tar.gz',
-    {'download_filename': '93e0090.tar.gz', 'filename': 'nvptx-tools-20230122.tar.gz'},
+    {'download_filename': '93e0090.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
 ]
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
@@ -45,7 +45,7 @@ checksums = [
     {'mpc-1.3.1.tar.gz': 'ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8'},
     {'isl-0.26.tar.bz2': '5eac8664e9d67be6bd0bee5085d6840b8baf738c06814df47eaf4166d9776436'},
     {'newlib-4.3.0.20230120.tar.gz': '83a62a99af59e38eb9b0c58ed092ee24d700fff43a22c03e433955113ef35150'},
-    {'nvptx-tools-20230122.tar.gz': 'af05fac26e9a83d337758a5495dc35f7a7bbfd90cd09f4a5d3242d059f235e08'},
+    {'nvptx-tools-20240419.tar.gz': 'a4f65efe0ba960d75a18741faf2b93dbf51c2492a53b734d590ce5da4bd3f237'},
     {'GCCcore-6.2.0-fix-find-isl.patch': '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68'},
     {'GCCcore-9.3.0_gmp-c99.patch': '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e'},
     {'GCCcore-12.1.0_fix-double-destruct.patch': '2e09c125318b6c15ec60f1807d77fb7d1f32b64a4e5d1c9a3da89ba2ca738d35'},

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-13.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-13.1.0.eb
@@ -28,7 +28,7 @@ sources = [
     'mpc-1.3.1.tar.gz',
     'isl-0.26.tar.bz2',
     'newlib-4.3.0.20230120.tar.gz',
-    {'download_filename': '93e0090.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
+    {'download_filename': '9962793.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
 ]
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-13.2.0.eb
@@ -28,7 +28,7 @@ sources = [
     'mpc-1.3.1.tar.gz',
     'isl-0.26.tar.bz2',
     'newlib-4.3.0.20230120.tar.gz',
-    {'download_filename': '2c6d503.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
+    {'download_filename': '9962793.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
 ]
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-13.2.0.eb
@@ -28,7 +28,7 @@ sources = [
     'mpc-1.3.1.tar.gz',
     'isl-0.26.tar.bz2',
     'newlib-4.3.0.20230120.tar.gz',
-    {'download_filename': '2c6d503.tar.gz', 'filename': 'nvptx-tools-20230725.tar.gz'},
+    {'download_filename': '2c6d503.tar.gz', 'filename': 'nvptx-tools-20240419.tar.gz'},
 ]
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
@@ -46,7 +46,7 @@ checksums = [
     {'mpc-1.3.1.tar.gz': 'ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8'},
     {'isl-0.26.tar.bz2': '5eac8664e9d67be6bd0bee5085d6840b8baf738c06814df47eaf4166d9776436'},
     {'newlib-4.3.0.20230120.tar.gz': '83a62a99af59e38eb9b0c58ed092ee24d700fff43a22c03e433955113ef35150'},
-    {'nvptx-tools-20230725.tar.gz': '17ce1f2c64f09c6f1cb709e3af869bb90b0102c412f25da55f338e35bc74b2e2'},
+    {'nvptx-tools-20240419.tar.gz': 'a4f65efe0ba960d75a18741faf2b93dbf51c2492a53b734d590ce5da4bd3f237'},
     {'GCCcore-6.2.0-fix-find-isl.patch': '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68'},
     {'GCCcore-9.3.0_gmp-c99.patch': '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e'},
     {'GCCcore-12.1.0_fix-double-destruct.patch': '2e09c125318b6c15ec60f1807d77fb7d1f32b64a4e5d1c9a3da89ba2ca738d35'},


### PR DESCRIPTION
Fixes #23074

GCCcore 12.x, 13.1, 13.2 builds failed when using CUDA 12 due to the `sm_35` gpu-name flag not being recognized.
[CUDA 12](https://docs.nvidia.com/cuda/archive/12.0.0/cuda-toolkit-release-notes/#cuda-libraries) libraries removed support for compute capabilities `sm_35` and `sm_37`.
The `nvtx-tools` package used by `GCCcore` introduced a [fix](https://github.com/SourceryTools/nvptx-tools/commit/13216705844e5d7c9d20b4e34f89a39017e191d4#diff-5d92d01a011b195a642f1fc5b9704a1b2dea168a392c9ad3a4c1a56720ee52bc) bumping the baseline architecture from `sm_35` to `sm_50`.

Therefore, the version of `nvtx-tools` installed by `GCCcore` is updated to `20240419`, the same used by GCCcore 13.3.