### PR TITLE
fix typo in `%(version)s` template in easyconfig for AlphaFold v2.3.2 w/ CUDA 12.1.1

### DIFF
--- a/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.3.2-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.3.2-foss-2023a-CUDA-12.1.1.eb
@@ -145,7 +145,7 @@ modextravars = {
     # https://jax.readthedocs.io/en/latest/gpu_memory_allocation.html
     'XLA_PYTHON_CLIENT_MEM_FRACTION': '2.5',
     # Download with $EBROOTALPHAFOLD/scripts/download_all_data.sh /path/to/AlphaFold_DBs/$EBVERSIONALPHAFOLD
-    'ALPHAFOLD_DATA_DIR': '/path/to/AlphaFold_DBs/%(versions)s',  # please adapt
+    'ALPHAFOLD_DATA_DIR': '/path/to/AlphaFold_DBs/%(version)s',
     # Adapt in order to use a different version of UniRef30 by default,
     # e.g.,  v2023_02 from https://wwwuser.gwdg.de/~compbiol/uniclust/2023_02/UniRef30_2023_02_hhsuite.tar.gz:
     'ALPHAFOLD_UNIREF30_VER': '2021_03',


### PR DESCRIPTION
Fixes https://github.com/easybuilders/easybuild-easyconfigs/issues/23851