### PR TITLE
remove lic server from sources in ABAQUS-2024-hotfix-2441.eb

### DIFF
--- a/easybuild/easyconfigs/a/ABAQUS/ABAQUS-2024-hotfix-2441.eb
+++ b/easybuild/easyconfigs/a/ABAQUS/ABAQUS-2024-hotfix-2441.eb
@@ -18,7 +18,6 @@ sources = [
     '%(version)s.AM_SIM_Abaqus_Extend.AllOS.6-6.tar',
     # hotfixes
     '%%(version)s.FP.CFA.%s.Part_SIMULIA_EstPrd.Linux64.tar' % local_hotfix,
-    '%%(version)s.FP.CFA.%s.Part_SIMULIA_FlexNet.Linux64.tar' % local_hotfix,
 ]
 
 download_instructions = f"""{name} requires manual download from https://www.3ds.com/support/software-downloads.
@@ -34,8 +33,6 @@ checksums = [
     {'2024.AM_SIM_Abaqus_Extend.AllOS.6-6.tar': '482829b1c364966ae01a577233bddf6b377b8e3cd9b7f77dd95830d4636677d7'},
     {'2024.FP.CFA.2441.Part_SIMULIA_EstPrd.Linux64.tar':
      '9b3601feda8925e134f854996b508805683899896d18eafdbaef4d96e688976c'},
-    {'2024.FP.CFA.2441.Part_SIMULIA_FlexNet.Linux64.tar':
-     '976710d17581a69dc7087e9a0c571ba40fe3e26dee4d1a8d589470bc6fb16f34'},
 ]
 
 moduleclass = 'cae'


### PR DESCRIPTION
`%%(version)s.FP.CFA.%s.Part_SIMULIA_FlexNet.Linux64.tar` is the SIMULIA FlexNet License Server package thus not needed (in general).