### PR TITLE
update and fix templates in cuDNN + NCCL easyconfigs

### DIFF
--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.0.4.30-CUDA-11.0.2.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.0.4.30-CUDA-11.0.2.eb
@@ -3,9 +3,7 @@
 ##
 name = 'cuDNN'
 version = '8.0.4.30'
-local_cuda_version = '11.0.2'
-local_cuda_version_majmin = '.'.join(local_cuda_version.split('.')[:2])
-versionsuffix = '-CUDA-%s' % local_cuda_version
+versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://developer.nvidia.com/cudnn'
 description = """The NVIDIA CUDA Deep Neural Network library (cuDNN) is
@@ -13,22 +11,16 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
-# By downloading, you accept the cuDNN Software License Agreement
-# (https://docs.nvidia.com/deeplearning/sdk/cudnn-sla/index.html)
-# accept_eula = True
 source_urls = ['https://developer.download.nvidia.com/compute/redist/cudnn/v%s/' % '.'.join(version.split('.')[:3])]
-local_tarball_tmpl = '-'.join(['%%(namelower)s', local_cuda_version_majmin, 'linux', '%s', 'v%%(version)s.tgz'])
-sources = [local_tarball_tmpl % '%(cudnnarch)s']
-checksums = [
-    {
-        local_tarball_tmpl % 'x64':
-            '38a81a28952e314e21577432b0bab68357ef9de7f6c8858f721f78df9ee60c35',
-        local_tarball_tmpl % 'ppc64le':
-            '8da8ed689b1a348182ddd3f59b6758a502e11dc6708c33f96e3b4a40e033d2e1',
-    }
-]
+sources = ['%(namelower)s-%(cudashortver)s-linux-%(cudnnarch)s-v%(version)s.tgz']
+checksums = [{
+    '%(namelower)s-%(cudashortver)s-linux-x64-v%(version)s.tgz':
+    '38a81a28952e314e21577432b0bab68357ef9de7f6c8858f721f78df9ee60c35',
+    '%(namelower)s-%(cudashortver)s-linux-ppc64le-v%(version)s.tgz':
+    '8da8ed689b1a348182ddd3f59b6758a502e11dc6708c33f96e3b4a40e033d2e1',
+}]
 
-dependencies = [('CUDAcore', local_cuda_version)]
+dependencies = [('CUDAcore', '11.0.2')]
 
 sanity_check_paths = {
     'files': ['include/cudnn.h', 'lib64/libcudnn_static.a'],

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.0.4.30-CUDA-11.1.1.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.0.4.30-CUDA-11.1.1.eb
@@ -3,9 +3,7 @@
 ##
 name = 'cuDNN'
 version = '8.0.4.30'
-local_cuda_version = '11.1.1'
-local_cuda_version_majmin = '.'.join(local_cuda_version.split('.')[:2])
-versionsuffix = '-CUDA-%s' % local_cuda_version
+versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://developer.nvidia.com/cudnn'
 description = """The NVIDIA CUDA Deep Neural Network library (cuDNN) is
@@ -13,22 +11,16 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
-# By downloading, you accept the cuDNN Software License Agreement
-# (https://docs.nvidia.com/deeplearning/sdk/cudnn-sla/index.html)
-# accept_eula = True
 source_urls = ['https://developer.download.nvidia.com/compute/redist/cudnn/v%s/' % '.'.join(version.split('.')[:3])]
-local_tarball_tmpl = '-'.join(['%%(namelower)s', local_cuda_version_majmin, 'linux', '%s', 'v%%(version)s.tgz'])
-sources = [local_tarball_tmpl % '%(cudnnarch)s']
-checksums = [
-    {
-        local_tarball_tmpl % 'x64':
-            '8f4c662343afce5998ce963500fe3bb167e9a508c1a1a949d821a4b80fa9beab',
-        local_tarball_tmpl % 'ppc64le':
-            'b4ddb51610cbae806017616698635a9914c3e1eb14259f3a39ee5c84e7106712',
-    }
-]
+sources = ['%(namelower)s-%(cudashortver)s-linux-%(cudnnarch)s-v%(version)s.tgz']
+checksums = [{
+    '%(namelower)s-%(cudashortver)s-linux-x64-v%(version)s.tgz':
+    '8f4c662343afce5998ce963500fe3bb167e9a508c1a1a949d821a4b80fa9beab',
+    '%(namelower)s-%(cudashortver)s-linux-ppc64le-v%(version)s.tgz':
+    'b4ddb51610cbae806017616698635a9914c3e1eb14259f3a39ee5c84e7106712',
+}]
 
