### PR TITLE
deal with case where the tagbot comment is too long

### DIFF
--- a/.github/workflows/tagbot.py
+++ b/.github/workflows/tagbot.py
@@ -235,6 +235,11 @@ if updated_software:
         if existing_comment["user"]["login"] == "github-actions[bot]":  # Bot username in GitHub Actions
             comment_id = existing_comment["id"]
 
+    if len(str) >= 65536:
+        # Comment is too long to post, so post a message saying that
+        comment = "Diff of new easyconfig(s) against existing ones is too long for a GitHub comment. "
+        comment += "Use `--review-pr` (and `--review-pr-filter` / `--review-pr-max`) locally."
+
     if comment_id:
         # Update existing comment
         url = f"{GITHUB_API_URL}/repos/{repo}/issues/comments/{comment_id}"


### PR DESCRIPTION
In #24469 there is no comparison with existing easyconfigs because the comment is too long:
```
Failed to post comment: 422, {"message":"Validation Failed","errors":[{"resource":"IssueComment","code":"unprocessable","field":"data","message":"Body is too long (maximum is 65536 characters)"}],"documentation_url":"https://docs.github.com/rest/issues/comments#create-an-issue-comment","status":"422"}
```