### PR TITLE
add `-lpthread` to configure options for `Parallel-Hashmap v2.0.0`

### DIFF
--- a/easybuild/easyconfigs/p/Parallel-Hashmap/Parallel-Hashmap-2.0.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/p/Parallel-Hashmap/Parallel-Hashmap-2.0.0-GCCcore-13.3.0.eb
@@ -25,7 +25,7 @@ builddependencies = [
 
 configopts = ' '.join([
     '-DPHMAP_BUILD_TESTS=ON',
-    '-DPHMAP_GTEST_LIBS="-lgmock_main -lgmock -lgtest"',
+    '-DPHMAP_GTEST_LIBS="-lgmock_main -lgmock -lgtest -lpthread"',
     '-DPHMAP_BUILD_EXAMPLES=OFF',
 ])
 


### PR DESCRIPTION
Explicitly include -lpthread in configopts due to multiple 'undefined reference' errors in build on Rocky 8

(created using `eb --new-pr`)
