### PR TITLE
remove `MATLAB` and `OpenFOAM-Extend` from the checksum exclusion whitelist

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1236,7 +1236,9 @@ class EasyConfigTest(TestCase):
 
         # list of software for which checksums can not be required,
         # e.g. because 'source' files need to be constructed manually
-        whitelist = []
+        whitelist = [
+            'OCaml-*',
+        ]
 
         # filter out deprecated easyconfigs
         retained_changed_ecs = [ec for ec in self.changed_ecs if not ec['deprecated']]


### PR DESCRIPTION
#24223 remove `Kent_tools`, but further checking shows that all of these can be removed.

All `MATLAB` and `OpenFOAM-Extend` easyconfigs have checksums, so the need for this is no longer there.

`OCaml` has extensions with no checksums, so must remain in the whitelist.