### PR TITLE
Fix failing test_pr_python_packages when extensions have templates

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1309,7 +1309,7 @@ class EasyConfigTest(TestCase):
 
             # --no-build-isolation option for 'pip install' should be enabled
             pip_no_build_isolation = ec.get('pip_no_build_isolation', True)
-            for ext in ec['exts_list']:
+            for ext in ec.get_ref('exts_list'):
                 if isinstance(ext, (tuple, list)) and len(ext) >= 3:
                     ext_opts = ext[2]
                     pip_no_build_isolation &= ext_opts.get('pip_no_build_isolation', True)
@@ -1389,7 +1389,7 @@ class EasyConfigTest(TestCase):
             exts_defaultclass = ec.get('exts_defaultclass')
             if exts_defaultclass == 'RPackage' or ec.name == 'R':
                 seen_exts = set()
-                for ext in ec['exts_list']:
+                for ext in ec.get_ref('exts_list'):
                     if isinstance(ext, (tuple, list)):
                         ext_name = ext[0]
                     else:


### PR DESCRIPTION
We don't need to resolve templates for this test so don't try. This fails if e.g. `%(start_dir)s` is used.

Similar for `test_pr_R_packages`