### PR TITLE
remove unneccessary env variable which has nothing to do with mcpl

### DIFF
--- a/easybuild/easyconfigs/m/mcpl/mcpl-2.2.0-foss-2023a.eb
+++ b/easybuild/easyconfigs/m/mcpl/mcpl-2.2.0-foss-2023a.eb
@@ -40,6 +40,4 @@ sanity_check_commands = [
     "mcpltool -v"
 ]
 
-modextravars = {'MCXTRACE': "%(installdir)s/%(namelower)s/%(version)s"}
-
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/m/mcpl/mcpl-2.2.0-foss-2024a.eb
+++ b/easybuild/easyconfigs/m/mcpl/mcpl-2.2.0-foss-2024a.eb
@@ -40,6 +40,4 @@ sanity_check_commands = [
     "mcpltool -v"
 ]
 
-modextravars = {'MCXTRACE': "%(installdir)s/%(namelower)s/%(version)s"}
-
 moduleclass = 'lib'


### PR DESCRIPTION
By a mistake the easyconfig sets the environment variable MCXTRACE which originates from a different easyconfig (McXtrace which can use mcpl). This PR removes that line.