### PR TITLE
include `intel-compilers` in the toolchain multi-variant checks

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -53,7 +53,6 @@ from easybuild.framework.easyconfig.parser import (
 )
 from easybuild.framework.easyconfig.tools import check_sha256_checksums, dep_graph, get_paths_for, process_easyconfig
 from easybuild.tools import config, LooseVersion
-from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import GENERAL_CLASS, build_option
 from easybuild.tools.filetools import change_dir, is_generic_easyblock, read_file, remove_file
 from easybuild.tools.filetools import verify_checksum, which, write_file
@@ -724,31 +723,13 @@ class EasyConfigTest(TestCase):
             if len(v2_dep_vars) == 1 and len(v3_dep_vars) == 1:
                 res = True
 
-        # two variants is OK if one is for Python 2.x and the other is for Python 3.x (based on versionsuffix)
+        # two variants is OK if one is for Python 2.x and the other is for Python 3.x
         elif len(dep_vars) == 2:
+            # there's no versionsuffix anymore for Python 3, but we still allow variants depending on Python 2.x + 3.x
             py2_dep_vars = [x for x in dep_vars.keys() if '; versionsuffix: -Python-2.' in x]
-            py3_dep_vars = [x for x in dep_vars.keys() if '; versionsuffix: -Python-3.' in x]
+            py3_dep_vars = [x for x in dep_vars.keys() if x.strip().endswith('; versionsuffix:')]
             if len(py2_dep_vars) == 1 and len(py3_dep_vars) == 1:
                 res = True
-
-            # for recent generations, there's no versionsuffix anymore for Python 3,
-            # but we still allow variants depending on Python 2.x + 3.x
-            is_recent_gen = False
-            full_toolchain_regex = re.compile(r'^20[1-9][0-9][ab]$')
-            gcc_toolchain_regex = re.compile(r'^GCC(core)?-[0-9]?[0-9]\.[0-9]$')
-            if full_toolchain_regex.match(gen):
-                is_recent_gen = LooseVersion(gen) >= LooseVersion('2020b')
-            elif gcc_toolchain_regex.match(gen):
-                genver = gen.split('-', 1)[1]
-                is_recent_gen = LooseVersion(genver) >= LooseVersion('10.2')
-            else:
-                raise EasyBuildError("Unknown type of toolchain generation: %s" % gen)
-
-            if is_recent_gen:
-                py2_dep_vars = [x for x in dep_vars.keys() if '; versionsuffix: -Python-2.' in x]
-                py3_dep_vars = [x for x in dep_vars.keys() if x.strip().endswith('; versionsuffix:')]
-                if len(py2_dep_vars) == 1 and len(py3_dep_vars) == 1:
-                    res = True
 
         return res
 
@@ -874,18 +855,7 @@ class EasyConfigTest(TestCase):
             ],
         }))
 
