### PR TITLE
enable running of tests for spdlog

### DIFF
--- a/easybuild/easyconfigs/s/spdlog/spdlog-1.10.0-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/s/spdlog/spdlog-1.10.0-GCCcore-11.2.0.eb
@@ -17,12 +17,11 @@ builddependencies = [
     ('CMake', '3.21.1'),
 ]
 
-_shared_configopts = " ".join([
-    "-DSPDLOG_BUILD_SHARED=ON",
-    "-DSPDLOG_BUILD_PIC=ON",
-])
+_base_configopts = ' -DSPDLOG_BUILD_TESTS=ON -DSPDLOG_BUILD_PIC=ON '
 
-configopts = ["", _shared_configopts]
+configopts = [f'{_base_configopts} -DSPDLOG_BUILD_SHARED={x}' for x in ('OFF', 'ON')]
+
+runtest = 'test'
 
 sanity_check_paths = {
     'files': ['include/%(name)s/%(name)s.h', 'lib/lib%(name)s.a', f'lib/lib%(name)s.{SHLIB_EXT}'],

--- a/easybuild/easyconfigs/s/spdlog/spdlog-1.11.0-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/s/spdlog/spdlog-1.11.0-GCCcore-12.2.0.eb
@@ -17,12 +17,11 @@ builddependencies = [
     ('CMake', '3.24.3'),
 ]
 
-_shared_configopts = " ".join([
-    "-DSPDLOG_BUILD_SHARED=ON",
-    "-DSPDLOG_BUILD_PIC=ON",
-])
+_base_configopts = ' -DSPDLOG_BUILD_TESTS=ON -DSPDLOG_BUILD_PIC=ON '
 
-configopts = ["", _shared_configopts]
+configopts = [f'{_base_configopts} -DSPDLOG_BUILD_SHARED={x}' for x in ('OFF', 'ON')]
+
+runtest = 'test'
 
 sanity_check_paths = {
     'files': ['include/%(name)s/%(name)s.h', 'lib/lib%(name)s.a', f'lib/lib%(name)s.{SHLIB_EXT}'],

--- a/easybuild/easyconfigs/s/spdlog/spdlog-1.11.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/s/spdlog/spdlog-1.11.0-GCCcore-12.3.0.eb
@@ -17,12 +17,11 @@ builddependencies = [
     ('CMake', '3.26.3'),
 ]
 
-_shared_configopts = " ".join([
-    "-DSPDLOG_BUILD_SHARED=ON",
-    "-DSPDLOG_BUILD_PIC=ON",
-])
+_base_configopts = ' -DSPDLOG_BUILD_TESTS=ON -DSPDLOG_BUILD_PIC=ON '
 
-configopts = ["", _shared_configopts]
+configopts = [f'{_base_configopts} -DSPDLOG_BUILD_SHARED={x}' for x in ('OFF', 'ON')]
+
+runtest = 'test'
 
 sanity_check_paths = {
     'files': ['include/%(name)s/%(name)s.h', 'lib/lib%(name)s.a', f'lib/lib%(name)s.{SHLIB_EXT}'],

--- a/easybuild/easyconfigs/s/spdlog/spdlog-1.12.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/s/spdlog/spdlog-1.12.0-GCCcore-13.2.0.eb
@@ -17,12 +17,11 @@ builddependencies = [
     ('CMake', '3.27.6'),
 ]
 
-_shared_configopts = " ".join([
-    "-DSPDLOG_BUILD_SHARED=ON",
-    "-DSPDLOG_BUILD_PIC=ON",
-])
+_base_configopts = ' -DSPDLOG_BUILD_TESTS=ON -DSPDLOG_BUILD_PIC=ON '
 
-configopts = ["", _shared_configopts]
+configopts = [f'{_base_configopts} -DSPDLOG_BUILD_SHARED={x}' for x in ('OFF', 'ON')]
+
+runtest = 'test'
 
 sanity_check_paths = {
     'files': ['include/%(name)s/%(name)s.h', 'lib/lib%(name)s.a', f'lib/lib%(name)s.{SHLIB_EXT}'],

--- a/easybuild/easyconfigs/s/spdlog/spdlog-1.12.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/s/spdlog/spdlog-1.12.0-GCCcore-13.3.0.eb
@@ -17,12 +17,11 @@ builddependencies = [
     ('CMake', '3.29.3'),
 ]
 
-_shared_configopts = " ".join([
-    "-DSPDLOG_BUILD_SHARED=ON",
-    "-DSPDLOG_BUILD_PIC=ON",
-])
+_base_configopts = ' -DSPDLOG_BUILD_TESTS=ON -DSPDLOG_BUILD_PIC=ON '
 
-configopts = ["", _shared_configopts]
+configopts = [f'{_base_configopts} -DSPDLOG_BUILD_SHARED={x}' for x in ('OFF', 'ON')]
+
+runtest = 'test'
 
 sanity_check_paths = {
     'files': ['include/%(name)s/%(name)s.h', 'lib/lib%(name)s.a', f'lib/lib%(name)s.{SHLIB_EXT}'],

--- a/easybuild/easyconfigs/s/spdlog/spdlog-1.15.3-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/s/spdlog/spdlog-1.15.3-GCCcore-13.3.0.eb
@@ -17,9 +17,15 @@ builddependencies = [
     ('CMake', '3.29.3'),
 ]
 
+_base_configopts = ' -DSPDLOG_BUILD_TESTS=ON -DSPDLOG_BUILD_PIC=ON '
+
+configopts = [f'{_base_configopts} -DSPDLOG_BUILD_SHARED={x}' for x in ('OFF', 'ON')]
+
+runtest = 'test'
+
 sanity_check_paths = {
-    'files': ['include/spdlog/spdlog.h', 'lib/libspdlog.a'],
-    'dirs': ['lib/cmake', 'lib/pkgconfig'],
+    'files': ['include/%(name)s/%(name)s.h', 'lib/lib%(name)s.a', f'lib/lib%(name)s.{SHLIB_EXT}'],
+    'dirs': ['lib64/cmake', 'lib64/pkgconfig'],
 }
 
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/s/spdlog/spdlog-1.15.3-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/s/spdlog/spdlog-1.15.3-GCCcore-14.2.0.eb
@@ -17,12 +17,11 @@ builddependencies = [
     ('CMake', '3.31.3'),
 ]
 
-_shared_configopts = " ".join([
-    "-DSPDLOG_BUILD_SHARED=ON",
-    "-DSPDLOG_BUILD_PIC=ON",
-])
+_base_configopts = ' -DSPDLOG_BUILD_TESTS=ON -DSPDLOG_BUILD_PIC=ON '
 
-configopts = ["", _shared_configopts]
+configopts = [f'{_base_configopts} -DSPDLOG_BUILD_SHARED={x}' for x in ('OFF', 'ON')]
+
+runtest = 'test'
 
 sanity_check_paths = {
     'files': ['include/%(name)s/%(name)s.h', 'lib/lib%(name)s.a', f'lib/lib%(name)s.{SHLIB_EXT}'],


### PR DESCRIPTION
A rebuild of the packages on top of this pr (without a separate `--installpath`), or also:

- #24308
- #24310

should fix the error in https://github.com/easybuilders/easybuild-easyconfigs/pull/22643#issuecomment-3462206536