### PR TITLE
restore `ADMIXTURE/1.3.0`

### DIFF
--- a/easybuild/easyconfigs/a/ADMIXTURE/ADMIXTURE-1.3.0.eb
+++ b/easybuild/easyconfigs/a/ADMIXTURE/ADMIXTURE-1.3.0.eb
@@ -1,0 +1,25 @@
+easyblock = "Tarball"
+
+name = 'ADMIXTURE'
+version = '1.3.0'
+
+homepage = 'https://dalexander.github.io/admixture/index.html'
+description = """ Software tool for maximum likelihood estimation of individual
+ancestries from multilocus SNP genotype datasets. It uses the same statistical
+model as STRUCTURE but calculates estimates much more rapidly using a
+fast numerical optimization algorithm. """
+
+toolchain = SYSTEM
+
+source_urls = ['https://dalexander.github.io/admixture/binaries/']
+sources = [f'%(namelower)s_linux-{version}.tar.gz']
+checksums = ['353e8b170c81f8d95946bf18bc78afda5d6bd32645b2a68658bd6781ff35703c']
+
+sanity_check_paths = {
+    'files': ['%(namelower)s'],
+    'dirs': [],
+}
+
+modextrapaths = {'PATH': ''}
+
+moduleclass = 'bio'


### PR DESCRIPTION
This got accidentally removed in #22955, as there had been an `ADMIXTURE/1.3.0` cleared up in the EB5 archiving (#19013) so the git history shows this as being a much older file.