### PR TITLE
Update HDF5-1.14.0-iimpi-2022b.eb - update name of updated exec h5cc in postinstallcmds

### DIFF
--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.14.0-iimpi-2022b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.14.0-iimpi-2022b.eb
@@ -15,7 +15,7 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['a571cc83efda62e1a51a0a912dd916d01895801c5025af91669484a1575a6ef4']
 
 _regex = 's, -I[^[:space:]]+H5FDsubfiling , -I%(installdir)s/include ,g'
-postinstallcmds = ['sed -i -r "%s" %%(installdir)s/bin/%s' % (_regex, x) for x in ['h5c++', 'h5pcc']]
+postinstallcmds = ['sed -i -r "%s" %%(installdir)s/bin/%s' % (_regex, x) for x in ['h5c++', 'h5cc']]
 
 dependencies = [
     ('zlib', '1.2.12'),


### PR DESCRIPTION
Discussed here:
- https://github.com/easybuilders/easybuild-easyconfigs/pull/17469#issuecomment-3008824817