### PR TITLE
{perf}[iimpi/2025b] MUST v1.11.2

### DIFF
--- a/easybuild/easyconfigs/m/MUST/MUST-1.11.2-iimpi-2025b.eb
+++ b/easybuild/easyconfigs/m/MUST/MUST-1.11.2-iimpi-2025b.eb
@@ -49,4 +49,3 @@ sanity_check_paths = {
 }
 
 moduleclass = 'perf'
-


### PR DESCRIPTION
We recently added MUST v.1.11.1 for the same toolchain version, but we fixed a few important bugs in this release and would like to have that version also available since we want to integrate MUST into [EESSI](https://www.eessi.io/docs/). If there is only one version allowed per toolchain version, I can remove v.1.11.1.