### PR TITLE
Establish `2025b` toolchain (and rename / remove candidate toolchains 2025.07 / 2025.08 )

### DIFF
--- a/easybuild/easyconfigs/a/ASE/ASE-3.25.0-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.25.0-gfbf-2025b.eb
@@ -10,7 +10,7 @@ description = """ASE is a python package providing an open source Atomic Simulat
 From version 3.20.1 we also include the ase-ext package, it contains optional reimplementations
 in C of functions in ASE.  ASE uses it automatically when installed."""
 
-toolchain = {'name': 'gfbf', 'version': '2025.07'}
+toolchain = {'name': 'gfbf', 'version': '2025b'}
 
 dependencies = [
     ('Python', '3.13.5'),

--- a/easybuild/easyconfigs/b/bokeh/bokeh-3.7.3-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/b/bokeh/bokeh-3.7.3-gfbf-2025b.eb
@@ -6,7 +6,7 @@ version = '3.7.3'
 homepage = 'https://github.com/bokeh/bokeh'
 description = "Statistical and novel interactive HTML plots for Python"
 
-toolchain = {'name': 'gfbf', 'version': '2025.07'}
+toolchain = {'name': 'gfbf', 'version': '2025b'}
 
 builddependencies = [
     ('meson-python', '0.18.0'),

--- a/easybuild/easyconfigs/f/FFTW.MPI/FFTW.MPI-3.3.10-gompi-2025b.eb
+++ b/easybuild/easyconfigs/f/FFTW.MPI/FFTW.MPI-3.3.10-gompi-2025b.eb
@@ -5,7 +5,7 @@ homepage = 'https://www.fftw.org'
 description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
 in one or more dimensions, of arbitrary input size, and of both real and complex data."""
 
-toolchain = {'name': 'gompi', 'version': '2025.07'}
+toolchain = {'name': 'gompi', 'version': '2025b'}
 toolchainopts = {'pic': True}
 
 source_urls = [homepage]

--- a/easybuild/easyconfigs/f/FLINT/FLINT-3.3.1-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/f/FLINT/FLINT-3.3.1-gfbf-2025b.eb
@@ -10,7 +10,7 @@ description = """FLINT (Fast Library for Number Theory) is a C library in suppor
  factoring, solving linear systems, and evaluating special functions. In addition, FLINT provides
  various low-level routines for fast arithmetic. FLINT is extensively documented and tested."""
 
-toolchain = {'name': 'gfbf', 'version': '2025.07'}
+toolchain = {'name': 'gfbf', 'version': '2025b'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://www.flintlib.org/download']

--- a/easybuild/easyconfigs/f/foss/foss-2025b.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2025b.eb
@@ -1,7 +1,7 @@
 easyblock = 'Toolchain'
 
 name = 'foss'
-version = '2025.07'
+version = '2025b'
 
 homepage = 'https://easybuild.readthedocs.io/en/master/Common-toolchains.html#foss-toolchain'
 description = """GNU Compiler Collection (GCC) based compiler toolchain, including

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2025.2-foss-2025b.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2025.2-foss-2025b.eb
@@ -29,7 +29,7 @@ for both single and double precision.
 It also contains the gmxapi extension for the single precision MPI build.
 """
 
-toolchain = {'name': 'foss', 'version': '2025.07'}
+toolchain = {'name': 'foss', 'version': '2025b'}
 toolchainopts = {'openmp': True, 'usempi': True}
 
 source_urls = [

--- a/easybuild/easyconfigs/g/gfbf/gfbf-2025b.eb
+++ b/easybuild/easyconfigs/g/gfbf/gfbf-2025b.eb
@@ -1,7 +1,7 @@
 easyblock = 'Toolchain'
 
 name = 'gfbf'
-version = '2025.07'
+version = '2025b'
 
 homepage = '(none)'
 description = """GNU Compiler Collection (GCC) based compiler toolchain, including

--- a/easybuild/easyconfigs/g/gompi/gompi-2025b.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2025b.eb
@@ -1,7 +1,7 @@
 easyblock = 'Toolchain'
 
 name = 'gompi'
-version = '2025.07'
+version = '2025b'
 
 homepage = '(none)'
 description = """GNU Compiler Collection (GCC) based compiler toolchain,

--- a/easybuild/easyconfigs/h/HPCG/HPCG-3.1-foss-2025b.eb
+++ b/easybuild/easyconfigs/h/HPCG/HPCG-3.1-foss-2025b.eb
@@ -5,7 +5,7 @@ homepage = 'https://software.sandia.gov/hpcg'
 description = """The HPCG Benchmark project is an effort to create a more relevant metric for ranking HPC systems than
  the High Performance LINPACK (HPL) benchmark, that is currently used by the TOP500 benchmark."""
 
-toolchain = {'name': 'foss', 'version': '2025.07'}
+toolchain = {'name': 'foss', 'version': '2025b'}
 toolchainopts = {'usempi': True, 'openmp': True}
 
 source_urls = ['http://www.hpcg-benchmark.org/downloads']

--- a/easybuild/easyconfigs/h/HPCG/HPCG-3.1-intel-2025b.eb
+++ b/easybuild/easyconfigs/h/HPCG/HPCG-3.1-intel-2025b.eb
@@ -5,7 +5,7 @@ homepage = 'https://software.sandia.gov/hpcg'
 description = """The HPCG Benchmark project is an effort to create a more relevant metric for ranking HPC systems than
  the High Performance LINPACK (HPL) benchmark, that is currently used by the TOP500 benchmark."""
 
-toolchain = {'name': 'intel', 'version': '2025.08'}
+toolchain = {'name': 'intel', 'version': '2025b'}
 toolchainopts = {'usempi': True, 'openmp': True}
 
 source_urls = ['http://www.hpcg-benchmark.org/downloads']

--- a/easybuild/easyconfigs/h/hmmlearn/hmmlearn-0.3.3-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/h/hmmlearn/hmmlearn-0.3.3-gfbf-2025b.eb
@@ -6,7 +6,7 @@ version = '0.3.3'
 homepage = 'https://github.com/hmmlearn/hmmlearn'
 description = "hmmlearn is a set of algorithms for unsupervised learning and inference of Hidden Markov Models"
 
-toolchain = {'name': 'gfbf', 'version': '2025.07'}
+toolchain = {'name': 'gfbf', 'version': '2025b'}
 
 sources = [SOURCE_TAR_GZ]
 checksums = ['1d3c5dc4c5257e0c238dc1fe5387700b8cb987eab808edb3e0c73829f1cc44ec']

--- a/easybuild/easyconfigs/i/iimkl/iimkl-2025b.eb
+++ b/easybuild/easyconfigs/i/iimkl/iimkl-2025b.eb
@@ -1,18 +1,18 @@
 # This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild
 easyblock = 'Toolchain'
 
-name = 'iimpi'
-version = '2025.08'
+name = 'iimkl'
+version = '2025b'
 
-homepage = 'https://software.intel.com/parallel-studio-xe'
-description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
+homepage = 'https://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Intel C/C++ and Fortran compilers, alongside Intel Math Kernel Library (MKL)."""
 
 toolchain = SYSTEM
 
 local_comp_ver = '2025.2.0'
 dependencies = [
     ('intel-compilers', local_comp_ver),
-    ('impi', '2021.16.1', '', ('intel-compilers', local_comp_ver)),
+    ('imkl', '2025.2.0', '', SYSTEM),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2025b.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2025b.eb
@@ -1,18 +1,18 @@
 # This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild
 easyblock = 'Toolchain'
 
-name = 'iimkl'
-version = '2025.07'
+name = 'iimpi'
+version = '2025b'
 
-homepage = 'https://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
-description = """Intel C/C++ and Fortran compilers, alongside Intel Math Kernel Library (MKL)."""
+homepage = 'https://software.intel.com/parallel-studio-xe'
+description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
 local_comp_ver = '2025.2.0'
 dependencies = [
     ('intel-compilers', local_comp_ver),
-    ('imkl', '2025.2.0', '', SYSTEM),
+    ('impi', '2021.16.1', '', ('intel-compilers', local_comp_ver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/imageio/imageio-2.37.0-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/i/imageio/imageio-2.37.0-gfbf-2025b.eb
@@ -7,7 +7,7 @@ homepage = 'https://imageio.github.io'
 description = """Imageio is a Python library that provides an easy interface to read and write a wide range of
  image data, including animated images, video, volumetric data, and scientific formats."""
 
-toolchain = {'name': 'gfbf', 'version': '2025.07'}
+toolchain = {'name': 'gfbf', 'version': '2025b'}
 
 sources = [SOURCE_TAR_GZ]
 checksums = ['71b57b3669666272c818497aebba2b4c5f20d5b37c81720e5e1a56d59c492996']

--- a/easybuild/easyconfigs/i/imkl-FFTW/imkl-FFTW-2025.2.0-iimpi-2025b.eb
+++ b/easybuild/easyconfigs/i/imkl-FFTW/imkl-FFTW-2025.2.0-iimpi-2025b.eb
@@ -4,7 +4,7 @@ version = '2025.2.0'
 homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html'
 description = "FFTW interfaces using Intel oneAPI Math Kernel Library"
 
-toolchain = {'name': 'iimpi', 'version': '2025.08'}
+toolchain = {'name': 'iimpi', 'version': '2025b'}
 
 dependencies = [('imkl', version, '', SYSTEM)]
 

--- a/easybuild/easyconfigs/i/intel/intel-2025b.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2025b.eb
@@ -1,7 +1,7 @@
 easyblock = 'Toolchain'
 
 name = 'intel'
-version = '2025.08'
+version = '2025b'
 
 homepage = 'https://docs.easybuild.io/common-toolchains/#common_toolchains_overview_intel'
 description = "Compiler toolchain including Intel compilers, Intel MPI and Intel Math Kernel Library (MKL)."

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-3.10.5-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-3.10.5-gfbf-2025b.eb
@@ -8,7 +8,7 @@ description = """matplotlib is a python 2D plotting library which produces publi
  hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
  and ipython shell, web application servers, and six graphical user interface toolkits."""
 
-toolchain = {'name': 'gfbf', 'version': '2025.07'}
+toolchain = {'name': 'gfbf', 'version': '2025b'}
 
 builddependencies = [
     ('pkgconf', '2.4.3'),

--- a/easybuild/easyconfigs/m/mpi4py/mpi4py-4.1.0-gompi-2025b.eb
+++ b/easybuild/easyconfigs/m/mpi4py/mpi4py-4.1.0-gompi-2025b.eb
@@ -7,7 +7,7 @@ homepage = 'https://github.com/mpi4py/mpi4py'
 description = """MPI for Python (mpi4py) provides bindings of the Message Passing Interface (MPI) standard for
  the Python programming language, allowing any Python program to exploit multiple processors."""
 
-toolchain = {'name': 'gompi', 'version': '2025.07'}
+toolchain = {'name': 'gompi', 'version': '2025b'}
 
 builddependencies = [
     ('Cython', '3.1.2'),

--- a/easybuild/easyconfigs/n/networkx/networkx-3.5-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/n/networkx/networkx-3.5-gfbf-2025b.eb
@@ -7,7 +7,7 @@ homepage = 'https://pypi.python.org/pypi/networkx'
 description = """NetworkX is a Python package for the creation, manipulation,
 and study of the structure, dynamics, and functions of complex networks."""
 
-toolchain = {'name': 'gfbf', 'version': '2025.07'}
+toolchain = {'name': 'gfbf', 'version': '2025b'}
 
 sources = [SOURCE_TAR_GZ]
 checksums = ['d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037']

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.2.2-gompi-2025b-fb.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.2.2-gompi-2025b-fb.eb
@@ -6,7 +6,7 @@ homepage = 'https://www.netlib.org/scalapack/'
 description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
  redesigned for distributed memory MIMD parallel computers."""
 
-toolchain = {'name': 'gompi', 'version': '2025.07'}
+toolchain = {'name': 'gompi', 'version': '2025b'}
 toolchainopts = {'extra_fflags': '-lpthread', 'openmp': True, 'pic': True, 'usempi': True}
 
 source_urls = ['https://github.com/Reference-ScaLAPACK/scalapack/archive/refs/tags/']

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2025.07-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2025.07-gfbf-2025b.eb
@@ -6,7 +6,7 @@ version = '2025.07'
 homepage = 'https://python.org/'
 description = "Bundle of Python packages for scientific software"
 
-toolchain = {'name': 'gfbf', 'version': '2025.07'}
+toolchain = {'name': 'gfbf', 'version': '2025b'}
 toolchainopts = {'pic': True, 'lowopt': True}
 
 builddependencies = [

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-1.7.1-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-1.7.1-gfbf-2025b.eb
@@ -9,7 +9,7 @@ building upon numpy, scipy, and matplotlib. As a machine-learning module,
 it provides versatile tools for data mining and analysis in any field of science and engineering.
 It strives to be simple and efficient, accessible to everybody, and reusable in various contexts."""
 
-toolchain = {'name': 'gfbf', 'version': '2025.07'}
+toolchain = {'name': 'gfbf', 'version': '2025b'}
 
 builddependencies = [
     ('meson-python', '0.18.0'),

--- a/easybuild/easyconfigs/s/spglib-python/spglib-python-2.6.0-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/s/spglib-python/spglib-python-2.6.0-gfbf-2025b.eb
@@ -9,7 +9,7 @@ description = """Spglib for Python.
 Spglib is a library for finding and handling crystal symmetries written in C.
 """
 
-toolchain = {'name': 'gfbf', 'version': '2025.07'}
+toolchain = {'name': 'gfbf', 'version': '2025b'}
 
 builddependencies = [
     ('scikit-build-core', '0.11.5'),


### PR DESCRIPTION
Renames all existing EasyConfigs for 2025.07 / 2025.08 to 2025b.
As discussed on Slack, we've successfully built GROMACS with `foss/2025.07`, which is a nice target to test.
For Intel, PRs are open for HPL and HPCG to test with. Based on their results, the toolchain looks similar to our prior ones.

**PRs using candidate toolchains:**
- [x] https://github.com/easybuilders/easybuild-easyconfigs/pull/23707
- [ ] https://github.com/easybuilders/easybuild-easyconfigs/pull/23704
- [ ] https://github.com/easybuilders/easybuild-easyconfigs/pull/23692
- [ ] https://github.com/easybuilders/easybuild-easyconfigs/pull/23683
- [ ] https://github.com/easybuilders/easybuild-easyconfigs/pull/23626
- [ ] https://github.com/easybuilders/easybuild-easyconfigs/pull/23703
- [ ] https://github.com/easybuilders/easybuild-easyconfigs/pull/23702
- [ ] https://github.com/easybuilders/easybuild-easyconfigs/pull/23709