### PR TITLE
{devel} [GCCc0re-13.2] pkg-config v0.9.2

### DIFF
--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.2-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.2-GCCcore-13.2.0.eb
@@ -1,0 +1,39 @@
+# pkgconf should be used in preference to pkg-config
+# This is included for use only in software that fails to build when using pkgconf
+easyblock = 'ConfigureMake'
+
+name = 'pkg-config'
+version = '0.29.2'
+
+homepage = 'https://www.freedesktop.org/wiki/Software/pkg-config/'
+
+description = """
+ pkg-config is a helper tool used when compiling applications and libraries.
+ It helps you insert the correct compiler options on the command line so an
+ application can use gcc -o test test.c `pkg-config --libs --cflags glib-2.0`
+ for instance, rather than hard-coding values on where to find glib (or other
+ libraries).
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591']
+
+builddependencies = [
+    ('make', '4.4.1'),
+    ('binutils', '2.40'),
+]
+
+# don't use PAX, it might break.
+tar_config_opts = True
+
+configopts = " --with-internal-glib"
+
+sanity_check_paths = {
+    'files': ['bin/pkg-config'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
### Add `pkg-config 0.29.2 `built with `GCCcore 13.2.0`

The previous EasyBuild files for `pkg-config` included multiple variants with different toolchains.  
This **PR** adds a new variant built specifically with `GCCcore 13.2.0`.