### PR TITLE
{data}[gfbf/2025a] zarr v3.1.1

### DIFF
--- a/easybuild/easyconfigs/z/zarr/zarr-3.0.10-foss-2025a.eb
+++ b/easybuild/easyconfigs/z/zarr/zarr-3.0.10-foss-2025a.eb
@@ -1,0 +1,42 @@
+easyblock = "PythonBundle"
+
+name = 'zarr'
+version = '3.0.10'
+
+homepage = 'https://zarr.readthedocs.io/en/stable/'
+description = """Zarr is a Python package providing an implementation of compressed,
+chunked, N-dimensional arrays, designed for use in parallel computing."""
+
+toolchain = {'name': 'foss', 'version': '2025a'}
+
+builddependencies = [
+    ('hatchling', '1.27.0'),
+    ('Cython', '3.1.1'),
+]
+
+dependencies = [
+    ('Python', '3.13.1'),
+    ('SciPy-bundle', '2025.06'),
+    ('py-cpuinfo', '9.0.0'),
+    ('PyYAML', '6.0.2'),
+    ('Deprecated', '1.2.18'),
+    ('setuptools', '80.9.0'),
+]
+
+exts_list = [
+    ('donfig', '0.8.1.post1', {
+        'checksums': ['3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52'],
+    }),
+    ('crc32c', '2.7.1', {
+        'checksums': ['f91b144a21eef834d64178e01982bb9179c354b3e9e5f4c803b0e5096384968c'],
+    }),
+    ('numcodecs', '0.16.1', {
+        'use_pip_extras': 'crc32c',
+        'checksums': ['c47f20d656454568c6b4697ce02081e6bbb512f198738c6a56fafe8029c97fb1'],
+    }),
+    (name, version, {
+        'checksums': ['1fd1318ade646f692d8f604be0e0ad125675a061196e612e3f7a2cfa9e957d1c'],
+    }),
+]
+
+moduleclass = 'data'


### PR DESCRIPTION
New versions of `anndata` 0.12.x are not compatible with `zarr` 3.0.x:
```
dependencies = [
    ...
    "zarr >=2.18.7, !=3.0.*",
]
```
`zarr-3.0.10` is not yet used as a dependency in other EasyConfig so this should be ok.

(created using `eb --new-pr`)