### PR TITLE
{lib}[foss/2023a] TensorFlow v2.15.1 w/ CUDA 12.1.1 + ARM-CUDA

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.15.1-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.15.1-foss-2023a-CUDA-12.1.1.eb
@@ -51,6 +51,11 @@ dependencies = [
     ('tensorboard', '2.15.1'),
 ]
 
+local_arm_patch = {
+    'TensorFlow_2.15.1_ARM_CUDA.patch':
+        '47a15867370806e4d8c113d893bf5fe11c8f82e0faf8fec9d8bce90ee5610aa2'
+}
+
 # Dependencies created and updated using findPythonDeps, see:
 # https://docs.easybuild.io/api/easybuild/scripts/findPythonDeps
 # Notable changes since 2.13.0-foss-2023a
@@ -102,7 +107,7 @@ exts_list = [
             'TensorFlow-2.15.1_fix-cuda_build_defs.patch',
             'TensorFlow-2.15.1_disable-avx512-extensions.patch',
             'TensorFlow-2.15.1_disable-tf32-in-fused-matmul-tests.patch'
-        ],
+        ] + ([local_arm_patch] if ARCH == 'aarch64' else []),
         'source_tmpl': 'v%(version)s.tar.gz',
         'source_urls': ['https://github.com/tensorflow/tensorflow/archive/'],
         'test_script': 'TensorFlow-2.x_mnist-test.py',
@@ -168,8 +173,9 @@ exts_list = [
              '506ceecff67237eed9cd9e9e114bc1461f35a343f77f83cb3dab710aa701dc0f'},
             {'TensorFlow-2.15.1_disable-tf32-in-fused-matmul-tests.patch':
              'f78aa0e8f814a57e8d2e6b24ff095df49e8654aadb797393fa95a9378d0aa662'},
-        ],
+        ] + ([local_arm_patch] if ARCH == 'aarch64' else []),
     }),
 ]
+
 
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow_2.15.1_ARM_CUDA.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow_2.15.1_ARM_CUDA.patch
@@ -1,0 +1,56 @@
+diff -ruN a/tensorflow-2.15.1/third_party/absl/absl.eb b/tensorflow-2.15.1/third_party/absl/absl.eb
+--- a/tensorflow-2.15.1/third_party/absl/absl.eb	1970-01-01 01:00:00.000000000 +0100
++++ b/tensorflow-2.15.1/third_party/absl/absl.eb	2025-05-21 09:48:59.000000000 +0200
+@@ -0,0 +1,24 @@
++easyblock = 'Bundle'
++
++name = 'absl-py'
++version = '2.2.2'
++
++homepage = 'https://github.com/abseil/abseil-py'
++description = """absl-py is a collection of Python library code for building Python
++applications. The code is collected from Google's own Python code base, and has
++been extensively tested and used in production."""
++
++toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
++
++dependencies = [('Python', '3.11.3')]
++
++exts_list = [
++    ('absl-py', version, {
++        'modulename': 'absl',
++        'source_tmpl': '%(name)s-%(version)s.tar.gz',
++        'source_urls': ['https://files.pythonhosted.org/packages/source/a/absl-py/'],
++        # You can also add the checksum once verified
++    }),
++]
++
++moduleclass = 'tools'
+diff -ruN a/tensorflow-2.15.1/third_party/absl/absl_combined_fix.patch b/tensorflow-2.15.1/third_party/absl/absl_combined_fix.patch
+--- a/tensorflow-2.15.1/third_party/absl/absl_combined_fix.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/tensorflow-2.15.1/third_party/absl/absl_combined_fix.patch	2025-05-22 09:43:35.000000000 +0200
+@@ -0,0 +1,11 @@
++--- a/absl/base/config.h	2023-03-27 16:58:21.000000000 +0200
+++++ b/absl/base/config.h	2025-05-21 11:31:45.501755010 +0200
++@@ -936,7 +936,7 @@
++ // https://llvm.org/docs/CompileCudaWithLLVM.html#detecting-clang-vs-nvcc-from-code
++ #ifdef ABSL_INTERNAL_HAVE_ARM_NEON
++ #error ABSL_INTERNAL_HAVE_ARM_NEON cannot be directly set
++-#elif defined(__ARM_NEON) && !defined(__CUDA_ARCH__)
+++#elif defined(__ARM_NEON) && !defined(__CUDACC__)
++ #define ABSL_INTERNAL_HAVE_ARM_NEON 1
++ #endif
++
+diff -ruN a/tensorflow-2.15.1/third_party/absl/workspace.bzl b/tensorflow-2.15.1/third_party/absl/workspace.bzl
+--- a/tensorflow-2.15.1/third_party/absl/workspace.bzl	2024-03-08 03:19:10.000000000 +0100
++++ b/tensorflow-2.15.1/third_party/absl/workspace.bzl	2025-05-22 09:08:29.000000000 +0200
+@@ -44,7 +44,7 @@
+         system_link_files = SYS_LINKS,
+         # This patch pulls in a fix for designated initializers that MSVC
+         # complains about. It shouldn't be necessary at the next LTS release.
+-        patch_file = ["//third_party/absl:absl_designated_initializers.patch"],
+-        strip_prefix = "abseil-cpp-{commit}".format(commit = ABSL_COMMIT),
++	patch_file = ["//third_party/absl:absl_designated_initializers.patch", "//third_party/absl:absl_combined_fix.patch"],
++	strip_prefix = "abseil-cpp-{commit}".format(commit = ABSL_COMMIT),
+         urls = tf_mirror_urls("https://github.com/abseil/abseil-cpp/archive/{commit}.tar.gz".format(commit = ABSL_COMMIT)),
+     )


