### PR TITLE
Mesa: fix broken source_urls for versions 23.x 

### DIFF
--- a/easybuild/easyconfigs/m/Mesa/Mesa-23.1.4-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-23.1.4-GCCcore-12.3.0.eb
@@ -20,7 +20,7 @@ toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 
 source_urls = [
     'https://archive.mesa3d.org/',
-    'https://archive.mesa3d.org/older-versions/%(version_major)s.x/',
+    'https://archive.mesa3d.org/%(version_major)s.x/',
 ]
 sources = [SOURCELOWER_TAR_XZ]
 checksums = ['7261a17fb94867e3dc5a90d8a1f100fa04b0cbbde51d25302c0872b5e9a10959']

--- a/easybuild/easyconfigs/m/Mesa/Mesa-23.1.9-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-23.1.9-GCCcore-13.2.0.eb
@@ -20,7 +20,7 @@ toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 
 source_urls = [
     'https://archive.mesa3d.org/',
-    'https://archive.mesa3d.org/older-versions/%(version_major)s.x/',
+    'https://archive.mesa3d.org/%(version_major)s.x/',
 ]
 sources = [SOURCELOWER_TAR_XZ]
 checksums = ['295ba27c28146ed09214e8ce79afa1659edf9d142decc3c91f804552d64f7510']


### PR DESCRIPTION
To reflect the current structure of the [archive.mesa3d.org](https://archive.mesa3d.org/) website.

The old path:
`https://archive.mesa3d.org/older-versions/%(version_major)s.x/`
no longer resolves for versions 23.x
Replaced with:
`https://archive.mesa3d.org/%(version_major)s.x/`
which matches the live layout for 23.x tarballs.

Tested against:

Mesa-23.1.4-GCCcore-13.2.0.eb

Successful download and checksum match.