### PR TITLE
Update EasyConfig test suite to respect `intel-compilers/2025.2.0` for 2025b

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -977,6 +977,7 @@ class EasyConfigTest(TestCase):
             '2025.0.0': None,
             '2025.1.0': None,
             '2025.1.1': '2025a',
+            '2025.2.0': '2025b',
         }
 
         multi_dep_vars_msg = ''


### PR DESCRIPTION
Required for test suite in #23589 to pass, since no default mapping exists.

See e.g.: https://github.com/easybuilders/easybuild-easyconfigs/actions/runs/16806795013/job/47601243580?pr=23589
```
======================================================================
FAIL: test_dep_versions_per_toolchain_generation (test.easyconfigs.easyconfigs.EasyConfigTest)
Check whether there's only one dependency version per toolchain generation actively used.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/easybuild-easyconfigs/easybuild-easyconfigs/test/easyconfigs/easyconfigs.py", line 1026, in test_dep_versions_per_toolchain_generation
    self.fail("No mapping for intel-compilers %s to toolchain generation!" % ic_ver)
AssertionError: No mapping for intel-compilers 2025.2.0 to toolchain generation!
```