### PR TITLE
{data}[GCCcore-13.2.0] pugixml v1.14

### DIFF
--- a/easybuild/easyconfigs/p/pugixml/pugixml-1.14-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/p/pugixml/pugixml-1.14-GCCcore-13.2.0.eb
@@ -1,0 +1,38 @@
+easyblock = 'CMakeMake'
+
+name = 'pugixml'
+version = '1.14'
+
+homepage = 'https://pugixml.org/'
+description = "pugixml is a light-weight C++ XML processing library"
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/zeux/pugixml/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['610f98375424b5614754a6f34a491adbddaaec074e9044577d965160ec103d2e']
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('make', '4.4.1'),
+    ('CMake', '3.27.6'),
+]
+
+configopts = " ".join([
+    "-DBUILD_SHARED_LIBS=ON",
+    "-DPUGIXML_BUILD_SHARED_AND_STATIC_LIBS=ON",
+])
+
+sanity_check_paths = {
+    'files': [
+        'include/pugiconfig.hpp',
+        'include/pugixml.hpp',
+        'lib/libpugixml.a',
+        'lib/libpugixml.%s' % SHLIB_EXT,
+        'lib/pkgconfig/pugixml.pc'
+    ],
+    'dirs': ['lib/cmake/pugixml'],
+}
+
+moduleclass = 'data'


### PR DESCRIPTION
### Add `pugixml` built with `GCCcore 13.2.0`
The previous EasyBuild files for `pugixml` included multiple variants with different toolchains.
This PR adds a new variant `V1.14`  built  with `GCCcore 13.2.0.`