### PR TITLE
improve reported errors in easyconfigs test suite

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -330,7 +330,7 @@ class EasyConfigTest(TestCase):
 
         self.assertEqual(check_conflicts(self.ordered_specs, modules_tool(), check_inter_ec_conflicts=False,
                                          return_conflicts=True),
-                         "")
+                         [])
 
     def test_deps(self):
         """Perform checks on dependencies in easyconfig files"""


### PR DESCRIPTION
- Use the new `return_conflicts` parameter to show the conflicts in the error message instead of printing it to stderr during the status output when the test is run.
- [x] Requires https://github.com/easybuilders/easybuild-framework/pull/5000
- Especially "binutils or GCC is a build dep: " is a misleading message when the test fails because it is not.