### PR TITLE
add patch to fix integer overflow bug in scikit-bio v0.6.2

### DIFF
--- a/easybuild/easyconfigs/s/scikit-bio/fix-cython-segmentation-error_scikit-bio-0.6.2.patch
+++ b/easybuild/easyconfigs/s/scikit-bio/fix-cython-segmentation-error_scikit-bio-0.6.2.patch
@@ -1,0 +1,17 @@
+Fix integer overflow bug
+
+An integer overflow bug in Cython causes segmentation faults when building large
+interval trees. This bug is fixed upstream form v0.6.3 onwards. This patch
+applies the upstream fix (Commit 5e04026).
+diff -ruN scikit-bio-0.6.2.orig/skbio/metadata/_intersection.pyx scikit-bio-0.6.2/skbio/metadata/_intersection.pyx
+--- scikit-bio-0.6.2.orig/skbio/metadata/_intersection.pyx	2024-07-08 01:52:43.000000000 +0200
++++ scikit-bio-0.6.2/skbio/metadata/_intersection.pyx	2025-10-14 11:04:19.846626429 +0200
+@@ -94,7 +94,7 @@
+         # uniform into a binomial because it naturally scales with
+         # tree size.  Also, python's uniform is perfect since the
+         # upper limit is not inclusive, which gives us undefined here.
+-        self.priority = ceil(nlog * log(-1.0/(1.0 * rand()/(RAND_MAX + 1) - 1)))
++        self.priority = ceil(nlog * log(-1.0/(rand()/(RAND_MAX + 1.0) - 1)))
+         self.start    = start
+         self.end      = end
+         self.interval = interval

--- a/easybuild/easyconfigs/s/scikit-bio/scikit-bio-0.6.2-foss-2023b.eb
+++ b/easybuild/easyconfigs/s/scikit-bio/scikit-bio-0.6.2-foss-2023b.eb
@@ -30,7 +30,12 @@ exts_list = [
     }),
     (name, version, {
         'modulename': 'skbio',
-        'checksums': ['af217ad12243cdaeef74a8f3bebe0d04aefda2a22d963d634201a36318b1a404'],
+        'patches': ['fix-cython-segmentation-error_scikit-bio-0.6.2.patch'],
+        'checksums': [
+            {'scikit-bio-0.6.2.tar.gz': 'af217ad12243cdaeef74a8f3bebe0d04aefda2a22d963d634201a36318b1a404'},
+            {'fix-cython-segmentation-error_scikit-bio-0.6.2.patch':
+             'd5e7f2266eb2f19905c5ff4b56e691c42ea0372c8c85a08791074ecf28aced51'},
+        ],
     }),
 ]
 


### PR DESCRIPTION
This PR back-ports a fix for an integer overflow bug in Cython that is caught during installation by the test suite.

The bug causes segmentation faults when creating large interval trees.
