### PR TITLE
Add additional patches for OpenMPI-5.0.7 from 2025a

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.7-GCC-14.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.7-GCC-14.2.0.eb
@@ -16,7 +16,7 @@ patches = [
 checksums = [
     {'openmpi-5.0.7.tar.bz2': '119f2009936a403334d0df3c0d74d5595a32d99497f9b1d41e90019fee2fc2dd'},
     {'OpenMPI-5.0.7_build-with-internal-cuda-header.patch':
-     '03945c5f1f007fbd07e9177d0caefd059de4642c82ef93da99f207d942f2bc60'},
+     '14ffaf02a9c675ac66a2a9af727295179d4ce097174c88db59669d460d8c4da1'},
     {'OpenMPI-5.0.7_fix-sshmem-build-failure.patch':
      '7382a5bbe44c6eff9ab05c8f315a8911d529749655126d4375e44e809bfedec7'},
     {'OpenMPI-5.0.7_fix_gpfs_compatibility.patch':

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.7-GCC-14.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.7-GCC-14.2.0.eb
@@ -16,7 +16,7 @@ patches = [
 checksums = [
     {'openmpi-5.0.7.tar.bz2': '119f2009936a403334d0df3c0d74d5595a32d99497f9b1d41e90019fee2fc2dd'},
     {'OpenMPI-5.0.7_build-with-internal-cuda-header.patch':
-     '14ffaf02a9c675ac66a2a9af727295179d4ce097174c88db59669d460d8c4da1'},
+     '03945c5f1f007fbd07e9177d0caefd059de4642c82ef93da99f207d942f2bc60'},
     {'OpenMPI-5.0.7_fix-sshmem-build-failure.patch':
      '7382a5bbe44c6eff9ab05c8f315a8911d529749655126d4375e44e809bfedec7'},
     {'OpenMPI-5.0.7_fix_gpfs_compatibility.patch':
@@ -41,6 +41,8 @@ dependencies = [
 
 # CUDA related patches and custom configure option can be removed if CUDA support isn't wanted.
 preconfigopts = 'gcc -Iopal/mca/cuda/include -shared opal/mca/cuda/lib/cuda.c -o opal/mca/cuda/lib/libcuda.so && '
-configopts = '--with-cuda=%(start_dir)s/opal/mca/cuda --with-show-load-errors=no '
+configopts = '--with-cuda=%(start_dir)s/opal/mca/cuda --with-show-load-errors=no'
+# Do not pick up the system library automatically
+configopts += ' --without-xpmem'
 
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.7-GCC-14.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.7-GCC-14.2.0.eb
@@ -9,15 +9,18 @@ toolchain = {'name': 'GCC', 'version': '14.2.0'}
 source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_BZ2]
 patches = [
-    ('OpenMPI-5.0.6_build-with-internal-cuda-header.patch', 1),
+    ('OpenMPI-5.0.7_build-with-internal-cuda-header.patch', 1),
     ('OpenMPI-5.0.7_fix-sshmem-build-failure.patch'),
+    ('OpenMPI-5.0.7_fix_gpfs_compatibility.patch'),
 ]
 checksums = [
     {'openmpi-5.0.7.tar.bz2': '119f2009936a403334d0df3c0d74d5595a32d99497f9b1d41e90019fee2fc2dd'},
-    {'OpenMPI-5.0.6_build-with-internal-cuda-header.patch':
-     '4821f0740ae4b97f3ff5259f7bac67a11d8cdeede3b1425825c241cf6a2864bb'},
+    {'OpenMPI-5.0.7_build-with-internal-cuda-header.patch':
+     '14ffaf02a9c675ac66a2a9af727295179d4ce097174c88db59669d460d8c4da1'},
     {'OpenMPI-5.0.7_fix-sshmem-build-failure.patch':
      '7382a5bbe44c6eff9ab05c8f315a8911d529749655126d4375e44e809bfedec7'},
+    {'OpenMPI-5.0.7_fix_gpfs_compatibility.patch':
+     '9739134ce273a691c9deac6e410510653a88c1542b60dbf8789e4a423447d4f6'},
 ]
 
 builddependencies = [
@@ -38,8 +41,6 @@ dependencies = [
 
 # CUDA related patches and custom configure option can be removed if CUDA support isn't wanted.
 preconfigopts = 'gcc -Iopal/mca/cuda/include -shared opal/mca/cuda/lib/cuda.c -o opal/mca/cuda/lib/libcuda.so && '
-configopts = '--with-cuda=%(start_dir)s/opal/mca/cuda --with-show-load-errors=no'
-# Do not pick up the system library automatically
-configopts += ' --without-xpmem'
+configopts = '--with-cuda=%(start_dir)s/opal/mca/cuda --with-show-load-errors=no '
 
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.7-GCC-14.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.7-GCC-14.2.0.eb
@@ -42,6 +42,10 @@ dependencies = [
 # CUDA related patches and custom configure option can be removed if CUDA support isn't wanted.
 preconfigopts = 'gcc -Iopal/mca/cuda/include -shared opal/mca/cuda/lib/cuda.c -o opal/mca/cuda/lib/libcuda.so && '
 configopts = '--with-cuda=%(start_dir)s/opal/mca/cuda --with-show-load-errors=no'
+# Disable building Level Zero components of romio if system dependencies are picked up. Sources are not based on
+# recent Level Zero interface anyway, so there's a high chance that builds fail.
+# See https://github.com/open-mpi/ompi/issues/10235
+preconfigopts += 'sed -i "s/have_ze=yes/have_ze=no/" %(start_dir)s/3rd-party/romio341/mpl/configure && '
 # Do not pick up the system library automatically
 configopts += ' --without-xpmem'
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.7_build-with-internal-cuda-header.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.7_build-with-internal-cuda-header.patch
@@ -1,0 +1,154 @@
+# What: Allow building Open MPI with an internal CUDA header and stub library via
+#       --with-cuda=%(start_dir)s/opal/mca/cuda 
+#       by providing an internal minimal cuda.h header file, and function stubs.
+#       This eliminates the CUDA (build)dependency; as long as the runtime CUDA version is 8.0+,
+#       the system's libcuda.so will be used successfully by dynamically loaded plugins in
+#       $EBROOTOPENMPI/lib/openmpi, not by the main libmpi.so.
+#
+# Author: Bart Oldeman <bart.oldeman@calculquebec.ca>
+#         maxim-masterov
+
+diff -Nru openmpi-5.0.7.orig/opal/mca/cuda/include/cuda.h openmpi-5.0.7/opal/mca/cuda/include/cuda.h
+--- openmpi-5.0.7.orig/opal/mca/cuda/include/cuda.h	1970-01-01 01:00:00.000000000 +0100
++++ openmpi-5.0.7/opal/mca/cuda/include/cuda.h	2025-07-31 15:13:01.066525357 +0200
+@@ -0,0 +1,102 @@
++/* This header provides minimal parts of the CUDA Driver API, without having to
++   rely on the proprietary CUDA toolkit.
++
++   References (to avoid copying from NVidia's proprietary cuda.h):
++   https://github.com/gcc-mirror/gcc/blob/master/include/cuda/cuda.h
++   https://github.com/Theano/libgpuarray/blob/master/src/loaders/libcuda.h
++   https://github.com/CPFL/gdev/blob/master/cuda/driver/cuda.h
++   https://github.com/CudaWrangler/cuew/blob/master/include/cuew.h
++*/
++
++#ifndef OMPI_CUDA_H
++#define OMPI_CUDA_H
++
++#include <stddef.h>
++
++#define CUDA_VERSION 8000
++
++typedef void *CUcontext;
++typedef int CUdevice;
++#if defined(__LP64__) || defined(_WIN64)
++typedef unsigned long long CUdeviceptr;
++#else
++typedef unsigned CUdeviceptr;
++#endif
++typedef void *CUevent;
++typedef void *CUstream;
++
++typedef enum {
++  CUDA_SUCCESS = 0,
++  CUDA_ERROR_INVALID_VALUE = 1,
++  CUDA_ERROR_NOT_INITIALIZED = 3,
++  CUDA_ERROR_DEINITIALIZED = 4,
++  CUDA_ERROR_ALREADY_MAPPED = 208,
++  CUDA_ERROR_NOT_READY = 600,
++  CUDA_ERROR_UNKNOWN = 999,
++} CUresult;
++
++enum {
++  CU_EVENT_DISABLE_TIMING = 0x2,
++  CU_EVENT_INTERPROCESS = 0x4,
++};
++
++enum {
++  CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS = 0x1,
++};
++
++typedef enum {
++  CU_POINTER_ATTRIBUTE_CONTEXT = 1,
++  CU_POINTER_ATTRIBUTE_MEMORY_TYPE = 2,
++  CU_POINTER_ATTRIBUTE_SYNC_MEMOPS = 6,
++  CU_POINTER_ATTRIBUTE_BUFFER_ID = 7,
++  CU_POINTER_ATTRIBUTE_IS_MANAGED = 8,
++} CUpointer_attribute;
++
++typedef enum {
++  CU_MEMORYTYPE_HOST = 0x01,
++  CU_MEMORYTYPE_DEVICE = 0x02,
++} CUmemorytype;
++
++#define CU_IPC_HANDLE_SIZE 64
++typedef struct CUipcEventHandle_st {
++  char reserved[CU_IPC_HANDLE_SIZE];
++} CUipcEventHandle;
++
++typedef struct CUipcMemHandle_st {
++    char reserved[CU_IPC_HANDLE_SIZE];
++} CUipcMemHandle;
++
++CUresult cuPointerGetAttribute(void *, CUpointer_attribute, CUdeviceptr);
++CUresult cuMemcpyAsync(CUdeviceptr, CUdeviceptr, size_t, CUstream);
++CUresult cuMemAlloc(CUdeviceptr *, size_t);
++CUresult cuMemFree(CUdeviceptr buf);
++CUresult cuCtxGetCurrent(void *cuContext);
++CUresult cuStreamCreate(CUstream *, int);
++CUresult cuEventCreate(CUevent *, int);
++CUresult cuEventRecord(CUevent, CUstream);
++CUresult cuEventQuery(CUevent);
++CUresult cuEventDestroy(CUevent);
++CUresult cuMemHostRegister(void *, size_t, unsigned int);
++CUresult cuMemHostUnregister(void *);
++CUresult cuMemGetAddressRange(CUdeviceptr *, size_t *, CUdeviceptr);
++CUresult cuIpcGetEventHandle(CUipcEventHandle *, CUevent);
++CUresult cuIpcOpenEventHandle(CUevent *, CUipcEventHandle);
++CUresult cuIpcOpenMemHandle(CUdeviceptr *, CUipcMemHandle, unsigned int);
++CUresult cuIpcCloseMemHandle(CUdeviceptr);
++CUresult cuIpcGetMemHandle(CUipcMemHandle *, CUdeviceptr);
++CUresult cuCtxGetDevice(CUdevice *);
++CUresult cuDeviceCanAccessPeer(int *, CUdevice, CUdevice);
++CUresult cuCtxSetCurrent(CUcontext);
++CUresult cuStreamSynchronize(CUstream);
++CUresult cuStreamDestroy(CUstream);
++CUresult cuPointerSetAttribute(const void *, CUpointer_attribute, CUdeviceptr);
++CUresult cuDeviceGetPCIBusId(char*, int, CUdevice);
++CUresult cuPointerGetAttributes(unsigned int, CUpointer_attribute *, void **, CUdeviceptr);
++CUresult cuDeviceGetCount(int *count);
++CUresult cuDeviceGet(CUdevice *device, int ordinal);
++CUresult cuCtxPushCurrent(CUcontext ctx);
++CUresult cuCtxPopCurrent(CUcontext *pctx);
++CUresult cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int *flags, int *active);
++CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev);
++
++#endif
+diff -Nru openmpi-5.0.7.orig/opal/mca/cuda/lib/cuda.c openmpi-5.0.7/opal/mca/cuda/lib/cuda.c
+--- openmpi-5.0.7.orig/opal/mca/cuda/lib/cuda.c	1970-01-01 01:00:00.000000000 +0100
++++ openmpi-5.0.7/opal/mca/cuda/lib/cuda.c	2025-07-31 15:12:14.193775373 +0200
+@@ -0,0 +1,34 @@
++#include "cuda.h"
++
++CUresult cuPointerGetAttribute(void *, CUpointer_attribute, CUdeviceptr) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuMemcpyAsync(CUdeviceptr, CUdeviceptr, size_t, CUstream) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuMemAlloc(CUdeviceptr *, size_t) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuMemFree(CUdeviceptr buf) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuCtxGetCurrent(void *cuContext) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuStreamCreate(CUstream *, int) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuEventCreate(CUevent *, int) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuEventRecord(CUevent, CUstream) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuEventQuery(CUevent) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuEventDestroy(CUevent) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuMemHostRegister(void *, size_t, unsigned int) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuMemHostUnregister(void *) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuMemGetAddressRange(CUdeviceptr *, size_t *, CUdeviceptr) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuIpcGetEventHandle(CUipcEventHandle *, CUevent) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuIpcOpenEventHandle(CUevent *, CUipcEventHandle) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuIpcOpenMemHandle(CUdeviceptr *, CUipcMemHandle, unsigned int) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuIpcCloseMemHandle(CUdeviceptr) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuIpcGetMemHandle(CUipcMemHandle *, CUdeviceptr) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuCtxGetDevice(CUdevice *) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuDeviceCanAccessPeer(int *, CUdevice, CUdevice) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuCtxSetCurrent(CUcontext) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuStreamSynchronize(CUstream) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuStreamDestroy(CUstream) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuPointerSetAttribute(const void *, CUpointer_attribute, CUdeviceptr) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuDeviceGetPCIBusId(char*, int, CUdevice) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuPointerGetAttributes(unsigned int, CUpointer_attribute *, void **, CUdeviceptr) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuDeviceGetCount(int *count) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuDeviceGet(CUdevice *device, int ordinal) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuCtxPushCurrent(CUcontext ctx) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuCtxPopCurrent(CUcontext *pctx) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int *flags, int *active) { return CUDA_ERROR_UNKNOWN; }
++CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev) { return CUDA_ERROR_UNKNOWN; }

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.7_fix_gpfs_compatibility.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.7_fix_gpfs_compatibility.patch
@@ -1,0 +1,19 @@
+# What: This patch fiexs incompatibility issue with GPFS >= v5.2.3. For more details see
+#       https://github.com/open-mpi/ompi/issues/13313
+# Author: maxim-masterov
+
+diff -Nru openmpi-5.0.7.orig/ompi/mca/fs/gpfs/fs_gpfs_file_set_info.c openmpi-5.0.7/ompi/mca/fs/gpfs/fs_gpfs_file_set_info.c
+--- openmpi-5.0.7.orig/ompi/mca/fs/gpfs/fs_gpfs_file_set_info.c	2025-07-28 10:20:48.651341000 +0200
++++ openmpi-5.0.7/ompi/mca/fs/gpfs/fs_gpfs_file_set_info.c	2025-07-28 10:22:11.494552111 +0200
+@@ -313,7 +313,11 @@
+         gpfs_hint_SetReplication.gpfsSetReplication.maxMetadataReplicas = atoi(token);
+         gpfs_hint_SetReplication.gpfsSetReplication.dataReplicas = atoi(token);
+         gpfs_hint_SetReplication.gpfsSetReplication.maxDataReplicas = atoi(token);
++#ifdef GPFS_FCNTL_SET_REPLICATIONX /* GPFS >= 5.2.3-0, see #13313 */
++        gpfs_hint_SetReplication.gpfsSetReplication.perfReplicas = 0;
++#else
+         gpfs_hint_SetReplication.gpfsSetReplication.reserved = 0;
++#endif
+         free(info_str_dup);
+ 
+         rc = gpfs_fcntl(gpfs_file_handle, &gpfs_hint_SetReplication);


### PR DESCRIPTION
- Fix OpenMPI incompatibility with GPFS >= 5.2.3
- Fix stubs for OpenMPI build with internal CUDA