### PR TITLE
Add patch to fix UCX-18.0.0 compatibility with CUDA 12.9 (R575)

### DIFF
--- a/easybuild/easyconfigs/u/UCX/UCX-1.18.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.18.0-GCCcore-13.3.0.eb
@@ -1,7 +1,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'UCX'
-version = '1.19.0'
+version = '1.18.0'
 
 homepage = 'https://www.openucx.org/'
 description = """Unified Communication X
@@ -9,7 +9,7 @@ An open-source production grade communication framework for data centric
 and high-performance applications
 """
 
-toolchain = {'name': 'GCCcore', 'version': '14.3.0'}
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
@@ -19,22 +19,22 @@ patches = [
     'UCX-1.18.0_fix_bistro_hooks.patch',
 ]
 checksums = [
-    {'ucx-1.19.0.tar.gz': '9af07d55281059542f20c5b411db668643543174e51ac71f53f7ac839164f285'},
+    {'ucx-1.18.0.tar.gz': 'fa75070f5fa7442731b4ef5fc9549391e147ed3d859afeb1dad2d4513b39dc33'},
     {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
-    {'UCX-1.18.0_fix_bistro_hooks.patch': '6357f1ebb1569e30d0855e48404fdf38a5a7060a87789f54d7bb751f957be20c'}, 
+    {'UCX-1.18.0_fix_bistro_hooks.patch': '6357f1ebb1569e30d0855e48404fdf38a5a7060a87789f54d7bb751f957be20c'},
 ]
 
 builddependencies = [
-    ('binutils', '2.44'),
-    ('Autotools', '20250527'),
-    ('pkgconf', '2.4.3'),
+    ('binutils', '2.42'),
+    ('Autotools', '20231222'),
+    ('pkgconf', '2.2.0'),
 ]
 
 osdependencies = [OS_PKG_IBVERBS_DEV]
 
 dependencies = [
     ('zlib', '1.3.1'),
-    ('numactl', '2.0.19'),
+    ('numactl', '2.0.18'),
 ]
 
 configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '

--- a/easybuild/easyconfigs/u/UCX/UCX-1.18.0-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.18.0-GCCcore-14.2.0.eb
@@ -16,10 +16,12 @@ source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
 sources = ['%(namelower)s-%(version)s.tar.gz']
 patches = [
     'UCX-1.13.1-dynamic_modules.patch',
+    'UCX-1.18.0_fix_bistro_hooks.patch',
 ]
 checksums = [
     {'ucx-1.18.0.tar.gz': 'fa75070f5fa7442731b4ef5fc9549391e147ed3d859afeb1dad2d4513b39dc33'},
     {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
+    {'UCX-1.18.0_fix_bistro_hooks.patch': '6357f1ebb1569e30d0855e48404fdf38a5a7060a87789f54d7bb751f957be20c'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/u/UCX/UCX-1.18.0_fix_bistro_hooks.patch
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.18.0_fix_bistro_hooks.patch
@@ -1,0 +1,51 @@
+# What: Fix inability of UCX to create an rcache with CUDA 12.9 (R575 driver)
+#       See https://github.com/openucx/ucx/issues/10868
+#       Based on https://github.com/openucx/ucx/pull/10627
+# Author: maxim-masterov
+
+From f4ff1e5dd5b17bc0192d987db1917a10fb5aa63a Mon Sep 17 00:00:00 2001
+From: Ilia Yastrebov <iyastrebov@nvidia.com>
+Date: Fri, 11 Apr 2025 15:28:36 +0000
+Subject: [PATCH] UCM/CUDA: Fixed cuda12.9 amd64 bistro hook missing
+ instruction
+
+---
+ src/ucm/bistro/bistro_x86_64.c | 16 +++++++++++++---
+ 1 file changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/src/ucm/bistro/bistro_x86_64.c b/src/ucm/bistro/bistro_x86_64.c
+index dd01bb462d2..9ea9d61be3a 100644
+--- a/src/ucm/bistro/bistro_x86_64.c
++++ b/src/ucm/bistro/bistro_x86_64.c
+@@ -82,6 +82,9 @@ typedef struct {
+ /* Immediate Grp 1(1A), Ev, Iz */
+ #define UCM_BISTRO_X86_IMM_GRP1_EV_IZ 0x81
+ 
++/* Immediate Grp 1(1A), Ev, Ib - 8-bit immediate */
++#define UCM_BISTRO_X86_IMM_GRP1_EV_IB 0x83
++
+ /* MOV Ev,Gv */
+ #define UCM_BISTRO_X86_MOV_EV_GV 0x89
+ 
+@@ -156,11 +159,18 @@ ucs_status_t ucm_bistro_relocate_one(ucm_bistro_relocate_context_t *ctx)
+         /* push reg */
+         goto out_copy_src;
+     } else if ((rex == UCM_BISTRO_X86_REX_W) &&
+-               (opcode == UCM_BISTRO_X86_IMM_GRP1_EV_IZ)) {
++               ((opcode == UCM_BISTRO_X86_IMM_GRP1_EV_IZ) ||  /* sub $imm32, r/m64 */
++                (opcode == UCM_BISTRO_X86_IMM_GRP1_EV_IB))) { /* sub $imm8, r/m64 */
+         modrm = *ucs_serialize_next(&ctx->src_p, const uint8_t);
+         if (modrm == UCM_BISTRO_X86_MODRM_SUB_SP) {
+-            /* sub $imm32, %rsp */
+-            ucs_serialize_next(&ctx->src_p, const uint32_t);
++            if (opcode == UCM_BISTRO_X86_IMM_GRP1_EV_IB) {
++                /* sub $imm8, %rsp */
++                ucs_serialize_next(&ctx->src_p, const uint8_t);
++            } else {
++                /* sub $imm32, %rsp */
++                ucs_serialize_next(&ctx->src_p, const uint32_t);
++            }
++
+             goto out_copy_src;
+         }
+     } else if ((rex == UCM_BISTRO_X86_REX_W) &&


### PR DESCRIPTION
UCX-1.18.0 fails to install bistro hooks for CUDA 12.9 (R575 and above), which leads to UCC crash. 
See https://github.com/openucx/ucx/issues/10868 and https://github.com/openucx/ucx/pull/10627
