### PR TITLE
Adding Pyomo v6.9.2 for 2024a

### DIFF
--- a/easybuild/easyconfigs/p/Pyomo/Pyomo-6.9.2-gompi-2024a.eb
+++ b/easybuild/easyconfigs/p/Pyomo/Pyomo-6.9.2-gompi-2024a.eb
@@ -1,0 +1,33 @@
+easyblock = 'PythonBundle'
+
+name = 'Pyomo'
+version = '6.9.2'
+
+homepage = 'https://www.pyomo.org/'
+description = """ Pyomo is a Python-based open-source software package that supports a diverse set of optimization
+ capabilities for formulating and analyzing optimization models. """
+
+toolchain = {'name': 'gompi', 'version': '2024a'}
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('Python-bundle-PyPI', '2024.06'),
+    ('mpi4py', '4.0.1'),
+    ('PLY', '3.11'),
+]
+
+exts_list = [
+    ('PyUtilib', '6.0.0', {
+        'preinstallopts': """sed -i "s/'nose',//g" setup.py && """,
+        'checksums': ['d3c14f8ed9028a831b2bf51b8ab7776eba87e66cfc58a06b99c359aaa640f040'],
+    }),
+    (name, version, {
+        'source_urls': ['https://github.com/%(name)s/%(namelower)s/archive/refs/tags/'],
+        'sources': ['%(version)s.tar.gz'],
+        'checksums': ['bc19ef93305795fc386e115b984b248da507e19c12a58c14027eb8c09c509227'],
+    }),
+]
+
+sanity_check_commands = ['pyomo -h']
+
+moduleclass = 'math'


### PR DESCRIPTION
For this new version of Pyomo, I switch to `gompi` instead of `foss` (as in the older versions).