### PR TITLE
set `$MAX_JOBS` when installing Triton 3.1.0 to control how many cores are used

### DIFF
--- a/easybuild/easyconfigs/t/Triton/Triton-3.1.0-foss-2024a-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/t/Triton/Triton-3.1.0-foss-2024a-CUDA-12.6.0.eb
@@ -75,6 +75,8 @@ _tr_preinstallopts += 'export LLVM_SYSPATH=%(builddir)s/easybuild_obj/ && '
 
 _tr_preinstallopts += 'export TRITON_BUILD_WITH_CLANG_LLD=false && '
 _tr_preinstallopts += 'export TRITON_HOME=%(builddir)s && '
+# fix setup.py max_jobs - use MAX_JOBS not os.cpu_count()
+_tr_preinstallopts += 'export MAX_JOBS=%(parallel)s && '
 
 _tr_installopts = "-v "
 


### PR DESCRIPTION
Fix for setup.py: https://github.com/triton-lang/triton/blob/cf34004b8a67d290a962da166f5aa2fc66751326/python/setup.py#L387C24-L387C70
os.cpu_count() returns wrong number of used cpus
for me it fails on `cmake --build ... -j72`, when I have 8 cpus available 
There used to be a patch for this in v2.1.0: https://github.com/easybuilders/easybuild-easyconfigs/blob/9206d02f52d6f0f301df519805075055d734f6ac/easybuild/easyconfigs/t/Triton/Triton-2.1.0-use_eb_env_python_build.patch#L81