### PR TITLE
Add missing dependencies libxml2 & zstd to libarchive

### DIFF
--- a/easybuild/easyconfigs/g/gzip/gzip-1.13-GCCcore-13.1.0.eb
+++ b/easybuild/easyconfigs/g/gzip/gzip-1.13-GCCcore-13.1.0.eb
@@ -1,0 +1,24 @@
+easyblock = 'ConfigureMake'
+
+name = 'gzip'
+version = '1.13'
+
+homepage = 'https://www.gnu.org/software/gzip/'
+description = "gzip (GNU zip) is a popular data compression program as a replacement for compress"
+
+toolchain = {'name': 'GCCcore', 'version': '13.1.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['20fc818aeebae87cdbf209d35141ad9d3cf312b35a5e6be61bfcfbf9eddd212a']
+
+builddependencies = [('binutils', '2.40')]
+
+sanity_check_paths = {
+    'files': ["bin/gunzip", "bin/gzip", "bin/uncompress"],
+    'dirs': [],
+}
+
+sanity_check_commands = [True, ('gzip', '--version')]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.5.1-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.5.1-GCCcore-10.3.0.eb
@@ -25,7 +25,9 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.2.11'),
     ('XZ', '5.2.5'),
+    ('libxml2', '2.9.10'),
     ('OpenSSL', '1.1', '', SYSTEM),
+    ('zstd', '1.4.9'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.5.1-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.5.1-GCCcore-11.2.0.eb
@@ -22,7 +22,9 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.2.11'),
     ('XZ', '5.2.5'),
+    ('libxml2', '2.9.10'),
     ('OpenSSL', '1.1', '', SYSTEM),
+    ('zstd', '1.5.0'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.6.1-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.6.1-GCCcore-11.3.0.eb
@@ -27,7 +27,9 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.2.12'),
     ('XZ', '5.2.5'),
+    ('libxml2', '2.9.13'),
     ('OpenSSL', '1.1', '', SYSTEM),
+    ('zstd', '1.5.2'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.6.1-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.6.1-GCCcore-12.2.0.eb
@@ -27,7 +27,9 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.2.12'),
     ('XZ', '5.2.7'),
+    ('libxml2', '2.10.3'),
     ('OpenSSL', '1.1', '', SYSTEM),
+    ('zstd', '1.5.2'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.6.2-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.6.2-GCCcore-12.3.0.eb
@@ -27,7 +27,9 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.2.13'),
     ('XZ', '5.4.2'),
+    ('libxml2', '2.11.4'),
     ('OpenSSL', '1.1', '', SYSTEM),
+    ('zstd', '1.5.5'),
 ]
 
 postinstallcmds = ["sed -i 's/iconv//g' %(installdir)s/lib/pkgconfig/libarchive.pc"]

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.6.2-GCCcore-13.1.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.6.2-GCCcore-13.1.0.eb
@@ -27,7 +27,9 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.2.13'),
     ('XZ', '5.4.2'),
+    ('libxml2', '2.11.5'),
     ('OpenSSL', '1.1', '', SYSTEM),
+    ('zstd', '1.5.5'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.7.2-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.7.2-GCCcore-13.2.0.eb
@@ -27,7 +27,9 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.2.13'),
     ('XZ', '5.4.4'),
+    ('libxml2', '2.11.5'),
     ('OpenSSL', '1.1', '', SYSTEM),
+    ('zstd', '1.5.5'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.7.4-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.7.4-GCCcore-13.3.0.eb
@@ -24,7 +24,9 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.3.1'),
     ('XZ', '5.4.5'),
+    ('libxml2', '2.12.7'),
     ('OpenSSL', '3', '', SYSTEM),
+    ('zstd', '1.5.6'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.7.7-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.7.7-GCCcore-14.2.0.eb
@@ -22,7 +22,9 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.3.1'),
     ('XZ', '5.6.3'),
+    ('libxml2', '2.13.4'),
     ('OpenSSL', '3', '', SYSTEM),
+    ('zstd', '1.5.6'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libarchive/libarchive-3.8.1-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/l/libarchive/libarchive-3.8.1-GCCcore-14.3.0.eb
@@ -23,7 +23,9 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.3.1'),
     ('XZ', '5.8.1'),
+    ('libxml2', '2.14.3'),
     ('OpenSSL', '3', '', SYSTEM),
+    ('zstd', '1.5.7'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.11.5-GCCcore-13.1.0.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.11.5-GCCcore-13.1.0.eb
@@ -1,0 +1,27 @@
+name = 'libxml2'
+version = '2.11.5'
+
+homepage = 'https://gitlab.gnome.org/GNOME/libxml2/-/wikis'
+
+description = """
+ Libxml2 is the XML C parser and toolchain developed for the Gnome project
+ (but usable outside of the Gnome platform).
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.1.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://download.gnome.org/sources/libxml2/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['3727b078c360ec69fa869de14bd6f75d7ee8d36987b071e6928d4720a28df3a6']
+
+builddependencies = [
+    ('binutils', '2.40'),
+]
+
+dependencies = [
+    ('XZ', '5.4.2'),
+    ('zlib', '1.2.13'),
+]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/lz4/lz4-1.9.4-GCCcore-13.1.0.eb
+++ b/easybuild/easyconfigs/l/lz4/lz4-1.9.4-GCCcore-13.1.0.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'lz4'
+version = '1.9.4'
+
+homepage = 'https://lz4.github.io/lz4/'
+description = """LZ4 is lossless compression algorithm, providing compression speed at 400 MB/s per core.
+ It features an extremely fast decoder, with speed in multiple GB/s per core."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.1.0'}
+
+github_account = '%(name)s'
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b']
+
+builddependencies = [('binutils', '2.40')]
+
+skipsteps = ['configure']
+
+installopts = "PREFIX=%(installdir)s"
+
+runtest = 'check'
+
+sanity_check_paths = {
+    'files': ["bin/lz4", "lib/liblz4.%s" % SHLIB_EXT, "include/lz4.h"],
+    'dirs': ["lib/pkgconfig"]
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/z/zstd/zstd-1.5.5-GCCcore-13.1.0.eb
+++ b/easybuild/easyconfigs/z/zstd/zstd-1.5.5-GCCcore-13.1.0.eb
@@ -1,0 +1,41 @@
+easyblock = 'ConfigureMake'
+
+name = 'zstd'
+version = '1.5.5'
+
+homepage = 'https://facebook.github.io/zstd'
+description = """Zstandard is a real-time compression algorithm, providing high compression ratios.
+ It offers a very wide range of compression/speed trade-off, while being backed by a very fast decoder.
+ It also offers a special mode for small data, called dictionary compression, and can create dictionaries
+ from any sample set."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.1.0'}
+
+github_account = 'facebook'
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['98e9c3d949d1b924e28e01eccb7deed865eefebf25c2f21c702e5cd5b63b85e1']
+
+builddependencies = [
+    ('binutils', '2.40'),
+]
+
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('gzip', '1.13'),
+    ('XZ', '5.4.2'),
+    ('lz4', '1.9.4'),
+]
+
+skipsteps = ['configure']
+
+runtest = 'check'
+
+installopts = "PREFIX=%(installdir)s"
+
+sanity_check_paths = {
+    'files': ["bin/zstd", "lib/libzstd.%s" % SHLIB_EXT, "include/zstd.h"],
+    'dirs': ["lib/pkgconfig"]
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
Configure searches for those and might pick up system libraries without the modules.

Fixes https://github.com/easybuilders/easybuild-easyconfigs/issues/23513