### PR TITLE
add `Xvfb` dependency for TurboVNC 3.1.2, it provides `xkbcomp` which is used at startup to compile keymap

### DIFF
--- a/easybuild/easyconfigs/t/TurboVNC/TurboVNC-3.1.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/t/TurboVNC/TurboVNC-3.1.2-GCCcore-13.3.0.eb
@@ -29,7 +29,7 @@ dependencies = [
     ('Mesa', '24.1.3'),
     ('libGLU', '9.0.3'),
     ('libglvnd', '1.7.0'),
-    ('Xfvb', '21.1.14'),  # Requires xkbcomp to compile keymap
+    ('Xvfb', '21.1.14'),  # Requires xkbcomp to compile keymap
     ('OpenSSL', '3', '', SYSTEM),
 ]
 


### PR DESCRIPTION
Without this dependency I see
```
ocaisa@~$ vncserver
...

TurboVNC Server (Xvnc) 64-bit v3.1.2 (build 20251015)
Copyright (C) 1999-2024 The VirtualGL Project and many others (see README.md)
Visit http://www.TurboVNC.org for more information on TurboVNC

...
15/10/2025 13:14:28 VNC extension running!
sh: 1: xkbcomp: not found
sh: 1: xkbcomp: not found
XKB: Failed to compile keymap
Keyboard initialization failed. This could be a missing or incorrect setup of xkeyboard-config.
(EE)
Fatal server error:
(EE) Failed to activate virtual core keyboard: 2(EE)
```