### PR TITLE
{bio}[gompi/2024a] DaliLite 5 using DSSP

### DIFF
--- a/easybuild/easyconfigs/d/DaliLite/DaliLite-5.0-gompi-2024a.eb
+++ b/easybuild/easyconfigs/d/DaliLite/DaliLite-5.0-gompi-2024a.eb
@@ -28,7 +28,8 @@ dependencies = [
 build_cmd = ' cd %(builddir)s/%(name)s.v%(version_major)s/bin && '
 build_cmd += ' sed -i \'s/DSSP_EXE=".*"/DSSP_EXE="mkdssp --output-format=dssp"/\' mpidali.pm &&'
 build_cmd += ' make clean && '
-build_cmd += ' make OPENMPI_PATH=$EBROOTOPENMPI/bin '
+build_cmd += ' make && '
+build_cmd += ' make CFLAGS="${FCFLAGS} -std=legacy -fallow-argument-mismatch" OPENMPI_PATH=$EBROOTOPENMPI/bin parallel '
 
 # Installation
 _bin_files = ['dsspcmbi', 'filter95fitz', 'fssp', 'pipe', 'pipedccp', 'puu', 'puutos',

--- a/easybuild/easyconfigs/d/DaliLite/DaliLite-5.0-gompi-2024a.eb
+++ b/easybuild/easyconfigs/d/DaliLite/DaliLite-5.0-gompi-2024a.eb
@@ -32,7 +32,7 @@ build_cmd += ' make && '
 build_cmd += ' make CFLAGS="${FCFLAGS} -std=legacy -fallow-argument-mismatch" OPENMPI_PATH=$EBROOTOPENMPI/bin parallel '
 
 # Installation
-_bin_files = ['dsspcmbi', 'filter95fitz', 'fssp', 'pipe', 'pipedccp', 'puu', 'puutos',
+_bin_files = ['dsspcmbi', 'filter95fitz', 'fssp', 'mpicompare', 'pipe', 'pipedccp', 'puu', 'puutos',
               'selfdccp', 'serialcompare']
 _perl_scripts = ['applymatrix.pl', 'dali.pl', 'dat2fasta.pl', 'dccp2dalicon.pl', 'fsspfilter.pl',
                  'fsspselect.pl', 'htmljs.pl', 'import.pl', 'pipe96-free.pl', 'pipe96.pl', 'sortdccp.pl']


### PR DESCRIPTION
An update of DaliLite. This EC file is to make DaliLite use DSSP as indicated in [the document](http://ekhidna2.biocenter.helsinki.fi/dali/README.v5.html).

NOTE: I created one previous PR of about the same thing for older toolchain weeks ago ( https://github.com/easybuilders/easybuild-easyconfigs/pull/22767 ). It is hard for me to rebase (or something like that) that branch to current develop so I created this one. Would close the old PR later.