### PR TITLE
Add bistro fix to all UCX versions from 1.13.1 onwards

### DIFF
--- a/easybuild/easyconfigs/u/UCX/UCX-1.13.1-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.13.1-GCCcore-12.2.0.eb
@@ -18,6 +18,7 @@ patches = [
     'UCX-1.11.0_fix-implicit-odp-release.patch',
     'UCX-1.13.1-dynamic_modules.patch',
     'UCX-1.13.1_fix-undeclared-PTR.patch',
+    'UCX-1.18.0_fix_bistro_hooks.patch',
 ]
 checksums = [
     ('efc37829b68e131d2acc82a3fd4334bfd611156a756837ffeb650ab9a9dd3828',
@@ -25,6 +26,7 @@ checksums = [
     {'UCX-1.11.0_fix-implicit-odp-release.patch': 'e21d66b75f3727a98dbd1737b419a6f77c0c5a8ac660a21affcbf10bb3b941ed'},
     {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
     {'UCX-1.13.1_fix-undeclared-PTR.patch': 'ef22c29604552ad3223f2a6bac352f30023cc5cf68f786abfdc4ad7c04189a76'},
+    {'UCX-1.18.0_fix_bistro_hooks.patch': '6357f1ebb1569e30d0855e48404fdf38a5a7060a87789f54d7bb751f957be20c'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/u/UCX/UCX-1.14.0-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.14.0-GCCcore-12.2.0.eb
@@ -17,11 +17,13 @@ sources = ['%(namelower)s-%(version)s.tar.gz']
 patches = [
     'UCX-1.11.0_fix-implicit-odp-release.patch',
     'UCX-1.13.1-dynamic_modules.patch',
+    'UCX-1.18.0_fix_bistro_hooks.patch',
 ]
 checksums = [
     {'ucx-1.14.0.tar.gz': '9bd95e2059de5dece9dddd049aacfca3d21bfca025748a6a0b1be4486e28afdd'},
     {'UCX-1.11.0_fix-implicit-odp-release.patch': 'e21d66b75f3727a98dbd1737b419a6f77c0c5a8ac660a21affcbf10bb3b941ed'},
     {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
+    {'UCX-1.18.0_fix_bistro_hooks.patch': '6357f1ebb1569e30d0855e48404fdf38a5a7060a87789f54d7bb751f957be20c'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/u/UCX/UCX-1.14.1-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.14.1-GCCcore-12.3.0.eb
@@ -17,11 +17,13 @@ sources = ['%(namelower)s-%(version)s.tar.gz']
 patches = [
     'UCX-1.11.0_fix-implicit-odp-release.patch',
     'UCX-1.13.1-dynamic_modules.patch',
+    'UCX-1.18.0_fix_bistro_hooks.patch',
 ]
 checksums = [
     {'ucx-1.14.1.tar.gz': 'baa0634cafb269a3112f626eb226bcd2ca8c9fcf0fec3b8e2a3553baad5f77aa'},
     {'UCX-1.11.0_fix-implicit-odp-release.patch': 'e21d66b75f3727a98dbd1737b419a6f77c0c5a8ac660a21affcbf10bb3b941ed'},
     {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
+    {'UCX-1.18.0_fix_bistro_hooks.patch': '6357f1ebb1569e30d0855e48404fdf38a5a7060a87789f54d7bb751f957be20c'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/u/UCX/UCX-1.15.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.15.0-GCCcore-13.2.0.eb
@@ -16,10 +16,12 @@ source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
 sources = ['%(namelower)s-%(version)s.tar.gz']
 patches = [
     'UCX-1.13.1-dynamic_modules.patch',
+    'UCX-1.18.0_fix_bistro_hooks.patch',
 ]
 checksums = [
     {'ucx-1.15.0.tar.gz': '4b202087076bc1c98f9249144f0c277a8ea88ad4ca6f404f94baa9cb3aebda6d'},
     {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
+    {'UCX-1.18.0_fix_bistro_hooks.patch': '6357f1ebb1569e30d0855e48404fdf38a5a7060a87789f54d7bb751f957be20c'},
 ]
 
 # Uncomment when updating to final release

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-GCCcore-13.2.0.eb
@@ -16,10 +16,12 @@ source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
 sources = ['%(namelower)s-%(version)s.tar.gz']
 patches = [
     'UCX-1.13.1-dynamic_modules.patch',
+    'UCX-1.18.0_fix_bistro_hooks.patch',
 ]
 checksums = [
     {'ucx-1.16.0.tar.gz': 'f73770d3b583c91aba5fb07557e655ead0786e057018bfe42f0ebe8716e9d28c'},
     {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
+    {'UCX-1.18.0_fix_bistro_hooks.patch': '6357f1ebb1569e30d0855e48404fdf38a5a7060a87789f54d7bb751f957be20c'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/u/UCX/UCX-1.16.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.16.0-GCCcore-13.3.0.eb
@@ -16,10 +16,12 @@ source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
 sources = ['%(namelower)s-%(version)s.tar.gz']
 patches = [
     'UCX-1.13.1-dynamic_modules.patch',
+    'UCX-1.18.0_fix_bistro_hooks.patch',
 ]
 checksums = [
     {'ucx-1.16.0.tar.gz': 'f73770d3b583c91aba5fb07557e655ead0786e057018bfe42f0ebe8716e9d28c'},
     {'UCX-1.13.1-dynamic_modules.patch': '00874687bd90b795fff61aaa183f6c6bea2210aa1003b28f23d9ebf7066f8782'},
+    {'UCX-1.18.0_fix_bistro_hooks.patch': '6357f1ebb1569e30d0855e48404fdf38a5a7060a87789f54d7bb751f957be20c'},
 ]
 
 builddependencies = [


### PR DESCRIPTION
The issue from https://github.com/easybuilders/easybuild-easyconfigs/pull/23843 is also present in all older UCX versions, and causes similar issues on H100's with CUDA 12.9 drivers. The same patch that was applied there applies to these versions. I have tested it for versions UCX versions 1.14.1 and 1.15.0 by running `mpirun -np 2 osu_latency -c -d cuda D D`. Considering how it works for these versions, as well as 1.18.0, I think it makes sense to _at least_ apply it also to the 1.16.0 versions. Although I don't have the toolchains to test it, I would be surprised if the same fix doesn't work there - the relevant part of the code is nearly unchanged, and the patch applies with some small offset. But, if reviewers doubt this, I'd be fine with removing 1.13.1 and 1.14.0 from this PR.

Edit: actually 1.13.1 might be needed for EESSI/2023.06, it's part of the 2022b toolchain in there. I cannot test because our H100's are combined with zen4, and 2022b isn't supported on zen4. If a site has H100 with a different CPU architecture, they can easily test this. Maybe @bedroge ?