### PR TITLE
{lang}[foss/2023b] Fix package dependencies versions for OCaml

### DIFF
--- a/easybuild/easyconfigs/o/OCaml/OCaml-4.14.0-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/o/OCaml/OCaml-4.14.0-GCC-11.3.0.eb
@@ -45,8 +45,8 @@ exts_list = [
     ('ocamlfind', '1.9.6'),
     ('batteries', '3.7.2'),
     ('conf-pkg-config', '3'),
-    ('dune-configurator', '3.14.0'),
-    ('dune', '3.14.0'),
+    ('dune-configurator', '3.15.3'),
+    ('dune', '3.15.3'),
     ('base', 'v0.16.3'),
     ('stdio', 'v0.16.0'),
 ]

--- a/easybuild/easyconfigs/o/OCaml/OCaml-5.1.1-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/o/OCaml/OCaml-5.1.1-GCC-13.2.0.eb
@@ -45,8 +45,8 @@ exts_list = [
     ('ocamlfind', '1.9.6'),
     ('batteries', '3.8.0'),
     ('conf-pkg-config', '3'),
-    ('dune-configurator', '3.14.2'),
-    ('dune', '3.14.2'),
+    ('dune-configurator', '3.15.3'),
+    ('dune', '3.15.3'),
     ('base', 'v0.16.3'),
     ('stdio', 'v0.16.0'),
 ]


### PR DESCRIPTION
Some versions of OCaml packages are no longer available in OPAM. Update dependencies to the nearest available version.