### PR TITLE
fix hardcoded path to java binary in canu v2.3 + add OpenSSL dependency

### DIFF
--- a/easybuild/easyconfigs/c/canu/canu-2.3-GCCcore-13.3.0-Java-11.eb
+++ b/easybuild/easyconfigs/c/canu/canu-2.3-GCCcore-13.3.0-Java-11.eb
@@ -23,7 +23,6 @@ dependencies = [
     ('Java', '11', '', SYSTEM),
     ('Perl', '5.38.2'),
     ('gnuplot', '6.0.1'),
-    # mark next line if the environment has OpenSSL3
     ('OpenSSL', '3', '', SYSTEM),
 ]
 


### PR DESCRIPTION
As the discussion in https://github.com/marbl/canu/issues/2359, the Failed Java version check problem also happened to me. This modification hard-codes the bundled java binary path to variable `$java` in `Defaults.pm`. This might be the simplest way to fix this issue according to the discussion thread.