### PR TITLE
Fix failing contourpy installation in matplotlib-3.7.2-iimkl-2023a with rpath (EB5 default)

### DIFF
--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-3.7.2-iimkl-2023a.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-3.7.2-iimkl-2023a.eb
@@ -54,7 +54,6 @@ exts_list = [
             {'kiwisolver-1.4.4-fix_version.patch': '6753afbb3a88856493fcfa0b33989f35742f57bfd41ff3b7f71a98797e1bfbd0'},
         ],
     }),
-
     ('contourpy', '1.1.0', {
         # ignore linker flags at compile-time - fix icpx errors
         'preinstallopts': 'export CXXFLAGS="$CXXFLAGS -Qunused-arguments" && ',

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-3.7.2-iimkl-2023a.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-3.7.2-iimkl-2023a.eb
@@ -54,7 +54,10 @@ exts_list = [
             {'kiwisolver-1.4.4-fix_version.patch': '6753afbb3a88856493fcfa0b33989f35742f57bfd41ff3b7f71a98797e1bfbd0'},
         ],
     }),
+
     ('contourpy', '1.1.0', {
+        # ignore linker flags at compile-time - fix icpx errors
+        'preinstallopts': 'export CXXFLAGS="$CXXFLAGS -Qunused-arguments" && ',
         'checksums': ['e53046c3863828d21d531cc3b53786e6580eb1ba02477e8681009b6aa0870b21'],
     }),
     (name, version, {


### PR DESCRIPTION
For https://github.com/vscentrum/vsc-software-stack/issues/563
```
FAILED: src/_contourpy.cpython-311-x86_64-linux-gnu.so.p/line_type.cpp.o
      icpx: error: -Wl,-rpath=~/matplotlib/3.7.2-iimkl-2023a/lib: 'linker' input unused [-Werror,-Wunused-command-line-argument]
      icpx: error: -Wl,-rpath=~/matplotlib/3.7.2-iimkl-2023a/lib64: 'linker' input unused [-Werror,-Wunused-command-line-argument]
      icpx: error: -Wl,-rpath=$ORIGIN: 'linker' input unused [-Werror,-Wunused-command-line-argument]
      icpx: error: -Wl,-rpath=$ORIGIN/../lib: 'linker' input unused [-Werror,-Wunused-command-line-argument]
      icpx: error: -Wl,-rpath=$ORIGIN/../lib64: 'linker' input unused [-Werror,-Wunused-command-line-argument]
      icpx: error: -Wl,--disable-new-dtags: 'linker' input unused [-Werror,-Wunused-command-line-argument]
```