### PR TITLE
{devel}[GCCcore-13.2.0] Setuptools-80.9.0

### DIFF
--- a/easybuild/easyconfigs/f/fenics-dolfinx/fenics-dolfinx-0.9.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/f/fenics-dolfinx/fenics-dolfinx-0.9.0-foss-2023b.eb
@@ -1,13 +1,10 @@
-# Dolfinx package for FEniCS
-
 easyblock = 'CMakeMake'
 
 name = 'fenics-dolfinx'
 version = '0.9.0'
 
 homepage = 'https://github.com/FEniCS/dolfinx'
-
-description = "DOLFINx is the computational environment of FEniCSx - C++ library."
+description = "DOLFINx is the computational environment of FEniCSx - C++ library"
 
 toolchain = {'name': 'foss', 'version': '2023b'}
 
@@ -21,20 +18,20 @@ configopts = (
 )
 
 builddependencies = [
-    ('make', '4.4.1'),
     ('CMake', '3.27.6'),
+    ('HDF5', '1.14.3'),
+    ('make', '4.4.1'),
     ('pkgconf', '2.0.3'),
 ]
 
 dependencies = [
+    ('Boost','1.83.0'),
+    ('ParMETIS','4.0.3'),
     ('PETSc', '3.22.5'),
     ('fenics-basix', '0.9.0'),
-    ('HDF5', '1.14.3'),
-    ('ParMETIS','4.0.3'),
-    ('Boost','1.83.0'),
-    ('spdlog', '1.12.0'),
-    ('pugixml', '1.14'),
     ('fenics-ufcx', '0.9.0'),
+    ('pugixml', '1.14'),
+    ('spdlog', '1.12.0'),
 ]
 
 srcdir = "cpp"

--- a/easybuild/easyconfigs/f/fenics-dolfinx/fenics-dolfinx-0.9.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/f/fenics-dolfinx/fenics-dolfinx-0.9.0-foss-2023b.eb
@@ -1,0 +1,50 @@
+# Dolfinx package for FEniCS
+
+easyblock = 'CMakeMake'
+
+name = 'fenics-dolfinx'
+version = '0.9.0'
+
+homepage = 'https://github.com/FEniCS/dolfinx'
+
+description = "DOLFINx is the computational environment of FEniCSx - C++ library."
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+
+source_urls = ['https://github.com/FEniCS/dolfinx/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['b266c74360c2590c5745d74768c04568c965b44739becca4cd6b5aa58cdbbbd1']
+
+configopts = (
+    ' -DDOLFINX_UFCX_PYTHON=OFF '
+    ' -DDOLFINX_BASIX_PYTHON=OFF '
+    ' -DSCOTCH_TEST_RUNS=OFF '
+    ' -DSCOTCH_ZLIB_TEST_RUNS=OFF '
+)
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('PETSc', '3.22.5'),
+    ('fenics-basix', '0.9.0'),
+    ('HDF5', '1.14.3'),
+    ('ParMETIS','4.0.3'),
+    ('SCOTCH', '7.0.4'),
+    ('Boost','1.83.0'),
+    ('spdlog', '1.12.0'),
+    ('pugixml', '1.14'),
+    ('fenics-ufcx', '0.9.0'),
+]
+
+srcdir = "cpp"
+
+
+sanity_check_paths = {
+    'files': ['lib/libdolfinx.so'],
+    'dirs': ['include/dolfinx'],
+}
+
+moduleclass = 'cae'

--- a/easybuild/easyconfigs/f/fenics-dolfinx/fenics-dolfinx-0.9.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/f/fenics-dolfinx/fenics-dolfinx-0.9.0-foss-2023b.eb
@@ -30,7 +30,7 @@ dependencies = [
     ('PETSc', '3.22.5'),
     ('fenics-basix', '0.9.0'),
     ('fenics-ufcx', '0.9.0'),
-    ('pugixml', '1.14'),
+    ('pugixml', '1.14', '-pic'),
     ('spdlog', '1.12.0'),
 ]
 

--- a/easybuild/easyconfigs/f/fenics-dolfinx/fenics-dolfinx-0.9.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/f/fenics-dolfinx/fenics-dolfinx-0.9.0-foss-2023b.eb
@@ -18,13 +18,12 @@ checksums = ['b266c74360c2590c5745d74768c04568c965b44739becca4cd6b5aa58cdbbbd1']
 configopts = (
     ' -DDOLFINX_UFCX_PYTHON=OFF '
     ' -DDOLFINX_BASIX_PYTHON=OFF '
-    ' -DSCOTCH_TEST_RUNS=OFF '
-    ' -DSCOTCH_ZLIB_TEST_RUNS=OFF '
 )
 
 builddependencies = [
+    ('make', '4.4.1'),
     ('CMake', '3.27.6'),
-    ('pkg-config', '0.29.2'),
+    ('pkgconf', '2.0.3'),
 ]
 
 dependencies = [
@@ -32,7 +31,6 @@ dependencies = [
     ('fenics-basix', '0.9.0'),
     ('HDF5', '1.14.3'),
     ('ParMETIS','4.0.3'),
-    ('SCOTCH', '7.0.4'),
     ('Boost','1.83.0'),
     ('spdlog', '1.12.0'),
     ('pugixml', '1.14'),
@@ -40,7 +38,6 @@ dependencies = [
 ]
 
 srcdir = "cpp"
-
 
 sanity_check_paths = {
     'files': ['lib/libdolfinx.so'],

--- a/easybuild/easyconfigs/s/setuptools/setuptools-80.9.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/s/setuptools/setuptools-80.9.0-GCCcore-13.2.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'PythonBundle'
+
+name = 'setuptools'
+version = '80.9.0'
+
+homepage = "https://pypi.org/project/setuptools"
+description = """Easily download, build, install, upgrade, and uninstall Python packages"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+builddependencies = [
+    ('binutils', '2.40'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+]
+
+exts_list = [
+    ('packaging', '25.0', {
+        'checksums': ['d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f'],
+    }),
+    (name, version, {
+        'checksums': ['f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c'],
+    }),
+]
+
+moduleclass = 'devel'


### PR DESCRIPTION
Add pugixml built with GCCcore 13.2.0
The previous EasyBuild files for pugixml included multiple variants with different toolchains.
This PR adds a new variant built with GCCcore 13.2.0.