### PR TITLE
ignore failing time formatter tests for LLVM 20.1.8

### DIFF
--- a/easybuild/easyconfigs/l/LLVM/LLVM-20.1.8-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-20.1.8-GCCcore-14.3.0.eb
@@ -82,7 +82,10 @@ test_suite_ignore_patterns = [
     "Driver/atomic.f90",
     "Driver/gcc-toolchain-install-dir.f90",
     "api_tests/test_ompd_get_icv_from_scope.c",
+    "std/time/time.syn/formatter",
+    # Those 2 might fail with "tzdb: the path '/etc/localtime' is not a symlink"
+    "std/time/time.zone/time.zone.db/time.zone.db.tzdb",
+    "std/time/time.zone/time.zone.db/time.zone.db.access",
 ]
-
 
 moduleclass = 'compiler'


### PR DESCRIPTION
Fixes #23632