### PR TITLE
fix homepage + source URL for Gblocks 0.91b

### DIFF
--- a/easybuild/easyconfigs/g/Gblocks/Gblocks-0.91b.eb
+++ b/easybuild/easyconfigs/g/Gblocks/Gblocks-0.91b.eb
@@ -3,12 +3,12 @@ easyblock = 'Tarball'
 name = 'Gblocks'
 version = '0.91b'
 
-homepage = 'https://www.biologiaevolutiva.org/jcastresana/Gblocks.html'
+homepage = 'https://molevol-ibe.csic.es/Gblocks.html'
 description = "Selection of conserved blocks from multiple alignments for their use in phylogenetic analysis"
 
 toolchain = SYSTEM
 
-source_urls = ['https://www.biologiaevolutiva.org/jcastresana/Gblocks/']
+source_urls = ['https://molevol-ibe.csic.es/Gblocks/']
 sources = [{
     'filename': 'Gblocks_Linux64_%(version)s.tar.Z',
     'extract_cmd': 'tar xfz %s'


### PR DESCRIPTION
This was changed in https://github.com/easybuilders/easybuild-easyconfigs/pull/19797, but it no longer works, and apparently things changed back to the old URL now. See https://www.biologiaevolutiva.org/jcastresana/, which redirects to https://molevol-ibe.csic.es/.