### PR DESCRIPTION
TensorFlow v2.15.1 w/ CUDA 12.1.1 fails to on ARM + CUDA with the error shown below:

```
/include/arm_neon.h(40): error: identifier "__Int8x8_t" is undefined
  typedef __Int8x8_t int8x8_t;
          ^

include/arm_neon.h(41): error: identifier "__Int16x4_t" is undefined
  typedef __Int16x4_t int16x4_t;
          ^

include/arm_neon.h(42): error: identifier "__Int32x2_t" is undefined
  typedef __Int32x2_t int32x2_t;
          ^
include/arm_neon.h(43): error: identifier "__Int64x1_t" is undefined
  typedef __Int64x1_t int64x1_t;
          ^

include/arm_neon.h(44): error: identifier "__Float16x4_t" is undefined
  typedef __Float16x4_t float16x4_t;
          ^

include/arm_neon.h(45): error: identifier "__Float32x2_t" is undefined
  typedef __Float32x2_t float32x2_t;
          ^

include/arm_neon.h(46): error: identifier "__Poly8x8_t" is undefined
  typedef __Poly8x8_t poly8x8_t;
          ^

include/arm_neon.h(47): error: identifier "__Poly16x4_t" is undefined
  typedef __Poly16x4_t poly16x4_t;
          ^
Error limit reached.
100 errors detected in the compilation of "tensorflow/core/kernels/reshape_util_gpu.cu.cc".
Compilation terminated.
Target //tensorflow/tools/pip_package:build_pip_package failed to build

```
This PR adds a patch where it introduces changes to the easyconfig when used on `aarch64`.

The expected output of the changes:

CPU tests:
Executed 847 out of 847 tests: 847 tests pass.

GPU tests
Executed 189 out of 189 tests: 188 tests pass and 1 fails locally

