### PR TITLE
add missing dependencies needed by aiida-core for the RESTapi and for atomic_tools + change toolchain to from `gfbf/2023a` to `foss/2023a`

### DIFF
--- a/easybuild/easyconfigs/a/aiida-core/aiida-core-2.5.1-foss-2023a.eb
+++ b/easybuild/easyconfigs/a/aiida-core/aiida-core-2.5.1-foss-2023a.eb
@@ -9,7 +9,7 @@ An open-source Python infrastructure to help researchers with automating, managi
 sharing and reproducing the complex workflows associated with modern computational science and all associated data.
 """
 
-toolchain = {'name': 'gfbf', 'version': '2023a'}
+toolchain = {'name': 'foss', 'version': '2023a'}
 toolchainopts = {'pic': True}
 
 builddependencies = [
@@ -23,13 +23,15 @@ dependencies = [
     ('paramiko', '3.2.0'),  # paramiko
     ('SQLAlchemy', '2.0.25'),  # greenlet, alembic, SQLAlchemy
     ('Graphviz', '8.1.0'),  # graphviz
+    ('matplotlib', '3.7.2'),
     ('jupyter-server', '2.7.2'),  # PyYAML, tornado, ipython, ipywidgets, jupyter_server
     ('jedi', '0.19.0'),  # jedi
     ('wrapt', '1.15.0'),  # wrapt, numpy, scipy
     ('aiohttp', '3.8.5'),  # multidict, yarl
     ('psycopg2', '2.9.9'),  # PostgreSQL, psycopg2
     ('plumpy', '0.21.6'),  # plumpy kiwipy aio-pika
-    ('spglib-python', '2.1.0'),  # Needed for spglib -> seekpath -> [rest]
+    ('ASE', '3.22.1'),  # Needed for spglib -> seekpath -> [rest]
+    ('pymatgen', '2023.12.18'),  # pymatgen
     ('Flask', '2.3.3'),  # Used to enable the `verdi restapi` command
 ]
 


### PR DESCRIPTION
- Added dependencies required by the CLI `verdi restapi` subcommand
- Added extra dependencies from `[atomic_tools]`. Replaces: #20458
- Removed `verdi status` sanity check as it could fail if some non mandatory services are not found with an existing profile under $HOME/.aiida

## Notes

I am not adding a `verdi restapi` check as the `--help` would not fail even without deps and properly testing it requires having a profile setup