### PR TITLE
{devel}[GCCcore-13.2.0] Setuptools v80.9.0

### DIFF
--- a/easybuild/easyconfigs/s/setuptools/setuptools-80.9.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/s/setuptools/setuptools-80.9.0-GCCcore-13.2.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'PythonBundle'
+
+name = 'setuptools'
+version = '80.9.0'
+
+homepage = "https://pypi.org/project/setuptools"
+description = """Easily download, build, install, upgrade, and uninstall Python packages"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+builddependencies = [
+    ('binutils', '2.40'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+]
+
+exts_list = [
+    ('packaging', '25.0', {
+        'checksums': ['d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f'],
+    }),
+    (name, version, {
+        'checksums': ['f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c'],
+    }),
+]
+
+moduleclass = 'devel'


### PR DESCRIPTION
Add `Setuptools` built with GCCcore 13.2.0

The previous Easyconfig  for `Setuptools` included multiple variants with different toolchains.
This PR adds a Easyconfig built with GCCcore 13.2.0.