``` 
Create a `tf.sparse.SparseTensor` and use `tf.sparse.to_dense` instead.
2025-07-14 22:05:24.196765: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1929] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 94876 MB memory:  -> device: 0, name: NVIDIA GH200 480GB, pci bus id: 0009:01:00.0, compute capability: 9.0
2025-07-14 22:05:24.216862: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 99485220864 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216882: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 89536700416 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216887: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 80583024640 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216890: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 72524718080 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216892: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 65272246272 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216903: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 58745020416 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216914: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 52870516736 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216916: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 47583465472 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216918: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 42825117696 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216921: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 38542606336 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216923: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 34688344064 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216925: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 31219509248 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216927: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 28097558528 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216929: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 25287802880 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216931: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 22759022592 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216934: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 20483119104 on device 0 within provided limit.  limit=2147483648]
2025-07-14 22:05:24.216981: W external/local_xla/xla/stream_executor/stream_executor_pimpl.cc:463] Not enough memory to allocate 2241240576 on device 0 within provided limit.  limit=2147483648]
INFO:tensorflow:time(__main__.SparseToDenseTest.test2d): 0.62s
I0714 22:05:24.369109 84022298500416 test_util.py:2574] time(__main__.SparseToDenseTest.test2d): 0.62s
[       OK ] SparseToDenseTest.test2d
[ RUN      ] SparseToDenseTest.test3d
INFO:tensorflow:time(__main__.SparseToDenseTest.test3d): 0.0s
I0714 22:05:24.372016 84022298500416 test_util.py:2574] time(__main__.SparseToDenseTest.test3d): 0.0s
[       OK ] SparseToDenseTest.test3d
[ RUN      ] SparseToDenseTest.testBadDefault
2025-07-14 22:05:24.374394: W tensorflow/core/framework/op_kernel.cc:1839] OP_REQUIRES failed at sparse_to_dense_op.cc:218 : INVALID_ARGUMENT: default_value should be a scalar.
INFO:tensorflow:time(__main__.SparseToDenseTest.testBadDefault): 0.0s
I0714 22:05:24.374547 84022298500416 test_util.py:2574] time(__main__.SparseToDenseTest.testBadDefault): 0.0s
[       OK ] SparseToDenseTest.testBadDefault
[ RUN      ] SparseToDenseTest.testBadNumValues
2025-07-14 22:05:24.376781: W tensorflow/core/framework/op_kernel.cc:1839] OP_REQUIRES failed at sparse_to_dense_op.cc:218 : INVALID_ARGUMENT: sparse_values has incorrect shape [3], should be [] or [2]
INFO:tensorflow:time(__main__.SparseToDenseTest.testBadNumValues): 0.0s
I0714 22:05:24.376892 84022298500416 test_util.py:2574] time(__main__.SparseToDenseTest.testBadNumValues): 0.0s
[       OK ] SparseToDenseTest.testBadNumValues
[ RUN      ] SparseToDenseTest.testBadShape
2025-07-14 22:05:24.378949: W tensorflow/core/framework/op_kernel.cc:1839] OP_REQUIRES failed at sparse_to_dense_op.cc:218 : INVALID_ARGUMENT: output_shape must be rank 1, got shape [2,1]
INFO:tensorflow:time(__main__.SparseToDenseTest.testBadShape): 0.0s
I0714 22:05:24.379058 84022298500416 test_util.py:2574] time(__main__.SparseToDenseTest.testBadShape): 0.0s
[       OK ] SparseToDenseTest.testBadShape
[ RUN      ] SparseToDenseTest.testBadValue
2025-07-14 22:05:24.381188: W tensorflow/core/framework/op_kernel.cc:1839] OP_REQUIRES failed at sparse_to_dense_op.cc:218 : INVALID_ARGUMENT: sparse_values has incorrect shape [2,1], should be [] or [2]
INFO:tensorflow:time(__main__.SparseToDenseTest.testBadValue): 0.0s
I0714 22:05:24.381294 84022298500416 test_util.py:2574] time(__main__.SparseToDenseTest.testBadValue): 0.0s
2025-07-14 22:05:24.378949: W tensorflow/core/framework/op_kernel.cc:1839] OP_REQUIRES failed at sparse_to_dense_op.cc:218 : INVALID_ARGUMENT: output_shape must be rank 1, got shape [2,1]
INFO:tensorflow:time(__main__.SparseToDenseTest.testBadShape): 0.0s
I0714 22:05:24.379058 84022298500416 test_util.py:2574] time(__main__.SparseToDenseTest.testBadShape): 0.0s
[       OK ] SparseToDenseTest.testBadShape
[ RUN      ] SparseToDenseTest.testBadValue
2025-07-14 22:05:24.381188: W tensorflow/core/framework/op_kernel.cc:1839] OP_REQUIRES failed at sparse_to_dense_op.cc:218 : INVALID_ARGUMENT: sparse_values has incorrect shape [2,1], should be [] or [2]
INFO:tensorflow:time(__main__.SparseToDenseTest.testBadValue): 0.0s
I0714 22:05:24.381294 84022298500416 test_util.py:2574] time(__main__.SparseToDenseTest.testBadValue): 0.0s
[       OK ] SparseToDenseTest.testBadValue
[ RUN      ] SparseToDenseTest.testComplex
INFO:tensorflow:time(__main__.SparseToDenseTest.testComplex): 0.1s
I0714 22:05:24.478588 84022298500416 test_util.py:2574] time(__main__.SparseToDenseTest.testComplex): 0.1s
[       OK ] SparseToDenseTest.testComplex
[ RUN      ] SparseToDenseTest.testEmptyNonZeros
INFO:tensorflow:time(__main__.SparseToDenseTest.testEmptyNonZeros): 0.0s
I0714 22:05:24.481788 84022298500416 test_util.py:2574] time(__main__.SparseToDenseTest.testEmptyNonZeros): 0.0s
[       OK ] SparseToDenseTest.testEmptyNonZeros
[ RUN      ] SparseToDenseTest.testFloatTypes0 (tf.bfloat16)
INFO:tensorflow:time(__main__.SparseToDenseTest.testFloatTypes0 (tf.bfloat16)): 0.0s
I0714 22:05:24.485352 84022298500416 test_util.py:2574] time(__main__.SparseToDenseTest.testFloatTypes0 (tf.bfloat16)): 0.0s
[       OK ] SparseToDenseTest.testFloatTypes0 (tf.bfloat16)
[ RUN      ] SparseToDenseTest.testFloatTypes1 (tf.float16)
Fatal Python error: Segmentation fault
```
