### PR TITLE
{math,data,chem}[lfoss/2023b] Add files for compiling QE with lfoss TC 2023b

### DIFF
--- a/easybuild/easyconfigs/e/ELPA/ELPA-2025.01.002-lfoss-2023b.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2025.01.002-lfoss-2023b.eb
@@ -1,0 +1,48 @@
+# #
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Authors::   Inge Gutheil <i.gutheil@fz-juelich.de>, Alan O'Cais <a.ocais@fz-juelich.de>
+# License::   MIT/GPL
+#
+# #
+
+name = 'ELPA'
+version = '2025.01.002'
+
+homepage = 'https://elpa.mpcdf.mpg.de/'
+description = "Eigenvalue SoLvers for Petaflop-Applications."
+
+toolchain = {'name': 'lfoss', 'version': '2023b'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = ['https://gitlab.mpcdf.mpg.de/elpa/elpa/-/archive/release_%s/' % version]
+sources = ['elpa-release_%(version)s.tar.gz']
+patches = [
+    '%(name)s-2023.05.001_fix_hardcoded_perl_path.patch',
+    '%(name)s-2023.05.001_fix_AVX512_support.patch',
+]
+checksums = [
+    {'elpa-release_2025.01.002.tar.gz': '1a27af959d689a476fe1283fe0b86543d15dbdc4a9bd0778efcdc2b04a2967ca'},
+    {'ELPA-2023.05.001_fix_hardcoded_perl_path.patch':
+     '0548105065777a2ed07dde306636251c4f96e555a801647564de37d1ddd7b0b5'},
+    {'ELPA-2023.05.001_fix_AVX512_support.patch': 'ecf08b64fe1da432a218040fa45d4ecfbb3269d58cb018b12da5a2d854bf96be'},
+]
+
+builddependencies = [
+    ('Autotools', '20220317'),
+    ('Python', '3.11.5'),
+    ('Perl', '5.38.0'),
+]
+
+preconfigopts = './autogen.sh && export LDFLAGS="-lm $LDFLAGS" && autoreconf && '
+
+# See https://github.com/marekandreas/elpa/blob/master/documentation/INSTALL.md?plain=1#L600
+prebuildopts = 'sed -i \'s:\\\\$wl:-Wl,:g\' libtool && '
+
+# When building in parallel, the file test_setup_mpi.mod is sometimes
+# used before it is built, leading to an error.  This must be a bug in
+# the makefile affecting parallel builds.
+maxparallel = 1
+
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.14.6-lompi-2023b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.14.6-lompi-2023b.eb
@@ -1,0 +1,54 @@
+easyblock = 'CMakeMake'
+
+name = 'HDF5'
+# Note: Odd minor releases are only RCs and should not be used.
+version = '1.14.6'
+
+homepage = 'https://portal.hdfgroup.org/display/support'
+description = """HDF5 is a data model, library, and file format for storing and managing data.
+ It supports an unlimited variety of datatypes, and is designed for flexible
+ and efficient I/O and for high volume and complex data."""
+
+toolchain = {'name': 'lompi', 'version': '2023b'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['https://github.com/HDFGroup/hdf5/archive']
+sources = ['hdf5_%(version)s.tar.gz']
+checksums = ['09ee1c671a87401a5201c06106650f62badeea5a3b3941e9b1e2e1e08317357f']
+
+builddependencies = [('CMake', '3.27.6')]
+
+dependencies = [
+    ('libaec', '1.0.6'),
+    ('Perl', '5.38.0'),
+    ('zlib', '1.2.13'),
+]
+
+preconfigopts = 'export LDFLAGS="$LDFLAGS -pthread" && '
+preconfigopts += 'export RUNPARALLEL="mpirun -np $${NPROCS:=3}" && '
+configopts = ' '.join([
+    '-DHDF5_BUILD_CPP_LIB=ON',
+    '-DHDF5_BUILD_FORTRAN=ON',
+    '-DHDF5_ENABLE_THREADSAFE=ON',
+    '-DALLOW_UNSUPPORTED=ON',  # fortran+threadsafe requires unsupported
+    '-DHDF5_ENABLE_PARALLEL=ON',
+])
+# h5redeploy is shipped in 1.14.6 but not installed by CMake. This will be removed in a future HDF5 release.
+postinstallcmds = [
+    "cp ../hdf5*/bin/h5redeploy.in %(installdir)s/bin/h5redeploy && chmod +x %(installdir)s/bin/h5redeploy",
+]
+
+_extra_binaries = ["h5perf", "h5pcc", "h5pfc", "ph5diff"]
+_h5binaries = ["c++", "copy", "debug", "diff", "dump", "import", "jam", "ls", "mkgrp", "perf_serial", "redeploy",
+               "repack", "repart", "stat", "unjam"]
+_binaries = ["h5%s" % x for x in _h5binaries] + _extra_binaries
+_libs = ["libhdf5%s.%s" % (lib, SHLIB_EXT) for lib in ['', '_cpp', '_fortran', '_hl_cpp', '_hl', '_hl_fortran']]
+
+sanity_check_paths = {
+    'files': [f"bin/{x}" for x in _binaries] + [f"lib/{lib}" for lib in _libs],
+    'dirs': ['include'],
+}
+
+modextravars = {'HDF5_DIR': ''}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/l/libxc/libxc-6.2.2-llvm-compilers-20.1.5.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-6.2.2-llvm-compilers-20.1.5.eb
@@ -1,0 +1,52 @@
+easyblock = 'CMakeMake'
+
+name = 'libxc'
+version = '6.2.2'
+
+homepage = 'https://libxc.gitlab.io'
+description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
+ The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
+
+toolchain = {'name': 'llvm-compilers', 'version': '20.1.5'}
+
+source_urls = ['https://gitlab.com/libxc/libxc/-/archive/%(version)s/']
+sources = [SOURCE_TAR_GZ]
+checksums = [
+    ('a0f6f1bba7ba5c0c85b2bfe65aca1591025f509a7f11471b4cd651a79491b045',
+     '3b0523924579cf494cafc6fea92945257f35692b004217d3dfd3ea7ca780e8dc',
+     'd1b65ef74615a1e539d87a0e6662f04baf3a2316706b4e2e686da3193b26b20f'),
+]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('Perl', '5.38.0'),
+]
+
+local_common_configopts = "-DENABLE_FORTRAN=ON -DENABLE_XHOST=OFF "
+
+# don't disable building of third and fourth derivates, since it's required by some software that depends on libxc
+# (like ABINIT, which requires "3rd derivatives of energy")
+# see also https://github.com/pyscf/pyscf/issues/1103
+local_common_configopts += "-DDISABLE_KXC=OFF -DDISABLE_LXC=OFF"
+
+# perform iterative build to get both static and shared libraries
+configopts = [
+    local_common_configopts + ' -DBUILD_SHARED_LIBS=OFF',
+    local_common_configopts + ' -DBUILD_SHARED_LIBS=ON',
+]
+
+# make sure that built libraries (libxc*.so*) in build directory are picked when running tests
+# this is required when RPATH linking is used
+pretestopts = "export LD_LIBRARY_PATH=%(builddir)s/easybuild_obj:$LD_LIBRARY_PATH && "
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['bin/xc-info'] +
+             ['lib/libxc%s.%s' % (x, y) for x in ['', 'f03', 'f90'] for y in ['a', SHLIB_EXT]],
+    'dirs': ['include', 'lib/pkgconfig', 'lib/cmake/Libxc'],
+}
+
+sanity_check_commands = ['xc-info 1']
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.5-lfoss-2023b.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.5-lfoss-2023b.eb
@@ -1,0 +1,99 @@
+name = 'QuantumESPRESSO'
+version = '7.5'
+
+homepage = 'https://www.quantum-espresso.org'
+description = '''Quantum ESPRESSO  is an integrated suite of computer codes
+for electronic-structure calculations and materials modeling at the nanoscale.
+It is based on density-functional theory, plane waves, and pseudopotentials
+(both norm-conserving and ultrasoft).
+'''
+
+toolchain = {'name': 'lfoss', 'version': '2023b'}
+
+toolchainopts = {
+    'usempi': True,
+    'openmp': True,
+}
+
+# Check hashes inside external/submodule_commit_hash_records when making file for new version
+_lapack_hash = '12d825396fcef1e0a1b27be9f119f9e554621e55'
+_mbd_hash = '89a3cc199c0a200c9f0f688c3229ef6b9a8d63bd'
+_devxlib_hash = 'a6b89ef77b1ceda48e967921f1f5488d2df9226d'
+_fox_hash = '3453648e6837658b747b895bb7bef4b1ed2eac40'
+# Different from the one at tag qe-7.5, see https://github.com/anharmonic/d3q/issues/30
+# Compiling on top of 168313d9 results in an undefined reference to `zgemm3m_` requires the commit after to work
+_d3q_hash = 'fba772c180a8956227f0df077b841ec3039c610a'
+_qe_gipaw_hash = '717e55c36f28c512d232321adb10d5a66d3e1072'
+_qmcpack_hash = 'f72ab25fa4ea755c1b4b230ae8074b47d5509c70'
+_w90_hash = '1d6b187374a2d50b509e5e79e2cab01a79ff7ce1'
+
+sources = [
+    {
+        'filename': 'q-e-qe-%(version)s.tar.gz',
+        'extract_cmd': 'mkdir -p %(builddir)s/qe-%(version)s && tar xzvf %s --strip-components=1 -C $_',
+        'source_urls': ['https://gitlab.com/QEF/q-e/-/archive/qe-%(version)s'],
+    },
+]
+checksums = [
+    {'q-e-qe-7.5.tar.gz': '7e1f7a9a21b63192f5135218bee20a5321b66582e4756536681b76e9c59b3cc8'},
+    {'lapack-12d82539.tar.xz': '88aea5bca5e730e99fda0a5b9d677d6036c7dd82874e0deaed5cccef1f880111'},
+    {'mbd-89a3cc19.tar.xz': 'd026bf0e9334874670a23cd854f445baac003d4f099afa46bab667bc67abb450'},
+    {'devxlib-a6b89ef7.tar.xz': '0a9b7e5350f44017a2390c85176d1683c6ecec0e4b716a59d727f7650f16e807'},
+    {'d3q-fba772c1.tar.xz': '184e1e171c34e4f30952c082c39c3fdab2b7a25b2f7cd19e522b55f45ac1215b'},
+    {'fox-3453648e.tar.xz': 'c8c55cdf9eb2709aebac86a58f936480ee66438dffd3d65c6a35ca7771c031b3'},
+    {'qe-gipaw-717e55c3.tar.xz': '10e1ec9cda0e5480f708c08ff65b216f7611b0378a225133116c5884b3424a33'},
+    {'pw2qmcpack-f72ab25f.tar.xz': 'bc9513c4901ec2469d56b8a6b66f56878cb13e3bc7fbcdc5dba0ca6dad880ab9'},
+    {'wannier90-1d6b1873.tar.xz': '351531aaf3434a9aac92d39ee40df5eb949aa27d14fcb93518bf08444478cd2a'},
+]
+
+_github_repos = [
+    ('github', 'Reference-LAPACK', 'lapack', _lapack_hash, 'lapack'),
+    ('github', 'libmbd', 'libmbd', _mbd_hash, 'mbd'),
+    ('gitlab', 'max-centre/components', 'devicexlib', _devxlib_hash, 'devxlib'),
+    ('github', 'anharmonic', 'd3q', _d3q_hash, 'd3q'),
+    ('github', 'pietrodelugas', 'fox', _fox_hash, 'fox'),
+    ('github', 'dceresoli', 'qe-gipaw', _qe_gipaw_hash, 'qe-gipaw'),
+    ('github', 'QMCPACK', 'pw2qmcpack', _qmcpack_hash, 'pw2qmcpack'),
+    ('github', 'wannier-developers', 'wannier90', _w90_hash, 'wannier90'),
+]
+
+for _provider, _owner, _repo, _commit, _name in _github_repos:
+    sources.append({
+        'filename': '%s-%s.tar.xz' % (_name, _commit[:8]),
+        'git_config': {
+            'url': f'https://{_provider}.com/{_owner}',
+            'repo_name': _repo,
+            'commit': _commit,
+            'clone_into': _name,
+        },
+    })
+
+builddependencies = [
+    ('M4', '1.4.19'),
+    ('CMake', '3.27.6'),
+    ('pkgconf', '2.0.3'),
+]
+dependencies = [
+    ('HDF5', '1.14.6'),
+    ('ELPA', '2025.01.002'),
+    ('libxc', '6.2.2'),
+]
+
+# Disabled because of
+# https://gitlab.com/QEF/q-e/-/issues/667
+# https://github.com/anharmonic/d3q/issues/15
+build_shared_libs = False
+with_scalapack = True
+with_fox = True
+with_gipaw = True
+# Will hit a error: loc(".../7.5/lfoss-2023b/qe-7.5/external/d3q/src/d3_shuffle.f90":190:1):
+#  .../LLVM/20.1.5/GCCcore-13.2.0/llvm-project-20.1.5.src/flang/lib/Lower/CallInterface.cpp:1115:
+# not yet implemented: VOLATILE in procedure interface
+with_d3q = False
+with_qmcpack = True
+
+test_suite_threshold = 0.98
+test_suite_max_failed = 5  # Allow for some flaky tests (failed due to strict thresholds)
+test_suite_allow_failures = []
+
+moduleclass = 'chem'


### PR DESCRIPTION
Requires:

- https://github.com/easybuilders/easybuild-framework/pull/4914
- https://github.com/easybuilders/easybuild-easyblocks/pull/3759
- #24495 
- #23051

In order to add `d3q` we will need either LLVM >= 21 or the patch from https://github.com/llvm/llvm-project/pull/132486 which unfortunately cannot be applied cleanly

**Needs rebuild of `Autoconf` with**

- https://github.com/easybuilders/easybuild-easyconfigs/pull/24693