### PR TITLE
add patch to update `sse2neon.h` in RAxML 8.2.13 sources

### DIFF
--- a/easybuild/easyconfigs/r/RAxML/RAxML-8.2.13-gompi-2023a.eb
+++ b/easybuild/easyconfigs/r/RAxML/RAxML-8.2.13-gompi-2023a.eb
@@ -10,10 +10,14 @@ toolchain = {'name': 'gompi', 'version': '2023a'}
 
 source_urls = ['https://github.com/stamatak/standard-RAxML/archive/']
 sources = ['v%(version)s.tar.gz']
-patches = ['raxml_8.2.13_respect_eb_settings.patch']
+patches = [
+    'raxml_8.2.13_respect_eb_settings.patch',
+    'raxml-8.2.13_update_sse2neon.patch',
+]
 checksums = [
-    '28e500793324bd7d330b396ef27ea49c9186fa5e1edb3d5439036dc6c33e6067',
-    '66412303ccbb2720e3dbb5acb1179fe441a2aaa563d033c5f0292f5ba1e08c3b',
+    {'v8.2.13.tar.gz': '28e500793324bd7d330b396ef27ea49c9186fa5e1edb3d5439036dc6c33e6067'},
+    {'raxml_8.2.13_respect_eb_settings.patch': '66412303ccbb2720e3dbb5acb1179fe441a2aaa563d033c5f0292f5ba1e08c3b'},
+    {'raxml-8.2.13_update_sse2neon.patch': '077a1bf2f914eb19f54ee28b04c349a54d35965b4fce1cfa4d69066b2375d456'},
 ]
 
 buildopts = '-f Makefile.gcc && rm *.o && '

--- a/easybuild/easyconfigs/r/RAxML/RAxML-8.2.13-gompi-2023b.eb
+++ b/easybuild/easyconfigs/r/RAxML/RAxML-8.2.13-gompi-2023b.eb
@@ -10,10 +10,14 @@ toolchain = {'name': 'gompi', 'version': '2023b'}
 
 source_urls = ['https://github.com/stamatak/standard-RAxML/archive/']
 sources = ['v%(version)s.tar.gz']
-patches = ['raxml_8.2.13_respect_eb_settings.patch']
+patches = [
+    'raxml_8.2.13_respect_eb_settings.patch',
+    'raxml-8.2.13_update_sse2neon.patch',
+]
 checksums = [
-    '28e500793324bd7d330b396ef27ea49c9186fa5e1edb3d5439036dc6c33e6067',
-    '66412303ccbb2720e3dbb5acb1179fe441a2aaa563d033c5f0292f5ba1e08c3b',
+    {'v8.2.13.tar.gz': '28e500793324bd7d330b396ef27ea49c9186fa5e1edb3d5439036dc6c33e6067'},
+    {'raxml_8.2.13_respect_eb_settings.patch': '66412303ccbb2720e3dbb5acb1179fe441a2aaa563d033c5f0292f5ba1e08c3b'},
+    {'raxml-8.2.13_update_sse2neon.patch': '077a1bf2f914eb19f54ee28b04c349a54d35965b4fce1cfa4d69066b2375d456'},
 ]
 
 buildopts = '-f Makefile.gcc && rm *.o && '

--- a/easybuild/easyconfigs/r/RAxML/RAxML-8.2.13-gompi-2024a.eb
+++ b/easybuild/easyconfigs/r/RAxML/RAxML-8.2.13-gompi-2024a.eb
@@ -10,10 +10,14 @@ toolchain = {'name': 'gompi', 'version': '2024a'}
 
 source_urls = ['https://github.com/stamatak/standard-RAxML/archive/']
 sources = ['v%(version)s.tar.gz']
-patches = ['raxml_8.2.13_respect_eb_settings.patch']
+patches = [
+    'raxml_8.2.13_respect_eb_settings.patch',
+    'raxml-8.2.13_update_sse2neon.patch',
+]
 checksums = [
     {'v8.2.13.tar.gz': '28e500793324bd7d330b396ef27ea49c9186fa5e1edb3d5439036dc6c33e6067'},
     {'raxml_8.2.13_respect_eb_settings.patch': '66412303ccbb2720e3dbb5acb1179fe441a2aaa563d033c5f0292f5ba1e08c3b'},
+    {'raxml-8.2.13_update_sse2neon.patch': '077a1bf2f914eb19f54ee28b04c349a54d35965b4fce1cfa4d69066b2375d456'},
 ]
 
 buildopts = '-f Makefile.gcc && rm *.o && '

--- a/easybuild/easyconfigs/r/RAxML/raxml-8.2.13_update_sse2neon.patch
+++ b/easybuild/easyconfigs/r/RAxML/raxml-8.2.13_update_sse2neon.patch
@@ -1,0 +1,8754 @@
+Update version of ss2neon.h to
+https://github.com/DLTcollab/sse2neon/pull/677 (Sept. 2025)
+as there are compilation failures for the old version with recent (12+) GCC compilers
+
+diff -rupN standard-RAxML-8.2.13_orig/sse2neon.h standard-RAxML-8.2.13/sse2neon.h
+--- standard-RAxML-8.2.13_orig/sse2neon.h	2023-10-04 07:33:55.000000000 +0000
++++ standard-RAxML-8.2.13/sse2neon.h	2025-11-19 10:13:18.677211569 +0000
+@@ -1,6 +1,30 @@
+ #ifndef SSE2NEON_H
+ #define SSE2NEON_H
+ 
++/*
++ * sse2neon is freely redistributable under the MIT License.
++ *
++ * Copyright (c) 2015-2024 SSE2NEON Contributors.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to deal
++ * in the Software without restriction, including without limitation the rights
++ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++ * copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in
++ * all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++
+ // This header file provides a simple API translation layer
+ // between SSE intrinsics to their corresponding Arm/Aarch64 NEON versions
+ //
+@@ -26,28 +50,8 @@
+ //   Jonathan Hue <jhue@adobe.com>
+ //   Cuda Chen <clh960524@gmail.com>
+ //   Aymen Qader <aymen.qader@arm.com>
+-
+-/*
+- * sse2neon is freely redistributable under the MIT License.
+- *
+- * Permission is hereby granted, free of charge, to any person obtaining a copy
+- * of this software and associated documentation files (the "Software"), to deal
+- * in the Software without restriction, including without limitation the rights
+- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+- * copies of the Software, and to permit persons to whom the Software is
+- * furnished to do so, subject to the following conditions:
+- *
+- * The above copyright notice and this permission notice shall be included in
+- * all copies or substantial portions of the Software.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+- * SOFTWARE.
+- */
++//   Anthony Roberts <anthony.roberts@linaro.org>
++//   Sean Luchen <seanluchen@google.com>
+ 
+ /* Tunable configurations */
+ 
+@@ -59,7 +63,7 @@
+ #ifndef SSE2NEON_PRECISE_MINMAX
+ #define SSE2NEON_PRECISE_MINMAX (0)
+ #endif
+-/* _mm_rcp_ps and _mm_div_ps */
++/* _mm_rcp_ps */
+ #ifndef SSE2NEON_PRECISE_DIV
+ #define SSE2NEON_PRECISE_DIV (0)
+ #endif
+@@ -72,6 +76,13 @@
+ #define SSE2NEON_PRECISE_DP (0)
+ #endif
+ 
++/* Enable inclusion of windows.h on MSVC platforms
++ * This makes _mm_clflush functional on windows, as there is no builtin.
++ */
++#ifndef SSE2NEON_INCLUDE_WINDOWS_H
++#define SSE2NEON_INCLUDE_WINDOWS_H (0)
++#endif
++
+ /* compiler specific definitions */
+ #if defined(__GNUC__) || defined(__clang__)
+ #pragma push_macro("FORCE_INLINE")
+@@ -80,8 +91,10 @@
+ #define ALIGN_STRUCT(x) __attribute__((aligned(x)))
+ #define _sse2neon_likely(x) __builtin_expect(!!(x), 1)
+ #define _sse2neon_unlikely(x) __builtin_expect(!!(x), 0)
+-#else /* non-GNU / non-clang compilers */
+-#warning "Macro name collisions may happen with unsupported compiler."
++#elif defined(_MSC_VER)
++#if _MSVC_TRADITIONAL
++#error Using the traditional MSVC preprocessor is not supported! Use /Zc:preprocessor instead.
++#endif
+ #ifndef FORCE_INLINE
+ #define FORCE_INLINE static inline
+ #endif
+@@ -90,6 +103,17 @@
+ #endif
+ #define _sse2neon_likely(x) (x)
+ #define _sse2neon_unlikely(x) (x)
++#else
++#pragma message("Macro name collisions may happen with unsupported compilers.")
++#endif
++
++#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 10
++#warning "GCC versions earlier than 10 are not supported."
++#endif
++
++#if defined(__OPTIMIZE__) && !defined(SSE2NEON_SUPPRESS_WARNINGS)
++#warning \
++    "Report any potential compiler optimization issues when using SSE2NEON. See the 'Optimization' section at https://github.com/DLTcollab/sse2neon."
+ #endif
+ 
+ /* C language does not allow initializing a variable with a function call. */
+@@ -99,31 +123,94 @@
+ #define _sse2neon_const const
+ #endif
+ 
++#include <fenv.h>
+ #include <stdint.h>
+ #include <stdlib.h>
++#include <string.h>
+ 
+-#if defined(_WIN32)
+-/* Definitions for _mm_{malloc,free} are provided by <malloc.h>
+- * from both MinGW-w64 and MSVC.
+- */
++FORCE_INLINE double sse2neon_recast_u64_f64(uint64_t val)
++{
++    double tmp;
++    memcpy(&tmp, &val, sizeof(uint64_t));
++    return tmp;
++}
++FORCE_INLINE int64_t sse2neon_recast_f64_s64(double val)
++{
++    int64_t tmp;
++    memcpy(&tmp, &val, sizeof(uint64_t));
++    return tmp;
++}
++
++#if defined(_WIN32) && !defined(__MINGW32__)
++/* Definitions for _mm_{malloc,free} are provided by <malloc.h> from MSVC. */
+ #define SSE2NEON_ALLOC_DEFINED
+ #endif
+ 
+ /* If using MSVC */
+ #ifdef _MSC_VER
++#if defined(_M_ARM64EC)
++#define _DISABLE_SOFTINTRIN_ 1
++#endif
+ #include <intrin.h>
++#if SSE2NEON_INCLUDE_WINDOWS_H
++#include <processthreadsapi.h>
++#include <windows.h>
++#endif
++
++#if !defined(__cplusplus)
++#error SSE2NEON only supports C++ compilation with this compiler
++#endif
++
++#ifdef SSE2NEON_ALLOC_DEFINED
++#include <malloc.h>
++#endif
++
+ #if (defined(_M_AMD64) || defined(__x86_64__)) || \
+-    (defined(_M_ARM) || defined(__arm__))
++    (defined(_M_ARM64) || defined(_M_ARM64EC) || defined(__arm64__))
+ #define SSE2NEON_HAS_BITSCAN64
+ #endif
+ #endif
+ 
++#if defined(__GNUC__) || defined(__clang__)
++#define _sse2neon_define0(type, s, body) \
++    __extension__({                      \
++        type _a = (s);                   \
++        body                             \
++    })
++#define _sse2neon_define1(type, s, body) \
++    __extension__({                      \
++        type _a = (s);                   \
++        body                             \
++    })
++#define _sse2neon_define2(type, a, b, body) \
++    __extension__({                         \
++        type _a = (a), _b = (b);            \
++        body                                \
++    })
++#define _sse2neon_return(ret) (ret)
++#else
++#define _sse2neon_define0(type, a, body) [=](type _a) { body }(a)
++#define _sse2neon_define1(type, a, body) [](type _a) { body }(a)
++#define _sse2neon_define2(type, a, b, body) \
++    [](type _a, type _b) { body }((a), (b))
++#define _sse2neon_return(ret) return ret
++#endif
++
++#define _sse2neon_init(...) \
++    {                       \
++        __VA_ARGS__         \
++    }
++
+ /* Compiler barrier */
++#if defined(_MSC_VER) && !defined(__clang__)
++#define SSE2NEON_BARRIER() _ReadWriteBarrier()
++#else
+ #define SSE2NEON_BARRIER()                     \
+     do {                                       \
+         __asm__ __volatile__("" ::: "memory"); \
+         (void) 0;                              \
+     } while (0)
++#endif
+ 
+ /* Memory barriers
+  * __atomic_thread_fence does not include a compiler barrier; instead,
+@@ -142,8 +229,8 @@ FORCE_INLINE void _sse2neon_smp_mb(void)
+     atomic_thread_fence(memory_order_seq_cst);
+ #elif defined(__GNUC__) || defined(__clang__)
+     __atomic_thread_fence(__ATOMIC_SEQ_CST);
+-#else
+-    /* FIXME: MSVC support */
++#else /* MSVC */
++    __dmb(_ARM64_BARRIER_ISH);
+ #endif
+ }
+ 
+@@ -162,8 +249,8 @@ FORCE_INLINE void _sse2neon_smp_mb(void)
+ #pragma GCC push_options
+ #pragma GCC target("fpu=neon")
+ #endif
+-#elif defined(__aarch64__)
+-#if !defined(__clang__)
++#elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
++#if !defined(__clang__) && !defined(_MSC_VER)
+ #pragma GCC push_options
+ #pragma GCC target("+simd")
+ #endif
+@@ -172,23 +259,26 @@ FORCE_INLINE void _sse2neon_smp_mb(void)
+ #error \
+     "You must enable NEON instructions (e.g. -mfpu=neon-fp-armv8) to use SSE2NEON."
+ #endif
+-#if !defined(__clang__)
++#if !defined(__clang__) && !defined(_MSC_VER)
+ #pragma GCC push_options
+ #endif
+ #else
+-#error "Unsupported target. Must be either ARMv7-A+NEON or ARMv8-A."
++#error \
++    "Unsupported target. Must be either ARMv7-A+NEON or ARMv8-A \
++(you could try setting target explicitly with -march or -mcpu)"
+ #endif
+ #endif
+ 
+ #include <arm_neon.h>
+-#if !defined(__aarch64__) && (__ARM_ARCH == 8)
++#if (!defined(__aarch64__) && !defined(_M_ARM64) && !defined(_M_ARM64EC)) && \
++    (__ARM_ARCH == 8)
+ #if defined __has_include && __has_include(<arm_acle.h>)
+ #include <arm_acle.h>
+ #endif
+ #endif
+ 
+ /* Apple Silicon cache lines are double of what is commonly used by Intel, AMD
+- * and other Arm microarchtectures use.
++ * and other Arm microarchitectures use.
+  * From sysctl -a on Apple M1:
+  * hw.cachelinesize: 128
+  */
+@@ -198,8 +288,8 @@ FORCE_INLINE void _sse2neon_smp_mb(void)
+ #define SSE2NEON_CACHELINE_SIZE 64
+ #endif
+ 
+-/* Rounding functions require either Aarch64 instructions or libm failback */
+-#if !defined(__aarch64__)
++/* Rounding functions require either Aarch64 instructions or libm fallback */
++#if !defined(__aarch64__) && !defined(_M_ARM64) && !defined(_M_ARM64EC)
+ #include <math.h>
+ #endif
+ 
+@@ -208,7 +298,7 @@ FORCE_INLINE void _sse2neon_smp_mb(void)
+  * To write or access to these registers in user mode,
+  * we have to perform syscall instead.
+  */
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(_M_ARM64) && !defined(_M_ARM64EC)
+ #include <sys/time.h>
+ #endif
+ 
+@@ -247,6 +337,15 @@ FORCE_INLINE void _sse2neon_smp_mb(void)
+ #define _MM_SHUFFLE(fp3, fp2, fp1, fp0) \
+     (((fp3) << 6) | ((fp2) << 4) | ((fp1) << 2) | ((fp0)))
+ 
++/**
++ * MACRO for shuffle parameter for _mm_shuffle_pd().
++ * Argument fp1 is a digit[01] that represents the fp from argument "b"
++ * of mm_shuffle_pd that will be placed in fp1 of result.
++ * fp0 is a digit[01] that represents the fp from argument "a" of mm_shuffle_pd
++ * that will be placed in fp0 of result.
++ */
++#define _MM_SHUFFLE2(fp1, fp0) (((fp1) << 1) | (fp0))
++
+ #if __has_builtin(__builtin_shufflevector)
+ #define _sse2neon_shuffle(type, a, b, ...) \
+     __builtin_shufflevector(a, b, __VA_ARGS__)
+@@ -308,13 +407,18 @@ typedef float32x4_t __m128; /* 128-bit v
+ // On ARM 32-bit architecture, the float64x2_t is not supported.
+ // The data type __m128d should be represented in a different way for related
+ // intrinsic conversion.
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+ typedef float64x2_t __m128d; /* 128-bit vector containing 2 doubles */
+ #else
+ typedef float32x4_t __m128d;
+ #endif
+ typedef int64x2_t __m128i; /* 128-bit vector containing integers */
+ 
++// Some intrinsics operate on unaligned data types.
++typedef int16_t ALIGN_STRUCT(1) unaligned_int16_t;
++typedef int32_t ALIGN_STRUCT(1) unaligned_int32_t;
++typedef int64_t ALIGN_STRUCT(1) unaligned_int64_t;
++
+ // __int64 is defined in the Intrinsics Guide which maps to different datatype
+ // in different data model
+ #if !(defined(_WIN32) || defined(_WIN64) || defined(__int64))
+@@ -404,7 +508,7 @@ typedef int64x2_t __m128i; /* 128-bit ve
+ 
+ #define vreinterpret_f32_m64(x) vreinterpret_f32_s64(x)
+ 
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+ #define vreinterpretq_m128d_s32(x) vreinterpretq_f64_s32(x)
+ #define vreinterpretq_m128d_s64(x) vreinterpretq_f64_s64(x)
+ 
+@@ -441,7 +545,7 @@ typedef int64x2_t __m128i; /* 128-bit ve
+ // by applications which attempt to access the contents of an __m128 struct
+ // directly.  It is important to note that accessing the __m128 struct directly
+ // is bad coding practice by Microsoft: @see:
+-// https://docs.microsoft.com/en-us/cpp/cpp/m128
++// https://learn.microsoft.com/en-us/cpp/cpp/m128
+ //
+ // However, some legacy source code may try to access the contents of an __m128
+ // struct directly so the developer can use the SIMDVec as an alias for it.  Any
+@@ -485,7 +589,7 @@ typedef union ALIGN_STRUCT(16) SIMDVec {
+ 
+ // Function declaration
+ // SSE
+-FORCE_INLINE unsigned int _MM_GET_ROUNDING_MODE();
++FORCE_INLINE unsigned int _MM_GET_ROUNDING_MODE(void);
+ FORCE_INLINE __m128 _mm_move_ss(__m128, __m128);
+ FORCE_INLINE __m128 _mm_or_ps(__m128, __m128);
+ FORCE_INLINE __m128 _mm_set_ps1(float);
+@@ -501,7 +605,7 @@ FORCE_INLINE __m128i _mm_set_epi32(int,
+ FORCE_INLINE __m128i _mm_set_epi64x(int64_t, int64_t);
+ FORCE_INLINE __m128d _mm_set_pd(double, double);
+ FORCE_INLINE __m128i _mm_set1_epi32(int);
+-FORCE_INLINE __m128i _mm_setzero_si128();
++FORCE_INLINE __m128i _mm_setzero_si128(void);
+ // SSE4.1
+ FORCE_INLINE __m128d _mm_ceil_pd(__m128d);
+ FORCE_INLINE __m128 _mm_ceil_ps(__m128);
+@@ -516,7 +620,7 @@ FORCE_INLINE uint32_t _mm_crc32_u8(uint3
+ 
+ // Older gcc does not define vld1q_u8_x4 type
+ #if defined(__GNUC__) && !defined(__clang__) &&                        \
+-    ((__GNUC__ <= 12 && defined(__arm__)) ||                           \
++    ((__GNUC__ <= 13 && defined(__arm__)) ||                           \
+      (__GNUC__ == 10 && __GNUC_MINOR__ < 3 && defined(__aarch64__)) || \
+      (__GNUC__ <= 9 && defined(__aarch64__)))
+ FORCE_INLINE uint8x16x4_t _sse2neon_vld1q_u8_x4(const uint8_t *p)
+@@ -536,7 +640,7 @@ FORCE_INLINE uint8x16x4_t _sse2neon_vld1
+ }
+ #endif
+ 
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(_M_ARM64) && !defined(_M_ARM64EC)
+ /* emulate vaddv u8 variant */
+ FORCE_INLINE uint8_t _sse2neon_vaddv_u8(uint8x8_t v8)
+ {
+@@ -551,7 +655,7 @@ FORCE_INLINE uint8_t _sse2neon_vaddv_u8(
+ }
+ #endif
+ 
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(_M_ARM64) && !defined(_M_ARM64EC)
+ /* emulate vaddvq u8 variant */
+ FORCE_INLINE uint8_t _sse2neon_vaddvq_u8(uint8x16_t a)
+ {
+@@ -569,7 +673,7 @@ FORCE_INLINE uint8_t _sse2neon_vaddvq_u8
+ }
+ #endif
+ 
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(_M_ARM64) && !defined(_M_ARM64EC)
+ /* emulate vaddvq u16 variant */
+ FORCE_INLINE uint16_t _sse2neon_vaddvq_u16(uint16x8_t a)
+ {
+@@ -599,7 +703,7 @@ FORCE_INLINE uint16_t _sse2neon_vaddvq_u
+  * This last part, <data_type>, is a little complicated. It identifies the
+  * content of the input values, and can be set to any of the following values:
+  * + ps - vectors contain floats (ps stands for packed single-precision)
+- * + pd - vectors cantain doubles (pd stands for packed double-precision)
++ * + pd - vectors contain doubles (pd stands for packed double-precision)
+  * + epi8/epi16/epi32/epi64 - vectors contain 8-bit/16-bit/32-bit/64-bit
+  *                            signed integers
+  * + epu8/epu16/epu32/epu64 - vectors contain 8-bit/16-bit/32-bit/64-bit
+@@ -621,50 +725,16 @@ FORCE_INLINE uint16_t _sse2neon_vaddvq_u
+  *                                  4, 5, 12, 13, 6, 7, 14, 15);
+  *   // Shuffle packed 8-bit integers
+  *   __m128i v_out = _mm_shuffle_epi8(v_in, v_perm); // pshufb
+- *
+- * Data (Number, Binary, Byte Index):
+-    +------+------+-------------+------+------+-------------+
+-    |      1      |      2      |      3      |      4      | Number
+-    +------+------+------+------+------+------+------+------+
+-    | 0000 | 0001 | 0000 | 0010 | 0000 | 0011 | 0000 | 0100 | Binary
+-    +------+------+------+------+------+------+------+------+
+-    |    0 |    1 |    2 |    3 |    4 |    5 |    6 |    7 | Index
+-    +------+------+------+------+------+------+------+------+
+-
+-    +------+------+------+------+------+------+------+------+
+-    |      5      |      6      |      7      |      8      | Number
+-    +------+------+------+------+------+------+------+------+
+-    | 0000 | 0101 | 0000 | 0110 | 0000 | 0111 | 0000 | 1000 | Binary
+-    +------+------+------+------+------+------+------+------+
+-    |    8 |    9 |   10 |   11 |   12 |   13 |   14 |   15 | Index
+-    +------+------+------+------+------+------+------+------+
+- * Index (Byte Index):
+-    +------+------+------+------+------+------+------+------+
+-    |    1 |    0 |    2 |    3 |    8 |    9 |   10 |   11 |
+-    +------+------+------+------+------+------+------+------+
+-
+-    +------+------+------+------+------+------+------+------+
+-    |    4 |    5 |   12 |   13 |    6 |    7 |   14 |   15 |
+-    +------+------+------+------+------+------+------+------+
+- * Result:
+-    +------+------+------+------+------+------+------+------+
+-    |    1 |    0 |    2 |    3 |    8 |    9 |   10 |   11 | Index
+-    +------+------+------+------+------+------+------+------+
+-    | 0001 | 0000 | 0000 | 0010 | 0000 | 0101 | 0000 | 0110 | Binary
+-    +------+------+------+------+------+------+------+------+
+-    |     256     |      2      |      5      |      6      | Number
+-    +------+------+------+------+------+------+------+------+
+-
+-    +------+------+------+------+------+------+------+------+
+-    |    4 |    5 |   12 |   13 |    6 |    7 |   14 |   15 | Index
+-    +------+------+------+------+------+------+------+------+
+-    | 0000 | 0011 | 0000 | 0111 | 0000 | 0100 | 0000 | 1000 | Binary
+-    +------+------+------+------+------+------+------+------+
+-    |      3      |      7      |      4      |      8      | Number
+-    +------+------+------+------+------+------+-------------+
+  */
+ 
+ /* Constants for use with _mm_prefetch. */
++#if defined(_M_ARM64EC)
++/* winnt.h already defines these constants as macros, so undefine them first. */
++#undef _MM_HINT_NTA
++#undef _MM_HINT_T0
++#undef _MM_HINT_T1
++#undef _MM_HINT_T2
++#endif
+ enum _mm_hint {
+     _MM_HINT_NTA = 0, /* load data to L1 and L2 cache, mark it as NTA */
+     _MM_HINT_T0 = 1,  /* load data to L1 and L2 cache */
+@@ -680,7 +750,7 @@ typedef struct {
+     uint8_t bit23 : 1;
+     uint8_t bit24 : 1;
+     uint8_t res2 : 7;
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     uint32_t res3;
+ #endif
+ } fpcr_bitfield;
+@@ -820,24 +890,24 @@ FORCE_INLINE __m128 _mm_shuffle_ps_2032(
+     return vreinterpretq_m128_f32(vcombine_f32(a32, b20));
+ }
+ 
+-// Kahan summation for accurate summation of floating-point numbers.
+-// http://blog.zachbjornson.com/2019/08/11/fast-float-summation.html
+-FORCE_INLINE void _sse2neon_kadd_f32(float *sum, float *c, float y)
+-{
+-    y -= *c;
+-    float t = *sum + y;
+-    *c = (t - *sum) - y;
+-    *sum = t;
+-}
+-
+-#if defined(__ARM_FEATURE_CRYPTO) && \
+-    (defined(__aarch64__) || __has_builtin(__builtin_arm_crypto_vmullp64))
++// For MSVC, we check only if it is ARM64, as every single ARM64 processor
++// supported by WoA has crypto extensions. If this changes in the future,
++// this can be verified via the runtime-only method of:
++// IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE)
++#if ((defined(_M_ARM64) || defined(_M_ARM64EC)) && !defined(__clang__)) || \
++    (defined(__ARM_FEATURE_CRYPTO) &&                                      \
++     (defined(__aarch64__) || __has_builtin(__builtin_arm_crypto_vmullp64)))
+ // Wraps vmull_p64
+ FORCE_INLINE uint64x2_t _sse2neon_vmull_p64(uint64x1_t _a, uint64x1_t _b)
+ {
+     poly64_t a = vget_lane_p64(vreinterpret_p64_u64(_a), 0);
+     poly64_t b = vget_lane_p64(vreinterpret_p64_u64(_b), 0);
++#if defined(_MSC_VER) && !defined(__clang__)
++    __n64 a1 = {a}, b1 = {b};
++    return vreinterpretq_u64_p128(vmull_p64(a1, b1));
++#else
+     return vreinterpretq_u64_p128(vmull_p64(a, b));
++#endif
+ }
+ #else  // ARMv7 polyfill
+ // ARMv7/some A64 lacks vmull_p64, but it has vmull_p8.
+@@ -950,26 +1020,22 @@ static uint64x2_t _sse2neon_vmull_p64(ui
+ //   __m128i _mm_shuffle_epi32_default(__m128i a,
+ //                                     __constrange(0, 255) int imm) {
+ //       __m128i ret;
+-//       ret[0] = a[imm        & 0x3];   ret[1] = a[(imm >> 2) & 0x3];
+-//       ret[2] = a[(imm >> 4) & 0x03];  ret[3] = a[(imm >> 6) & 0x03];
++//       ret[0] = a[(imm)        & 0x3];   ret[1] = a[((imm) >> 2) & 0x3];
++//       ret[2] = a[((imm) >> 4) & 0x03];  ret[3] = a[((imm) >> 6) & 0x03];
+ //       return ret;
+ //   }
+ #define _mm_shuffle_epi32_default(a, imm)                                   \
+-    __extension__({                                                         \
+-        int32x4_t ret;                                                      \
+-        ret = vmovq_n_s32(                                                  \
+-            vgetq_lane_s32(vreinterpretq_s32_m128i(a), (imm) & (0x3)));     \
+-        ret = vsetq_lane_s32(                                               \
+-            vgetq_lane_s32(vreinterpretq_s32_m128i(a), ((imm) >> 2) & 0x3), \
+-            ret, 1);                                                        \
+-        ret = vsetq_lane_s32(                                               \
++    vreinterpretq_m128i_s32(vsetq_lane_s32(                                 \
++        vgetq_lane_s32(vreinterpretq_s32_m128i(a), ((imm) >> 6) & 0x3),     \
++        vsetq_lane_s32(                                                     \
+             vgetq_lane_s32(vreinterpretq_s32_m128i(a), ((imm) >> 4) & 0x3), \
+-            ret, 2);                                                        \
+-        ret = vsetq_lane_s32(                                               \
+-            vgetq_lane_s32(vreinterpretq_s32_m128i(a), ((imm) >> 6) & 0x3), \
+-            ret, 3);                                                        \
+-        vreinterpretq_m128i_s32(ret);                                       \
+-    })
++            vsetq_lane_s32(vgetq_lane_s32(vreinterpretq_s32_m128i(a),       \
++                                          ((imm) >> 2) & 0x3),              \
++                           vmovq_n_s32(vgetq_lane_s32(                      \
++                               vreinterpretq_s32_m128i(a), (imm) & (0x3))), \
++                           1),                                              \
++            2),                                                             \
++        3))
+ 
+ // Takes the upper 64 bits of a and places it in the low end of the result
+ // Takes the lower 64 bits of a and places it into the high end of the result.
+@@ -1053,62 +1119,49 @@ FORCE_INLINE __m128i _mm_shuffle_epi_333
+     return vreinterpretq_m128i_s32(vcombine_s32(a32, a33));
+ }
+ 
+-// FORCE_INLINE __m128i _mm_shuffle_epi32_splat(__m128i a, __constrange(0,255)
+-// int imm)
+-#if defined(__aarch64__)
+-#define _mm_shuffle_epi32_splat(a, imm)                          \
+-    __extension__({                                              \
+-        vreinterpretq_m128i_s32(                                 \
+-            vdupq_laneq_s32(vreinterpretq_s32_m128i(a), (imm))); \
+-    })
+-#else
+-#define _mm_shuffle_epi32_splat(a, imm)                                      \
+-    __extension__({                                                          \
+-        vreinterpretq_m128i_s32(                                             \
+-            vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_m128i(a), (imm)))); \
+-    })
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
++#define _mm_shuffle_epi32_splat(a, imm) \
++    vreinterpretq_m128i_s32(vdupq_laneq_s32(vreinterpretq_s32_m128i(a), (imm)))
++#else
++#define _mm_shuffle_epi32_splat(a, imm) \
++    vreinterpretq_m128i_s32(            \
++        vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_m128i(a), (imm))))
+ #endif
+ 
+-// NEON does not support a general purpose permute intrinsic
+-// Selects four specific single-precision, floating-point values from a and b,
+-// based on the mask i.
++// NEON does not support a general purpose permute intrinsic.
++// Shuffle single-precision (32-bit) floating-point elements in a using the
++// control in imm8, and store the results in dst.
+ //
+ // C equivalent:
+ //   __m128 _mm_shuffle_ps_default(__m128 a, __m128 b,
+ //                                 __constrange(0, 255) int imm) {
+ //       __m128 ret;
+-//       ret[0] = a[imm        & 0x3];   ret[1] = a[(imm >> 2) & 0x3];
+-//       ret[2] = b[(imm >> 4) & 0x03];  ret[3] = b[(imm >> 6) & 0x03];
++//       ret[0] = a[(imm)        & 0x3];   ret[1] = a[((imm) >> 2) & 0x3];
++//       ret[2] = b[((imm) >> 4) & 0x03];  ret[3] = b[((imm) >> 6) & 0x03];
+ //       return ret;
+ //   }
+ //
+-// https://msdn.microsoft.com/en-us/library/vstudio/5f0858x0(v=vs.100).aspx
+-#define _mm_shuffle_ps_default(a, b, imm)                                  \
+-    __extension__({                                                        \
+-        float32x4_t ret;                                                   \
+-        ret = vmovq_n_f32(                                                 \
+-            vgetq_lane_f32(vreinterpretq_f32_m128(a), (imm) & (0x3)));     \
+-        ret = vsetq_lane_f32(                                              \
+-            vgetq_lane_f32(vreinterpretq_f32_m128(a), ((imm) >> 2) & 0x3), \
+-            ret, 1);                                                       \
+-        ret = vsetq_lane_f32(                                              \
+-            vgetq_lane_f32(vreinterpretq_f32_m128(b), ((imm) >> 4) & 0x3), \
+-            ret, 2);                                                       \
+-        ret = vsetq_lane_f32(                                              \
+-            vgetq_lane_f32(vreinterpretq_f32_m128(b), ((imm) >> 6) & 0x3), \
+-            ret, 3);                                                       \
+-        vreinterpretq_m128_f32(ret);                                       \
+-    })
+-
+-// Shuffles the lower 4 signed or unsigned 16-bit integers in a as specified
+-// by imm.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/y41dkk37(v=vs.100)
+-// FORCE_INLINE __m128i _mm_shufflelo_epi16_function(__m128i a,
+-//                                                   __constrange(0,255) int
+-//                                                   imm)
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_shuffle_ps
++#define _mm_shuffle_ps_default(a, b, imm)                                      \
++    vreinterpretq_m128_f32(vsetq_lane_f32(                                     \
++        vgetq_lane_f32(vreinterpretq_f32_m128(b), ((imm) >> 6) & 0x3),         \
++        vsetq_lane_f32(                                                        \
++            vgetq_lane_f32(vreinterpretq_f32_m128(b), ((imm) >> 4) & 0x3),     \
++            vsetq_lane_f32(                                                    \
++                vgetq_lane_f32(vreinterpretq_f32_m128(a), ((imm) >> 2) & 0x3), \
++                vmovq_n_f32(                                                   \
++                    vgetq_lane_f32(vreinterpretq_f32_m128(a), (imm) & (0x3))), \
++                1),                                                            \
++            2),                                                                \
++        3))
++
++// Shuffle 16-bit integers in the low 64 bits of a using the control in imm8.
++// Store the results in the low 64 bits of dst, with the high 64 bits being
++// copied from a to dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_shufflelo_epi16
+ #define _mm_shufflelo_epi16_function(a, imm)                                  \
+-    __extension__({                                                           \
+-        int16x8_t ret = vreinterpretq_s16_m128i(a);                           \
++    _sse2neon_define1(                                                        \
++        __m128i, a, int16x8_t ret = vreinterpretq_s16_m128i(_a);              \
+         int16x4_t lowBits = vget_low_s16(ret);                                \
+         ret = vsetq_lane_s16(vget_lane_s16(lowBits, (imm) & (0x3)), ret, 0);  \
+         ret = vsetq_lane_s16(vget_lane_s16(lowBits, ((imm) >> 2) & 0x3), ret, \
+@@ -1117,18 +1170,15 @@ FORCE_INLINE __m128i _mm_shuffle_epi_333
+                              2);                                              \
+         ret = vsetq_lane_s16(vget_lane_s16(lowBits, ((imm) >> 6) & 0x3), ret, \
+                              3);                                              \
+-        vreinterpretq_m128i_s16(ret);                                         \
+-    })
++        _sse2neon_return(vreinterpretq_m128i_s16(ret));)
+ 
+-// Shuffles the upper 4 signed or unsigned 16-bit integers in a as specified
+-// by imm.
+-// https://msdn.microsoft.com/en-us/library/13ywktbs(v=vs.100).aspx
+-// FORCE_INLINE __m128i _mm_shufflehi_epi16_function(__m128i a,
+-//                                                   __constrange(0,255) int
+-//                                                   imm)
++// Shuffle 16-bit integers in the high 64 bits of a using the control in imm8.
++// Store the results in the high 64 bits of dst, with the low 64 bits being
++// copied from a to dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_shufflehi_epi16
+ #define _mm_shufflehi_epi16_function(a, imm)                                   \
+-    __extension__({                                                            \
+-        int16x8_t ret = vreinterpretq_s16_m128i(a);                            \
++    _sse2neon_define1(                                                         \
++        __m128i, a, int16x8_t ret = vreinterpretq_s16_m128i(_a);               \
+         int16x4_t highBits = vget_high_s16(ret);                               \
+         ret = vsetq_lane_s16(vget_lane_s16(highBits, (imm) & (0x3)), ret, 4);  \
+         ret = vsetq_lane_s16(vget_lane_s16(highBits, ((imm) >> 2) & 0x3), ret, \
+@@ -1137,8 +1187,7 @@ FORCE_INLINE __m128i _mm_shuffle_epi_333
+                              6);                                               \
+         ret = vsetq_lane_s16(vget_lane_s16(highBits, ((imm) >> 6) & 0x3), ret, \
+                              7);                                               \
+-        vreinterpretq_m128i_s16(ret);                                          \
+-    })
++        _sse2neon_return(vreinterpretq_m128i_s16(ret));)
+ 
+ /* MMX */
+ 
+@@ -1147,22 +1196,19 @@ FORCE_INLINE void _mm_empty(void) {}
+ 
+ /* SSE */
+ 
+-// Adds the four single-precision, floating-point values of a and b.
+-//
+-//   r0 := a0 + b0
+-//   r1 := a1 + b1
+-//   r2 := a2 + b2
+-//   r3 := a3 + b3
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/c9848chc(v=vs.100).aspx
++// Add packed single-precision (32-bit) floating-point elements in a and b, and
++// store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_add_ps
+ FORCE_INLINE __m128 _mm_add_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_f32(
+         vaddq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
+ }
+ 
+-// adds the scalar single-precision floating point values of a and b.
+-// https://msdn.microsoft.com/en-us/library/be94x2y6(v=vs.100).aspx
++// Add the lower single-precision (32-bit) floating-point element in a and b,
++// store the result in the lower element of dst, and copy the upper 3 packed
++// elements from a to the upper elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_add_ss
+ FORCE_INLINE __m128 _mm_add_ss(__m128 a, __m128 b)
+ {
+     float32_t b0 = vgetq_lane_f32(vreinterpretq_f32_m128(b), 0);
+@@ -1171,30 +1217,18 @@ FORCE_INLINE __m128 _mm_add_ss(__m128 a,
+     return vreinterpretq_m128_f32(vaddq_f32(a, value));
+ }
+ 
+-// Computes the bitwise AND of the four single-precision, floating-point values
+-// of a and b.
+-//
+-//   r0 := a0 & b0
+-//   r1 := a1 & b1
+-//   r2 := a2 & b2
+-//   r3 := a3 & b3
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/73ck1xc5(v=vs.100).aspx
++// Compute the bitwise AND of packed single-precision (32-bit) floating-point
++// elements in a and b, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_and_ps
+ FORCE_INLINE __m128 _mm_and_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_s32(
+         vandq_s32(vreinterpretq_s32_m128(a), vreinterpretq_s32_m128(b)));
+ }
+ 
+-// Computes the bitwise AND-NOT of the four single-precision, floating-point
+-// values of a and b.
+-//
+-//   r0 := ~a0 & b0
+-//   r1 := ~a1 & b1
+-//   r2 := ~a2 & b2
+-//   r3 := ~a3 & b3
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/68h7wd02(v=vs.100).aspx
++// Compute the bitwise NOT of packed single-precision (32-bit) floating-point
++// elements in a and then AND with b, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_andnot_ps
+ FORCE_INLINE __m128 _mm_andnot_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_s32(
+@@ -1204,12 +1238,6 @@ FORCE_INLINE __m128 _mm_andnot_ps(__m128
+ 
+ // Average packed unsigned 16-bit integers in a and b, and store the results in
+ // dst.
+-//
+-//   FOR j := 0 to 3
+-//     i := j*16
+-//     dst[i+15:i] := (a[i+15:i] + b[i+15:i] + 1) >> 1
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_avg_pu16
+ FORCE_INLINE __m64 _mm_avg_pu16(__m64 a, __m64 b)
+ {
+@@ -1219,12 +1247,6 @@ FORCE_INLINE __m64 _mm_avg_pu16(__m64 a,
+ 
+ // Average packed unsigned 8-bit integers in a and b, and store the results in
+ // dst.
+-//
+-//   FOR j := 0 to 7
+-//     i := j*8
+-//     dst[i+7:i] := (a[i+7:i] + b[i+7:i] + 1) >> 1
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_avg_pu8
+ FORCE_INLINE __m64 _mm_avg_pu8(__m64 a, __m64 b)
+ {
+@@ -1232,173 +1254,192 @@ FORCE_INLINE __m64 _mm_avg_pu8(__m64 a,
+         vrhadd_u8(vreinterpret_u8_m64(a), vreinterpret_u8_m64(b)));
+ }
+ 
+-// Compares for equality.
+-// https://msdn.microsoft.com/en-us/library/vstudio/36aectz5(v=vs.100).aspx
++// Compare packed single-precision (32-bit) floating-point elements in a and b
++// for equality, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpeq_ps
+ FORCE_INLINE __m128 _mm_cmpeq_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_u32(
+         vceqq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
+ }
+ 
+-// Compares for equality.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/k423z28e(v=vs.100)
++// Compare the lower single-precision (32-bit) floating-point elements in a and
++// b for equality, store the result in the lower element of dst, and copy the
++// upper 3 packed elements from a to the upper elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpeq_ss
+ FORCE_INLINE __m128 _mm_cmpeq_ss(__m128 a, __m128 b)
+ {
+     return _mm_move_ss(a, _mm_cmpeq_ps(a, b));
+ }
+ 
+-// Compares for greater than or equal.
+-// https://msdn.microsoft.com/en-us/library/vstudio/fs813y2t(v=vs.100).aspx
++// Compare packed single-precision (32-bit) floating-point elements in a and b
++// for greater-than-or-equal, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpge_ps
+ FORCE_INLINE __m128 _mm_cmpge_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_u32(
+         vcgeq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
+ }
+ 
+-// Compares for greater than or equal.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/kesh3ddc(v=vs.100)
++// Compare the lower single-precision (32-bit) floating-point elements in a and
++// b for greater-than-or-equal, store the result in the lower element of dst,
++// and copy the upper 3 packed elements from a to the upper elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpge_ss
+ FORCE_INLINE __m128 _mm_cmpge_ss(__m128 a, __m128 b)
+ {
+     return _mm_move_ss(a, _mm_cmpge_ps(a, b));
+ }
+ 
+-// Compares for greater than.
+-//
+-//   r0 := (a0 > b0) ? 0xffffffff : 0x0
+-//   r1 := (a1 > b1) ? 0xffffffff : 0x0
+-//   r2 := (a2 > b2) ? 0xffffffff : 0x0
+-//   r3 := (a3 > b3) ? 0xffffffff : 0x0
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/11dy102s(v=vs.100).aspx
++// Compare packed single-precision (32-bit) floating-point elements in a and b
++// for greater-than, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpgt_ps
+ FORCE_INLINE __m128 _mm_cmpgt_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_u32(
+         vcgtq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
+ }
+ 
+-// Compares for greater than.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/1xyyyy9e(v=vs.100)
++// Compare the lower single-precision (32-bit) floating-point elements in a and
++// b for greater-than, store the result in the lower element of dst, and copy
++// the upper 3 packed elements from a to the upper elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpgt_ss
+ FORCE_INLINE __m128 _mm_cmpgt_ss(__m128 a, __m128 b)
+ {
+     return _mm_move_ss(a, _mm_cmpgt_ps(a, b));
+ }
+ 
+-// Compares for less than or equal.
+-//
+-//   r0 := (a0 <= b0) ? 0xffffffff : 0x0
+-//   r1 := (a1 <= b1) ? 0xffffffff : 0x0
+-//   r2 := (a2 <= b2) ? 0xffffffff : 0x0
+-//   r3 := (a3 <= b3) ? 0xffffffff : 0x0
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/1s75w83z(v=vs.100).aspx
++// Compare packed single-precision (32-bit) floating-point elements in a and b
++// for less-than-or-equal, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmple_ps
+ FORCE_INLINE __m128 _mm_cmple_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_u32(
+         vcleq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
+ }
+ 
+-// Compares for less than or equal.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/a7x0hbhw(v=vs.100)
++// Compare the lower single-precision (32-bit) floating-point elements in a and
++// b for less-than-or-equal, store the result in the lower element of dst, and
++// copy the upper 3 packed elements from a to the upper elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmple_ss
+ FORCE_INLINE __m128 _mm_cmple_ss(__m128 a, __m128 b)
+ {
+     return _mm_move_ss(a, _mm_cmple_ps(a, b));
+ }
+ 
+-// Compares for less than
+-// https://msdn.microsoft.com/en-us/library/vstudio/f330yhc8(v=vs.100).aspx
++// Compare packed single-precision (32-bit) floating-point elements in a and b
++// for less-than, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmplt_ps
+ FORCE_INLINE __m128 _mm_cmplt_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_u32(
+         vcltq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
+ }
+ 
+-// Compares for less than
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/fy94wye7(v=vs.100)
++// Compare the lower single-precision (32-bit) floating-point elements in a and
++// b for less-than, store the result in the lower element of dst, and copy the
++// upper 3 packed elements from a to the upper elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmplt_ss
+ FORCE_INLINE __m128 _mm_cmplt_ss(__m128 a, __m128 b)
+ {
+     return _mm_move_ss(a, _mm_cmplt_ps(a, b));
+ }
+ 
+-// Compares for inequality.
+-// https://msdn.microsoft.com/en-us/library/sf44thbx(v=vs.100).aspx
++// Compare packed single-precision (32-bit) floating-point elements in a and b
++// for not-equal, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpneq_ps
+ FORCE_INLINE __m128 _mm_cmpneq_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_u32(vmvnq_u32(
+         vceqq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b))));
+ }
+ 
+-// Compares for inequality.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/ekya8fh4(v=vs.100)
++// Compare the lower single-precision (32-bit) floating-point elements in a and
++// b for not-equal, store the result in the lower element of dst, and copy the
++// upper 3 packed elements from a to the upper elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpneq_ss
+ FORCE_INLINE __m128 _mm_cmpneq_ss(__m128 a, __m128 b)
+ {
+     return _mm_move_ss(a, _mm_cmpneq_ps(a, b));
+ }
+ 
+-// Compares for not greater than or equal.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/wsexys62(v=vs.100)
++// Compare packed single-precision (32-bit) floating-point elements in a and b
++// for not-greater-than-or-equal, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpnge_ps
+ FORCE_INLINE __m128 _mm_cmpnge_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_u32(vmvnq_u32(
+         vcgeq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b))));
+ }
+ 
+-// Compares for not greater than or equal.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/fk2y80s8(v=vs.100)
++// Compare the lower single-precision (32-bit) floating-point elements in a and
++// b for not-greater-than-or-equal, store the result in the lower element of
++// dst, and copy the upper 3 packed elements from a to the upper elements of
++// dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpnge_ss
+ FORCE_INLINE __m128 _mm_cmpnge_ss(__m128 a, __m128 b)
+ {
+     return _mm_move_ss(a, _mm_cmpnge_ps(a, b));
+ }
+ 
+-// Compares for not greater than.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/d0xh7w0s(v=vs.100)
++// Compare packed single-precision (32-bit) floating-point elements in a and b
++// for not-greater-than, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpngt_ps
+ FORCE_INLINE __m128 _mm_cmpngt_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_u32(vmvnq_u32(
+         vcgtq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b))));
+ }
+ 
+-// Compares for not greater than.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/z7x9ydwh(v=vs.100)
++// Compare the lower single-precision (32-bit) floating-point elements in a and
++// b for not-greater-than, store the result in the lower element of dst, and
++// copy the upper 3 packed elements from a to the upper elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpngt_ss
+ FORCE_INLINE __m128 _mm_cmpngt_ss(__m128 a, __m128 b)
+ {
+     return _mm_move_ss(a, _mm_cmpngt_ps(a, b));
+ }
+ 
+-// Compares for not less than or equal.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/6a330kxw(v=vs.100)
++// Compare packed single-precision (32-bit) floating-point elements in a and b
++// for not-less-than-or-equal, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpnle_ps
+ FORCE_INLINE __m128 _mm_cmpnle_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_u32(vmvnq_u32(
+         vcleq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b))));
+ }
+ 
+-// Compares for not less than or equal.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/z7x9ydwh(v=vs.100)
++// Compare the lower single-precision (32-bit) floating-point elements in a and
++// b for not-less-than-or-equal, store the result in the lower element of dst,
++// and copy the upper 3 packed elements from a to the upper elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpnle_ss
+ FORCE_INLINE __m128 _mm_cmpnle_ss(__m128 a, __m128 b)
+ {
+     return _mm_move_ss(a, _mm_cmpnle_ps(a, b));
+ }
+ 
+-// Compares for not less than.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/4686bbdw(v=vs.100)
++// Compare packed single-precision (32-bit) floating-point elements in a and b
++// for not-less-than, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpnlt_ps
+ FORCE_INLINE __m128 _mm_cmpnlt_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_u32(vmvnq_u32(
+         vcltq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b))));
+ }
+ 
+-// Compares for not less than.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/56b9z2wf(v=vs.100)
++// Compare the lower single-precision (32-bit) floating-point elements in a and
++// b for not-less-than, store the result in the lower element of dst, and copy
++// the upper 3 packed elements from a to the upper elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpnlt_ss
+ FORCE_INLINE __m128 _mm_cmpnlt_ss(__m128 a, __m128 b)
+ {
+     return _mm_move_ss(a, _mm_cmpnlt_ps(a, b));
+ }
+ 
+-// Compares the four 32-bit floats in a and b to check if any values are NaN.
+-// Ordered compare between each value returns true for "orderable" and false for
+-// "not orderable" (NaN).
+-// https://msdn.microsoft.com/en-us/library/vstudio/0h9w00fx(v=vs.100).aspx see
+-// also:
++// Compare packed single-precision (32-bit) floating-point elements in a and b
++// to see if neither is NaN, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpord_ps
++//
++// See also:
+ // http://stackoverflow.com/questions/8627331/what-does-ordered-unordered-comparison-mean
+ // http://stackoverflow.com/questions/29349621/neon-isnanval-intrinsics
+ FORCE_INLINE __m128 _mm_cmpord_ps(__m128 a, __m128 b)
+@@ -1413,15 +1454,18 @@ FORCE_INLINE __m128 _mm_cmpord_ps(__m128
+     return vreinterpretq_m128_u32(vandq_u32(ceqaa, ceqbb));
+ }
+ 
+-// Compares for ordered.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/343t62da(v=vs.100)
++// Compare the lower single-precision (32-bit) floating-point elements in a and
++// b to see if neither is NaN, store the result in the lower element of dst, and
++// copy the upper 3 packed elements from a to the upper elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpord_ss
+ FORCE_INLINE __m128 _mm_cmpord_ss(__m128 a, __m128 b)
+ {
+     return _mm_move_ss(a, _mm_cmpord_ps(a, b));
+ }
+ 
+-// Compares for unordered.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/khy6fk1t(v=vs.100)
++// Compare packed single-precision (32-bit) floating-point elements in a and b
++// to see if either is NaN, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpunord_ps
+ FORCE_INLINE __m128 _mm_cmpunord_ps(__m128 a, __m128 b)
+ {
+     uint32x4_t f32a =
+@@ -1431,16 +1475,18 @@ FORCE_INLINE __m128 _mm_cmpunord_ps(__m1
+     return vreinterpretq_m128_u32(vmvnq_u32(vandq_u32(f32a, f32b)));
+ }
+ 
+-// Compares for unordered.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/2as2387b(v=vs.100)
++// Compare the lower single-precision (32-bit) floating-point elements in a and
++// b to see if either is NaN, store the result in the lower element of dst, and
++// copy the upper 3 packed elements from a to the upper elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpunord_ss
+ FORCE_INLINE __m128 _mm_cmpunord_ss(__m128 a, __m128 b)
+ {
+     return _mm_move_ss(a, _mm_cmpunord_ps(a, b));
+ }
+ 
+-// Compares the lower single-precision floating point scalar values of a and b
+-// using an equality operation. :
+-// https://msdn.microsoft.com/en-us/library/93yx2h2b(v=vs.100).aspx
++// Compare the lower single-precision (32-bit) floating-point element in a and b
++// for equality, and return the boolean result (0 or 1).
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_comieq_ss
+ FORCE_INLINE int _mm_comieq_ss(__m128 a, __m128 b)
+ {
+     uint32x4_t a_eq_b =
+@@ -1448,9 +1494,9 @@ FORCE_INLINE int _mm_comieq_ss(__m128 a,
+     return vgetq_lane_u32(a_eq_b, 0) & 0x1;
+ }
+ 
+-// Compares the lower single-precision floating point scalar values of a and b
+-// using a greater than or equal operation. :
+-// https://msdn.microsoft.com/en-us/library/8t80des6(v=vs.100).aspx
++// Compare the lower single-precision (32-bit) floating-point element in a and b
++// for greater-than-or-equal, and return the boolean result (0 or 1).
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_comige_ss
+ FORCE_INLINE int _mm_comige_ss(__m128 a, __m128 b)
+ {
+     uint32x4_t a_ge_b =
+@@ -1458,9 +1504,9 @@ FORCE_INLINE int _mm_comige_ss(__m128 a,
+     return vgetq_lane_u32(a_ge_b, 0) & 0x1;
+ }
+ 
+-// Compares the lower single-precision floating point scalar values of a and b
+-// using a greater than operation. :
+-// https://msdn.microsoft.com/en-us/library/b0738e0t(v=vs.100).aspx
++// Compare the lower single-precision (32-bit) floating-point element in a and b
++// for greater-than, and return the boolean result (0 or 1).
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_comigt_ss
+ FORCE_INLINE int _mm_comigt_ss(__m128 a, __m128 b)
+ {
+     uint32x4_t a_gt_b =
+@@ -1468,9 +1514,9 @@ FORCE_INLINE int _mm_comigt_ss(__m128 a,
+     return vgetq_lane_u32(a_gt_b, 0) & 0x1;
+ }
+ 
+-// Compares the lower single-precision floating point scalar values of a and b
+-// using a less than or equal operation. :
+-// https://msdn.microsoft.com/en-us/library/1w4t7c57(v=vs.90).aspx
++// Compare the lower single-precision (32-bit) floating-point element in a and b
++// for less-than-or-equal, and return the boolean result (0 or 1).
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_comile_ss
+ FORCE_INLINE int _mm_comile_ss(__m128 a, __m128 b)
+ {
+     uint32x4_t a_le_b =
+@@ -1478,11 +1524,9 @@ FORCE_INLINE int _mm_comile_ss(__m128 a,
+     return vgetq_lane_u32(a_le_b, 0) & 0x1;
+ }
+ 
+-// Compares the lower single-precision floating point scalar values of a and b
+-// using a less than operation. :
+-// https://msdn.microsoft.com/en-us/library/2kwe606b(v=vs.90).aspx Important
+-// note!! The documentation on MSDN is incorrect!  If either of the values is a
+-// NAN the docs say you will get a one, but in fact, it will return a zero!!
++// Compare the lower single-precision (32-bit) floating-point element in a and b
++// for less-than, and return the boolean result (0 or 1).
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_comilt_ss
+ FORCE_INLINE int _mm_comilt_ss(__m128 a, __m128 b)
+ {
+     uint32x4_t a_lt_b =
+@@ -1490,9 +1534,9 @@ FORCE_INLINE int _mm_comilt_ss(__m128 a,
+     return vgetq_lane_u32(a_lt_b, 0) & 0x1;
+ }
+ 
+-// Compares the lower single-precision floating point scalar values of a and b
+-// using an inequality operation. :
+-// https://msdn.microsoft.com/en-us/library/bafh5e0a(v=vs.90).aspx
++// Compare the lower single-precision (32-bit) floating-point element in a and b
++// for not-equal, and return the boolean result (0 or 1).
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_comineq_ss
+ FORCE_INLINE int _mm_comineq_ss(__m128 a, __m128 b)
+ {
+     return !_mm_comieq_ss(a, b);
+@@ -1502,12 +1546,6 @@ FORCE_INLINE int _mm_comineq_ss(__m128 a
+ // (32-bit) floating-point elements, store the results in the lower 2 elements
+ // of dst, and copy the upper 2 packed elements from a to the upper elements of
+ // dst.
+-//
+-//   dst[31:0] := Convert_Int32_To_FP32(b[31:0])
+-//   dst[63:32] := Convert_Int32_To_FP32(b[63:32])
+-//   dst[95:64] := a[95:64]
+-//   dst[127:96] := a[127:96]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvt_pi2ps
+ FORCE_INLINE __m128 _mm_cvt_pi2ps(__m128 a, __m64 b)
+ {
+@@ -1518,16 +1556,11 @@ FORCE_INLINE __m128 _mm_cvt_pi2ps(__m128
+ 
+ // Convert packed single-precision (32-bit) floating-point elements in a to
+ // packed 32-bit integers, and store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-//       i := 32*j
+-//       dst[i+31:i] := Convert_FP32_To_Int32(a[i+31:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvt_ps2pi
+ FORCE_INLINE __m64 _mm_cvt_ps2pi(__m128 a)
+ {
+-#if defined(__aarch64__) || defined(__ARM_FEATURE_DIRECTED_ROUNDING)
++#if (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)) || \
++    defined(__ARM_FEATURE_DIRECTED_ROUNDING)
+     return vreinterpret_m64_s32(
+         vget_low_s32(vcvtnq_s32_f32(vrndiq_f32(vreinterpretq_f32_m128(a)))));
+ #else
+@@ -1539,10 +1572,6 @@ FORCE_INLINE __m64 _mm_cvt_ps2pi(__m128
+ // Convert the signed 32-bit integer b to a single-precision (32-bit)
+ // floating-point element, store the result in the lower element of dst, and
+ // copy the upper 3 packed elements from a to the upper elements of dst.
+-//
+-//   dst[31:0] := Convert_Int32_To_FP32(b[31:0])
+-//   dst[127:32] := a[127:32]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvt_si2ss
+ FORCE_INLINE __m128 _mm_cvt_si2ss(__m128 a, int b)
+ {
+@@ -1555,7 +1584,8 @@ FORCE_INLINE __m128 _mm_cvt_si2ss(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvt_ss2si
+ FORCE_INLINE int _mm_cvt_ss2si(__m128 a)
+ {
+-#if defined(__aarch64__) || defined(__ARM_FEATURE_DIRECTED_ROUNDING)
++#if (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)) || \
++    defined(__ARM_FEATURE_DIRECTED_ROUNDING)
+     return vgetq_lane_s32(vcvtnq_s32_f32(vrndiq_f32(vreinterpretq_f32_m128(a))),
+                           0);
+ #else
+@@ -1567,13 +1597,6 @@ FORCE_INLINE int _mm_cvt_ss2si(__m128 a)
+ 
+ // Convert packed 16-bit integers in a to packed single-precision (32-bit)
+ // floating-point elements, and store the results in dst.
+-//
+-//   FOR j := 0 to 3
+-//      i := j*16
+-//      m := j*32
+-//      dst[m+31:m] := Convert_Int16_To_FP32(a[i+15:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtpi16_ps
+ FORCE_INLINE __m128 _mm_cvtpi16_ps(__m64 a)
+ {
+@@ -1584,12 +1607,6 @@ FORCE_INLINE __m128 _mm_cvtpi16_ps(__m64
+ // Convert packed 32-bit integers in b to packed single-precision (32-bit)
+ // floating-point elements, store the results in the lower 2 elements of dst,
+ // and copy the upper 2 packed elements from a to the upper elements of dst.
+-//
+-//   dst[31:0] := Convert_Int32_To_FP32(b[31:0])
+-//   dst[63:32] := Convert_Int32_To_FP32(b[63:32])
+-//   dst[95:64] := a[95:64]
+-//   dst[127:96] := a[127:96]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtpi32_ps
+ FORCE_INLINE __m128 _mm_cvtpi32_ps(__m128 a, __m64 b)
+ {
+@@ -1603,12 +1620,6 @@ FORCE_INLINE __m128 _mm_cvtpi32_ps(__m12
+ // of dst, then convert the packed signed 32-bit integers in b to
+ // single-precision (32-bit) floating-point element, and store the results in
+ // the upper 2 elements of dst.
+-//
+-//   dst[31:0] := Convert_Int32_To_FP32(a[31:0])
+-//   dst[63:32] := Convert_Int32_To_FP32(a[63:32])
+-//   dst[95:64] := Convert_Int32_To_FP32(b[31:0])
+-//   dst[127:96] := Convert_Int32_To_FP32(b[63:32])
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtpi32x2_ps
+ FORCE_INLINE __m128 _mm_cvtpi32x2_ps(__m64 a, __m64 b)
+ {
+@@ -1618,13 +1629,6 @@ FORCE_INLINE __m128 _mm_cvtpi32x2_ps(__m
+ 
+ // Convert the lower packed 8-bit integers in a to packed single-precision
+ // (32-bit) floating-point elements, and store the results in dst.
+-//
+-//   FOR j := 0 to 3
+-//      i := j*8
+-//      m := j*32
+-//      dst[m+31:m] := Convert_Int8_To_FP32(a[i+7:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtpi8_ps
+ FORCE_INLINE __m128 _mm_cvtpi8_ps(__m64 a)
+ {
+@@ -1636,17 +1640,6 @@ FORCE_INLINE __m128 _mm_cvtpi8_ps(__m64
+ // packed 16-bit integers, and store the results in dst. Note: this intrinsic
+ // will generate 0x7FFF, rather than 0x8000, for input values between 0x7FFF and
+ // 0x7FFFFFFF.
+-//
+-//   FOR j := 0 to 3
+-//     i := 16*j
+-//     k := 32*j
+-//     IF a[k+31:k] >= FP32(0x7FFF) && a[k+31:k] <= FP32(0x7FFFFFFF)
+-//       dst[i+15:i] := 0x7FFF
+-//     ELSE
+-//       dst[i+15:i] := Convert_FP32_To_Int16(a[k+31:k])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtps_pi16
+ FORCE_INLINE __m64 _mm_cvtps_pi16(__m128 a)
+ {
+@@ -1656,12 +1649,6 @@ FORCE_INLINE __m64 _mm_cvtps_pi16(__m128
+ 
+ // Convert packed single-precision (32-bit) floating-point elements in a to
+ // packed 32-bit integers, and store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-//       i := 32*j
+-//       dst[i+31:i] := Convert_FP32_To_Int32(a[i+31:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtps_pi32
+ #define _mm_cvtps_pi32(a) _mm_cvt_ps2pi(a)
+ 
+@@ -1669,17 +1656,6 @@ FORCE_INLINE __m64 _mm_cvtps_pi16(__m128
+ // packed 8-bit integers, and store the results in lower 4 elements of dst.
+ // Note: this intrinsic will generate 0x7F, rather than 0x80, for input values
+ // between 0x7F and 0x7FFFFFFF.
+-//
+-//   FOR j := 0 to 3
+-//     i := 8*j
+-//     k := 32*j
+-//     IF a[k+31:k] >= FP32(0x7F) && a[k+31:k] <= FP32(0x7FFFFFFF)
+-//       dst[i+7:i] := 0x7F
+-//     ELSE
+-//       dst[i+7:i] := Convert_FP32_To_Int8(a[k+31:k])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtps_pi8
+ FORCE_INLINE __m64 _mm_cvtps_pi8(__m128 a)
+ {
+@@ -1689,13 +1665,6 @@ FORCE_INLINE __m64 _mm_cvtps_pi8(__m128
+ 
+ // Convert packed unsigned 16-bit integers in a to packed single-precision
+ // (32-bit) floating-point elements, and store the results in dst.
+-//
+-//   FOR j := 0 to 3
+-//      i := j*16
+-//      m := j*32
+-//      dst[m+31:m] := Convert_UInt16_To_FP32(a[i+15:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtpu16_ps
+ FORCE_INLINE __m128 _mm_cvtpu16_ps(__m64 a)
+ {
+@@ -1706,13 +1675,6 @@ FORCE_INLINE __m128 _mm_cvtpu16_ps(__m64
+ // Convert the lower packed unsigned 8-bit integers in a to packed
+ // single-precision (32-bit) floating-point elements, and store the results in
+ // dst.
+-//
+-//   FOR j := 0 to 3
+-//      i := j*8
+-//      m := j*32
+-//      dst[m+31:m] := Convert_UInt8_To_FP32(a[i+7:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtpu8_ps
+ FORCE_INLINE __m128 _mm_cvtpu8_ps(__m64 a)
+ {
+@@ -1723,20 +1685,12 @@ FORCE_INLINE __m128 _mm_cvtpu8_ps(__m64
+ // Convert the signed 32-bit integer b to a single-precision (32-bit)
+ // floating-point element, store the result in the lower element of dst, and
+ // copy the upper 3 packed elements from a to the upper elements of dst.
+-//
+-//   dst[31:0] := Convert_Int32_To_FP32(b[31:0])
+-//   dst[127:32] := a[127:32]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsi32_ss
+ #define _mm_cvtsi32_ss(a, b) _mm_cvt_si2ss(a, b)
+ 
+ // Convert the signed 64-bit integer b to a single-precision (32-bit)
+ // floating-point element, store the result in the lower element of dst, and
+ // copy the upper 3 packed elements from a to the upper elements of dst.
+-//
+-//   dst[31:0] := Convert_Int64_To_FP32(b[63:0])
+-//   dst[127:32] := a[127:32]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsi64_ss
+ FORCE_INLINE __m128 _mm_cvtsi64_ss(__m128 a, int64_t b)
+ {
+@@ -1745,9 +1699,6 @@ FORCE_INLINE __m128 _mm_cvtsi64_ss(__m12
+ }
+ 
+ // Copy the lower single-precision (32-bit) floating-point element of a to dst.
+-//
+-//   dst[31:0] := a[31:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtss_f32
+ FORCE_INLINE float _mm_cvtss_f32(__m128 a)
+ {
+@@ -1756,21 +1707,16 @@ FORCE_INLINE float _mm_cvtss_f32(__m128
+ 
+ // Convert the lower single-precision (32-bit) floating-point element in a to a
+ // 32-bit integer, and store the result in dst.
+-//
+-//   dst[31:0] := Convert_FP32_To_Int32(a[31:0])
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtss_si32
+ #define _mm_cvtss_si32(a) _mm_cvt_ss2si(a)
+ 
+ // Convert the lower single-precision (32-bit) floating-point element in a to a
+ // 64-bit integer, and store the result in dst.
+-//
+-//   dst[63:0] := Convert_FP32_To_Int64(a[31:0])
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtss_si64
+ FORCE_INLINE int64_t _mm_cvtss_si64(__m128 a)
+ {
+-#if defined(__aarch64__) || defined(__ARM_FEATURE_DIRECTED_ROUNDING)
++#if (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)) || \
++    defined(__ARM_FEATURE_DIRECTED_ROUNDING)
+     return (int64_t) vgetq_lane_f32(vrndiq_f32(vreinterpretq_f32_m128(a)), 0);
+ #else
+     float32_t data = vgetq_lane_f32(
+@@ -1781,12 +1727,6 @@ FORCE_INLINE int64_t _mm_cvtss_si64(__m1
+ 
+ // Convert packed single-precision (32-bit) floating-point elements in a to
+ // packed 32-bit integers with truncation, and store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-//      i := 32*j
+-//      dst[i+31:i] := Convert_FP32_To_Int32_Truncate(a[i+31:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtt_ps2pi
+ FORCE_INLINE __m64 _mm_cvtt_ps2pi(__m128 a)
+ {
+@@ -1796,9 +1736,6 @@ FORCE_INLINE __m64 _mm_cvtt_ps2pi(__m128
+ 
+ // Convert the lower single-precision (32-bit) floating-point element in a to a
+ // 32-bit integer with truncation, and store the result in dst.
+-//
+-//   dst[31:0] := Convert_FP32_To_Int32_Truncate(a[31:0])
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtt_ss2si
+ FORCE_INLINE int _mm_cvtt_ss2si(__m128 a)
+ {
+@@ -1807,60 +1744,49 @@ FORCE_INLINE int _mm_cvtt_ss2si(__m128 a
+ 
+ // Convert packed single-precision (32-bit) floating-point elements in a to
+ // packed 32-bit integers with truncation, and store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-//      i := 32*j
+-//      dst[i+31:i] := Convert_FP32_To_Int32_Truncate(a[i+31:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvttps_pi32
+ #define _mm_cvttps_pi32(a) _mm_cvtt_ps2pi(a)
+ 
+ // Convert the lower single-precision (32-bit) floating-point element in a to a
+ // 32-bit integer with truncation, and store the result in dst.
+-//
+-//   dst[31:0] := Convert_FP32_To_Int32_Truncate(a[31:0])
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvttss_si32
+ #define _mm_cvttss_si32(a) _mm_cvtt_ss2si(a)
+ 
+ // Convert the lower single-precision (32-bit) floating-point element in a to a
+ // 64-bit integer with truncation, and store the result in dst.
+-//
+-//   dst[63:0] := Convert_FP32_To_Int64_Truncate(a[31:0])
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvttss_si64
+ FORCE_INLINE int64_t _mm_cvttss_si64(__m128 a)
+ {
+     return (int64_t) vgetq_lane_f32(vreinterpretq_f32_m128(a), 0);
+ }
+ 
+-// Divides the four single-precision, floating-point values of a and b.
+-//
+-//   r0 := a0 / b0
+-//   r1 := a1 / b1
+-//   r2 := a2 / b2
+-//   r3 := a3 / b3
+-//
+-// https://msdn.microsoft.com/en-us/library/edaw8147(v=vs.100).aspx
++// Divide packed single-precision (32-bit) floating-point elements in a by
++// packed elements in b, and store the results in dst.
++// Due to ARMv7-A NEON's lack of a precise division intrinsic, we implement
++// division by multiplying a by b's reciprocal before using the Newton-Raphson
++// method to approximate the results.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_div_ps
+ FORCE_INLINE __m128 _mm_div_ps(__m128 a, __m128 b)
+ {
+-#if defined(__aarch64__) && !SSE2NEON_PRECISE_DIV
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128_f32(
+         vdivq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
+ #else
+     float32x4_t recip = vrecpeq_f32(vreinterpretq_f32_m128(b));
+     recip = vmulq_f32(recip, vrecpsq_f32(recip, vreinterpretq_f32_m128(b)));
+-#if SSE2NEON_PRECISE_DIV
+     // Additional Netwon-Raphson iteration for accuracy
+     recip = vmulq_f32(recip, vrecpsq_f32(recip, vreinterpretq_f32_m128(b)));
+-#endif
+     return vreinterpretq_m128_f32(vmulq_f32(vreinterpretq_f32_m128(a), recip));
+ #endif
+ }
+ 
+-// Divides the scalar single-precision floating point value of a by b.
+-// https://msdn.microsoft.com/en-us/library/4y73xa49(v=vs.100).aspx
++// Divide the lower single-precision (32-bit) floating-point element in a by the
++// lower single-precision (32-bit) floating-point element in b, store the result
++// in the lower element of dst, and copy the upper 3 packed elements from a to
++// the upper elements of dst.
++// Warning: ARMv7-A does not produce the same result compared to Intel and not
++// IEEE-compliant.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_div_ss
+ FORCE_INLINE __m128 _mm_div_ss(__m128 a, __m128 b)
+ {
+     float32_t value =
+@@ -1880,27 +1806,51 @@ FORCE_INLINE __m128 _mm_div_ss(__m128 a,
+ #if !defined(SSE2NEON_ALLOC_DEFINED)
+ FORCE_INLINE void _mm_free(void *addr)
+ {
++#if defined(_WIN32)
++    _aligned_free(addr);
++#else
+     free(addr);
++#endif
+ }
+ #endif
+ 
++FORCE_INLINE uint64_t _sse2neon_get_fpcr(void)
++{
++    uint64_t value;
++#if defined(_MSC_VER) && !defined(__clang__)
++    value = _ReadStatusReg(ARM64_FPCR);
++#else
++    __asm__ __volatile__("mrs %0, FPCR" : "=r"(value)); /* read */
++#endif
++    return value;
++}
++
++FORCE_INLINE void _sse2neon_set_fpcr(uint64_t value)
++{
++#if defined(_MSC_VER) && !defined(__clang__)
++    _WriteStatusReg(ARM64_FPCR, value);
++#else
++    __asm__ __volatile__("msr FPCR, %0" ::"r"(value)); /* write */
++#endif
++}
++
+ // Macro: Get the flush zero bits from the MXCSR control and status register.
+ // The flush zero may contain any of the following flags: _MM_FLUSH_ZERO_ON or
+ // _MM_FLUSH_ZERO_OFF
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_MM_GET_FLUSH_ZERO_MODE
+-FORCE_INLINE unsigned int _sse2neon_mm_get_flush_zero_mode()
++FORCE_INLINE unsigned int _sse2neon_mm_get_flush_zero_mode(void)
+ {
+     union {
+         fpcr_bitfield field;
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+         uint64_t value;
+ #else
+         uint32_t value;
+ #endif
+     } r;
+ 
+-#if defined(__aarch64__)
+-    __asm__ __volatile__("mrs %0, FPCR" : "=r"(r.value)); /* read */
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
++    r.value = _sse2neon_get_fpcr();
+ #else
+     __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(r.value)); /* read */
+ #endif
+@@ -1912,41 +1862,35 @@ FORCE_INLINE unsigned int _sse2neon_mm_g
+ // The rounding mode may contain any of the following flags: _MM_ROUND_NEAREST,
+ // _MM_ROUND_DOWN, _MM_ROUND_UP, _MM_ROUND_TOWARD_ZERO
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_MM_GET_ROUNDING_MODE
+-FORCE_INLINE unsigned int _MM_GET_ROUNDING_MODE()
++FORCE_INLINE unsigned int _MM_GET_ROUNDING_MODE(void)
+ {
+-    union {
+-        fpcr_bitfield field;
+-#if defined(__aarch64__)
+-        uint64_t value;
+-#else
+-        uint32_t value;
+-#endif
+-    } r;
+-
+-#if defined(__aarch64__)
+-    __asm__ __volatile__("mrs %0, FPCR" : "=r"(r.value)); /* read */
+-#else
+-    __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(r.value)); /* read */
+-#endif
+-
+-    if (r.field.bit22) {
+-        return r.field.bit23 ? _MM_ROUND_TOWARD_ZERO : _MM_ROUND_UP;
+-    } else {
+-        return r.field.bit23 ? _MM_ROUND_DOWN : _MM_ROUND_NEAREST;
++    switch (fegetround()) {
++    case FE_TONEAREST:
++        return _MM_ROUND_NEAREST;
++    case FE_DOWNWARD:
++        return _MM_ROUND_DOWN;
++    case FE_UPWARD:
++        return _MM_ROUND_UP;
++    case FE_TOWARDZERO:
++        return _MM_ROUND_TOWARD_ZERO;
++    default:
++        // fegetround() must return _MM_ROUND_NEAREST, _MM_ROUND_DOWN,
++        // _MM_ROUND_UP, _MM_ROUND_TOWARD_ZERO on success. all the other error
++        // cases we treat them as FE_TOWARDZERO (truncate).
++        return _MM_ROUND_TOWARD_ZERO;
+     }
+ }
+ 
+ // Copy a to dst, and insert the 16-bit integer i into dst at the location
+ // specified by imm8.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_insert_pi16
+-#define _mm_insert_pi16(a, b, imm)                               \
+-    __extension__({                                              \
+-        vreinterpret_m64_s16(                                    \
+-            vset_lane_s16((b), vreinterpret_s16_m64(a), (imm))); \
+-    })
++#define _mm_insert_pi16(a, b, imm) \
++    vreinterpret_m64_s16(vset_lane_s16((b), vreinterpret_s16_m64(a), (imm)))
+ 
+-// Loads four single-precision, floating-point values.
+-// https://msdn.microsoft.com/en-us/library/vstudio/zzd50xxt(v=vs.100).aspx
++// Load 128-bits (composed of 4 packed single-precision (32-bit) floating-point
++// elements) from memory into dst. mem_addr must be aligned on a 16-byte
++// boundary or a general-protection exception may be generated.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_load_ps
+ FORCE_INLINE __m128 _mm_load_ps(const float *p)
+ {
+     return vreinterpretq_m128_f32(vld1q_f32(p));
+@@ -1963,49 +1907,37 @@ FORCE_INLINE __m128 _mm_load_ps(const fl
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_load_ps1
+ #define _mm_load_ps1 _mm_load1_ps
+ 
+-// Loads an single - precision, floating - point value into the low word and
+-// clears the upper three words.
+-// https://msdn.microsoft.com/en-us/library/548bb9h4%28v=vs.90%29.aspx
++// Load a single-precision (32-bit) floating-point element from memory into the
++// lower of dst, and zero the upper 3 elements. mem_addr does not need to be
++// aligned on any particular boundary.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_load_ss
+ FORCE_INLINE __m128 _mm_load_ss(const float *p)
+ {
+     return vreinterpretq_m128_f32(vsetq_lane_f32(*p, vdupq_n_f32(0), 0));
+ }
+ 
+-// Loads a single single-precision, floating-point value, copying it into all
+-// four words
+-// https://msdn.microsoft.com/en-us/library/vstudio/5cdkf716(v=vs.100).aspx
++// Load a single-precision (32-bit) floating-point element from memory into all
++// elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_load1_ps
+ FORCE_INLINE __m128 _mm_load1_ps(const float *p)
+ {
+     return vreinterpretq_m128_f32(vld1q_dup_f32(p));
+ }
+ 
+-// Sets the upper two single-precision, floating-point values with 64
+-// bits of data loaded from the address p; the lower two values are passed
+-// through from a.
+-//
+-//   r0 := a0
+-//   r1 := a1
+-//   r2 := *p0
+-//   r3 := *p1
+-//
+-// https://msdn.microsoft.com/en-us/library/w92wta0x(v%3dvs.100).aspx
++// Load 2 single-precision (32-bit) floating-point elements from memory into the
++// upper 2 elements of dst, and copy the lower 2 elements from a to dst.
++// mem_addr does not need to be aligned on any particular boundary.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadh_pi
+ FORCE_INLINE __m128 _mm_loadh_pi(__m128 a, __m64 const *p)
+ {
+     return vreinterpretq_m128_f32(
+         vcombine_f32(vget_low_f32(a), vld1_f32((const float32_t *) p)));
+ }
+ 
+-// Sets the lower two single-precision, floating-point values with 64
+-// bits of data loaded from the address p; the upper two values are passed
+-// through from a.
+-//
+-// Return Value
+-//   r0 := *p0
+-//   r1 := *p1
+-//   r2 := a2
+-//   r3 := a3
+-//
+-// https://msdn.microsoft.com/en-us/library/s57cyak2(v=vs.100).aspx
++// Load 2 single-precision (32-bit) floating-point elements from memory into the
++// lower 2 elements of dst, and copy the upper 2 elements from a to dst.
++// mem_addr does not need to be aligned on any particular boundary.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadl_pi
+ FORCE_INLINE __m128 _mm_loadl_pi(__m128 a, __m64 const *p)
+ {
+     return vreinterpretq_m128_f32(
+@@ -2015,12 +1947,6 @@ FORCE_INLINE __m128 _mm_loadl_pi(__m128
+ // Load 4 single-precision (32-bit) floating-point elements from memory into dst
+ // in reverse order. mem_addr must be aligned on a 16-byte boundary or a
+ // general-protection exception may be generated.
+-//
+-//   dst[31:0] := MEM[mem_addr+127:mem_addr+96]
+-//   dst[63:32] := MEM[mem_addr+95:mem_addr+64]
+-//   dst[95:64] := MEM[mem_addr+63:mem_addr+32]
+-//   dst[127:96] := MEM[mem_addr+31:mem_addr]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadr_ps
+ FORCE_INLINE __m128 _mm_loadr_ps(const float *p)
+ {
+@@ -2028,8 +1954,10 @@ FORCE_INLINE __m128 _mm_loadr_ps(const f
+     return vreinterpretq_m128_f32(vextq_f32(v, v, 2));
+ }
+ 
+-// Loads four single-precision, floating-point values.
+-// https://msdn.microsoft.com/en-us/library/x1b16s7z%28v=vs.90%29.aspx
++// Load 128-bits (composed of 4 packed single-precision (32-bit) floating-point
++// elements) from memory into dst. mem_addr does not need to be aligned on any
++// particular boundary.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_ps
+ FORCE_INLINE __m128 _mm_loadu_ps(const float *p)
+ {
+     // for neon, alignment doesn't matter, so _mm_load_ps and _mm_loadu_ps are
+@@ -2038,35 +1966,31 @@ FORCE_INLINE __m128 _mm_loadu_ps(const f
+ }
+ 
+ // Load unaligned 16-bit integer from memory into the first element of dst.
+-//
+-//   dst[15:0] := MEM[mem_addr+15:mem_addr]
+-//   dst[MAX:16] := 0
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_si16
+ FORCE_INLINE __m128i _mm_loadu_si16(const void *p)
+ {
+     return vreinterpretq_m128i_s16(
+-        vsetq_lane_s16(*(const int16_t *) p, vdupq_n_s16(0), 0));
++        vsetq_lane_s16(*(const unaligned_int16_t *) p, vdupq_n_s16(0), 0));
+ }
+ 
+ // Load unaligned 64-bit integer from memory into the first element of dst.
+-//
+-//   dst[63:0] := MEM[mem_addr+63:mem_addr]
+-//   dst[MAX:64] := 0
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_si64
+ FORCE_INLINE __m128i _mm_loadu_si64(const void *p)
+ {
+     return vreinterpretq_m128i_s64(
+-        vcombine_s64(vld1_s64((const int64_t *) p), vdup_n_s64(0)));
++        vsetq_lane_s64(*(const unaligned_int64_t *) p, vdupq_n_s64(0), 0));
+ }
+ 
+-// Allocate aligned blocks of memory.
+-// https://software.intel.com/en-us/
+-//         cpp-compiler-developer-guide-and-reference-allocating-and-freeing-aligned-memory-blocks
++// Allocate size bytes of memory, aligned to the alignment specified in align,
++// and return a pointer to the allocated memory. _mm_free should be used to free
++// memory that is allocated with _mm_malloc.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_malloc
+ #if !defined(SSE2NEON_ALLOC_DEFINED)
+ FORCE_INLINE void *_mm_malloc(size_t size, size_t align)
+ {
++#if defined(_WIN32)
++    return _aligned_malloc(size, align);
++#else
+     void *ptr;
+     if (align == 1)
+         return malloc(size);
+@@ -2075,6 +1999,7 @@ FORCE_INLINE void *_mm_malloc(size_t siz
+     if (!posix_memalign(&ptr, align, size))
+         return ptr;
+     return NULL;
++#endif
+ }
+ #endif
+ 
+@@ -2100,12 +2025,6 @@ FORCE_INLINE void _mm_maskmove_si64(__m6
+ 
+ // Compare packed signed 16-bit integers in a and b, and store packed maximum
+ // values in dst.
+-//
+-//   FOR j := 0 to 3
+-//      i := j*16
+-//      dst[i+15:i] := MAX(a[i+15:i], b[i+15:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_max_pi16
+ FORCE_INLINE __m64 _mm_max_pi16(__m64 a, __m64 b)
+ {
+@@ -2113,9 +2032,11 @@ FORCE_INLINE __m64 _mm_max_pi16(__m64 a,
+         vmax_s16(vreinterpret_s16_m64(a), vreinterpret_s16_m64(b)));
+ }
+ 
+-// Computes the maximums of the four single-precision, floating-point values of
+-// a and b.
+-// https://msdn.microsoft.com/en-us/library/vstudio/ff5d607a(v=vs.100).aspx
++// Compare packed single-precision (32-bit) floating-point elements in a and b,
++// and store packed maximum values in dst. dst does not follow the IEEE Standard
++// for Floating-Point Arithmetic (IEEE 754) maximum value when inputs are NaN or
++// signed-zero values.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_max_ps
+ FORCE_INLINE __m128 _mm_max_ps(__m128 a, __m128 b)
+ {
+ #if SSE2NEON_PRECISE_MINMAX
+@@ -2130,12 +2051,6 @@ FORCE_INLINE __m128 _mm_max_ps(__m128 a,
+ 
+ // Compare packed unsigned 8-bit integers in a and b, and store packed maximum
+ // values in dst.
+-//
+-//   FOR j := 0 to 7
+-//      i := j*8
+-//      dst[i+7:i] := MAX(a[i+7:i], b[i+7:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_max_pu8
+ FORCE_INLINE __m64 _mm_max_pu8(__m64 a, __m64 b)
+ {
+@@ -2143,9 +2058,12 @@ FORCE_INLINE __m64 _mm_max_pu8(__m64 a,
+         vmax_u8(vreinterpret_u8_m64(a), vreinterpret_u8_m64(b)));
+ }
+ 
+-// Computes the maximum of the two lower scalar single-precision floating point
+-// values of a and b.
+-// https://msdn.microsoft.com/en-us/library/s6db5esz(v=vs.100).aspx
++// Compare the lower single-precision (32-bit) floating-point elements in a and
++// b, store the maximum value in the lower element of dst, and copy the upper 3
++// packed elements from a to the upper element of dst. dst does not follow the
++// IEEE Standard for Floating-Point Arithmetic (IEEE 754) maximum value when
++// inputs are NaN or signed-zero values.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_max_ss
+ FORCE_INLINE __m128 _mm_max_ss(__m128 a, __m128 b)
+ {
+     float32_t value = vgetq_lane_f32(_mm_max_ps(a, b), 0);
+@@ -2155,12 +2073,6 @@ FORCE_INLINE __m128 _mm_max_ss(__m128 a,
+ 
+ // Compare packed signed 16-bit integers in a and b, and store packed minimum
+ // values in dst.
+-//
+-//   FOR j := 0 to 3
+-//      i := j*16
+-//      dst[i+15:i] := MIN(a[i+15:i], b[i+15:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_min_pi16
+ FORCE_INLINE __m64 _mm_min_pi16(__m64 a, __m64 b)
+ {
+@@ -2168,9 +2080,11 @@ FORCE_INLINE __m64 _mm_min_pi16(__m64 a,
+         vmin_s16(vreinterpret_s16_m64(a), vreinterpret_s16_m64(b)));
+ }
+ 
+-// Computes the minima of the four single-precision, floating-point values of a
+-// and b.
+-// https://msdn.microsoft.com/en-us/library/vstudio/wh13kadz(v=vs.100).aspx
++// Compare packed single-precision (32-bit) floating-point elements in a and b,
++// and store packed minimum values in dst. dst does not follow the IEEE Standard
++// for Floating-Point Arithmetic (IEEE 754) minimum value when inputs are NaN or
++// signed-zero values.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_min_ps
+ FORCE_INLINE __m128 _mm_min_ps(__m128 a, __m128 b)
+ {
+ #if SSE2NEON_PRECISE_MINMAX
+@@ -2185,12 +2099,6 @@ FORCE_INLINE __m128 _mm_min_ps(__m128 a,
+ 
+ // Compare packed unsigned 8-bit integers in a and b, and store packed minimum
+ // values in dst.
+-//
+-//   FOR j := 0 to 7
+-//      i := j*8
+-//      dst[i+7:i] := MIN(a[i+7:i], b[i+7:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_min_pu8
+ FORCE_INLINE __m64 _mm_min_pu8(__m64 a, __m64 b)
+ {
+@@ -2198,9 +2106,12 @@ FORCE_INLINE __m64 _mm_min_pu8(__m64 a,
+         vmin_u8(vreinterpret_u8_m64(a), vreinterpret_u8_m64(b)));
+ }
+ 
+-// Computes the minimum of the two lower scalar single-precision floating point
+-// values of a and b.
+-// https://msdn.microsoft.com/en-us/library/0a9y7xaa(v=vs.100).aspx
++// Compare the lower single-precision (32-bit) floating-point elements in a and
++// b, store the minimum value in the lower element of dst, and copy the upper 3
++// packed elements from a to the upper element of dst. dst does not follow the
++// IEEE Standard for Floating-Point Arithmetic (IEEE 754) minimum value when
++// inputs are NaN or signed-zero values.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_min_ss
+ FORCE_INLINE __m128 _mm_min_ss(__m128 a, __m128 b)
+ {
+     float32_t value = vgetq_lane_f32(_mm_min_ps(a, b), 0);
+@@ -2208,8 +2119,10 @@ FORCE_INLINE __m128 _mm_min_ss(__m128 a,
+         vsetq_lane_f32(value, vreinterpretq_f32_m128(a), 0));
+ }
+ 
+-// Sets the low word to the single-precision, floating-point value of b
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/35hdzazd(v=vs.100)
++// Move the lower single-precision (32-bit) floating-point element from b to the
++// lower element of dst, and copy the upper 3 packed elements from a to the
++// upper elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_move_ss
+ FORCE_INLINE __m128 _mm_move_ss(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_f32(
+@@ -2217,25 +2130,26 @@ FORCE_INLINE __m128 _mm_move_ss(__m128 a
+                        vreinterpretq_f32_m128(a), 0));
+ }
+ 
+-// Moves the upper two values of B into the lower two values of A.
+-//
+-//   r3 := a3
+-//   r2 := a2
+-//   r1 := b3
+-//   r0 := b2
+-FORCE_INLINE __m128 _mm_movehl_ps(__m128 __A, __m128 __B)
+-{
+-    float32x2_t a32 = vget_high_f32(vreinterpretq_f32_m128(__A));
+-    float32x2_t b32 = vget_high_f32(vreinterpretq_f32_m128(__B));
++// Move the upper 2 single-precision (32-bit) floating-point elements from b to
++// the lower 2 elements of dst, and copy the upper 2 elements from a to the
++// upper 2 elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_movehl_ps
++FORCE_INLINE __m128 _mm_movehl_ps(__m128 a, __m128 b)
++{
++#if defined(aarch64__)
++    return vreinterpretq_m128_u64(
++        vzip2q_u64(vreinterpretq_u64_m128(b), vreinterpretq_u64_m128(a)));
++#else
++    float32x2_t a32 = vget_high_f32(vreinterpretq_f32_m128(a));
++    float32x2_t b32 = vget_high_f32(vreinterpretq_f32_m128(b));
+     return vreinterpretq_m128_f32(vcombine_f32(b32, a32));
++#endif
+ }
+ 
+-// Moves the lower two values of B into the upper two values of A.
+-//
+-//   r3 := b1
+-//   r2 := b0
+-//   r1 := a1
+-//   r0 := a0
++// Move the lower 2 single-precision (32-bit) floating-point elements from b to
++// the upper 2 elements of dst, and copy the lower 2 elements from a to the
++// lower 2 elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_movelh_ps
+ FORCE_INLINE __m128 _mm_movelh_ps(__m128 __A, __m128 __B)
+ {
+     float32x2_t a10 = vget_low_f32(vreinterpretq_f32_m128(__A));
+@@ -2249,53 +2163,44 @@ FORCE_INLINE __m128 _mm_movelh_ps(__m128
+ FORCE_INLINE int _mm_movemask_pi8(__m64 a)
+ {
+     uint8x8_t input = vreinterpret_u8_m64(a);
+-#if defined(__aarch64__)
+-    static const int8x8_t shift = {0, 1, 2, 3, 4, 5, 6, 7};
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
++    static const int8_t shift[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+     uint8x8_t tmp = vshr_n_u8(input, 7);
+-    return vaddv_u8(vshl_u8(tmp, shift));
++    return vaddv_u8(vshl_u8(tmp, vld1_s8(shift)));
+ #else
+-    // Refer the implementation of `_mm_movemask_epi8`
+-    uint16x4_t high_bits = vreinterpret_u16_u8(vshr_n_u8(input, 7));
+-    uint32x2_t paired16 =
+-        vreinterpret_u32_u16(vsra_n_u16(high_bits, high_bits, 7));
+-    uint8x8_t paired32 =
+-        vreinterpret_u8_u32(vsra_n_u32(paired16, paired16, 14));
+-    return vget_lane_u8(paired32, 0) | ((int) vget_lane_u8(paired32, 4) << 4);
++    // Note: Uses the same method as _mm_movemask_epi8.
++    uint8x8_t msbs = vshr_n_u8(input, 7);
++    uint32x2_t bits = vreinterpret_u32_u8(msbs);
++    bits = vsra_n_u32(bits, bits, 7);
++    bits = vsra_n_u32(bits, bits, 14);
++    uint8x8_t output = vreinterpret_u8_u32(bits);
++    return (vget_lane_u8(output, 4) << 4) | vget_lane_u8(output, 0);
+ #endif
+ }
+ 
+-// NEON does not provide this method
+-// Creates a 4-bit mask from the most significant bits of the four
+-// single-precision, floating-point values.
+-// https://msdn.microsoft.com/en-us/library/vstudio/4490ys29(v=vs.100).aspx
++// Set each bit of mask dst based on the most significant bit of the
++// corresponding packed single-precision (32-bit) floating-point element in a.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_movemask_ps
+ FORCE_INLINE int _mm_movemask_ps(__m128 a)
+ {
+     uint32x4_t input = vreinterpretq_u32_m128(a);
+-#if defined(__aarch64__)
+-    static const int32x4_t shift = {0, 1, 2, 3};
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
++    static const int32_t shift[4] = {0, 1, 2, 3};
+     uint32x4_t tmp = vshrq_n_u32(input, 31);
+-    return vaddvq_u32(vshlq_u32(tmp, shift));
++    return vaddvq_u32(vshlq_u32(tmp, vld1q_s32(shift)));
+ #else
+-    // Uses the exact same method as _mm_movemask_epi8, see that for details.
+-    // Shift out everything but the sign bits with a 32-bit unsigned shift
+-    // right.
+-    uint64x2_t high_bits = vreinterpretq_u64_u32(vshrq_n_u32(input, 31));
+-    // Merge the two pairs together with a 64-bit unsigned shift right + add.
+-    uint8x16_t paired =
+-        vreinterpretq_u8_u64(vsraq_n_u64(high_bits, high_bits, 31));
+-    // Extract the result.
+-    return vgetq_lane_u8(paired, 0) | (vgetq_lane_u8(paired, 8) << 2);
++    // Note: Uses the same method as _mm_movemask_epi8.
++    uint32x4_t msbs = vshrq_n_u32(input, 31);
++    uint64x2_t bits = vreinterpretq_u64_u32(msbs);
++    bits = vsraq_n_u64(bits, bits, 31);
++    uint8x16_t output = vreinterpretq_u8_u64(bits);
++    return (vgetq_lane_u8(output, 8) << 2) | vgetq_lane_u8(output, 0);
+ #endif
+ }
+ 
+-// Multiplies the four single-precision, floating-point values of a and b.
+-//
+-//   r0 := a0 * b0
+-//   r1 := a1 * b1
+-//   r2 := a2 * b2
+-//   r3 := a3 * b3
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/22kbk6t9(v=vs.100).aspx
++// Multiply packed single-precision (32-bit) floating-point elements in a and b,
++// and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mul_ps
+ FORCE_INLINE __m128 _mm_mul_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_f32(
+@@ -2305,10 +2210,6 @@ FORCE_INLINE __m128 _mm_mul_ps(__m128 a,
+ // Multiply the lower single-precision (32-bit) floating-point element in a and
+ // b, store the result in the lower element of dst, and copy the upper 3 packed
+ // elements from a to the upper elements of dst.
+-//
+-//   dst[31:0] := a[31:0] * b[31:0]
+-//   dst[127:32] := a[127:32]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mul_ss
+ FORCE_INLINE __m128 _mm_mul_ss(__m128 a, __m128 b)
+ {
+@@ -2325,9 +2226,9 @@ FORCE_INLINE __m64 _mm_mulhi_pu16(__m64
+         vmull_u16(vreinterpret_u16_m64(a), vreinterpret_u16_m64(b)), 16));
+ }
+ 
+-// Computes the bitwise OR of the four single-precision, floating-point values
+-// of a and b.
+-// https://msdn.microsoft.com/en-us/library/vstudio/7ctdsyy0(v=vs.100).aspx
++// Compute the bitwise OR of packed single-precision (32-bit) floating-point
++// elements in a and b, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_or_ps
+ FORCE_INLINE __m128 _mm_or_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_s32(
+@@ -2336,23 +2237,11 @@ FORCE_INLINE __m128 _mm_or_ps(__m128 a,
+ 
+ // Average packed unsigned 8-bit integers in a and b, and store the results in
+ // dst.
+-//
+-//   FOR j := 0 to 7
+-//     i := j*8
+-//     dst[i+7:i] := (a[i+7:i] + b[i+7:i] + 1) >> 1
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_m_pavgb
+ #define _m_pavgb(a, b) _mm_avg_pu8(a, b)
+ 
+ // Average packed unsigned 16-bit integers in a and b, and store the results in
+ // dst.
+-//
+-//   FOR j := 0 to 3
+-//     i := j*16
+-//     dst[i+15:i] := (a[i+15:i] + b[i+15:i] + 1) >> 1
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_m_pavgw
+ #define _m_pavgw(a, b) _mm_avg_pu16(a, b)
+ 
+@@ -2398,10 +2287,27 @@ FORCE_INLINE __m128 _mm_or_ps(__m128 a,
+ #define _m_pmulhuw(a, b) _mm_mulhi_pu16(a, b)
+ 
+ // Fetch the line of data from memory that contains address p to a location in
+-// the cache heirarchy specified by the locality hint i.
++// the cache hierarchy specified by the locality hint i.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_prefetch
+ FORCE_INLINE void _mm_prefetch(char const *p, int i)
+ {
++    (void) i;
++#if defined(_MSC_VER) && !defined(__clang__)
++    switch (i) {
++    case _MM_HINT_NTA:
++        __prefetch2(p, 1);
++        break;
++    case _MM_HINT_T0:
++        __prefetch2(p, 0);
++        break;
++    case _MM_HINT_T1:
++        __prefetch2(p, 2);
++        break;
++    case _MM_HINT_T2:
++        __prefetch2(p, 4);
++        break;
++    }
++#else
+     switch (i) {
+     case _MM_HINT_NTA:
+         __builtin_prefetch(p, 0, 0);
+@@ -2416,6 +2322,7 @@ FORCE_INLINE void _mm_prefetch(char cons
+         __builtin_prefetch(p, 0, 1);
+         break;
+     }
++#endif
+ }
+ 
+ // Compute the absolute differences of packed unsigned 8-bit integers in a and
+@@ -2449,30 +2356,42 @@ FORCE_INLINE __m128 _mm_rcp_ps(__m128 in
+ // floating-point element in a, store the result in the lower element of dst,
+ // and copy the upper 3 packed elements from a to the upper elements of dst. The
+ // maximum relative error for this approximation is less than 1.5*2^-12.
+-//
+-//   dst[31:0] := (1.0 / a[31:0])
+-//   dst[127:32] := a[127:32]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_rcp_ss
+ FORCE_INLINE __m128 _mm_rcp_ss(__m128 a)
+ {
+     return _mm_move_ss(a, _mm_rcp_ps(a));
+ }
+ 
+-// Computes the approximations of the reciprocal square roots of the four
+-// single-precision floating point values of in.
+-// The current precision is 1% error.
+-// https://msdn.microsoft.com/en-us/library/22hfsh53(v=vs.100).aspx
++// Compute the approximate reciprocal square root of packed single-precision
++// (32-bit) floating-point elements in a, and store the results in dst. The
++// maximum relative error for this approximation is less than 1.5*2^-12.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_rsqrt_ps
+ FORCE_INLINE __m128 _mm_rsqrt_ps(__m128 in)
+ {
+     float32x4_t out = vrsqrteq_f32(vreinterpretq_f32_m128(in));
+-#if SSE2NEON_PRECISE_SQRT
+-    // Additional Netwon-Raphson iteration for accuracy
++
++    // Generate masks for detecting whether input has any 0.0f/-0.0f
++    // (which becomes positive/negative infinity by IEEE-754 arithmetic rules).
++    const uint32x4_t pos_inf = vdupq_n_u32(0x7F800000);
++    const uint32x4_t neg_inf = vdupq_n_u32(0xFF800000);
++    const uint32x4_t has_pos_zero =
++        vceqq_u32(pos_inf, vreinterpretq_u32_f32(out));
++    const uint32x4_t has_neg_zero =
++        vceqq_u32(neg_inf, vreinterpretq_u32_f32(out));
++
+     out = vmulq_f32(
+         out, vrsqrtsq_f32(vmulq_f32(vreinterpretq_f32_m128(in), out), out));
++#if SSE2NEON_PRECISE_SQRT
++    // Additional Netwon-Raphson iteration for accuracy
+     out = vmulq_f32(
+         out, vrsqrtsq_f32(vmulq_f32(vreinterpretq_f32_m128(in), out), out));
+ #endif
++
++    // Set output vector element to infinity/negative-infinity if
++    // the corresponding input vector element is 0.0f/-0.0f.
++    out = vbslq_f32(has_pos_zero, (float32x4_t) pos_inf, out);
++    out = vbslq_f32(has_neg_zero, (float32x4_t) neg_inf, out);
++
+     return vreinterpretq_m128_f32(out);
+ }
+ 
+@@ -2496,7 +2415,7 @@ FORCE_INLINE __m64 _mm_sad_pu8(__m64 a,
+     uint64x1_t t = vpaddl_u32(vpaddl_u16(
+         vpaddl_u8(vabd_u8(vreinterpret_u8_m64(a), vreinterpret_u8_m64(b)))));
+     return vreinterpret_m64_u16(
+-        vset_lane_u16(vget_lane_u64(t, 0), vdup_n_u16(0), 0));
++        vset_lane_u16((uint16_t) vget_lane_u64(t, 0), vdup_n_u16(0), 0));
+ }
+ 
+ // Macro: Set the flush zero bits of the MXCSR control and status register to
+@@ -2509,38 +2428,40 @@ FORCE_INLINE void _sse2neon_mm_set_flush
+     // regardless of the value of the FZ bit.
+     union {
+         fpcr_bitfield field;
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+         uint64_t value;
+ #else
+         uint32_t value;
+ #endif
+     } r;
+ 
+-#if defined(__aarch64__)
+-    __asm__ __volatile__("mrs %0, FPCR" : "=r"(r.value)); /* read */
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
++    r.value = _sse2neon_get_fpcr();
+ #else
+     __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(r.value)); /* read */
+ #endif
+ 
+     r.field.bit24 = (flag & _MM_FLUSH_ZERO_MASK) == _MM_FLUSH_ZERO_ON;
+ 
+-#if defined(__aarch64__)
+-    __asm__ __volatile__("msr FPCR, %0" ::"r"(r)); /* write */
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
++    _sse2neon_set_fpcr(r.value);
+ #else
+-    __asm__ __volatile__("vmsr FPSCR, %0" ::"r"(r));        /* write */
++    __asm__ __volatile__("vmsr FPSCR, %0" ::"r"(r)); /* write */
+ #endif
+ }
+ 
+-// Sets the four single-precision, floating-point values to the four inputs.
+-// https://msdn.microsoft.com/en-us/library/vstudio/afh0zf75(v=vs.100).aspx
++// Set packed single-precision (32-bit) floating-point elements in dst with the
++// supplied values.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set_ps
+ FORCE_INLINE __m128 _mm_set_ps(float w, float z, float y, float x)
+ {
+     float ALIGN_STRUCT(16) data[4] = {x, y, z, w};
+     return vreinterpretq_m128_f32(vld1q_f32(data));
+ }
+ 
+-// Sets the four single-precision, floating-point values to w.
+-// https://msdn.microsoft.com/en-us/library/vstudio/2x1se8ha(v=vs.100).aspx
++// Broadcast single-precision (32-bit) floating-point value a to all elements of
++// dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set_ps1
+ FORCE_INLINE __m128 _mm_set_ps1(float _w)
+ {
+     return vreinterpretq_m128_f32(vdupq_n_f32(_w));
+@@ -2553,44 +2474,26 @@ FORCE_INLINE __m128 _mm_set_ps1(float _w
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_MM_SET_ROUNDING_MODE
+ FORCE_INLINE void _MM_SET_ROUNDING_MODE(int rounding)
+ {
+-    union {
+-        fpcr_bitfield field;
+-#if defined(__aarch64__)
+-        uint64_t value;
+-#else
+-        uint32_t value;
+-#endif
+-    } r;
+-
+-#if defined(__aarch64__)
+-    __asm__ __volatile__("mrs %0, FPCR" : "=r"(r.value)); /* read */
+-#else
+-    __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(r.value)); /* read */
+-#endif
+-
+     switch (rounding) {
+-    case _MM_ROUND_TOWARD_ZERO:
+-        r.field.bit22 = 1;
+-        r.field.bit23 = 1;
++    case _MM_ROUND_NEAREST:
++        rounding = FE_TONEAREST;
+         break;
+     case _MM_ROUND_DOWN:
+-        r.field.bit22 = 0;
+-        r.field.bit23 = 1;
++        rounding = FE_DOWNWARD;
+         break;
+     case _MM_ROUND_UP:
+-        r.field.bit22 = 1;
+-        r.field.bit23 = 0;
++        rounding = FE_UPWARD;
++        break;
++    case _MM_ROUND_TOWARD_ZERO:
++        rounding = FE_TOWARDZERO;
+         break;
+-    default:  //_MM_ROUND_NEAREST
+-        r.field.bit22 = 0;
+-        r.field.bit23 = 0;
++    default:
++        // rounding must be _MM_ROUND_NEAREST, _MM_ROUND_DOWN, _MM_ROUND_UP,
++        // _MM_ROUND_TOWARD_ZERO. all the other invalid values we treat them as
++        // FE_TOWARDZERO (truncate).
++        rounding = FE_TOWARDZERO;
+     }
+-
+-#if defined(__aarch64__)
+-    __asm__ __volatile__("msr FPCR, %0" ::"r"(r)); /* write */
+-#else
+-    __asm__ __volatile__("vmsr FPSCR, %0" ::"r"(r));        /* write */
+-#endif
++    fesetround(rounding);
+ }
+ 
+ // Copy single-precision (32-bit) floating-point element a to the lower element
+@@ -2601,39 +2504,42 @@ FORCE_INLINE __m128 _mm_set_ss(float a)
+     return vreinterpretq_m128_f32(vsetq_lane_f32(a, vdupq_n_f32(0), 0));
+ }
+ 
+-// Sets the four single-precision, floating-point values to w.
+-//
+-//   r0 := r1 := r2 := r3 := w
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/2x1se8ha(v=vs.100).aspx
++// Broadcast single-precision (32-bit) floating-point value a to all elements of
++// dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set1_ps
+ FORCE_INLINE __m128 _mm_set1_ps(float _w)
+ {
+     return vreinterpretq_m128_f32(vdupq_n_f32(_w));
+ }
+ 
++// Set the MXCSR control and status register with the value in unsigned 32-bit
++// integer a.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_setcsr
+ // FIXME: _mm_setcsr() implementation supports changing the rounding mode only.
+ FORCE_INLINE void _mm_setcsr(unsigned int a)
+ {
+     _MM_SET_ROUNDING_MODE(a);
+ }
+ 
++// Get the unsigned 32-bit value of the MXCSR control and status register.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_getcsr
+ // FIXME: _mm_getcsr() implementation supports reading the rounding mode only.
+-FORCE_INLINE unsigned int _mm_getcsr()
++FORCE_INLINE unsigned int _mm_getcsr(void)
+ {
+     return _MM_GET_ROUNDING_MODE();
+ }
+ 
+-// Sets the four single-precision, floating-point values to the four inputs in
+-// reverse order.
+-// https://msdn.microsoft.com/en-us/library/vstudio/d2172ct3(v=vs.100).aspx
++// Set packed single-precision (32-bit) floating-point elements in dst with the
++// supplied values in reverse order.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_setr_ps
+ FORCE_INLINE __m128 _mm_setr_ps(float w, float z, float y, float x)
+ {
+     float ALIGN_STRUCT(16) data[4] = {w, z, y, x};
+     return vreinterpretq_m128_f32(vld1q_f32(data));
+ }
+ 
+-// Clears the four single-precision, floating-point values.
+-// https://msdn.microsoft.com/en-us/library/vstudio/tk1t2tbz(v=vs.100).aspx
++// Return vector of type __m128 with all elements set to zero.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_setzero_ps
+ FORCE_INLINE __m128 _mm_setzero_ps(void)
+ {
+     return vreinterpretq_m128_f32(vdupq_n_f32(0));
+@@ -2643,29 +2549,26 @@ FORCE_INLINE __m128 _mm_setzero_ps(void)
+ // in dst.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_shuffle_pi16
+ #ifdef _sse2neon_shuffle
+-#define _mm_shuffle_pi16(a, imm)                                           \
+-    __extension__({                                                        \
+-        vreinterpret_m64_s16(vshuffle_s16(                                 \
+-            vreinterpret_s16_m64(a), vreinterpret_s16_m64(a), (imm & 0x3), \
+-            ((imm >> 2) & 0x3), ((imm >> 4) & 0x3), ((imm >> 6) & 0x3)));  \
+-    })
+-#else
+-#define _mm_shuffle_pi16(a, imm)                                               \
+-    __extension__({                                                            \
+-        int16x4_t ret;                                                         \
+-        ret =                                                                  \
+-            vmov_n_s16(vget_lane_s16(vreinterpret_s16_m64(a), (imm) & (0x3))); \
+-        ret = vset_lane_s16(                                                   \
+-            vget_lane_s16(vreinterpret_s16_m64(a), ((imm) >> 2) & 0x3), ret,   \
+-            1);                                                                \
+-        ret = vset_lane_s16(                                                   \
+-            vget_lane_s16(vreinterpret_s16_m64(a), ((imm) >> 4) & 0x3), ret,   \
+-            2);                                                                \
+-        ret = vset_lane_s16(                                                   \
+-            vget_lane_s16(vreinterpret_s16_m64(a), ((imm) >> 6) & 0x3), ret,   \
+-            3);                                                                \
+-        vreinterpret_m64_s16(ret);                                             \
+-    })
++#define _mm_shuffle_pi16(a, imm)                                         \
++    vreinterpret_m64_s16(vshuffle_s16(                                   \
++        vreinterpret_s16_m64(a), vreinterpret_s16_m64(a), ((imm) & 0x3), \
++        (((imm) >> 2) & 0x3), (((imm) >> 4) & 0x3), (((imm) >> 6) & 0x3)))
++#else
++#define _mm_shuffle_pi16(a, imm)                                              \
++    _sse2neon_define1(                                                        \
++        __m64, a, int16x4_t ret;                                              \
++        ret = vmov_n_s16(                                                     \
++            vget_lane_s16(vreinterpret_s16_m64(_a), (imm) & (0x3)));          \
++        ret = vset_lane_s16(                                                  \
++            vget_lane_s16(vreinterpret_s16_m64(_a), ((imm) >> 2) & 0x3), ret, \
++            1);                                                               \
++        ret = vset_lane_s16(                                                  \
++            vget_lane_s16(vreinterpret_s16_m64(_a), ((imm) >> 4) & 0x3), ret, \
++            2);                                                               \
++        ret = vset_lane_s16(                                                  \
++            vget_lane_s16(vreinterpret_s16_m64(_a), ((imm) >> 6) & 0x3), ret, \
++            3);                                                               \
++        _sse2neon_return(vreinterpret_m64_s16(ret));)
+ #endif
+ 
+ // Perform a serializing operation on all store-to-memory instructions that were
+@@ -2712,82 +2615,78 @@ FORCE_INLINE void _mm_lfence(void)
+         vreinterpretq_m128_f32(_shuf);                                         \
+     })
+ #else  // generic
+-#define _mm_shuffle_ps(a, b, imm)                          \
+-    __extension__({                                        \
+-        __m128 ret;                                        \
+-        switch (imm) {                                     \
+-        case _MM_SHUFFLE(1, 0, 3, 2):                      \
+-            ret = _mm_shuffle_ps_1032((a), (b));           \
+-            break;                                         \
+-        case _MM_SHUFFLE(2, 3, 0, 1):                      \
+-            ret = _mm_shuffle_ps_2301((a), (b));           \
+-            break;                                         \
+-        case _MM_SHUFFLE(0, 3, 2, 1):                      \
+-            ret = _mm_shuffle_ps_0321((a), (b));           \
+-            break;                                         \
+-        case _MM_SHUFFLE(2, 1, 0, 3):                      \
+-            ret = _mm_shuffle_ps_2103((a), (b));           \
+-            break;                                         \
+-        case _MM_SHUFFLE(1, 0, 1, 0):                      \
+-            ret = _mm_movelh_ps((a), (b));                 \
+-            break;                                         \
+-        case _MM_SHUFFLE(1, 0, 0, 1):                      \
+-            ret = _mm_shuffle_ps_1001((a), (b));           \
+-            break;                                         \
+-        case _MM_SHUFFLE(0, 1, 0, 1):                      \
+-            ret = _mm_shuffle_ps_0101((a), (b));           \
+-            break;                                         \
+-        case _MM_SHUFFLE(3, 2, 1, 0):                      \
+-            ret = _mm_shuffle_ps_3210((a), (b));           \
+-            break;                                         \
+-        case _MM_SHUFFLE(0, 0, 1, 1):                      \
+-            ret = _mm_shuffle_ps_0011((a), (b));           \
+-            break;                                         \
+-        case _MM_SHUFFLE(0, 0, 2, 2):                      \
+-            ret = _mm_shuffle_ps_0022((a), (b));           \
+-            break;                                         \
+-        case _MM_SHUFFLE(2, 2, 0, 0):                      \
+-            ret = _mm_shuffle_ps_2200((a), (b));           \
+-            break;                                         \
+-        case _MM_SHUFFLE(3, 2, 0, 2):                      \
+-            ret = _mm_shuffle_ps_3202((a), (b));           \
+-            break;                                         \
+-        case _MM_SHUFFLE(3, 2, 3, 2):                      \
+-            ret = _mm_movehl_ps((b), (a));                 \
+-            break;                                         \
+-        case _MM_SHUFFLE(1, 1, 3, 3):                      \
+-            ret = _mm_shuffle_ps_1133((a), (b));           \
+-            break;                                         \
+-        case _MM_SHUFFLE(2, 0, 1, 0):                      \
+-            ret = _mm_shuffle_ps_2010((a), (b));           \
+-            break;                                         \
+-        case _MM_SHUFFLE(2, 0, 0, 1):                      \
+-            ret = _mm_shuffle_ps_2001((a), (b));           \
+-            break;                                         \
+-        case _MM_SHUFFLE(2, 0, 3, 2):                      \
+-            ret = _mm_shuffle_ps_2032((a), (b));           \
+-            break;                                         \
+-        default:                                           \
+-            ret = _mm_shuffle_ps_default((a), (b), (imm)); \
+-            break;                                         \
+-        }                                                  \
+-        ret;                                               \
+-    })
++#define _mm_shuffle_ps(a, b, imm)                            \
++    _sse2neon_define2(                                       \
++        __m128, a, b, __m128 ret; switch (imm) {             \
++            case _MM_SHUFFLE(1, 0, 3, 2):                    \
++                ret = _mm_shuffle_ps_1032(_a, _b);           \
++                break;                                       \
++            case _MM_SHUFFLE(2, 3, 0, 1):                    \
++                ret = _mm_shuffle_ps_2301(_a, _b);           \
++                break;                                       \
++            case _MM_SHUFFLE(0, 3, 2, 1):                    \
++                ret = _mm_shuffle_ps_0321(_a, _b);           \
++                break;                                       \
++            case _MM_SHUFFLE(2, 1, 0, 3):                    \
++                ret = _mm_shuffle_ps_2103(_a, _b);           \
++                break;                                       \
++            case _MM_SHUFFLE(1, 0, 1, 0):                    \
++                ret = _mm_movelh_ps(_a, _b);                 \
++                break;                                       \
++            case _MM_SHUFFLE(1, 0, 0, 1):                    \
++                ret = _mm_shuffle_ps_1001(_a, _b);           \
++                break;                                       \
++            case _MM_SHUFFLE(0, 1, 0, 1):                    \
++                ret = _mm_shuffle_ps_0101(_a, _b);           \
++                break;                                       \
++            case _MM_SHUFFLE(3, 2, 1, 0):                    \
++                ret = _mm_shuffle_ps_3210(_a, _b);           \
++                break;                                       \
++            case _MM_SHUFFLE(0, 0, 1, 1):                    \
++                ret = _mm_shuffle_ps_0011(_a, _b);           \
++                break;                                       \
++            case _MM_SHUFFLE(0, 0, 2, 2):                    \
++                ret = _mm_shuffle_ps_0022(_a, _b);           \
++                break;                                       \
++            case _MM_SHUFFLE(2, 2, 0, 0):                    \
++                ret = _mm_shuffle_ps_2200(_a, _b);           \
++                break;                                       \
++            case _MM_SHUFFLE(3, 2, 0, 2):                    \
++                ret = _mm_shuffle_ps_3202(_a, _b);           \
++                break;                                       \
++            case _MM_SHUFFLE(3, 2, 3, 2):                    \
++                ret = _mm_movehl_ps(_b, _a);                 \
++                break;                                       \
++            case _MM_SHUFFLE(1, 1, 3, 3):                    \
++                ret = _mm_shuffle_ps_1133(_a, _b);           \
++                break;                                       \
++            case _MM_SHUFFLE(2, 0, 1, 0):                    \
++                ret = _mm_shuffle_ps_2010(_a, _b);           \
++                break;                                       \
++            case _MM_SHUFFLE(2, 0, 0, 1):                    \
++                ret = _mm_shuffle_ps_2001(_a, _b);           \
++                break;                                       \
++            case _MM_SHUFFLE(2, 0, 3, 2):                    \
++                ret = _mm_shuffle_ps_2032(_a, _b);           \
++                break;                                       \
++            default:                                         \
++                ret = _mm_shuffle_ps_default(_a, _b, (imm)); \
++                break;                                       \
++        } _sse2neon_return(ret);)
+ #endif
+ 
+-// Computes the approximations of square roots of the four single-precision,
+-// floating-point values of a. First computes reciprocal square roots and then
+-// reciprocals of the four values.
+-//
+-//   r0 := sqrt(a0)
+-//   r1 := sqrt(a1)
+-//   r2 := sqrt(a2)
+-//   r3 := sqrt(a3)
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/8z67bwwk(v=vs.100).aspx
++// Compute the square root of packed single-precision (32-bit) floating-point
++// elements in a, and store the results in dst.
++// Due to ARMv7-A NEON's lack of a precise square root intrinsic, we implement
++// square root by multiplying input in with its reciprocal square root before
++// using the Newton-Raphson method to approximate the results.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sqrt_ps
+ FORCE_INLINE __m128 _mm_sqrt_ps(__m128 in)
+ {
+-#if SSE2NEON_PRECISE_SQRT
++#if (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)) && \
++    !SSE2NEON_PRECISE_SQRT
++    return vreinterpretq_m128_f32(vsqrtq_f32(vreinterpretq_f32_m128(in)));
++#else
+     float32x4_t recip = vrsqrteq_f32(vreinterpretq_f32_m128(in));
+ 
+     // Test for vrsqrteq_f32(0) -> positive infinity case.
+@@ -2798,28 +2697,23 @@ FORCE_INLINE __m128 _mm_sqrt_ps(__m128 i
+     recip = vreinterpretq_f32_u32(
+         vandq_u32(vmvnq_u32(div_by_zero), vreinterpretq_u32_f32(recip)));
+ 
+-    // Additional Netwon-Raphson iteration for accuracy
+     recip = vmulq_f32(
+         vrsqrtsq_f32(vmulq_f32(recip, recip), vreinterpretq_f32_m128(in)),
+         recip);
++    // Additional Netwon-Raphson iteration for accuracy
+     recip = vmulq_f32(
+         vrsqrtsq_f32(vmulq_f32(recip, recip), vreinterpretq_f32_m128(in)),
+         recip);
+ 
+     // sqrt(s) = s * 1/sqrt(s)
+     return vreinterpretq_m128_f32(vmulq_f32(vreinterpretq_f32_m128(in), recip));
+-#elif defined(__aarch64__)
+-    return vreinterpretq_m128_f32(vsqrtq_f32(vreinterpretq_f32_m128(in)));
+-#else
+-    float32x4_t recipsq = vrsqrteq_f32(vreinterpretq_f32_m128(in));
+-    float32x4_t sq = vrecpeq_f32(recipsq);
+-    return vreinterpretq_m128_f32(sq);
+ #endif
+ }
+ 
+-// Computes the approximation of the square root of the scalar single-precision
+-// floating point value of in.
+-// https://msdn.microsoft.com/en-us/library/ahfsc22d(v=vs.100).aspx
++// Compute the square root of the lower single-precision (32-bit) floating-point
++// element in a, store the result in the lower element of dst, and copy the
++// upper 3 packed elements from a to the upper elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sqrt_ss
+ FORCE_INLINE __m128 _mm_sqrt_ss(__m128 in)
+ {
+     float32_t value =
+@@ -2828,8 +2722,10 @@ FORCE_INLINE __m128 _mm_sqrt_ss(__m128 i
+         vsetq_lane_f32(value, vreinterpretq_f32_m128(in), 0));
+ }
+ 
+-// Stores four single-precision, floating-point values.
+-// https://msdn.microsoft.com/en-us/library/vstudio/s3h4ay6y(v=vs.100).aspx
++// Store 128-bits (composed of 4 packed single-precision (32-bit) floating-point
++// elements) from a into memory. mem_addr must be aligned on a 16-byte boundary
++// or a general-protection exception may be generated.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_store_ps
+ FORCE_INLINE void _mm_store_ps(float *p, __m128 a)
+ {
+     vst1q_f32(p, vreinterpretq_f32_m128(a));
+@@ -2838,12 +2734,6 @@ FORCE_INLINE void _mm_store_ps(float *p,
+ // Store the lower single-precision (32-bit) floating-point element from a into
+ // 4 contiguous elements in memory. mem_addr must be aligned on a 16-byte
+ // boundary or a general-protection exception may be generated.
+-//
+-//   MEM[mem_addr+31:mem_addr] := a[31:0]
+-//   MEM[mem_addr+63:mem_addr+32] := a[31:0]
+-//   MEM[mem_addr+95:mem_addr+64] := a[31:0]
+-//   MEM[mem_addr+127:mem_addr+96] := a[31:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_store_ps1
+ FORCE_INLINE void _mm_store_ps1(float *p, __m128 a)
+ {
+@@ -2851,8 +2741,9 @@ FORCE_INLINE void _mm_store_ps1(float *p
+     vst1q_f32(p, vdupq_n_f32(a0));
+ }
+ 
+-// Stores the lower single - precision, floating - point value.
+-// https://msdn.microsoft.com/en-us/library/tzz10fbx(v=vs.100).aspx
++// Store the lower single-precision (32-bit) floating-point element from a into
++// memory. mem_addr does not need to be aligned on any particular boundary.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_store_ss
+ FORCE_INLINE void _mm_store_ss(float *p, __m128 a)
+ {
+     vst1q_lane_f32(p, vreinterpretq_f32_m128(a), 0);
+@@ -2861,34 +2752,20 @@ FORCE_INLINE void _mm_store_ss(float *p,
+ // Store the lower single-precision (32-bit) floating-point element from a into
+ // 4 contiguous elements in memory. mem_addr must be aligned on a 16-byte
+ // boundary or a general-protection exception may be generated.
+-//
+-//   MEM[mem_addr+31:mem_addr] := a[31:0]
+-//   MEM[mem_addr+63:mem_addr+32] := a[31:0]
+-//   MEM[mem_addr+95:mem_addr+64] := a[31:0]
+-//   MEM[mem_addr+127:mem_addr+96] := a[31:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_store1_ps
+ #define _mm_store1_ps _mm_store_ps1
+ 
+-// Stores the upper two single-precision, floating-point values of a to the
+-// address p.
+-//
+-//   *p0 := a2
+-//   *p1 := a3
+-//
+-// https://msdn.microsoft.com/en-us/library/a7525fs8(v%3dvs.90).aspx
++// Store the upper 2 single-precision (32-bit) floating-point elements from a
++// into memory.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storeh_pi
+ FORCE_INLINE void _mm_storeh_pi(__m64 *p, __m128 a)
+ {
+     *p = vreinterpret_m64_f32(vget_high_f32(a));
+ }
+ 
+-// Stores the lower two single-precision floating point values of a to the
+-// address p.
+-//
+-//   *p0 := a0
+-//   *p1 := a1
+-//
+-// https://msdn.microsoft.com/en-us/library/h54t98ks(v=vs.90).aspx
++// Store the lower 2 single-precision (32-bit) floating-point elements from a
++// into memory.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storel_pi
+ FORCE_INLINE void _mm_storel_pi(__m64 *p, __m128 a)
+ {
+     *p = vreinterpret_m64_f32(vget_low_f32(a));
+@@ -2897,12 +2774,6 @@ FORCE_INLINE void _mm_storel_pi(__m64 *p
+ // Store 4 single-precision (32-bit) floating-point elements from a into memory
+ // in reverse order. mem_addr must be aligned on a 16-byte boundary or a
+ // general-protection exception may be generated.
+-//
+-//   MEM[mem_addr+31:mem_addr] := a[127:96]
+-//   MEM[mem_addr+63:mem_addr+32] := a[95:64]
+-//   MEM[mem_addr+95:mem_addr+64] := a[63:32]
+-//   MEM[mem_addr+127:mem_addr+96] := a[31:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storer_ps
+ FORCE_INLINE void _mm_storer_ps(float *p, __m128 a)
+ {
+@@ -2911,8 +2782,10 @@ FORCE_INLINE void _mm_storer_ps(float *p
+     vst1q_f32(p, rev);
+ }
+ 
+-// Stores four single-precision, floating-point values.
+-// https://msdn.microsoft.com/en-us/library/44e30x22(v=vs.100).aspx
++// Store 128-bits (composed of 4 packed single-precision (32-bit) floating-point
++// elements) from a into memory. mem_addr does not need to be aligned on any
++// particular boundary.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storeu_ps
+ FORCE_INLINE void _mm_storeu_ps(float *p, __m128 a)
+ {
+     vst1q_f32(p, vreinterpretq_f32_m128(a));
+@@ -2952,14 +2825,10 @@ FORCE_INLINE void _mm_stream_ps(float *p
+ #endif
+ }
+ 
+-// Subtracts the four single-precision, floating-point values of a and b.
+-//
+-//   r0 := a0 - b0
+-//   r1 := a1 - b1
+-//   r2 := a2 - b2
+-//   r3 := a3 - b3
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/1zad2k61(v=vs.100).aspx
++// Subtract packed single-precision (32-bit) floating-point elements in b from
++// packed single-precision (32-bit) floating-point elements in a, and store the
++// results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sub_ps
+ FORCE_INLINE __m128 _mm_sub_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_f32(
+@@ -2970,10 +2839,6 @@ FORCE_INLINE __m128 _mm_sub_ps(__m128 a,
+ // the lower single-precision (32-bit) floating-point element in a, store the
+ // result in the lower element of dst, and copy the upper 3 packed elements from
+ // a to the upper elements of dst.
+-//
+-//   dst[31:0] := a[31:0] - b[31:0]
+-//   dst[127:32] := a[127:32]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sub_ss
+ FORCE_INLINE __m128 _mm_sub_ss(__m128 a, __m128 b)
+ {
+@@ -3016,6 +2881,9 @@ FORCE_INLINE __m128i _mm_undefined_si128
+ #pragma GCC diagnostic ignored "-Wuninitialized"
+ #endif
+     __m128i a;
++#if defined(_MSC_VER)
++    a = _mm_setzero_si128();
++#endif
+     return a;
+ #if defined(__GNUC__) || defined(__clang__)
+ #pragma GCC diagnostic pop
+@@ -3031,24 +2899,21 @@ FORCE_INLINE __m128 _mm_undefined_ps(voi
+ #pragma GCC diagnostic ignored "-Wuninitialized"
+ #endif
+     __m128 a;
++#if defined(_MSC_VER)
++    a = _mm_setzero_ps();
++#endif
+     return a;
+ #if defined(__GNUC__) || defined(__clang__)
+ #pragma GCC diagnostic pop
+ #endif
+ }
+ 
+-// Selects and interleaves the upper two single-precision, floating-point values
+-// from a and b.
+-//
+-//   r0 := a2
+-//   r1 := b2
+-//   r2 := a3
+-//   r3 := b3
+-//
+-// https://msdn.microsoft.com/en-us/library/skccxx7d%28v=vs.90%29.aspx
++// Unpack and interleave single-precision (32-bit) floating-point elements from
++// the high half a and b, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_unpackhi_ps
+ FORCE_INLINE __m128 _mm_unpackhi_ps(__m128 a, __m128 b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128_f32(
+         vzip2q_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
+ #else
+@@ -3059,18 +2924,12 @@ FORCE_INLINE __m128 _mm_unpackhi_ps(__m1
+ #endif
+ }
+ 
+-// Selects and interleaves the lower two single-precision, floating-point values
+-// from a and b.
+-//
+-//   r0 := a0
+-//   r1 := b0
+-//   r2 := a1
+-//   r3 := b1
+-//
+-// https://msdn.microsoft.com/en-us/library/25st103b%28v=vs.90%29.aspx
++// Unpack and interleave single-precision (32-bit) floating-point elements from
++// the low half of a and b, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_unpacklo_ps
+ FORCE_INLINE __m128 _mm_unpacklo_ps(__m128 a, __m128 b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128_f32(
+         vzip1q_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
+ #else
+@@ -3081,9 +2940,9 @@ FORCE_INLINE __m128 _mm_unpacklo_ps(__m1
+ #endif
+ }
+ 
+-// Computes bitwise EXOR (exclusive-or) of the four single-precision,
+-// floating-point values of a and b.
+-// https://msdn.microsoft.com/en-us/library/ss6k3wk8(v=vs.100).aspx
++// Compute the bitwise XOR of packed single-precision (32-bit) floating-point
++// elements in a and b, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_xor_ps
+ FORCE_INLINE __m128 _mm_xor_ps(__m128 a, __m128 b)
+ {
+     return vreinterpretq_m128_s32(
+@@ -3092,42 +2951,32 @@ FORCE_INLINE __m128 _mm_xor_ps(__m128 a,
+ 
+ /* SSE2 */
+ 
+-// Adds the 8 signed or unsigned 16-bit integers in a to the 8 signed or
+-// unsigned 16-bit integers in b.
+-// https://msdn.microsoft.com/en-us/library/fceha5k4(v=vs.100).aspx
++// Add packed 16-bit integers in a and b, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_add_epi16
+ FORCE_INLINE __m128i _mm_add_epi16(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s16(
+         vaddq_s16(vreinterpretq_s16_m128i(a), vreinterpretq_s16_m128i(b)));
+ }
+ 
+-// Adds the 4 signed or unsigned 32-bit integers in a to the 4 signed or
+-// unsigned 32-bit integers in b.
+-//
+-//   r0 := a0 + b0
+-//   r1 := a1 + b1
+-//   r2 := a2 + b2
+-//   r3 := a3 + b3
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/09xs4fkk(v=vs.100).aspx
++// Add packed 32-bit integers in a and b, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_add_epi32
+ FORCE_INLINE __m128i _mm_add_epi32(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s32(
+         vaddq_s32(vreinterpretq_s32_m128i(a), vreinterpretq_s32_m128i(b)));
+ }
+ 
+-// Adds the 4 signed or unsigned 64-bit integers in a to the 4 signed or
+-// unsigned 32-bit integers in b.
+-// https://msdn.microsoft.com/en-us/library/vstudio/09xs4fkk(v=vs.100).aspx
++// Add packed 64-bit integers in a and b, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_add_epi64
+ FORCE_INLINE __m128i _mm_add_epi64(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s64(
+         vaddq_s64(vreinterpretq_s64_m128i(a), vreinterpretq_s64_m128i(b)));
+ }
+ 
+-// Adds the 16 signed or unsigned 8-bit integers in a to the 16 signed or
+-// unsigned 8-bit integers in b.
+-// https://technet.microsoft.com/en-us/subscriptions/yc7tcyzs(v=vs.90)
++// Add packed 8-bit integers in a and b, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_add_epi8
+ FORCE_INLINE __m128i _mm_add_epi8(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s8(
+@@ -3139,15 +2988,21 @@ FORCE_INLINE __m128i _mm_add_epi8(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_add_pd
+ FORCE_INLINE __m128d _mm_add_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vaddq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)));
+ #else
+-    double *da = (double *) &a;
+-    double *db = (double *) &b;
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
+     double c[2];
+-    c[0] = da[0] + db[0];
+-    c[1] = da[1] + db[1];
++    c[0] = a0 + b0;
++    c[1] = a1 + b1;
+     return vld1q_f32((float32_t *) c);
+ #endif
+ }
+@@ -3155,29 +3010,24 @@ FORCE_INLINE __m128d _mm_add_pd(__m128d
+ // Add the lower double-precision (64-bit) floating-point element in a and b,
+ // store the result in the lower element of dst, and copy the upper element from
+ // a to the upper element of dst.
+-//
+-//   dst[63:0] := a[63:0] + b[63:0]
+-//   dst[127:64] := a[127:64]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_add_sd
+ FORCE_INLINE __m128d _mm_add_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return _mm_move_sd(a, _mm_add_pd(a, b));
+ #else
+-    double *da = (double *) &a;
+-    double *db = (double *) &b;
++    double a0, a1, b0;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    a1 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
+     double c[2];
+-    c[0] = da[0] + db[0];
+-    c[1] = da[1];
++    c[0] = a0 + b0;
++    c[1] = a1;
+     return vld1q_f32((float32_t *) c);
+ #endif
+ }
+ 
+ // Add 64-bit integers a and b, and store the result in dst.
+-//
+-//   dst[63:0] := a[63:0] + b[63:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_add_si64
+ FORCE_INLINE __m64 _mm_add_si64(__m64 a, __m64 b)
+ {
+@@ -3185,15 +3035,9 @@ FORCE_INLINE __m64 _mm_add_si64(__m64 a,
+         vadd_s64(vreinterpret_s64_m64(a), vreinterpret_s64_m64(b)));
+ }
+ 
+-// Adds the 8 signed 16-bit integers in a to the 8 signed 16-bit integers in b
+-// and saturates.
+-//
+-//   r0 := SignedSaturate(a0 + b0)
+-//   r1 := SignedSaturate(a1 + b1)
+-//   ...
+-//   r7 := SignedSaturate(a7 + b7)
+-//
+-// https://msdn.microsoft.com/en-us/library/1a306ef8(v=vs.100).aspx
++// Add packed signed 16-bit integers in a and b using saturation, and store the
++// results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_adds_epi16
+ FORCE_INLINE __m128i _mm_adds_epi16(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s16(
+@@ -3202,12 +3046,6 @@ FORCE_INLINE __m128i _mm_adds_epi16(__m1
+ 
+ // Add packed signed 8-bit integers in a and b using saturation, and store the
+ // results in dst.
+-//
+-//   FOR j := 0 to 15
+-//     i := j*8
+-//     dst[i+7:i] := Saturate8( a[i+7:i] + b[i+7:i] )
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_adds_epi8
+ FORCE_INLINE __m128i _mm_adds_epi8(__m128i a, __m128i b)
+ {
+@@ -3224,9 +3062,9 @@ FORCE_INLINE __m128i _mm_adds_epu16(__m1
+         vqaddq_u16(vreinterpretq_u16_m128i(a), vreinterpretq_u16_m128i(b)));
+ }
+ 
+-// Adds the 16 unsigned 8-bit integers in a to the 16 unsigned 8-bit integers in
+-// b and saturates..
+-// https://msdn.microsoft.com/en-us/library/9hahyddy(v=vs.100).aspx
++// Add packed unsigned 8-bit integers in a and b using saturation, and store the
++// results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_adds_epu8
+ FORCE_INLINE __m128i _mm_adds_epu8(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u8(
+@@ -3235,12 +3073,6 @@ FORCE_INLINE __m128i _mm_adds_epu8(__m12
+ 
+ // Compute the bitwise AND of packed double-precision (64-bit) floating-point
+ // elements in a and b, and store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-//     i := j*64
+-//     dst[i+63:i] := a[i+63:i] AND b[i+63:i]
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_and_pd
+ FORCE_INLINE __m128d _mm_and_pd(__m128d a, __m128d b)
+ {
+@@ -3248,12 +3080,9 @@ FORCE_INLINE __m128d _mm_and_pd(__m128d
+         vandq_s64(vreinterpretq_s64_m128d(a), vreinterpretq_s64_m128d(b)));
+ }
+ 
+-// Computes the bitwise AND of the 128-bit value in a and the 128-bit value in
+-// b.
+-//
+-//   r := a & b
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/6d1txsa8(v=vs.100).aspx
++// Compute the bitwise AND of 128 bits (representing integer data) in a and b,
++// and store the result in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_and_si128
+ FORCE_INLINE __m128i _mm_and_si128(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s32(
+@@ -3262,12 +3091,6 @@ FORCE_INLINE __m128i _mm_and_si128(__m12
+ 
+ // Compute the bitwise NOT of packed double-precision (64-bit) floating-point
+ // elements in a and then AND with b, and store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-// 	     i := j*64
+-// 	     dst[i+63:i] := ((NOT a[i+63:i]) AND b[i+63:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_andnot_pd
+ FORCE_INLINE __m128d _mm_andnot_pd(__m128d a, __m128d b)
+ {
+@@ -3276,12 +3099,9 @@ FORCE_INLINE __m128d _mm_andnot_pd(__m12
+         vbicq_s64(vreinterpretq_s64_m128d(b), vreinterpretq_s64_m128d(a)));
+ }
+ 
+-// Computes the bitwise AND of the 128-bit value in b and the bitwise NOT of the
+-// 128-bit value in a.
+-//
+-//   r := (~a) & b
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/1beaceh8(v=vs.100).aspx
++// Compute the bitwise NOT of 128 bits (representing integer data) in a and then
++// AND with b, and store the result in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_andnot_si128
+ FORCE_INLINE __m128i _mm_andnot_si128(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s32(
+@@ -3289,30 +3109,18 @@ FORCE_INLINE __m128i _mm_andnot_si128(__
+                   vreinterpretq_s32_m128i(a)));  // *NOTE* argument swap
+ }
+ 
+-// Computes the average of the 8 unsigned 16-bit integers in a and the 8
+-// unsigned 16-bit integers in b and rounds.
+-//
+-//   r0 := (a0 + b0) / 2
+-//   r1 := (a1 + b1) / 2
+-//   ...
+-//   r7 := (a7 + b7) / 2
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/y13ca3c8(v=vs.90).aspx
++// Average packed unsigned 16-bit integers in a and b, and store the results in
++// dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_avg_epu16
+ FORCE_INLINE __m128i _mm_avg_epu16(__m128i a, __m128i b)
+ {
+     return (__m128i) vrhaddq_u16(vreinterpretq_u16_m128i(a),
+                                  vreinterpretq_u16_m128i(b));
+ }
+ 
+-// Computes the average of the 16 unsigned 8-bit integers in a and the 16
+-// unsigned 8-bit integers in b and rounds.
+-//
+-//   r0 := (a0 + b0) / 2
+-//   r1 := (a1 + b1) / 2
+-//   ...
+-//   r15 := (a15 + b15) / 2
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/8zwh554a(v%3dvs.90).aspx
++// Average packed unsigned 8-bit integers in a and b, and store the results in
++// dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_avg_epu8
+ FORCE_INLINE __m128i _mm_avg_epu8(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u8(
+@@ -3353,9 +3161,9 @@ FORCE_INLINE __m128d _mm_castps_pd(__m12
+     return vreinterpretq_m128d_s32(vreinterpretq_s32_m128(a));
+ }
+ 
+-// Applies a type cast to reinterpret four 32-bit floating point values passed
+-// in as a 128-bit parameter as packed 32-bit integers.
+-// https://msdn.microsoft.com/en-us/library/bb514099.aspx
++// Cast vector of type __m128 to type __m128i. This intrinsic is only used for
++// compilation and does not generate any instructions, thus it has zero latency.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_castps_si128
+ FORCE_INLINE __m128i _mm_castps_si128(__m128 a)
+ {
+     return vreinterpretq_m128i_s32(vreinterpretq_s32_m128(a));
+@@ -3366,16 +3174,16 @@ FORCE_INLINE __m128i _mm_castps_si128(__
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_castsi128_pd
+ FORCE_INLINE __m128d _mm_castsi128_pd(__m128i a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(vreinterpretq_f64_m128i(a));
+ #else
+     return vreinterpretq_m128d_f32(vreinterpretq_f32_m128i(a));
+ #endif
+ }
+ 
+-// Applies a type cast to reinterpret four 32-bit integers passed in as a
+-// 128-bit parameter as packed 32-bit floating point values.
+-// https://msdn.microsoft.com/en-us/library/bb514029.aspx
++// Cast vector of type __m128i to type __m128. This intrinsic is only used for
++// compilation and does not generate any instructions, thus it has zero latency.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_castsi128_ps
+ FORCE_INLINE __m128 _mm_castsi128_ps(__m128i a)
+ {
+     return vreinterpretq_m128_s32(vreinterpretq_s32_m128i(a));
+@@ -3401,14 +3209,14 @@ FORCE_INLINE void _mm_clflush(void const
+     uintptr_t ptr = (uintptr_t) p;
+     __builtin___clear_cache((char *) ptr,
+                             (char *) ptr + SSE2NEON_CACHELINE_SIZE);
+-#else
+-    /* FIXME: MSVC support */
++#elif (_MSC_VER) && SSE2NEON_INCLUDE_WINDOWS_H
++    FlushInstructionCache(GetCurrentProcess(), p, SSE2NEON_CACHELINE_SIZE);
+ #endif
+ }
+ 
+-// Compares the 8 signed or unsigned 16-bit integers in a and the 8 signed or
+-// unsigned 16-bit integers in b for equality.
+-// https://msdn.microsoft.com/en-us/library/2ay060te(v=vs.100).aspx
++// Compare packed 16-bit integers in a and b for equality, and store the results
++// in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpeq_epi16
+ FORCE_INLINE __m128i _mm_cmpeq_epi16(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u16(
+@@ -3416,16 +3224,17 @@ FORCE_INLINE __m128i _mm_cmpeq_epi16(__m
+ }
+ 
+ // Compare packed 32-bit integers in a and b for equality, and store the results
+-// in dst
++// in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpeq_epi32
+ FORCE_INLINE __m128i _mm_cmpeq_epi32(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u32(
+         vceqq_s32(vreinterpretq_s32_m128i(a), vreinterpretq_s32_m128i(b)));
+ }
+ 
+-// Compares the 16 signed or unsigned 8-bit integers in a and the 16 signed or
+-// unsigned 8-bit integers in b for equality.
+-// https://msdn.microsoft.com/en-us/library/windows/desktop/bz5xk21a(v=vs.90).aspx
++// Compare packed 8-bit integers in a and b for equality, and store the results
++// in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpeq_epi8
+ FORCE_INLINE __m128i _mm_cmpeq_epi8(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u8(
+@@ -3437,7 +3246,7 @@ FORCE_INLINE __m128i _mm_cmpeq_epi8(__m1
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpeq_pd
+ FORCE_INLINE __m128d _mm_cmpeq_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_u64(
+         vceqq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)));
+ #else
+@@ -3463,17 +3272,21 @@ FORCE_INLINE __m128d _mm_cmpeq_sd(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpge_pd
+ FORCE_INLINE __m128d _mm_cmpge_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_u64(
+         vcgeq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)));
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t b1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(b));
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
+     uint64_t d[2];
+-    d[0] = (*(double *) &a0) >= (*(double *) &b0) ? ~UINT64_C(0) : UINT64_C(0);
+-    d[1] = (*(double *) &a1) >= (*(double *) &b1) ? ~UINT64_C(0) : UINT64_C(0);
++    d[0] = a0 >= b0 ? ~UINT64_C(0) : UINT64_C(0);
++    d[1] = a1 >= b1 ? ~UINT64_C(0) : UINT64_C(0);
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+ #endif
+@@ -3485,54 +3298,43 @@ FORCE_INLINE __m128d _mm_cmpge_pd(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpge_sd
+ FORCE_INLINE __m128d _mm_cmpge_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return _mm_move_sd(a, _mm_cmpge_pd(a, b));
+ #else
+     // expand "_mm_cmpge_pd()" to reduce unnecessary operations
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
++    double a0, b0;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    uint64_t a1 = vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1);
++    b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
+     uint64_t d[2];
+-    d[0] = (*(double *) &a0) >= (*(double *) &b0) ? ~UINT64_C(0) : UINT64_C(0);
++    d[0] = a0 >= b0 ? ~UINT64_C(0) : UINT64_C(0);
+     d[1] = a1;
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+ #endif
+ }
+ 
+-// Compares the 8 signed 16-bit integers in a and the 8 signed 16-bit integers
+-// in b for greater than.
+-//
+-//   r0 := (a0 > b0) ? 0xffff : 0x0
+-//   r1 := (a1 > b1) ? 0xffff : 0x0
+-//   ...
+-//   r7 := (a7 > b7) ? 0xffff : 0x0
+-//
+-// https://technet.microsoft.com/en-us/library/xd43yfsa(v=vs.100).aspx
++// Compare packed signed 16-bit integers in a and b for greater-than, and store
++// the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpgt_epi16
+ FORCE_INLINE __m128i _mm_cmpgt_epi16(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u16(
+         vcgtq_s16(vreinterpretq_s16_m128i(a), vreinterpretq_s16_m128i(b)));
+ }
+ 
+-// Compares the 4 signed 32-bit integers in a and the 4 signed 32-bit integers
+-// in b for greater than.
+-// https://msdn.microsoft.com/en-us/library/vstudio/1s9f2z0y(v=vs.100).aspx
++// Compare packed signed 32-bit integers in a and b for greater-than, and store
++// the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpgt_epi32
+ FORCE_INLINE __m128i _mm_cmpgt_epi32(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u32(
+         vcgtq_s32(vreinterpretq_s32_m128i(a), vreinterpretq_s32_m128i(b)));
+ }
+ 
+-// Compares the 16 signed 8-bit integers in a and the 16 signed 8-bit integers
+-// in b for greater than.
+-//
+-//   r0 := (a0 > b0) ? 0xff : 0x0
+-//   r1 := (a1 > b1) ? 0xff : 0x0
+-//   ...
+-//   r15 := (a15 > b15) ? 0xff : 0x0
+-//
+-// https://msdn.microsoft.com/zh-tw/library/wf45zt2b(v=vs.100).aspx
++// Compare packed signed 8-bit integers in a and b for greater-than, and store
++// the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpgt_epi8
+ FORCE_INLINE __m128i _mm_cmpgt_epi8(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u8(
+@@ -3544,17 +3346,21 @@ FORCE_INLINE __m128i _mm_cmpgt_epi8(__m1
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpgt_pd
+ FORCE_INLINE __m128d _mm_cmpgt_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_u64(
+         vcgtq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)));
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t b1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(b));
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
+     uint64_t d[2];
+-    d[0] = (*(double *) &a0) > (*(double *) &b0) ? ~UINT64_C(0) : UINT64_C(0);
+-    d[1] = (*(double *) &a1) > (*(double *) &b1) ? ~UINT64_C(0) : UINT64_C(0);
++    d[0] = a0 > b0 ? ~UINT64_C(0) : UINT64_C(0);
++    d[1] = a1 > b1 ? ~UINT64_C(0) : UINT64_C(0);
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+ #endif
+@@ -3566,15 +3372,16 @@ FORCE_INLINE __m128d _mm_cmpgt_pd(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpgt_sd
+ FORCE_INLINE __m128d _mm_cmpgt_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return _mm_move_sd(a, _mm_cmpgt_pd(a, b));
+ #else
+     // expand "_mm_cmpge_pd()" to reduce unnecessary operations
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
++    double a0, b0;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    uint64_t a1 = vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1);
++    b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
+     uint64_t d[2];
+-    d[0] = (*(double *) &a0) > (*(double *) &b0) ? ~UINT64_C(0) : UINT64_C(0);
++    d[0] = a0 > b0 ? ~UINT64_C(0) : UINT64_C(0);
+     d[1] = a1;
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+@@ -3586,17 +3393,21 @@ FORCE_INLINE __m128d _mm_cmpgt_sd(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmple_pd
+ FORCE_INLINE __m128d _mm_cmple_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_u64(
+         vcleq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)));
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t b1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(b));
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
+     uint64_t d[2];
+-    d[0] = (*(double *) &a0) <= (*(double *) &b0) ? ~UINT64_C(0) : UINT64_C(0);
+-    d[1] = (*(double *) &a1) <= (*(double *) &b1) ? ~UINT64_C(0) : UINT64_C(0);
++    d[0] = a0 <= b0 ? ~UINT64_C(0) : UINT64_C(0);
++    d[1] = a1 <= b1 ? ~UINT64_C(0) : UINT64_C(0);
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+ #endif
+@@ -3608,49 +3419,46 @@ FORCE_INLINE __m128d _mm_cmple_pd(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmple_sd
+ FORCE_INLINE __m128d _mm_cmple_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return _mm_move_sd(a, _mm_cmple_pd(a, b));
+ #else
+     // expand "_mm_cmpge_pd()" to reduce unnecessary operations
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
++    double a0, b0;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    uint64_t a1 = vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1);
++    b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
+     uint64_t d[2];
+-    d[0] = (*(double *) &a0) <= (*(double *) &b0) ? ~UINT64_C(0) : UINT64_C(0);
++    d[0] = a0 <= b0 ? ~UINT64_C(0) : UINT64_C(0);
+     d[1] = a1;
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+ #endif
+ }
+ 
+-// Compares the 8 signed 16-bit integers in a and the 8 signed 16-bit integers
+-// in b for less than.
+-//
+-//   r0 := (a0 < b0) ? 0xffff : 0x0
+-//   r1 := (a1 < b1) ? 0xffff : 0x0
+-//   ...
+-//   r7 := (a7 < b7) ? 0xffff : 0x0
+-//
+-// https://technet.microsoft.com/en-us/library/t863edb2(v=vs.100).aspx
++// Compare packed signed 16-bit integers in a and b for less-than, and store the
++// results in dst. Note: This intrinsic emits the pcmpgtw instruction with the
++// order of the operands switched.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmplt_epi16
+ FORCE_INLINE __m128i _mm_cmplt_epi16(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u16(
+         vcltq_s16(vreinterpretq_s16_m128i(a), vreinterpretq_s16_m128i(b)));
+ }
+ 
+-
+-// Compares the 4 signed 32-bit integers in a and the 4 signed 32-bit integers
+-// in b for less than.
+-// https://msdn.microsoft.com/en-us/library/vstudio/4ak0bf5d(v=vs.100).aspx
++// Compare packed signed 32-bit integers in a and b for less-than, and store the
++// results in dst. Note: This intrinsic emits the pcmpgtd instruction with the
++// order of the operands switched.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmplt_epi32
+ FORCE_INLINE __m128i _mm_cmplt_epi32(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u32(
+         vcltq_s32(vreinterpretq_s32_m128i(a), vreinterpretq_s32_m128i(b)));
+ }
+ 
+-// Compares the 16 signed 8-bit integers in a and the 16 signed 8-bit integers
+-// in b for lesser than.
+-// https://msdn.microsoft.com/en-us/library/windows/desktop/9s46csht(v=vs.90).aspx
++// Compare packed signed 8-bit integers in a and b for less-than, and store the
++// results in dst. Note: This intrinsic emits the pcmpgtb instruction with the
++// order of the operands switched.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmplt_epi8
+ FORCE_INLINE __m128i _mm_cmplt_epi8(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u8(
+@@ -3662,17 +3470,21 @@ FORCE_INLINE __m128i _mm_cmplt_epi8(__m1
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmplt_pd
+ FORCE_INLINE __m128d _mm_cmplt_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_u64(
+         vcltq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)));
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t b1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(b));
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
+     uint64_t d[2];
+-    d[0] = (*(double *) &a0) < (*(double *) &b0) ? ~UINT64_C(0) : UINT64_C(0);
+-    d[1] = (*(double *) &a1) < (*(double *) &b1) ? ~UINT64_C(0) : UINT64_C(0);
++    d[0] = a0 < b0 ? ~UINT64_C(0) : UINT64_C(0);
++    d[1] = a1 < b1 ? ~UINT64_C(0) : UINT64_C(0);
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+ #endif
+@@ -3684,14 +3496,15 @@ FORCE_INLINE __m128d _mm_cmplt_pd(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmplt_sd
+ FORCE_INLINE __m128d _mm_cmplt_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return _mm_move_sd(a, _mm_cmplt_pd(a, b));
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
++    double a0, b0;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    uint64_t a1 = vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1);
++    b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
+     uint64_t d[2];
+-    d[0] = (*(double *) &a0) < (*(double *) &b0) ? ~UINT64_C(0) : UINT64_C(0);
++    d[0] = a0 < b0 ? ~UINT64_C(0) : UINT64_C(0);
+     d[1] = a1;
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+@@ -3703,7 +3516,7 @@ FORCE_INLINE __m128d _mm_cmplt_sd(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpneq_pd
+ FORCE_INLINE __m128d _mm_cmpneq_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_s32(vmvnq_s32(vreinterpretq_s32_u64(
+         vceqq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)))));
+ #else
+@@ -3729,20 +3542,22 @@ FORCE_INLINE __m128d _mm_cmpneq_sd(__m12
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpnge_pd
+ FORCE_INLINE __m128d _mm_cmpnge_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_u64(veorq_u64(
+         vcgeq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)),
+         vdupq_n_u64(UINT64_MAX)));
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t b1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(b));
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
+     uint64_t d[2];
+-    d[0] =
+-        !((*(double *) &a0) >= (*(double *) &b0)) ? ~UINT64_C(0) : UINT64_C(0);
+-    d[1] =
+-        !((*(double *) &a1) >= (*(double *) &b1)) ? ~UINT64_C(0) : UINT64_C(0);
++    d[0] = !(a0 >= b0) ? ~UINT64_C(0) : UINT64_C(0);
++    d[1] = !(a1 >= b1) ? ~UINT64_C(0) : UINT64_C(0);
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+ #endif
+@@ -3762,20 +3577,22 @@ FORCE_INLINE __m128d _mm_cmpnge_sd(__m12
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_cmpngt_pd
+ FORCE_INLINE __m128d _mm_cmpngt_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_u64(veorq_u64(
+         vcgtq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)),
+         vdupq_n_u64(UINT64_MAX)));
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t b1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(b));
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
+     uint64_t d[2];
+-    d[0] =
+-        !((*(double *) &a0) > (*(double *) &b0)) ? ~UINT64_C(0) : UINT64_C(0);
+-    d[1] =
+-        !((*(double *) &a1) > (*(double *) &b1)) ? ~UINT64_C(0) : UINT64_C(0);
++    d[0] = !(a0 > b0) ? ~UINT64_C(0) : UINT64_C(0);
++    d[1] = !(a1 > b1) ? ~UINT64_C(0) : UINT64_C(0);
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+ #endif
+@@ -3795,20 +3612,22 @@ FORCE_INLINE __m128d _mm_cmpngt_sd(__m12
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpnle_pd
+ FORCE_INLINE __m128d _mm_cmpnle_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_u64(veorq_u64(
+         vcleq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)),
+         vdupq_n_u64(UINT64_MAX)));
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t b1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(b));
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
+     uint64_t d[2];
+-    d[0] =
+-        !((*(double *) &a0) <= (*(double *) &b0)) ? ~UINT64_C(0) : UINT64_C(0);
+-    d[1] =
+-        !((*(double *) &a1) <= (*(double *) &b1)) ? ~UINT64_C(0) : UINT64_C(0);
++    d[0] = !(a0 <= b0) ? ~UINT64_C(0) : UINT64_C(0);
++    d[1] = !(a1 <= b1) ? ~UINT64_C(0) : UINT64_C(0);
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+ #endif
+@@ -3828,20 +3647,22 @@ FORCE_INLINE __m128d _mm_cmpnle_sd(__m12
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpnlt_pd
+ FORCE_INLINE __m128d _mm_cmpnlt_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_u64(veorq_u64(
+         vcltq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)),
+         vdupq_n_u64(UINT64_MAX)));
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t b1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(b));
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
+     uint64_t d[2];
+-    d[0] =
+-        !((*(double *) &a0) < (*(double *) &b0)) ? ~UINT64_C(0) : UINT64_C(0);
+-    d[1] =
+-        !((*(double *) &a1) < (*(double *) &b1)) ? ~UINT64_C(0) : UINT64_C(0);
++    d[0] = !(a0 < b0) ? ~UINT64_C(0) : UINT64_C(0);
++    d[1] = !(a1 < b1) ? ~UINT64_C(0) : UINT64_C(0);
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+ #endif
+@@ -3861,7 +3682,7 @@ FORCE_INLINE __m128d _mm_cmpnlt_sd(__m12
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpord_pd
+ FORCE_INLINE __m128d _mm_cmpord_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     // Excluding NaNs, any two floating point numbers can be compared.
+     uint64x2_t not_nan_a =
+         vceqq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(a));
+@@ -3869,19 +3690,17 @@ FORCE_INLINE __m128d _mm_cmpord_pd(__m12
+         vceqq_f64(vreinterpretq_f64_m128d(b), vreinterpretq_f64_m128d(b));
+     return vreinterpretq_m128d_u64(vandq_u64(not_nan_a, not_nan_b));
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t b1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(b));
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
+     uint64_t d[2];
+-    d[0] = ((*(double *) &a0) == (*(double *) &a0) &&
+-            (*(double *) &b0) == (*(double *) &b0))
+-               ? ~UINT64_C(0)
+-               : UINT64_C(0);
+-    d[1] = ((*(double *) &a1) == (*(double *) &a1) &&
+-            (*(double *) &b1) == (*(double *) &b1))
+-               ? ~UINT64_C(0)
+-               : UINT64_C(0);
++    d[0] = (a0 == a0 && b0 == b0) ? ~UINT64_C(0) : UINT64_C(0);
++    d[1] = (a1 == a1 && b1 == b1) ? ~UINT64_C(0) : UINT64_C(0);
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+ #endif
+@@ -3893,17 +3712,15 @@ FORCE_INLINE __m128d _mm_cmpord_pd(__m12
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpord_sd
+ FORCE_INLINE __m128d _mm_cmpord_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return _mm_move_sd(a, _mm_cmpord_pd(a, b));
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
++    double a0, b0;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    uint64_t a1 = vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1);
++    b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
+     uint64_t d[2];
+-    d[0] = ((*(double *) &a0) == (*(double *) &a0) &&
+-            (*(double *) &b0) == (*(double *) &b0))
+-               ? ~UINT64_C(0)
+-               : UINT64_C(0);
++    d[0] = (a0 == a0 && b0 == b0) ? ~UINT64_C(0) : UINT64_C(0);
+     d[1] = a1;
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+@@ -3915,7 +3732,7 @@ FORCE_INLINE __m128d _mm_cmpord_sd(__m12
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpunord_pd
+ FORCE_INLINE __m128d _mm_cmpunord_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     // Two NaNs are not equal in comparison operation.
+     uint64x2_t not_nan_a =
+         vceqq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(a));
+@@ -3924,19 +3741,17 @@ FORCE_INLINE __m128d _mm_cmpunord_pd(__m
+     return vreinterpretq_m128d_s32(
+         vmvnq_s32(vreinterpretq_s32_u64(vandq_u64(not_nan_a, not_nan_b))));
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t b1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(b));
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
+     uint64_t d[2];
+-    d[0] = ((*(double *) &a0) == (*(double *) &a0) &&
+-            (*(double *) &b0) == (*(double *) &b0))
+-               ? UINT64_C(0)
+-               : ~UINT64_C(0);
+-    d[1] = ((*(double *) &a1) == (*(double *) &a1) &&
+-            (*(double *) &b1) == (*(double *) &b1))
+-               ? UINT64_C(0)
+-               : ~UINT64_C(0);
++    d[0] = (a0 == a0 && b0 == b0) ? UINT64_C(0) : ~UINT64_C(0);
++    d[1] = (a1 == a1 && b1 == b1) ? UINT64_C(0) : ~UINT64_C(0);
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+ #endif
+@@ -3948,17 +3763,15 @@ FORCE_INLINE __m128d _mm_cmpunord_pd(__m
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpunord_sd
+ FORCE_INLINE __m128d _mm_cmpunord_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return _mm_move_sd(a, _mm_cmpunord_pd(a, b));
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
++    double a0, b0;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    uint64_t a1 = vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1);
++    b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
+     uint64_t d[2];
+-    d[0] = ((*(double *) &a0) == (*(double *) &a0) &&
+-            (*(double *) &b0) == (*(double *) &b0))
+-               ? UINT64_C(0)
+-               : ~UINT64_C(0);
++    d[0] = (a0 == a0 && b0 == b0) ? UINT64_C(0) : ~UINT64_C(0);
+     d[1] = a1;
+ 
+     return vreinterpretq_m128d_u64(vld1q_u64(d));
+@@ -3970,13 +3783,13 @@ FORCE_INLINE __m128d _mm_cmpunord_sd(__m
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_comige_sd
+ FORCE_INLINE int _mm_comige_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vgetq_lane_u64(vcgeq_f64(a, b), 0) & 0x1;
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-
+-    return (*(double *) &a0 >= *(double *) &b0);
++    double a0, b0;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    return a0 >= b0;
+ #endif
+ }
+ 
+@@ -3985,13 +3798,14 @@ FORCE_INLINE int _mm_comige_sd(__m128d a
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_comigt_sd
+ FORCE_INLINE int _mm_comigt_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vgetq_lane_u64(vcgtq_f64(a, b), 0) & 0x1;
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
++    double a0, b0;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
+ 
+-    return (*(double *) &a0 > *(double *) &b0);
++    return a0 > b0;
+ #endif
+ }
+ 
+@@ -4000,13 +3814,14 @@ FORCE_INLINE int _mm_comigt_sd(__m128d a
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_comile_sd
+ FORCE_INLINE int _mm_comile_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vgetq_lane_u64(vcleq_f64(a, b), 0) & 0x1;
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
++    double a0, b0;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
+ 
+-    return (*(double *) &a0 <= *(double *) &b0);
++    return a0 <= b0;
+ #endif
+ }
+ 
+@@ -4015,13 +3830,14 @@ FORCE_INLINE int _mm_comile_sd(__m128d a
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_comilt_sd
+ FORCE_INLINE int _mm_comilt_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vgetq_lane_u64(vcltq_f64(a, b), 0) & 0x1;
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
++    double a0, b0;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
+ 
+-    return (*(double *) &a0 < *(double *) &b0);
++    return a0 < b0;
+ #endif
+ }
+ 
+@@ -4030,7 +3846,7 @@ FORCE_INLINE int _mm_comilt_sd(__m128d a
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_comieq_sd
+ FORCE_INLINE int _mm_comieq_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vgetq_lane_u64(vceqq_f64(a, b), 0) & 0x1;
+ #else
+     uint32x4_t a_not_nan =
+@@ -4056,17 +3872,10 @@ FORCE_INLINE int _mm_comineq_sd(__m128d
+ 
+ // Convert packed signed 32-bit integers in a to packed double-precision
+ // (64-bit) floating-point elements, and store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-//     i := j*32
+-//     m := j*64
+-//     dst[m+63:m] := Convert_Int32_To_FP64(a[i+31:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtepi32_pd
+ FORCE_INLINE __m128d _mm_cvtepi32_pd(__m128i a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vcvtq_f64_s64(vmovl_s32(vget_low_s32(vreinterpretq_s32_m128i(a)))));
+ #else
+@@ -4076,9 +3885,9 @@ FORCE_INLINE __m128d _mm_cvtepi32_pd(__m
+ #endif
+ }
+ 
+-// Converts the four signed 32-bit integer values of a to single-precision,
+-// floating-point values
+-// https://msdn.microsoft.com/en-us/library/vstudio/36bwxcx5(v=vs.100).aspx
++// Convert packed signed 32-bit integers in a to packed single-precision
++// (32-bit) floating-point elements, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtepi32_ps
+ FORCE_INLINE __m128 _mm_cvtepi32_ps(__m128i a)
+ {
+     return vreinterpretq_m128_f32(vcvtq_f32_s32(vreinterpretq_s32_m128i(a)));
+@@ -4086,13 +3895,6 @@ FORCE_INLINE __m128 _mm_cvtepi32_ps(__m1
+ 
+ // Convert packed double-precision (64-bit) floating-point elements in a to
+ // packed 32-bit integers, and store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-//      i := 32*j
+-//      k := 64*j
+-//      dst[i+31:i] := Convert_FP64_To_Int32(a[k+63:k])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtpd_epi32
+ FORCE_INLINE __m128i _mm_cvtpd_epi32(__m128d a)
+ {
+@@ -4104,27 +3906,26 @@ FORCE_INLINE __m128i _mm_cvtpd_epi32(__m
+         vcombine_s32(vmovn_s64(integers), vdup_n_s32(0)));
+ #else
+     __m128d rnd = _mm_round_pd(a, _MM_FROUND_CUR_DIRECTION);
+-    double d0 = ((double *) &rnd)[0];
+-    double d1 = ((double *) &rnd)[1];
++    double d0, d1;
++    d0 = sse2neon_recast_u64_f64(
++        vgetq_lane_u64(vreinterpretq_u64_m128d(rnd), 0));
++    d1 = sse2neon_recast_u64_f64(
++        vgetq_lane_u64(vreinterpretq_u64_m128d(rnd), 1));
+     return _mm_set_epi32(0, 0, (int32_t) d1, (int32_t) d0);
+ #endif
+ }
+ 
+ // Convert packed double-precision (64-bit) floating-point elements in a to
+ // packed 32-bit integers, and store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-//      i := 32*j
+-//      k := 64*j
+-//      dst[i+31:i] := Convert_FP64_To_Int32(a[k+63:k])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtpd_pi32
+ FORCE_INLINE __m64 _mm_cvtpd_pi32(__m128d a)
+ {
+     __m128d rnd = _mm_round_pd(a, _MM_FROUND_CUR_DIRECTION);
+-    double d0 = ((double *) &rnd)[0];
+-    double d1 = ((double *) &rnd)[1];
++    double d0, d1;
++    d0 = sse2neon_recast_u64_f64(
++        vgetq_lane_u64(vreinterpretq_u64_m128d(rnd), 0));
++    d1 = sse2neon_recast_u64_f64(
++        vgetq_lane_u64(vreinterpretq_u64_m128d(rnd), 1));
+     int32_t ALIGN_STRUCT(16) data[2] = {(int32_t) d0, (int32_t) d1};
+     return vreinterpret_m64_s32(vld1_s32(data));
+ }
+@@ -4132,40 +3933,26 @@ FORCE_INLINE __m64 _mm_cvtpd_pi32(__m128
+ // Convert packed double-precision (64-bit) floating-point elements in a to
+ // packed single-precision (32-bit) floating-point elements, and store the
+ // results in dst.
+-//
+-//   FOR j := 0 to 1
+-//     i := 32*j
+-//     k := 64*j
+-//     dst[i+31:i] := Convert_FP64_To_FP32(a[k+64:k])
+-//   ENDFOR
+-//   dst[127:64] := 0
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtpd_ps
+ FORCE_INLINE __m128 _mm_cvtpd_ps(__m128d a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     float32x2_t tmp = vcvt_f32_f64(vreinterpretq_f64_m128d(a));
+     return vreinterpretq_m128_f32(vcombine_f32(tmp, vdup_n_f32(0)));
+ #else
+-    float a0 = (float) ((double *) &a)[0];
+-    float a1 = (float) ((double *) &a)[1];
+-    return _mm_set_ps(0, 0, a1, a0);
++    double a0, a1;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    a1 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    return _mm_set_ps(0, 0, (float) a1, (float) a0);
+ #endif
+ }
+ 
+ // Convert packed signed 32-bit integers in a to packed double-precision
+ // (64-bit) floating-point elements, and store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-//     i := j*32
+-//     m := j*64
+-//     dst[m+63:m] := Convert_Int32_To_FP64(a[i+31:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtpi32_pd
+ FORCE_INLINE __m128d _mm_cvtpi32_pd(__m64 a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vcvtq_f64_s64(vmovl_s32(vreinterpret_s32_m64(a))));
+ #else
+@@ -4175,22 +3962,17 @@ FORCE_INLINE __m128d _mm_cvtpi32_pd(__m6
+ #endif
+ }
+ 
+-// Converts the four single-precision, floating-point values of a to signed
+-// 32-bit integer values.
+-//
+-//   r0 := (int) a0
+-//   r1 := (int) a1
+-//   r2 := (int) a2
+-//   r3 := (int) a3
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/xdc42k5e(v=vs.100).aspx
++// Convert packed single-precision (32-bit) floating-point elements in a to
++// packed 32-bit integers, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtps_epi32
+ // *NOTE*. The default rounding mode on SSE is 'round to even', which ARMv7-A
+ // does not support! It is supported on ARMv8-A however.
+ FORCE_INLINE __m128i _mm_cvtps_epi32(__m128 a)
+ {
+ #if defined(__ARM_FEATURE_FRINT)
+     return vreinterpretq_m128i_s32(vcvtq_s32_f32(vrnd32xq_f32(a)));
+-#elif defined(__aarch64__) || defined(__ARM_FEATURE_DIRECTED_ROUNDING)
++#elif (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)) || \
++    defined(__ARM_FEATURE_DIRECTED_ROUNDING)
+     switch (_MM_GET_ROUNDING_MODE()) {
+     case _MM_ROUND_NEAREST:
+         return vreinterpretq_m128i_s32(vcvtnq_s32_f32(a));
+@@ -4240,17 +4022,10 @@ FORCE_INLINE __m128i _mm_cvtps_epi32(__m
+ // Convert packed single-precision (32-bit) floating-point elements in a to
+ // packed double-precision (64-bit) floating-point elements, and store the
+ // results in dst.
+-//
+-//   FOR j := 0 to 1
+-//     i := 64*j
+-//     k := 32*j
+-//     dst[i+63:i] := Convert_FP32_To_FP64(a[k+31:k])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtps_pd
+ FORCE_INLINE __m128d _mm_cvtps_pd(__m128 a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vcvt_f64_f32(vget_low_f32(vreinterpretq_f32_m128(a))));
+ #else
+@@ -4261,58 +4036,50 @@ FORCE_INLINE __m128d _mm_cvtps_pd(__m128
+ }
+ 
+ // Copy the lower double-precision (64-bit) floating-point element of a to dst.
+-//
+-//   dst[63:0] := a[63:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsd_f64
+ FORCE_INLINE double _mm_cvtsd_f64(__m128d a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return (double) vgetq_lane_f64(vreinterpretq_f64_m128d(a), 0);
+ #else
+-    return ((double *) &a)[0];
++    double _a =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    return _a;
+ #endif
+ }
+ 
+ // Convert the lower double-precision (64-bit) floating-point element in a to a
+ // 32-bit integer, and store the result in dst.
+-//
+-//   dst[31:0] := Convert_FP64_To_Int32(a[63:0])
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsd_si32
+ FORCE_INLINE int32_t _mm_cvtsd_si32(__m128d a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return (int32_t) vgetq_lane_f64(vrndiq_f64(vreinterpretq_f64_m128d(a)), 0);
+ #else
+     __m128d rnd = _mm_round_pd(a, _MM_FROUND_CUR_DIRECTION);
+-    double ret = ((double *) &rnd)[0];
++    double ret = sse2neon_recast_u64_f64(
++        vgetq_lane_u64(vreinterpretq_u64_m128d(rnd), 0));
+     return (int32_t) ret;
+ #endif
+ }
+ 
+ // Convert the lower double-precision (64-bit) floating-point element in a to a
+ // 64-bit integer, and store the result in dst.
+-//
+-//   dst[63:0] := Convert_FP64_To_Int64(a[63:0])
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsd_si64
+ FORCE_INLINE int64_t _mm_cvtsd_si64(__m128d a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return (int64_t) vgetq_lane_f64(vrndiq_f64(vreinterpretq_f64_m128d(a)), 0);
+ #else
+     __m128d rnd = _mm_round_pd(a, _MM_FROUND_CUR_DIRECTION);
+-    double ret = ((double *) &rnd)[0];
++    double ret = sse2neon_recast_u64_f64(
++        vgetq_lane_u64(vreinterpretq_u64_m128d(rnd), 0));
+     return (int64_t) ret;
+ #endif
+ }
+ 
+ // Convert the lower double-precision (64-bit) floating-point element in a to a
+ // 64-bit integer, and store the result in dst.
+-//
+-//   dst[63:0] := Convert_FP64_To_Int64(a[63:0])
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsd_si64x
+ #define _mm_cvtsd_si64x _mm_cvtsd_si64
+ 
+@@ -4323,20 +4090,19 @@ FORCE_INLINE int64_t _mm_cvtsd_si64(__m1
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsd_ss
+ FORCE_INLINE __m128 _mm_cvtsd_ss(__m128 a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128_f32(vsetq_lane_f32(
+         vget_lane_f32(vcvt_f32_f64(vreinterpretq_f64_m128d(b)), 0),
+         vreinterpretq_f32_m128(a), 0));
+ #else
+-    return vreinterpretq_m128_f32(vsetq_lane_f32((float) ((double *) &b)[0],
+-                                                 vreinterpretq_f32_m128(a), 0));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    return vreinterpretq_m128_f32(
++        vsetq_lane_f32((float) b0, vreinterpretq_f32_m128(a), 0));
+ #endif
+ }
+ 
+ // Copy the lower 32-bit integer in a to dst.
+-//
+-//   dst[31:0] := a[31:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsi128_si32
+ FORCE_INLINE int _mm_cvtsi128_si32(__m128i a)
+ {
+@@ -4344,9 +4110,6 @@ FORCE_INLINE int _mm_cvtsi128_si32(__m12
+ }
+ 
+ // Copy the lower 64-bit integer in a to dst.
+-//
+-//   dst[63:0] := a[63:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsi128_si64
+ FORCE_INLINE int64_t _mm_cvtsi128_si64(__m128i a)
+ {
+@@ -4363,32 +4126,23 @@ FORCE_INLINE int64_t _mm_cvtsi128_si64(_
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsi32_sd
+ FORCE_INLINE __m128d _mm_cvtsi32_sd(__m128d a, int32_t b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vsetq_lane_f64((double) b, vreinterpretq_f64_m128d(a), 0));
+ #else
+-    double bf = (double) b;
++    int64_t _b = sse2neon_recast_f64_s64((double) b);
+     return vreinterpretq_m128d_s64(
+-        vsetq_lane_s64(*(int64_t *) &bf, vreinterpretq_s64_m128d(a), 0));
++        vsetq_lane_s64(_b, vreinterpretq_s64_m128d(a), 0));
+ #endif
+ }
+ 
+ // Copy the lower 64-bit integer in a to dst.
+-//
+-//   dst[63:0] := a[63:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsi128_si64x
+ #define _mm_cvtsi128_si64x(a) _mm_cvtsi128_si64(a)
+ 
+-// Moves 32-bit integer a to the least significant 32 bits of an __m128 object,
+-// zero extending the upper bits.
+-//
+-//   r0 := a
+-//   r1 := 0x0
+-//   r2 := 0x0
+-//   r3 := 0x0
+-//
+-// https://msdn.microsoft.com/en-us/library/ct3539ha%28v=vs.90%29.aspx
++// Copy 32-bit integer a to the lower elements of dst, and zero the upper
++// elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsi32_si128
+ FORCE_INLINE __m128i _mm_cvtsi32_si128(int a)
+ {
+     return vreinterpretq_m128i_s32(vsetq_lane_s32(a, vdupq_n_s32(0), 0));
+@@ -4400,21 +4154,19 @@ FORCE_INLINE __m128i _mm_cvtsi32_si128(i
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsi64_sd
+ FORCE_INLINE __m128d _mm_cvtsi64_sd(__m128d a, int64_t b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vsetq_lane_f64((double) b, vreinterpretq_f64_m128d(a), 0));
+ #else
+-    double bf = (double) b;
++    int64_t _b = sse2neon_recast_f64_s64((double) b);
+     return vreinterpretq_m128d_s64(
+-        vsetq_lane_s64(*(int64_t *) &bf, vreinterpretq_s64_m128d(a), 0));
++        vsetq_lane_s64(_b, vreinterpretq_s64_m128d(a), 0));
+ #endif
+ }
+ 
+-// Moves 64-bit integer a to the least significant 64 bits of an __m128 object,
+-// zero extending the upper bits.
+-//
+-//   r0 := a
+-//   r1 := 0x0
++// Copy 64-bit integer a to the lower element of dst, and zero the upper
++// element.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsi64_si128
+ FORCE_INLINE __m128i _mm_cvtsi64_si128(int64_t a)
+ {
+     return vreinterpretq_m128i_s64(vsetq_lane_s64(a, vdupq_n_s64(0), 0));
+@@ -4435,20 +4187,16 @@ FORCE_INLINE __m128i _mm_cvtsi64_si128(i
+ // double-precision (64-bit) floating-point element, store the result in the
+ // lower element of dst, and copy the upper element from a to the upper element
+ // of dst.
+-//
+-//   dst[63:0] := Convert_FP32_To_FP64(b[31:0])
+-//   dst[127:64] := a[127:64]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtss_sd
+ FORCE_INLINE __m128d _mm_cvtss_sd(__m128d a, __m128 b)
+ {
+     double d = (double) vgetq_lane_f32(vreinterpretq_f32_m128(b), 0);
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vsetq_lane_f64(d, vreinterpretq_f64_m128d(a), 0));
+ #else
+-    return vreinterpretq_m128d_s64(
+-        vsetq_lane_s64(*(int64_t *) &d, vreinterpretq_s64_m128d(a), 0));
++    return vreinterpretq_m128d_s64(vsetq_lane_s64(
++        sse2neon_recast_f64_s64(d), vreinterpretq_s64_m128d(a), 0));
+ #endif
+ }
+ 
+@@ -4457,8 +4205,9 @@ FORCE_INLINE __m128d _mm_cvtss_sd(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvttpd_epi32
+ FORCE_INLINE __m128i _mm_cvttpd_epi32(__m128d a)
+ {
+-    double a0 = ((double *) &a)[0];
+-    double a1 = ((double *) &a)[1];
++    double a0, a1;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    a1 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
+     return _mm_set_epi32(0, 0, (int32_t) a1, (int32_t) a0);
+ }
+ 
+@@ -4467,15 +4216,16 @@ FORCE_INLINE __m128i _mm_cvttpd_epi32(__
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvttpd_pi32
+ FORCE_INLINE __m64 _mm_cvttpd_pi32(__m128d a)
+ {
+-    double a0 = ((double *) &a)[0];
+-    double a1 = ((double *) &a)[1];
++    double a0, a1;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    a1 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
+     int32_t ALIGN_STRUCT(16) data[2] = {(int32_t) a0, (int32_t) a1};
+     return vreinterpret_m64_s32(vld1_s32(data));
+ }
+ 
+-// Converts the four single-precision, floating-point values of a to signed
+-// 32-bit integer values using truncate.
+-// https://msdn.microsoft.com/en-us/library/vstudio/1h005y6x(v=vs.100).aspx
++// Convert packed single-precision (32-bit) floating-point elements in a to
++// packed 32-bit integers with truncation, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvttps_epi32
+ FORCE_INLINE __m128i _mm_cvttps_epi32(__m128 a)
+ {
+     return vreinterpretq_m128i_s32(vcvtq_s32_f32(vreinterpretq_f32_m128(a)));
+@@ -4483,60 +4233,53 @@ FORCE_INLINE __m128i _mm_cvttps_epi32(__
+ 
+ // Convert the lower double-precision (64-bit) floating-point element in a to a
+ // 32-bit integer with truncation, and store the result in dst.
+-//
+-//   dst[63:0] := Convert_FP64_To_Int32_Truncate(a[63:0])
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvttsd_si32
+ FORCE_INLINE int32_t _mm_cvttsd_si32(__m128d a)
+ {
+-    double ret = *((double *) &a);
+-    return (int32_t) ret;
++    double _a =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    return (int32_t) _a;
+ }
+ 
+ // Convert the lower double-precision (64-bit) floating-point element in a to a
+ // 64-bit integer with truncation, and store the result in dst.
+-//
+-//   dst[63:0] := Convert_FP64_To_Int64_Truncate(a[63:0])
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvttsd_si64
+ FORCE_INLINE int64_t _mm_cvttsd_si64(__m128d a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vgetq_lane_s64(vcvtq_s64_f64(vreinterpretq_f64_m128d(a)), 0);
+ #else
+-    double ret = *((double *) &a);
+-    return (int64_t) ret;
++    double _a =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    return (int64_t) _a;
+ #endif
+ }
+ 
+ // Convert the lower double-precision (64-bit) floating-point element in a to a
+ // 64-bit integer with truncation, and store the result in dst.
+-//
+-//   dst[63:0] := Convert_FP64_To_Int64_Truncate(a[63:0])
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvttsd_si64x
+ #define _mm_cvttsd_si64x(a) _mm_cvttsd_si64(a)
+ 
+ // Divide packed double-precision (64-bit) floating-point elements in a by
+ // packed elements in b, and store the results in dst.
+-//
+-//  FOR j := 0 to 1
+-//    i := 64*j
+-//    dst[i+63:i] := a[i+63:i] / b[i+63:i]
+-//  ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_div_pd
+ FORCE_INLINE __m128d _mm_div_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vdivq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)));
+ #else
+-    double *da = (double *) &a;
+-    double *db = (double *) &b;
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
+     double c[2];
+-    c[0] = da[0] / db[0];
+-    c[1] = da[1] / db[1];
++    c[0] = a0 / b0;
++    c[1] = a1 / b1;
+     return vld1q_f32((float32_t *) c);
+ #endif
+ }
+@@ -4548,7 +4291,7 @@ FORCE_INLINE __m128d _mm_div_pd(__m128d
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_div_sd
+ FORCE_INLINE __m128d _mm_div_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     float64x2_t tmp =
+         vdivq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b));
+     return vreinterpretq_m128d_f64(
+@@ -4558,33 +4301,29 @@ FORCE_INLINE __m128d _mm_div_sd(__m128d
+ #endif
+ }
+ 
+-// Extracts the selected signed or unsigned 16-bit integer from a and zero
+-// extends.
+-// https://msdn.microsoft.com/en-us/library/6dceta0c(v=vs.100).aspx
++// Extract a 16-bit integer from a, selected with imm8, and store the result in
++// the lower element of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_extract_epi16
+ // FORCE_INLINE int _mm_extract_epi16(__m128i a, __constrange(0,8) int imm)
+ #define _mm_extract_epi16(a, imm) \
+     vgetq_lane_u16(vreinterpretq_u16_m128i(a), (imm))
+ 
+-// Inserts the least significant 16 bits of b into the selected 16-bit integer
+-// of a.
+-// https://msdn.microsoft.com/en-us/library/kaze8hz1%28v=vs.100%29.aspx
++// Copy a to dst, and insert the 16-bit integer i into dst at the location
++// specified by imm8.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_insert_epi16
+ // FORCE_INLINE __m128i _mm_insert_epi16(__m128i a, int b,
+ //                                       __constrange(0,8) int imm)
+-#define _mm_insert_epi16(a, b, imm)                                  \
+-    __extension__({                                                  \
+-        vreinterpretq_m128i_s16(                                     \
+-            vsetq_lane_s16((b), vreinterpretq_s16_m128i(a), (imm))); \
+-    })
++#define _mm_insert_epi16(a, b, imm) \
++    vreinterpretq_m128i_s16(        \
++        vsetq_lane_s16((b), vreinterpretq_s16_m128i(a), (imm)))
+ 
+-// Loads two double-precision from 16-byte aligned memory, floating-point
+-// values.
+-//
+-//   dst[127:0] := MEM[mem_addr+127:mem_addr]
+-//
++// Load 128-bits (composed of 2 packed double-precision (64-bit) floating-point
++// elements) from memory into dst. mem_addr must be aligned on a 16-byte
++// boundary or a general-protection exception may be generated.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_load_pd
+ FORCE_INLINE __m128d _mm_load_pd(const double *p)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(vld1q_f64(p));
+ #else
+     const float *fp = (const float *) p;
+@@ -4595,24 +4334,16 @@ FORCE_INLINE __m128d _mm_load_pd(const d
+ 
+ // Load a double-precision (64-bit) floating-point element from memory into both
+ // elements of dst.
+-//
+-//   dst[63:0] := MEM[mem_addr+63:mem_addr]
+-//   dst[127:64] := MEM[mem_addr+63:mem_addr]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_load_pd1
+ #define _mm_load_pd1 _mm_load1_pd
+ 
+ // Load a double-precision (64-bit) floating-point element from memory into the
+ // lower of dst, and zero the upper element. mem_addr does not need to be
+ // aligned on any particular boundary.
+-//
+-//   dst[63:0] := MEM[mem_addr+63:mem_addr]
+-//   dst[127:64] := 0
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_load_sd
+ FORCE_INLINE __m128d _mm_load_sd(const double *p)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(vsetq_lane_f64(*p, vdupq_n_f64(0), 0));
+ #else
+     const float *fp = (const float *) p;
+@@ -4621,8 +4352,9 @@ FORCE_INLINE __m128d _mm_load_sd(const d
+ #endif
+ }
+ 
+-// Loads 128-bit value. :
+-// https://msdn.microsoft.com/en-us/library/atzzad1h(v=vs.80).aspx
++// Load 128-bits of integer data from memory into dst. mem_addr must be aligned
++// on a 16-byte boundary or a general-protection exception may be generated.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_load_si128
+ FORCE_INLINE __m128i _mm_load_si128(const __m128i *p)
+ {
+     return vreinterpretq_m128i_s32(vld1q_s32((const int32_t *) p));
+@@ -4630,14 +4362,10 @@ FORCE_INLINE __m128i _mm_load_si128(cons
+ 
+ // Load a double-precision (64-bit) floating-point element from memory into both
+ // elements of dst.
+-//
+-//   dst[63:0] := MEM[mem_addr+63:mem_addr]
+-//   dst[127:64] := MEM[mem_addr+63:mem_addr]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_load1_pd
+ FORCE_INLINE __m128d _mm_load1_pd(const double *p)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(vld1q_dup_f64(p));
+ #else
+     return vreinterpretq_m128d_s64(vdupq_n_s64(*(const int64_t *) p));
+@@ -4647,14 +4375,10 @@ FORCE_INLINE __m128d _mm_load1_pd(const
+ // Load a double-precision (64-bit) floating-point element from memory into the
+ // upper element of dst, and copy the lower element from a to dst. mem_addr does
+ // not need to be aligned on any particular boundary.
+-//
+-//   dst[63:0] := a[63:0]
+-//   dst[127:64] := MEM[mem_addr+63:mem_addr]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadh_pd
+ FORCE_INLINE __m128d _mm_loadh_pd(__m128d a, const double *p)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vcombine_f64(vget_low_f64(vreinterpretq_f64_m128d(a)), vld1_f64(p)));
+ #else
+@@ -4677,14 +4401,10 @@ FORCE_INLINE __m128i _mm_loadl_epi64(__m
+ // Load a double-precision (64-bit) floating-point element from memory into the
+ // lower element of dst, and copy the upper element from a to dst. mem_addr does
+ // not need to be aligned on any particular boundary.
+-//
+-//   dst[63:0] := MEM[mem_addr+63:mem_addr]
+-//   dst[127:64] := a[127:64]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadl_pd
+ FORCE_INLINE __m128d _mm_loadl_pd(__m128d a, const double *p)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vcombine_f64(vld1_f64(p), vget_high_f64(vreinterpretq_f64_m128d(a))));
+ #else
+@@ -4697,14 +4417,10 @@ FORCE_INLINE __m128d _mm_loadl_pd(__m128
+ // Load 2 double-precision (64-bit) floating-point elements from memory into dst
+ // in reverse order. mem_addr must be aligned on a 16-byte boundary or a
+ // general-protection exception may be generated.
+-//
+-//   dst[63:0] := MEM[mem_addr+127:mem_addr+64]
+-//   dst[127:64] := MEM[mem_addr+63:mem_addr]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadr_pd
+ FORCE_INLINE __m128d _mm_loadr_pd(const double *p)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     float64x2_t v = vld1q_f64(p);
+     return vreinterpretq_m128d_f64(vextq_f64(v, v, 1));
+ #else
+@@ -4720,38 +4436,31 @@ FORCE_INLINE __m128d _mm_loadu_pd(const
+     return _mm_load_pd(p);
+ }
+ 
+-// Loads 128-bit value. :
+-// https://msdn.microsoft.com/zh-cn/library/f4k12ae8(v=vs.90).aspx
++// Load 128-bits of integer data from memory into dst. mem_addr does not need to
++// be aligned on any particular boundary.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_si128
+ FORCE_INLINE __m128i _mm_loadu_si128(const __m128i *p)
+ {
+-    return vreinterpretq_m128i_s32(vld1q_s32((const int32_t *) p));
++    return vreinterpretq_m128i_s32(vld1q_s32((const unaligned_int32_t *) p));
+ }
+ 
+ // Load unaligned 32-bit integer from memory into the first element of dst.
+-//
+-//   dst[31:0] := MEM[mem_addr+31:mem_addr]
+-//   dst[MAX:32] := 0
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_si32
+ FORCE_INLINE __m128i _mm_loadu_si32(const void *p)
+ {
+     return vreinterpretq_m128i_s32(
+-        vsetq_lane_s32(*(const int32_t *) p, vdupq_n_s32(0), 0));
++        vsetq_lane_s32(*(const unaligned_int32_t *) p, vdupq_n_s32(0), 0));
+ }
+ 
+-// Multiplies the 8 signed 16-bit integers from a by the 8 signed 16-bit
+-// integers from b.
+-//
+-//   r0 := (a0 * b0) + (a1 * b1)
+-//   r1 := (a2 * b2) + (a3 * b3)
+-//   r2 := (a4 * b4) + (a5 * b5)
+-//   r3 := (a6 * b6) + (a7 * b7)
+-// https://msdn.microsoft.com/en-us/library/yht36sa6(v=vs.90).aspx
++// Multiply packed signed 16-bit integers in a and b, producing intermediate
++// signed 32-bit integers. Horizontally add adjacent pairs of intermediate
++// 32-bit integers, and pack the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_madd_epi16
+ FORCE_INLINE __m128i _mm_madd_epi16(__m128i a, __m128i b)
+ {
+     int32x4_t low = vmull_s16(vget_low_s16(vreinterpretq_s16_m128i(a)),
+                               vget_low_s16(vreinterpretq_s16_m128i(b)));
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     int32x4_t high =
+         vmull_high_s16(vreinterpretq_s16_m128i(a), vreinterpretq_s16_m128i(b));
+ 
+@@ -4782,18 +4491,18 @@ FORCE_INLINE void _mm_maskmoveu_si128(__
+     vst1q_s8((int8_t *) mem_addr, masked);
+ }
+ 
+-// Computes the pairwise maxima of the 8 signed 16-bit integers from a and the 8
+-// signed 16-bit integers from b.
+-// https://msdn.microsoft.com/en-us/LIBRary/3x060h7c(v=vs.100).aspx
++// Compare packed signed 16-bit integers in a and b, and store packed maximum
++// values in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_max_epi16
+ FORCE_INLINE __m128i _mm_max_epi16(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s16(
+         vmaxq_s16(vreinterpretq_s16_m128i(a), vreinterpretq_s16_m128i(b)));
+ }
+ 
+-// Computes the pairwise maxima of the 16 unsigned 8-bit integers from a and the
+-// 16 unsigned 8-bit integers from b.
+-// https://msdn.microsoft.com/en-us/library/st6634za(v=vs.100).aspx
++// Compare packed unsigned 8-bit integers in a and b, and store packed maximum
++// values in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_max_epu8
+ FORCE_INLINE __m128i _mm_max_epu8(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u8(
+@@ -4805,7 +4514,7 @@ FORCE_INLINE __m128i _mm_max_epu8(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_max_pd
+ FORCE_INLINE __m128d _mm_max_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+ #if SSE2NEON_PRECISE_MINMAX
+     float64x2_t _a = vreinterpretq_f64_m128d(a);
+     float64x2_t _b = vreinterpretq_f64_m128d(b);
+@@ -4815,15 +4524,19 @@ FORCE_INLINE __m128d _mm_max_pd(__m128d
+         vmaxq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)));
+ #endif
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t b1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t d[2];
+-    d[0] = (*(double *) &a0) > (*(double *) &b0) ? a0 : b0;
+-    d[1] = (*(double *) &a1) > (*(double *) &b1) ? a1 : b1;
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
++    int64_t d[2];
++    d[0] = a0 > b0 ? sse2neon_recast_f64_s64(a0) : sse2neon_recast_f64_s64(b0);
++    d[1] = a1 > b1 ? sse2neon_recast_f64_s64(a1) : sse2neon_recast_f64_s64(b1);
+ 
+-    return vreinterpretq_m128d_u64(vld1q_u64(d));
++    return vreinterpretq_m128d_s64(vld1q_s64(d));
+ #endif
+ }
+ 
+@@ -4833,28 +4546,30 @@ FORCE_INLINE __m128d _mm_max_pd(__m128d
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_max_sd
+ FORCE_INLINE __m128d _mm_max_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return _mm_move_sd(a, _mm_max_pd(a, b));
+ #else
+-    double *da = (double *) &a;
+-    double *db = (double *) &b;
+-    double c[2] = {da[0] > db[0] ? da[0] : db[0], da[1]};
++    double a0, a1, b0;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    a1 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double c[2] = {a0 > b0 ? a0 : b0, a1};
+     return vreinterpretq_m128d_f32(vld1q_f32((float32_t *) c));
+ #endif
+ }
+ 
+-// Computes the pairwise minima of the 8 signed 16-bit integers from a and the 8
+-// signed 16-bit integers from b.
+-// https://msdn.microsoft.com/en-us/library/vstudio/6te997ew(v=vs.100).aspx
++// Compare packed signed 16-bit integers in a and b, and store packed minimum
++// values in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_min_epi16
+ FORCE_INLINE __m128i _mm_min_epi16(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s16(
+         vminq_s16(vreinterpretq_s16_m128i(a), vreinterpretq_s16_m128i(b)));
+ }
+ 
+-// Computes the pairwise minima of the 16 unsigned 8-bit integers from a and the
+-// 16 unsigned 8-bit integers from b.
+-// https://msdn.microsoft.com/ko-kr/library/17k8cf58(v=vs.100).aspxx
++// Compare packed unsigned 8-bit integers in a and b, and store packed minimum
++// values in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_min_epu8
+ FORCE_INLINE __m128i _mm_min_epu8(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u8(
+@@ -4866,7 +4581,7 @@ FORCE_INLINE __m128i _mm_min_epu8(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_min_pd
+ FORCE_INLINE __m128d _mm_min_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+ #if SSE2NEON_PRECISE_MINMAX
+     float64x2_t _a = vreinterpretq_f64_m128d(a);
+     float64x2_t _b = vreinterpretq_f64_m128d(b);
+@@ -4876,14 +4591,18 @@ FORCE_INLINE __m128d _mm_min_pd(__m128d
+         vminq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)));
+ #endif
+ #else
+-    uint64_t a0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t a1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(a));
+-    uint64_t b0 = (uint64_t) vget_low_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t b1 = (uint64_t) vget_high_u64(vreinterpretq_u64_m128d(b));
+-    uint64_t d[2];
+-    d[0] = (*(double *) &a0) < (*(double *) &b0) ? a0 : b0;
+-    d[1] = (*(double *) &a1) < (*(double *) &b1) ? a1 : b1;
+-    return vreinterpretq_m128d_u64(vld1q_u64(d));
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
++    int64_t d[2];
++    d[0] = a0 < b0 ? sse2neon_recast_f64_s64(a0) : sse2neon_recast_f64_s64(b0);
++    d[1] = a1 < b1 ? sse2neon_recast_f64_s64(a1) : sse2neon_recast_f64_s64(b1);
++    return vreinterpretq_m128d_s64(vld1q_s64(d));
+ #endif
+ }
+ 
+@@ -4893,22 +4612,20 @@ FORCE_INLINE __m128d _mm_min_pd(__m128d
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_min_sd
+ FORCE_INLINE __m128d _mm_min_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return _mm_move_sd(a, _mm_min_pd(a, b));
+ #else
+-    double *da = (double *) &a;
+-    double *db = (double *) &b;
+-    double c[2] = {da[0] < db[0] ? da[0] : db[0], da[1]};
++    double a0, a1, b0;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    a1 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double c[2] = {a0 < b0 ? a0 : b0, a1};
+     return vreinterpretq_m128d_f32(vld1q_f32((float32_t *) c));
+ #endif
+ }
+ 
+ // Copy the lower 64-bit integer in a to the lower element of dst, and zero the
+ // upper element.
+-//
+-//   dst[63:0] := a[63:0]
+-//   dst[127:64] := 0
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_move_epi64
+ FORCE_INLINE __m128i _mm_move_epi64(__m128i a)
+ {
+@@ -4919,10 +4636,6 @@ FORCE_INLINE __m128i _mm_move_epi64(__m1
+ // Move the lower double-precision (64-bit) floating-point element from b to the
+ // lower element of dst, and copy the upper element from a to the upper element
+ // of dst.
+-//
+-//   dst[63:0] := b[63:0]
+-//   dst[127:64] := a[127:64]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_move_sd
+ FORCE_INLINE __m128d _mm_move_sd(__m128d a, __m128d b)
+ {
+@@ -4931,44 +4644,31 @@ FORCE_INLINE __m128d _mm_move_sd(__m128d
+                      vget_high_f32(vreinterpretq_f32_m128d(a))));
+ }
+ 
+-// NEON does not provide a version of this function.
+-// Creates a 16-bit mask from the most significant bits of the 16 signed or
+-// unsigned 8-bit integers in a and zero extends the upper bits.
+-// https://msdn.microsoft.com/en-us/library/vstudio/s090c8fk(v=vs.100).aspx
++// Create mask from the most significant bit of each 8-bit element in a, and
++// store the result in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_movemask_epi8
+ FORCE_INLINE int _mm_movemask_epi8(__m128i a)
+ {
+-    // Use increasingly wide shifts+adds to collect the sign bits
+-    // together.
+-    // Since the widening shifts would be rather confusing to follow in little
+-    // endian, everything will be illustrated in big endian order instead. This
+-    // has a different result - the bits would actually be reversed on a big
+-    // endian machine.
++    // Note: Everything will be illustrated in big-endian order.
+ 
+     // Starting input (only half the elements are shown):
+-    // 89 ff 1d c0 00 10 99 33
++    // 11111111 11111111 00000000 11111111 00000000 00000000 11111111 00000000
++    // ff       ff       00       ff       00       00       ff       00
+     uint8x16_t input = vreinterpretq_u8_m128i(a);
+ 
+-    // Shift out everything but the sign bits with an unsigned shift right.
+-    //
+-    // Bytes of the vector::
+-    // 89 ff 1d c0 00 10 99 33
+-    // \  \  \  \  \  \  \  \    high_bits = (uint16x4_t)(input >> 7)
+-    //  |  |  |  |  |  |  |  |
+-    // 01 01 00 01 00 00 01 00
+-    //
+-    // Bits of first important lane(s):
+-    // 10001001 (89)
+-    // \______
+-    //        |
+-    // 00000001 (01)
+-    uint16x8_t high_bits = vreinterpretq_u16_u8(vshrq_n_u8(input, 7));
+-
+-    // Merge the even lanes together with a 16-bit unsigned shift right + add.
+-    // 'xx' represents garbage data which will be ignored in the final result.
+-    // In the important bytes, the add functions like a binary OR.
++    // Right-shift each 8-bit element by 7,
++    // effectively extracting the MSB into the LSB.
++    // (ff becomes a 01 | 11111111 becomes a 00000001)
++    uint8x16_t msbs = vshrq_n_u8(input, 7);
++
++    // Reinterpret 16x8-bit elements as 2x64-bit elements.
++    // (In our example, we only handle 1x64-bit element)
++    uint64x2_t bits = vreinterpretq_u64_u8(msbs);
++
++    // The bits B are shifted to the right by C and merged with A.
+     //
+     // 01 01 00 01 00 00 01 00
+-    //  \_ |  \_ |  \_ |  \_ |   paired16 = (uint32x4_t)(input + (input >> 7))
++    //  \_ |  \_ |  \_ |  \_ |   bits = (uint64x1_t)(bits + (bits >> 7))
+     //    \|    \|    \|    \|
+     // xx 03 xx 01 xx 00 xx 02
+     //
+@@ -4976,13 +4676,9 @@ FORCE_INLINE int _mm_movemask_epi8(__m12
+     //        \_______ |
+     //                \|
+     // xxxxxxxx xxxxxx11 (xx 03)
+-    uint32x4_t paired16 =
+-        vreinterpretq_u32_u16(vsraq_n_u16(high_bits, high_bits, 7));
+-
+-    // Repeat with a wider 32-bit shift + add.
++    bits = vsraq_n_u64(bits, bits, 7);
+     // xx 03 xx 01 xx 00 xx 02
+-    //     \____ |     \____ |  paired32 = (uint64x1_t)(paired16 + (paired16 >>
+-    //     14))
++    //     \____ |     \____ |   bits = (uint64x1_t)(bits + (bits >> 14))
+     //          \|          \|
+     // xx xx xx 0d xx xx xx 02
+     //
+@@ -4990,13 +4686,9 @@ FORCE_INLINE int _mm_movemask_epi8(__m12
+     //        \\_____ ||
+     //         '----.\||
+     // xxxxxxxx xxxx1101 (xx 0d)
+-    uint64x2_t paired32 =
+-        vreinterpretq_u64_u32(vsraq_n_u32(paired16, paired16, 14));
+-
+-    // Last, an even wider 64-bit shift + add to get our result in the low 8 bit
+-    // lanes. xx xx xx 0d xx xx xx 02
+-    //            \_________ |   paired64 = (uint8x8_t)(paired32 + (paired32 >>
+-    //            28))
++    bits = vsraq_n_u64(bits, bits, 14);
++    // xx xx xx 0d xx xx xx 02
++    //            \_________ |   bits = (uint64x1_t)(bits + (bits >> 28))
+     //                      \|
+     // xx xx xx xx xx xx xx d2
+     //
+@@ -5004,15 +4696,16 @@ FORCE_INLINE int _mm_movemask_epi8(__m12
+     //     \   \___ |  |
+     //      '---.  \|  |
+     // xxxxxxxx 11010010 (xx d2)
+-    uint8x16_t paired64 =
+-        vreinterpretq_u8_u64(vsraq_n_u64(paired32, paired32, 28));
++    bits = vsraq_n_u64(bits, bits, 28);
+ 
+-    // Extract the low 8 bits from each 64-bit lane with 2 8-bit extracts.
+-    // xx xx xx xx xx xx xx d2
+-    //                      ||  return paired64[0]
+-    //                      d2
+-    // Note: Little endian would return the correct value 4b (01001011) instead.
+-    return vgetq_lane_u8(paired64, 0) | ((int) vgetq_lane_u8(paired64, 8) << 8);
++    // Reinterpret 2x64-bit elements as 16x8-bit elements.
++    uint8x16_t output = vreinterpretq_u8_u64(bits);
++
++    // Note: Little-endian would return the correct value 4b (01001011) instead.
++    int low = vgetq_lane_u8(output, 0);   // xxxxxxxx
++    int high = vgetq_lane_u8(output, 8);  // 11010010
++
++    return (high << 8) | low;  // 0000000 0000000 11010010 xxxxxxxx
+ }
+ 
+ // Set each bit of mask dst based on the most significant bit of the
+@@ -5022,13 +4715,11 @@ FORCE_INLINE int _mm_movemask_pd(__m128d
+ {
+     uint64x2_t input = vreinterpretq_u64_m128d(a);
+     uint64x2_t high_bits = vshrq_n_u64(input, 63);
+-    return vgetq_lane_u64(high_bits, 0) | (vgetq_lane_u64(high_bits, 1) << 1);
++    return (int) (vgetq_lane_u64(high_bits, 0) |
++                  (vgetq_lane_u64(high_bits, 1) << 1));
+ }
+ 
+ // Copy the lower 64-bit integer in a to dst.
+-//
+-//   dst[63:0] := a[63:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_movepi64_pi64
+ FORCE_INLINE __m64 _mm_movepi64_pi64(__m128i a)
+ {
+@@ -5037,10 +4728,6 @@ FORCE_INLINE __m64 _mm_movepi64_pi64(__m
+ 
+ // Copy the 64-bit integer a to the lower element of dst, and zero the upper
+ // element.
+-//
+-//   dst[63:0] := a[63:0]
+-//   dst[127:64] := 0
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_movpi64_epi64
+ FORCE_INLINE __m128i _mm_movpi64_epi64(__m64 a)
+ {
+@@ -5050,9 +4737,7 @@ FORCE_INLINE __m128i _mm_movpi64_epi64(_
+ 
+ // Multiply the low unsigned 32-bit integers from each packed 64-bit element in
+ // a and b, and store the unsigned 64-bit results in dst.
+-//
+-//   r0 :=  (a0 & 0xFFFFFFFF) * (b0 & 0xFFFFFFFF)
+-//   r1 :=  (a2 & 0xFFFFFFFF) * (b2 & 0xFFFFFFFF)
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mul_epu32
+ FORCE_INLINE __m128i _mm_mul_epu32(__m128i a, __m128i b)
+ {
+     // vmull_u32 upcasts instead of masking, so we downcast.
+@@ -5066,15 +4751,21 @@ FORCE_INLINE __m128i _mm_mul_epu32(__m12
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mul_pd
+ FORCE_INLINE __m128d _mm_mul_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vmulq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)));
+ #else
+-    double *da = (double *) &a;
+-    double *db = (double *) &b;
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
+     double c[2];
+-    c[0] = da[0] * db[0];
+-    c[1] = da[1] * db[1];
++    c[0] = a0 * b0;
++    c[1] = a1 * b1;
+     return vld1q_f32((float32_t *) c);
+ #endif
+ }
+@@ -5090,9 +4781,6 @@ FORCE_INLINE __m128d _mm_mul_sd(__m128d
+ 
+ // Multiply the low unsigned 32-bit integers from a and b, and store the
+ // unsigned 64-bit result in dst.
+-//
+-//   dst[63:0] := a[31:0] * b[31:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mul_su32
+ FORCE_INLINE __m64 _mm_mul_su32(__m64 a, __m64 b)
+ {
+@@ -5100,15 +4788,10 @@ FORCE_INLINE __m64 _mm_mul_su32(__m64 a,
+         vmull_u32(vreinterpret_u32_m64(a), vreinterpret_u32_m64(b))));
+ }
+ 
+-// Multiplies the 8 signed 16-bit integers from a by the 8 signed 16-bit
+-// integers from b.
+-//
+-//   r0 := (a0 * b0)[31:16]
+-//   r1 := (a1 * b1)[31:16]
+-//   ...
+-//   r7 := (a7 * b7)[31:16]
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/59hddw1d(v=vs.100).aspx
++// Multiply the packed signed 16-bit integers in a and b, producing intermediate
++// 32-bit integers, and store the high 16 bits of the intermediate integers in
++// dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mulhi_epi16
+ FORCE_INLINE __m128i _mm_mulhi_epi16(__m128i a, __m128i b)
+ {
+     /* FIXME: issue with large values because of result saturation */
+@@ -5135,7 +4818,7 @@ FORCE_INLINE __m128i _mm_mulhi_epu16(__m
+     uint16x4_t a3210 = vget_low_u16(vreinterpretq_u16_m128i(a));
+     uint16x4_t b3210 = vget_low_u16(vreinterpretq_u16_m128i(b));
+     uint32x4_t ab3210 = vmull_u16(a3210, b3210);
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     uint32x4_t ab7654 =
+         vmull_high_u16(vreinterpretq_u16_m128i(a), vreinterpretq_u16_m128i(b));
+     uint16x8_t r = vuzp2q_u16(vreinterpretq_u16_u32(ab3210),
+@@ -5151,15 +4834,9 @@ FORCE_INLINE __m128i _mm_mulhi_epu16(__m
+ #endif
+ }
+ 
+-// Multiplies the 8 signed or unsigned 16-bit integers from a by the 8 signed or
+-// unsigned 16-bit integers from b.
+-//
+-//   r0 := (a0 * b0)[15:0]
+-//   r1 := (a1 * b1)[15:0]
+-//   ...
+-//   r7 := (a7 * b7)[15:0]
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/9ks1472s(v=vs.100).aspx
++// Multiply the packed 16-bit integers in a and b, producing intermediate 32-bit
++// integers, and store the low 16 bits of the intermediate integers in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mullo_epi16
+ FORCE_INLINE __m128i _mm_mullo_epi16(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s16(
+@@ -5175,20 +4852,18 @@ FORCE_INLINE __m128d _mm_or_pd(__m128d a
+         vorrq_s64(vreinterpretq_s64_m128d(a), vreinterpretq_s64_m128d(b)));
+ }
+ 
+-// Computes the bitwise OR of the 128-bit value in a and the 128-bit value in b.
+-//
+-//   r := a | b
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/ew8ty0db(v=vs.100).aspx
++// Compute the bitwise OR of 128 bits (representing integer data) in a and b,
++// and store the result in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_or_si128
+ FORCE_INLINE __m128i _mm_or_si128(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s32(
+         vorrq_s32(vreinterpretq_s32_m128i(a), vreinterpretq_s32_m128i(b)));
+ }
+ 
+-// Packs the 16 signed 16-bit integers from a and b into 8-bit integers and
+-// saturates.
+-// https://msdn.microsoft.com/en-us/library/k4y4f7w5%28v=vs.90%29.aspx
++// Convert packed signed 16-bit integers from a and b to packed 8-bit integers
++// using signed saturation, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packs_epi16
+ FORCE_INLINE __m128i _mm_packs_epi16(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s8(
+@@ -5196,19 +4871,9 @@ FORCE_INLINE __m128i _mm_packs_epi16(__m
+                     vqmovn_s16(vreinterpretq_s16_m128i(b))));
+ }
+ 
+-// Packs the 8 signed 32-bit integers from a and b into signed 16-bit integers
+-// and saturates.
+-//
+-//   r0 := SignedSaturate(a0)
+-//   r1 := SignedSaturate(a1)
+-//   r2 := SignedSaturate(a2)
+-//   r3 := SignedSaturate(a3)
+-//   r4 := SignedSaturate(b0)
+-//   r5 := SignedSaturate(b1)
+-//   r6 := SignedSaturate(b2)
+-//   r7 := SignedSaturate(b3)
+-//
+-// https://msdn.microsoft.com/en-us/library/393t56f9%28v=vs.90%29.aspx
++// Convert packed signed 32-bit integers from a and b to packed 16-bit integers
++// using signed saturation, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packs_epi32
+ FORCE_INLINE __m128i _mm_packs_epi32(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s16(
+@@ -5216,19 +4881,9 @@ FORCE_INLINE __m128i _mm_packs_epi32(__m
+                      vqmovn_s32(vreinterpretq_s32_m128i(b))));
+ }
+ 
+-// Packs the 16 signed 16 - bit integers from a and b into 8 - bit unsigned
+-// integers and saturates.
+-//
+-//   r0 := UnsignedSaturate(a0)
+-//   r1 := UnsignedSaturate(a1)
+-//   ...
+-//   r7 := UnsignedSaturate(a7)
+-//   r8 := UnsignedSaturate(b0)
+-//   r9 := UnsignedSaturate(b1)
+-//   ...
+-//   r15 := UnsignedSaturate(b7)
+-//
+-// https://msdn.microsoft.com/en-us/library/07ad1wx4(v=vs.100).aspx
++// Convert packed signed 16-bit integers from a and b to packed 8-bit integers
++// using unsigned saturation, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packus_epi16
+ FORCE_INLINE __m128i _mm_packus_epi16(const __m128i a, const __m128i b)
+ {
+     return vreinterpretq_m128i_u8(
+@@ -5241,9 +4896,14 @@ FORCE_INLINE __m128i _mm_packus_epi16(co
+ // 'yield' instruction isn't a good fit because it's effectively a nop on most
+ // Arm cores. Experience with several databases has shown has shown an 'isb' is
+ // a reasonable approximation.
+-FORCE_INLINE void _mm_pause()
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_pause
++FORCE_INLINE void _mm_pause(void)
+ {
++#if defined(_MSC_VER) && !defined(__clang__)
++    __isb(_ARM64_BARRIER_SY);
++#else
+     __asm__ __volatile__("isb\n");
++#endif
+ }
+ 
+ // Compute the absolute differences of packed unsigned 8-bit integers in a and
+@@ -5257,8 +4917,8 @@ FORCE_INLINE __m128i _mm_sad_epu8(__m128
+     return vreinterpretq_m128i_u64(vpaddlq_u32(vpaddlq_u16(t)));
+ }
+ 
+-// Sets the 8 signed 16-bit integer values.
+-// https://msdn.microsoft.com/en-au/library/3e0fek84(v=vs.90).aspx
++// Set packed 16-bit integers in dst with the supplied values.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set_epi16
+ FORCE_INLINE __m128i _mm_set_epi16(short i7,
+                                    short i6,
+                                    short i5,
+@@ -5272,33 +4932,31 @@ FORCE_INLINE __m128i _mm_set_epi16(short
+     return vreinterpretq_m128i_s16(vld1q_s16(data));
+ }
+ 
+-// Sets the 4 signed 32-bit integer values.
+-// https://msdn.microsoft.com/en-us/library/vstudio/019beekt(v=vs.100).aspx
++// Set packed 32-bit integers in dst with the supplied values.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set_epi32
+ FORCE_INLINE __m128i _mm_set_epi32(int i3, int i2, int i1, int i0)
+ {
+     int32_t ALIGN_STRUCT(16) data[4] = {i0, i1, i2, i3};
+     return vreinterpretq_m128i_s32(vld1q_s32(data));
+ }
+ 
+-// Returns the __m128i structure with its two 64-bit integer values
+-// initialized to the values of the two 64-bit integers passed in.
+-// https://msdn.microsoft.com/en-us/library/dk2sdw0h(v=vs.120).aspx
++// Set packed 64-bit integers in dst with the supplied values.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set_epi64
+ FORCE_INLINE __m128i _mm_set_epi64(__m64 i1, __m64 i2)
+ {
+-    return _mm_set_epi64x((int64_t) i1, (int64_t) i2);
++    return _mm_set_epi64x(vget_lane_s64(i1, 0), vget_lane_s64(i2, 0));
+ }
+ 
+-// Returns the __m128i structure with its two 64-bit integer values
+-// initialized to the values of the two 64-bit integers passed in.
+-// https://msdn.microsoft.com/en-us/library/dk2sdw0h(v=vs.120).aspx
++// Set packed 64-bit integers in dst with the supplied values.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set_epi64x
+ FORCE_INLINE __m128i _mm_set_epi64x(int64_t i1, int64_t i2)
+ {
+     return vreinterpretq_m128i_s64(
+         vcombine_s64(vcreate_s64(i2), vcreate_s64(i1)));
+ }
+ 
+-// Sets the 16 signed 8-bit integer values.
+-// https://msdn.microsoft.com/en-us/library/x0cx8zd3(v=vs.90).aspx
++// Set packed 8-bit integers in dst with the supplied values.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set_epi8
+ FORCE_INLINE __m128i _mm_set_epi8(signed char b15,
+                                   signed char b14,
+                                   signed char b13,
+@@ -5316,11 +4974,11 @@ FORCE_INLINE __m128i _mm_set_epi8(signed
+                                   signed char b1,
+                                   signed char b0)
+ {
+-    int8_t ALIGN_STRUCT(16)
+-        data[16] = {(int8_t) b0,  (int8_t) b1,  (int8_t) b2,  (int8_t) b3,
+-                    (int8_t) b4,  (int8_t) b5,  (int8_t) b6,  (int8_t) b7,
+-                    (int8_t) b8,  (int8_t) b9,  (int8_t) b10, (int8_t) b11,
+-                    (int8_t) b12, (int8_t) b13, (int8_t) b14, (int8_t) b15};
++    int8_t ALIGN_STRUCT(16) data[16] = {
++        (int8_t) b0,  (int8_t) b1,  (int8_t) b2,  (int8_t) b3,
++        (int8_t) b4,  (int8_t) b5,  (int8_t) b6,  (int8_t) b7,
++        (int8_t) b8,  (int8_t) b9,  (int8_t) b10, (int8_t) b11,
++        (int8_t) b12, (int8_t) b13, (int8_t) b14, (int8_t) b15};
+     return (__m128i) vld1q_s8(data);
+ }
+ 
+@@ -5330,7 +4988,7 @@ FORCE_INLINE __m128i _mm_set_epi8(signed
+ FORCE_INLINE __m128d _mm_set_pd(double e1, double e0)
+ {
+     double ALIGN_STRUCT(16) data[2] = {e0, e1};
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(vld1q_f64((float64_t *) data));
+ #else
+     return vreinterpretq_m128d_f32(vld1q_f32((float32_t *) data));
+@@ -5347,61 +5005,43 @@ FORCE_INLINE __m128d _mm_set_pd(double e
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set_sd
+ FORCE_INLINE __m128d _mm_set_sd(double a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(vsetq_lane_f64(a, vdupq_n_f64(0), 0));
+ #else
+     return _mm_set_pd(0, a);
+ #endif
+ }
+ 
+-// Sets the 8 signed 16-bit integer values to w.
+-//
+-//   r0 := w
+-//   r1 := w
+-//   ...
+-//   r7 := w
+-//
+-// https://msdn.microsoft.com/en-us/library/k0ya3x0e(v=vs.90).aspx
++// Broadcast 16-bit integer a to all elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set1_epi16
+ FORCE_INLINE __m128i _mm_set1_epi16(short w)
+ {
+     return vreinterpretq_m128i_s16(vdupq_n_s16(w));
+ }
+ 
+-// Sets the 4 signed 32-bit integer values to i.
+-//
+-//   r0 := i
+-//   r1 := i
+-//   r2 := i
+-//   r3 := I
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/h4xscxat(v=vs.100).aspx
++// Broadcast 32-bit integer a to all elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set1_epi32
+ FORCE_INLINE __m128i _mm_set1_epi32(int _i)
+ {
+     return vreinterpretq_m128i_s32(vdupq_n_s32(_i));
+ }
+ 
+-// Sets the 2 signed 64-bit integer values to i.
+-// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/whtfzhzk(v=vs.100)
++// Broadcast 64-bit integer a to all elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set1_epi64
+ FORCE_INLINE __m128i _mm_set1_epi64(__m64 _i)
+ {
+-    return vreinterpretq_m128i_s64(vdupq_n_s64((int64_t) _i));
++    return vreinterpretq_m128i_s64(vdupq_lane_s64(_i, 0));
+ }
+ 
+-// Sets the 2 signed 64-bit integer values to i.
++// Broadcast 64-bit integer a to all elements of dst.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set1_epi64x
+ FORCE_INLINE __m128i _mm_set1_epi64x(int64_t _i)
+ {
+     return vreinterpretq_m128i_s64(vdupq_n_s64(_i));
+ }
+ 
+-// Sets the 16 signed 8-bit integer values to b.
+-//
+-//   r0 := b
+-//   r1 := b
+-//   ...
+-//   r15 := b
+-//
+-// https://msdn.microsoft.com/en-us/library/6e14xhyf(v=vs.100).aspx
++// Broadcast 8-bit integer a to all elements of dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set1_epi8
+ FORCE_INLINE __m128i _mm_set1_epi8(signed char w)
+ {
+     return vreinterpretq_m128i_s8(vdupq_n_s8(w));
+@@ -5412,20 +5052,16 @@ FORCE_INLINE __m128i _mm_set1_epi8(signe
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_set1_pd
+ FORCE_INLINE __m128d _mm_set1_pd(double d)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(vdupq_n_f64(d));
+ #else
+-    return vreinterpretq_m128d_s64(vdupq_n_s64(*(int64_t *) &d));
++    int64_t _d = sse2neon_recast_f64_s64(d);
++    return vreinterpretq_m128d_s64(vdupq_n_s64(_d));
+ #endif
+ }
+ 
+-// Sets the 8 signed 16-bit integer values in reverse order.
+-//
+-// Return Value
+-//   r0 := w0
+-//   r1 := w1
+-//   ...
+-//   r7 := w7
++// Set packed 16-bit integers in dst with the supplied values in reverse order.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_setr_epi16
+ FORCE_INLINE __m128i _mm_setr_epi16(short w0,
+                                     short w1,
+                                     short w2,
+@@ -5439,8 +5075,8 @@ FORCE_INLINE __m128i _mm_setr_epi16(shor
+     return vreinterpretq_m128i_s16(vld1q_s16((int16_t *) data));
+ }
+ 
+-// Sets the 4 signed 32-bit integer values in reverse order
+-// https://technet.microsoft.com/en-us/library/security/27yb3ee5(v=vs.90).aspx
++// Set packed 32-bit integers in dst with the supplied values in reverse order.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_setr_epi32
+ FORCE_INLINE __m128i _mm_setr_epi32(int i3, int i2, int i1, int i0)
+ {
+     int32_t ALIGN_STRUCT(16) data[4] = {i3, i2, i1, i0};
+@@ -5454,8 +5090,8 @@ FORCE_INLINE __m128i _mm_setr_epi64(__m6
+     return vreinterpretq_m128i_s64(vcombine_s64(e1, e0));
+ }
+ 
+-// Sets the 16 signed 8-bit integer values in reverse order.
+-// https://msdn.microsoft.com/en-us/library/2khb9c7k(v=vs.90).aspx
++// Set packed 8-bit integers in dst with the supplied values in reverse order.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_setr_epi8
+ FORCE_INLINE __m128i _mm_setr_epi8(signed char b0,
+                                    signed char b1,
+                                    signed char b2,
+@@ -5473,11 +5109,11 @@ FORCE_INLINE __m128i _mm_setr_epi8(signe
+                                    signed char b14,
+                                    signed char b15)
+ {
+-    int8_t ALIGN_STRUCT(16)
+-        data[16] = {(int8_t) b0,  (int8_t) b1,  (int8_t) b2,  (int8_t) b3,
+-                    (int8_t) b4,  (int8_t) b5,  (int8_t) b6,  (int8_t) b7,
+-                    (int8_t) b8,  (int8_t) b9,  (int8_t) b10, (int8_t) b11,
+-                    (int8_t) b12, (int8_t) b13, (int8_t) b14, (int8_t) b15};
++    int8_t ALIGN_STRUCT(16) data[16] = {
++        (int8_t) b0,  (int8_t) b1,  (int8_t) b2,  (int8_t) b3,
++        (int8_t) b4,  (int8_t) b5,  (int8_t) b6,  (int8_t) b7,
++        (int8_t) b8,  (int8_t) b9,  (int8_t) b10, (int8_t) b11,
++        (int8_t) b12, (int8_t) b13, (int8_t) b14, (int8_t) b15};
+     return (__m128i) vld1q_s8(data);
+ }
+ 
+@@ -5493,25 +5129,26 @@ FORCE_INLINE __m128d _mm_setr_pd(double
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_setzero_pd
+ FORCE_INLINE __m128d _mm_setzero_pd(void)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(vdupq_n_f64(0));
+ #else
+     return vreinterpretq_m128d_f32(vdupq_n_f32(0));
+ #endif
+ }
+ 
+-// Sets the 128-bit value to zero
+-// https://msdn.microsoft.com/en-us/library/vstudio/ys7dw0kh(v=vs.100).aspx
++// Return vector of type __m128i with all elements set to zero.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_setzero_si128
+ FORCE_INLINE __m128i _mm_setzero_si128(void)
+ {
+     return vreinterpretq_m128i_s32(vdupq_n_s32(0));
+ }
+ 
+-// Shuffles the 4 signed or unsigned 32-bit integers in a as specified by imm.
+-// https://msdn.microsoft.com/en-us/library/56f67xbk%28v=vs.90%29.aspx
++// Shuffle 32-bit integers in a using the control in imm8, and store the results
++// in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_shuffle_epi32
+ // FORCE_INLINE __m128i _mm_shuffle_epi32(__m128i a,
+ //                                        __constrange(0,255) int imm)
+-#ifdef _sse2neon_shuffle
++#if defined(_sse2neon_shuffle)
+ #define _mm_shuffle_epi32(a, imm)                                            \
+     __extension__({                                                          \
+         int32x4_t _input = vreinterpretq_s32_m128i(a);                       \
+@@ -5521,82 +5158,75 @@ FORCE_INLINE __m128i _mm_setzero_si128(v
+         vreinterpretq_m128i_s32(_shuf);                                      \
+     })
+ #else  // generic
+-#define _mm_shuffle_epi32(a, imm)                        \
+-    __extension__({                                      \
+-        __m128i ret;                                     \
+-        switch (imm) {                                   \
+-        case _MM_SHUFFLE(1, 0, 3, 2):                    \
+-            ret = _mm_shuffle_epi_1032((a));             \
+-            break;                                       \
+-        case _MM_SHUFFLE(2, 3, 0, 1):                    \
+-            ret = _mm_shuffle_epi_2301((a));             \
+-            break;                                       \
+-        case _MM_SHUFFLE(0, 3, 2, 1):                    \
+-            ret = _mm_shuffle_epi_0321((a));             \
+-            break;                                       \
+-        case _MM_SHUFFLE(2, 1, 0, 3):                    \
+-            ret = _mm_shuffle_epi_2103((a));             \
+-            break;                                       \
+-        case _MM_SHUFFLE(1, 0, 1, 0):                    \
+-            ret = _mm_shuffle_epi_1010((a));             \
+-            break;                                       \
+-        case _MM_SHUFFLE(1, 0, 0, 1):                    \
+-            ret = _mm_shuffle_epi_1001((a));             \
+-            break;                                       \
+-        case _MM_SHUFFLE(0, 1, 0, 1):                    \
+-            ret = _mm_shuffle_epi_0101((a));             \
+-            break;                                       \
+-        case _MM_SHUFFLE(2, 2, 1, 1):                    \
+-            ret = _mm_shuffle_epi_2211((a));             \
+-            break;                                       \
+-        case _MM_SHUFFLE(0, 1, 2, 2):                    \
+-            ret = _mm_shuffle_epi_0122((a));             \
+-            break;                                       \
+-        case _MM_SHUFFLE(3, 3, 3, 2):                    \
+-            ret = _mm_shuffle_epi_3332((a));             \
+-            break;                                       \
+-        case _MM_SHUFFLE(0, 0, 0, 0):                    \
+-            ret = _mm_shuffle_epi32_splat((a), 0);       \
+-            break;                                       \
+-        case _MM_SHUFFLE(1, 1, 1, 1):                    \
+-            ret = _mm_shuffle_epi32_splat((a), 1);       \
+-            break;                                       \
+-        case _MM_SHUFFLE(2, 2, 2, 2):                    \
+-            ret = _mm_shuffle_epi32_splat((a), 2);       \
+-            break;                                       \
+-        case _MM_SHUFFLE(3, 3, 3, 3):                    \
+-            ret = _mm_shuffle_epi32_splat((a), 3);       \
+-            break;                                       \
+-        default:                                         \
+-            ret = _mm_shuffle_epi32_default((a), (imm)); \
+-            break;                                       \
+-        }                                                \
+-        ret;                                             \
+-    })
++#define _mm_shuffle_epi32(a, imm)                           \
++    _sse2neon_define1(                                      \
++        __m128i, a, __m128i ret; switch (imm) {             \
++            case _MM_SHUFFLE(1, 0, 3, 2):                   \
++                ret = _mm_shuffle_epi_1032(_a);             \
++                break;                                      \
++            case _MM_SHUFFLE(2, 3, 0, 1):                   \
++                ret = _mm_shuffle_epi_2301(_a);             \
++                break;                                      \
++            case _MM_SHUFFLE(0, 3, 2, 1):                   \
++                ret = _mm_shuffle_epi_0321(_a);             \
++                break;                                      \
++            case _MM_SHUFFLE(2, 1, 0, 3):                   \
++                ret = _mm_shuffle_epi_2103(_a);             \
++                break;                                      \
++            case _MM_SHUFFLE(1, 0, 1, 0):                   \
++                ret = _mm_shuffle_epi_1010(_a);             \
++                break;                                      \
++            case _MM_SHUFFLE(1, 0, 0, 1):                   \
++                ret = _mm_shuffle_epi_1001(_a);             \
++                break;                                      \
++            case _MM_SHUFFLE(0, 1, 0, 1):                   \
++                ret = _mm_shuffle_epi_0101(_a);             \
++                break;                                      \
++            case _MM_SHUFFLE(2, 2, 1, 1):                   \
++                ret = _mm_shuffle_epi_2211(_a);             \
++                break;                                      \
++            case _MM_SHUFFLE(0, 1, 2, 2):                   \
++                ret = _mm_shuffle_epi_0122(_a);             \
++                break;                                      \
++            case _MM_SHUFFLE(3, 3, 3, 2):                   \
++                ret = _mm_shuffle_epi_3332(_a);             \
++                break;                                      \
++            case _MM_SHUFFLE(0, 0, 0, 0):                   \
++                ret = _mm_shuffle_epi32_splat(_a, 0);       \
++                break;                                      \
++            case _MM_SHUFFLE(1, 1, 1, 1):                   \
++                ret = _mm_shuffle_epi32_splat(_a, 1);       \
++                break;                                      \
++            case _MM_SHUFFLE(2, 2, 2, 2):                   \
++                ret = _mm_shuffle_epi32_splat(_a, 2);       \
++                break;                                      \
++            case _MM_SHUFFLE(3, 3, 3, 3):                   \
++                ret = _mm_shuffle_epi32_splat(_a, 3);       \
++                break;                                      \
++            default:                                        \
++                ret = _mm_shuffle_epi32_default(_a, (imm)); \
++                break;                                      \
++        } _sse2neon_return(ret);)
+ #endif
+ 
+ // Shuffle double-precision (64-bit) floating-point elements using the control
+ // in imm8, and store the results in dst.
+-//
+-//   dst[63:0] := (imm8[0] == 0) ? a[63:0] : a[127:64]
+-//   dst[127:64] := (imm8[1] == 0) ? b[63:0] : b[127:64]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_shuffle_pd
+ #ifdef _sse2neon_shuffle
+ #define _mm_shuffle_pd(a, b, imm8)                                            \
+     vreinterpretq_m128d_s64(                                                  \
+         vshuffleq_s64(vreinterpretq_s64_m128d(a), vreinterpretq_s64_m128d(b), \
+-                      imm8 & 0x1, ((imm8 & 0x2) >> 1) + 2))
++                      (imm8) & 0x1, (((imm8) & 0x2) >> 1) + 2))
+ #else
+-#define _mm_shuffle_pd(a, b, imm8)                                     \
+-    _mm_castsi128_pd(_mm_set_epi64x(                                   \
+-        vgetq_lane_s64(vreinterpretq_s64_m128d(b), (imm8 & 0x2) >> 1), \
+-        vgetq_lane_s64(vreinterpretq_s64_m128d(a), imm8 & 0x1)))
++#define _mm_shuffle_pd(a, b, imm8)                                       \
++    _mm_castsi128_pd(_mm_set_epi64x(                                     \
++        vgetq_lane_s64(vreinterpretq_s64_m128d(b), ((imm8) & 0x2) >> 1), \
++        vgetq_lane_s64(vreinterpretq_s64_m128d(a), (imm8) & 0x1)))
+ #endif
+ 
+ // FORCE_INLINE __m128i _mm_shufflehi_epi16(__m128i a,
+ //                                          __constrange(0,255) int imm)
+-#ifdef _sse2neon_shuffle
++#if defined(_sse2neon_shuffle)
+ #define _mm_shufflehi_epi16(a, imm)                                           \
+     __extension__({                                                           \
+         int16x8_t _input = vreinterpretq_s16_m128i(a);                        \
+@@ -5612,7 +5242,7 @@ FORCE_INLINE __m128i _mm_setzero_si128(v
+ 
+ // FORCE_INLINE __m128i _mm_shufflelo_epi16(__m128i a,
+ //                                          __constrange(0,255) int imm)
+-#ifdef _sse2neon_shuffle
++#if defined(_sse2neon_shuffle)
+ #define _mm_shufflelo_epi16(a, imm)                                  \
+     __extension__({                                                  \
+         int16x8_t _input = vreinterpretq_s16_m128i(a);               \
+@@ -5627,16 +5257,6 @@ FORCE_INLINE __m128i _mm_setzero_si128(v
+ 
+ // Shift packed 16-bit integers in a left by count while shifting in zeros, and
+ // store the results in dst.
+-//
+-//   FOR j := 0 to 7
+-//     i := j*16
+-//     IF count[63:0] > 15
+-//       dst[i+15:i] := 0
+-//     ELSE
+-//       dst[i+15:i] := ZeroExtend16(a[i+15:i] << count[63:0])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sll_epi16
+ FORCE_INLINE __m128i _mm_sll_epi16(__m128i a, __m128i count)
+ {
+@@ -5650,16 +5270,6 @@ FORCE_INLINE __m128i _mm_sll_epi16(__m12
+ 
+ // Shift packed 32-bit integers in a left by count while shifting in zeros, and
+ // store the results in dst.
+-//
+-//   FOR j := 0 to 3
+-//     i := j*32
+-//     IF count[63:0] > 31
+-//       dst[i+31:i] := 0
+-//     ELSE
+-//       dst[i+31:i] := ZeroExtend32(a[i+31:i] << count[63:0])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sll_epi32
+ FORCE_INLINE __m128i _mm_sll_epi32(__m128i a, __m128i count)
+ {
+@@ -5673,16 +5283,6 @@ FORCE_INLINE __m128i _mm_sll_epi32(__m12
+ 
+ // Shift packed 64-bit integers in a left by count while shifting in zeros, and
+ // store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-//     i := j*64
+-//     IF count[63:0] > 63
+-//       dst[i+63:i] := 0
+-//     ELSE
+-//       dst[i+63:i] := ZeroExtend64(a[i+63:i] << count[63:0])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sll_epi64
+ FORCE_INLINE __m128i _mm_sll_epi64(__m128i a, __m128i count)
+ {
+@@ -5696,37 +5296,17 @@ FORCE_INLINE __m128i _mm_sll_epi64(__m12
+ 
+ // Shift packed 16-bit integers in a left by imm8 while shifting in zeros, and
+ // store the results in dst.
+-//
+-//   FOR j := 0 to 7
+-//     i := j*16
+-//     IF imm8[7:0] > 15
+-//       dst[i+15:i] := 0
+-//     ELSE
+-//       dst[i+15:i] := ZeroExtend16(a[i+15:i] << imm8[7:0])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_slli_epi16
+ FORCE_INLINE __m128i _mm_slli_epi16(__m128i a, int imm)
+ {
+     if (_sse2neon_unlikely(imm & ~15))
+         return _mm_setzero_si128();
+     return vreinterpretq_m128i_s16(
+-        vshlq_s16(vreinterpretq_s16_m128i(a), vdupq_n_s16(imm)));
++        vshlq_s16(vreinterpretq_s16_m128i(a), vdupq_n_s16((int16_t) imm)));
+ }
+ 
+ // Shift packed 32-bit integers in a left by imm8 while shifting in zeros, and
+ // store the results in dst.
+-//
+-//   FOR j := 0 to 3
+-//     i := j*32
+-//     IF imm8[7:0] > 31
+-//       dst[i+31:i] := 0
+-//     ELSE
+-//       dst[i+31:i] := ZeroExtend32(a[i+31:i] << imm8[7:0])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_slli_epi32
+ FORCE_INLINE __m128i _mm_slli_epi32(__m128i a, int imm)
+ {
+@@ -5738,16 +5318,6 @@ FORCE_INLINE __m128i _mm_slli_epi32(__m1
+ 
+ // Shift packed 64-bit integers in a left by imm8 while shifting in zeros, and
+ // store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-//     i := j*64
+-//     IF imm8[7:0] > 63
+-//       dst[i+63:i] := 0
+-//     ELSE
+-//       dst[i+63:i] := ZeroExtend64(a[i+63:i] << imm8[7:0])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_slli_epi64
+ FORCE_INLINE __m128i _mm_slli_epi64(__m128i a, int imm)
+ {
+@@ -5759,38 +5329,30 @@ FORCE_INLINE __m128i _mm_slli_epi64(__m1
+ 
+ // Shift a left by imm8 bytes while shifting in zeros, and store the results in
+ // dst.
+-//
+-//   tmp := imm8[7:0]
+-//   IF tmp > 15
+-//     tmp := 16
+-//   FI
+-//   dst[127:0] := a[127:0] << (tmp*8)
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_slli_si128
+-#define _mm_slli_si128(a, imm)                                         \
+-    __extension__({                                                    \
+-        int8x16_t ret;                                                 \
+-        if (_sse2neon_unlikely(imm == 0))                              \
+-            ret = vreinterpretq_s8_m128i(a);                           \
+-        else if (_sse2neon_unlikely((imm) & ~15))                      \
+-            ret = vdupq_n_s8(0);                                       \
+-        else                                                           \
+-            ret = vextq_s8(vdupq_n_s8(0), vreinterpretq_s8_m128i(a),   \
+-                           ((imm <= 0 || imm > 15) ? 0 : (16 - imm))); \
+-        vreinterpretq_m128i_s8(ret);                                   \
+-    })
++#define _mm_slli_si128(a, imm)                                                \
++    _sse2neon_define1(                                                        \
++        __m128i, a, int8x16_t ret;                                            \
++        if (_sse2neon_unlikely((imm) == 0)) ret = vreinterpretq_s8_m128i(_a); \
++        else if (_sse2neon_unlikely((imm) & ~15)) ret = vdupq_n_s8(0);        \
++        else ret = vextq_s8(vdupq_n_s8(0), vreinterpretq_s8_m128i(_a),        \
++                            (((imm) <= 0 || (imm) > 15) ? 0 : (16 - (imm)))); \
++        _sse2neon_return(vreinterpretq_m128i_s8(ret));)
+ 
+ // Compute the square root of packed double-precision (64-bit) floating-point
+ // elements in a, and store the results in dst.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sqrt_pd
+ FORCE_INLINE __m128d _mm_sqrt_pd(__m128d a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(vsqrtq_f64(vreinterpretq_f64_m128d(a)));
+ #else
+-    double a0 = sqrt(((double *) &a)[0]);
+-    double a1 = sqrt(((double *) &a)[1]);
+-    return _mm_set_pd(a1, a0);
++    double a0, a1;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    a1 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double _a0 = sqrt(a0);
++    double _a1 = sqrt(a1);
++    return _mm_set_pd(_a1, _a0);
+ #endif
+ }
+ 
+@@ -5800,115 +5362,67 @@ FORCE_INLINE __m128d _mm_sqrt_pd(__m128d
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sqrt_sd
+ FORCE_INLINE __m128d _mm_sqrt_sd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return _mm_move_sd(a, _mm_sqrt_pd(b));
+ #else
+-    return _mm_set_pd(((double *) &a)[1], sqrt(((double *) &b)[0]));
++    double _a, _b;
++    _a = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    _b = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    return _mm_set_pd(_a, sqrt(_b));
+ #endif
+ }
+ 
+ // Shift packed 16-bit integers in a right by count while shifting in sign bits,
+ // and store the results in dst.
+-//
+-//   FOR j := 0 to 7
+-//     i := j*16
+-//     IF count[63:0] > 15
+-//       dst[i+15:i] := (a[i+15] ? 0xFFFF : 0x0)
+-//     ELSE
+-//       dst[i+15:i] := SignExtend16(a[i+15:i] >> count[63:0])
+-//     FI
+-//  ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sra_epi16
+ FORCE_INLINE __m128i _mm_sra_epi16(__m128i a, __m128i count)
+ {
+-    int64_t c = (int64_t) vget_low_s64((int64x2_t) count);
++    int64_t c = vgetq_lane_s64(count, 0);
+     if (_sse2neon_unlikely(c & ~15))
+         return _mm_cmplt_epi16(a, _mm_setzero_si128());
+-    return vreinterpretq_m128i_s16(vshlq_s16((int16x8_t) a, vdupq_n_s16(-c)));
++    return vreinterpretq_m128i_s16(
++        vshlq_s16((int16x8_t) a, vdupq_n_s16((int16_t) -c)));
+ }
+ 
+ // Shift packed 32-bit integers in a right by count while shifting in sign bits,
+ // and store the results in dst.
+-//
+-//   FOR j := 0 to 3
+-//     i := j*32
+-//     IF count[63:0] > 31
+-//       dst[i+31:i] := (a[i+31] ? 0xFFFFFFFF : 0x0)
+-//     ELSE
+-//       dst[i+31:i] := SignExtend32(a[i+31:i] >> count[63:0])
+-//     FI
+-//  ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sra_epi32
+ FORCE_INLINE __m128i _mm_sra_epi32(__m128i a, __m128i count)
+ {
+-    int64_t c = (int64_t) vget_low_s64((int64x2_t) count);
++    int64_t c = vgetq_lane_s64(count, 0);
+     if (_sse2neon_unlikely(c & ~31))
+         return _mm_cmplt_epi32(a, _mm_setzero_si128());
+-    return vreinterpretq_m128i_s32(vshlq_s32((int32x4_t) a, vdupq_n_s32(-c)));
++    return vreinterpretq_m128i_s32(
++        vshlq_s32((int32x4_t) a, vdupq_n_s32((int) -c)));
+ }
+ 
+ // Shift packed 16-bit integers in a right by imm8 while shifting in sign
+ // bits, and store the results in dst.
+-//
+-//   FOR j := 0 to 7
+-//     i := j*16
+-//     IF imm8[7:0] > 15
+-//       dst[i+15:i] := (a[i+15] ? 0xFFFF : 0x0)
+-//     ELSE
+-//       dst[i+15:i] := SignExtend16(a[i+15:i] >> imm8[7:0])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_srai_epi16
+ FORCE_INLINE __m128i _mm_srai_epi16(__m128i a, int imm)
+ {
+-    const int count = (imm & ~15) ? 15 : imm;
++    const int16_t count = (imm & ~15) ? 15 : (int16_t) imm;
+     return (__m128i) vshlq_s16((int16x8_t) a, vdupq_n_s16(-count));
+ }
+ 
+ // Shift packed 32-bit integers in a right by imm8 while shifting in sign bits,
+ // and store the results in dst.
+-//
+-//   FOR j := 0 to 3
+-//     i := j*32
+-//     IF imm8[7:0] > 31
+-//       dst[i+31:i] := (a[i+31] ? 0xFFFFFFFF : 0x0)
+-//     ELSE
+-//       dst[i+31:i] := SignExtend32(a[i+31:i] >> imm8[7:0])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_srai_epi32
+ // FORCE_INLINE __m128i _mm_srai_epi32(__m128i a, __constrange(0,255) int imm)
+-#define _mm_srai_epi32(a, imm)                                               \
+-    __extension__({                                                          \
+-        __m128i ret;                                                         \
+-        if (_sse2neon_unlikely((imm) == 0)) {                                \
+-            ret = a;                                                         \
+-        } else if (_sse2neon_likely(0 < (imm) && (imm) < 32)) {              \
+-            ret = vreinterpretq_m128i_s32(                                   \
+-                vshlq_s32(vreinterpretq_s32_m128i(a), vdupq_n_s32(-(imm)))); \
+-        } else {                                                             \
+-            ret = vreinterpretq_m128i_s32(                                   \
+-                vshrq_n_s32(vreinterpretq_s32_m128i(a), 31));                \
+-        }                                                                    \
+-        ret;                                                                 \
+-    })
++#define _mm_srai_epi32(a, imm)                                                \
++    _sse2neon_define0(                                                        \
++        __m128i, a, __m128i ret; if (_sse2neon_unlikely((imm) == 0)) {        \
++            ret = _a;                                                         \
++        } else if (_sse2neon_likely(0 < (imm) && (imm) < 32)) {               \
++            ret = vreinterpretq_m128i_s32(                                    \
++                vshlq_s32(vreinterpretq_s32_m128i(_a), vdupq_n_s32(-(imm)))); \
++        } else {                                                              \
++            ret = vreinterpretq_m128i_s32(                                    \
++                vshrq_n_s32(vreinterpretq_s32_m128i(_a), 31));                \
++        } _sse2neon_return(ret);)
+ 
+ // Shift packed 16-bit integers in a right by count while shifting in zeros, and
+ // store the results in dst.
+-//
+-//   FOR j := 0 to 7
+-//     i := j*16
+-//     IF count[63:0] > 15
+-//       dst[i+15:i] := 0
+-//     ELSE
+-//       dst[i+15:i] := ZeroExtend16(a[i+15:i] >> count[63:0])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_srl_epi16
+ FORCE_INLINE __m128i _mm_srl_epi16(__m128i a, __m128i count)
+ {
+@@ -5922,16 +5436,6 @@ FORCE_INLINE __m128i _mm_srl_epi16(__m12
+ 
+ // Shift packed 32-bit integers in a right by count while shifting in zeros, and
+ // store the results in dst.
+-//
+-//   FOR j := 0 to 3
+-//     i := j*32
+-//     IF count[63:0] > 31
+-//       dst[i+31:i] := 0
+-//     ELSE
+-//       dst[i+31:i] := ZeroExtend32(a[i+31:i] >> count[63:0])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_srl_epi32
+ FORCE_INLINE __m128i _mm_srl_epi32(__m128i a, __m128i count)
+ {
+@@ -5945,16 +5449,6 @@ FORCE_INLINE __m128i _mm_srl_epi32(__m12
+ 
+ // Shift packed 64-bit integers in a right by count while shifting in zeros, and
+ // store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-//     i := j*64
+-//     IF count[63:0] > 63
+-//       dst[i+63:i] := 0
+-//     ELSE
+-//       dst[i+63:i] := ZeroExtend64(a[i+63:i] >> count[63:0])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_srl_epi64
+ FORCE_INLINE __m128i _mm_srl_epi64(__m128i a, __m128i count)
+ {
+@@ -5968,100 +5462,51 @@ FORCE_INLINE __m128i _mm_srl_epi64(__m12
+ 
+ // Shift packed 16-bit integers in a right by imm8 while shifting in zeros, and
+ // store the results in dst.
+-//
+-//   FOR j := 0 to 7
+-//     i := j*16
+-//     IF imm8[7:0] > 15
+-//       dst[i+15:i] := 0
+-//     ELSE
+-//       dst[i+15:i] := ZeroExtend16(a[i+15:i] >> imm8[7:0])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_srli_epi16
+-#define _mm_srli_epi16(a, imm)                                               \
+-    __extension__({                                                          \
+-        __m128i ret;                                                         \
+-        if (_sse2neon_unlikely((imm) & ~15)) {                               \
+-            ret = _mm_setzero_si128();                                       \
+-        } else {                                                             \
+-            ret = vreinterpretq_m128i_u16(                                   \
+-                vshlq_u16(vreinterpretq_u16_m128i(a), vdupq_n_s16(-(imm)))); \
+-        }                                                                    \
+-        ret;                                                                 \
+-    })
++#define _mm_srli_epi16(a, imm)                                                 \
++    _sse2neon_define0(                                                         \
++        __m128i, a, __m128i ret; if (_sse2neon_unlikely((imm) & ~15)) {        \
++            ret = _mm_setzero_si128();                                         \
++        } else {                                                               \
++            ret = vreinterpretq_m128i_u16(vshlq_u16(                           \
++                vreinterpretq_u16_m128i(_a), vdupq_n_s16((int16_t) - (imm)))); \
++        } _sse2neon_return(ret);)
+ 
+ // Shift packed 32-bit integers in a right by imm8 while shifting in zeros, and
+ // store the results in dst.
+-//
+-//   FOR j := 0 to 3
+-//     i := j*32
+-//     IF imm8[7:0] > 31
+-//       dst[i+31:i] := 0
+-//     ELSE
+-//       dst[i+31:i] := ZeroExtend32(a[i+31:i] >> imm8[7:0])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_srli_epi32
+ // FORCE_INLINE __m128i _mm_srli_epi32(__m128i a, __constrange(0,255) int imm)
+-#define _mm_srli_epi32(a, imm)                                               \
+-    __extension__({                                                          \
+-        __m128i ret;                                                         \
+-        if (_sse2neon_unlikely((imm) & ~31)) {                               \
+-            ret = _mm_setzero_si128();                                       \
+-        } else {                                                             \
+-            ret = vreinterpretq_m128i_u32(                                   \
+-                vshlq_u32(vreinterpretq_u32_m128i(a), vdupq_n_s32(-(imm)))); \
+-        }                                                                    \
+-        ret;                                                                 \
+-    })
++#define _mm_srli_epi32(a, imm)                                                \
++    _sse2neon_define0(                                                        \
++        __m128i, a, __m128i ret; if (_sse2neon_unlikely((imm) & ~31)) {       \
++            ret = _mm_setzero_si128();                                        \
++        } else {                                                              \
++            ret = vreinterpretq_m128i_u32(                                    \
++                vshlq_u32(vreinterpretq_u32_m128i(_a), vdupq_n_s32(-(imm)))); \
++        } _sse2neon_return(ret);)
+ 
+ // Shift packed 64-bit integers in a right by imm8 while shifting in zeros, and
+ // store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-//     i := j*64
+-//     IF imm8[7:0] > 63
+-//       dst[i+63:i] := 0
+-//     ELSE
+-//       dst[i+63:i] := ZeroExtend64(a[i+63:i] >> imm8[7:0])
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_srli_epi64
+-#define _mm_srli_epi64(a, imm)                                               \
+-    __extension__({                                                          \
+-        __m128i ret;                                                         \
+-        if (_sse2neon_unlikely((imm) & ~63)) {                               \
+-            ret = _mm_setzero_si128();                                       \
+-        } else {                                                             \
+-            ret = vreinterpretq_m128i_u64(                                   \
+-                vshlq_u64(vreinterpretq_u64_m128i(a), vdupq_n_s64(-(imm)))); \
+-        }                                                                    \
+-        ret;                                                                 \
+-    })
++#define _mm_srli_epi64(a, imm)                                                \
++    _sse2neon_define0(                                                        \
++        __m128i, a, __m128i ret; if (_sse2neon_unlikely((imm) & ~63)) {       \
++            ret = _mm_setzero_si128();                                        \
++        } else {                                                              \
++            ret = vreinterpretq_m128i_u64(                                    \
++                vshlq_u64(vreinterpretq_u64_m128i(_a), vdupq_n_s64(-(imm)))); \
++        } _sse2neon_return(ret);)
+ 
+ // Shift a right by imm8 bytes while shifting in zeros, and store the results in
+ // dst.
+-//
+-//   tmp := imm8[7:0]
+-//   IF tmp > 15
+-//     tmp := 16
+-//   FI
+-//   dst[127:0] := a[127:0] >> (tmp*8)
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_srli_si128
+-#define _mm_srli_si128(a, imm)                                       \
+-    __extension__({                                                  \
+-        int8x16_t ret;                                               \
+-        if (_sse2neon_unlikely((imm) & ~15))                         \
+-            ret = vdupq_n_s8(0);                                     \
+-        else                                                         \
+-            ret = vextq_s8(vreinterpretq_s8_m128i(a), vdupq_n_s8(0), \
+-                           (imm > 15 ? 0 : imm));                    \
+-        vreinterpretq_m128i_s8(ret);                                 \
+-    })
++#define _mm_srli_si128(a, imm)                                         \
++    _sse2neon_define1(                                                 \
++        __m128i, a, int8x16_t ret;                                     \
++        if (_sse2neon_unlikely((imm) & ~15)) ret = vdupq_n_s8(0);      \
++        else ret = vextq_s8(vreinterpretq_s8_m128i(_a), vdupq_n_s8(0), \
++                            ((imm) > 15 ? 0 : (imm)));                 \
++        _sse2neon_return(vreinterpretq_m128i_s8(ret));)
+ 
+ // Store 128-bits (composed of 2 packed double-precision (64-bit) floating-point
+ // elements) from a into memory. mem_addr must be aligned on a 16-byte boundary
+@@ -6069,7 +5514,7 @@ FORCE_INLINE __m128i _mm_srl_epi64(__m12
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_store_pd
+ FORCE_INLINE void _mm_store_pd(double *mem_addr, __m128d a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     vst1q_f64((float64_t *) mem_addr, vreinterpretq_f64_m128d(a));
+ #else
+     vst1q_f32((float32_t *) mem_addr, vreinterpretq_f32_m128d(a));
+@@ -6082,7 +5527,7 @@ FORCE_INLINE void _mm_store_pd(double *m
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_store_pd1
+ FORCE_INLINE void _mm_store_pd1(double *mem_addr, __m128d a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     float64x1_t a_low = vget_low_f64(vreinterpretq_f64_m128d(a));
+     vst1q_f64((float64_t *) mem_addr,
+               vreinterpretq_f64_m128d(vcombine_f64(a_low, a_low)));
+@@ -6098,15 +5543,16 @@ FORCE_INLINE void _mm_store_pd1(double *
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=mm_store_sd
+ FORCE_INLINE void _mm_store_sd(double *mem_addr, __m128d a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     vst1_f64((float64_t *) mem_addr, vget_low_f64(vreinterpretq_f64_m128d(a)));
+ #else
+     vst1_u64((uint64_t *) mem_addr, vget_low_u64(vreinterpretq_u64_m128d(a)));
+ #endif
+ }
+ 
+-// Stores four 32-bit integer values as (as a __m128i value) at the address p.
+-// https://msdn.microsoft.com/en-us/library/vstudio/edk11s13(v=vs.100).aspx
++// Store 128-bits of integer data from a into memory. mem_addr must be aligned
++// on a 16-byte boundary or a general-protection exception may be generated.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_store_si128
+ FORCE_INLINE void _mm_store_si128(__m128i *p, __m128i a)
+ {
+     vst1q_s32((int32_t *) p, vreinterpretq_s32_m128i(a));
+@@ -6120,21 +5566,18 @@ FORCE_INLINE void _mm_store_si128(__m128
+ 
+ // Store the upper double-precision (64-bit) floating-point element from a into
+ // memory.
+-//
+-//   MEM[mem_addr+63:mem_addr] := a[127:64]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storeh_pd
+ FORCE_INLINE void _mm_storeh_pd(double *mem_addr, __m128d a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     vst1_f64((float64_t *) mem_addr, vget_high_f64(vreinterpretq_f64_m128d(a)));
+ #else
+     vst1_f32((float32_t *) mem_addr, vget_high_f32(vreinterpretq_f32_m128d(a)));
+ #endif
+ }
+ 
+-// Reads the lower 64 bits of b and stores them into the lower 64 bits of a.
+-// https://msdn.microsoft.com/en-us/library/hhwf428f%28v=vs.90%29.aspx
++// Store 64-bit integer from the first element of a into memory.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storel_epi64
+ FORCE_INLINE void _mm_storel_epi64(__m128i *a, __m128i b)
+ {
+     vst1_u64((uint64_t *) a, vget_low_u64(vreinterpretq_u64_m128i(b)));
+@@ -6142,13 +5585,10 @@ FORCE_INLINE void _mm_storel_epi64(__m12
+ 
+ // Store the lower double-precision (64-bit) floating-point element from a into
+ // memory.
+-//
+-//   MEM[mem_addr+63:mem_addr] := a[63:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storel_pd
+ FORCE_INLINE void _mm_storel_pd(double *mem_addr, __m128d a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     vst1_f64((float64_t *) mem_addr, vget_low_f64(vreinterpretq_f64_m128d(a)));
+ #else
+     vst1_f32((float32_t *) mem_addr, vget_low_f32(vreinterpretq_f32_m128d(a)));
+@@ -6158,10 +5598,6 @@ FORCE_INLINE void _mm_storel_pd(double *
+ // Store 2 double-precision (64-bit) floating-point elements from a into memory
+ // in reverse order. mem_addr must be aligned on a 16-byte boundary or a
+ // general-protection exception may be generated.
+-//
+-//   MEM[mem_addr+63:mem_addr] := a[127:64]
+-//   MEM[mem_addr+127:mem_addr+64] := a[63:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storer_pd
+ FORCE_INLINE void _mm_storer_pd(double *mem_addr, __m128d a)
+ {
+@@ -6178,14 +5614,16 @@ FORCE_INLINE void _mm_storeu_pd(double *
+     _mm_store_pd(mem_addr, a);
+ }
+ 
+-// Stores 128-bits of integer data a at the address p.
++// Store 128-bits of integer data from a into memory. mem_addr does not need to
++// be aligned on any particular boundary.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storeu_si128
+ FORCE_INLINE void _mm_storeu_si128(__m128i *p, __m128i a)
+ {
+     vst1q_s32((int32_t *) p, vreinterpretq_s32_m128i(a));
+ }
+ 
+-// Stores 32-bits of integer data a at the address p.
++// Store 32-bit integer from the first element of a into memory. mem_addr does
++// not need to be aligned on any particular boundary.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storeu_si32
+ FORCE_INLINE void _mm_storeu_si32(void *p, __m128i a)
+ {
+@@ -6200,18 +5638,18 @@ FORCE_INLINE void _mm_storeu_si32(void *
+ FORCE_INLINE void _mm_stream_pd(double *p, __m128d a)
+ {
+ #if __has_builtin(__builtin_nontemporal_store)
+-    __builtin_nontemporal_store(a, (float32x4_t *) p);
+-#elif defined(__aarch64__)
++    __builtin_nontemporal_store(a, (__m128d *) p);
++#elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     vst1q_f64(p, vreinterpretq_f64_m128d(a));
+ #else
+     vst1q_s64((int64_t *) p, vreinterpretq_s64_m128d(a));
+ #endif
+ }
+ 
+-// Stores the data in a to the address p without polluting the caches.  If the
+-// cache line containing address p is already in the cache, the cache will be
+-// updated.
+-// https://msdn.microsoft.com/en-us/library/ba08y07y%28v=vs.90%29.aspx
++// Store 128-bits of integer data from a into memory using a non-temporal memory
++// hint. mem_addr must be aligned on a 16-byte boundary or a general-protection
++// exception may be generated.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_stream_si128
+ FORCE_INLINE void _mm_stream_si128(__m128i *p, __m128i a)
+ {
+ #if __has_builtin(__builtin_nontemporal_store)
+@@ -6248,25 +5686,18 @@ FORCE_INLINE __m128i _mm_sub_epi16(__m12
+         vsubq_s16(vreinterpretq_s16_m128i(a), vreinterpretq_s16_m128i(b)));
+ }
+ 
+-// Subtracts the 4 signed or unsigned 32-bit integers of b from the 4 signed or
+-// unsigned 32-bit integers of a.
+-//
+-//   r0 := a0 - b0
+-//   r1 := a1 - b1
+-//   r2 := a2 - b2
+-//   r3 := a3 - b3
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/fhh866h0(v=vs.100).aspx
++// Subtract packed 32-bit integers in b from packed 32-bit integers in a, and
++// store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sub_epi32
+ FORCE_INLINE __m128i _mm_sub_epi32(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s32(
+         vsubq_s32(vreinterpretq_s32_m128i(a), vreinterpretq_s32_m128i(b)));
+ }
+ 
+-// Subtract 2 packed 64-bit integers in b from 2 packed 64-bit integers in a,
+-// and store the results in dst.
+-//    r0 := a0 - b0
+-//    r1 := a1 - b1
++// Subtract packed 64-bit integers in b from packed 64-bit integers in a, and
++// store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sub_epi64
+ FORCE_INLINE __m128i _mm_sub_epi64(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s64(
+@@ -6285,24 +5716,24 @@ FORCE_INLINE __m128i _mm_sub_epi8(__m128
+ // Subtract packed double-precision (64-bit) floating-point elements in b from
+ // packed double-precision (64-bit) floating-point elements in a, and store the
+ // results in dst.
+-//
+-//   FOR j := 0 to 1
+-//     i := j*64
+-//     dst[i+63:i] := a[i+63:i] - b[i+63:i]
+-//   ENDFOR
+-//
+ //  https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=mm_sub_pd
+ FORCE_INLINE __m128d _mm_sub_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vsubq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)));
+ #else
+-    double *da = (double *) &a;
+-    double *db = (double *) &b;
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
+     double c[2];
+-    c[0] = da[0] - db[0];
+-    c[1] = da[1] - db[1];
++    c[0] = a0 - b0;
++    c[1] = a1 - b1;
+     return vld1q_f32((float32_t *) c);
+ #endif
+ }
+@@ -6318,9 +5749,6 @@ FORCE_INLINE __m128d _mm_sub_sd(__m128d
+ }
+ 
+ // Subtract 64-bit integer b from 64-bit integer a, and store the result in dst.
+-//
+-//   dst[63:0] := a[63:0] - b[63:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sub_si64
+ FORCE_INLINE __m64 _mm_sub_si64(__m64 a, __m64 b)
+ {
+@@ -6328,54 +5756,36 @@ FORCE_INLINE __m64 _mm_sub_si64(__m64 a,
+         vsub_s64(vreinterpret_s64_m64(a), vreinterpret_s64_m64(b)));
+ }
+ 
+-// Subtracts the 8 signed 16-bit integers of b from the 8 signed 16-bit integers
+-// of a and saturates.
+-//
+-//   r0 := SignedSaturate(a0 - b0)
+-//   r1 := SignedSaturate(a1 - b1)
+-//   ...
+-//   r7 := SignedSaturate(a7 - b7)
+-//
+-// https://technet.microsoft.com/en-us/subscriptions/3247z5b8(v=vs.90)
++// Subtract packed signed 16-bit integers in b from packed 16-bit integers in a
++// using saturation, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_subs_epi16
+ FORCE_INLINE __m128i _mm_subs_epi16(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s16(
+         vqsubq_s16(vreinterpretq_s16_m128i(a), vreinterpretq_s16_m128i(b)));
+ }
+ 
+-// Subtracts the 16 signed 8-bit integers of b from the 16 signed 8-bit integers
+-// of a and saturates.
+-//
+-//   r0 := SignedSaturate(a0 - b0)
+-//   r1 := SignedSaturate(a1 - b1)
+-//   ...
+-//   r15 := SignedSaturate(a15 - b15)
+-//
+-// https://technet.microsoft.com/en-us/subscriptions/by7kzks1(v=vs.90)
++// Subtract packed signed 8-bit integers in b from packed 8-bit integers in a
++// using saturation, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_subs_epi8
+ FORCE_INLINE __m128i _mm_subs_epi8(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s8(
+         vqsubq_s8(vreinterpretq_s8_m128i(a), vreinterpretq_s8_m128i(b)));
+ }
+ 
+-// Subtracts the 8 unsigned 16-bit integers of bfrom the 8 unsigned 16-bit
+-// integers of a and saturates..
+-// https://technet.microsoft.com/en-us/subscriptions/index/f44y0s19(v=vs.90).aspx
++// Subtract packed unsigned 16-bit integers in b from packed unsigned 16-bit
++// integers in a using saturation, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_subs_epu16
+ FORCE_INLINE __m128i _mm_subs_epu16(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u16(
+         vqsubq_u16(vreinterpretq_u16_m128i(a), vreinterpretq_u16_m128i(b)));
+ }
+ 
+-// Subtracts the 16 unsigned 8-bit integers of b from the 16 unsigned 8-bit
+-// integers of a and saturates.
+-//
+-//   r0 := UnsignedSaturate(a0 - b0)
+-//   r1 := UnsignedSaturate(a1 - b1)
+-//   ...
+-//   r15 := UnsignedSaturate(a15 - b15)
+-//
+-// https://technet.microsoft.com/en-us/subscriptions/yadkxc18(v=vs.90)
++// Subtract packed unsigned 8-bit integers in b from packed unsigned 8-bit
++// integers in a using saturation, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_subs_epu8
+ FORCE_INLINE __m128i _mm_subs_epu8(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u8(
+@@ -6398,28 +5808,21 @@ FORCE_INLINE __m128d _mm_undefined_pd(vo
+ #pragma GCC diagnostic ignored "-Wuninitialized"
+ #endif
+     __m128d a;
++#if defined(_MSC_VER) && !defined(__clang__)
++    a = _mm_setzero_pd();
++#endif
+     return a;
+ #if defined(__GNUC__) || defined(__clang__)
+ #pragma GCC diagnostic pop
+ #endif
+ }
+ 
+-// Interleaves the upper 4 signed or unsigned 16-bit integers in a with the
+-// upper 4 signed or unsigned 16-bit integers in b.
+-//
+-//   r0 := a4
+-//   r1 := b4
+-//   r2 := a5
+-//   r3 := b5
+-//   r4 := a6
+-//   r5 := b6
+-//   r6 := a7
+-//   r7 := b7
+-//
+-// https://msdn.microsoft.com/en-us/library/03196cz7(v=vs.100).aspx
++// Unpack and interleave 16-bit integers from the high half of a and b, and
++// store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_unpackhi_epi16
+ FORCE_INLINE __m128i _mm_unpackhi_epi16(__m128i a, __m128i b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128i_s16(
+         vzip2q_s16(vreinterpretq_s16_m128i(a), vreinterpretq_s16_m128i(b)));
+ #else
+@@ -6430,12 +5833,12 @@ FORCE_INLINE __m128i _mm_unpackhi_epi16(
+ #endif
+ }
+ 
+-// Interleaves the upper 2 signed or unsigned 32-bit integers in a with the
+-// upper 2 signed or unsigned 32-bit integers in b.
+-// https://msdn.microsoft.com/en-us/library/65sa7cbs(v=vs.100).aspx
++// Unpack and interleave 32-bit integers from the high half of a and b, and
++// store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_unpackhi_epi32
+ FORCE_INLINE __m128i _mm_unpackhi_epi32(__m128i a, __m128i b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128i_s32(
+         vzip2q_s32(vreinterpretq_s32_m128i(a), vreinterpretq_s32_m128i(b)));
+ #else
+@@ -6446,33 +5849,27 @@ FORCE_INLINE __m128i _mm_unpackhi_epi32(
+ #endif
+ }
+ 
+-// Interleaves the upper signed or unsigned 64-bit integer in a with the
+-// upper signed or unsigned 64-bit integer in b.
+-//
+-//   r0 := a1
+-//   r1 := b1
++// Unpack and interleave 64-bit integers from the high half of a and b, and
++// store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_unpackhi_epi64
+ FORCE_INLINE __m128i _mm_unpackhi_epi64(__m128i a, __m128i b)
+ {
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
++    return vreinterpretq_m128i_s64(
++        vzip2q_s64(vreinterpretq_s64_m128i(a), vreinterpretq_s64_m128i(b)));
++#else
+     int64x1_t a_h = vget_high_s64(vreinterpretq_s64_m128i(a));
+     int64x1_t b_h = vget_high_s64(vreinterpretq_s64_m128i(b));
+     return vreinterpretq_m128i_s64(vcombine_s64(a_h, b_h));
++#endif
+ }
+ 
+-// Interleaves the upper 8 signed or unsigned 8-bit integers in a with the upper
+-// 8 signed or unsigned 8-bit integers in b.
+-//
+-//   r0 := a8
+-//   r1 := b8
+-//   r2 := a9
+-//   r3 := b9
+-//   ...
+-//   r14 := a15
+-//   r15 := b15
+-//
+-// https://msdn.microsoft.com/en-us/library/t5h7783k(v=vs.100).aspx
++// Unpack and interleave 8-bit integers from the high half of a and b, and store
++// the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_unpackhi_epi8
+ FORCE_INLINE __m128i _mm_unpackhi_epi8(__m128i a, __m128i b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128i_s8(
+         vzip2q_s8(vreinterpretq_s8_m128i(a), vreinterpretq_s8_m128i(b)));
+ #else
+@@ -6487,18 +5884,10 @@ FORCE_INLINE __m128i _mm_unpackhi_epi8(_
+ 
+ // Unpack and interleave double-precision (64-bit) floating-point elements from
+ // the high half of a and b, and store the results in dst.
+-//
+-//   DEFINE INTERLEAVE_HIGH_QWORDS(src1[127:0], src2[127:0]) {
+-//     dst[63:0] := src1[127:64]
+-//     dst[127:64] := src2[127:64]
+-//     RETURN dst[127:0]
+-//   }
+-//   dst[127:0] := INTERLEAVE_HIGH_QWORDS(a[127:0], b[127:0])
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_unpackhi_pd
+ FORCE_INLINE __m128d _mm_unpackhi_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vzip2q_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)));
+ #else
+@@ -6508,22 +5897,12 @@ FORCE_INLINE __m128d _mm_unpackhi_pd(__m
+ #endif
+ }
+ 
+-// Interleaves the lower 4 signed or unsigned 16-bit integers in a with the
+-// lower 4 signed or unsigned 16-bit integers in b.
+-//
+-//   r0 := a0
+-//   r1 := b0
+-//   r2 := a1
+-//   r3 := b1
+-//   r4 := a2
+-//   r5 := b2
+-//   r6 := a3
+-//   r7 := b3
+-//
+-// https://msdn.microsoft.com/en-us/library/btxb17bw%28v=vs.90%29.aspx
++// Unpack and interleave 16-bit integers from the low half of a and b, and store
++// the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_unpacklo_epi16
+ FORCE_INLINE __m128i _mm_unpacklo_epi16(__m128i a, __m128i b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128i_s16(
+         vzip1q_s16(vreinterpretq_s16_m128i(a), vreinterpretq_s16_m128i(b)));
+ #else
+@@ -6534,18 +5913,12 @@ FORCE_INLINE __m128i _mm_unpacklo_epi16(
+ #endif
+ }
+ 
+-// Interleaves the lower 2 signed or unsigned 32 - bit integers in a with the
+-// lower 2 signed or unsigned 32 - bit integers in b.
+-//
+-//   r0 := a0
+-//   r1 := b0
+-//   r2 := a1
+-//   r3 := b1
+-//
+-// https://msdn.microsoft.com/en-us/library/x8atst9d(v=vs.100).aspx
++// Unpack and interleave 32-bit integers from the low half of a and b, and store
++// the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_unpacklo_epi32
+ FORCE_INLINE __m128i _mm_unpacklo_epi32(__m128i a, __m128i b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128i_s32(
+         vzip1q_s32(vreinterpretq_s32_m128i(a), vreinterpretq_s32_m128i(b)));
+ #else
+@@ -6556,28 +5929,27 @@ FORCE_INLINE __m128i _mm_unpacklo_epi32(
+ #endif
+ }
+ 
++// Unpack and interleave 64-bit integers from the low half of a and b, and store
++// the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_unpacklo_epi64
+ FORCE_INLINE __m128i _mm_unpacklo_epi64(__m128i a, __m128i b)
+ {
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
++    return vreinterpretq_m128i_s64(
++        vzip1q_s64(vreinterpretq_s64_m128i(a), vreinterpretq_s64_m128i(b)));
++#else
+     int64x1_t a_l = vget_low_s64(vreinterpretq_s64_m128i(a));
+     int64x1_t b_l = vget_low_s64(vreinterpretq_s64_m128i(b));
+     return vreinterpretq_m128i_s64(vcombine_s64(a_l, b_l));
++#endif
+ }
+ 
+-// Interleaves the lower 8 signed or unsigned 8-bit integers in a with the lower
+-// 8 signed or unsigned 8-bit integers in b.
+-//
+-//   r0 := a0
+-//   r1 := b0
+-//   r2 := a1
+-//   r3 := b1
+-//   ...
+-//   r14 := a7
+-//   r15 := b7
+-//
+-// https://msdn.microsoft.com/en-us/library/xf7k860c%28v=vs.90%29.aspx
++// Unpack and interleave 8-bit integers from the low half of a and b, and store
++// the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_unpacklo_epi8
+ FORCE_INLINE __m128i _mm_unpacklo_epi8(__m128i a, __m128i b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128i_s8(
+         vzip1q_s8(vreinterpretq_s8_m128i(a), vreinterpretq_s8_m128i(b)));
+ #else
+@@ -6590,18 +5962,10 @@ FORCE_INLINE __m128i _mm_unpacklo_epi8(_
+ 
+ // Unpack and interleave double-precision (64-bit) floating-point elements from
+ // the low half of a and b, and store the results in dst.
+-//
+-//   DEFINE INTERLEAVE_QWORDS(src1[127:0], src2[127:0]) {
+-//     dst[63:0] := src1[63:0]
+-//     dst[127:64] := src2[63:0]
+-//     RETURN dst[127:0]
+-//   }
+-//   dst[127:0] := INTERLEAVE_QWORDS(a[127:0], b[127:0])
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_unpacklo_pd
+ FORCE_INLINE __m128d _mm_unpacklo_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vzip1q_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)));
+ #else
+@@ -6613,12 +5977,6 @@ FORCE_INLINE __m128d _mm_unpacklo_pd(__m
+ 
+ // Compute the bitwise XOR of packed double-precision (64-bit) floating-point
+ // elements in a and b, and store the results in dst.
+-//
+-//   FOR j := 0 to 1
+-//      i := j*64
+-//      dst[i+63:i] := a[i+63:i] XOR b[i+63:i]
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_xor_pd
+ FORCE_INLINE __m128d _mm_xor_pd(__m128d a, __m128d b)
+ {
+@@ -6626,8 +5984,9 @@ FORCE_INLINE __m128d _mm_xor_pd(__m128d
+         veorq_s64(vreinterpretq_s64_m128d(a), vreinterpretq_s64_m128d(b)));
+ }
+ 
+-// Computes the bitwise XOR of the 128-bit value in a and the 128-bit value in
+-// b.  https://msdn.microsoft.com/en-us/library/fzt08www(v=vs.100).aspx
++// Compute the bitwise XOR of 128 bits (representing integer data) in a and b,
++// and store the result in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_xor_si128
+ FORCE_INLINE __m128i _mm_xor_si128(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s32(
+@@ -6639,21 +5998,11 @@ FORCE_INLINE __m128i _mm_xor_si128(__m12
+ // Alternatively add and subtract packed double-precision (64-bit)
+ // floating-point elements in a to/from packed elements in b, and store the
+ // results in dst.
+-//
+-// FOR j := 0 to 1
+-//   i := j*64
+-//   IF ((j & 1) == 0)
+-//     dst[i+63:i] := a[i+63:i] - b[i+63:i]
+-//   ELSE
+-//     dst[i+63:i] := a[i+63:i] + b[i+63:i]
+-//   FI
+-// ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_addsub_pd
+ FORCE_INLINE __m128d _mm_addsub_pd(__m128d a, __m128d b)
+ {
+     _sse2neon_const __m128d mask = _mm_set_pd(1.0f, -1.0f);
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(vfmaq_f64(vreinterpretq_f64_m128d(a),
+                                              vreinterpretq_f64_m128d(b),
+                                              vreinterpretq_f64_m128d(mask)));
+@@ -6669,7 +6018,8 @@ FORCE_INLINE __m128d _mm_addsub_pd(__m12
+ FORCE_INLINE __m128 _mm_addsub_ps(__m128 a, __m128 b)
+ {
+     _sse2neon_const __m128 mask = _mm_setr_ps(-1.0f, 1.0f, -1.0f, 1.0f);
+-#if defined(__aarch64__) || defined(__ARM_FEATURE_FMA) /* VFPv4+ */
++#if (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)) || \
++    defined(__ARM_FEATURE_FMA) /* VFPv4+ */
+     return vreinterpretq_m128_f32(vfmaq_f32(vreinterpretq_f32_m128(a),
+                                             vreinterpretq_f32_m128(mask),
+                                             vreinterpretq_f32_m128(b)));
+@@ -6683,23 +6033,29 @@ FORCE_INLINE __m128 _mm_addsub_ps(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_hadd_pd
+ FORCE_INLINE __m128d _mm_hadd_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vpaddq_f64(vreinterpretq_f64_m128d(a), vreinterpretq_f64_m128d(b)));
+ #else
+-    double *da = (double *) &a;
+-    double *db = (double *) &b;
+-    double c[] = {da[0] + da[1], db[0] + db[1]};
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
++    double c[] = {a0 + a1, b0 + b1};
+     return vreinterpretq_m128d_u64(vld1q_u64((uint64_t *) c));
+ #endif
+ }
+ 
+-// Computes pairwise add of each argument as single-precision, floating-point
+-// values a and b.
+-// https://msdn.microsoft.com/en-us/library/yd9wecaa.aspx
++// Horizontally add adjacent pairs of single-precision (32-bit) floating-point
++// elements in a and b, and pack the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_hadd_ps
+ FORCE_INLINE __m128 _mm_hadd_ps(__m128 a, __m128 b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128_f32(
+         vpaddq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
+ #else
+@@ -6715,17 +6071,23 @@ FORCE_INLINE __m128 _mm_hadd_ps(__m128 a
+ // Horizontally subtract adjacent pairs of double-precision (64-bit)
+ // floating-point elements in a and b, and pack the results in dst.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_hsub_pd
+-FORCE_INLINE __m128d _mm_hsub_pd(__m128d _a, __m128d _b)
++FORCE_INLINE __m128d _mm_hsub_pd(__m128d a, __m128d b)
+ {
+-#if defined(__aarch64__)
+-    float64x2_t a = vreinterpretq_f64_m128d(_a);
+-    float64x2_t b = vreinterpretq_f64_m128d(_b);
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
++    float64x2_t _a = vreinterpretq_f64_m128d(a);
++    float64x2_t _b = vreinterpretq_f64_m128d(b);
+     return vreinterpretq_m128d_f64(
+-        vsubq_f64(vuzp1q_f64(a, b), vuzp2q_f64(a, b)));
++        vsubq_f64(vuzp1q_f64(_a, _b), vuzp2q_f64(_a, _b)));
+ #else
+-    double *da = (double *) &_a;
+-    double *db = (double *) &_b;
+-    double c[] = {da[0] - da[1], db[0] - db[1]};
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
++    double c[] = {a0 - a1, b0 - b1};
+     return vreinterpretq_m128d_u64(vld1q_u64((uint64_t *) c));
+ #endif
+ }
+@@ -6737,7 +6099,7 @@ FORCE_INLINE __m128 _mm_hsub_ps(__m128 _
+ {
+     float32x4_t a = vreinterpretq_f32_m128(_a);
+     float32x4_t b = vreinterpretq_f32_m128(_b);
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128_f32(
+         vsubq_f32(vuzp1q_f32(a, b), vuzp2q_f32(a, b)));
+ #else
+@@ -6749,18 +6111,11 @@ FORCE_INLINE __m128 _mm_hsub_ps(__m128 _
+ // Load 128-bits of integer data from unaligned memory into dst. This intrinsic
+ // may perform better than _mm_loadu_si128 when the data crosses a cache line
+ // boundary.
+-//
+-//   dst[127:0] := MEM[mem_addr+127:mem_addr]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_lddqu_si128
+ #define _mm_lddqu_si128 _mm_loadu_si128
+ 
+ // Load a double-precision (64-bit) floating-point element from memory into both
+ // elements of dst.
+-//
+-//   dst[63:0] := MEM[mem_addr+63:mem_addr]
+-//   dst[127:64] := MEM[mem_addr+63:mem_addr]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loaddup_pd
+ #define _mm_loaddup_pd _mm_load1_pd
+ 
+@@ -6769,7 +6124,7 @@ FORCE_INLINE __m128 _mm_hsub_ps(__m128 _
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_movedup_pd
+ FORCE_INLINE __m128d _mm_movedup_pd(__m128d a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(
+         vdupq_laneq_f64(vreinterpretq_f64_m128d(a), 0));
+ #else
+@@ -6783,7 +6138,7 @@ FORCE_INLINE __m128d _mm_movedup_pd(__m1
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_movehdup_ps
+ FORCE_INLINE __m128 _mm_movehdup_ps(__m128 a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128_f32(
+         vtrn2q_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(a)));
+ #elif defined(_sse2neon_shuffle)
+@@ -6802,7 +6157,7 @@ FORCE_INLINE __m128 _mm_movehdup_ps(__m1
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_moveldup_ps
+ FORCE_INLINE __m128 _mm_moveldup_ps(__m128 a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128_f32(
+         vtrn1q_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(a)));
+ #elif defined(_sse2neon_shuffle)
+@@ -6820,12 +6175,6 @@ FORCE_INLINE __m128 _mm_moveldup_ps(__m1
+ 
+ // Compute the absolute value of packed signed 16-bit integers in a, and store
+ // the unsigned results in dst.
+-//
+-//   FOR j := 0 to 7
+-//     i := j*16
+-//     dst[i+15:i] := ABS(a[i+15:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_abs_epi16
+ FORCE_INLINE __m128i _mm_abs_epi16(__m128i a)
+ {
+@@ -6834,12 +6183,6 @@ FORCE_INLINE __m128i _mm_abs_epi16(__m12
+ 
+ // Compute the absolute value of packed signed 32-bit integers in a, and store
+ // the unsigned results in dst.
+-//
+-//   FOR j := 0 to 3
+-//     i := j*32
+-//     dst[i+31:i] := ABS(a[i+31:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_abs_epi32
+ FORCE_INLINE __m128i _mm_abs_epi32(__m128i a)
+ {
+@@ -6848,12 +6191,6 @@ FORCE_INLINE __m128i _mm_abs_epi32(__m12
+ 
+ // Compute the absolute value of packed signed 8-bit integers in a, and store
+ // the unsigned results in dst.
+-//
+-//   FOR j := 0 to 15
+-//     i := j*8
+-//     dst[i+7:i] := ABS(a[i+7:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_abs_epi8
+ FORCE_INLINE __m128i _mm_abs_epi8(__m128i a)
+ {
+@@ -6862,12 +6199,6 @@ FORCE_INLINE __m128i _mm_abs_epi8(__m128
+ 
+ // Compute the absolute value of packed signed 16-bit integers in a, and store
+ // the unsigned results in dst.
+-//
+-//   FOR j := 0 to 3
+-//     i := j*16
+-//     dst[i+15:i] := ABS(a[i+15:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_abs_pi16
+ FORCE_INLINE __m64 _mm_abs_pi16(__m64 a)
+ {
+@@ -6876,12 +6207,6 @@ FORCE_INLINE __m64 _mm_abs_pi16(__m64 a)
+ 
+ // Compute the absolute value of packed signed 32-bit integers in a, and store
+ // the unsigned results in dst.
+-//
+-//   FOR j := 0 to 1
+-//     i := j*32
+-//     dst[i+31:i] := ABS(a[i+31:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_abs_pi32
+ FORCE_INLINE __m64 _mm_abs_pi32(__m64 a)
+ {
+@@ -6890,12 +6215,6 @@ FORCE_INLINE __m64 _mm_abs_pi32(__m64 a)
+ 
+ // Compute the absolute value of packed signed 8-bit integers in a, and store
+ // the unsigned results in dst.
+-//
+-//   FOR j := 0 to 7
+-//     i := j*8
+-//     dst[i+7:i] := ABS(a[i+7:i])
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_abs_pi8
+ FORCE_INLINE __m64 _mm_abs_pi8(__m64 a)
+ {
+@@ -6904,62 +6223,69 @@ FORCE_INLINE __m64 _mm_abs_pi8(__m64 a)
+ 
+ // Concatenate 16-byte blocks in a and b into a 32-byte temporary result, shift
+ // the result right by imm8 bytes, and store the low 16 bytes in dst.
+-//
+-//   tmp[255:0] := ((a[127:0] << 128)[255:0] OR b[127:0]) >> (imm8*8)
+-//   dst[127:0] := tmp[127:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_alignr_epi8
+-#define _mm_alignr_epi8(a, b, imm)                                            \
+-    __extension__({                                                           \
+-        uint8x16_t _a = vreinterpretq_u8_m128i(a);                            \
+-        uint8x16_t _b = vreinterpretq_u8_m128i(b);                            \
+-        __m128i ret;                                                          \
+-        if (_sse2neon_unlikely((imm) & ~31))                                  \
+-            ret = vreinterpretq_m128i_u8(vdupq_n_u8(0));                      \
+-        else if (imm >= 16)                                                   \
+-            ret = _mm_srli_si128(a, imm >= 16 ? imm - 16 : 0);                \
+-        else                                                                  \
+-            ret =                                                             \
+-                vreinterpretq_m128i_u8(vextq_u8(_b, _a, imm < 16 ? imm : 0)); \
+-        ret;                                                                  \
++#if defined(__GNUC__) && !defined(__clang__)
++#define _mm_alignr_epi8(a, b, imm)                                 \
++    __extension__({                                                \
++        uint8x16_t _a = vreinterpretq_u8_m128i(a);                 \
++        uint8x16_t _b = vreinterpretq_u8_m128i(b);                 \
++        __m128i ret;                                               \
++        if (_sse2neon_unlikely((imm) & ~31))                       \
++            ret = vreinterpretq_m128i_u8(vdupq_n_u8(0));           \
++        else if ((imm) >= 16)                                      \
++            ret = _mm_srli_si128(a, (imm) >= 16 ? (imm) - 16 : 0); \
++        else                                                       \
++            ret = vreinterpretq_m128i_u8(                          \
++                vextq_u8(_b, _a, (imm) < 16 ? (imm) : 0));         \
++        ret;                                                       \
+     })
+ 
++#else
++#define _mm_alignr_epi8(a, b, imm)                                  \
++    _sse2neon_define2(                                              \
++        __m128i, a, b, uint8x16_t __a = vreinterpretq_u8_m128i(_a); \
++        uint8x16_t __b = vreinterpretq_u8_m128i(_b); __m128i ret;   \
++        if (_sse2neon_unlikely((imm) & ~31)) ret =                  \
++            vreinterpretq_m128i_u8(vdupq_n_u8(0));                  \
++        else if ((imm) >= 16) ret =                                 \
++            _mm_srli_si128(_a, (imm) >= 16 ? (imm) - 16 : 0);       \
++        else ret = vreinterpretq_m128i_u8(                          \
++            vextq_u8(__b, __a, (imm) < 16 ? (imm) : 0));            \
++        _sse2neon_return(ret);)
++
++#endif
++
+ // Concatenate 8-byte blocks in a and b into a 16-byte temporary result, shift
+ // the result right by imm8 bytes, and store the low 8 bytes in dst.
+-//
+-//   tmp[127:0] := ((a[63:0] << 64)[127:0] OR b[63:0]) >> (imm8*8)
+-//   dst[63:0] := tmp[63:0]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_alignr_pi8
+ #define _mm_alignr_pi8(a, b, imm)                                           \
+-    __extension__({                                                         \
+-        __m64 ret;                                                          \
+-        if (_sse2neon_unlikely((imm) >= 16)) {                              \
++    _sse2neon_define2(                                                      \
++        __m64, a, b, __m64 ret; if (_sse2neon_unlikely((imm) >= 16)) {      \
+             ret = vreinterpret_m64_s8(vdup_n_s8(0));                        \
+         } else {                                                            \
+-            uint8x8_t tmp_low, tmp_high;                                    \
++            uint8x8_t tmp_low;                                              \
++            uint8x8_t tmp_high;                                             \
+             if ((imm) >= 8) {                                               \
+-                const int idx = (imm) -8;                                   \
+-                tmp_low = vreinterpret_u8_m64(a);                           \
++                const int idx = (imm) - 8;                                  \
++                tmp_low = vreinterpret_u8_m64(_a);                          \
+                 tmp_high = vdup_n_u8(0);                                    \
+                 ret = vreinterpret_m64_u8(vext_u8(tmp_low, tmp_high, idx)); \
+             } else {                                                        \
+                 const int idx = (imm);                                      \
+-                tmp_low = vreinterpret_u8_m64(b);                           \
+-                tmp_high = vreinterpret_u8_m64(a);                          \
++                tmp_low = vreinterpret_u8_m64(_b);                          \
++                tmp_high = vreinterpret_u8_m64(_a);                         \
+                 ret = vreinterpret_m64_u8(vext_u8(tmp_low, tmp_high, idx)); \
+             }                                                               \
+-        }                                                                   \
+-        ret;                                                                \
+-    })
++        } _sse2neon_return(ret);)
+ 
+-// Computes pairwise add of each argument as a 16-bit signed or unsigned integer
+-// values a and b.
++// Horizontally add adjacent pairs of 16-bit integers in a and b, and pack the
++// signed 16-bit results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_hadd_epi16
+ FORCE_INLINE __m128i _mm_hadd_epi16(__m128i _a, __m128i _b)
+ {
+     int16x8_t a = vreinterpretq_s16_m128i(_a);
+     int16x8_t b = vreinterpretq_s16_m128i(_b);
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128i_s16(vpaddq_s16(a, b));
+ #else
+     return vreinterpretq_m128i_s16(
+@@ -6968,13 +6294,14 @@ FORCE_INLINE __m128i _mm_hadd_epi16(__m1
+ #endif
+ }
+ 
+-// Computes pairwise add of each argument as a 32-bit signed or unsigned integer
+-// values a and b.
++// Horizontally add adjacent pairs of 32-bit integers in a and b, and pack the
++// signed 32-bit results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_hadd_epi32
+ FORCE_INLINE __m128i _mm_hadd_epi32(__m128i _a, __m128i _b)
+ {
+     int32x4_t a = vreinterpretq_s32_m128i(_a);
+     int32x4_t b = vreinterpretq_s32_m128i(_b);
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128i_s32(vpaddq_s32(a, b));
+ #else
+     return vreinterpretq_m128i_s32(
+@@ -7001,11 +6328,12 @@ FORCE_INLINE __m64 _mm_hadd_pi32(__m64 a
+         vpadd_s32(vreinterpret_s32_m64(a), vreinterpret_s32_m64(b)));
+ }
+ 
+-// Computes saturated pairwise sub of each argument as a 16-bit signed
+-// integer values a and b.
++// Horizontally add adjacent pairs of signed 16-bit integers in a and b using
++// saturation, and pack the signed 16-bit results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_hadds_epi16
+ FORCE_INLINE __m128i _mm_hadds_epi16(__m128i _a, __m128i _b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     int16x8_t a = vreinterpretq_s16_m128i(_a);
+     int16x8_t b = vreinterpretq_s16_m128i(_b);
+     return vreinterpretq_s64_s16(
+@@ -7030,7 +6358,7 @@ FORCE_INLINE __m64 _mm_hadds_pi16(__m64
+ {
+     int16x4_t a = vreinterpret_s16_m64(_a);
+     int16x4_t b = vreinterpret_s16_m64(_b);
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpret_s64_s16(vqadd_s16(vuzp1_s16(a, b), vuzp2_s16(a, b)));
+ #else
+     int16x4x2_t res = vuzp_s16(a, b);
+@@ -7045,7 +6373,7 @@ FORCE_INLINE __m128i _mm_hsub_epi16(__m1
+ {
+     int16x8_t a = vreinterpretq_s16_m128i(_a);
+     int16x8_t b = vreinterpretq_s16_m128i(_b);
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128i_s16(
+         vsubq_s16(vuzp1q_s16(a, b), vuzp2q_s16(a, b)));
+ #else
+@@ -7061,7 +6389,7 @@ FORCE_INLINE __m128i _mm_hsub_epi32(__m1
+ {
+     int32x4_t a = vreinterpretq_s32_m128i(_a);
+     int32x4_t b = vreinterpretq_s32_m128i(_b);
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128i_s32(
+         vsubq_s32(vuzp1q_s32(a, b), vuzp2q_s32(a, b)));
+ #else
+@@ -7077,7 +6405,7 @@ FORCE_INLINE __m64 _mm_hsub_pi16(__m64 _
+ {
+     int16x4_t a = vreinterpret_s16_m64(_a);
+     int16x4_t b = vreinterpret_s16_m64(_b);
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpret_m64_s16(vsub_s16(vuzp1_s16(a, b), vuzp2_s16(a, b)));
+ #else
+     int16x4x2_t c = vuzp_s16(a, b);
+@@ -7092,7 +6420,7 @@ FORCE_INLINE __m64 _mm_hsub_pi32(__m64 _
+ {
+     int32x2_t a = vreinterpret_s32_m64(_a);
+     int32x2_t b = vreinterpret_s32_m64(_b);
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpret_m64_s32(vsub_s32(vuzp1_s32(a, b), vuzp2_s32(a, b)));
+ #else
+     int32x2x2_t c = vuzp_s32(a, b);
+@@ -7100,14 +6428,14 @@ FORCE_INLINE __m64 _mm_hsub_pi32(__m64 _
+ #endif
+ }
+ 
+-// Computes saturated pairwise difference of each argument as a 16-bit signed
+-// integer values a and b.
++// Horizontally subtract adjacent pairs of signed 16-bit integers in a and b
++// using saturation, and pack the signed 16-bit results in dst.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_hsubs_epi16
+ FORCE_INLINE __m128i _mm_hsubs_epi16(__m128i _a, __m128i _b)
+ {
+     int16x8_t a = vreinterpretq_s16_m128i(_a);
+     int16x8_t b = vreinterpretq_s16_m128i(_b);
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128i_s16(
+         vqsubq_s16(vuzp1q_s16(a, b), vuzp2q_s16(a, b)));
+ #else
+@@ -7123,7 +6451,7 @@ FORCE_INLINE __m64 _mm_hsubs_pi16(__m64
+ {
+     int16x4_t a = vreinterpret_s16_m64(_a);
+     int16x4_t b = vreinterpret_s16_m64(_b);
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpret_m64_s16(vqsub_s16(vuzp1_s16(a, b), vuzp2_s16(a, b)));
+ #else
+     int16x4x2_t c = vuzp_s16(a, b);
+@@ -7135,15 +6463,10 @@ FORCE_INLINE __m64 _mm_hsubs_pi16(__m64
+ // signed 8-bit integer from b, producing intermediate signed 16-bit integers.
+ // Horizontally add adjacent pairs of intermediate signed 16-bit integers,
+ // and pack the saturated results in dst.
+-//
+-//   FOR j := 0 to 7
+-//      i := j*16
+-//      dst[i+15:i] := Saturate_To_Int16( a[i+15:i+8]*b[i+15:i+8] +
+-//      a[i+7:i]*b[i+7:i] )
+-//   ENDFOR
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_maddubs_epi16
+ FORCE_INLINE __m128i _mm_maddubs_epi16(__m128i _a, __m128i _b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     uint8x16_t a = vreinterpretq_u8_m128i(_a);
+     int8x16_t b = vreinterpretq_s8_m128i(_b);
+     int16x8_t tl = vmulq_s16(vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(a))),
+@@ -7204,12 +6527,7 @@ FORCE_INLINE __m64 _mm_maddubs_pi16(__m6
+ // Multiply packed signed 16-bit integers in a and b, producing intermediate
+ // signed 32-bit integers. Shift right by 15 bits while rounding up, and store
+ // the packed 16-bit integers in dst.
+-//
+-//   r0 := Round(((int32_t)a0 * (int32_t)b0) >> 15)
+-//   r1 := Round(((int32_t)a1 * (int32_t)b1) >> 15)
+-//   r2 := Round(((int32_t)a2 * (int32_t)b2) >> 15)
+-//   ...
+-//   r7 := Round(((int32_t)a7 * (int32_t)b7) >> 15)
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mulhrs_epi16
+ FORCE_INLINE __m128i _mm_mulhrs_epi16(__m128i a, __m128i b)
+ {
+     // Has issues due to saturation
+@@ -7252,7 +6570,7 @@ FORCE_INLINE __m128i _mm_shuffle_epi8(__
+     uint8x16_t idx = vreinterpretq_u8_m128i(b);  // input b
+     uint8x16_t idx_masked =
+         vandq_u8(idx, vdupq_n_u8(0x8F));  // avoid using meaningless bits
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128i_s8(vqtbl1q_s8(tbl, idx_masked));
+ #elif defined(__GNUC__)
+     int8x16_t ret;
+@@ -7275,17 +6593,6 @@ FORCE_INLINE __m128i _mm_shuffle_epi8(__
+ 
+ // Shuffle packed 8-bit integers in a according to shuffle control mask in the
+ // corresponding 8-bit element of b, and store the results in dst.
+-//
+-//   FOR j := 0 to 7
+-//     i := j*8
+-//     IF b[i+7] == 1
+-//       dst[i+7:i] := 0
+-//     ELSE
+-//       index[2:0] := b[i+2:i]
+-//       dst[i+7:i] := a[index*8+7:index*8]
+-//     FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_shuffle_pi8
+ FORCE_INLINE __m64 _mm_shuffle_pi8(__m64 a, __m64 b)
+ {
+@@ -7299,16 +6606,7 @@ FORCE_INLINE __m64 _mm_shuffle_pi8(__m64
+ // 16-bit integer in b is negative, and store the results in dst.
+ // Element in dst are zeroed out when the corresponding element
+ // in b is zero.
+-//
+-//   for i in 0..7
+-//     if b[i] < 0
+-//       r[i] := -a[i]
+-//     else if b[i] == 0
+-//       r[i] := 0
+-//     else
+-//       r[i] := a[i]
+-//     fi
+-//   done
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sign_epi16
+ FORCE_INLINE __m128i _mm_sign_epi16(__m128i _a, __m128i _b)
+ {
+     int16x8_t a = vreinterpretq_s16_m128i(_a);
+@@ -7318,7 +6616,7 @@ FORCE_INLINE __m128i _mm_sign_epi16(__m1
+     // (b < 0) ? 0xFFFF : 0
+     uint16x8_t ltMask = vreinterpretq_u16_s16(vshrq_n_s16(b, 15));
+     // (b == 0) ? 0xFFFF : 0
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     int16x8_t zeroMask = vreinterpretq_s16_u16(vceqzq_s16(b));
+ #else
+     int16x8_t zeroMask = vreinterpretq_s16_u16(vceqq_s16(b, vdupq_n_s16(0)));
+@@ -7336,16 +6634,7 @@ FORCE_INLINE __m128i _mm_sign_epi16(__m1
+ // 32-bit integer in b is negative, and store the results in dst.
+ // Element in dst are zeroed out when the corresponding element
+ // in b is zero.
+-//
+-//   for i in 0..3
+-//     if b[i] < 0
+-//       r[i] := -a[i]
+-//     else if b[i] == 0
+-//       r[i] := 0
+-//     else
+-//       r[i] := a[i]
+-//     fi
+-//   done
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sign_epi32
+ FORCE_INLINE __m128i _mm_sign_epi32(__m128i _a, __m128i _b)
+ {
+     int32x4_t a = vreinterpretq_s32_m128i(_a);
+@@ -7356,7 +6645,7 @@ FORCE_INLINE __m128i _mm_sign_epi32(__m1
+     uint32x4_t ltMask = vreinterpretq_u32_s32(vshrq_n_s32(b, 31));
+ 
+     // (b == 0) ? 0xFFFFFFFF : 0
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     int32x4_t zeroMask = vreinterpretq_s32_u32(vceqzq_s32(b));
+ #else
+     int32x4_t zeroMask = vreinterpretq_s32_u32(vceqq_s32(b, vdupq_n_s32(0)));
+@@ -7374,16 +6663,7 @@ FORCE_INLINE __m128i _mm_sign_epi32(__m1
+ // 8-bit integer in b is negative, and store the results in dst.
+ // Element in dst are zeroed out when the corresponding element
+ // in b is zero.
+-//
+-//   for i in 0..15
+-//     if b[i] < 0
+-//       r[i] := -a[i]
+-//     else if b[i] == 0
+-//       r[i] := 0
+-//     else
+-//       r[i] := a[i]
+-//     fi
+-//   done
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sign_epi8
+ FORCE_INLINE __m128i _mm_sign_epi8(__m128i _a, __m128i _b)
+ {
+     int8x16_t a = vreinterpretq_s8_m128i(_a);
+@@ -7394,7 +6674,7 @@ FORCE_INLINE __m128i _mm_sign_epi8(__m12
+     uint8x16_t ltMask = vreinterpretq_u8_s8(vshrq_n_s8(b, 7));
+ 
+     // (b == 0) ? 0xFF : 0
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     int8x16_t zeroMask = vreinterpretq_s8_u8(vceqzq_s8(b));
+ #else
+     int8x16_t zeroMask = vreinterpretq_s8_u8(vceqq_s8(b, vdupq_n_s8(0)));
+@@ -7412,18 +6692,6 @@ FORCE_INLINE __m128i _mm_sign_epi8(__m12
+ // Negate packed 16-bit integers in a when the corresponding signed 16-bit
+ // integer in b is negative, and store the results in dst. Element in dst are
+ // zeroed out when the corresponding element in b is zero.
+-//
+-//   FOR j := 0 to 3
+-//      i := j*16
+-//      IF b[i+15:i] < 0
+-//        dst[i+15:i] := -(a[i+15:i])
+-//      ELSE IF b[i+15:i] == 0
+-//        dst[i+15:i] := 0
+-//      ELSE
+-//        dst[i+15:i] := a[i+15:i]
+-//      FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sign_pi16
+ FORCE_INLINE __m64 _mm_sign_pi16(__m64 _a, __m64 _b)
+ {
+@@ -7435,7 +6703,7 @@ FORCE_INLINE __m64 _mm_sign_pi16(__m64 _
+     uint16x4_t ltMask = vreinterpret_u16_s16(vshr_n_s16(b, 15));
+ 
+     // (b == 0) ? 0xFFFF : 0
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     int16x4_t zeroMask = vreinterpret_s16_u16(vceqz_s16(b));
+ #else
+     int16x4_t zeroMask = vreinterpret_s16_u16(vceq_s16(b, vdup_n_s16(0)));
+@@ -7453,18 +6721,6 @@ FORCE_INLINE __m64 _mm_sign_pi16(__m64 _
+ // Negate packed 32-bit integers in a when the corresponding signed 32-bit
+ // integer in b is negative, and store the results in dst. Element in dst are
+ // zeroed out when the corresponding element in b is zero.
+-//
+-//   FOR j := 0 to 1
+-//      i := j*32
+-//      IF b[i+31:i] < 0
+-//        dst[i+31:i] := -(a[i+31:i])
+-//      ELSE IF b[i+31:i] == 0
+-//        dst[i+31:i] := 0
+-//      ELSE
+-//        dst[i+31:i] := a[i+31:i]
+-//      FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sign_pi32
+ FORCE_INLINE __m64 _mm_sign_pi32(__m64 _a, __m64 _b)
+ {
+@@ -7476,7 +6732,7 @@ FORCE_INLINE __m64 _mm_sign_pi32(__m64 _
+     uint32x2_t ltMask = vreinterpret_u32_s32(vshr_n_s32(b, 31));
+ 
+     // (b == 0) ? 0xFFFFFFFF : 0
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     int32x2_t zeroMask = vreinterpret_s32_u32(vceqz_s32(b));
+ #else
+     int32x2_t zeroMask = vreinterpret_s32_u32(vceq_s32(b, vdup_n_s32(0)));
+@@ -7494,18 +6750,6 @@ FORCE_INLINE __m64 _mm_sign_pi32(__m64 _
+ // Negate packed 8-bit integers in a when the corresponding signed 8-bit integer
+ // in b is negative, and store the results in dst. Element in dst are zeroed out
+ // when the corresponding element in b is zero.
+-//
+-//   FOR j := 0 to 7
+-//      i := j*8
+-//      IF b[i+7:i] < 0
+-//        dst[i+7:i] := -(a[i+7:i])
+-//      ELSE IF b[i+7:i] == 0
+-//        dst[i+7:i] := 0
+-//      ELSE
+-//        dst[i+7:i] := a[i+7:i]
+-//      FI
+-//   ENDFOR
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sign_pi8
+ FORCE_INLINE __m64 _mm_sign_pi8(__m64 _a, __m64 _b)
+ {
+@@ -7517,7 +6761,7 @@ FORCE_INLINE __m64 _mm_sign_pi8(__m64 _a
+     uint8x8_t ltMask = vreinterpret_u8_s8(vshr_n_s8(b, 7));
+ 
+     // (b == 0) ? 0xFF : 0
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     int8x8_t zeroMask = vreinterpret_s8_u8(vceqz_s8(b));
+ #else
+     int8x8_t zeroMask = vreinterpret_s8_u8(vceq_s8(b, vdup_n_s8(0)));
+@@ -7536,57 +6780,48 @@ FORCE_INLINE __m64 _mm_sign_pi8(__m64 _a
+ 
+ // Blend packed 16-bit integers from a and b using control mask imm8, and store
+ // the results in dst.
+-//
+-//   FOR j := 0 to 7
+-//       i := j*16
+-//       IF imm8[j]
+-//           dst[i+15:i] := b[i+15:i]
+-//       ELSE
+-//           dst[i+15:i] := a[i+15:i]
+-//       FI
+-//   ENDFOR
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_blend_epi16
+ // FORCE_INLINE __m128i _mm_blend_epi16(__m128i a, __m128i b,
+ //                                      __constrange(0,255) int imm)
+-#define _mm_blend_epi16(a, b, imm)                                            \
+-    __extension__({                                                           \
+-        const uint16_t _mask[8] = {((imm) & (1 << 0)) ? (uint16_t) -1 : 0x0,  \
+-                                   ((imm) & (1 << 1)) ? (uint16_t) -1 : 0x0,  \
+-                                   ((imm) & (1 << 2)) ? (uint16_t) -1 : 0x0,  \
+-                                   ((imm) & (1 << 3)) ? (uint16_t) -1 : 0x0,  \
+-                                   ((imm) & (1 << 4)) ? (uint16_t) -1 : 0x0,  \
+-                                   ((imm) & (1 << 5)) ? (uint16_t) -1 : 0x0,  \
+-                                   ((imm) & (1 << 6)) ? (uint16_t) -1 : 0x0,  \
+-                                   ((imm) & (1 << 7)) ? (uint16_t) -1 : 0x0}; \
+-        uint16x8_t _mask_vec = vld1q_u16(_mask);                              \
+-        uint16x8_t _a = vreinterpretq_u16_m128i(a);                           \
+-        uint16x8_t _b = vreinterpretq_u16_m128i(b);                           \
+-        vreinterpretq_m128i_u16(vbslq_u16(_mask_vec, _b, _a));                \
+-    })
++#define _mm_blend_epi16(a, b, imm)                                      \
++    _sse2neon_define2(                                                  \
++        __m128i, a, b,                                                  \
++        const uint16_t _mask[8] =                                       \
++            _sse2neon_init(((imm) & (1 << 0)) ? (uint16_t) - 1 : 0x0,   \
++                           ((imm) & (1 << 1)) ? (uint16_t) - 1 : 0x0,   \
++                           ((imm) & (1 << 2)) ? (uint16_t) - 1 : 0x0,   \
++                           ((imm) & (1 << 3)) ? (uint16_t) - 1 : 0x0,   \
++                           ((imm) & (1 << 4)) ? (uint16_t) - 1 : 0x0,   \
++                           ((imm) & (1 << 5)) ? (uint16_t) - 1 : 0x0,   \
++                           ((imm) & (1 << 6)) ? (uint16_t) - 1 : 0x0,   \
++                           ((imm) & (1 << 7)) ? (uint16_t) - 1 : 0x0);  \
++        uint16x8_t _mask_vec = vld1q_u16(_mask);                        \
++        uint16x8_t __a = vreinterpretq_u16_m128i(_a);                   \
++        uint16x8_t __b = vreinterpretq_u16_m128i(_b); _sse2neon_return( \
++            vreinterpretq_m128i_u16(vbslq_u16(_mask_vec, __b, __a)));)
+ 
+ // Blend packed double-precision (64-bit) floating-point elements from a and b
+ // using control mask imm8, and store the results in dst.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_blend_pd
+-#define _mm_blend_pd(a, b, imm)                                \
+-    __extension__({                                            \
+-        const uint64_t _mask[2] = {                            \
+-            ((imm) & (1 << 0)) ? ~UINT64_C(0) : UINT64_C(0),   \
+-            ((imm) & (1 << 1)) ? ~UINT64_C(0) : UINT64_C(0)};  \
+-        uint64x2_t _mask_vec = vld1q_u64(_mask);               \
+-        uint64x2_t _a = vreinterpretq_u64_m128d(a);            \
+-        uint64x2_t _b = vreinterpretq_u64_m128d(b);            \
+-        vreinterpretq_m128d_u64(vbslq_u64(_mask_vec, _b, _a)); \
+-    })
++#define _mm_blend_pd(a, b, imm)                                              \
++    _sse2neon_define2(                                                       \
++        __m128d, a, b,                                                       \
++        const uint64_t _mask[2] =                                            \
++            _sse2neon_init(((imm) & (1 << 0)) ? ~UINT64_C(0) : UINT64_C(0),  \
++                           ((imm) & (1 << 1)) ? ~UINT64_C(0) : UINT64_C(0)); \
++        uint64x2_t _mask_vec = vld1q_u64(_mask);                             \
++        uint64x2_t __a = vreinterpretq_u64_m128d(_a);                        \
++        uint64x2_t __b = vreinterpretq_u64_m128d(_b); _sse2neon_return(      \
++            vreinterpretq_m128d_u64(vbslq_u64(_mask_vec, __b, __a)));)
+ 
+ // Blend packed single-precision (32-bit) floating-point elements from a and b
+ // using mask, and store the results in dst.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_blend_ps
+ FORCE_INLINE __m128 _mm_blend_ps(__m128 _a, __m128 _b, const char imm8)
+ {
+-    const uint32_t ALIGN_STRUCT(16)
+-        data[4] = {((imm8) & (1 << 0)) ? UINT32_MAX : 0,
+-                   ((imm8) & (1 << 1)) ? UINT32_MAX : 0,
+-                   ((imm8) & (1 << 2)) ? UINT32_MAX : 0,
+-                   ((imm8) & (1 << 3)) ? UINT32_MAX : 0};
++    const uint32_t ALIGN_STRUCT(16) data[4] = {
++        (imm8 & (1 << 0)) ? UINT32_MAX : 0, (imm8 & (1 << 1)) ? UINT32_MAX : 0,
++        (imm8 & (1 << 2)) ? UINT32_MAX : 0, (imm8 & (1 << 3)) ? UINT32_MAX : 0};
+     uint32x4_t mask = vld1q_u32(data);
+     float32x4_t a = vreinterpretq_f32_m128(_a);
+     float32x4_t b = vreinterpretq_f32_m128(_b);
+@@ -7595,15 +6830,7 @@ FORCE_INLINE __m128 _mm_blend_ps(__m128
+ 
+ // Blend packed 8-bit integers from a and b using mask, and store the results in
+ // dst.
+-//
+-//   FOR j := 0 to 15
+-//       i := j*8
+-//       IF mask[i+7]
+-//           dst[i+7:i] := b[i+7:i]
+-//       ELSE
+-//           dst[i+7:i] := a[i+7:i]
+-//       FI
+-//   ENDFOR
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_blendv_epi8
+ FORCE_INLINE __m128i _mm_blendv_epi8(__m128i _a, __m128i _b, __m128i _mask)
+ {
+     // Use a signed shift right to create a mask with the sign bit
+@@ -7621,7 +6848,7 @@ FORCE_INLINE __m128d _mm_blendv_pd(__m12
+ {
+     uint64x2_t mask =
+         vreinterpretq_u64_s64(vshrq_n_s64(vreinterpretq_s64_m128d(_mask), 63));
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     float64x2_t a = vreinterpretq_f64_m128d(_a);
+     float64x2_t b = vreinterpretq_f64_m128d(_b);
+     return vreinterpretq_m128d_f64(vbslq_f64(mask, b, a));
+@@ -7651,11 +6878,13 @@ FORCE_INLINE __m128 _mm_blendv_ps(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_ceil_pd
+ FORCE_INLINE __m128d _mm_ceil_pd(__m128d a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(vrndpq_f64(vreinterpretq_f64_m128d(a)));
+ #else
+-    double *f = (double *) &a;
+-    return _mm_set_pd(ceil(f[1]), ceil(f[0]));
++    double a0, a1;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    a1 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    return _mm_set_pd(ceil(a1), ceil(a0));
+ #endif
+ }
+ 
+@@ -7665,7 +6894,8 @@ FORCE_INLINE __m128d _mm_ceil_pd(__m128d
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_ceil_ps
+ FORCE_INLINE __m128 _mm_ceil_ps(__m128 a)
+ {
+-#if defined(__aarch64__) || defined(__ARM_FEATURE_DIRECTED_ROUNDING)
++#if (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)) || \
++    defined(__ARM_FEATURE_DIRECTED_ROUNDING)
+     return vreinterpretq_m128_f32(vrndpq_f32(vreinterpretq_f32_m128(a)));
+ #else
+     float *f = (float *) &a;
+@@ -7687,10 +6917,6 @@ FORCE_INLINE __m128d _mm_ceil_sd(__m128d
+ // an integer value, store the result as a single-precision floating-point
+ // element in the lower element of dst, and copy the upper 3 packed elements
+ // from a to the upper elements of dst.
+-//
+-//   dst[31:0] := CEIL(b[31:0])
+-//   dst[127:32] := a[127:32]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_ceil_ss
+ FORCE_INLINE __m128 _mm_ceil_ss(__m128 a, __m128 b)
+ {
+@@ -7701,7 +6927,7 @@ FORCE_INLINE __m128 _mm_ceil_ss(__m128 a
+ // in dst
+ FORCE_INLINE __m128i _mm_cmpeq_epi64(__m128i a, __m128i b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128i_u64(
+         vceqq_u64(vreinterpretq_u64_m128i(a), vreinterpretq_u64_m128i(b)));
+ #else
+@@ -7714,16 +6940,18 @@ FORCE_INLINE __m128i _mm_cmpeq_epi64(__m
+ #endif
+ }
+ 
+-// Converts the four signed 16-bit integers in the lower 64 bits to four signed
+-// 32-bit integers.
++// Sign extend packed 16-bit integers in a to packed 32-bit integers, and store
++// the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtepi16_epi32
+ FORCE_INLINE __m128i _mm_cvtepi16_epi32(__m128i a)
+ {
+     return vreinterpretq_m128i_s32(
+         vmovl_s16(vget_low_s16(vreinterpretq_s16_m128i(a))));
+ }
+ 
+-// Converts the two signed 16-bit integers in the lower 32 bits two signed
+-// 32-bit integers.
++// Sign extend packed 16-bit integers in a to packed 64-bit integers, and store
++// the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtepi16_epi64
+ FORCE_INLINE __m128i _mm_cvtepi16_epi64(__m128i a)
+ {
+     int16x8_t s16x8 = vreinterpretq_s16_m128i(a);     /* xxxx xxxx xxxx 0B0A */
+@@ -7732,16 +6960,18 @@ FORCE_INLINE __m128i _mm_cvtepi16_epi64(
+     return vreinterpretq_m128i_s64(s64x2);
+ }
+ 
+-// Converts the two signed 32-bit integers in the lower 64 bits to two signed
+-// 64-bit integers.
++// Sign extend packed 32-bit integers in a to packed 64-bit integers, and store
++// the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtepi32_epi64
+ FORCE_INLINE __m128i _mm_cvtepi32_epi64(__m128i a)
+ {
+     return vreinterpretq_m128i_s64(
+         vmovl_s32(vget_low_s32(vreinterpretq_s32_m128i(a))));
+ }
+ 
+-// Converts the four unsigned 8-bit integers in the lower 16 bits to four
+-// unsigned 32-bit integers.
++// Sign extend packed 8-bit integers in a to packed 16-bit integers, and store
++// the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtepi8_epi16
+ FORCE_INLINE __m128i _mm_cvtepi8_epi16(__m128i a)
+ {
+     int8x16_t s8x16 = vreinterpretq_s8_m128i(a);    /* xxxx xxxx xxxx DCBA */
+@@ -7749,8 +6979,9 @@ FORCE_INLINE __m128i _mm_cvtepi8_epi16(_
+     return vreinterpretq_m128i_s16(s16x8);
+ }
+ 
+-// Converts the four unsigned 8-bit integers in the lower 32 bits to four
+-// unsigned 32-bit integers.
++// Sign extend packed 8-bit integers in a to packed 32-bit integers, and store
++// the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtepi8_epi32
+ FORCE_INLINE __m128i _mm_cvtepi8_epi32(__m128i a)
+ {
+     int8x16_t s8x16 = vreinterpretq_s8_m128i(a);      /* xxxx xxxx xxxx DCBA */
+@@ -7759,8 +6990,9 @@ FORCE_INLINE __m128i _mm_cvtepi8_epi32(_
+     return vreinterpretq_m128i_s32(s32x4);
+ }
+ 
+-// Converts the two signed 8-bit integers in the lower 32 bits to four
+-// signed 64-bit integers.
++// Sign extend packed 8-bit integers in the low 8 bytes of a to packed 64-bit
++// integers, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtepi8_epi64
+ FORCE_INLINE __m128i _mm_cvtepi8_epi64(__m128i a)
+ {
+     int8x16_t s8x16 = vreinterpretq_s8_m128i(a);      /* xxxx xxxx xxxx xxBA */
+@@ -7770,16 +7002,18 @@ FORCE_INLINE __m128i _mm_cvtepi8_epi64(_
+     return vreinterpretq_m128i_s64(s64x2);
+ }
+ 
+-// Converts the four unsigned 16-bit integers in the lower 64 bits to four
+-// unsigned 32-bit integers.
++// Zero extend packed unsigned 16-bit integers in a to packed 32-bit integers,
++// and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtepu16_epi32
+ FORCE_INLINE __m128i _mm_cvtepu16_epi32(__m128i a)
+ {
+     return vreinterpretq_m128i_u32(
+         vmovl_u16(vget_low_u16(vreinterpretq_u16_m128i(a))));
+ }
+ 
+-// Converts the two unsigned 16-bit integers in the lower 32 bits to two
+-// unsigned 64-bit integers.
++// Zero extend packed unsigned 16-bit integers in a to packed 64-bit integers,
++// and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtepu16_epi64
+ FORCE_INLINE __m128i _mm_cvtepu16_epi64(__m128i a)
+ {
+     uint16x8_t u16x8 = vreinterpretq_u16_m128i(a);     /* xxxx xxxx xxxx 0B0A */
+@@ -7788,8 +7022,9 @@ FORCE_INLINE __m128i _mm_cvtepu16_epi64(
+     return vreinterpretq_m128i_u64(u64x2);
+ }
+ 
+-// Converts the two unsigned 32-bit integers in the lower 64 bits to two
+-// unsigned 64-bit integers.
++// Zero extend packed unsigned 32-bit integers in a to packed 64-bit integers,
++// and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtepu32_epi64
+ FORCE_INLINE __m128i _mm_cvtepu32_epi64(__m128i a)
+ {
+     return vreinterpretq_m128i_u64(
+@@ -7806,9 +7041,9 @@ FORCE_INLINE __m128i _mm_cvtepu8_epi16(_
+     return vreinterpretq_m128i_u16(u16x8);
+ }
+ 
+-// Converts the four unsigned 8-bit integers in the lower 32 bits to four
+-// unsigned 32-bit integers.
+-// https://msdn.microsoft.com/en-us/library/bb531467%28v=vs.100%29.aspx
++// Zero extend packed unsigned 8-bit integers in a to packed 32-bit integers,
++// and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtepu8_epi32
+ FORCE_INLINE __m128i _mm_cvtepu8_epi32(__m128i a)
+ {
+     uint8x16_t u8x16 = vreinterpretq_u8_m128i(a);      /* xxxx xxxx xxxx DCBA */
+@@ -7817,8 +7052,9 @@ FORCE_INLINE __m128i _mm_cvtepu8_epi32(_
+     return vreinterpretq_m128i_u32(u32x4);
+ }
+ 
+-// Converts the two unsigned 8-bit integers in the lower 16 bits to two
+-// unsigned 64-bit integers.
++// Zero extend packed unsigned 8-bit integers in the low 8 bytes of a to packed
++// 64-bit integers, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtepu8_epi64
+ FORCE_INLINE __m128i _mm_cvtepu8_epi64(__m128i a)
+ {
+     uint8x16_t u8x16 = vreinterpretq_u8_m128i(a);      /* xxxx xxxx xxxx xxBA */
+@@ -7848,7 +7084,7 @@ FORCE_INLINE __m128d _mm_dp_pd(__m128d a
+         _mm_castsi128_pd(_mm_set_epi64x(bit5Mask, bit4Mask));
+     __m128d tmp = _mm_and_pd(mul, mulMask);
+ #else
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     double d0 = (imm & 0x10) ? vgetq_lane_f64(vreinterpretq_f64_m128d(a), 0) *
+                                    vgetq_lane_f64(vreinterpretq_f64_m128d(b), 0)
+                              : 0;
+@@ -7856,16 +7092,28 @@ FORCE_INLINE __m128d _mm_dp_pd(__m128d a
+                                    vgetq_lane_f64(vreinterpretq_f64_m128d(b), 1)
+                              : 0;
+ #else
+-    double d0 = (imm & 0x10) ? ((double *) &a)[0] * ((double *) &b)[0] : 0;
+-    double d1 = (imm & 0x20) ? ((double *) &a)[1] * ((double *) &b)[1] : 0;
++    double a0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    double a1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    double b0 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
++    double b1 =
++        sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 1));
++    double d0 = (imm & 0x10) ? a0 * b0 : 0;
++    double d1 = (imm & 0x20) ? a1 * b1 : 0;
+ #endif
+     __m128d tmp = _mm_set_pd(d1, d0);
+ #endif
+     // Sum the products
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     double sum = vpaddd_f64(vreinterpretq_f64_m128d(tmp));
+ #else
+-    double sum = *((double *) &tmp) + *(((double *) &tmp) + 1);
++    double _tmp0 = sse2neon_recast_u64_f64(
++        vgetq_lane_u64(vreinterpretq_u64_m128d(tmp), 0));
++    double _tmp1 = sse2neon_recast_u64_f64(
++        vgetq_lane_u64(vreinterpretq_u64_m128d(tmp), 1));
++    double sum = _tmp0 + _tmp1;
+ #endif
+     // Conditionally store the sum
+     const __m128d sumMask =
+@@ -7880,59 +7128,65 @@ FORCE_INLINE __m128d _mm_dp_pd(__m128d a
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_dp_ps
+ FORCE_INLINE __m128 _mm_dp_ps(__m128 a, __m128 b, const int imm)
+ {
+-#if defined(__aarch64__)
++    float32x4_t elementwise_prod = _mm_mul_ps(a, b);
++
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     /* shortcuts */
+     if (imm == 0xFF) {
+-        return _mm_set1_ps(vaddvq_f32(_mm_mul_ps(a, b)));
++        return _mm_set1_ps(vaddvq_f32(elementwise_prod));
+     }
+-    if (imm == 0x7F) {
+-        float32x4_t m = _mm_mul_ps(a, b);
+-        m[3] = 0;
+-        return _mm_set1_ps(vaddvq_f32(m));
++
++    if ((imm & 0x0F) == 0x0F) {
++        if (!(imm & (1 << 4)))
++            elementwise_prod = vsetq_lane_f32(0.0f, elementwise_prod, 0);
++        if (!(imm & (1 << 5)))
++            elementwise_prod = vsetq_lane_f32(0.0f, elementwise_prod, 1);
++        if (!(imm & (1 << 6)))
++            elementwise_prod = vsetq_lane_f32(0.0f, elementwise_prod, 2);
++        if (!(imm & (1 << 7)))
++            elementwise_prod = vsetq_lane_f32(0.0f, elementwise_prod, 3);
++
++        return _mm_set1_ps(vaddvq_f32(elementwise_prod));
+     }
+ #endif
+ 
+-    float s = 0, c = 0;
+-    float32x4_t f32a = vreinterpretq_f32_m128(a);
+-    float32x4_t f32b = vreinterpretq_f32_m128(b);
++    float s = 0.0f;
+ 
+-    /* To improve the accuracy of floating-point summation, Kahan algorithm
+-     * is used for each operation.
+-     */
+     if (imm & (1 << 4))
+-        _sse2neon_kadd_f32(&s, &c, f32a[0] * f32b[0]);
++        s += vgetq_lane_f32(elementwise_prod, 0);
+     if (imm & (1 << 5))
+-        _sse2neon_kadd_f32(&s, &c, f32a[1] * f32b[1]);
++        s += vgetq_lane_f32(elementwise_prod, 1);
+     if (imm & (1 << 6))
+-        _sse2neon_kadd_f32(&s, &c, f32a[2] * f32b[2]);
++        s += vgetq_lane_f32(elementwise_prod, 2);
+     if (imm & (1 << 7))
+-        _sse2neon_kadd_f32(&s, &c, f32a[3] * f32b[3]);
+-    s += c;
++        s += vgetq_lane_f32(elementwise_prod, 3);
+ 
+-    float32x4_t res = {
+-        (imm & 0x1) ? s : 0,
+-        (imm & 0x2) ? s : 0,
+-        (imm & 0x4) ? s : 0,
+-        (imm & 0x8) ? s : 0,
++    const float32_t res[4] = {
++        (imm & 0x1) ? s : 0.0f,
++        (imm & 0x2) ? s : 0.0f,
++        (imm & 0x4) ? s : 0.0f,
++        (imm & 0x8) ? s : 0.0f,
+     };
+-    return vreinterpretq_m128_f32(res);
++    return vreinterpretq_m128_f32(vld1q_f32(res));
+ }
+ 
+-// Extracts the selected signed or unsigned 32-bit integer from a and zero
+-// extends.
++// Extract a 32-bit integer from a, selected with imm8, and store the result in
++// dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_extract_epi32
+ // FORCE_INLINE int _mm_extract_epi32(__m128i a, __constrange(0,4) int imm)
+ #define _mm_extract_epi32(a, imm) \
+     vgetq_lane_s32(vreinterpretq_s32_m128i(a), (imm))
+ 
+-// Extracts the selected signed or unsigned 64-bit integer from a and zero
+-// extends.
++// Extract a 64-bit integer from a, selected with imm8, and store the result in
++// dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_extract_epi64
+ // FORCE_INLINE __int64 _mm_extract_epi64(__m128i a, __constrange(0,2) int imm)
+ #define _mm_extract_epi64(a, imm) \
+     vgetq_lane_s64(vreinterpretq_s64_m128i(a), (imm))
+ 
+-// Extracts the selected signed or unsigned 8-bit integer from a and zero
+-// extends.
+-// FORCE_INLINE int _mm_extract_epi8(__m128i a, __constrange(0,16) int imm)
++// Extract an 8-bit integer from a, selected with imm8, and store the result in
++// the lower element of dst. FORCE_INLINE int _mm_extract_epi8(__m128i a,
++// __constrange(0,16) int imm)
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_extract_epi8
+ #define _mm_extract_epi8(a, imm) vgetq_lane_u8(vreinterpretq_u8_m128i(a), (imm))
+ 
+@@ -7946,11 +7200,13 @@ FORCE_INLINE __m128 _mm_dp_ps(__m128 a,
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_floor_pd
+ FORCE_INLINE __m128d _mm_floor_pd(__m128d a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128d_f64(vrndmq_f64(vreinterpretq_f64_m128d(a)));
+ #else
+-    double *f = (double *) &a;
+-    return _mm_set_pd(floor(f[1]), floor(f[0]));
++    double a0, a1;
++    a0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 0));
++    a1 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
++    return _mm_set_pd(floor(a1), floor(a0));
+ #endif
+ }
+ 
+@@ -7960,7 +7216,8 @@ FORCE_INLINE __m128d _mm_floor_pd(__m128
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_floor_ps
+ FORCE_INLINE __m128 _mm_floor_ps(__m128 a)
+ {
+-#if defined(__aarch64__) || defined(__ARM_FEATURE_DIRECTED_ROUNDING)
++#if (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)) || \
++    defined(__ARM_FEATURE_DIRECTED_ROUNDING)
+     return vreinterpretq_m128_f32(vrndmq_f32(vreinterpretq_f32_m128(a)));
+ #else
+     float *f = (float *) &a;
+@@ -7982,80 +7239,65 @@ FORCE_INLINE __m128d _mm_floor_sd(__m128
+ // an integer value, store the result as a single-precision floating-point
+ // element in the lower element of dst, and copy the upper 3 packed elements
+ // from a to the upper elements of dst.
+-//
+-//   dst[31:0] := FLOOR(b[31:0])
+-//   dst[127:32] := a[127:32]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_floor_ss
+ FORCE_INLINE __m128 _mm_floor_ss(__m128 a, __m128 b)
+ {
+     return _mm_move_ss(a, _mm_floor_ps(b));
+ }
+ 
+-// Inserts the least significant 32 bits of b into the selected 32-bit integer
+-// of a.
++// Copy a to dst, and insert the 32-bit integer i into dst at the location
++// specified by imm8.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_insert_epi32
+ // FORCE_INLINE __m128i _mm_insert_epi32(__m128i a, int b,
+ //                                       __constrange(0,4) int imm)
+-#define _mm_insert_epi32(a, b, imm)                                  \
+-    __extension__({                                                  \
+-        vreinterpretq_m128i_s32(                                     \
+-            vsetq_lane_s32((b), vreinterpretq_s32_m128i(a), (imm))); \
+-    })
++#define _mm_insert_epi32(a, b, imm) \
++    vreinterpretq_m128i_s32(        \
++        vsetq_lane_s32((b), vreinterpretq_s32_m128i(a), (imm)))
+ 
+-// Inserts the least significant 64 bits of b into the selected 64-bit integer
+-// of a.
++// Copy a to dst, and insert the 64-bit integer i into dst at the location
++// specified by imm8.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_insert_epi64
+ // FORCE_INLINE __m128i _mm_insert_epi64(__m128i a, __int64 b,
+ //                                       __constrange(0,2) int imm)
+-#define _mm_insert_epi64(a, b, imm)                                  \
+-    __extension__({                                                  \
+-        vreinterpretq_m128i_s64(                                     \
+-            vsetq_lane_s64((b), vreinterpretq_s64_m128i(a), (imm))); \
+-    })
+-
+-// Inserts the least significant 8 bits of b into the selected 8-bit integer
+-// of a.
++#define _mm_insert_epi64(a, b, imm) \
++    vreinterpretq_m128i_s64(        \
++        vsetq_lane_s64((b), vreinterpretq_s64_m128i(a), (imm)))
++
++// Copy a to dst, and insert the lower 8-bit integer from i into dst at the
++// location specified by imm8.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_insert_epi8
+ // FORCE_INLINE __m128i _mm_insert_epi8(__m128i a, int b,
+ //                                      __constrange(0,16) int imm)
+-#define _mm_insert_epi8(a, b, imm)                                 \
+-    __extension__({                                                \
+-        vreinterpretq_m128i_s8(                                    \
+-            vsetq_lane_s8((b), vreinterpretq_s8_m128i(a), (imm))); \
+-    })
++#define _mm_insert_epi8(a, b, imm) \
++    vreinterpretq_m128i_s8(vsetq_lane_s8((b), vreinterpretq_s8_m128i(a), (imm)))
+ 
+ // Copy a to tmp, then insert a single-precision (32-bit) floating-point
+ // element from b into tmp using the control in imm8. Store tmp to dst using
+ // the mask in imm8 (elements are zeroed out when the corresponding bit is set).
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=insert_ps
+ #define _mm_insert_ps(a, b, imm8)                                              \
+-    __extension__({                                                            \
++    _sse2neon_define2(                                                         \
++        __m128, a, b,                                                          \
+         float32x4_t tmp1 =                                                     \
+-            vsetq_lane_f32(vgetq_lane_f32(b, (imm8 >> 6) & 0x3),               \
+-                           vreinterpretq_f32_m128(a), 0);                      \
++            vsetq_lane_f32(vgetq_lane_f32(_b, ((imm8) >> 6) & 0x3),            \
++                           vreinterpretq_f32_m128(_a), 0);                     \
+         float32x4_t tmp2 =                                                     \
+-            vsetq_lane_f32(vgetq_lane_f32(tmp1, 0), vreinterpretq_f32_m128(a), \
+-                           ((imm8 >> 4) & 0x3));                               \
+-        const uint32_t data[4] = {((imm8) & (1 << 0)) ? UINT32_MAX : 0,        \
+-                                  ((imm8) & (1 << 1)) ? UINT32_MAX : 0,        \
+-                                  ((imm8) & (1 << 2)) ? UINT32_MAX : 0,        \
+-                                  ((imm8) & (1 << 3)) ? UINT32_MAX : 0};       \
++            vsetq_lane_f32(vgetq_lane_f32(tmp1, 0),                            \
++                           vreinterpretq_f32_m128(_a), (((imm8) >> 4) & 0x3)); \
++        const uint32_t data[4] =                                               \
++            _sse2neon_init(((imm8) & (1 << 0)) ? UINT32_MAX : 0,               \
++                           ((imm8) & (1 << 1)) ? UINT32_MAX : 0,               \
++                           ((imm8) & (1 << 2)) ? UINT32_MAX : 0,               \
++                           ((imm8) & (1 << 3)) ? UINT32_MAX : 0);              \
+         uint32x4_t mask = vld1q_u32(data);                                     \
+         float32x4_t all_zeros = vdupq_n_f32(0);                                \
+                                                                                \
+-        vreinterpretq_m128_f32(                                                \
+-            vbslq_f32(mask, all_zeros, vreinterpretq_f32_m128(tmp2)));         \
+-    })
++        _sse2neon_return(vreinterpretq_m128_f32(                               \
++            vbslq_f32(mask, all_zeros, vreinterpretq_f32_m128(tmp2))));)
+ 
+-// epi versions of min/max
+-// Computes the pariwise maximums of the four signed 32-bit integer values of a
+-// and b.
+-//
+-// A 128-bit parameter that can be defined with the following equations:
+-//   r0 := (a0 > b0) ? a0 : b0
+-//   r1 := (a1 > b1) ? a1 : b1
+-//   r2 := (a2 > b2) ? a2 : b2
+-//   r3 := (a3 > b3) ? a3 : b3
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/bb514055(v=vs.100).aspx
++// Compare packed signed 32-bit integers in a and b, and store packed maximum
++// values in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_max_epi32
+ FORCE_INLINE __m128i _mm_max_epi32(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s32(
+@@ -8089,16 +7331,9 @@ FORCE_INLINE __m128i _mm_max_epu32(__m12
+         vmaxq_u32(vreinterpretq_u32_m128i(a), vreinterpretq_u32_m128i(b)));
+ }
+ 
+-// Computes the pariwise minima of the four signed 32-bit integer values of a
+-// and b.
+-//
+-// A 128-bit parameter that can be defined with the following equations:
+-//   r0 := (a0 < b0) ? a0 : b0
+-//   r1 := (a1 < b1) ? a1 : b1
+-//   r2 := (a2 < b2) ? a2 : b2
+-//   r3 := (a3 < b3) ? a3 : b3
+-//
+-// https://msdn.microsoft.com/en-us/library/vstudio/bb531476(v=vs.100).aspx
++// Compare packed signed 32-bit integers in a and b, and store packed minimum
++// values in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_min_epi32
+ FORCE_INLINE __m128i _mm_min_epi32(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s32(
+@@ -8134,26 +7369,12 @@ FORCE_INLINE __m128i _mm_min_epu32(__m12
+ 
+ // Horizontally compute the minimum amongst the packed unsigned 16-bit integers
+ // in a, store the minimum and index in dst, and zero the remaining bits in dst.
+-//
+-//   index[2:0] := 0
+-//   min[15:0] := a[15:0]
+-//   FOR j := 0 to 7
+-//       i := j*16
+-//       IF a[i+15:i] < min[15:0]
+-//           index[2:0] := j
+-//           min[15:0] := a[i+15:i]
+-//       FI
+-//   ENDFOR
+-//   dst[15:0] := min[15:0]
+-//   dst[18:16] := index[2:0]
+-//   dst[127:19] := 0
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_minpos_epu16
+ FORCE_INLINE __m128i _mm_minpos_epu16(__m128i a)
+ {
+     __m128i dst;
+     uint16_t min, idx = 0;
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     // Find the minimum value
+     min = vminvq_u16(vreinterpretq_u16_m128i(a));
+ 
+@@ -8215,6 +7436,8 @@ FORCE_INLINE __m128i _mm_mpsadbw_epu8(__
+     default:
+ #if defined(__GNUC__) || defined(__clang__)
+         __builtin_unreachable();
++#elif defined(_MSC_VER)
++        __assume(0);
+ #endif
+         break;
+     }
+@@ -8239,6 +7462,8 @@ FORCE_INLINE __m128i _mm_mpsadbw_epu8(__
+     default:
+ #if defined(__GNUC__) || defined(__clang__)
+         __builtin_unreachable();
++#elif defined(_MSC_VER)
++        __assume(0);
+ #endif
+         break;
+     }
+@@ -8252,7 +7477,7 @@ FORCE_INLINE __m128i _mm_mpsadbw_epu8(__
+     c26 = vreinterpretq_s16_u16(vabdl_u8(vget_low_u8(_a_2), low_b));
+     uint8x16_t _a_3 = vextq_u8(_a, _a, 3);
+     c37 = vreinterpretq_s16_u16(vabdl_u8(vget_low_u8(_a_3), low_b));
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     // |0|4|2|6|
+     c04 = vpaddq_s16(c04, c26);
+     // |1|5|3|7|
+@@ -8278,9 +7503,7 @@ FORCE_INLINE __m128i _mm_mpsadbw_epu8(__
+ 
+ // Multiply the low signed 32-bit integers from each packed 64-bit element in
+ // a and b, and store the signed 64-bit results in dst.
+-//
+-//   r0 :=  (int64_t)(int32_t)a0 * (int64_t)(int32_t)b0
+-//   r1 :=  (int64_t)(int32_t)a2 * (int64_t)(int32_t)b2
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mul_epi32
+ FORCE_INLINE __m128i _mm_mul_epi32(__m128i a, __m128i b)
+ {
+     // vmull_s32 upcasts instead of masking, so we downcast.
+@@ -8289,26 +7512,18 @@ FORCE_INLINE __m128i _mm_mul_epi32(__m12
+     return vreinterpretq_m128i_s64(vmull_s32(a_lo, b_lo));
+ }
+ 
+-// Multiplies the 4 signed or unsigned 32-bit integers from a by the 4 signed or
+-// unsigned 32-bit integers from b.
+-// https://msdn.microsoft.com/en-us/library/vstudio/bb531409(v=vs.100).aspx
++// Multiply the packed 32-bit integers in a and b, producing intermediate 64-bit
++// integers, and store the low 32 bits of the intermediate integers in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mullo_epi32
+ FORCE_INLINE __m128i _mm_mullo_epi32(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_s32(
+         vmulq_s32(vreinterpretq_s32_m128i(a), vreinterpretq_s32_m128i(b)));
+ }
+ 
+-// Packs the 8 unsigned 32-bit integers from a and b into unsigned 16-bit
+-// integers and saturates.
+-//
+-//   r0 := UnsignedSaturate(a0)
+-//   r1 := UnsignedSaturate(a1)
+-//   r2 := UnsignedSaturate(a2)
+-//   r3 := UnsignedSaturate(a3)
+-//   r4 := UnsignedSaturate(b0)
+-//   r5 := UnsignedSaturate(b1)
+-//   r6 := UnsignedSaturate(b2)
+-//   r7 := UnsignedSaturate(b3)
++// Convert packed signed 32-bit integers from a and b to packed 16-bit integers
++// using unsigned saturation, and store the results in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packus_epi32
+ FORCE_INLINE __m128i _mm_packus_epi32(__m128i a, __m128i b)
+ {
+     return vreinterpretq_m128i_u16(
+@@ -8322,7 +7537,7 @@ FORCE_INLINE __m128i _mm_packus_epi32(__
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_round_pd
+ FORCE_INLINE __m128d _mm_round_pd(__m128d a, int rounding)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     switch (rounding) {
+     case (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC):
+         return vreinterpretq_m128d_f64(vrndnq_f64(vreinterpretq_f64_m128d(a)));
+@@ -8391,7 +7606,8 @@ FORCE_INLINE __m128d _mm_round_pd(__m128
+ // software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_round_ps
+ FORCE_INLINE __m128 _mm_round_ps(__m128 a, int rounding)
+ {
+-#if defined(__aarch64__) || defined(__ARM_FEATURE_DIRECTED_ROUNDING)
++#if (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)) || \
++    defined(__ARM_FEATURE_DIRECTED_ROUNDING)
+     switch (rounding) {
+     case (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC):
+         return vreinterpretq_m128_f32(vrndnq_f32(vreinterpretq_f32_m128(a)));
+@@ -8477,9 +7693,6 @@ FORCE_INLINE __m128 _mm_round_ss(__m128
+ // Load 128-bits of integer data from memory into dst using a non-temporal
+ // memory hint. mem_addr must be aligned on a 16-byte boundary or a
+ // general-protection exception may be generated.
+-//
+-//   dst[127:0] := MEM[mem_addr+127:mem_addr]
+-//
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_stream_load_si128
+ FORCE_INLINE __m128i _mm_stream_load_si128(__m128i *p)
+ {
+@@ -8515,14 +7728,22 @@ FORCE_INLINE int _mm_test_all_zeros(__m1
+ // zero, otherwise set CF to 0. Return 1 if both the ZF and CF values are zero,
+ // otherwise return 0.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=mm_test_mix_ones_zero
++// Note: Argument names may be wrong in the Intel intrinsics guide.
+ FORCE_INLINE int _mm_test_mix_ones_zeros(__m128i a, __m128i mask)
+ {
+-    uint64x2_t zf =
+-        vandq_u64(vreinterpretq_u64_m128i(mask), vreinterpretq_u64_m128i(a));
+-    uint64x2_t cf =
+-        vbicq_u64(vreinterpretq_u64_m128i(mask), vreinterpretq_u64_m128i(a));
+-    uint64x2_t result = vandq_u64(zf, cf);
+-    return !(vgetq_lane_u64(result, 0) | vgetq_lane_u64(result, 1));
++    uint64x2_t v = vreinterpretq_u64_m128i(a);
++    uint64x2_t m = vreinterpretq_u64_m128i(mask);
++
++    // find ones (set-bits) and zeros (clear-bits) under clip mask
++    uint64x2_t ones = vandq_u64(m, v);
++    uint64x2_t zeros = vbicq_u64(m, v);
++
++    // If both 128-bit variables are populated (non-zero) then return 1.
++    // For comparison purposes, first compact each var down to 32-bits.
++    uint32x2_t reduced = vpmax_u32(vqmovn_u64(ones), vqmovn_u64(zeros));
++
++    // if folding minimum is non-zero then both vars must be non-zero
++    return (vget_lane_u32(vpmin_u32(reduced, reduced), 0) != 0);
+ }
+ 
+ // Compute the bitwise AND of 128 bits (representing integer data) in a and b,
+@@ -8532,9 +7753,9 @@ FORCE_INLINE int _mm_test_mix_ones_zeros
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_testc_si128
+ FORCE_INLINE int _mm_testc_si128(__m128i a, __m128i b)
+ {
+-    int64x2_t s64 =
++    int64x2_t s64_vec =
+         vbicq_s64(vreinterpretq_s64_m128i(b), vreinterpretq_s64_m128i(a));
+-    return !(vgetq_lane_s64(s64, 0) | vgetq_lane_s64(s64, 1));
++    return !(vgetq_lane_s64(s64_vec, 0) | vgetq_lane_s64(s64_vec, 1));
+ }
+ 
+ // Compute the bitwise AND of 128 bits (representing integer data) in a and b,
+@@ -8552,17 +7773,17 @@ FORCE_INLINE int _mm_testc_si128(__m128i
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_testz_si128
+ FORCE_INLINE int _mm_testz_si128(__m128i a, __m128i b)
+ {
+-    int64x2_t s64 =
++    int64x2_t s64_vec =
+         vandq_s64(vreinterpretq_s64_m128i(a), vreinterpretq_s64_m128i(b));
+-    return !(vgetq_lane_s64(s64, 0) | vgetq_lane_s64(s64, 1));
++    return !(vgetq_lane_s64(s64_vec, 0) | vgetq_lane_s64(s64_vec, 1));
+ }
+ 
+ /* SSE4.2 */
+ 
+-const static uint16_t _sse2neon_cmpestr_mask16b[8] ALIGN_STRUCT(16) = {
++static const uint16_t ALIGN_STRUCT(16) _sse2neon_cmpestr_mask16b[8] = {
+     0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80,
+ };
+-const static uint8_t _sse2neon_cmpestr_mask8b[16] ALIGN_STRUCT(16) = {
++static const uint8_t ALIGN_STRUCT(16) _sse2neon_cmpestr_mask8b[16] = {
+     0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80,
+     0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80,
+ };
+@@ -8722,40 +7943,40 @@ const static uint8_t _sse2neon_cmpestr_m
+                                       SSE2NEON_CAT(u, size)))                \
+     } while (0)
+ 
+-#define SSE2NEON_CMP_EQUAL_ANY_IMPL(type)                                     \
+-    static int _sse2neon_cmp_##type##_equal_any(__m128i a, int la, __m128i b, \
+-                                                int lb)                       \
+-    {                                                                         \
+-        __m128i mtx[16];                                                      \
+-        PCMPSTR_EQ(a, b, mtx, SSE2NEON_CAT(SSE2NEON_SIZE_OF_, type),          \
+-                   SSE2NEON_CAT(SSE2NEON_NUMBER_OF_LANES_, type));            \
+-        return SSE2NEON_CAT(                                                  \
+-            _sse2neon_aggregate_equal_any_,                                   \
+-            SSE2NEON_CAT(                                                     \
+-                SSE2NEON_CAT(SSE2NEON_SIZE_OF_, type),                        \
+-                SSE2NEON_CAT(x, SSE2NEON_CAT(SSE2NEON_NUMBER_OF_LANES_,       \
+-                                             type))))(la, lb, mtx);           \
++#define SSE2NEON_CMP_EQUAL_ANY_IMPL(type)                               \
++    static uint16_t _sse2neon_cmp_##type##_equal_any(__m128i a, int la, \
++                                                     __m128i b, int lb) \
++    {                                                                   \
++        __m128i mtx[16];                                                \
++        PCMPSTR_EQ(a, b, mtx, SSE2NEON_CAT(SSE2NEON_SIZE_OF_, type),    \
++                   SSE2NEON_CAT(SSE2NEON_NUMBER_OF_LANES_, type));      \
++        return SSE2NEON_CAT(                                            \
++            _sse2neon_aggregate_equal_any_,                             \
++            SSE2NEON_CAT(                                               \
++                SSE2NEON_CAT(SSE2NEON_SIZE_OF_, type),                  \
++                SSE2NEON_CAT(x, SSE2NEON_CAT(SSE2NEON_NUMBER_OF_LANES_, \
++                                             type))))(la, lb, mtx);     \
+     }
+ 
+-#define SSE2NEON_CMP_RANGES_IMPL(type, data_type, us, byte_or_word)            \
+-    static int _sse2neon_cmp_##us##type##_ranges(__m128i a, int la, __m128i b, \
+-                                                 int lb)                       \
+-    {                                                                          \
+-        __m128i mtx[16];                                                       \
+-        PCMPSTR_RANGES(                                                        \
+-            a, b, mtx, data_type, us, SSE2NEON_CAT(SSE2NEON_SIZE_OF_, type),   \
+-            SSE2NEON_CAT(SSE2NEON_NUMBER_OF_LANES_, type), byte_or_word);      \
+-        return SSE2NEON_CAT(                                                   \
+-            _sse2neon_aggregate_ranges_,                                       \
+-            SSE2NEON_CAT(                                                      \
+-                SSE2NEON_CAT(SSE2NEON_SIZE_OF_, type),                         \
+-                SSE2NEON_CAT(x, SSE2NEON_CAT(SSE2NEON_NUMBER_OF_LANES_,        \
+-                                             type))))(la, lb, mtx);            \
++#define SSE2NEON_CMP_RANGES_IMPL(type, data_type, us, byte_or_word)          \
++    static uint16_t _sse2neon_cmp_##us##type##_ranges(__m128i a, int la,     \
++                                                      __m128i b, int lb)     \
++    {                                                                        \
++        __m128i mtx[16];                                                     \
++        PCMPSTR_RANGES(                                                      \
++            a, b, mtx, data_type, us, SSE2NEON_CAT(SSE2NEON_SIZE_OF_, type), \
++            SSE2NEON_CAT(SSE2NEON_NUMBER_OF_LANES_, type), byte_or_word);    \
++        return SSE2NEON_CAT(                                                 \
++            _sse2neon_aggregate_ranges_,                                     \
++            SSE2NEON_CAT(                                                    \
++                SSE2NEON_CAT(SSE2NEON_SIZE_OF_, type),                       \
++                SSE2NEON_CAT(x, SSE2NEON_CAT(SSE2NEON_NUMBER_OF_LANES_,      \
++                                             type))))(la, lb, mtx);          \
+     }
+ 
+ #define SSE2NEON_CMP_EQUAL_ORDERED_IMPL(type)                                  \
+-    static int _sse2neon_cmp_##type##_equal_ordered(__m128i a, int la,         \
+-                                                    __m128i b, int lb)         \
++    static uint16_t _sse2neon_cmp_##type##_equal_ordered(__m128i a, int la,    \
++                                                         __m128i b, int lb)    \
+     {                                                                          \
+         __m128i mtx[16];                                                       \
+         PCMPSTR_EQ(a, b, mtx, SSE2NEON_CAT(SSE2NEON_SIZE_OF_, type),           \
+@@ -8769,29 +7990,34 @@ const static uint8_t _sse2neon_cmpestr_m
+             SSE2NEON_CAT(SSE2NEON_NUMBER_OF_LANES_, type), la, lb, mtx);       \
+     }
+ 
+-static int _sse2neon_aggregate_equal_any_8x16(int la, int lb, __m128i mtx[16])
++static uint16_t _sse2neon_aggregate_equal_any_8x16(int la,
++                                                   int lb,
++                                                   __m128i mtx[16])
+ {
+-    int res = 0;
++    uint16_t res = 0;
+     int m = (1 << la) - 1;
+     uint8x8_t vec_mask = vld1_u8(_sse2neon_cmpestr_mask8b);
+-    uint8x8_t t_lo = vtst_u8(vdup_n_u8(m & 0xff), vec_mask);
+-    uint8x8_t t_hi = vtst_u8(vdup_n_u8(m >> 8), vec_mask);
++    uint8x8_t t_lo = vtst_u8(vdup_n_u8((uint8_t) (m & 0xff)), vec_mask);
++    uint8x8_t t_hi = vtst_u8(vdup_n_u8((uint8_t) (m >> 8)), vec_mask);
+     uint8x16_t vec = vcombine_u8(t_lo, t_hi);
+     for (int j = 0; j < lb; j++) {
+         mtx[j] = vreinterpretq_m128i_u8(
+             vandq_u8(vec, vreinterpretq_u8_m128i(mtx[j])));
+         mtx[j] = vreinterpretq_m128i_u8(
+             vshrq_n_u8(vreinterpretq_u8_m128i(mtx[j]), 7));
+-        int tmp = _sse2neon_vaddvq_u8(vreinterpretq_u8_m128i(mtx[j])) ? 1 : 0;
++        uint16_t tmp =
++            _sse2neon_vaddvq_u8(vreinterpretq_u8_m128i(mtx[j])) ? 1 : 0;
+         res |= (tmp << j);
+     }
+     return res;
+ }
+ 
+-static int _sse2neon_aggregate_equal_any_16x8(int la, int lb, __m128i mtx[16])
++static uint16_t _sse2neon_aggregate_equal_any_16x8(int la,
++                                                   int lb,
++                                                   __m128i mtx[16])
+ {
+-    int res = 0;
+-    int m = (1 << la) - 1;
++    uint16_t res = 0;
++    uint16_t m = (uint16_t) (1 << la) - 1;
+     uint16x8_t vec =
+         vtstq_u16(vdupq_n_u16(m), vld1q_u16(_sse2neon_cmpestr_mask16b));
+     for (int j = 0; j < lb; j++) {
+@@ -8799,7 +8025,8 @@ static int _sse2neon_aggregate_equal_any
+             vandq_u16(vec, vreinterpretq_u16_m128i(mtx[j])));
+         mtx[j] = vreinterpretq_m128i_u16(
+             vshrq_n_u16(vreinterpretq_u16_m128i(mtx[j]), 15));
+-        int tmp = _sse2neon_vaddvq_u16(vreinterpretq_u16_m128i(mtx[j])) ? 1 : 0;
++        uint16_t tmp =
++            _sse2neon_vaddvq_u16(vreinterpretq_u16_m128i(mtx[j])) ? 1 : 0;
+         res |= (tmp << j);
+     }
+     return res;
+@@ -8813,10 +8040,10 @@ static int _sse2neon_aggregate_equal_any
+ 
+ SSE2NEON_GENERATE_CMP_EQUAL_ANY(SSE2NEON_CMP_EQUAL_ANY_)
+ 
+-static int _sse2neon_aggregate_ranges_16x8(int la, int lb, __m128i mtx[16])
++static uint16_t _sse2neon_aggregate_ranges_16x8(int la, int lb, __m128i mtx[16])
+ {
+-    int res = 0;
+-    int m = (1 << la) - 1;
++    uint16_t res = 0;
++    uint16_t m = (uint16_t) (1 << la) - 1;
+     uint16x8_t vec =
+         vtstq_u16(vdupq_n_u16(m), vld1q_u16(_sse2neon_cmpestr_mask16b));
+     for (int j = 0; j < lb; j++) {
+@@ -8828,24 +8055,24 @@ static int _sse2neon_aggregate_ranges_16
+             vshrq_n_u32(vreinterpretq_u32_m128i(mtx[j]), 16));
+         uint32x4_t vec_res = vandq_u32(vreinterpretq_u32_m128i(mtx[j]),
+                                        vreinterpretq_u32_m128i(tmp));
+-#if defined(__aarch64__)
+-        int t = vaddvq_u32(vec_res) ? 1 : 0;
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
++        uint16_t t = vaddvq_u32(vec_res) ? 1 : 0;
+ #else
+         uint64x2_t sumh = vpaddlq_u32(vec_res);
+-        int t = vgetq_lane_u64(sumh, 0) + vgetq_lane_u64(sumh, 1);
++        uint16_t t = vgetq_lane_u64(sumh, 0) + vgetq_lane_u64(sumh, 1);
+ #endif
+         res |= (t << j);
+     }
+     return res;
+ }
+ 
+-static int _sse2neon_aggregate_ranges_8x16(int la, int lb, __m128i mtx[16])
++static uint16_t _sse2neon_aggregate_ranges_8x16(int la, int lb, __m128i mtx[16])
+ {
+-    int res = 0;
+-    int m = (1 << la) - 1;
++    uint16_t res = 0;
++    uint16_t m = (uint16_t) ((1 << la) - 1);
+     uint8x8_t vec_mask = vld1_u8(_sse2neon_cmpestr_mask8b);
+-    uint8x8_t t_lo = vtst_u8(vdup_n_u8(m & 0xff), vec_mask);
+-    uint8x8_t t_hi = vtst_u8(vdup_n_u8(m >> 8), vec_mask);
++    uint8x8_t t_lo = vtst_u8(vdup_n_u8((uint8_t) (m & 0xff)), vec_mask);
++    uint8x8_t t_hi = vtst_u8(vdup_n_u8((uint8_t) (m >> 8)), vec_mask);
+     uint8x16_t vec = vcombine_u8(t_lo, t_hi);
+     for (int j = 0; j < lb; j++) {
+         mtx[j] = vreinterpretq_m128i_u8(
+@@ -8856,7 +8083,7 @@ static int _sse2neon_aggregate_ranges_8x
+             vshrq_n_u16(vreinterpretq_u16_m128i(mtx[j]), 8));
+         uint16x8_t vec_res = vandq_u16(vreinterpretq_u16_m128i(mtx[j]),
+                                        vreinterpretq_u16_m128i(tmp));
+-        int t = _sse2neon_vaddvq_u16(vec_res) ? 1 : 0;
++        uint16_t t = _sse2neon_vaddvq_u16(vec_res) ? 1 : 0;
+         res |= (t << j);
+     }
+     return res;
+@@ -8878,22 +8105,25 @@ SSE2NEON_GENERATE_CMP_RANGES(SSE2NEON_CM
+ #undef SSE2NEON_CMP_RANGES_IS_BYTE
+ #undef SSE2NEON_CMP_RANGES_IS_WORD
+ 
+-static int _sse2neon_cmp_byte_equal_each(__m128i a, int la, __m128i b, int lb)
++static uint16_t _sse2neon_cmp_byte_equal_each(__m128i a,
++                                              int la,
++                                              __m128i b,
++                                              int lb)
+ {
+     uint8x16_t mtx =
+         vceqq_u8(vreinterpretq_u8_m128i(a), vreinterpretq_u8_m128i(b));
+-    int m0 = (la < lb) ? 0 : ((1 << la) - (1 << lb));
+-    int m1 = 0x10000 - (1 << la);
+-    int tb = 0x10000 - (1 << lb);
++    uint16_t m0 = (la < lb) ? 0 : (uint16_t) ((1 << la) - (1 << lb));
++    uint16_t m1 = (uint16_t) (0x10000 - (1 << la));
++    uint16_t tb = (uint16_t) (0x10000 - (1 << lb));
+     uint8x8_t vec_mask, vec0_lo, vec0_hi, vec1_lo, vec1_hi;
+     uint8x8_t tmp_lo, tmp_hi, res_lo, res_hi;
+     vec_mask = vld1_u8(_sse2neon_cmpestr_mask8b);
+-    vec0_lo = vtst_u8(vdup_n_u8(m0), vec_mask);
+-    vec0_hi = vtst_u8(vdup_n_u8(m0 >> 8), vec_mask);
+-    vec1_lo = vtst_u8(vdup_n_u8(m1), vec_mask);
+-    vec1_hi = vtst_u8(vdup_n_u8(m1 >> 8), vec_mask);
+-    tmp_lo = vtst_u8(vdup_n_u8(tb), vec_mask);
+-    tmp_hi = vtst_u8(vdup_n_u8(tb >> 8), vec_mask);
++    vec0_lo = vtst_u8(vdup_n_u8((uint8_t) m0), vec_mask);
++    vec0_hi = vtst_u8(vdup_n_u8((uint8_t) (m0 >> 8)), vec_mask);
++    vec1_lo = vtst_u8(vdup_n_u8((uint8_t) m1), vec_mask);
++    vec1_hi = vtst_u8(vdup_n_u8((uint8_t) (m1 >> 8)), vec_mask);
++    tmp_lo = vtst_u8(vdup_n_u8((uint8_t) tb), vec_mask);
++    tmp_hi = vtst_u8(vdup_n_u8((uint8_t) (tb >> 8)), vec_mask);
+ 
+     res_lo = vbsl_u8(vec0_lo, vdup_n_u8(0), vget_low_u8(mtx));
+     res_hi = vbsl_u8(vec0_hi, vdup_n_u8(0), vget_high_u8(mtx));
+@@ -8902,17 +8132,20 @@ static int _sse2neon_cmp_byte_equal_each
+     res_lo = vand_u8(res_lo, vec_mask);
+     res_hi = vand_u8(res_hi, vec_mask);
+ 
+-    int res = _sse2neon_vaddv_u8(res_lo) + (_sse2neon_vaddv_u8(res_hi) << 8);
+-    return res;
++    return _sse2neon_vaddv_u8(res_lo) +
++           (uint16_t) (_sse2neon_vaddv_u8(res_hi) << 8);
+ }
+ 
+-static int _sse2neon_cmp_word_equal_each(__m128i a, int la, __m128i b, int lb)
++static uint16_t _sse2neon_cmp_word_equal_each(__m128i a,
++                                              int la,
++                                              __m128i b,
++                                              int lb)
+ {
+     uint16x8_t mtx =
+         vceqq_u16(vreinterpretq_u16_m128i(a), vreinterpretq_u16_m128i(b));
+-    int m0 = (la < lb) ? 0 : ((1 << la) - (1 << lb));
+-    int m1 = 0x100 - (1 << la);
+-    int tb = 0x100 - (1 << lb);
++    uint16_t m0 = (uint16_t) ((la < lb) ? 0 : ((1 << la) - (1 << lb)));
++    uint16_t m1 = (uint16_t) (0x100 - (1 << la));
++    uint16_t tb = (uint16_t) (0x100 - (1 << lb));
+     uint16x8_t vec_mask = vld1q_u16(_sse2neon_cmpestr_mask16b);
+     uint16x8_t vec0 = vtstq_u16(vdupq_n_u16(m0), vec_mask);
+     uint16x8_t vec1 = vtstq_u16(vdupq_n_u16(m1), vec_mask);
+@@ -8927,18 +8160,22 @@ static int _sse2neon_cmp_word_equal_each
+ #define SSE2NEON_AGGREGATE_EQUAL_ORDER_IS_UWORD 0
+ 
+ #define SSE2NEON_AGGREGATE_EQUAL_ORDER_IMPL(size, number_of_lanes, data_type)  \
+-    static int _sse2neon_aggregate_equal_ordered_##size##x##number_of_lanes(   \
+-        int bound, int la, int lb, __m128i mtx[16])                            \
++    static uint16_t                                                            \
++        _sse2neon_aggregate_equal_ordered_##size##x##number_of_lanes(          \
++            int bound, int la, int lb, __m128i mtx[16])                        \
+     {                                                                          \
+-        int res = 0;                                                           \
+-        int m1 = SSE2NEON_IIF(data_type)(0x10000, 0x100) - (1 << la);          \
++        uint16_t res = 0;                                                      \
++        uint16_t m1 =                                                          \
++            (uint16_t) (SSE2NEON_IIF(data_type)(0x10000, 0x100) - (1 << la));  \
+         uint##size##x8_t vec_mask = SSE2NEON_IIF(data_type)(                   \
+             vld1_u##size(_sse2neon_cmpestr_mask##size##b),                     \
+             vld1q_u##size(_sse2neon_cmpestr_mask##size##b));                   \
+         uint##size##x##number_of_lanes##_t vec1 = SSE2NEON_IIF(data_type)(     \
+-            vcombine_u##size(vtst_u##size(vdup_n_u##size(m1), vec_mask),       \
+-                             vtst_u##size(vdup_n_u##size(m1 >> 8), vec_mask)), \
+-            vtstq_u##size(vdupq_n_u##size(m1), vec_mask));                     \
++            vcombine_u##size(                                                  \
++                vtst_u##size(vdup_n_u##size((uint##size##_t) m1), vec_mask),   \
++                vtst_u##size(vdup_n_u##size((uint##size##_t)(m1 >> 8)),        \
++                             vec_mask)),                                       \
++            vtstq_u##size(vdupq_n_u##size((uint##size##_t) m1), vec_mask));    \
+         uint##size##x##number_of_lanes##_t vec_minusone = vdupq_n_u##size(-1); \
+         uint##size##x##number_of_lanes##_t vec_zero = vdupq_n_u##size(0);      \
+         for (int j = 0; j < lb; j++) {                                         \
+@@ -8955,7 +8192,7 @@ static int _sse2neon_cmp_word_equal_each
+             int val = 1;                                                       \
+             for (int j = 0, k = i; j < bound - i && k < bound; j++, k++)       \
+                 val &= ptr[k * bound + j];                                     \
+-            res += val << i;                                                   \
++            res += (uint16_t) (val << i);                                      \
+         }                                                                      \
+         return res;                                                            \
+     }
+@@ -8979,37 +8216,40 @@ SSE2NEON_GENERATE_AGGREGATE_EQUAL_ORDER(
+ 
+ SSE2NEON_GENERATE_CMP_EQUAL_ORDERED(SSE2NEON_CMP_EQUAL_ORDERED_)
+ 
+-#define SSE2NEON_CMPESTR_LIST                          \
+-    _(CMP_UBYTE_EQUAL_ANY, cmp_byte_equal_any)         \
+-    _(CMP_UWORD_EQUAL_ANY, cmp_word_equal_any)         \
+-    _(CMP_SBYTE_EQUAL_ANY, cmp_byte_equal_any)         \
+-    _(CMP_SWORD_EQUAL_ANY, cmp_word_equal_any)         \
+-    _(CMP_UBYTE_RANGES, cmp_ubyte_ranges)              \
+-    _(CMP_UWORD_RANGES, cmp_uword_ranges)              \
+-    _(CMP_SBYTE_RANGES, cmp_sbyte_ranges)              \
+-    _(CMP_SWORD_RANGES, cmp_sword_ranges)              \
+-    _(CMP_UBYTE_EQUAL_EACH, cmp_byte_equal_each)       \
+-    _(CMP_UWORD_EQUAL_EACH, cmp_word_equal_each)       \
+-    _(CMP_SBYTE_EQUAL_EACH, cmp_byte_equal_each)       \
+-    _(CMP_SWORD_EQUAL_EACH, cmp_word_equal_each)       \
+-    _(CMP_UBYTE_EQUAL_ORDERED, cmp_byte_equal_ordered) \
+-    _(CMP_UWORD_EQUAL_ORDERED, cmp_word_equal_ordered) \
+-    _(CMP_SBYTE_EQUAL_ORDERED, cmp_byte_equal_ordered) \
+-    _(CMP_SWORD_EQUAL_ORDERED, cmp_word_equal_ordered)
++#define SSE2NEON_CMPESTR_LIST                                  \
++    _SSE2NEON(CMP_UBYTE_EQUAL_ANY, cmp_byte_equal_any)         \
++    _SSE2NEON(CMP_UWORD_EQUAL_ANY, cmp_word_equal_any)         \
++    _SSE2NEON(CMP_SBYTE_EQUAL_ANY, cmp_byte_equal_any)         \
++    _SSE2NEON(CMP_SWORD_EQUAL_ANY, cmp_word_equal_any)         \
++    _SSE2NEON(CMP_UBYTE_RANGES, cmp_ubyte_ranges)              \
++    _SSE2NEON(CMP_UWORD_RANGES, cmp_uword_ranges)              \
++    _SSE2NEON(CMP_SBYTE_RANGES, cmp_sbyte_ranges)              \
++    _SSE2NEON(CMP_SWORD_RANGES, cmp_sword_ranges)              \
++    _SSE2NEON(CMP_UBYTE_EQUAL_EACH, cmp_byte_equal_each)       \
++    _SSE2NEON(CMP_UWORD_EQUAL_EACH, cmp_word_equal_each)       \
++    _SSE2NEON(CMP_SBYTE_EQUAL_EACH, cmp_byte_equal_each)       \
++    _SSE2NEON(CMP_SWORD_EQUAL_EACH, cmp_word_equal_each)       \
++    _SSE2NEON(CMP_UBYTE_EQUAL_ORDERED, cmp_byte_equal_ordered) \
++    _SSE2NEON(CMP_UWORD_EQUAL_ORDERED, cmp_word_equal_ordered) \
++    _SSE2NEON(CMP_SBYTE_EQUAL_ORDERED, cmp_byte_equal_ordered) \
++    _SSE2NEON(CMP_SWORD_EQUAL_ORDERED, cmp_word_equal_ordered)
+ 
+ enum {
+-#define _(name, func_suffix) name,
++#define _SSE2NEON(name, func_suffix) name,
+     SSE2NEON_CMPESTR_LIST
+-#undef _
++#undef _SSE2NEON
+ };
+-typedef int (*cmpestr_func_t)(__m128i a, int la, __m128i b, int lb);
++typedef uint16_t (*cmpestr_func_t)(__m128i a, int la, __m128i b, int lb);
+ static cmpestr_func_t _sse2neon_cmpfunc_table[] = {
+-#define _(name, func_suffix) _sse2neon_##func_suffix,
++#define _SSE2NEON(name, func_suffix) _sse2neon_##func_suffix,
+     SSE2NEON_CMPESTR_LIST
+-#undef _
++#undef _SSE2NEON
+ };
+ 
+-FORCE_INLINE int _sse2neon_sido_negative(int res, int lb, int imm8, int bound)
++FORCE_INLINE uint16_t _sse2neon_sido_negative(int res,
++                                              int lb,
++                                              int imm8,
++                                              int bound)
+ {
+     switch (imm8 & 0x30) {
+     case _SIDD_NEGATIVE_POLARITY:
+@@ -9022,15 +8262,15 @@ FORCE_INLINE int _sse2neon_sido_negative
+         break;
+     }
+ 
+-    return res & ((bound == 8) ? 0xFF : 0xFFFF);
++    return (uint16_t) (res & ((bound == 8) ? 0xFF : 0xFFFF));
+ }
+ 
+ FORCE_INLINE int _sse2neon_clz(unsigned int x)
+ {
+-#if _MSC_VER
+-    DWORD cnt = 0;
+-    if (_BitScanForward(&cnt, x))
+-        return cnt;
++#if defined(_MSC_VER) && !defined(__clang__)
++    unsigned long cnt = 0;
++    if (_BitScanReverse(&cnt, x))
++        return 31 - cnt;
+     return 32;
+ #else
+     return x != 0 ? __builtin_clz(x) : 32;
+@@ -9039,10 +8279,10 @@ FORCE_INLINE int _sse2neon_clz(unsigned
+ 
+ FORCE_INLINE int _sse2neon_ctz(unsigned int x)
+ {
+-#if _MSC_VER
+-    DWORD cnt = 0;
+-    if (_BitScanReverse(&cnt, x))
+-        return 31 - cnt;
++#if defined(_MSC_VER) && !defined(__clang__)
++    unsigned long cnt = 0;
++    if (_BitScanForward(&cnt, x))
++        return cnt;
+     return 32;
+ #else
+     return x != 0 ? __builtin_ctz(x) : 32;
+@@ -9051,20 +8291,19 @@ FORCE_INLINE int _sse2neon_ctz(unsigned
+ 
+ FORCE_INLINE int _sse2neon_ctzll(unsigned long long x)
+ {
+-#if _MSC_VER
++#ifdef _MSC_VER
+     unsigned long cnt;
+-#ifdef defined(SSE2NEON_HAS_BITSCAN64)
+-    (defined(_M_AMD64) || defined(__x86_64__))
+-        if((_BitScanForward64(&cnt, x))
+-            return (int)(cnt);
++#if defined(SSE2NEON_HAS_BITSCAN64)
++    if (_BitScanForward64(&cnt, x))
++        return (int) (cnt);
+ #else
+     if (_BitScanForward(&cnt, (unsigned long) (x)))
+         return (int) cnt;
+     if (_BitScanForward(&cnt, (unsigned long) (x >> 32)))
+         return (int) (cnt + 32);
+-#endif
++#endif /* SSE2NEON_HAS_BITSCAN64 */
+     return 64;
+-#else
++#else /* assume GNU compatible compilers */
+     return x != 0 ? __builtin_ctzll(x) : 64;
+ #endif
+ }
+@@ -9072,7 +8311,7 @@ FORCE_INLINE int _sse2neon_ctzll(unsigne
+ #define SSE2NEON_MIN(x, y) (x) < (y) ? (x) : (y)
+ 
+ #define SSE2NEON_CMPSTR_SET_UPPER(var, imm) \
+-    const int var = (imm & 0x01) ? 8 : 16
++    const int var = ((imm) & 0x01) ? 8 : 16
+ 
+ #define SSE2NEON_CMPESTRX_LEN_PAIR(a, b, la, lb) \
+     int tmp1 = la ^ (la >> 31);                  \
+@@ -9087,28 +8326,28 @@ FORCE_INLINE int _sse2neon_ctzll(unsigne
+ // As the only difference of PCMPESTR* and PCMPISTR* is the way to calculate the
+ // length of string, we use SSE2NEON_CMP{I,E}STRX_GET_LEN to get the length of
+ // string a and b.
+-#define SSE2NEON_COMP_AGG(a, b, la, lb, imm8, IE)                  \
+-    SSE2NEON_CMPSTR_SET_UPPER(bound, imm8);                        \
+-    SSE2NEON_##IE##_LEN_PAIR(a, b, la, lb);                        \
+-    int r2 = (_sse2neon_cmpfunc_table[imm8 & 0x0f])(a, la, b, lb); \
++#define SSE2NEON_COMP_AGG(a, b, la, lb, imm8, IE)                         \
++    SSE2NEON_CMPSTR_SET_UPPER(bound, imm8);                               \
++    SSE2NEON_##IE##_LEN_PAIR(a, b, la, lb);                               \
++    uint16_t r2 = (_sse2neon_cmpfunc_table[(imm8) & 0x0f])(a, la, b, lb); \
+     r2 = _sse2neon_sido_negative(r2, lb, imm8, bound)
+ 
+-#define SSE2NEON_CMPSTR_GENERATE_INDEX(r2, bound, imm8)          \
+-    return (r2 == 0) ? bound                                     \
+-                     : ((imm8 & 0x40) ? (31 - _sse2neon_clz(r2)) \
+-                                      : _sse2neon_ctz(r2))
++#define SSE2NEON_CMPSTR_GENERATE_INDEX(r2, bound, imm8)            \
++    return (r2 == 0) ? bound                                       \
++                     : (((imm8) & 0x40) ? (31 - _sse2neon_clz(r2)) \
++                                        : _sse2neon_ctz(r2))
+ 
+ #define SSE2NEON_CMPSTR_GENERATE_MASK(dst)                                     \
+     __m128i dst = vreinterpretq_m128i_u8(vdupq_n_u8(0));                       \
+-    if (imm8 & 0x40) {                                                         \
++    if ((imm8) & 0x40) {                                                       \
+         if (bound == 8) {                                                      \
+             uint16x8_t tmp = vtstq_u16(vdupq_n_u16(r2),                        \
+                                        vld1q_u16(_sse2neon_cmpestr_mask16b));  \
+             dst = vreinterpretq_m128i_u16(vbslq_u16(                           \
+                 tmp, vdupq_n_u16(-1), vreinterpretq_u16_m128i(dst)));          \
+         } else {                                                               \
+-            uint8x16_t vec_r2 =                                                \
+-                vcombine_u8(vdup_n_u8(r2), vdup_n_u8(r2 >> 8));                \
++            uint8x16_t vec_r2 = vcombine_u8(vdup_n_u8((uint8_t) r2),           \
++                                            vdup_n_u8((uint8_t) (r2 >> 8)));   \
+             uint8x16_t tmp =                                                   \
+                 vtstq_u8(vec_r2, vld1q_u8(_sse2neon_cmpestr_mask8b));          \
+             dst = vreinterpretq_m128i_u8(                                      \
+@@ -9119,8 +8358,8 @@ FORCE_INLINE int _sse2neon_ctzll(unsigne
+             dst = vreinterpretq_m128i_u16(                                     \
+                 vsetq_lane_u16(r2 & 0xffff, vreinterpretq_u16_m128i(dst), 0)); \
+         } else {                                                               \
+-            dst = vreinterpretq_m128i_u8(                                      \
+-                vsetq_lane_u8(r2 & 0xff, vreinterpretq_u8_m128i(dst), 0));     \
++            dst = vreinterpretq_m128i_u8(vsetq_lane_u8(                        \
++                (uint8_t) (r2 & 0xff), vreinterpretq_u8_m128i(dst), 0));       \
+         }                                                                      \
+     }                                                                          \
+     return dst
+@@ -9198,6 +8437,9 @@ FORCE_INLINE int _mm_cmpestrs(__m128i a,
+                               int lb,
+                               const int imm8)
+ {
++    (void) a;
++    (void) b;
++    (void) lb;
+     SSE2NEON_CMPSTR_SET_UPPER(bound, imm8);
+     return la <= (bound - 1);
+ }
+@@ -9211,13 +8453,16 @@ FORCE_INLINE int _mm_cmpestrz(__m128i a,
+                               int lb,
+                               const int imm8)
+ {
++    (void) a;
++    (void) b;
++    (void) la;
+     SSE2NEON_CMPSTR_SET_UPPER(bound, imm8);
+     return lb <= (bound - 1);
+ }
+ 
+ #define SSE2NEON_CMPISTRX_LENGTH(str, len, imm8)                         \
+     do {                                                                 \
+-        if (imm8 & 0x01) {                                               \
++        if ((imm8) & 0x01) {                                             \
+             uint16x8_t equal_mask_##str =                                \
+                 vceqq_u16(vreinterpretq_u16_m128i(str), vdupq_n_u16(0)); \
+             uint8x8_t res_##str = vshrn_n_u16(equal_mask_##str, 4);      \
+@@ -9292,6 +8537,7 @@ FORCE_INLINE int _mm_cmpistro(__m128i a,
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpistrs
+ FORCE_INLINE int _mm_cmpistrs(__m128i a, __m128i b, const int imm8)
+ {
++    (void) b;
+     SSE2NEON_CMPSTR_SET_UPPER(bound, imm8);
+     int la;
+     SSE2NEON_CMPISTRX_LENGTH(a, la, imm8);
+@@ -9303,6 +8549,7 @@ FORCE_INLINE int _mm_cmpistrs(__m128i a,
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpistrz
+ FORCE_INLINE int _mm_cmpistrz(__m128i a, __m128i b, const int imm8)
+ {
++    (void) a;
+     SSE2NEON_CMPSTR_SET_UPPER(bound, imm8);
+     int lb;
+     SSE2NEON_CMPISTRX_LENGTH(b, lb, imm8);
+@@ -9313,7 +8560,7 @@ FORCE_INLINE int _mm_cmpistrz(__m128i a,
+ // in b for greater than.
+ FORCE_INLINE __m128i _mm_cmpgt_epi64(__m128i a, __m128i b)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     return vreinterpretq_m128i_u64(
+         vcgtq_s64(vreinterpretq_s64_m128i(a), vreinterpretq_s64_m128i(b)));
+ #else
+@@ -9324,83 +8571,124 @@ FORCE_INLINE __m128i _mm_cmpgt_epi64(__m
+ }
+ 
+ // Starting with the initial value in crc, accumulates a CRC32 value for
+-// unsigned 16-bit integer v.
+-// https://msdn.microsoft.com/en-us/library/bb531411(v=vs.100)
++// unsigned 16-bit integer v, and stores the result in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_crc32_u16
+ FORCE_INLINE uint32_t _mm_crc32_u16(uint32_t crc, uint16_t v)
+ {
+ #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
+     __asm__ __volatile__("crc32ch %w[c], %w[c], %w[v]\n\t"
+                          : [c] "+r"(crc)
+                          : [v] "r"(v));
+-#elif (__ARM_ARCH == 8) && defined(__ARM_FEATURE_CRC32)
++#elif ((__ARM_ARCH == 8) && defined(__ARM_FEATURE_CRC32)) || \
++    ((defined(_M_ARM64) || defined(_M_ARM64EC)) && !defined(__clang__))
+     crc = __crc32ch(crc, v);
+ #else
+-    crc = _mm_crc32_u8(crc, v & 0xff);
+-    crc = _mm_crc32_u8(crc, (v >> 8) & 0xff);
++    crc = _mm_crc32_u8(crc, (uint8_t) (v & 0xff));
++    crc = _mm_crc32_u8(crc, (uint8_t) ((v >> 8) & 0xff));
+ #endif
+     return crc;
+ }
+ 
+ // Starting with the initial value in crc, accumulates a CRC32 value for
+-// unsigned 32-bit integer v.
+-// https://msdn.microsoft.com/en-us/library/bb531394(v=vs.100)
++// unsigned 32-bit integer v, and stores the result in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_crc32_u32
+ FORCE_INLINE uint32_t _mm_crc32_u32(uint32_t crc, uint32_t v)
+ {
+ #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
+     __asm__ __volatile__("crc32cw %w[c], %w[c], %w[v]\n\t"
+                          : [c] "+r"(crc)
+                          : [v] "r"(v));
+-#elif (__ARM_ARCH == 8) && defined(__ARM_FEATURE_CRC32)
++#elif ((__ARM_ARCH == 8) && defined(__ARM_FEATURE_CRC32)) || \
++    ((defined(_M_ARM64) || defined(_M_ARM64EC)) && !defined(__clang__))
+     crc = __crc32cw(crc, v);
+ #else
+-    crc = _mm_crc32_u16(crc, v & 0xffff);
+-    crc = _mm_crc32_u16(crc, (v >> 16) & 0xffff);
++    crc = _mm_crc32_u16(crc, (uint16_t) (v & 0xffff));
++    crc = _mm_crc32_u16(crc, (uint16_t) ((v >> 16) & 0xffff));
+ #endif
+     return crc;
+ }
+ 
+ // Starting with the initial value in crc, accumulates a CRC32 value for
+-// unsigned 64-bit integer v.
+-// https://msdn.microsoft.com/en-us/library/bb514033(v=vs.100)
++// unsigned 64-bit integer v, and stores the result in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_crc32_u64
+ FORCE_INLINE uint64_t _mm_crc32_u64(uint64_t crc, uint64_t v)
+ {
+ #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
+     __asm__ __volatile__("crc32cx %w[c], %w[c], %x[v]\n\t"
+                          : [c] "+r"(crc)
+                          : [v] "r"(v));
++#elif ((defined(_M_ARM64) || defined(_M_ARM64EC)) && !defined(__clang__))
++    crc = __crc32cd((uint32_t) crc, v);
+ #else
+-    crc = _mm_crc32_u32((uint32_t) (crc), v & 0xffffffff);
+-    crc = _mm_crc32_u32((uint32_t) (crc), (v >> 32) & 0xffffffff);
++    crc = _mm_crc32_u32((uint32_t) (crc), (uint32_t) (v & 0xffffffff));
++    crc = _mm_crc32_u32((uint32_t) (crc), (uint32_t) ((v >> 32) & 0xffffffff));
+ #endif
+     return crc;
+ }
+ 
+ // Starting with the initial value in crc, accumulates a CRC32 value for
+-// unsigned 8-bit integer v.
+-// https://msdn.microsoft.com/en-us/library/bb514036(v=vs.100)
++// unsigned 8-bit integer v, and stores the result in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_crc32_u8
+ FORCE_INLINE uint32_t _mm_crc32_u8(uint32_t crc, uint8_t v)
+ {
+ #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
+     __asm__ __volatile__("crc32cb %w[c], %w[c], %w[v]\n\t"
+                          : [c] "+r"(crc)
+                          : [v] "r"(v));
+-#elif (__ARM_ARCH == 8) && defined(__ARM_FEATURE_CRC32)
++#elif ((__ARM_ARCH == 8) && defined(__ARM_FEATURE_CRC32)) || \
++    ((defined(_M_ARM64) || defined(_M_ARM64EC)) && !defined(__clang__))
+     crc = __crc32cb(crc, v);
+ #else
+     crc ^= v;
+-    for (int bit = 0; bit < 8; bit++) {
+-        if (crc & 1)
+-            crc = (crc >> 1) ^ UINT32_C(0x82f63b78);
+-        else
+-            crc = (crc >> 1);
+-    }
++#if defined(__ARM_FEATURE_CRYPTO)
++    // Adapted from: https://mary.rs/lab/crc32/
++    // Barrent reduction
++    uint64x2_t orig =
++        vcombine_u64(vcreate_u64((uint64_t) (crc) << 24), vcreate_u64(0x0));
++    uint64x2_t tmp = orig;
++
++    // Polynomial P(x) of CRC32C
++    uint64_t p = 0x105EC76F1;
++    // Barrett Reduction (in bit-reflected form) constant mu_{64} = \lfloor
++    // 2^{64} / P(x) \rfloor = 0x11f91caf6
++    uint64_t mu = 0x1dea713f1;
++
++    // Multiply by mu_{64}
++    tmp = _sse2neon_vmull_p64(vget_low_u64(tmp), vcreate_u64(mu));
++    // Divide by 2^{64} (mask away the unnecessary bits)
++    tmp =
++        vandq_u64(tmp, vcombine_u64(vcreate_u64(0xFFFFFFFF), vcreate_u64(0x0)));
++    // Multiply by P(x) (shifted left by 1 for alignment reasons)
++    tmp = _sse2neon_vmull_p64(vget_low_u64(tmp), vcreate_u64(p));
++    // Subtract original from result
++    tmp = veorq_u64(tmp, orig);
++
++    // Extract the 'lower' (in bit-reflected sense) 32 bits
++    crc = vgetq_lane_u32(vreinterpretq_u32_u64(tmp), 1);
++#else  // Fall back to the generic table lookup approach
++    // Adapted from: https://create.stephan-brumme.com/crc32/
++    // Apply half-byte comparison algorithm for the best ratio between
++    // performance and lookup table.
++
++    // The lookup table just needs to store every 16th entry
++    // of the standard look-up table.
++    static const uint32_t crc32_half_byte_tbl[] = {
++        0x00000000, 0x105ec76f, 0x20bd8ede, 0x30e349b1, 0x417b1dbc, 0x5125dad3,
++        0x61c69362, 0x7198540d, 0x82f63b78, 0x92a8fc17, 0xa24bb5a6, 0xb21572c9,
++        0xc38d26c4, 0xd3d3e1ab, 0xe330a81a, 0xf36e6f75,
++    };
++
++    crc = (crc >> 4) ^ crc32_half_byte_tbl[crc & 0x0F];
++    crc = (crc >> 4) ^ crc32_half_byte_tbl[crc & 0x0F];
++#endif
+ #endif
+     return crc;
+ }
+ 
+ /* AES */
+ 
+-#if !defined(__ARM_FEATURE_CRYPTO)
++#if !defined(__ARM_FEATURE_CRYPTO) && \
++    ((!defined(_M_ARM64) && !defined(_M_ARM64EC)) || defined(__clang__))
+ /* clang-format off */
+ #define SSE2NEON_AES_SBOX(w)                                           \
+     {                                                                  \
+@@ -9500,12 +8788,11 @@ static const uint8_t _sse2neon_rsbox[256
+      ((y >> 4 & 1) * SSE2NEON_XT(SSE2NEON_XT(SSE2NEON_XT(SSE2NEON_XT(x))))))
+ #endif
+ 
+-// In the absence of crypto extensions, implement aesenc using regular neon
++// In the absence of crypto extensions, implement aesenc using regular NEON
+ // intrinsics instead. See:
+ // https://www.workofard.com/2017/01/accelerated-aes-for-the-arm64-linux-kernel/
+ // https://www.workofard.com/2017/07/ghash-for-low-end-cores/ and
+-// https://github.com/ColinIanKing/linux-next-mirror/blob/b5f466091e130caaf0735976648f72bd5e09aa84/crypto/aegis128-neon-inner.c#L52
+-// for more information Reproduced with permission of the author.
++// for more information.
+ FORCE_INLINE __m128i _mm_aesenc_si128(__m128i a, __m128i RoundKey)
+ {
+ #if defined(__aarch64__)
+@@ -9548,9 +8835,9 @@ FORCE_INLINE __m128i _mm_aesenc_si128(__
+ #define SSE2NEON_AES_B2W(b0, b1, b2, b3)                 \
+     (((uint32_t) (b3) << 24) | ((uint32_t) (b2) << 16) | \
+      ((uint32_t) (b1) << 8) | (uint32_t) (b0))
+-// muliplying 'x' by 2 in GF(2^8)
++// multiplying 'x' by 2 in GF(2^8)
+ #define SSE2NEON_AES_F2(x) ((x << 1) ^ (((x >> 7) & 1) * 0x011b /* WPOLY */))
+-// muliplying 'x' by 3 in GF(2^8)
++// multiplying 'x' by 3 in GF(2^8)
+ #define SSE2NEON_AES_F3(x) (SSE2NEON_AES_F2(x) ^ x)
+ #define SSE2NEON_AES_U0(p) \
+     SSE2NEON_AES_B2W(SSE2NEON_AES_F2(p), p, p, SSE2NEON_AES_F3(p))
+@@ -9628,14 +8915,14 @@ FORCE_INLINE __m128i _mm_aesdec_si128(__
+     v = vqtbx4q_u8(v, _sse2neon_vld1q_u8_x4(_sse2neon_rsbox + 0xc0), w - 0xc0);
+ 
+     // inverse mix columns
+-    // muliplying 'v' by 4 in GF(2^8)
++    // multiplying 'v' by 4 in GF(2^8)
+     w = (v << 1) ^ (uint8x16_t) (((int8x16_t) v >> 7) & 0x1b);
+     w = (w << 1) ^ (uint8x16_t) (((int8x16_t) w >> 7) & 0x1b);
+     v ^= w;
+     v ^= (uint8x16_t) vrev32q_u16((uint16x8_t) w);
+ 
+     w = (v << 1) ^ (uint8x16_t) (((int8x16_t) v >> 7) &
+-                                 0x1b);  // muliplying 'v' by 2 in GF(2^8)
++                                 0x1b);  // multiplying 'v' by 2 in GF(2^8)
+     w ^= (uint8x16_t) vrev32q_u16((uint16x8_t) v);
+     w ^= vqtbl1q_u8(v ^ w, vld1q_u8(ror32by8));
+ 
+@@ -9667,7 +8954,8 @@ FORCE_INLINE __m128i _mm_aesdec_si128(__
+                   SSE2NEON_MULTIPLY(g, 0x09) ^ SSE2NEON_MULTIPLY(h, 0x0e);
+     }
+ 
+-    return vreinterpretq_m128i_u8(vld1q_u8((uint8_t *) v)) ^ RoundKey;
++    return _mm_xor_si128(vreinterpretq_m128i_u8(vld1q_u8((uint8_t *) v)),
++                         RoundKey);
+ #endif
+ }
+ 
+@@ -9717,7 +9005,7 @@ FORCE_INLINE __m128i _mm_aesenclast_si12
+         _sse2neon_sbox[vgetq_lane_u8(vreinterpretq_u8_m128i(a), 11)],
+     };
+ 
+-    return vreinterpretq_m128i_u8(vld1q_u8(v)) ^ RoundKey;
++    return _mm_xor_si128(vreinterpretq_m128i_u8(vld1q_u8(v)), RoundKey);
+ #endif
+ }
+ 
+@@ -9755,7 +9043,8 @@ FORCE_INLINE __m128i _mm_aesdeclast_si12
+         v[((i / 4) + (i % 4)) % 4][i % 4] = _sse2neon_rsbox[_a[i]];
+     }
+ 
+-    return vreinterpretq_m128i_u8(vld1q_u8((uint8_t *) v)) ^ RoundKey;
++    return _mm_xor_si128(vreinterpretq_m128i_u8(vld1q_u8((uint8_t *) v)),
++                         RoundKey);
+ #endif
+ }
+ 
+@@ -9806,12 +9095,15 @@ FORCE_INLINE __m128i _mm_aesimc_si128(__
+ #endif
+ }
+ 
++// Assist in expanding the AES cipher key by computing steps towards generating
++// a round key for encryption cipher using data from a and an 8-bit round
++// constant specified in imm8, and store the result in dst.
++// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_aeskeygenassist_si128
++//
+ // Emits the Advanced Encryption Standard (AES) instruction aeskeygenassist.
+ // This instruction generates a round key for AES encryption. See
+ // https://kazakov.life/2017/11/01/cryptocurrency-mining-on-ios-devices/
+ // for details.
+-//
+-// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_aeskeygenassist_si128
+ FORCE_INLINE __m128i _mm_aeskeygenassist_si128(__m128i a, const int rcon)
+ {
+ #if defined(__aarch64__)
+@@ -9821,14 +9113,11 @@ FORCE_INLINE __m128i _mm_aeskeygenassist
+     v = vqtbx4q_u8(v, _sse2neon_vld1q_u8_x4(_sse2neon_sbox + 0x80), _a - 0x80);
+     v = vqtbx4q_u8(v, _sse2neon_vld1q_u8_x4(_sse2neon_sbox + 0xc0), _a - 0xc0);
+ 
+-    uint32x4_t select_mask = {0xffffffff, 0x0, 0xffffffff, 0x0};
+-    uint64x2_t v_mask = vshrq_n_u64(vreinterpretq_u64_u8(v), 32);
+-    uint32x4_t x = vbslq_u32(select_mask, vreinterpretq_u32_u64(v_mask),
+-                             vreinterpretq_u32_u8(v));
+-    uint32x4_t ror_x = vorrq_u32(vshrq_n_u32(x, 8), vshlq_n_u32(x, 24));
+-    uint32x4_t ror_xor_x = veorq_u32(ror_x, vdupq_n_u32(rcon));
++    uint32x4_t v_u32 = vreinterpretq_u32_u8(v);
++    uint32x4_t ror_v = vorrq_u32(vshrq_n_u32(v_u32, 8), vshlq_n_u32(v_u32, 24));
++    uint32x4_t ror_xor_v = veorq_u32(ror_v, vdupq_n_u32(rcon));
+ 
+-    return vreinterpretq_m128i_u32(vbslq_u32(select_mask, x, ror_xor_x));
++    return vreinterpretq_m128i_u32(vtrn2q_u32(v_u32, ror_xor_v));
+ 
+ #else /* ARMv7-A NEON implementation */
+     uint32_t X1 = _mm_cvtsi128_si32(_mm_shuffle_epi32(a, 0x55));
+@@ -9858,9 +9147,9 @@ FORCE_INLINE __m128i _mm_aeskeygenassist
+ // for more details.
+ FORCE_INLINE __m128i _mm_aesenc_si128(__m128i a, __m128i b)
+ {
+-    return vreinterpretq_m128i_u8(
+-        vaesmcq_u8(vaeseq_u8(vreinterpretq_u8_m128i(a), vdupq_n_u8(0))) ^
+-        vreinterpretq_u8_m128i(b));
++    return vreinterpretq_m128i_u8(veorq_u8(
++        vaesmcq_u8(vaeseq_u8(vreinterpretq_u8_m128i(a), vdupq_n_u8(0))),
++        vreinterpretq_u8_m128i(b)));
+ }
+ 
+ // Perform one round of an AES decryption flow on data (state) in a using the
+@@ -9889,15 +9178,15 @@ FORCE_INLINE __m128i _mm_aesenclast_si12
+ FORCE_INLINE __m128i _mm_aesdeclast_si128(__m128i a, __m128i RoundKey)
+ {
+     return vreinterpretq_m128i_u8(
+-               vaesdq_u8(vreinterpretq_u8_m128i(a), vdupq_n_u8(0))) ^
+-           vreinterpretq_u8_m128i(RoundKey);
++        veorq_u8(vaesdq_u8(vreinterpretq_u8_m128i(a), vdupq_n_u8(0)),
++                 vreinterpretq_u8_m128i(RoundKey)));
+ }
+ 
+ // Perform the InvMixColumns transformation on a and store the result in dst.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_aesimc_si128
+ FORCE_INLINE __m128i _mm_aesimc_si128(__m128i a)
+ {
+-    return vreinterpretq_m128i_u8(vaesimcq_u8(a));
++    return vreinterpretq_m128i_u8(vaesimcq_u8(vreinterpretq_u8_m128i(a)));
+ }
+ 
+ // Assist in expanding the AES cipher key by computing steps towards generating
+@@ -9909,6 +9198,7 @@ FORCE_INLINE __m128i _mm_aeskeygenassist
+     // AESE does ShiftRows and SubBytes on A
+     uint8x16_t u8 = vaeseq_u8(vreinterpretq_u8_m128i(a), vdupq_n_u8(0));
+ 
++#if !defined(_MSC_VER) || defined(__clang__)
+     uint8x16_t dest = {
+         // Undo ShiftRows step from AESE and extract X1 and X3
+         u8[0x4], u8[0x1], u8[0xE], u8[0xB],  // SubBytes(X1)
+@@ -9918,6 +9208,33 @@ FORCE_INLINE __m128i _mm_aeskeygenassist
+     };
+     uint32x4_t r = {0, (unsigned) rcon, 0, (unsigned) rcon};
+     return vreinterpretq_m128i_u8(dest) ^ vreinterpretq_m128i_u32(r);
++#else
++    // We have to do this hack because MSVC is strictly adhering to the CPP
++    // standard, in particular C++03 8.5.1 sub-section 15, which states that
++    // unions must be initialized by their first member type.
++
++    // As per the Windows ARM64 ABI, it is always little endian, so this works
++    __n128 dest{
++        ((uint64_t) u8.n128_u8[0x4] << 0) | ((uint64_t) u8.n128_u8[0x1] << 8) |
++            ((uint64_t) u8.n128_u8[0xE] << 16) |
++            ((uint64_t) u8.n128_u8[0xB] << 24) |
++            ((uint64_t) u8.n128_u8[0x1] << 32) |
++            ((uint64_t) u8.n128_u8[0xE] << 40) |
++            ((uint64_t) u8.n128_u8[0xB] << 48) |
++            ((uint64_t) u8.n128_u8[0x4] << 56),
++        ((uint64_t) u8.n128_u8[0xC] << 0) | ((uint64_t) u8.n128_u8[0x9] << 8) |
++            ((uint64_t) u8.n128_u8[0x6] << 16) |
++            ((uint64_t) u8.n128_u8[0x3] << 24) |
++            ((uint64_t) u8.n128_u8[0x9] << 32) |
++            ((uint64_t) u8.n128_u8[0x6] << 40) |
++            ((uint64_t) u8.n128_u8[0x3] << 48) |
++            ((uint64_t) u8.n128_u8[0xC] << 56)};
++
++    dest.n128_u32[1] = dest.n128_u32[1] ^ rcon;
++    dest.n128_u32[3] = dest.n128_u32[3] ^ rcon;
++
++    return dest;
++#endif
+ }
+ #endif
+ 
+@@ -9948,19 +9265,19 @@ FORCE_INLINE __m128i _mm_clmulepi64_si12
+     }
+ }
+ 
+-FORCE_INLINE unsigned int _sse2neon_mm_get_denormals_zero_mode()
++FORCE_INLINE unsigned int _sse2neon_mm_get_denormals_zero_mode(void)
+ {
+     union {
+         fpcr_bitfield field;
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+         uint64_t value;
+ #else
+         uint32_t value;
+ #endif
+     } r;
+ 
+-#if defined(__aarch64__)
+-    __asm__ __volatile__("mrs %0, FPCR" : "=r"(r.value)); /* read */
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
++    r.value = _sse2neon_get_fpcr();
+ #else
+     __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(r.value)); /* read */
+ #endif
+@@ -9973,9 +9290,11 @@ FORCE_INLINE unsigned int _sse2neon_mm_g
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_popcnt_u32
+ FORCE_INLINE int _mm_popcnt_u32(unsigned int a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+ #if __has_builtin(__builtin_popcount)
+     return __builtin_popcount(a);
++#elif defined(_MSC_VER)
++    return _CountOneBits(a);
+ #else
+     return (int) vaddlv_u8(vcnt_u8(vcreate_u8((uint64_t) a)));
+ #endif
+@@ -10000,9 +9319,11 @@ FORCE_INLINE int _mm_popcnt_u32(unsigned
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_popcnt_u64
+ FORCE_INLINE int64_t _mm_popcnt_u64(uint64_t a)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+ #if __has_builtin(__builtin_popcountll)
+     return __builtin_popcountll(a);
++#elif defined(_MSC_VER)
++    return _CountOneBits64(a);
+ #else
+     return (int64_t) vaddlv_u8(vcnt_u8(vcreate_u8(a)));
+ #endif
+@@ -10029,34 +9350,33 @@ FORCE_INLINE void _sse2neon_mm_set_denor
+     // regardless of the value of the FZ bit.
+     union {
+         fpcr_bitfield field;
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+         uint64_t value;
+ #else
+         uint32_t value;
+ #endif
+     } r;
+ 
+-#if defined(__aarch64__)
+-    __asm__ __volatile__("mrs %0, FPCR" : "=r"(r.value)); /* read */
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
++    r.value = _sse2neon_get_fpcr();
+ #else
+     __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(r.value)); /* read */
+ #endif
+ 
+     r.field.bit24 = (flag & _MM_DENORMALS_ZERO_MASK) == _MM_DENORMALS_ZERO_ON;
+ 
+-#if defined(__aarch64__)
+-    __asm__ __volatile__("msr FPCR, %0" ::"r"(r)); /* write */
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
++    _sse2neon_set_fpcr(r.value);
+ #else
+-    __asm__ __volatile__("vmsr FPSCR, %0" ::"r"(r));        /* write */
++    __asm__ __volatile__("vmsr FPSCR, %0" ::"r"(r)); /* write */
+ #endif
+ }
+ 
+ // Return the current 64-bit value of the processor's time-stamp counter.
+ // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=rdtsc
+-
+ FORCE_INLINE uint64_t _rdtsc(void)
+ {
+-#if defined(__aarch64__)
++#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+     uint64_t val;
+ 
+     /* According to ARM DDI 0487F.c, from Armv8.0 to Armv8.5 inclusive, the
+@@ -10065,7 +9385,11 @@ FORCE_INLINE uint64_t _rdtsc(void)
+      * bits wide and it is attributed with the flag 'cap_user_time_short'
+      * is true.
+      */
++#if defined(_MSC_VER) && !defined(__clang__)
++    val = _ReadStatusReg(ARM64_SYSREG(3, 3, 14, 0, 2));
++#else
+     __asm__ __volatile__("mrs %0, cntvct_el0" : "=r"(val));
++#endif
+ 
+     return val;
+ #else
+@@ -10099,4 +9423,3 @@ FORCE_INLINE uint64_t _rdtsc(void)
+ #endif
+ 
+ #endif
+-


### PR DESCRIPTION
RAxML ships with an old version of `sse2neon.h` which has problems with "recent" GCC compilers (as evidenced by the failure to build in EESSI, https://github.com/EESSI/software-layer/pull/1196#issuecomment-3547198828).

This PR updates the included header file to a Sept. 2025 version.