### PR TITLE
add patch to build versioned shared libraries in ecCodes v2.38.3

### DIFF
--- a/easybuild/easyconfigs/e/ecCodes/ecCodes-2.35.0_soversion.patch
+++ b/easybuild/easyconfigs/e/ecCodes/ecCodes-2.35.0_soversion.patch
@@ -1,0 +1,25 @@
+From: https://src.fedoraproject.org/rpms/eccodes/raw/epel8/f/eccodes-soversion.patch
+Add SOVERSION to CMakeLists library targets
+--- eccodes-2.35.0-Source.unchanged/fortran/CMakeLists.txt	2024-04-11 12:13:21.000000000 +0200
++++ eccodes-2.35.0-Source/fortran/CMakeLists.txt	2024-05-04 16:18:42.732436699 +0200
+@@ -46,7 +46,8 @@ if( HAVE_FORTRAN )
+                          GENERATED       grib_f90.f90 eccodes_f90.f90
+                          PUBLIC_INCLUDES $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>
+                                          $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
+-                         PRIVATE_LIBS    eccodes ${ECCODES_PTHREADS_LIBRARIES} )
++                         PRIVATE_LIBS    eccodes ${ECCODES_PTHREADS_LIBRARIES}
++                         SOVERSION       ${ECCODES_SOVERSION_F90})
+ 
+     if( DEFINED ecbuild_VERSION AND NOT ${ecbuild_VERSION} VERSION_LESS 3.1 )
+         # Installed module directory is not in the PUBLIC INCLUDES!
+--- eccodes-2.35.0-Source.unchanged/src/CMakeLists.txt	2024-04-11 12:13:21.000000000 +0200
++++ eccodes-2.35.0-Source/src/CMakeLists.txt	2024-05-04 16:18:42.733436675 +0200
+@@ -416,6 +416,8 @@ ecbuild_add_library( TARGET    eccodes
+                      PRIVATE_LIBS ${ECCODES_EXTRA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${AEC_LIBRARIES} ${PNG_LIBRARIES}
+                      PUBLIC_LIBS  ${CMATH_LIBRARIES} ${THREADS_LIBRARIES}
+                      TEMPLATES ${eccodes_extra_src_files}
++                     SOVERSION ${ECCODES_SOVERSION}
++
+                      INSTALL_HEADERS_LIST
+                               grib_api.h
+                               eccodes.h

--- a/easybuild/easyconfigs/e/ecCodes/ecCodes-2.38.3-gompi-2024a.eb
+++ b/easybuild/easyconfigs/e/ecCodes/ecCodes-2.38.3-gompi-2024a.eb
@@ -12,8 +12,12 @@ toolchain = {'name': 'gompi', 'version': '2024a'}
 toolchainopts = {'usempi': False}
 
 source_urls = ['https://github.com/ecmwf/eccodes/archive/refs/tags/']
-sources = [{'download_filename': '%(version)s.tar.gz', 'filename': '%(namelower)s-%(version)s.tar.gz'}]
-checksums = ['2f13adc4fbdfa3ea11f75ce4ed8937bf40a8fcedd760a519b15e4e17dedc9424']
+sources = [{'download_filename': '%(version)s.tar.gz', 'filename': SOURCELOWER_TAR_GZ}]
+patches = ['%(name)s-2.35.0_soversion.patch']
+checksums = [
+    {'eccodes-2.38.3.tar.gz': '2f13adc4fbdfa3ea11f75ce4ed8937bf40a8fcedd760a519b15e4e17dedc9424'},
+    {'ecCodes-2.35.0_soversion.patch': '8f63b0cd28ba92445dacd75c3d33442b3a06fb929292971116b55bad0e4ea176'},
+]
 
 builddependencies = [
     ('CMake', '3.29.3'),
@@ -28,18 +32,41 @@ dependencies = [
     ('libaec', '1.1.3'),
 ]
 
+# Debian currently versions as 0, RHEL as 0.1
+# So lets go with 0.1 and create the libfoo.0 symlink later
+_soversion = '0.1'
+_soversion_f90 = '0.1'
 # Python bindings are provided by a separate package 'eccodes-python'
-configopts = "-DENABLE_NETCDF=ON -DENABLE_PNG=ON -DENABLE_PYTHON=OFF -DENABLE_JPG=ON "
-configopts += "-DENABLE_JPG_LIBJASPER=ON -DENABLE_ECCODES_THREADS=ON"
+_copts = [
+    "-DENABLE_NETCDF=ON",
+    "-DENABLE_PNG=ON",
+    "-DENABLE_PYTHON=OFF",
+    "-DENABLE_JPG=ON",
+    "-DENABLE_JPG_LIBJASPER=ON",
+    "-DENABLE_ECCODES_THREADS=ON",
+    f"-DECCODES_SOVERSION={_soversion}",
+    f"-DECCODES_SOVERSION_F90={_soversion_f90}",
+]
+configopts = " ".join(_copts)
 
+# add symlinks for libfoo.X -> libfoo.X.Y
+_post_install_cmds = [
+    'cd %(installdir)s/lib',
+    f'ln -s lib%(namelower)s.{SHLIB_EXT}.{_soversion} lib%(namelower)s.{SHLIB_EXT}.{_soversion[0]}',
+    f'ln -s lib%(namelower)s_f90.{SHLIB_EXT}.{_soversion} lib%(namelower)s_f90.{SHLIB_EXT}.{_soversion[0]}'
+]
+postinstallcmds = [' && '.join(_post_install_cmds)]
+
+_files = ['bufr_compare', 'bufr_dump', 'bufr_ls', 'codes_info', 'grib_compare', 'grib_filter', 'grib_index_build',
+          'grib_to_netcdf', 'gts_dump', 'metar_compare', 'metar_get', 'bufr_compare_dir', 'bufr_filter', 'bufr_set',
+          'codes_parser', 'grib_copy', 'grib_get', 'grib_ls', 'gts_compare', 'gts_filter', 'metar_copy', 'metar_ls',
+          'bufr_copy', 'bufr_get', 'codes_bufr_filter', 'codes_split_file', 'grib_count', 'grib_get_data', 'gts_copy',
+          'gts_get', 'metar_dump', 'bufr_count', 'bufr_index_build', 'codes_count', 'grib2ppm', 'grib_dump',
+          'grib_histogram', 'grib_set', 'gts_count', 'gts_ls', 'metar_filter']
 
 sanity_check_paths = {
-    'files': ['bin/bufr_compare', 'bin/bufr_copy', 'bin/bufr_dump', 'bin/bufr_filter', 'bin/bufr_get', 'bin/bufr_ls',
-              'bin/grib_compare', 'bin/grib_copy', 'bin/grib_dump', 'bin/grib_filter', 'bin/grib_get', 'bin/grib_ls',
-              'bin/gts_compare', 'bin/gts_copy', 'bin/gts_dump', 'bin/gts_filter', 'bin/gts_get', 'bin/gts_ls',
-              'bin/metar_compare', 'bin/metar_copy', 'bin/metar_dump', 'bin/metar_filter', 'bin/metar_get',
-              'bin/metar_ls', 'bin/codes_count', 'bin/codes_info', 'bin/codes_split_file',
-              'lib/libeccodes_f90.%s' % SHLIB_EXT, 'lib/libeccodes.%s' % SHLIB_EXT],
+    'files': [f'bin/{x}' for x in _files] +
+             [f'lib/lib%(namelower)s_f90.{SHLIB_EXT}', f'lib/lib%(namelower)s.{SHLIB_EXT}'],
     'dirs': ['include'],
 }
 


### PR DESCRIPTION
adds a patch that sets `SOVERSION` in the `CMakeLists.txt` library targets. 
By doing this, CMake builds the library as `libeccodes{,_f90}.so.0.1` and creates symlinks `libeccodes{,_f90}.so -> libeccodes{,_f90}.so.0.1`. This PR then also adds a symlink for `libeccodes{,_f90}.so.0`.

motivation: we have run into some software that expects versioned libraries, since that's what Debian and RHEL (and likely others) are doing. Whilst we could patch that software, I don't see a downside to versioning the SO and creating symlinks.

(created using `eb --new-pr`)
