### PR TITLE
Add missing Python dependency to rocm-smi

### DIFF
--- a/easybuild/easyconfigs/r/rocm-smi/rocm-smi-4.5.0-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/r/rocm-smi/rocm-smi-4.5.0-GCCcore-11.2.0.eb
@@ -22,6 +22,10 @@ builddependencies = [
     ('CMake', '3.21.1'),
 ]
 
+dependencies = [
+    ('Python', '3.9.6'),  # Needed as rocm-smi is a python script
+]
+
 # This package hardcodes 'noexecheap' as a linker flag which is not supported
 # by 'ld.gold', to get around we explicitly force 'ld.bfd' here
 configopts = "-DCMAKE_CXX_FLAGS='-fuse-ld=bfd'"

--- a/easybuild/easyconfigs/r/rocm-smi/rocm-smi-5.4.4-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/r/rocm-smi/rocm-smi-5.4.4-GCCcore-11.3.0.eb
@@ -21,6 +21,10 @@ builddependencies = [
     ('CMake', '3.23.1'),
 ]
 
+dependencies = [
+    ('Python', '3.10.4'),  # Needed as rocm-smi is a python script
+]
+
 sanity_check_paths = {
     'files': ['bin/rocm-smi'],
     'dirs': [],

--- a/easybuild/easyconfigs/r/rocm-smi/rocm-smi-5.6.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/r/rocm-smi/rocm-smi-5.6.0-GCCcore-11.3.0.eb
@@ -28,6 +28,10 @@ builddependencies = [
     ('CMake', '3.23.1'),
 ]
 
+dependencies = [
+    ('Python', '3.10.4'),  # Needed as rocm-smi is a python script
+]
+
 # This package hardcodes 'noexecheap' as a linker flag which is not supported
 # by 'ld.gold', to get around we explicitly force 'ld.bfd' here
 configopts = "-DCMAKE_CXX_FLAGS='-fuse-ld=bfd' -DENABLE_DOCS=OFF"


### PR DESCRIPTION
rocm_smi_lib is a C/C++ library, but the binary is a Python wrapper around it. To avoid issues with the incorrect Python being used, add an explicit Python dependency.

See https://github.com/easybuilders/easybuild-easyconfigs/pull/23280#discussion_r2182488862 for more information