-        # two variants is OK, if they're for Python 2.x and 3.x
-        self.assertTrue(self.check_dep_vars('2020a', 'Python', {
-            'version: 2.7.18; versionsuffix:': ['SciPy-bundle-2020.03-foss-2020a-Python-2.7.18.eb'],
-            'version: 3.8.2; versionsuffix:': ['SciPy-bundle-2020.03-foss-2020a-Python-3.8.2.eb'],
-        }))
-
-        self.assertTrue(self.check_dep_vars('2020a', 'SciPy-bundle', {
-            'version: 2020.03; versionsuffix: -Python-2.7.18': ['matplotlib-3.2.1-foss-2020a-Python-2.7.18.eb'],
-            'version: 2020.03; versionsuffix: -Python-3.8.2': ['matplotlib-3.2.1-foss-2020a-Python-3.8.2.eb'],
-        }))
-
-        # for recent easyconfig generations, there's no versionsuffix anymore for Python 3
+        # two variants is OK, if they're for Python 2.x and 3.x, there's no versionsuffix anymore for Python 3
         self.assertTrue(self.check_dep_vars('2020b', 'Python', {
             'version: 2.7.18; versionsuffix:': ['SciPy-bundle-2020.11-foss-2020b-Python-2.7.18.eb'],
             'version: 3.8.6; versionsuffix:': ['SciPy-bundle-2020.11-foss-2020b.eb'],
@@ -899,12 +869,6 @@ class EasyConfigTest(TestCase):
         self.assertTrue(self.check_dep_vars('2020b', 'SciPy-bundle', {
             'version: 2020.11; versionsuffix: -Python-2.7.18': ['matplotlib-3.3.3-foss-2020b-Python-2.7.18.eb'],
             'version: 2020.11; versionsuffix:': ['matplotlib-3.3.3-foss-2020b.eb'],
-        }))
-
-        # not allowed for older generations (foss/intel 2020a or older, GCC(core) 10.1.0 or older)
-        self.assertFalse(self.check_dep_vars('2020a', 'SciPy-bundle', {
-            'version: 2020.03; versionsuffix: -Python-2.7.18': ['matplotlib-3.2.1-foss-2020a-Python-2.7.18.eb'],
-            'version: 2020.03; versionsuffix:': ['matplotlib-3.2.1-foss-2020a.eb'],
         }))
 
         # multiple dependency variants of specific software is OK, but only if indicated via versionsuffix
@@ -972,6 +936,8 @@ class EasyConfigTest(TestCase):
             # compiler-only subtoolchains GCCcore, this pattern has never checked GCC toolchains
             # retain the check as it has always been in the old generation check
             r'GCCcore-1(0\.3|[12]\.[0-9])',  # GCCcore 10.3 to 12.3
+            # intel-compilers
+            r'intel-compilers-202([0-2]\.[0-9]|3\.[01])',  # intel-compilers up to 2023.1
             # full toolchains, like foss/2021a or intel/2022b
             r'202([12][ab]|3a)',  # 2021a to 2023a
         ]
@@ -1062,6 +1028,29 @@ class EasyConfigTest(TestCase):
             '15.1': None,
         }
 
+        # map intel-compilers to toolchain generations
+        # only for recent generations, where we want to limit dependency variants as much as possible
+        # across all easyconfigs of that generation (regardless of whether a full toolchain or subtoolchain is used);
+        # see https://docs.easybuild.io/common-toolchains/#common_toolchains_overview
+        ic_tc_gen_map = {
+            '2021.2.0': '2021a',
+            '2021.3.0': None,
+            '2021.4.0': '2021b',
+            '2022.0.1': None,
+            '2022.0.2': None,
+            '2022.1.0': '2022a',
+            '2022.2.0': None,
+            '2022.2.1': '2022b',
+            '2023.0.0': None,
+            '2023.1.0': '2023a',
+            '2023.2.1': '2023b',
+            '2024.0.0': None,
+            '2024.2.0': '2024a',
+            '2025.0.0': None,
+            '2025.1.0': None,
+            '2025.1.1': '2025a',
+        }
+
         multi_dep_vars_msg = ''
         # restrict to checking dependencies of easyconfigs using common toolchains,
         # and GCCcore subtoolchain for common toolchains;
@@ -1069,6 +1058,8 @@ class EasyConfigTest(TestCase):
         patterns = [
             # compiler-only subtoolchains GCCcore and GCC
             r'GCC(core)?-1[3-9]\.[0-9]\.',  # GCCcore 13.x & newer
+            # intel-compilers
+            r'intel-compilers-202(3\.2|[4-9]\.[0-9])\.[0-9]',  # intel-compilers from 2023.2
             # full toolchains, like foss/2022b or intel/2023a
             r'20(23b|(2[4-9]|[3-9][0-9])[ab])',  # 2023b and newer
         ]
@@ -1094,9 +1085,17 @@ class EasyConfigTest(TestCase):
                         gcc_ver = tc_gen.split('-', 1)[1].rstrip('.')
                         if gcc_ver in gcc_tc_gen_map and gcc_tc_gen_map[gcc_ver] is not None:
                             tc_gen = gcc_tc_gen_map[gcc_ver]
-                        elif LooseVersion(gcc_ver) >= LooseVersion('10.2') and gcc_ver not in gcc_tc_gen_map:
+                        elif gcc_ver not in gcc_tc_gen_map:
                             # for recent GCC versions, we really want to have a mapping in place...
                             self.fail("No mapping for GCC(core) %s to toolchain generation!" % gcc_ver)
+
+                    if tc_gen.startswith('intel-compilers'):
+                        ic_ver = tc_gen.split('-')[2]
+                        if ic_ver in ic_tc_gen_map and ic_tc_gen_map[ic_ver] is not None:
+                            tc_gen = ic_tc_gen_map[ic_ver]
+                        elif ic_ver not in ic_tc_gen_map:
+                            # for recent intel-compilers versions, we really want to have a mapping in place...
+                            self.fail("No mapping for intel-compilers %s to toolchain generation!" % ic_ver)
 
                     if ec_deps is None:
                         ec_deps = get_deps_for(ec)


### PR DESCRIPTION
This adds the full toolchain generation test for `intel/2023b` and newer (`intel-compilters/2023.2.1`. For the older `intel-compilers` the checks are just inside the toolchain (and not toolchain generation).

The way this has been added it does check that we use the same version for both `intel` and `foss`.