### PR TITLE
Revert "only run easyconfigs test suite with Python 3.11 & Lua module syntax for now (easyconfigs merge sprint)"

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: ['3.11'] #['3.7', '3.11']
+        python: ['3.7', '3.11']
         modules_tool: [Lmod-8.6.8]
-        module_syntax: [Lua] #[Lua, Tcl]
+        module_syntax: [Lua, Tcl]
       fail-fast: false
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2


### PR DESCRIPTION
undoes changes made in:
* #24220

on hold until after today's merge sprint...