### PR TITLE
{tools}[GCCcore/14.2.0] SPIRV-tools v2025.1

### DIFF
--- a/easybuild/easyconfigs/s/SPIRV-tools/SPIRV-tools-2025.1-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/s/SPIRV-tools/SPIRV-tools-2025.1-GCCcore-14.2.0.eb
@@ -1,7 +1,7 @@
 easyblock = 'CMakeMake'
 
 name = 'SPIRV-tools'
-version = '2024.3'
+version = '2025.1'
 
 homepage = 'https://github.com/KhronosGroup/SPIRV-Tools'
 description = '''The SPIR-V Tools project provides an API and commands for processing SPIR-V modules.
@@ -15,12 +15,12 @@ toolchain = {'name': 'GCCcore', 'version': '14.2.0'}
 toolchainopts = {'pic': True, 'openmp': True, 'cstd': 'c++17'}
 
 # From https://github.com/KhronosGroup/SPIRV-Tools/blob/v2024.3/DEPS
-local_spirv_headers_commit = '2acb319af38d43be3ea76bfabf3998e5281d8d12'
-local_googletest_commit = '1d17ea141d2c11b8917d2c7d029f1c4e2b9769b2'
-local_google_effcee_commit = 'd74d33d93043952a99ae7cd7458baf6bc8df1da0'
-local_google_re2_commit = '4a8cee3dd3c3d81b6fe8b867811e193d5819df07'
+local_spirv_headers_commit = '09913f088a1197aba4aefd300a876b2ebbaa3391'
+local_googletest_commit = 'c00fd25b71a17e645e4567fcb465c3fa532827d2'
+local_google_effcee_commit = '12241cbc30f20730b656db7fd5a3fa36cd420843'
+local_google_re2_commit = '6dcd83d60f7944926bfd308cc13979fc53dd69ca'
 local_protobuf_commit = 'f0dc78d7e6e331b8c6bb2d5283e06aa26883ca7c'  # Equivalent to tag v21.12
-local_abseil_commit = '1315c900e1ddbb08a23e06eeb9a06450052ccb5e'
+local_abseil_commit = 'f004e6c0a9a25e16fd2a1ae671a9cacfa79625b4'
 
 local_github_repos = [
     ('KhronosGroup', 'SPIRV-Headers', local_spirv_headers_commit, 'spirv-headers'),
@@ -43,13 +43,13 @@ sources = [
     }
 ]
 checksums = [
-    {'SPIRV-tools-2024.3.tar.gz': '3961edff3410599112a50bfcda2d4a828f7cb12e8294ee0f6169976ef0532b83'},
-    {'SPIRV-Headers-2acb319a.tar.xz': 'dd0642dd9525c813864ff198f5a6a901426c589e7b532d855b1ca78e76524844'},
-    {'googletest-1d17ea14.tar.xz': '7a275798ac4580ea1e35dea33aac636e2564806029abe1b19c9cdd47331c14c9'},
-    {'effcee-d74d33d9.tar.xz': '40903cf0448205dab05d918aa8c7a32a816f287e7788424dd03a3ace8e2f48cf'},
-    {'re2-4a8cee3d.tar.xz': '10c5b56e9cf1d70e13c59eaf33adc092abd16bfc9b2538b307e91cae886231d5'},
+    {'SPIRV-tools-2025.1.tar.gz': '6a9313fa68e061d463f616357cd24cdf1c3a27d906ea791d7ba67dd1b6666a40'},
+    {'SPIRV-Headers-09913f08.tar.xz': 'ba3de7e2e702ea370362d230c4dfaa2a01a3a1c19179a0651a33500b188ee5ca'},
+    {'googletest-c00fd25b.tar.xz': '8cf00043d0c9084341e631f459946a10da48cabbd45002208edadcd24dad5810'},
+    {'effcee-12241cbc.tar.xz': '6198a8656cbc98037ba351c4d972ca742ec19148162da89ad1b2e875a304d8bb'},
+    {'re2-6dcd83d6.tar.xz': '58051b8e0b230f0795212f8a5a4391c423f0d102a28dba2b2a80d7fdc44fee42'},
     {'protobuf-f0dc78d7.tar.xz': 'edfca29ce9ea890de8f6fbd17cab3a1020d48f99aa354f666926bf466730704a'},
-    {'abseil-cpp-1315c900.tar.xz': '96aafd90b43298877a5e24a2cedd42a0fa8a8c5b7ce7bab8cde1bdb2ac9190b2'},
+    {'abseil-cpp-f004e6c0.tar.xz': '08970163ac291ee954242c196f77c529aaebf74ddb3a1765a334f68ca445e16d'},
 ]
 
 local_ext_dir = '%(builddir)s/spirv-tools/external'


### PR DESCRIPTION
Added EC and patches for SPIRV-tools

Requires:
- https://github.com/easybuilders/easybuild-easyconfigs/pull/23175