### PR TITLE
enhance patch file to show output when LAMMPS Python package failed to install

### DIFF
--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-28Oct2024-foss-2023a-kokkos-mace-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-28Oct2024-foss-2023a-kokkos-mace-CUDA-12.1.1.eb
@@ -21,7 +21,7 @@ patches = [
 checksums = [
     {'LAMMPS-28Oct2024.tar.gz': '43d1432782806ddae40a9f8fd3a7c7c0dc2fad0c74c440e1b189f42b33da2777'},
     {'LAMMPS-2Aug2023_install_lammps_python_package_in_eb_software_module.patch':
-     '723c944b62b9d28427d25e80a7a67049631702d344df49268a6846aa0cd0fe04'},
+     '314ab1064af74ddfcf4091dfe9f90fa32cfa4100e8d01fea7b59b019575a7c51'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Aug2024-foss-2023b-kokkos.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Aug2024-foss-2023b-kokkos.eb
@@ -26,7 +26,7 @@ patches = [
 checksums = [
     {'stable_29Aug2024.tar.gz': '6112e0cc352c3140a4874c7f74db3c0c8e30134024164509ecf3772b305fde2e'},
     {'LAMMPS-2Aug2023_install_lammps_python_package_in_eb_software_module.patch':
-     '723c944b62b9d28427d25e80a7a67049631702d344df49268a6846aa0cd0fe04'},
+     '314ab1064af74ddfcf4091dfe9f90fa32cfa4100e8d01fea7b59b019575a7c51'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Aug2024_update2-foss-2023a-kokkos.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Aug2024_update2-foss-2023a-kokkos.eb
@@ -26,7 +26,7 @@ patches = [
 checksums = [
     {'stable_29Aug2024_update2.tar.gz': 'f8ca3f021a819ced8658055f7750e235c51b4937ddb621cf1bd7bee08e0b6266'},
     {'LAMMPS-2Aug2023_install_lammps_python_package_in_eb_software_module.patch':
-     '723c944b62b9d28427d25e80a7a67049631702d344df49268a6846aa0cd0fe04'},
+     '314ab1064af74ddfcf4091dfe9f90fa32cfa4100e8d01fea7b59b019575a7c51'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Aug2024_update2-foss-2023b-kokkos-CUDA-12.4.0.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Aug2024_update2-foss-2023b-kokkos-CUDA-12.4.0.eb
@@ -33,7 +33,7 @@ patches = [
 checksums = [
     {'stable_29Aug2024_update2.tar.gz': 'f8ca3f021a819ced8658055f7750e235c51b4937ddb621cf1bd7bee08e0b6266'},
     {'LAMMPS-2Aug2023_install_lammps_python_package_in_eb_software_module.patch':
-     '723c944b62b9d28427d25e80a7a67049631702d344df49268a6846aa0cd0fe04'},
+     '314ab1064af74ddfcf4091dfe9f90fa32cfa4100e8d01fea7b59b019575a7c51'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Aug2024_update2-foss-2024a-kokkos-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Aug2024_update2-foss-2024a-kokkos-CUDA-12.6.0.eb
@@ -33,7 +33,7 @@ patches = [
 checksums = [
     {'stable_29Aug2024_update2.tar.gz': 'f8ca3f021a819ced8658055f7750e235c51b4937ddb621cf1bd7bee08e0b6266'},
     {'LAMMPS-2Aug2023_install_lammps_python_package_in_eb_software_module.patch':
-     '723c944b62b9d28427d25e80a7a67049631702d344df49268a6846aa0cd0fe04'},
+     '314ab1064af74ddfcf4091dfe9f90fa32cfa4100e8d01fea7b59b019575a7c51'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Aug2024_update2-foss-2024a-kokkos.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Aug2024_update2-foss-2024a-kokkos.eb
@@ -26,7 +26,7 @@ patches = [
 checksums = [
     {'stable_29Aug2024_update2.tar.gz': 'f8ca3f021a819ced8658055f7750e235c51b4937ddb621cf1bd7bee08e0b6266'},
     {'LAMMPS-2Aug2023_install_lammps_python_package_in_eb_software_module.patch':
-     '723c944b62b9d28427d25e80a7a67049631702d344df49268a6846aa0cd0fe04'},
+     '314ab1064af74ddfcf4091dfe9f90fa32cfa4100e8d01fea7b59b019575a7c51'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-2Aug2023_install_lammps_python_package_in_eb_software_module.patch
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-2Aug2023_install_lammps_python_package_in_eb_software_module.patch
@@ -34,7 +34,7 @@ diff -ru lammps-stable_2Aug2023_update2.orig/python/install.py lammps-stable_2Au
 +  print(txt)
 +  sys.exit(0)
 +except subprocess.CalledProcessError as err:
-+  sys.exit(0)
++  sys.exit(err.output.decode('UTF-8'))
 +try:
    txt = subprocess.check_output([py_exe, '-m', 'pip', 'install', '--force-reinstall', wheel], stderr=subprocess.STDOUT, shell=False)
    print(txt.decode('UTF-8'))

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-2Aug2023_update2-foss-2023a-kokkos-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-2Aug2023_update2-foss-2023a-kokkos-CUDA-12.1.1.eb
@@ -28,7 +28,7 @@ patches = [
 checksums = [
     {'stable_2Aug2023_update2.tar.gz': '3bcecabc9cad08d0a4e4d989b52d29c58505f7ead8ebacf43c9db8d9fd3d564a'},
     {'LAMMPS-2Aug2023_install_lammps_python_package_in_eb_software_module.patch':
-     '723c944b62b9d28427d25e80a7a67049631702d344df49268a6846aa0cd0fe04'},
+     '314ab1064af74ddfcf4091dfe9f90fa32cfa4100e8d01fea7b59b019575a7c51'},
     {'LAMMPS-2Aug2023_fix-timestep-balance-example.patch':
      '6f68387ced2b4bd0a06e4c3d31b0ffd47042476777d87d8a0ca6b19a4e6a1777'},
 ]

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb
@@ -27,7 +27,7 @@ patches = [
 checksums = [
     {'stable_2Aug2023_update2.tar.gz': '3bcecabc9cad08d0a4e4d989b52d29c58505f7ead8ebacf43c9db8d9fd3d564a'},
     {'LAMMPS-2Aug2023_install_lammps_python_package_in_eb_software_module.patch':
-     '723c944b62b9d28427d25e80a7a67049631702d344df49268a6846aa0cd0fe04'},
+     '314ab1064af74ddfcf4091dfe9f90fa32cfa4100e8d01fea7b59b019575a7c51'},
     {'LAMMPS-2Aug2023_fix-timestep-balance-example.patch':
      '6f68387ced2b4bd0a06e4c3d31b0ffd47042476777d87d8a0ca6b19a4e6a1777'},
 ]

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-2Aug2023_update2-foss-2024a-kokkos-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-2Aug2023_update2-foss-2024a-kokkos-CUDA-12.6.0.eb
@@ -34,7 +34,7 @@ patches = [
 checksums = [
     {'stable_2Aug2023_update2.tar.gz': '3bcecabc9cad08d0a4e4d989b52d29c58505f7ead8ebacf43c9db8d9fd3d564a'},
     {'LAMMPS-2Aug2023_install_lammps_python_package_in_eb_software_module.patch':
-     '723c944b62b9d28427d25e80a7a67049631702d344df49268a6846aa0cd0fe04'},
+     '314ab1064af74ddfcf4091dfe9f90fa32cfa4100e8d01fea7b59b019575a7c51'},
     {'LAMMPS-2Aug2023_fix-timestep-balance-example.patch':
      '6f68387ced2b4bd0a06e4c3d31b0ffd47042476777d87d8a0ca6b19a4e6a1777'},
 ]


### PR DESCRIPTION
We patch LAMMPS but exit with success (Error code 0) when the Python package failed to install causing the issue to be hidden and the sanity check then fails with the root cause missing.

Adapt the patch to show the stdout/stderr and exit with an error code != 0. See similar code in newer lammps versions: https://github.com/lammps/lammps/blob/48e49bcc862cfbd4535609c0d08cdbf15ce9a956/python/install.py#L159C1-L159C90


For us the cause was `PIP_REQUIRE_VIRTUALENV=1` being set by the Python module. See https://github.com/easybuilders/easybuild-easyblocks/pull/3915 for a fix