### PR TITLE
{tools}[foss/2023b] petsc4py v3.22.5

### DIFF
--- a/easybuild/easyconfigs/p/petsc4py/petsc4py-3.22.5-foss-2023b.eb
+++ b/easybuild/easyconfigs/p/petsc4py/petsc4py-3.22.5-foss-2023b.eb
@@ -8,8 +8,7 @@ description = "petsc4py are Python bindings for PETSc, the Portable, Extensible 
 
 toolchain = {'name': 'foss', 'version': '2023b'}
 
-source_urls = ['https://pypi.python.org/packages/source/p/petsc4py']
-sources = ['%(name)s-%(version)s.tar.gz']
+sources = [SOURCE_TAR_GZ]
 checksums = ['058478cdba163e162d17ad14a8f71d519049a7c84807cd33a14c7f852988ec2e']
 
 dependencies = [


### PR DESCRIPTION
Add a Python bindings for PETSc of 2023b toolchain.

The version of petsc4py and PETSc must be the same. There was no release 3.22.5 for petsc4py in PyPI, but foss/2023b is using PETSc version 3.22.5. This commit originally built petsc4py from the bindings directory of the 3.22.5 release of PETSc.

Now the source code for the petsc4py v3.22.5 has been [released in PyPI](https://gitlab.com/petsc/petsc/-/issues/1799), and the package is being built from the PyPI source code.