### PR TITLE
Remove `max_failed_tests` in PyTorch easyconfigs where the used value was less or equal to the default

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.11.0-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.11.0-foss-2021a-CUDA-11.3.1.eb
@@ -133,10 +133,6 @@ excluded_tests = {
 
 runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
 
-# several tests are known to be flaky, and fail in some contexts (like having multiple GPUs available),
-# so we allow some (out of ~90k) tests to fail before treating the installation to be faulty
-max_failed_tests = 1
-
 # The readelf sanity check command can be taken out once the TestRPATH test from
 # https://github.com/pytorch/pytorch/pull/68912 is accepted, since it is then checked as part of the PyTorch test suite
 local_libcaffe2 = "$EBROOTPYTORCH/lib/python%%(pyshortver)s/site-packages/torch/lib/libcaffe2_nvrtc.%s" % SHLIB_EXT

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a-CUDA-11.7.0.eb
@@ -170,10 +170,6 @@ excluded_tests = {
     ]
 }
 
-# several tests are known to be flaky, and fail in some contexts (like having multiple GPUs available),
-# so we allow some tests to fail before treating the installation to be faulty
-max_failed_tests = 4
-
 runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
 
 # The readelf sanity check command can be taken out once the TestRPATH test from

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.12.1-foss-2022a.eb
@@ -155,10 +155,6 @@ excluded_tests = {
 
 runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
 
-# Some tests fail randomöy due to random inputs being used
-# So allow a low number of tests to fail as the tests "usually" succeed
-max_failed_tests = 2
-
 tests = ['PyTorch-check-cpp-extension.py']
 
 moduleclass = 'ai'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.13.1-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.13.1-foss-2022a-CUDA-11.7.0.eb
@@ -160,11 +160,6 @@ sanity_check_commands = [
     "readelf -d %s | egrep 'RPATH|RUNPATH' | grep -v stubs" % local_libcaffe2,
 ]
 
-# Especially test_quantization has a few corner cases that are triggered by the random input values,
-# those cannot be easily avoided, see https://github.com/pytorch/pytorch/issues/107030
-# So allow a low number of tests to fail as the tests "usually" succeed
-max_failed_tests = 2
-
 tests = ['PyTorch-check-cpp-extension.py']
 
 moduleclass = 'ai'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.13.1-foss-2022b-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.13.1-foss-2022b-CUDA-11.7.0.eb
@@ -187,11 +187,6 @@ sanity_check_commands = [
     "readelf -d %s | egrep 'RPATH|RUNPATH' | grep -v stubs" % local_libcaffe2,
 ]
 
-# Especially test_quantization has a few corner cases that are triggered by the random input values,
-# those cannot be easily avoided, see https://github.com/pytorch/pytorch/issues/107030
-# So allow a low number of tests to fail as the tests "usually" succeed
-max_failed_tests = 2
-
 tests = ['PyTorch-check-cpp-extension.py']
 
 moduleclass = 'ai'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.13.1-foss-2022b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.13.1-foss-2022b.eb
@@ -154,11 +154,6 @@ excluded_tests = {
 
 runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
 
-# Especially test_quantization has a few corner cases that are triggered by the random input values,
-# those cannot be easily avoided, see https://github.com/pytorch/pytorch/issues/107030
-# So allow a low number of tests to fail as the tests "usually" succeed
-max_failed_tests = 5
-
 tests = ['PyTorch-check-cpp-extension.py']
 
 moduleclass = 'ai'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.0.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.0.1-foss-2022a.eb
@@ -137,11 +137,6 @@ excluded_tests = {
 
 runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
 
-# Especially test_quantization has a few corner cases that are triggered by the random input values,
-# those cannot be easily avoided, see https://github.com/pytorch/pytorch/issues/107030
-# So allow a low number of tests to fail as the tests "usually" succeed
-max_failed_tests = 2
-
 tests = ['PyTorch-check-cpp-extension.py']
 
 moduleclass = 'ai'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.0.1-foss-2022b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.0.1-foss-2022b.eb
@@ -142,11 +142,6 @@ excluded_tests = {
 
 runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
 
-# Especially test_quantization has a few corner cases that are triggered by the random input values,
-# those cannot be easily avoided, see https://github.com/pytorch/pytorch/issues/107030
-# So allow a low number of tests to fail as the tests "usually" succeed
-max_failed_tests = 3
-
 tests = ['PyTorch-check-cpp-extension.py']
 
 moduleclass = 'ai'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.1.2-foss-2022a.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.1.2-foss-2022a.eb
@@ -168,11 +168,6 @@ excluded_tests = {
 
 runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
 
-# Especially test_quantization has a few corner cases that are triggered by the random input values,
-# those cannot be easily avoided, see https://github.com/pytorch/pytorch/issues/107030
-# So allow a low number of tests to fail as the tests "usually" succeed
-max_failed_tests = 2
-
 tests = ['PyTorch-check-cpp-extension.py']
 
 moduleclass = 'ai'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.1.2-foss-2022b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.1.2-foss-2022b.eb
@@ -168,11 +168,6 @@ excluded_tests = {
 
 runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
 
-# Especially test_quantization has a few corner cases that are triggered by the random input values,
-# those cannot be easily avoided, see https://github.com/pytorch/pytorch/issues/107030
-# So allow a low number of tests to fail as the tests "usually" succeed
-max_failed_tests = 2
-
 tests = ['PyTorch-check-cpp-extension.py']
 
 moduleclass = 'ai'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.1.2-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.1.2-foss-2023a-CUDA-12.1.1.eb
@@ -219,12 +219,6 @@ excluded_tests = {
 
 runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
 
-# Especially test_quantization has a few corner cases that are triggered by the random input values,
-# those cannot be easily avoided, see https://github.com/pytorch/pytorch/issues/107030
-# test_nn is also prone to spurious failures: https://github.com/pytorch/pytorch/issues/118294
-# So allow a low number of tests to fail as the tests "usually" succeed
-max_failed_tests = 2
-
 # The readelf sanity check command can be taken out once the TestRPATH test from
 # https://github.com/pytorch/pytorch/pull/109493 is accepted, since it is then checked as part of the PyTorch test suite
 local_libcaffe2 = "$EBROOTPYTORCH/lib/python%%(pyshortver)s/site-packages/torch/lib/libcaffe2_nvrtc.%s" % SHLIB_EXT

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.1.2-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.1.2-foss-2023a.eb
@@ -172,11 +172,6 @@ excluded_tests = {
 
 runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
 
-# Especially test_quantization has a few corner cases that are triggered by the random input values,
-# those cannot be easily avoided, see https://github.com/pytorch/pytorch/issues/107030
-# So allow a low number of tests to fail as the tests "usually" succeed
-max_failed_tests = 2
-
 tests = ['PyTorch-check-cpp-extension.py']
 
 moduleclass = 'ai'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.1.2-foss-2023b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.1.2-foss-2023b.eb
@@ -174,11 +174,6 @@ excluded_tests = {
 
 runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
 
-# Especially test_quantization has a few corner cases that are triggered by the random input values,
-# those cannot be easily avoided, see https://github.com/pytorch/pytorch/issues/107030
-# So allow a low number of tests to fail as the tests "usually" succeed
-max_failed_tests = 2
-
 tests = ['PyTorch-check-cpp-extension.py']
 
 moduleclass = 'ai'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.3.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.3.0-foss-2023b.eb
@@ -183,11 +183,6 @@ excluded_tests = {
 local_test_opts = '--continue-through-error --pipe-logs --verbose %(excluded_tests)s'
 runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py ' + local_test_opts
 
-# Especially test_quantization has a few corner cases that are triggered by the random input values,
-# those cannot be easily avoided, see https://github.com/pytorch/pytorch/issues/107030
-# So allow a low number of tests to fail as the tests "usually" succeed
-max_failed_tests = 6
-
 tests = ['PyTorch-check-cpp-extension.py']
 
 moduleclass = 'ai'


### PR DESCRIPTION
See https://github.com/easybuilders/easybuild-easyconfigs/pull/23552#issuecomment-3140707728

edit: requires:
- https://github.com/easybuilders/easybuild-easyblocks/pull/3869