### PR TITLE
add existing patches to fix failing tests for `Net::SSLeay` 1.94 and `Sys::Info::Driver::Linux` 0.7905 to relevant versions of `Perl-bundle-CPAN`

### DIFF
--- a/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.38.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.38.0-GCCcore-13.2.0.eb
@@ -2084,7 +2084,18 @@ exts_list = [
     ('Sys::Info::Driver::Linux', '0.7905', {
         'source_tmpl': 'Sys-Info-Driver-Linux-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BU/BURAK'],
-        'checksums': ['899c329bd3508ec5849ad0e5dadfa7c3679bbacaea9dda12404a7893032e8b7b'],
+        'patches': [
+            ('Perl-bundle-5.36.1-debian-release.patch'),
+            ('Perl-bundle-5.36.1-pod.patch'),
+        ],
+        'checksums': [
+            {'Sys-Info-Driver-Linux-0.7905.tar.gz':
+             '899c329bd3508ec5849ad0e5dadfa7c3679bbacaea9dda12404a7893032e8b7b'},
+            {'Perl-bundle-5.36.1-debian-release.patch':
+             '18b8d876db5b3abe7e5a1bb8c6abf8b5fef481b56294472fcf9f96f974c56c48'},
+            {'Perl-bundle-5.36.1-pod.patch':
+             '7c70bd91a06c256a8d85845e011e53a1a9d4f8a250d9f06bd06f5004596f271a'},
+        ],
     }),
     ('Sys::Info', '0.7811', {
         'source_tmpl': 'Sys-Info-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.38.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.38.2-GCCcore-13.3.0.eb
@@ -2090,7 +2090,18 @@ exts_list = [
     ('Sys::Info::Driver::Linux', '0.7905', {
         'source_tmpl': 'Sys-Info-Driver-Linux-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BU/BURAK'],
-        'checksums': ['899c329bd3508ec5849ad0e5dadfa7c3679bbacaea9dda12404a7893032e8b7b'],
+        'patches': [
+            ('Perl-bundle-5.36.1-debian-release.patch'),
+            ('Perl-bundle-5.36.1-pod.patch'),
+        ],
+        'checksums': [
+            {'Sys-Info-Driver-Linux-0.7905.tar.gz':
+             '899c329bd3508ec5849ad0e5dadfa7c3679bbacaea9dda12404a7893032e8b7b'},
+            {'Perl-bundle-5.36.1-debian-release.patch':
+             '18b8d876db5b3abe7e5a1bb8c6abf8b5fef481b56294472fcf9f96f974c56c48'},
+            {'Perl-bundle-5.36.1-pod.patch':
+             '7c70bd91a06c256a8d85845e011e53a1a9d4f8a250d9f06bd06f5004596f271a'},
+        ],
     }),
     ('Sys::Info', '0.7811', {
         'source_tmpl': 'Sys-Info-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.40.0-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.40.0-GCCcore-14.2.0.eb
@@ -2105,7 +2105,18 @@ exts_list = [
     ('Sys::Info::Driver::Linux', '0.7905', {
         'source_tmpl': 'Sys-Info-Driver-Linux-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BU/BURAK'],
-        'checksums': ['899c329bd3508ec5849ad0e5dadfa7c3679bbacaea9dda12404a7893032e8b7b'],
+        'patches': [
+            ('Perl-bundle-5.36.1-debian-release.patch'),
+            ('Perl-bundle-5.36.1-pod.patch'),
+        ],
+        'checksums': [
+            {'Sys-Info-Driver-Linux-0.7905.tar.gz':
+             '899c329bd3508ec5849ad0e5dadfa7c3679bbacaea9dda12404a7893032e8b7b'},
+            {'Perl-bundle-5.36.1-debian-release.patch':
+             '18b8d876db5b3abe7e5a1bb8c6abf8b5fef481b56294472fcf9f96f974c56c48'},
+            {'Perl-bundle-5.36.1-pod.patch':
+             '7c70bd91a06c256a8d85845e011e53a1a9d4f8a250d9f06bd06f5004596f271a'},
+        ],
     }),
     ('Sys::Info', '0.7811', {
         'source_tmpl': 'Sys-Info-%(version)s.tar.gz',

--- a/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.40.2-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.40.2-GCCcore-14.3.0.eb
@@ -2114,7 +2114,18 @@ exts_list = [
     ('Sys::Info::Driver::Linux', '0.7905', {
         'source_tmpl': 'Sys-Info-Driver-Linux-%(version)s.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/B/BU/BURAK'],
-        'checksums': ['899c329bd3508ec5849ad0e5dadfa7c3679bbacaea9dda12404a7893032e8b7b'],
+        'patches': [
+            ('Perl-bundle-5.36.1-debian-release.patch'),
+            ('Perl-bundle-5.36.1-pod.patch'),
+        ],
+        'checksums': [
+            {'Sys-Info-Driver-Linux-0.7905.tar.gz':
+             '899c329bd3508ec5849ad0e5dadfa7c3679bbacaea9dda12404a7893032e8b7b'},
+            {'Perl-bundle-5.36.1-debian-release.patch':
+             '18b8d876db5b3abe7e5a1bb8c6abf8b5fef481b56294472fcf9f96f974c56c48'},
+            {'Perl-bundle-5.36.1-pod.patch':
+             '7c70bd91a06c256a8d85845e011e53a1a9d4f8a250d9f06bd06f5004596f271a'},
+        ],
     }),
     ('Sys::Info', '0.7811', {
         'source_tmpl': 'Sys-Info-%(version)s.tar.gz',


### PR DESCRIPTION
Ran into the following issue when building Perl-CPAN-bundle 5.40.0 for EESSI (see https://github.com/EESSI/software-layer/pull/1228).  

```
t/local/31_rsa_generate_key.t ............... ok

#   Failed test 'X509V3_EXT_print nid=103       extended-cert.cert.pem:4'
#   at t/local/32_x509_get_cert_info.t line 273.
#          got: 'Full Name:
#   URI:http://intermediate-ca.net-ssleay.example/crl1.crl
# 
# Full Name:
#   URI:http://intermediate-ca.net-ssleay.example/crl2.crl
# '
#     expected: 'Full Name:
#   URI:http://intermediate-ca.net-ssleay.example/crl1.crl
# Full Name:
#   URI:http://intermediate-ca.net-ssleay.example/crl2.crl'

#   Failed test 'X509V3_EXT_print nid=86        extended-cert.cert.pem:6'
#   at t/local/32_x509_get_cert_info.t line 273.
#          got: 'email:intermediate-ca@net-ssleay.example, URI:http://intermediate-ca.net-ssleay.example, DNS:intermediate-ca.net-ssleay.example, Registered ID:1.2.0.0, IP Address:192.
168.0.1, IP Address:FD25:F814:AFB5:9873:0:0:0:1, othername: emailAddress:ica@net-ssleay.example'
#     expected: 'email:intermediate-ca@net-ssleay.example, URI:http://intermediate-ca.net-ssleay.example, DNS:intermediate-ca.net-ssleay.example, Registered ID:1.2.0.0, IP Address:192.
168.0.1, IP Address:FD25:F814:AFB5:9873:0:0:0:1, othername: emailAddress::ica@net-ssleay.example'

#   Failed test 'X509V3_EXT_print nid=85        extended-cert.cert.pem:8'
#   at t/local/32_x509_get_cert_info.t line 273.
#          got: 'email:john.doe@net-ssleay.example, URI:http://johndoe.net-ssleay.example, DNS:johndoe.net-ssleay.example, Registered ID:1.2.3.4, IP Address:192.168.0.2, IP Address:FD2
5:F814:AFB5:9873:0:0:0:2, othername: emailAddress:jd@net-ssleay.example'
#     expected: 'email:john.doe@net-ssleay.example, URI:http://johndoe.net-ssleay.example, DNS:johndoe.net-ssleay.example, Registered ID:1.2.3.4, IP Address:192.168.0.2, IP Address:FD2
5:F814:AFB5:9873:0:0:0:2, othername: emailAddress::jd@net-ssleay.example'
# Looks like you failed 3 tests of 746.
t/local/32_x509_get_cert_info.t ............. 
Dubious, test returned 3 (wstat 768, 0x300)
Failed 3/746 subtests 
t/local/33_x509_create_cert.t ............... ok
```

This is a known issue (https://github.com/radiator-software/p5-net-ssleay/issues/513) for newer OpenSSL 3 versions, and it was fixed with https://github.com/radiator-software/p5-net-ssleay/pull/520. That patch had actually already been applied to version 5.40.2 of the bundle by @Thyre in https://github.com/easybuilders/easybuild-easyconfigs/pull/23557. Both version 5.38.2 and 5.40.0 of the bundle use the same version of `Net:SSLeay` and also depend on OpenSSL 3, so I'm applying the same patch to both of them.


edit: while testing the fix, I ran into another failed test for `Sys::Info::Driver::Linux`:

```
Can't open /etc/ARRAY(0x1d1a010): No such file or directory at /tmp/bedroge/easybuild/build/PerlbundleCPAN/5.40.0/GCCcore-14.2.0/SysInfoDriverLinux/Sys-Info-Driver-Linux-0.7905/blib/lib/Sys/Info/Driver/Linux/OS.pm line 204.
```

That had already been solved in `Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb`. The version of the extension is still the same for all newer easyconfigs, so I'm applying them there as well.