### PR TITLE
{ai}[gfbf/2025b] jax v0.8.1 

### DIFF
--- a/easybuild/easyconfigs/j/jax/jax-0.8.1-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/j/jax/jax-0.8.1-gfbf-2025b.eb
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 # downloading xla  tarball to avoid that Bazel downloads it during the build
-# note: following commits *must* be the exact same onces used upstream
+# note: following commits *must* be the exact same ones used upstream
 # XLA_COMMIT from jax-jaxlib: third_party/xla/workspace.bzl
 _xla_commit = 'a7e58876b73dfa9bb6bc785f6981a332c133bb55'
 


### PR DESCRIPTION
This Jax version doesn't require patches since errors have been treated by Google team. Easyconfig compiled.

Edits:

1. XLA_commit: [Link](https://github.com/jax-ml/jax/blob/8fc84ad2edc63fb3ac99abd56cae33653c8dc86e/third_party/xla/revision.bzl#L24)
2. Avoid `jaxlib-%(version)s-dev0+selfbuilt.whl` naming issue to jaxlib: [Link](https://github.com/jax-ml/jax/commit/d424f5b5b38b75b6577d2c30532abbb693353742)
3. [Patch1](https://github.com/easybuilders/easybuild-easyconfigs/blob/923e5d9c1bf9ad9a93cb21732ea6ea99ae490508/easybuild/easyconfigs/j/jax/jax-0.7.0_fix-mosaic.patch) from jax-0.7.0 no longer needed because of fix here: [Link](https://github.com/jax-ml/jax/blob/8fc84ad2edc63fb3ac99abd56cae33653c8dc86e/jaxlib/mlir/_mlir_libs/jax_mlir_ext.cc#L78)
4. [Patch 2](https://github.com/easybuilders/easybuild-easyconfigs/blob/923e5d9c1bf9ad9a93cb21732ea6ea99ae490508/easybuild/easyconfigs/j/jax/jax-0.7.0_jax-version-fix.patch) from jax-0.7.0 no longer needed because naming can be set up
`--repo_env=ML_WHEEL_TYPE=release`


Requires:

- [x] [Bazel/7.7.0](https://github.com/easybuilders/easybuild-easyconfigs/pull/24729)