### PR TITLE
Fix source distribution CI check

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -170,8 +170,14 @@ jobs:
     - name: Inspect files included in source distribution
       working-directory: dist
       run: |
-          tar xfz easybuild-easyconfigs*tar.gz
-          cd easybuild-easyconfigs-*/
+          ls
+          if [ -f easybuild-easyconfigs*tar.gz ]; then
+            tar xzf easybuild-easyconfigs*tar.gz
+            cd easybuild-easyconfigs-*/
+          else
+            tar xzf easybuild_easyconfigs*tar.gz
+            cd easybuild_easyconfigs-*/
+          fi
 
           # .git folder should not be there in source tarball
           dot_git_files=$(find . -name .git)


### PR DESCRIPTION
Due to a recent change in setuptools and/or distutils `python setup.py sdist` normalizes filenames by replacing dashes by underscores.
We need to detect this and refer to the file with or without underscore.

Also put output into groups instead of silencing it