### PR TITLE
{cae}[gfbf/2023b] fenics-ffcx v0.9.0

### DIFF
--- a/easybuild/easyconfigs/f/fenics-ffcx/fenics-ffcx-0.9.0-gfbf-2023b.eb
+++ b/easybuild/easyconfigs/f/fenics-ffcx/fenics-ffcx-0.9.0-gfbf-2023b.eb
@@ -1,0 +1,33 @@
+# FFCx package for FEniCS, 
+
+easyblock = 'PythonPackage'
+
+name = 'fenics-ffcx'
+version = '0.9.0'
+
+homepage = 'https://github.com/FEniCS/ffcx'
+description = "FFCx is a compiler for finite element variational forms."
+
+toolchain = {'name': 'gfbf', 'version': '2023b'}
+
+source_urls = ['https://github.com/FEniCS/ffcx/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['afa517272a3d2249f513cb711c50b77cf8368dd0b8f5ea4b759142229204a448']
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('setuptools', '64.0.3'),
+    ('cffi', '1.15.1'),     
+    ('SciPy-bundle','2023.11'),   
+    ('fenics-ufl-py', '2024.2.0'),
+    ('fenics-basix-py', '0.9.0'),
+]
+
+options = {'modulename': 'ffcx'}
+
+sanity_check_paths = {
+    'files': ['lib/python%(pyshortver)s/site-packages/ffcx/__init__.py'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/ffcx'],
+}
+
+moduleclass = 'cae'

--- a/easybuild/easyconfigs/f/fenics-ffcx/fenics-ffcx-0.9.0-gfbf-2023b.eb
+++ b/easybuild/easyconfigs/f/fenics-ffcx/fenics-ffcx-0.9.0-gfbf-2023b.eb
@@ -6,6 +6,7 @@ name = 'fenics-ffcx'
 version = '0.9.0'
 
 homepage = 'https://github.com/FEniCS/ffcx'
+
 description = "FFCx is a compiler for finite element variational forms."
 
 toolchain = {'name': 'gfbf', 'version': '2023b'}
@@ -19,10 +20,9 @@ dependencies = [
     ('setuptools', '64.0.3'),
     ('cffi', '1.15.1'),     
     ('SciPy-bundle','2023.11'),   
-    ('fenics-ufl-py', '2024.2.0'),
+    ('fenics-ufl', '2024.2.0'),
     ('fenics-basix-py', '0.9.0'),
 ]
-
 options = {'modulename': 'ffcx'}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/fenics-ffcx/fenics-ffcx-0.9.0-gfbf-2023b.eb
+++ b/easybuild/easyconfigs/f/fenics-ffcx/fenics-ffcx-0.9.0-gfbf-2023b.eb
@@ -1,13 +1,10 @@
-# FFCx package for FEniCS, 
-
 easyblock = 'PythonPackage'
 
 name = 'fenics-ffcx'
 version = '0.9.0'
 
 homepage = 'https://github.com/FEniCS/ffcx'
-
-description = "FFCx is a compiler for finite element variational forms."
+description = "FFCx is a compiler for finite element variational forms"
 
 toolchain = {'name': 'gfbf', 'version': '2023b'}
 
@@ -16,13 +13,14 @@ sources = ['v%(version)s.tar.gz']
 checksums = ['afa517272a3d2249f513cb711c50b77cf8368dd0b8f5ea4b759142229204a448']
 
 dependencies = [
-    ('Python', '3.11.5'),
-    ('setuptools', '64.0.3'),
-    ('cffi', '1.15.1'),     
-    ('SciPy-bundle','2023.11'),   
-    ('fenics-ufl', '2024.2.0'),
+    ('cffi', '1.15.1'),
     ('fenics-basix-py', '0.9.0'),
+    ('fenics-ufl', '2024.2.0'),
+    ('Python', '3.11.5'),
+    ('SciPy-bundle','2023.11'),
+    ('setuptools', '64.0.3'),
 ]
+
 options = {'modulename': 'ffcx'}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/fenics-ffcx/fenics-ffcx-0.9.0-gfbf-2023b.eb
+++ b/easybuild/easyconfigs/f/fenics-ffcx/fenics-ffcx-0.9.0-gfbf-2023b.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('fenics-ufl', '2024.2.0'),
     ('Python', '3.11.5'),
     ('SciPy-bundle','2023.11'),
-    ('setuptools', '64.0.3'),
+    ('setuptools', '80.9.0'),
 ]
 
 options = {'modulename': 'ffcx'}


### PR DESCRIPTION
### Add EasyConfig for ` fenics-ffcx v0.9.0`

This PR adds a **new EasyBuild recipe** for [FFCx](https://github.com/FEniCS/ffcx).
`FFCx` takes variational forms defined in `UFL` and generates efficient low-level C code for use in `DOLFINx`. 

- **Version:** `0.9.0  `
- **Toolchain:** `gfbf/2023b ` 

It works together with: [UFL](https://github.com/FEniCS/ufl) ,  [Basix](https://github.com/FEniCS/basix) .

- **Dependencies:**  `fenics-ufl 2024.2.0`  ,  `fenics-basix-py 0.9.0`  
