### PR TITLE
LLVM fix for libffi

### DIFF
--- a/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-18.1.8-GCCcore-13.3.0.eb
@@ -43,6 +43,7 @@ builddependencies = [
 ]
 
 dependencies = [
+    ('libffi', '3.4.5'),
     ('libxml2', '2.12.7'),
     ('ncurses', '6.5'),
     ('zlib', '1.3.1'),
@@ -75,9 +76,5 @@ skip_sanitizer_tests = False
 test_suite_max_failed = 150  # Could increase depending on build targets
 test_suite_timeout_single = 5 * 60
 # test_suite_timeout_total = 10*3600
-
-# LLVM will produce .mod files for its flang installation at the 3rd stage of the build via Clang+Flang
-# These should not be checked for sanity, as we want to build LLVM on top of GCCcore to be used as a new toolchain
-skip_mod_files_sanity_check = True
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-19.1.7-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-19.1.7-GCCcore-13.3.0.eb
@@ -46,6 +46,7 @@ builddependencies = [
 ]
 
 dependencies = [
+    ('libffi', '3.4.5'),
     ('libxml2', '2.12.7'),
     ('ncurses', '6.5'),
     ('zlib', '1.3.1'),
@@ -84,9 +85,5 @@ test_suite_ignore_patterns = [
     "Driver/gcc-toolchain-install-dir.f90",
     "api_tests/test_ompd_get_icv_from_scope.c",
 ]
-
-# LLVM will produce .mod files for its flang installation at the 3rd stage of the build via Clang+Flang
-# These should not be checked for sanity, as we want to build LLVM on top of GCCcore to be used as a new toolchain
-skip_mod_files_sanity_check = True
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-20.1.4-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-20.1.4-GCCcore-13.3.0.eb
@@ -46,6 +46,7 @@ builddependencies = [
 ]
 
 dependencies = [
+    ('libffi', '3.4.5'),
     ('libxml2', '2.12.7'),
     ('ncurses', '6.5'),
     ('zlib', '1.3.1'),
@@ -82,9 +83,5 @@ test_suite_ignore_patterns = [
     "Driver/gcc-toolchain-install-dir.f90",
     "api_tests/test_ompd_get_icv_from_scope.c",
 ]
-
-# LLVM will produce .mod files for its flang installation at the 3rd stage of the build via Clang+Flang
-# These should not be checked for sanity, as we want to build LLVM on top of GCCcore to be used as a new toolchain
-skip_mod_files_sanity_check = True
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-20.1.5-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-20.1.5-GCCcore-13.2.0.eb
@@ -43,6 +43,7 @@ builddependencies = [
 ]
 
 dependencies = [
+    ('libffi', '3.4.4'),
     ('libxml2', '2.11.5'),
     ('ncurses', '6.4'),
     ('zlib', '1.2.13'),
@@ -79,9 +80,5 @@ test_suite_ignore_patterns = [
     "Driver/gcc-toolchain-install-dir.f90",
     "api_tests/test_ompd_get_icv_from_scope.c",
 ]
-
-# LLVM will produce .mod files for its flang installation at the 3rd stage of the build via Clang+Flang
-# These should not be checked for sanity, as we want to build LLVM on top of GCCcore to be used as a new toolchain
-skip_mod_files_sanity_check = True
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-20.1.5-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-20.1.5-GCCcore-13.3.0.eb
@@ -84,8 +84,4 @@ test_suite_ignore_patterns = [
     "api_tests/test_ompd_get_icv_from_scope.c",
 ]
 
-# LLVM will produce .mod files for its flang installation at the 3rd stage of the build via Clang+Flang
-# These should not be checked for sanity, as we want to build LLVM on top of GCCcore to be used as a new toolchain
-skip_mod_files_sanity_check = True
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-20.1.5-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-20.1.5-GCCcore-13.3.0.eb
@@ -46,6 +46,7 @@ builddependencies = [
 ]
 
 dependencies = [
+    ('libffi', '3.4.5'),
     ('libxml2', '2.12.7'),
     ('ncurses', '6.5'),
     ('zlib', '1.3.1'),


### PR DESCRIPTION
Companion PR to 

- https://github.com/easybuilders/easybuild-easyblocks/pull/3849

## Notes

- `libffi` was already an indirect dependency but this future proofs it and makes it clear it is also a dependency
- Removed the `skip_mod_files_sanity_check` option as it is now being set by the EasyBlock when needed
- Even if the linked issue is related to `offload` which has been introduced since `LLVM >= 19` the added configure options are also available for `18.1.8`
