### PR TITLE
don't run `autoreconf` for jq 1.7.1, as a release tarball is used as source

### DIFF
--- a/easybuild/easyconfigs/j/jq/jq-1.7.1-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/j/jq/jq-1.7.1-GCCcore-13.2.0.eb
@@ -9,17 +9,13 @@ description = """jq is a lightweight and flexible command-line JSON processor.""
 toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 
 source_urls = ['https://github.com/jqlang/jq/releases/download/jq-%(version)s']
-sources = ['jq-%(version)s.tar.gz']
+sources = [SOURCELOWER_TAR_GZ]
 checksums = ['478c9ca129fd2e3443fe27314b455e211e0d8c60bc8ff7df703873deeee580c2']
 
 builddependencies = [
     ('binutils', '2.40'),
-    ('Bison', '3.8.2'),
-    ('flex', '2.6.4'),
     ('Autotools', '20220317'),
 ]
-
-preconfigopts = "autoreconf -fi && "
 
 configopts = '--with-oniguruma=builtin'
 


### PR DESCRIPTION
Bug fix for jq/1.7.1 on GCCcore/13.2.0

Problem: As per the `jq` [build instructions](https://github.com/jqlang/jq?tab=readme-ov-file#instructions) "If you're not using the latest git version but instead building a released tarball (available on the release page), skip the autoreconf step, and flex or bison won't be needed."

Remove the `preconfigopts` line and `Bison` and `flex` from the  `builddependencies`; otherwise, the built binary doesn't actually know what version it is, i.e. `jq --version` just outputs `jq-` instead of `jq-1.7.1`.

Also switch to using `SOURCELOWER_TAR_GZ` template constant for readability/maintainability