### PR TITLE
remove `'sanity_pip_check': True` from easyconfig templates

### DIFF
--- a/contrib/easyconfig-templates/2022a/PythonBundle-minimal.eb.tmpl
+++ b/contrib/easyconfig-templates/2022a/PythonBundle-minimal.eb.tmpl
@@ -33,6 +33,5 @@ exts_list = [
     }),
 ]
 
-sanity_pip_check = True
 
 moduleclass = 'class_name'

--- a/contrib/easyconfig-templates/2022a/PythonBundle-scipy.eb.tmpl
+++ b/contrib/easyconfig-templates/2022a/PythonBundle-scipy.eb.tmpl
@@ -30,6 +30,5 @@ exts_list = [
     }),
 ]
 
-sanity_pip_check = True
 
 moduleclass = 'class_name'

--- a/contrib/easyconfig-templates/2023a/PythonBundle-minimal.eb.tmpl
+++ b/contrib/easyconfig-templates/2023a/PythonBundle-minimal.eb.tmpl
@@ -33,6 +33,5 @@ exts_list = [
     }),
 ]
 
-sanity_pip_check = True
 
 moduleclass = 'class_name'

--- a/contrib/easyconfig-templates/2023a/PythonBundle-pytest.eb.tmpl
+++ b/contrib/easyconfig-templates/2023a/PythonBundle-pytest.eb.tmpl
@@ -29,6 +29,5 @@ exts_list = [
     }),
 ]
 
-sanity_pip_check = True
 
 moduleclass = 'class_name'

--- a/contrib/easyconfig-templates/2023a/PythonBundle-scipy.eb.tmpl
+++ b/contrib/easyconfig-templates/2023a/PythonBundle-scipy.eb.tmpl
@@ -30,6 +30,5 @@ exts_list = [
     }),
 ]
 
-sanity_pip_check = True
 
 moduleclass = 'class_name'

--- a/contrib/easyconfig-templates/2024a/PythonBundle-minimal.eb.tmpl
+++ b/contrib/easyconfig-templates/2024a/PythonBundle-minimal.eb.tmpl
@@ -33,6 +33,5 @@ exts_list = [
     }),
 ]
 
-sanity_pip_check = True
 
 moduleclass = 'class_name'

--- a/contrib/easyconfig-templates/2024a/PythonBundle-pytest.eb.tmpl
+++ b/contrib/easyconfig-templates/2024a/PythonBundle-pytest.eb.tmpl
@@ -29,6 +29,5 @@ exts_list = [
     }),
 ]
 
-sanity_pip_check = True
 
 moduleclass = 'class_name'

--- a/contrib/easyconfig-templates/2024a/PythonBundle-scipy.eb.tmpl
+++ b/contrib/easyconfig-templates/2024a/PythonBundle-scipy.eb.tmpl
@@ -30,6 +30,5 @@ exts_list = [
     }),
 ]
 
-sanity_pip_check = True
 
 moduleclass = 'class_name'


### PR DESCRIPTION
The `sanity_pip_check': True` option is enabled by default since EasyBuild 5 and checks in PRs fail if this option is set explicitly.