-dependencies = [('CUDAcore', local_cuda_version)]
+dependencies = [('CUDAcore', '11.1.1')]
 
 sanity_check_paths = {
     'files': ['include/cudnn.h', 'lib64/libcudnn_static.a'],

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.0.5.39-CUDA-11.1.1.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.0.5.39-CUDA-11.1.1.eb
@@ -4,9 +4,7 @@
 
 name = 'cuDNN'
 version = '8.0.5.39'
-local_cuda_version = '11.1.1'
-local_cuda_version_majmin = '.'.join(local_cuda_version.split('.')[:2])
-versionsuffix = '-CUDA-%s' % local_cuda_version
+versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://developer.nvidia.com/cudnn'
 description = """The NVIDIA CUDA Deep Neural Network library (cuDNN) is
@@ -14,22 +12,16 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
-# By downloading, you accept the cuDNN Software License Agreement
-# (https://docs.nvidia.com/deeplearning/sdk/cudnn-sla/index.html)
-# accept_eula = True
 source_urls = ['https://developer.download.nvidia.com/compute/redist/cudnn/v%s/' % '.'.join(version.split('.')[:3])]
-local_tarball_tmpl = '-'.join(['%%(namelower)s', local_cuda_version_majmin, 'linux', '%s', 'v%%(version)s.tgz'])
-sources = [local_tarball_tmpl % '%(cudnnarch)s']
-checksums = [
-    {
-        local_tarball_tmpl % 'x64':
-            '1d046bfa79399dabcc6f6cb1507918754439442ea0ca9e0fbecdd446f9b00cce',
-        local_tarball_tmpl % 'aarch64sbsa':
-            '0c3542c51b42131247cd9f839d0ebefe4e02bb46d1716be1682cb2919278085a',
-    }
-]
+sources = ['%(namelower)s-%(cudashortver)s-linux-%(cudnnarch)s-v%(version)s.tgz']
+checksums = [{
+    '%(namelower)s-%(cudashortver)s-linux-x64-v%(version)s.tgz':
+    '1d046bfa79399dabcc6f6cb1507918754439442ea0ca9e0fbecdd446f9b00cce',
+    '%(namelower)s-%(cudashortver)s-linux-ppc64le-v%(version)s.tgz':
+    '0c3542c51b42131247cd9f839d0ebefe4e02bb46d1716be1682cb2919278085a',
+}]
 
-dependencies = [('CUDAcore', local_cuda_version)]
+dependencies = [('CUDAcore', '11.1.1')]
 
 sanity_check_paths = {
     'files': ['include/cudnn.h', 'lib64/libcudnn_static.a'],

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.1.0.77-CUDA-11.2.1.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.1.0.77-CUDA-11.2.1.eb
@@ -5,9 +5,7 @@
 
 name = 'cuDNN'
 version = '8.1.0.77'
-local_cuda_version = '11.2.1'
-local_cuda_version_majmin = '.'.join(local_cuda_version.split('.')[:2])
-versionsuffix = '-CUDA-%s' % local_cuda_version
+versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://developer.nvidia.com/cudnn'
 description = """The NVIDIA CUDA Deep Neural Network library (cuDNN) is
@@ -15,24 +13,18 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
-# By downloading, you accept the cuDNN Software License Agreement
-# (https://docs.nvidia.com/deeplearning/sdk/cudnn-sla/index.html)
-# accept_eula = True
 source_urls = ['https://developer.download.nvidia.com/compute/redist/cudnn/v%s/' % '.'.join(version.split('.')[:3])]
-local_tarball_tmpl = '-'.join(['%%(namelower)s', local_cuda_version_majmin, 'linux', '%s', 'v%%(version)s.tgz'])
-sources = [local_tarball_tmpl % '%(cudnnarch)s']
-checksums = [
-    {
-        local_tarball_tmpl % 'x64':
-            'dbe82faf071d91ba9bcf00480146ad33f462482dfee56caf4479c1b8dabe3ecb',
-        local_tarball_tmpl % 'ppc64le':
-            '0d3f8fa21959e9f94889841cc8445aecf41d2f3c557091b447313afb43034037',
-        local_tarball_tmpl % 'aarch64sbsa':
-            'ba16ff486b68a8b50b69b32702612634954de529f39cfff68c12b8bfc1958499',
-    }
-]
+sources = ['%(namelower)s-%(cudashortver)s-linux-%(cudnnarch)s-v%(version)s.tgz']
+checksums = [{
+    '%(namelower)s-%(cudashortver)s-linux-x64-v%(version)s.tgz':
+    'dbe82faf071d91ba9bcf00480146ad33f462482dfee56caf4479c1b8dabe3ecb',
+    '%(namelower)s-%(cudashortver)s-linux-ppc64le-v%(version)s.tgz':
+    '0d3f8fa21959e9f94889841cc8445aecf41d2f3c557091b447313afb43034037',
+    '%(namelower)s-%(cudashortver)s-linux-aarch64sbsa-v%(version)s.tgz':
+    'ba16ff486b68a8b50b69b32702612634954de529f39cfff68c12b8bfc1958499',
+}]
 
-dependencies = [('CUDAcore', local_cuda_version)]
+dependencies = [('CUDAcore', '11.2.1')]
 
 sanity_check_paths = {
     'files': ['include/cudnn.h', 'lib64/libcudnn_static.a'],

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.1.1.33-CUDA-11.2.1.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.1.1.33-CUDA-11.2.1.eb
@@ -5,9 +5,7 @@
 
 name = 'cuDNN'
 version = '8.1.1.33'
-local_cuda_version = '11.2.1'
-local_cuda_version_majmin = '.'.join(local_cuda_version.split('.')[:2])
-versionsuffix = '-CUDA-%s' % local_cuda_version
+versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://developer.nvidia.com/cudnn'
 description = """The NVIDIA CUDA Deep Neural Network library (cuDNN) is
@@ -15,24 +13,18 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
-# By downloading, you accept the cuDNN Software License Agreement
-# (https://docs.nvidia.com/deeplearning/sdk/cudnn-sla/index.html)
-# accept_eula = True
 source_urls = ['https://developer.download.nvidia.com/compute/redist/cudnn/v%s/' % '.'.join(version.split('.')[:3])]
-local_tarball_tmpl = '-'.join(['%%(namelower)s', local_cuda_version_majmin, 'linux', '%s', 'v%%(version)s.tgz'])
-sources = [local_tarball_tmpl % '%(cudnnarch)s']
-checksums = [
-    {
-        local_tarball_tmpl % 'x64':
-            '98a8784e92862f20018d20c281b30d4a0cd951f93694f6433ccf4ae9c502ba6a',
-        local_tarball_tmpl % 'ppc64le':
-            'c3e535a5d633ad8f4d50be0b6f8efd084c6c6ed3525c07cbd89fc508b1d76c7a',
-        local_tarball_tmpl % 'aarch64sbsa':
-            '4f7e4f5698539659d51f28dff0da11e5445a5ae58439af1d8a8e9f2d93535245',
-    }
-]
+sources = ['%(namelower)s-%(cudashortver)s-linux-%(cudnnarch)s-v%(version)s.tgz']
+checksums = [{
+    '%(namelower)s-%(cudashortver)s-linux-x64-v%(version)s.tgz':
+    '98a8784e92862f20018d20c281b30d4a0cd951f93694f6433ccf4ae9c502ba6a',
+    '%(namelower)s-%(cudashortver)s-linux-ppc64le-v%(version)s.tgz':
+    'c3e535a5d633ad8f4d50be0b6f8efd084c6c6ed3525c07cbd89fc508b1d76c7a',
+    '%(namelower)s-%(cudashortver)s-linux-aarch64sbsa-v%(version)s.tgz':
+    '4f7e4f5698539659d51f28dff0da11e5445a5ae58439af1d8a8e9f2d93535245',
+}]
 
-dependencies = [('CUDAcore', local_cuda_version)]
+dependencies = [('CUDAcore', '11.2.1')]
 
 sanity_check_paths = {
     'files': ['include/cudnn.h', 'lib64/libcudnn_static.a'],

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.2.1.32-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.2.1.32-CUDA-11.3.1.eb
@@ -1,8 +1,6 @@
 name = 'cuDNN'
 version = '8.2.1.32'
-local_cuda_version = '11.3.1'
-local_cuda_version_majmin = '.'.join(local_cuda_version.split('.')[:2])
-versionsuffix = '-CUDA-%s' % local_cuda_version
+versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://developer.nvidia.com/cudnn'
 description = """The NVIDIA CUDA Deep Neural Network library (cuDNN) is
@@ -10,24 +8,18 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
-# By downloading, you accept the cuDNN Software License Agreement
-# (https://docs.nvidia.com/deeplearning/sdk/cudnn-sla/index.html)
-# accept_eula = True
 source_urls = ['https://developer.download.nvidia.com/compute/redist/cudnn/v%s/' % '.'.join(version.split('.')[:3])]
-local_tarball_tmpl = '-'.join(['%%(namelower)s', local_cuda_version_majmin, 'linux', '%s', 'v%%(version)s.tgz'])
-sources = [local_tarball_tmpl % '%(cudnnarch)s']
-checksums = [
-    {
-        local_tarball_tmpl % 'x64':
-            '39412acd9ef5dd27954b6b9f5df75bd381c5d7ceb7979af6c743a7f4521f9c77',
-        local_tarball_tmpl % 'ppc64le':
-            '4ee4f2afeaae34fdb06da8d4942a6802aae94ecc51f307292c45966eecbe5fb9',
-        local_tarball_tmpl % 'aarch64sbsa':
-            'e3a0e570cb8ba01d5d45e6eb1ebe29ff22fd5fb8ad45bfe7a448f4f95065ec1e',
-    }
-]
+sources = ['%(namelower)s-%(cudashortver)s-linux-%(cudnnarch)s-v%(version)s.tgz']
+checksums = [{
+    '%(namelower)s-%(cudashortver)s-linux-x64-v%(version)s.tgz':
+    '39412acd9ef5dd27954b6b9f5df75bd381c5d7ceb7979af6c743a7f4521f9c77',
+    '%(namelower)s-%(cudashortver)s-linux-ppc64le-v%(version)s.tgz':
+    '4ee4f2afeaae34fdb06da8d4942a6802aae94ecc51f307292c45966eecbe5fb9',
+    '%(namelower)s-%(cudashortver)s-linux-aarch64sbsa-v%(version)s.tgz':
+    'e3a0e570cb8ba01d5d45e6eb1ebe29ff22fd5fb8ad45bfe7a448f4f95065ec1e',
+}]
 
-dependencies = [('CUDA', local_cuda_version)]
+dependencies = [('CUDA', '11.3.1')]
 
 sanity_check_paths = {
     'files': ['include/cudnn.h', 'lib64/libcudnn_static.a'],

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.2.2.26-CUDA-11.4.0.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.2.2.26-CUDA-11.4.0.eb
@@ -4,9 +4,7 @@
 
 name = 'cuDNN'
 version = '8.2.2.26'
-local_cuda_version = '11.4.0'
-local_cuda_version_majmin = '.'.join(local_cuda_version.split('.')[:2])
-versionsuffix = '-CUDA-%s' % local_cuda_version
+versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://developer.nvidia.com/cudnn'
 description = """The NVIDIA CUDA Deep Neural Network library (cuDNN) is
@@ -14,24 +12,18 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
-# By downloading, you accept the cuDNN Software License Agreement
-# (https://docs.nvidia.com/deeplearning/sdk/cudnn-sla/index.html)
-# accept_eula = True
 source_urls = ['https://developer.download.nvidia.com/compute/redist/cudnn/v%s/' % '.'.join(version.split('.')[:3])]
-local_tarball_tmpl = '-'.join(['%%(namelower)s', local_cuda_version_majmin, 'linux', '%s', 'v%%(version)s.tgz'])
-sources = [local_tarball_tmpl % '%(cudnnarch)s']
-checksums = [
-    {
-        local_tarball_tmpl % 'aarch64sbsa':
-            'e240d45d79eecb2257fcb8a219324f19d8e2d6e145fbd035a38d267580d65e9a',
-        local_tarball_tmpl % 'ppc64le':
-            'b11b9e515a86978dc21ab50a7d2320bfb505cbce9dffa25480225c597c682b43',
-        local_tarball_tmpl % 'x64':
-            'fbc631ce19688e87d7d2420403b20db97885b17f718f0f51d7e9fc0905d86e07',
-    }
-]
+sources = ['%(namelower)s-%(cudashortver)s-linux-%(cudnnarch)s-v%(version)s.tgz']
+checksums = [{
+    '%(namelower)s-%(cudashortver)s-linux-aarch64sbsa-v%(version)s.tgz':
+    'e240d45d79eecb2257fcb8a219324f19d8e2d6e145fbd035a38d267580d65e9a',
+    '%(namelower)s-%(cudashortver)s-linux-ppc64le-v%(version)s.tgz':
+    'b11b9e515a86978dc21ab50a7d2320bfb505cbce9dffa25480225c597c682b43',
+    '%(namelower)s-%(cudashortver)s-linux-x64-v%(version)s.tgz':
+    'fbc631ce19688e87d7d2420403b20db97885b17f718f0f51d7e9fc0905d86e07',
+}]
 
-dependencies = [('CUDAcore', local_cuda_version)]
+dependencies = [('CUDAcore', '11.4.0')]
 
 sanity_check_paths = {
     'files': ['include/cudnn.h', 'lib64/libcudnn_static.a'],

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.2.2.26-CUDA-11.4.1.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.2.2.26-CUDA-11.4.1.eb
@@ -1,8 +1,6 @@
 name = 'cuDNN'
 version = '8.2.2.26'
-local_cuda_version = '11.4.1'
-local_cuda_version_majmin = '.'.join(local_cuda_version.split('.')[:2])
-versionsuffix = '-CUDA-%s' % local_cuda_version
+versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://developer.nvidia.com/cudnn'
 description = """The NVIDIA CUDA Deep Neural Network library (cuDNN) is
@@ -10,24 +8,18 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
-# By downloading, you accept the cuDNN Software License Agreement
-# (https://docs.nvidia.com/deeplearning/sdk/cudnn-sla/index.html)
-# accept_eula = True
 source_urls = ['https://developer.download.nvidia.com/compute/redist/cudnn/v%s/' % '.'.join(version.split('.')[:3])]
-local_tarball_tmpl = '-'.join(['%%(namelower)s', local_cuda_version_majmin, 'linux', '%s', 'v%%(version)s.tgz'])
-sources = [local_tarball_tmpl % '%(cudnnarch)s']
-checksums = [
-    {
-        local_tarball_tmpl % 'x64':
-            'fbc631ce19688e87d7d2420403b20db97885b17f718f0f51d7e9fc0905d86e07',
-        local_tarball_tmpl % 'ppc64le':
-            'b11b9e515a86978dc21ab50a7d2320bfb505cbce9dffa25480225c597c682b43',
-        local_tarball_tmpl % 'aarch64sbsa':
-            'e240d45d79eecb2257fcb8a219324f19d8e2d6e145fbd035a38d267580d65e9a',
-    }
-]
+sources = ['%(namelower)s-%(cudashortver)s-linux-%(cudnnarch)s-v%(version)s.tgz']
+checksums = [{
+    '%(namelower)s-%(cudashortver)s-linux-x64-v%(version)s.tgz':
+    'fbc631ce19688e87d7d2420403b20db97885b17f718f0f51d7e9fc0905d86e07',
+    '%(namelower)s-%(cudashortver)s-linux-ppc64le-v%(version)s.tgz':
+    'b11b9e515a86978dc21ab50a7d2320bfb505cbce9dffa25480225c597c682b43',
+    '%(namelower)s-%(cudashortver)s-linux-aarch64sbsa-v%(version)s.tgz':
+    'e240d45d79eecb2257fcb8a219324f19d8e2d6e145fbd035a38d267580d65e9a',
+}]
 
-dependencies = [('CUDA', local_cuda_version)]
+dependencies = [('CUDA', '11.4.1')]
 
 sanity_check_paths = {
     'files': ['include/cudnn.h', 'lib64/libcudnn_static.a'],

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.4.0.27-CUDA-11.6.0.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.4.0.27-CUDA-11.6.0.eb
@@ -1,8 +1,6 @@
 name = 'cuDNN'
 version = '8.4.0.27'
-local_cuda_version = '11.6.0'
-local_cuda_version_majmin = '.'.join(local_cuda_version.split('.')[:2])
-versionsuffix = '-CUDA-%s' % local_cuda_version
+versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://developer.nvidia.com/cudnn'
 description = """The NVIDIA CUDA Deep Neural Network library (cuDNN) is
@@ -10,25 +8,20 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
-source_urls = [
-    'https://developer.download.nvidia.com/compute/redist/cudnn/v%s/local_installers/%s/' %
-    ('.'.join(version.split('.')[:3]), local_cuda_version_majmin)
-]
-local_cudnn_cuda_version = '%%(version)s_cuda{maj_min}'.format(maj_min=local_cuda_version_majmin)
-local_tarball_tmpl = '-'.join(['%%(namelower)s', 'linux', '%s', local_cudnn_cuda_version, 'archive.tar.xz'])
-sources = [local_tarball_tmpl % '%(cudnnarch)s']
-checksums = [
-    {
-        local_tarball_tmpl % 'x86_64':
-            'd19bdafd9800c79d29e6f6fffa9f9e2c10d1132d6c2ff10b1593e057e74dd050',
-        local_tarball_tmpl % 'ppc64le':
-            '7ef72353331cf42b357f53cb4a4971fb07e2f0b2ae66e03d54933df52de411c8',
-        local_tarball_tmpl % 'sbsa':
-            '3972ab37b6f0271274931f69c5675c3b61d16f8f5a2dedd422a5efd7b0f358e5',
-    }
-]
+source_urls = ['https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s']
+# note: cuDNN 8.4 is not specific to CUDA 11.6,
+# see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
+sources = ['%(namelower)s-linux-%(cudnnarch)s-%(version)s_cuda11.6-archive.tar.xz']
+checksums = [{
+    '%(namelower)s-linux-x86_64-%(version)s_cuda11.6-archive.tar.xz':
+    'd19bdafd9800c79d29e6f6fffa9f9e2c10d1132d6c2ff10b1593e057e74dd050',
+    '%(namelower)s-linux-ppc64le-%(version)s_cuda11.6-archive.tar.xz':
+    '7ef72353331cf42b357f53cb4a4971fb07e2f0b2ae66e03d54933df52de411c8',
+    '%(namelower)s-linux-sbsa-%(version)s_cuda11.6-archive.tar.xz':
+    '3972ab37b6f0271274931f69c5675c3b61d16f8f5a2dedd422a5efd7b0f358e5',
+}]
 
-dependencies = [('CUDA', local_cuda_version)]
+dependencies = [('CUDA', '11.6.0')]
 
 sanity_check_paths = {
     'files': [

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.4.1.50-CUDA-11.5.2.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.4.1.50-CUDA-11.5.2.eb
@@ -8,12 +8,9 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
+source_urls = ['https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s']
 # note: cuDNN 8.4.1 is not specific to CUDA 11.6,
 # see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
-local_short_ver = '.'.join(version.split('.')[:3])
-source_urls = [
-    'https://developer.download.nvidia.com/compute/redist/cudnn/v%s/local_installers/11.6/' % local_short_ver,
-]
 sources = ['%(namelower)s-linux-%(cudnnarch)s-%(version)s_cuda11.6-archive.tar.xz']
 checksums = [
     {

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.4.1.50-CUDA-11.6.0.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.4.1.50-CUDA-11.6.0.eb
@@ -1,8 +1,6 @@
 name = 'cuDNN'
 version = '8.4.1.50'
-local_cuda_version = '11.6.0'
-local_cuda_version_majmin = '.'.join(local_cuda_version.split('.')[:2])
-versionsuffix = '-CUDA-%s' % local_cuda_version
+versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://developer.nvidia.com/cudnn'
 description = """The NVIDIA CUDA Deep Neural Network library (cuDNN) is
@@ -10,25 +8,22 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
-source_urls = [
-    'https://developer.download.nvidia.com/compute/redist/cudnn/v%s/local_installers/%s/' %
-    ('.'.join(version.split('.')[:3]), local_cuda_version_majmin)
-]
-local_cudnn_cuda_version = '%%(version)s_cuda{maj_min}'.format(maj_min=local_cuda_version_majmin)
-local_tarball_tmpl = '-'.join(['%%(namelower)s', 'linux', '%s', local_cudnn_cuda_version, 'archive.tar.xz'])
-sources = [local_tarball_tmpl % '%(cudnnarch)s']
+source_urls = ['https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s']
+# note: cuDNN 8.4.1 is not specific to CUDA 11.6,
+# see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
+sources = ['%(namelower)s-linux-%(cudnnarch)s-%(version)s_cuda11.6-archive.tar.xz']
 checksums = [
     {
-        local_tarball_tmpl % 'x86_64':
+        '%(namelower)s-linux-x86_64-%(version)s_cuda11.6-archive.tar.xz':
             'ec96d2376d81fca42bdd3d4c3d705a99b29a065bab57f920561c763e29c67d01',
-        local_tarball_tmpl % 'ppc64le':
+        '%(namelower)s-linux-ppc64le-%(version)s_cuda11.6-archive.tar.xz':
             '8b806cbfdc81352bf76716d1e53b42537665d110c6ffc068be910505c10e1b98',
-        local_tarball_tmpl % 'sbsa':
+        '%(namelower)s-linux-sbsa-%(version)s_cuda11.6-archive.tar.xz':
             '0b1b9fac5b78974e2fdaaa74843db18f636ce8f3d999d62ff2a615b9978fc360',
     }
 ]
 
-dependencies = [('CUDA', local_cuda_version)]
+dependencies = [('CUDA', '11.6.0')]
 
 sanity_check_paths = {
     'files': [

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.4.1.50-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.4.1.50-CUDA-11.7.0.eb
@@ -8,12 +8,9 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
+source_urls = ['https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s']
 # note: cuDNN 8.4.1 is not specific to CUDA 11.6,
 # see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
-local_short_ver = '.'.join(version.split('.')[:3])
-source_urls = [
-    'https://developer.download.nvidia.com/compute/redist/cudnn/v%s/local_installers/11.6/' % local_short_ver,
-]
 sources = ['%(namelower)s-linux-%(cudnnarch)s-%(version)s_cuda11.6-archive.tar.xz']
 checksums = [
     {

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.5.0.96-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.5.0.96-CUDA-11.7.0.eb
@@ -8,11 +8,9 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
+source_urls = ['https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s']
 # note: cuDNN is tied to specific to CUDA versions,
 # see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
-local_short_ver = '.'.join(version.split('.')[:3])
-source_urls = ['https://developer.download.nvidia.com/compute/redist/cudnn/'
-               'v%s/local_installers/%%(cudashortver)s/' % local_short_ver]
 sources = ['%(namelower)s-linux-%(cudnnarch)s-%(version)s_cuda%(cudamajver)s-archive.tar.xz']
 checksums = [
     {

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.6.0.163-CUDA-11.8.0.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.6.0.163-CUDA-11.8.0.eb
@@ -7,21 +7,16 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
+source_urls = ['https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s']
 # note: cuDNN is tied to specific to CUDA versions,
 # see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
-local_short_ver = '.'.join(version.split('.')[:3])
-local_cuda_major = '11'  # Is there a way to make this parametric? '%(cudaver)'.split(...) obviously doesn't work...
-
-source_urls = [
-    'https://developer.download.nvidia.com/compute/redist/cudnn/v%s/local_installers/%%(cudashortver)s/' % local_short_ver  # noqa: E501
-]
-sources = ['%%(namelower)s-linux-%%(cudnnarch)s-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major]
+sources = ['%(namelower)s-linux-%(cudnnarch)s-%(version)s_cuda%(cudamajver)s-archive.tar.xz']
 checksums = [{
-    '%%(namelower)s-linux-x86_64-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-x86_64-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         'bbc396df47294c657edc09c600674d608cb1bfc80b82dcf4547060c21711159e',
-    '%%(namelower)s-linux-ppc64le-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-ppc64le-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         'c8a25e7e3df1bb9c4e18a4f24dd5f25cfd4bbe8b7054e34008e53b2be4f58a80',
-    '%%(namelower)s-linux-sbsa-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-sbsa-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         'a0202278d3cbd4f3adc3f7816bff6071621cb042b0903698b477acac8928ac06',
 }]
 

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.7.0.84-CUDA-11.8.0.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.7.0.84-CUDA-11.8.0.eb
@@ -7,21 +7,16 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
+source_urls = ['https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s']
 # note: cuDNN is tied to specific to CUDA versions,
 # see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
-local_short_ver = '.'.join(version.split('.')[:3])
-local_cuda_major = '11'
-
-source_urls = [
-    'https://developer.download.nvidia.com/compute/redist/cudnn/v%s/local_installers/%%(cudashortver)s/' % local_short_ver  # noqa: E501
-]
-sources = ['%%(namelower)s-linux-%%(cudnnarch)s-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major]
+sources = ['%(namelower)s-linux-%(cudnnarch)s-%(version)s_cuda%(cudamajver)s-archive.tar.xz']
 checksums = [{
-    '%%(namelower)s-linux-x86_64-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-x86_64-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         '976c4cba7233c97ae74006afab5172976300ba40f5b250a21f8cf71f59c9f76d',
-    '%%(namelower)s-linux-ppc64le-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-ppc64le-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         '0433d6d8b6841298e049e8a542750aa330a6e046a52ad95fae0c2f75dabe5575',
-    '%%(namelower)s-linux-sbsa-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-sbsa-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         'cf967f78dbf6c075243cc83aa18759e370db3754aa15b12a0a14e8bf67a3a9d4',
 }]
 

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.8.0.121-CUDA-12.0.0.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.8.0.121-CUDA-12.0.0.eb
@@ -7,21 +7,16 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
+source_urls = ['https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s']
 # note: cuDNN is tied to specific to CUDA versions,
 # see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
-local_short_ver = '.'.join(version.split('.')[:3])
-local_cuda_major = '12'
-
-source_urls = [
-    'https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s/'
-]
-sources = ['%%(namelower)s-linux-%%(cudnnarch)s-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major]
+sources = ['%(namelower)s-linux-%(cudnnarch)s-%(version)s_cuda%(cudamajver)s-archive.tar.xz']
 checksums = [{
-    '%%(namelower)s-linux-ppc64le-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-ppc64le-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         'cd41ab8b61f5beb54e32c3668ecd311ce926c39006fba256b053dd7d248419d4',
-    '%%(namelower)s-linux-sbsa-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-sbsa-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         'fc668519a8344e9d05335bad4bc5d23a504cdc7579aea41f12d6aa0f3079e709',
-    '%%(namelower)s-linux-x86_64-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-x86_64-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         'a0792b666caaf593a9dd4130979578fd3a78230f4407645c295700ef8e7aaaf2',
 }]
 

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.9.2.26-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.9.2.26-CUDA-12.1.1.eb
@@ -7,21 +7,16 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
+source_urls = ['https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s']
 # note: cuDNN is tied to specific to CUDA versions,
 # see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
-local_short_ver = '.'.join(version.split('.')[:3])
-local_cuda_major = '12'
-
-source_urls = [
-    'https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s/'
-]
-sources = ['%%(namelower)s-linux-%%(cudnnarch)s-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major]
+sources = ['%(namelower)s-linux-%(cudnnarch)s-%(version)s_cuda%(cudamajver)s-archive.tar.xz']
 checksums = [{
-    '%%(namelower)s-linux-ppc64le-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-ppc64le-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         '4f5e5bd01570c4805b93fb199f8bb6f8475d016948c55abf48fed9ffe89d13e5',
-    '%%(namelower)s-linux-sbsa-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-sbsa-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         '898d00c82f9ad8797bd6f6c639327b320a38fa4aeebfb2b3fbb2db0d38f7e1b0',
-    '%%(namelower)s-linux-x86_64-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-x86_64-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         'ccafd7d15c2bf26187d52d79d9ccf95104f4199980f5075a7c1ee3347948ce32',
 }]
 

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.9.2.26-CUDA-12.2.0.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.9.2.26-CUDA-12.2.0.eb
@@ -7,21 +7,16 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
+source_urls = ['https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s']
 # note: cuDNN is tied to specific to CUDA versions,
 # see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
-local_short_ver = '.'.join(version.split('.')[:3])
-local_cuda_major = '12'
-
-source_urls = [
-    'https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s/'
-]
-sources = ['%%(namelower)s-linux-%%(cudnnarch)s-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major]
+sources = ['%(namelower)s-linux-%(cudnnarch)s-%(version)s_cuda%(cudamajver)s-archive.tar.xz']
 checksums = [{
-    '%%(namelower)s-linux-ppc64le-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-ppc64le-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         '4f5e5bd01570c4805b93fb199f8bb6f8475d016948c55abf48fed9ffe89d13e5',
-    '%%(namelower)s-linux-sbsa-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-sbsa-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         '898d00c82f9ad8797bd6f6c639327b320a38fa4aeebfb2b3fbb2db0d38f7e1b0',
-    '%%(namelower)s-linux-x86_64-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-x86_64-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         'ccafd7d15c2bf26187d52d79d9ccf95104f4199980f5075a7c1ee3347948ce32',
 }]
 

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-8.9.7.29-CUDA-12.3.0.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-8.9.7.29-CUDA-12.3.0.eb
@@ -7,22 +7,17 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
+source_urls = ['https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s']
 # note: cuDNN is tied to specific to CUDA versions,
 # see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
-local_short_ver = '.'.join(version.split('.')[:3])
-local_cuda_major = '12'
-
-source_urls = [
-    'https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s/'
-]
-sources = ['%%(namelower)s-linux-%%(cudnnarch)s-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major]
+sources = ['%(namelower)s-linux-%(cudnnarch)s-%(version)s_cuda%(cudamajver)s-archive.tar.xz']
 checksums = [{
-    '%%(namelower)s-linux-ppc64le-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
-        '8574d291b299f9cc0134304473c9933bd098cc717e8d0876f4aba9f9eebe1b76',
-    '%%(namelower)s-linux-sbsa-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
-        'e98b7c80010785e5d5ca01ee4ce9b5b0c8c73587ea6f8648be34d3f8d1d47bd1',
-    '%%(namelower)s-linux-x86_64-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
-        '475333625c7e42a7af3ca0b2f7506a106e30c93b1aa0081cd9c13efb6e21e3bb',
+    '%(namelower)s-linux-ppc64le-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
+    '8574d291b299f9cc0134304473c9933bd098cc717e8d0876f4aba9f9eebe1b76',
+    '%(namelower)s-linux-sbsa-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
+    'e98b7c80010785e5d5ca01ee4ce9b5b0c8c73587ea6f8648be34d3f8d1d47bd1',
+    '%(namelower)s-linux-x86_64-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
+    '475333625c7e42a7af3ca0b2f7506a106e30c93b1aa0081cd9c13efb6e21e3bb',
 }]
 
 dependencies = [('CUDA', '12.3.0')]

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-9.1.1.17-CUDA-12.4.0.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-9.1.1.17-CUDA-12.4.0.eb
@@ -7,19 +7,14 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
+source_urls = ['https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s']
 # note: cuDNN is tied to specific to CUDA versions,
 # see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
-local_short_ver = '.'.join(version.split('.')[:3])
-local_cuda_major = '12'
-
-source_urls = [
-    'https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s/'
-]
-sources = ['%%(namelower)s-linux-%%(cudnnarch)s-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major]
+sources = ['%(namelower)s-linux-%(cudnnarch)s-%(version)s_cuda%(cudamajver)s-archive.tar.xz']
 checksums = [{
-    '%%(namelower)s-linux-sbsa-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-sbsa-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         '19bd66ee9fb30348f18801a398d0bec98b4663866efa244ca122825b3429526c',
-    '%%(namelower)s-linux-x86_64-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-x86_64-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         '992b4be26899cc4c618bb1f6989261df7d0a9f9032b2217bf1fce9dd3228c904',
 }]
 

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-9.10.1.4-CUDA-12.8.0.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-9.10.1.4-CUDA-12.8.0.eb
@@ -7,20 +7,18 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
-# note: cuDNN is tied to specific to CUDA versions,
-# see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
-local_cuda_major = '12'
-
 source_urls = [
     'https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s/'
 ]
-sources = ['%%(namelower)s-linux-%%(cudnnarch)s-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major]
+# note: cuDNN is tied to specific to CUDA versions,
+# see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
+sources = ['%(namelower)s-linux-%(cudnnarch)s-%(version)s_cuda%(cudamajver)s-archive.tar.xz']
 checksums = [{
-    f'%(namelower)s-linux-aarch64-%(version)s_cuda{local_cuda_major}-archive.tar.xz':
+    '%(namelower)s-linux-aarch64-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         'e8752e3708b54bb0cea0efc4a083218d9d1fc35a443b50343bab1d902f27ec34',
-    f'%(namelower)s-linux-sbsa-%(version)s_cuda{local_cuda_major}-archive.tar.xz':
+    '%(namelower)s-linux-sbsa-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         'd5cd68d4d09a151ad839a352f6fa01c3f86ccfb498704456892b992c3d8e4c88',
-    f'%(namelower)s-linux-x86_64-%(version)s_cuda{local_cuda_major}-archive.tar.xz':
+    '%(namelower)s-linux-x86_64-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         'be759754e5bd1fcd9b490e224796c87f093c1e92b2b6357854d5371b6aeeb8be',
 }]
 

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-9.5.0.50-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-9.5.0.50-CUDA-12.6.0.eb
@@ -7,19 +7,14 @@ a GPU-accelerated library of primitives for deep neural networks."""
 
 toolchain = SYSTEM
 
+source_urls = ['https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s']
 # note: cuDNN is tied to specific to CUDA versions,
 # see also https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
-local_short_ver = '.'.join(version.split('.')[:3])
-local_cuda_major = '12'
-
-source_urls = [
-    'https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-%(cudnnarch)s/'
-]
-sources = ['%%(namelower)s-linux-%%(cudnnarch)s-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major]
+sources = ['%(namelower)s-linux-%(cudnnarch)s-%(version)s_cuda%(cudamajver)s-archive.tar.xz']
 checksums = [{
-    '%%(namelower)s-linux-sbsa-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-sbsa-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         '494b640a69feb40ce806a726aa63a1de6b2ec459acbe6a116ef6fe3e6b27877d',
-    '%%(namelower)s-linux-x86_64-%%(version)s_cuda%s-archive.tar.xz' % local_cuda_major:
+    '%(namelower)s-linux-x86_64-%(version)s_cuda%(cudamajver)s-archive.tar.xz':
         '86e4e4f4c09b31d3850b402d94ea52741a2f94c2f717ddc8899a14aca96e032d',
 }]
 

--- a/easybuild/easyconfigs/n/NCCL/NCCL-2.8.3-CUDA-11.0.2.eb
+++ b/easybuild/easyconfigs/n/NCCL/NCCL-2.8.3-CUDA-11.0.2.eb
@@ -3,7 +3,7 @@ easyblock = "MakeCp"
 name = 'NCCL'
 version = '2.8.3'
 local_cuda_version = '11.0.2'
-versionsuffix = '-CUDA-%s' % local_cuda_version
+versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://developer.nvidia.com/nccl'
 description = """The NVIDIA Collective Communications Library (NCCL) implements multi-GPU and multi-node collective

--- a/easybuild/easyconfigs/n/NCCL/NCCL-2.8.3-CUDA-11.1.1.eb
+++ b/easybuild/easyconfigs/n/NCCL/NCCL-2.8.3-CUDA-11.1.1.eb
@@ -3,7 +3,7 @@ easyblock = "MakeCp"
 name = 'NCCL'
 version = '2.8.3'
 local_cuda_version = '11.1.1'
-versionsuffix = '-CUDA-%s' % local_cuda_version
+versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://developer.nvidia.com/nccl'
 description = """The NVIDIA Collective Communications Library (NCCL) implements multi-GPU and multi-node collective

--- a/easybuild/easyconfigs/n/NCCL/NCCL-2.9.9-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/n/NCCL/NCCL-2.9.9-CUDA-11.3.1.eb
@@ -6,7 +6,7 @@ easyblock = "MakeCp"
 name = 'NCCL'
 version = '2.9.9'
 local_cuda_version = '11.3.1'
-versionsuffix = '-CUDA-%s' % local_cuda_version
+versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://developer.nvidia.com/nccl'
 description = """The NVIDIA Collective Communications Library (NCCL) implements multi-GPU and multi-node collective


### PR DESCRIPTION
Use the correct templates for CUDA and software versions to avoid local variables and double-templates

This is just a cleanup for easier updating going forward. Tests with `--fetch --force-redownload` suffice for this