### PR TITLE
{lib}[GCCcore/14.3.0] Bump scikit-build-core to 0.11.5

### DIFF
--- a/easybuild/easyconfigs/n/ninja-python/ninja-python-1.11.1.4-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/n/ninja-python/ninja-python-1.11.1.4-GCCcore-14.3.0.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '14.3.0'}
 builddependencies = [
     ('binutils', '2.44'),
     ('CMake', '4.0.3'),
-    ('scikit-build-core', '0.11.1'),
+    ('scikit-build-core', '0.11.5'),
     ('hatchling', '1.27.0'),  # for hatch-fancy-pypi-readme
 ]
 

--- a/easybuild/easyconfigs/s/scikit-build-core/scikit-build-core-0.11.5-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/s/scikit-build-core/scikit-build-core-0.11.5-GCCcore-14.3.0.eb
@@ -1,7 +1,7 @@
 easyblock = 'PythonBundle'
 
 name = 'scikit-build-core'
-version = '0.11.1'
+version = '0.11.5'
 
 homepage = 'https://scikit-build.readthedocs.io/en/latest/'
 description = """Scikit-build-core is a complete ground-up rewrite of scikit-build on top of
@@ -29,7 +29,7 @@ exts_list = [
         'checksums': ['a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712'],
     }),
     ('scikit_build_core', version, {
-        'checksums': ['4e5988df5cd33f0bdb9967b72663ca99f50383c9bc21d8b24fa40c0661ae72b7'],
+        'checksums': ['8f0a1edb86cb087876f3c699d2a2682012efd8867b390ed37355f13949d0628e'],
     }),
 ]
 


### PR DESCRIPTION
Older versions blocks updating e.g. pybind11. Was accidentally missed when providing scikit-build-core for new toolchain.