### PR TITLE
{chem}[foss/2025a] QuantumESPRESSO 7.5 

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.5-foss-2025a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.5-foss-2025a.eb
@@ -21,7 +21,8 @@ _mbd_hash = '89a3cc199c0a200c9f0f688c3229ef6b9a8d63bd'
 _devxlib_hash = 'a6b89ef77b1ceda48e967921f1f5488d2df9226d'
 _fox_hash = '3453648e6837658b747b895bb7bef4b1ed2eac40'
 # Different from the one at tag qe-7.5, see https://github.com/anharmonic/d3q/issues/30
-_d3q_hash = '168313d925ccbfcacbc918977006f52ec8a15bed'
+# Compiling on top of 168313d9 results in an undefined reference to `zgemm3m_` requires the commit after to work
+_d3q_hash = 'fba772c180a8956227f0df077b841ec3039c610a'
 _qe_gipaw_hash = '717e55c36f28c512d232321adb10d5a66d3e1072'
 _qmcpack_hash = 'f72ab25fa4ea755c1b4b230ae8074b47d5509c70'
 _w90_hash = '1d6b187374a2d50b509e5e79e2cab01a79ff7ce1'
@@ -38,7 +39,7 @@ checksums = [
     {'lapack-12d82539.tar.xz': '88aea5bca5e730e99fda0a5b9d677d6036c7dd82874e0deaed5cccef1f880111'},
     {'mbd-89a3cc19.tar.xz': 'd026bf0e9334874670a23cd854f445baac003d4f099afa46bab667bc67abb450'},
     {'devxlib-a6b89ef7.tar.xz': '0a9b7e5350f44017a2390c85176d1683c6ecec0e4b716a59d727f7650f16e807'},
-    {'d3q-168313d9.tar.xz': '386716d22eb9d237519556c7b7dc96cfc89e544cb3abc4b60b2eb82247508bd3'},
+    {'d3q-fba772c1.tar.xz': '184e1e171c34e4f30952c082c39c3fdab2b7a25b2f7cd19e522b55f45ac1215b'},
     {'fox-3453648e.tar.xz': 'c8c55cdf9eb2709aebac86a58f936480ee66438dffd3d65c6a35ca7771c031b3'},
     {'qe-gipaw-717e55c3.tar.xz': '10e1ec9cda0e5480f708c08ff65b216f7611b0378a225133116c5884b3424a33'},
     {'pw2qmcpack-f72ab25f.tar.xz': 'bc9513c4901ec2469d56b8a6b66f56878cb13e3bc7fbcdc5dba0ca6dad880ab9'},


### PR DESCRIPTION
Patch needs to be adjusted according to 

- https://github.com/anharmonic/d3q/pull/31
- 
EDIT: Switched to using newer commit that fixed the problem from upstream see 
- https://github.com/anharmonic/d3q/issues/30