### PR TITLE
{tools} [GCCcore/13.3.0, GCCcore/13.2.0] JupyterLab-git v.0.51.2, JupyterLab-git v.0.51.1

### DIFF
--- a/easybuild/easyconfigs/j/JupyterLab-git/JupyterLab-git-0.51.1-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/j/JupyterLab-git/JupyterLab-git-0.51.1-GCCcore-13.2.0.eb
@@ -1,0 +1,67 @@
+# Author: Ehsan Moravveji (VSC - KU Leuven)
+
+easyblock = 'PythonBundle'
+
+name = 'JupyterLab-git'
+version = '0.51.1'
+
+homepage = 'https://www.domain.org'
+description = """A JupyterLab extension for version control using Git"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+builddependencies = [
+    ('hatchling', '1.18.0'),
+    ('hatch-jupyter-builder', '0.9.1'),
+    ('nodejs', '20.9.0'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+    ('IPython', '8.17.2'),
+    ('jupyter-server', '2.14.0'),
+    ('JupyterLab', '4.2.0'),
+    ('GitPython', '3.1.42'),
+]
+
+exts_list = [
+    ('jupyter-server-mathjax', '0.2.6', {
+        'modulename': 'jupyter_server_mathjax',
+        'source_tmpl': 'jupyter_server_mathjax-%(version)s.tar.gz',
+        'checksums': ['bb1e6b6dc0686c1fe386a22b5886163db548893a99c2810c36399e9c4ca23943'],
+    }),
+    ('nbdime', '4.0.1', {
+        'checksums': ['f1a760c0b00c1ba9b4945c16ce92577f393fb51d184f351b7685ba6e8502098e'],
+    }),
+    ('jupyterlab-git', version, {
+        'modulename': 'jupyterlab_git',
+        'source_tmpl': 'jupyterlab_git-%(version)s.tar.gz',
+        'checksums': ['b7bce89795d5ce88c8aaf0d79eb7a93d0535622f9be6b019ca9ae4d3b9a9ca6a'],
+    }),
+]
+
+# 'jlpm' installation is needed as specified in:
+# https://github.com/jupyterlab/jupyterlab-git/blob/main/pyproject.toml#L86
+postinstallcmds = [
+    'jlpm install',
+    'jlpm build:prod',
+]
+
+local_json_dir = 'etc/jupyter/jupyter_server_config.d'
+sanity_check_paths = {
+    'files': [f'{local_json_dir}/{x}.json' for x in ['jupyterlab_git', 'jupyter_server_mathjax', 'nbdime']],
+    'dirs': [
+        'share/jupyter/labextensions/@jupyterlab/git',
+        'share/jupyter/nbextensions',
+        'etc/jupyter/jupyter_notebook_config.d'
+    ],
+}
+
+modextrapaths = {
+    'JUPYTER_PATH': 'share/jupyter',
+    # For this specific extension, another environment variable is needed to expose the tool
+    'JUPYTER_CONFIG_PATH': 'etc/jupyter',
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/j/JupyterLab-git/JupyterLab-git-0.51.1-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/j/JupyterLab-git/JupyterLab-git-0.51.1-GCCcore-13.2.0.eb
@@ -11,6 +11,7 @@ description = """A JupyterLab extension for version control using Git"""
 toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 
 builddependencies = [
+    ('binutils', '2.40'),
     ('hatchling', '1.18.0'),
     ('hatch-jupyter-builder', '0.9.1'),
     ('nodejs', '20.9.0'),

--- a/easybuild/easyconfigs/j/JupyterLab-git/JupyterLab-git-0.51.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/j/JupyterLab-git/JupyterLab-git-0.51.2-GCCcore-13.3.0.eb
@@ -1,0 +1,67 @@
+# Author: Ehsan Moravveji (VSC - KU Leuven)
+
+easyblock = 'PythonBundle'
+
+name = 'JupyterLab-git'
+version = '0.51.2'
+
+homepage = 'https://www.domain.org'
+description = """A JupyterLab extension for version control using Git"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+builddependencies = [
+    ('hatchling', '1.24.2'),
+    ('hatch-jupyter-builder', '0.9.1'),
+    ('nodejs', '20.13.1'),
+]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('Python-bundle-PyPI', '2024.06'),
+    ('IPython', '8.28.0'),
+    ('jupyter-server', '2.14.2'),
+    ('JupyterLab', '4.2.5'),
+    ('GitPython', '3.1.43'),
+]
+
+exts_list = [
+    ('jupyter-server-mathjax', '0.2.6', {
+        'modulename': 'jupyter_server_mathjax',
+        'source_tmpl': 'jupyter_server_mathjax-%(version)s.tar.gz',
+        'checksums': ['bb1e6b6dc0686c1fe386a22b5886163db548893a99c2810c36399e9c4ca23943'],
+    }),
+    ('nbdime', '4.0.1', {
+        'checksums': ['f1a760c0b00c1ba9b4945c16ce92577f393fb51d184f351b7685ba6e8502098e'],
+    }),
+    ('jupyterlab-git', version, {
+        'modulename': 'jupyterlab_git',
+        'source_tmpl': 'jupyterlab_git-%(version)s.tar.gz',
+        'checksums': ['ad91d56f0298fd70e7d8f8cd1ee76d261f0dfb940cc490717a31d64df4b7d562'],
+    }),
+]
+
+# 'jlpm' installation is needed as specified in:
+# https://github.com/jupyterlab/jupyterlab-git/blob/main/pyproject.toml#L86
+postinstallcmds = [
+    'jlpm install',
+    'jlpm build:prod',
+]
+
+local_json_dir = 'etc/jupyter/jupyter_server_config.d'
+sanity_check_paths = {
+    'files': [f'{local_json_dir}/{x}.json' for x in ['jupyterlab_git', 'jupyter_server_mathjax', 'nbdime']],
+    'dirs': [
+        'share/jupyter/labextensions/@jupyterlab/git',
+        'share/jupyter/nbextensions',
+        'etc/jupyter/jupyter_notebook_config.d'
+    ],
+}
+
+modextrapaths = {
+    'JUPYTER_PATH': 'share/jupyter',
+    # For this specific extension, another environment variable is needed to expose the tool
+    'JUPYTER_CONFIG_PATH': 'etc/jupyter',
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/j/JupyterLab-git/JupyterLab-git-0.51.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/j/JupyterLab-git/JupyterLab-git-0.51.2-GCCcore-13.3.0.eb
@@ -11,6 +11,7 @@ description = """A JupyterLab extension for version control using Git"""
 toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
 
 builddependencies = [
+    ('binutils', '2.42'),
     ('hatchling', '1.24.2'),
     ('hatch-jupyter-builder', '0.9.1'),
     ('nodejs', '20.13.1'),


### PR DESCRIPTION
This PR adds two versions of `jupyterlab-git` plugin for JupyterLab for 2023b and 2024a toolchains. A similar installation based on the modules in 2023a fails with some `hatchling` issues.