### PR TITLE
{tools}[GCCcore/14.2.0] SPIRV-tools v2025.2.rc2

### DIFF
--- a/easybuild/easyconfigs/s/SPIRV-tools/SPIRV-tools-2025.2.rc2-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/s/SPIRV-tools/SPIRV-tools-2025.2.rc2-GCCcore-14.2.0.eb
@@ -1,0 +1,111 @@
+easyblock = 'CMakeMake'
+
+name = 'SPIRV-tools'
+version = '2025.2.rc2'
+
+homepage = 'https://github.com/KhronosGroup/SPIRV-Tools'
+description = '''The SPIR-V Tools project provides an API and commands for processing SPIR-V modules.
+The project includes an assembler, binary module parser, disassembler, validator, and optimizer for SPIR-V.
+Except for the optimizer, all are based on a common static library.
+The library contains all of the implementation details, and is used in the standalone tools whilst
+also enabling integration into other code bases directly.
+The optimizer implementation resides in its own library, which depends on the core library.'''
+
+toolchain = {'name': 'GCCcore', 'version': '14.2.0'}
+toolchainopts = {'pic': True, 'openmp': True, 'cstd': 'c++17'}
+
+# From https://github.com/KhronosGroup/SPIRV-Tools/blob/v2025.2-rc2/DEPS
+local_spirv_headers_commit = 'aa6cef192b8e693916eb713e7a9ccadf06062ceb'
+local_googletest_commit = '155b337c938a2953e5675f9dc18c99f05f4c85d0'
+local_google_effcee_commit = '874b47102c57a8979c0f154cf8e0eab53c0a0502'
+local_google_re2_commit = 'c84a140c93352cdabbfb547c531be34515b12228'
+local_protobuf_commit = 'f0dc78d7e6e331b8c6bb2d5283e06aa26883ca7c'  # Equivalent to tag v21.12
+local_abseil_commit = '8b2b78bb9bc570ea422fc891392d2ebdb35468b1'
+
+local_github_repos = [
+    ('KhronosGroup', 'SPIRV-Headers', local_spirv_headers_commit, 'spirv-headers'),
+    # Running with googletest also requires effcee -> re2 + abseil
+    ('google', 'googletest', local_googletest_commit, 'googletest'),
+    ('google', 'effcee', local_google_effcee_commit, 'effcee'),
+    ('google', 're2', local_google_re2_commit, 're2'),
+    ('protocolbuffers', 'protobuf', local_protobuf_commit, 'protobuf'),  # Required for spirv-fuzzer
+    ('abseil', 'abseil-cpp', local_abseil_commit, 'abseil_cpp'),
+]
+
+sources = [
+    # See https://github.com/KhronosGroup/SPIRV-Tools/?tab=readme-ov-file#source-code-organization
+    # The packages marked as `` in the above link needs to be added to the `external/` directory and not as deps
+    {
+        'download_filename': 'v%(version)s.tar.gz',
+        'filename': 'SPIRV-tools-%(version)s.tar.gz',
+        'extract_cmd': 'mkdir -p %(builddir)s/spirv-tools && tar xzvf %s --strip-components=1 -C $_',
+        'source_urls': ['https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags'],
+    }
+]
+checksums = [
+    {'SPIRV-tools-2025.2.rc2.tar.gz': '92e6094549573cd07bf74013c39ab2d029d110e3ca73bce33987e8657899c0e4'},
+    {'SPIRV-Headers-aa6cef19.tar.xz': 'd033dddca7e6692e1b27cb05f6dbf8d4fca23b11dd9cbfc015a43e7a04c878fa'},
+    {'googletest-155b337c.tar.xz': '881562c7704c1ee00ca8ebf3bd685b8e1ac60b60546e8767bcc8a324d40aef9f'},
+    {'effcee-874b4710.tar.xz': '52fe8301aed278b2b9c1148ed439f2fc1f6902b57eeafad5531ebb2f88881115'},
+    {'re2-c84a140c.tar.xz': 'b2e771cf5b693770f37a72425438948fa059988c34cdd960e1144047eba484a8'},
+    {'protobuf-f0dc78d7.tar.xz': 'edfca29ce9ea890de8f6fbd17cab3a1020d48f99aa354f666926bf466730704a'},
+    {'abseil-cpp-8b2b78bb.tar.xz': '37d92768017f4fcf707a91be3004547c52264613698cc149001b91ce9d96c48b'},
+]
+
+local_ext_dir = '%(builddir)s/spirv-tools/external'
+local_ext_cmd = 'tar xvf %s --strip-components=1 -C $_'
+for local_owner, local_repo, local_commit, local_dir in local_github_repos:
+    sources.append({
+        'filename': '%s-%s.tar.xz' % (local_repo, local_commit[:8]),
+        'extract_cmd': f'mkdir -p {local_ext_dir}/{local_dir} && {local_ext_cmd}',
+        'git_config': {
+            'url': f'https://github.com/{local_owner}',
+            'repo_name': local_repo,
+            'commit': local_commit,
+        },
+    })
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.31.3'),
+    ('Python', '3.13.1'),
+]
+
+configopts = ' '.join([
+    '-DSPIRV_BUILD_FUZZER=ON'
+])
+
+runtest = True
+
+sanity_check_paths = {
+    'files': [
+        'bin/spirv-as',
+        'bin/spirv-cfg',
+        'bin/spirv-dis',
+        'bin/spirv-lesspipe.sh',
+        'bin/spirv-link',
+        'bin/spirv-lint',
+        'bin/spirv-objdump',
+        'bin/spirv-opt',
+        'bin/spirv-reduce',
+        'bin/spirv-val',
+        'bin/spirv-fuzz',
+        'include/spirv-tools/libspirv.h',
+        'lib/libSPIRV-Tools.a',
+        'lib/libSPIRV-Tools-shared.so',
+    ],
+    'dirs': [
+        'lib/cmake/SPIRV-Tools'
+    ],
+}
+
+sanity_check_commands = [
+    'spirv-as --version',
+    'spirv-dis --version',
+    'spirv-link --version',
+    'spirv-opt --version',
+    'spirv-val --version',
+    'spirv-fuzz --version',
+]
+
+moduleclass = 'tools'


### PR DESCRIPTION
Alternative version to

- #23174

This version from tag `v2025.2.rc2` correspond to the same commit hash found in the requirement for the installation of `glslang=15.3.0`.

This would allow us to take `SPIRV-tools` as a dependency instead of rebuilding it as an external package.
I am not sure if it is guaranteed that the commits in https://github.com/KhronosGroup/glslang/blob/main/known_good.json will always correspond to a tagged version of `SPIRV-tools`