### PR TITLE
{math}[gfbf/2023b] fenics-ufl v2024.2.0

### DIFF
--- a/easybuild/easyconfigs/f/fenics-ufl/fenics-ufl-2024.2.0-gfbf-2023b.eb
+++ b/easybuild/easyconfigs/f/fenics-ufl/fenics-ufl-2024.2.0-gfbf-2023b.eb
@@ -1,0 +1,34 @@
+# UFL package for FEniCS, 
+
+easyblock = 'PythonPackage'  
+
+name = 'fenics-ufl' 
+version = '2024.2.0'
+
+homepage = 'https://github.com/FEniCS/ufl'
+
+description = "The Unified Form Language (UFL) is a domain specific language for defining the variational forms."
+
+
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+source_urls = ['https://github.com/FEniCS/ufl/archive']
+sources = ['%(version)s.tar.gz']
+checksums = ['d9353d23ccbdd9887f8d6edab74c04fe06d818da972072081dbf0c25bc86f5a7']
+
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle','2023.11')
+]
+
+options = {'modulename': 'ufl'}
+
+
+sanity_check_paths = {
+    'files': ['lib/python%(pyshortver)s//site-packages/ufl/__init__.py'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/ufl'],
+}
+
+moduleclass = 'cae'

--- a/easybuild/easyconfigs/f/fenics-ufl/fenics-ufl-2024.2.0-gfbf-2023b.eb
+++ b/easybuild/easyconfigs/f/fenics-ufl/fenics-ufl-2024.2.0-gfbf-2023b.eb
@@ -1,15 +1,10 @@
-# UFL package for FEniCS, 
-
 easyblock = 'PythonPackage'  
 
 name = 'fenics-ufl' 
 version = '2024.2.0'
 
-homepage = 'https://github.com/FEniCS/ufl'
-
-description = "The Unified Form Language (UFL) is a domain specific language for defining the variational forms."
-
-
+homepage = "https://github.com/FEniCS/ufl"
+description = "The Unified Form Language (UFL) is a domain-specific language for defining variational forms"
 
 toolchain = {'name': 'gfbf', 'version': '2023b'}
 
@@ -17,18 +12,16 @@ source_urls = ['https://github.com/FEniCS/ufl/archive']
 sources = ['%(version)s.tar.gz']
 checksums = ['d9353d23ccbdd9887f8d6edab74c04fe06d818da972072081dbf0c25bc86f5a7']
 
-
 dependencies = [
     ('Python', '3.11.5'),
     ('SciPy-bundle','2023.11')
 ]
-
-options = {'modulename': 'ufl'}
-
 
 sanity_check_paths = {
     'files': ['lib/python%(pyshortver)s//site-packages/ufl/__init__.py'],
     'dirs': ['lib/python%(pyshortver)s/site-packages/ufl'],
 }
 
-moduleclass = 'cae'
+options = {'modulename': 'ufl'}
+
+moduleclass = 'math'


### PR DESCRIPTION
### Add EasyConfig for `fenics-ufl v2024.2.0` with `gfbf/2023b` toolchain.


This PR adds a **new EasyBuild recipe** for [UFL](https://github.com/FEniCS/ufl), a pure Python package that provides a domain-specific language for defining variational forms.
  
UFL is a core component of the **FEniCSx Project** and generally used together with:   [DOLFINx](https://github.com/FEniCS/dolfinx) , [Basix](https://github.com/FEniCS/basix)  , [FFCx](https://github.com/FEniCS/ffcx)   

- **Version:** 2024.2.0 (compatible with [DOLFINx v0.9.0](https://github.com/easybuilders/easybuild-easyconfigs/pull/23796) ) 
- **Toolchain:** `gfbf/2023b`  

- **Dependencies:**  `SciPy-bundle 2023.11 `  , ` Python 3.11.5 `

