### PR TITLE
fix sources for librttopo 1.1.0

### DIFF
--- a/easybuild/easyconfigs/l/librttopo/librttopo-1.1.0-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/l/librttopo/librttopo-1.1.0-GCC-11.2.0.eb
@@ -11,20 +11,17 @@ data stores."""
 toolchain = {'name': 'GCC', 'version': '11.2.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://git.osgeo.org/gitea/rttopo/librttopo/archive']
+source_urls = ['https://download.osgeo.org/librttopo/src']
 sources = [SOURCE_TAR_GZ]
-checksums = ['2e2fcabb48193a712a6c76ac9a9be2a53f82e32f91a2bc834d9f1b4fa9cd879f']
+checksums = ['a77d8b787ba13f685de819348d5146f9f6ec56fd3bcf71e880dfc5e0086d4cb0']
 
 builddependencies = [
-    ('Autotools', '20210726'),
     ('pkgconf', '1.8.0'),
 ]
 
 dependencies = [
     ('GEOS', '3.9.1'),
 ]
-
-preconfigopts = './autogen.sh && '
 
 sanity_check_paths = {
     'files': ['include/librttopo.h', 'lib/librttopo.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/l/librttopo/librttopo-1.1.0-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/l/librttopo/librttopo-1.1.0-GCC-12.3.0.eb
@@ -11,22 +11,19 @@ data stores."""
 toolchain = {'name': 'GCC', 'version': '12.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://git.osgeo.org/gitea/rttopo/librttopo/archive']
+source_urls = ['https://download.osgeo.org/librttopo/src']
 sources = [SOURCE_TAR_GZ]
+checksums = ['a77d8b787ba13f685de819348d5146f9f6ec56fd3bcf71e880dfc5e0086d4cb0']
+
 # accept both old and new variant of source tarball (contents are identical, but tarball itself isn't)
-checksums = [('2e2fcabb48193a712a6c76ac9a9be2a53f82e32f91a2bc834d9f1b4fa9cd879f',
-              '60b49acb493c1ab545116fb0b0d223ee115166874902ad8165eb39e9fd98eaa9')]
 
 builddependencies = [
-    ('Autotools', '20220317'),
     ('pkgconf', '1.9.5'),
 ]
 
 dependencies = [
     ('GEOS', '3.12.0'),
 ]
-
-preconfigopts = './autogen.sh && '
 
 sanity_check_paths = {
     'files': ['include/librttopo.h', 'lib/librttopo.%s' % SHLIB_EXT],


### PR DESCRIPTION
Old sources are inaccessible, and the new tarball includes the `configure` script.