### PR TITLE
add (back) patch to make sure environment variables are defined for RStudio-Server v1.2.1335 terminal sessions

### DIFF
--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-1.2.1335-fix_env.patch
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-1.2.1335-fix_env.patch
@@ -1,0 +1,17 @@
+commit https://github.com/ComputeCanada/easybuild-easyconfigs/commit/7c6171057562a68086bcb81362f1e997ba4aaeba
+Author: @cmd-ntrf
+Date:   May 4 2019
+
+Without this patch, RStudio does not inherits environment variables set before launching it. Since R is provided by a separate module, it means RStudio has no idea where R is nor any other library or executables that were loaded before launching RStudio.
+
+diff -Nru rstudio-1.2.1335.orig/src/cpp/core/system/PosixSystem.cpp rstudio-1.2.1335/src/cpp/core/system/PosixSystem.cpp
+--- rstudio-1.2.1335.orig/src/cpp/core/system/PosixSystem.cpp	2019-03-28 05:08:20.000000000 +0000
++++ rstudio-1.2.1335/src/cpp/core/system/PosixSystem.cpp	2019-05-04 19:23:19.014327797 +0000
+@@ -2195,6 +2195,7 @@
+ 
+    // setup environment
+    core::system::Options env;
++   core::system::environment(&env);
+    copyEnvironmentVar("PATH", &env);
+    copyEnvironmentVar("MANPATH", &env);
+    copyEnvironmentVar("LANG", &env);

--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2024.09.0+375-foss-2023b-Java-11-R-4.4.1.eb
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2024.09.0+375-foss-2023b-Java-11-R-4.4.1.eb
@@ -22,7 +22,11 @@ toolchain = {'name': 'foss', 'version': '2023b'}
 
 source_urls = ['https://github.com/rstudio/rstudio/archive']
 sources = ['v%(version)s.tar.gz']
-checksums = ['8a29b77c53a3db8379d824a9f4a491843036003d105ed71981cd40fe39d2c8c8']
+patches = ['RStudio-Server-1.2.1335-fix_env.patch']
+checksums = [
+    {'v2024.09.0+375.tar.gz': '8a29b77c53a3db8379d824a9f4a491843036003d105ed71981cd40fe39d2c8c8'},
+    {'RStudio-Server-1.2.1335-fix_env.patch': 'a7b6edab4f5605f5695b5a987f2f1b229e90dbcfcb7a85cc2ea9341e8766941b'},
+]
 
 builddependencies = [
     ('ant', '1.10.14', '-Java-%(javaver)s', SYSTEM),


### PR DESCRIPTION
This reintroduces a patch we previously applied to `RStudio-Server`. As seen in https://github.com/EESSI/software-layer/pull/1292#issuecomment-3503472425, without this patch the full environment is not passed through to a terminal shell started in the RStudio-Server instance (`PATH` and `LD_LIBRARY_PATH` are, so most things work). This means that the `module` command does not work (for example), and in the case of EESSI this causes explicit breakage due to our use of a Gentoo Prefix.
