### PR TITLE
drop 'build' easyconfigs from foss to GCCcore

### DIFF
--- a/easybuild/easyconfigs/b/build/build-0.10.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/b/build/build-0.10.0-GCCcore-11.3.0.eb
@@ -8,6 +8,10 @@ description = """A simple, correct Python build frontend."""
 
 toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 
+builddependencies = [
+    ('binutils', '2.38'),
+]
+
 dependencies = [
     ('Python', '3.10.4'),
 ]

--- a/easybuild/easyconfigs/b/build/build-0.10.0-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/b/build/build-0.10.0-GCCcore-12.2.0.eb
@@ -8,6 +8,10 @@ description = """A simple, correct Python build frontend."""
 
 toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 
+builddependencies = [
+    ('binutils', '2.39'),
+]
+
 dependencies = [
     ('Python', '3.10.8'),
 ]

--- a/easybuild/easyconfigs/b/build/build-1.0.3-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/b/build/build-1.0.3-GCCcore-12.3.0.eb
@@ -8,6 +8,10 @@ description = """A simple, correct Python build frontend."""
 
 toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 
+builddependencies = [
+    ('binutils', '2.40'),
+]
+
 dependencies = [
     ('Python', '3.11.3'),
 ]

--- a/easybuild/easyconfigs/b/build/build-1.0.3-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/b/build/build-1.0.3-GCCcore-13.2.0.eb
@@ -8,6 +8,10 @@ description = """A simple, correct Python build frontend."""
 
 toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 
+builddependencies = [
+    ('binutils', '2.40'),
+]
+
 dependencies = [
     ('Python', '3.11.5'),
 ]


### PR DESCRIPTION
there is no need for these easyconfigs to be at `foss` level, so lets drop them down to `GCCcore`

see also: https://github.com/easybuilders/easybuild-easyconfigs/pull/24486