### PR TITLE
add patch for GCCcore 10.3-13.2 to fix AVX-512 vectorizer bug (upstream PR 114566)

### DIFF
--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-10.1-11.4_fix-avx512-vect-crash.patch
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-10.1-11.4_fix-avx512-vect-crash.patch
@@ -1,0 +1,120 @@
+From 327533790760809abd2549e613a676dde5f8cd93 Mon Sep 17 00:00:00 2001
+From: Jakub Jelinek <jakub@redhat.com>
+Date: Fri, 5 Apr 2024 14:56:14 +0200
+Subject: vect: Don't clear base_misaligned in update_epilogue_loop_vinfo
+ [PR114566]
+
+The following testcase is miscompiled, because in the vectorized
+epilogue the vectorizer assumes it can use aligned loads/stores
+(if the base decl gets alignment increased), but it actually doesn't
+increase that.
+This is because r10-4203-g97c1460367 added the hunk following
+patch removes.  The explanation feels reasonable, but actually it
+is not true as the testcase proves.
+The thing is, we vectorize the main loop with 64-byte vectors
+and the corresponding data refs have base_alignment 16 (the
+a array has DECL_ALIGN 128) and offset_alignment 32.  Now, because
+of the offset_alignment 32 rather than 64, we need to use unaligned
+loads/stores in the main loop (and ditto in the first load/store
+in vectorized epilogue).  But the second load/store in the vectorized
+epilogue uses only 32-byte vectors and because it is a multiple
+of offset_alignment, it checks if we could increase alignment of the
+a VAR_DECL, the function returns true, sets base_misaligned = true
+and says the access is then aligned.
+But when update_epilogue_loop_vinfo clears base_misaligned with the
+assumption that the var had to have the alignment increased already,
+the update of DECL_ALIGN doesn't happen anymore.
+
+Now, I'd think this base_alignment = false was needed before
+r10-4030-gd2db7f7901 change was committed where it incorrectly
+overwrote DECL_ALIGN even if it was already larger, rather than
+just always increasing it.  But with that change in, it doesn't
+make sense to me anymore.
+
+Note, the testcase is latent on the trunk, but reproduces on the 13
+branch.
+
+2024-04-05  Jakub Jelinek  <jakub@redhat.com>
+
+	PR tree-optimization/114566
+	* tree-vect-loop.c (update_epilogue_loop_vinfo): Don't clear
+	base_misaligned.
+
+	* gcc.target/i386/avx512f-pr114566.c: New test.
+
+(cherry picked from commit a844095e17c1a5aada1364c6f6eaade87ead463c)
+---
+ gcc/testsuite/gcc.target/i386/avx512f-pr114566.c | 34 ++++++++++++++++++++++++
+ gcc/tree-vect-loop.c                             |  8 +-----
+ 2 files changed, 35 insertions(+), 7 deletions(-)
+ create mode 100644 gcc/testsuite/gcc.target/i386/avx512f-pr114566.c
+
+diff --git a/gcc/testsuite/gcc.target/i386/avx512f-pr114566.c b/gcc/testsuite/gcc.target/i386/avx512f-pr114566.c
+new file mode 100644
+index 000000000000..abfab1bfcd5b
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/i386/avx512f-pr114566.c
+@@ -0,0 +1,34 @@
++/* PR tree-optimization/114566 */
++/* { dg-do run } */
++/* { dg-options "-O3 -mavx512f" } */
++/* { dg-additional-options "-fstack-protector-strong" { target fstack_protector } } */
++/* { dg-require-effective-target avx512f } */
++
++#define AVX512F
++#include "avx512f-helper.h"
++
++__attribute__((noipa)) int
++foo (float x, float y)
++{
++  float a[8][56];
++  __builtin_memset (a, 0, sizeof (a));
++
++  for (int j = 0; j < 8; j++)
++    for (int k = 0; k < 56; k++)
++      {
++	float b = k * y;
++	if (b < 0.)
++	  b = 0.;
++	if (b > 0.)
++	  b = 0.;
++	a[j][k] += b;
++      }
++
++  return __builtin_log (x);
++}
++
++void
++TEST (void)
++{
++  foo (86.25f, 0.625f);
++}
+diff --git a/gcc/tree-vect-loop.c b/gcc/tree-vect-loop.c
+index 76580c1e3dd7..01d1361c9f04 100644
+--- a/gcc/tree-vect-loop.c
++++ b/gcc/tree-vect-loop.c
+@@ -9296,9 +9296,7 @@ find_in_mapping (tree t, void *context)
+    corresponding dr_vec_info need to be reconnected to the EPILOGUE's
+    stmt_vec_infos, their statements need to point to their corresponding copy,
+    if they are gather loads or scatter stores then their reference needs to be
+-   updated to point to its corresponding copy and finally we set
+-   'base_misaligned' to false as we have already peeled for alignment in the
+-   prologue of the main loop.  */
++   updated to point to its corresponding copy.  */
+ 
+ static void
+ update_epilogue_loop_vinfo (class loop *epilogue, tree advance)
+@@ -9439,10 +9437,6 @@ update_epilogue_loop_vinfo (class loop *epilogue, tree advance)
+ 	}
+       DR_STMT (dr) = STMT_VINFO_STMT (stmt_vinfo);
+       stmt_vinfo->dr_aux.stmt = stmt_vinfo;
+-      /* The vector size of the epilogue is smaller than that of the main loop
+-	 so the alignment is either the same or lower. This means the dr will
+-	 thus by definition be aligned.  */
+-      STMT_VINFO_DR_INFO (stmt_vinfo)->base_misaligned = false;
+     }
+ 
+   epilogue_vinfo->shared->datarefs_copy.release ();
+-- 
+cgit 
+

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-10.3.0.eb
@@ -36,6 +36,7 @@ patches = [
     'gcc-10.3.0_fix-ice-in-tsubst.patch',
     'GCCcore-9.x-11.x_fix-unsigned-fpe-traps.patch',
     'GCC-10.x_fix-libsanitizer-cyclades.patch',
+    'GCCcore-10.1-11.4_fix-avx512-vect-crash.patch',
     'GCCcore-11_fix-libsanitzer-glibc-2.36.patch',
 ]
 checksums = [
@@ -53,6 +54,8 @@ checksums = [
     {'GCCcore-9.x-11.x_fix-unsigned-fpe-traps.patch':
      '03a2e4aeda78d398edd680d6a1ba842b8ceb29c126ebb7fe2e3541ddfe4fbed4'},
     {'GCC-10.x_fix-libsanitizer-cyclades.patch': 'ba1f1cdc3a370281a9c1a45758db48b7edbddb70a9f6b10951fe8a77e4931832'},
+    {'GCCcore-10.1-11.4_fix-avx512-vect-crash.patch':
+     'e4092255ac6d4d8228068093eda018de82649af191a31c90bd3fa12fe28b3f8e'},
     {'GCCcore-11_fix-libsanitzer-glibc-2.36.patch': '5c6c3b4655883a23dd9da7ef99751e5db23f35189c03689d2ab755b22cb39a60'},
 ]
 

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-11.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-11.1.0.eb
@@ -34,6 +34,7 @@ patches = [
     'GCCcore-9.3.0_gmp-c99.patch',
     'GCCcore-9.x-11.x_fix-unsigned-fpe-traps.patch',
     'GCC-10.x_fix-libsanitizer-cyclades.patch',
+    'GCCcore-10.1-11.4_fix-avx512-vect-crash.patch',
     'GCCcore-11_fix-libsanitzer-glibc-2.36.patch',
     'GCCcore-11.1.0_fix-AVX2-intrinsics.patch',
     'GCCcore-11.3.0_fix-vectorizer.patch',
@@ -51,6 +52,8 @@ checksums = [
     {'GCCcore-9.x-11.x_fix-unsigned-fpe-traps.patch':
      '03a2e4aeda78d398edd680d6a1ba842b8ceb29c126ebb7fe2e3541ddfe4fbed4'},
     {'GCC-10.x_fix-libsanitizer-cyclades.patch': 'ba1f1cdc3a370281a9c1a45758db48b7edbddb70a9f6b10951fe8a77e4931832'},
+    {'GCCcore-10.1-11.4_fix-avx512-vect-crash.patch':
+     'e4092255ac6d4d8228068093eda018de82649af191a31c90bd3fa12fe28b3f8e'},
     {'GCCcore-11_fix-libsanitzer-glibc-2.36.patch': '5c6c3b4655883a23dd9da7ef99751e5db23f35189c03689d2ab755b22cb39a60'},
     {'GCCcore-11.1.0_fix-AVX2-intrinsics.patch': 'a06c09cc6ba25ec4e0a28280eb6b25cdb331f7835d07ebb3a83536214d3d68fa'},
     {'GCCcore-11.3.0_fix-vectorizer.patch': '7dff25b678e2f65b81d9bf0c8402ad46c25a04b0c0d610db50b763ecc5f9ef98'},

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-11.2.0.eb
@@ -33,6 +33,7 @@ patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
     'GCCcore-9.3.0_gmp-c99.patch',
     'GCCcore-9.x-11.x_fix-unsigned-fpe-traps.patch',
+    'GCCcore-10.1-11.4_fix-avx512-vect-crash.patch',
     'GCCcore-11_fix-libsanitzer-glibc-2.36.patch',
     'GCCcore-11.1.0_fix-AVX2-intrinsics.patch',
     'GCCcore-11.3.0_fix-vectorizer.patch',
@@ -49,6 +50,8 @@ checksums = [
     {'GCCcore-9.3.0_gmp-c99.patch': '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e'},
     {'GCCcore-9.x-11.x_fix-unsigned-fpe-traps.patch':
      '03a2e4aeda78d398edd680d6a1ba842b8ceb29c126ebb7fe2e3541ddfe4fbed4'},
+    {'GCCcore-10.1-11.4_fix-avx512-vect-crash.patch':
+     'e4092255ac6d4d8228068093eda018de82649af191a31c90bd3fa12fe28b3f8e'},
     {'GCCcore-11_fix-libsanitzer-glibc-2.36.patch': '5c6c3b4655883a23dd9da7ef99751e5db23f35189c03689d2ab755b22cb39a60'},
     {'GCCcore-11.1.0_fix-AVX2-intrinsics.patch': 'a06c09cc6ba25ec4e0a28280eb6b25cdb331f7835d07ebb3a83536214d3d68fa'},
     {'GCCcore-11.3.0_fix-vectorizer.patch': '7dff25b678e2f65b81d9bf0c8402ad46c25a04b0c0d610db50b763ecc5f9ef98'},

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-11.3.0.eb
@@ -34,6 +34,7 @@ patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
     'GCCcore-9.3.0_gmp-c99.patch',
     'GCCcore-9.x-11.x_fix-unsigned-fpe-traps.patch',
+    'GCCcore-10.1-11.4_fix-avx512-vect-crash.patch',
     'GCCcore-11.3.0_fuse-ld-mold.patch',
     'GCCcore-11_fix-libsanitzer-glibc-2.36.patch',
     'GCCcore-11.3.0_fix-vectorizer.patch',
@@ -50,6 +51,8 @@ checksums = [
     {'GCCcore-9.3.0_gmp-c99.patch': '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e'},
     {'GCCcore-9.x-11.x_fix-unsigned-fpe-traps.patch':
      '03a2e4aeda78d398edd680d6a1ba842b8ceb29c126ebb7fe2e3541ddfe4fbed4'},
+    {'GCCcore-10.1-11.4_fix-avx512-vect-crash.patch':
+     'e4092255ac6d4d8228068093eda018de82649af191a31c90bd3fa12fe28b3f8e'},
     {'GCCcore-11.3.0_fuse-ld-mold.patch': 'bba64714f8b84ad58b3b43c0d21b4ffc298274ae699f514ed2934f002146d840'},
     {'GCCcore-11_fix-libsanitzer-glibc-2.36.patch': '5c6c3b4655883a23dd9da7ef99751e5db23f35189c03689d2ab755b22cb39a60'},
     {'GCCcore-11.3.0_fix-vectorizer.patch': '7dff25b678e2f65b81d9bf0c8402ad46c25a04b0c0d610db50b763ecc5f9ef98'},

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-11.4.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-11.4.0.eb
@@ -34,6 +34,7 @@ patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
     'GCCcore-9.3.0_gmp-c99.patch',
     'GCCcore-9.x-11.x_fix-unsigned-fpe-traps.patch',
+    'GCCcore-10.1-11.4_fix-avx512-vect-crash.patch',
     'GCCcore-11.3.0_fuse-ld-mold.patch',
 ]
 checksums = [
@@ -48,6 +49,8 @@ checksums = [
     {'GCCcore-9.3.0_gmp-c99.patch': '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e'},
     {'GCCcore-9.x-11.x_fix-unsigned-fpe-traps.patch':
      '03a2e4aeda78d398edd680d6a1ba842b8ceb29c126ebb7fe2e3541ddfe4fbed4'},
+    {'GCCcore-10.1-11.4_fix-avx512-vect-crash.patch':
+     'e4092255ac6d4d8228068093eda018de82649af191a31c90bd3fa12fe28b3f8e'},
     {'GCCcore-11.3.0_fuse-ld-mold.patch': 'bba64714f8b84ad58b3b43c0d21b4ffc298274ae699f514ed2934f002146d840'},
 ]
 

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-12.1-13.2_fix-avx512-vect-crash.patch
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-12.1-13.2_fix-avx512-vect-crash.patch
@@ -1,0 +1,118 @@
+From a844095e17c1a5aada1364c6f6eaade87ead463c Mon Sep 17 00:00:00 2001
+From: Jakub Jelinek <jakub@redhat.com>
+Date: Fri, 5 Apr 2024 14:56:14 +0200
+Subject: [PATCH] vect: Don't clear base_misaligned in
+ update_epilogue_loop_vinfo [PR114566]
+
+The following testcase is miscompiled, because in the vectorized
+epilogue the vectorizer assumes it can use aligned loads/stores
+(if the base decl gets alignment increased), but it actually doesn't
+increase that.
+This is because r10-4203-g97c1460367 added the hunk following
+patch removes.  The explanation feels reasonable, but actually it
+is not true as the testcase proves.
+The thing is, we vectorize the main loop with 64-byte vectors
+and the corresponding data refs have base_alignment 16 (the
+a array has DECL_ALIGN 128) and offset_alignment 32.  Now, because
+of the offset_alignment 32 rather than 64, we need to use unaligned
+loads/stores in the main loop (and ditto in the first load/store
+in vectorized epilogue).  But the second load/store in the vectorized
+epilogue uses only 32-byte vectors and because it is a multiple
+of offset_alignment, it checks if we could increase alignment of the
+a VAR_DECL, the function returns true, sets base_misaligned = true
+and says the access is then aligned.
+But when update_epilogue_loop_vinfo clears base_misaligned with the
+assumption that the var had to have the alignment increased already,
+the update of DECL_ALIGN doesn't happen anymore.
+
+Now, I'd think this base_alignment = false was needed before
+r10-4030-gd2db7f7901 change was committed where it incorrectly
+overwrote DECL_ALIGN even if it was already larger, rather than
+just always increasing it.  But with that change in, it doesn't
+make sense to me anymore.
+
+Note, the testcase is latent on the trunk, but reproduces on the 13
+branch.
+
+2024-04-05  Jakub Jelinek  <jakub@redhat.com>
+
+	PR tree-optimization/114566
+	* tree-vect-loop.cc (update_epilogue_loop_vinfo): Don't clear
+	base_misaligned.
+
+	* gcc.target/i386/avx512f-pr114566.c: New test.
+---
+ .../gcc.target/i386/avx512f-pr114566.c        | 34 +++++++++++++++++++
+ gcc/tree-vect-loop.cc                         |  8 +----
+ 2 files changed, 35 insertions(+), 7 deletions(-)
+ create mode 100644 gcc/testsuite/gcc.target/i386/avx512f-pr114566.c
+
+diff --git a/gcc/testsuite/gcc.target/i386/avx512f-pr114566.c b/gcc/testsuite/gcc.target/i386/avx512f-pr114566.c
+new file mode 100644
+index 000000000000..abfab1bfcd5b
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/i386/avx512f-pr114566.c
+@@ -0,0 +1,34 @@
++/* PR tree-optimization/114566 */
++/* { dg-do run } */
++/* { dg-options "-O3 -mavx512f" } */
++/* { dg-additional-options "-fstack-protector-strong" { target fstack_protector } } */
++/* { dg-require-effective-target avx512f } */
++
++#define AVX512F
++#include "avx512f-helper.h"
++
++__attribute__((noipa)) int
++foo (float x, float y)
++{
++  float a[8][56];
++  __builtin_memset (a, 0, sizeof (a));
++
++  for (int j = 0; j < 8; j++)
++    for (int k = 0; k < 56; k++)
++      {
++	float b = k * y;
++	if (b < 0.)
++	  b = 0.;
++	if (b > 0.)
++	  b = 0.;
++	a[j][k] += b;
++      }
++
++  return __builtin_log (x);
++}
++
++void
++TEST (void)
++{
++  foo (86.25f, 0.625f);
++}
+diff --git a/gcc/tree-vect-loop.cc b/gcc/tree-vect-loop.cc
+index 984636edbc5f..3ffcac8c6135 100644
+--- a/gcc/tree-vect-loop.cc
++++ b/gcc/tree-vect-loop.cc
+@@ -11590,9 +11590,7 @@ find_in_mapping (tree t, void *context)
+    corresponding dr_vec_info need to be reconnected to the EPILOGUE's
+    stmt_vec_infos, their statements need to point to their corresponding copy,
+    if they are gather loads or scatter stores then their reference needs to be
+-   updated to point to its corresponding copy and finally we set
+-   'base_misaligned' to false as we have already peeled for alignment in the
+-   prologue of the main loop.  */
++   updated to point to its corresponding copy.  */
+ 
+ static void
+ update_epilogue_loop_vinfo (class loop *epilogue, tree advance)
+@@ -11736,10 +11734,6 @@ update_epilogue_loop_vinfo (class loop *epilogue, tree advance)
+ 	}
+       DR_STMT (dr) = STMT_VINFO_STMT (stmt_vinfo);
+       stmt_vinfo->dr_aux.stmt = stmt_vinfo;
+-      /* The vector size of the epilogue is smaller than that of the main loop
+-	 so the alignment is either the same or lower. This means the dr will
+-	 thus by definition be aligned.  */
+-      STMT_VINFO_DR_INFO (stmt_vinfo)->base_misaligned = false;
+     }
+ 
+   epilogue_vinfo->shared->datarefs_copy.release ();
+-- 
+2.43.7
+

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-12.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-12.1.0.eb
@@ -33,6 +33,7 @@ sources = [
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
     'GCCcore-9.3.0_gmp-c99.patch',
+    'GCCcore-12.1-13.2_fix-avx512-vect-crash.patch',
     'GCCcore-12.1.0_allow-pragma-wself-init.patch',
     'GCCcore-12.1.0_fix-double-destruct.patch',
     'GCCcore-12.1.0_fix-Wuninitialized-in-AVX-headers.patch',
@@ -50,6 +51,8 @@ checksums = [
     {'nvptx-tools-20240419.tar.gz': 'a4f65efe0ba960d75a18741faf2b93dbf51c2492a53b734d590ce5da4bd3f237'},
     {'GCCcore-6.2.0-fix-find-isl.patch': '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68'},
     {'GCCcore-9.3.0_gmp-c99.patch': '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e'},
+    {'GCCcore-12.1-13.2_fix-avx512-vect-crash.patch':
+     '4a8fcde2961b3c4f60b23e1dd2b0af39d32a64a66365c707bb29de5d42b42d04'},
     {'GCCcore-12.1.0_allow-pragma-wself-init.patch':
      '464f5faa9b23e805995d10dcdacca83df6321cac70826e9a3bc5bc9cd737f6a1'},
     {'GCCcore-12.1.0_fix-double-destruct.patch': '2e09c125318b6c15ec60f1807d77fb7d1f32b64a4e5d1c9a3da89ba2ca738d35'},

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-12.2.0.eb
@@ -33,6 +33,7 @@ sources = [
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
     'GCCcore-9.3.0_gmp-c99.patch',
+    'GCCcore-12.1-13.2_fix-avx512-vect-crash.patch',
     'GCCcore-12.1.0_allow-pragma-wself-init.patch',
     'GCCcore-12.1.0_fix-double-destruct.patch',
     'GCCcore-12.1.0_fix-Wuninitialized-in-AVX-headers.patch',
@@ -51,6 +52,8 @@ checksums = [
     {'nvptx-tools-20240419.tar.gz': 'a4f65efe0ba960d75a18741faf2b93dbf51c2492a53b734d590ce5da4bd3f237'},
     {'GCCcore-6.2.0-fix-find-isl.patch': '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68'},
     {'GCCcore-9.3.0_gmp-c99.patch': '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e'},
+    {'GCCcore-12.1-13.2_fix-avx512-vect-crash.patch':
+     '4a8fcde2961b3c4f60b23e1dd2b0af39d32a64a66365c707bb29de5d42b42d04'},
     {'GCCcore-12.1.0_allow-pragma-wself-init.patch':
      '464f5faa9b23e805995d10dcdacca83df6321cac70826e9a3bc5bc9cd737f6a1'},
     {'GCCcore-12.1.0_fix-double-destruct.patch': '2e09c125318b6c15ec60f1807d77fb7d1f32b64a4e5d1c9a3da89ba2ca738d35'},

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-12.3.0.eb
@@ -33,6 +33,7 @@ sources = [
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
     'GCCcore-9.3.0_gmp-c99.patch',
+    'GCCcore-12.1-13.2_fix-avx512-vect-crash.patch',
     'GCCcore-12.1.0_fix-double-destruct.patch',
     'GCCcore-12.2.0_fix-avx512-misoptimization.patch',
     'GCCcore-12.2.0_improve-cuda-compatibility.patch',
@@ -49,6 +50,8 @@ checksums = [
     {'nvptx-tools-20240419.tar.gz': 'a4f65efe0ba960d75a18741faf2b93dbf51c2492a53b734d590ce5da4bd3f237'},
     {'GCCcore-6.2.0-fix-find-isl.patch': '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68'},
     {'GCCcore-9.3.0_gmp-c99.patch': '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e'},
+    {'GCCcore-12.1-13.2_fix-avx512-vect-crash.patch':
+     '4a8fcde2961b3c4f60b23e1dd2b0af39d32a64a66365c707bb29de5d42b42d04'},
     {'GCCcore-12.1.0_fix-double-destruct.patch': '2e09c125318b6c15ec60f1807d77fb7d1f32b64a4e5d1c9a3da89ba2ca738d35'},
     {'GCCcore-12.2.0_fix-avx512-misoptimization.patch':
      'bb3db707727b9975b0005346ef04230a96b3ad896f004a34262a82a244b5d436'},

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-13.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-13.1.0.eb
@@ -33,6 +33,7 @@ sources = [
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
     'GCCcore-9.3.0_gmp-c99.patch',
+    'GCCcore-12.1-13.2_fix-avx512-vect-crash.patch',
     'GCCcore-12.1.0_fix-double-destruct.patch',
     'GCCcore-12.2.0_fix-avx512-misoptimization.patch',
     'GCCcore-12.x_riscv_multiarch_support.patch',
@@ -48,6 +49,8 @@ checksums = [
     {'nvptx-tools-20240419.tar.gz': 'a4f65efe0ba960d75a18741faf2b93dbf51c2492a53b734d590ce5da4bd3f237'},
     {'GCCcore-6.2.0-fix-find-isl.patch': '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68'},
     {'GCCcore-9.3.0_gmp-c99.patch': '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e'},
+    {'GCCcore-12.1-13.2_fix-avx512-vect-crash.patch':
+     '4a8fcde2961b3c4f60b23e1dd2b0af39d32a64a66365c707bb29de5d42b42d04'},
     {'GCCcore-12.1.0_fix-double-destruct.patch': '2e09c125318b6c15ec60f1807d77fb7d1f32b64a4e5d1c9a3da89ba2ca738d35'},
     {'GCCcore-12.2.0_fix-avx512-misoptimization.patch':
      'bb3db707727b9975b0005346ef04230a96b3ad896f004a34262a82a244b5d436'},

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-13.2.0.eb
@@ -33,6 +33,7 @@ sources = [
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
     'GCCcore-9.3.0_gmp-c99.patch',
+    'GCCcore-12.1-13.2_fix-avx512-vect-crash.patch',
     'GCCcore-12.1.0_fix-double-destruct.patch',
     'GCCcore-12.2.0_fix-avx512-misoptimization.patch',
     'GCCcore-13.2.0_fix_slp_and_loop_mask_len.patch',
@@ -49,6 +50,8 @@ checksums = [
     {'nvptx-tools-20240419.tar.gz': 'a4f65efe0ba960d75a18741faf2b93dbf51c2492a53b734d590ce5da4bd3f237'},
     {'GCCcore-6.2.0-fix-find-isl.patch': '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68'},
     {'GCCcore-9.3.0_gmp-c99.patch': '0e135e1cc7cec701beea9d7d17a61bab34cfd496b4b555930016b98db99f922e'},
+    {'GCCcore-12.1-13.2_fix-avx512-vect-crash.patch':
+     '4a8fcde2961b3c4f60b23e1dd2b0af39d32a64a66365c707bb29de5d42b42d04'},
     {'GCCcore-12.1.0_fix-double-destruct.patch': '2e09c125318b6c15ec60f1807d77fb7d1f32b64a4e5d1c9a3da89ba2ca738d35'},
     {'GCCcore-12.2.0_fix-avx512-misoptimization.patch':
      'bb3db707727b9975b0005346ef04230a96b3ad896f004a34262a82a244b5d436'},


### PR DESCRIPTION
This fixes a segmentation fault in FlexiBLAS LAPACK tests when compiling for Zen4/Zen5

See also:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114566 and:
* #23974