### PR TITLE
{tools}[GCCcore/14.3.0] tcsh v6.24.16

### DIFF
--- a/easybuild/easyconfigs/t/tcsh/tcsh-6.24.16-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/t/tcsh/tcsh-6.24.16-GCCcore-14.3.0.eb
@@ -1,0 +1,45 @@
+# #
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+#  Contribution from University of Houston
+# Based on tcsh-6.24.13-GCCcore-13.3.0.eb
+# Author: Jerry Ebalunode <jebalunode@uh.edu>
+# #
+
+easyblock = 'ConfigureMake'
+
+name = 'tcsh'
+version = '6.24.16'
+
+homepage = 'https://www.tcsh.org'
+description = """Tcsh is an enhanced, but completely compatible version of the Berkeley UNIX C shell (csh).
+ It is a command language interpreter usable both as an interactive login shell and a shell script command
+ processor. It includes a command-line editor, programmable word completion, spelling correction, a history
+ mechanism, job control and a C-like syntax."""
+
+toolchain = {'name': 'GCCcore', 'version': '14.3.0'}
+
+source_urls = [
+    'https://astron.com/pub/%(namelower)s',
+    'https://astron.com/pub/%(namelower)s/old',
+    'ftp://ftp.astron.com/pub/%(namelower)s',
+    'ftp://ftp.astron.com/pub/%(namelower)s/old',
+]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['4208cf4630fb64d91d81987f854f9570a5a0e8a001a92827def37d0ed8f37364']
+
+builddependencies = [
+    ('binutils', '2.44'),
+]
+dependencies = [
+    ('ncurses', '6.5'),
+]
+
+postinstallcmds = ['ln -s %(name)s %(installdir)s/bin/csh']
+
+sanity_check_paths = {
+    'files': ['bin/%(name)s', 'bin/csh'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
add easyconfig for new version of tcsh, this will used in build foss-2025 e.g NAMD version 3.0.2  upstream packages that needs tcsh and tcl