### PR TITLE
HPL intel-2025b  remove now unneeded buildopt

### DIFF
--- a/easybuild/easyconfigs/h/HPL/HPL-2.3-intel-2025b.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.3-intel-2025b.eb
@@ -18,8 +18,4 @@ checksums = [
     '2a5bf9c4f328049828ddecec7ba3f05a9e25d236f4212747c53bd22fea80c5e6',  # HPL_parallel-make.patch
 ]
 
-# Explicitly disable optimization, since Intel compilers apply some default level not shown on the command line.
-# This breaks the result comparison, resulting in all tests failing residual checks.
-buildopts = 'CCNOOPT=\'$(HPL_DEFS) -O0\' '
-
 moduleclass = 'tools'


### PR DESCRIPTION
Following the merging of

-  https://github.com/easybuilders/easybuild-easyblocks/pull/3917

this option is now handled by the easyblock