### PR TITLE
{cae}[GCCcore-13.2.0] fenics-ufcx v0.9.0

### DIFF
--- a/easybuild/easyconfigs/f/fenics-ufcx/fenics-ufcx-0.9.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/f/fenics-ufcx/fenics-ufcx-0.9.0-GCCcore-13.2.0.eb
@@ -1,0 +1,26 @@
+easyblock = 'CMakeMake'
+
+name = 'fenics-ufcx'
+version = '0.9.0'  
+
+homepage = 'https://github.com/FEniCS/ffcx'
+description = "FFCx provides the ufcx.h interface header for generated finite element kernels, used by DOLFINx."
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+source_urls = ['https://github.com/FEniCS/ffcx/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['afa517272a3d2249f513cb711c50b77cf8368dd0b8f5ea4b759142229204a448']
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+]
+
+srcdir = 'cmake'
+
+sanity_check_paths = {
+    'files': ['include/ufcx.h', 'share/ufcx/cmake/ufcxConfig.cmake'],
+    'dirs': [],
+}
+
+moduleclass = 'cae'


### PR DESCRIPTION
Add EasyConfig for fenics-ufcx v0.9.0

The FEniCSx UFCx interface headers provide C++ interfaces used by 
code generated from UFL via FFCx. This package is a required 
dependency  C++ components of DOLFINx.
