### PR TITLE
Reset `$TCL_SRC_DIR` in `tclConfig.sh` created by Tcl

### DIFF
--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.11-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.11-GCCcore-10.3.0.eb
@@ -31,9 +31,11 @@ start_dir = 'unix'
 
 postinstallcmds = [
     'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh',
+] + [
     # Avoid that installations on top of Tcl try to access the (no longer existing) source directory
     # See https://core.tcl-lang.org/tk/tktview/b900dc755201139b5a7cecada73405c7681b7c03
-    """echo "TCL_SRC_DIR='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'""",
+    f"""echo "{d}='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'"""
+    for d in ('TCL_SRC_DIR', 'itcl_SRC_DIR', 'ITCL_SRC_DIR', 'tdbc_SRC_DIR', 'TDBC_SRC_DIR')
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.11-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.11-GCCcore-11.2.0.eb
@@ -31,9 +31,11 @@ start_dir = 'unix'
 
 postinstallcmds = [
     'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh',
+] + [
     # Avoid that installations on top of Tcl try to access the (no longer existing) source directory
     # See https://core.tcl-lang.org/tk/tktview/b900dc755201139b5a7cecada73405c7681b7c03
-    """echo "TCL_SRC_DIR='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'""",
+    f"""echo "{d}='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'"""
+    for d in ('TCL_SRC_DIR', 'itcl_SRC_DIR', 'ITCL_SRC_DIR', 'tdbc_SRC_DIR', 'TDBC_SRC_DIR')
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.12-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.12-GCCcore-11.3.0.eb
@@ -31,9 +31,11 @@ start_dir = 'unix'
 
 postinstallcmds = [
     'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh',
+] + [
     # Avoid that installations on top of Tcl try to access the (no longer existing) source directory
     # See https://core.tcl-lang.org/tk/tktview/b900dc755201139b5a7cecada73405c7681b7c03
-    """echo "TCL_SRC_DIR='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'""",
+    f"""echo "{d}='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'"""
+    for d in ('TCL_SRC_DIR', 'itcl_SRC_DIR', 'ITCL_SRC_DIR', 'tdbc_SRC_DIR', 'TDBC_SRC_DIR')
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.12-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.12-GCCcore-12.2.0.eb
@@ -31,9 +31,11 @@ start_dir = 'unix'
 
 postinstallcmds = [
     'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh',
+] + [
     # Avoid that installations on top of Tcl try to access the (no longer existing) source directory
     # See https://core.tcl-lang.org/tk/tktview/b900dc755201139b5a7cecada73405c7681b7c03
-    """echo "TCL_SRC_DIR='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'""",
+    f"""echo "{d}='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'"""
+    for d in ('TCL_SRC_DIR', 'itcl_SRC_DIR', 'ITCL_SRC_DIR', 'tdbc_SRC_DIR', 'TDBC_SRC_DIR')
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.13-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.13-GCCcore-12.3.0.eb
@@ -31,9 +31,11 @@ start_dir = 'unix'
 
 postinstallcmds = [
     'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh',
+] + [
     # Avoid that installations on top of Tcl try to access the (no longer existing) source directory
     # See https://core.tcl-lang.org/tk/tktview/b900dc755201139b5a7cecada73405c7681b7c03
-    """echo "TCL_SRC_DIR='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'""",
+    f"""echo "{d}='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'"""
+    for d in ('TCL_SRC_DIR', 'itcl_SRC_DIR', 'ITCL_SRC_DIR', 'tdbc_SRC_DIR', 'TDBC_SRC_DIR')
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.13-GCCcore-13.1.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.13-GCCcore-13.1.0.eb
@@ -31,9 +31,11 @@ start_dir = 'unix'
 
 postinstallcmds = [
     'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh',
+] + [
     # Avoid that installations on top of Tcl try to access the (no longer existing) source directory
     # See https://core.tcl-lang.org/tk/tktview/b900dc755201139b5a7cecada73405c7681b7c03
-    """echo "TCL_SRC_DIR='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'""",
+    f"""echo "{d}='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'"""
+    for d in ('TCL_SRC_DIR', 'itcl_SRC_DIR', 'ITCL_SRC_DIR', 'tdbc_SRC_DIR', 'TDBC_SRC_DIR')
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.13-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.13-GCCcore-13.2.0.eb
@@ -31,9 +31,11 @@ start_dir = 'unix'
 
 postinstallcmds = [
     'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh',
+] + [
     # Avoid that installations on top of Tcl try to access the (no longer existing) source directory
     # See https://core.tcl-lang.org/tk/tktview/b900dc755201139b5a7cecada73405c7681b7c03
-    """echo "TCL_SRC_DIR='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'""",
+    f"""echo "{d}='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'"""
+    for d in ('TCL_SRC_DIR', 'itcl_SRC_DIR', 'ITCL_SRC_DIR', 'tdbc_SRC_DIR', 'TDBC_SRC_DIR')
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.14-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.14-GCCcore-13.3.0.eb
@@ -31,9 +31,11 @@ start_dir = 'unix'
 
 postinstallcmds = [
     'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh',
+] + [
     # Avoid that installations on top of Tcl try to access the (no longer existing) source directory
     # See https://core.tcl-lang.org/tk/tktview/b900dc755201139b5a7cecada73405c7681b7c03
-    """echo "TCL_SRC_DIR='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'""",
+    f"""echo "{d}='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'"""
+    for d in ('TCL_SRC_DIR', 'itcl_SRC_DIR', 'ITCL_SRC_DIR', 'tdbc_SRC_DIR', 'TDBC_SRC_DIR')
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.16-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.16-GCCcore-14.2.0.eb
@@ -31,9 +31,11 @@ start_dir = 'unix'
 
 postinstallcmds = [
     'ln -s %(installdir)s/bin/tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh',
+] + [
     # Avoid that installations on top of Tcl try to access the (no longer existing) source directory
     # See https://core.tcl-lang.org/tk/tktview/b900dc755201139b5a7cecada73405c7681b7c03
-    """echo "TCL_SRC_DIR='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'""",
+    f"""echo "{d}='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'"""
+    for d in ('TCL_SRC_DIR', 'itcl_SRC_DIR', 'ITCL_SRC_DIR', 'tdbc_SRC_DIR', 'TDBC_SRC_DIR')
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/t/Tcl/Tcl-9.0.1-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-9.0.1-GCCcore-14.3.0.eb
@@ -42,9 +42,11 @@ postinstallcmds = [
     'ln -s tclsh%(version_major)s.%(version_minor)s %(installdir)s/bin/tclsh',
     f'ln -s libtcl%(version_major)s.%(version_minor)s.{SHLIB_EXT} '
     f'%(installdir)s/lib/libtcl.{SHLIB_EXT}',
+] + [
     # Avoid that installations on top of Tcl try to access the (no longer existing) source directory
     # See https://core.tcl-lang.org/tk/tktview/b900dc755201139b5a7cecada73405c7681b7c03
-    """echo "TCL_SRC_DIR='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'""",
+    f"""echo "{d}='%(installdir)s'" >> '%(installdir)s/lib/tclConfig.sh'"""
+    for d in ('TCL_SRC_DIR', 'itcl_SRC_DIR', 'ITCL_SRC_DIR', 'tdbc_SRC_DIR', 'TDBC_SRC_DIR')
 ]
 
 sanity_check_paths = {


### PR DESCRIPTION
When e.g. Tk is built on top of Tcl it will source this file and add include paths like `-I$TCL_SRC_DIR/unix` which (usually) don't exist anymore (removed after Tcl installation).
Hence those flags have no effect.

However if the path happens to be inaccessible (e.g. in another users $HOME) then the build fails with a permission issue.

Simply set this variable to the install dir which always exists.