### PR TITLE
enhance tagbot workflow to add toolchain labels

### DIFF
--- a/.github/workflows/tagbot.py
+++ b/.github/workflows/tagbot.py
@@ -177,7 +177,7 @@ for file in new_ecs + changed_ecs:
             continue
     # Check for common toolchains with our toolchain naming
     for toolchain_version in gcc_tc_gen_map.values():
-        if any([f"-{toolchain_name}-{toolchain_version}" in file_path for toolchain_name in toolchain_names])
+        if any(f"-{toolchain_name}-{toolchain_version}" in file_path for toolchain_name in toolchain_names):
             toolchain_present[toolchain_version] = True
             continue
 


### PR DESCRIPTION
Expand our label job to automatically add toolchain labels to PRs.
This covers both added and changed EasyConfigs.

The labeling only covers toolchains also checked in our test suite, and only GCC + Intel for now.

Generally, this should allow us to better keep track of PRs and their touched toolchains, and filter more easily by using respective labels. Relying on PR titles might not always work, since not everyone is using `eb --new-pr`.

For a test, see: https://github.com/Thyre/easybuild-easyconfigs/pull/1