### PR TITLE
{lib}[gcccoreflexiblas-14.3.0-3.4.5] PyTorch v2.9.0

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.0-gcccoreflexiblas-14.3.0-3.4.5-CUDA-12.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.0-gcccoreflexiblas-14.3.0-3.4.5-CUDA-12.eb
@@ -25,10 +25,79 @@ dependencies = [
 ]
 
 
-# PyTorch on Grace Hopper nodes don't have the same wheels and most of the
-# stuff is from the system
+# PyTorch on Grace Hopper nodes don't have the same wheels
 if ARCH == 'aarch64':
     exts_list = [
+        ('nvidia_nvtx_cu12', '12.8.90', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615'],
+        }),
+        ('nvidia_nvshmem_cu12', '3.3.20', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['0b0b960da3842212758e4fa4696b94f129090b30e5122fea3c5345916545cff0'],
+        }),
+        ('nvidia_nvjitlink_cu12', '12.8.93', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7'],
+        }),
+        ('nvidia_nccl_cu12', '2.27.5', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['31432ad4d1fb1004eb0c56203dc9bc2178a1ba69d1d9e02d64a6938ab5e40e7a'],
+        }),
+        ('nvidia_curand_cu12', '10.3.9.90', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux_2_27_%(arch)s.whl',
+            'checksums': ['dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd'],
+        }),
+        ('nvidia_cufile_cu12', '1.13.1.3', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux_2_27_%(arch)s.whl',
+            'checksums': ['4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a'],
+        }),
+        ('nvidia_cuda_runtime_cu12', '12.8.90', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d'],
+        }),
+        ('nvidia_cuda_nvrtc_cu12', '12.8.93', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8'],
+        }),
+        ('nvidia_cuda_cupti_cu12', '12.8.90', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed'],
+        }),
+        ('nvidia_cublas_cu12', '12.8.4.1', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux_2_27_%(arch)s.whl',
+            'checksums': ['b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0'],
+        }),
+        ('nvidia_cusparse_cu12', '12.5.8.93', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc'],
+        }),
+        ('nvidia_cufft_cu12', '11.3.3.83', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a'],
+        }),
+        ('nvidia_cudnn_cu12', '9.10.2.21', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux_2_27_%(arch)s.whl',
+            'checksums': ['c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8'],
+        }),
+        ('nvidia_cusolver_cu12', '11.7.3.90', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux_2_27_%(arch)s.whl',
+            'checksums': ['db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0'],
+        }),
         ('torch', version, {
             'sources': ['%(name)s-%(version)s-cp313-cp313-manylinux_2_28_%(arch)s.whl'],
             'checksums': ['c30a17fc83eeab346913e237c64b15b5ba6407fff812f6c541e322e19bc9ea0e'],

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.0-gcccoreflexiblas-14.3.0-3.4.5-CUDA-13.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.0-gcccoreflexiblas-14.3.0-3.4.5-CUDA-13.eb
@@ -24,10 +24,79 @@ dependencies = [
 ]
 
 
-# PyTorch on Grace Hopper nodes don't have the same wheels and most of the
-# stuff is from the system
+# PyTorch on Grace Hopper nodes don't have the same wheels
 if ARCH == 'aarch64':
     exts_list = [
+        ('nvidia_nvtx_cu12', '12.8.90', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615'],
+        }),
+        ('nvidia_nvshmem_cu12', '3.3.20', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['0b0b960da3842212758e4fa4696b94f129090b30e5122fea3c5345916545cff0'],
+        }),
+        ('nvidia_nvjitlink_cu12', '12.8.93', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7'],
+        }),
+        ('nvidia_nccl_cu12', '2.27.5', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['31432ad4d1fb1004eb0c56203dc9bc2178a1ba69d1d9e02d64a6938ab5e40e7a'],
+        }),
+        ('nvidia_curand_cu12', '10.3.9.90', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux_2_27_%(arch)s.whl',
+            'checksums': ['dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd'],
+        }),
+        ('nvidia_cufile_cu12', '1.13.1.3', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux_2_27_%(arch)s.whl',
+            'checksums': ['4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a'],
+        }),
+        ('nvidia_cuda_runtime_cu12', '12.8.90', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d'],
+        }),
+        ('nvidia_cuda_nvrtc_cu12', '12.8.93', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8'],
+        }),
+        ('nvidia_cuda_cupti_cu12', '12.8.90', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed'],
+        }),
+        ('nvidia_cublas_cu12', '12.8.4.1', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux_2_27_%(arch)s.whl',
+            'checksums': ['b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0'],
+        }),
+        ('nvidia_cusparse_cu12', '12.5.8.93', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc'],
+        }),
+        ('nvidia_cufft_cu12', '11.3.3.83', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+            'checksums': ['848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a'],
+        }),
+        ('nvidia_cudnn_cu12', '9.10.2.21', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux_2_27_%(arch)s.whl',
+            'checksums': ['c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8'],
+        }),
+        ('nvidia_cusolver_cu12', '11.7.3.90', {
+            'modulename': False,
+            'source_tmpl': '%(name)s-%(version)s-py3-none-manylinux_2_27_%(arch)s.whl',
+            'checksums': ['db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0'],
+        }),
         ('torch', version, {
             'sources': ['%(name)s-%(version)s-cp313-cp313-manylinux_2_28_%(arch)s.whl'],
             'checksums': ['c30a17fc83eeab346913e237c64b15b5ba6407fff812f6c541e322e19bc9ea0e'],


### PR DESCRIPTION
This PR adds PyTorch 2.9.0 for Stages/2026

Update 5.10.2025:

I propose adding the some of the respective `aarch64` prebuilt files to have a more symmetric and complete PyTorch since I encountered issues with aarch64 easyconfigs that require these nvidia extensions as well when I load PyTorch. **Question:** Is it a good option?

Looks like PyTorch aarch64 does not have the same extension requirements as x86_64.

cusparselt removed from aarch64 because of the following outcome even though [there are aarch64](https://pypi.org/project/nvidia-cusparselt-cu12/0.7.1/#nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl) releases:

```
== 2025-11-05 17:02:36,528 python.py:245 INFO Found 0 invalid packages out of 179 packages
== 2025-11-05 17:02:36,539 build_log.py:226 ERROR EasyBuild encountered an error (at easybuild/base/exceptions.py:126 in __init__): `/.../2026/software/Python/3.13.5-GCCcore-14.3.0/bin/python -m pip check` failed:
nvidia-cusparselt-cu12 0.7.1 is not supported on this platform
 (at easybuild/easyblocks/p/python.py:257 in run_pip_check)
== 2025-11-05 17:02:36,539 build_log.py:322 INFO ... (took 4 secs)
== 2025-11-05 17:02:36,539 filetools.py:2152 INFO Removing lock /.../easybuild/jupiter/software/.locks/_e_project1_XXXX_XXXX_easybuild_jupiter_software_PyTorch_2.9.0-gcccoreflexiblas-14.3.0-3.4.5-CUDA-13.lock...

```

Looking for an alternative in the meantime.