### PR TITLE
Add Autoconf patch also to 2.71 for 2023b

### DIFF
--- a/easybuild/easyconfigs/a/Autoconf/Autoconf-2.71-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/a/Autoconf/Autoconf-2.71-GCCcore-13.2.0.eb
@@ -18,10 +18,15 @@ toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-patches = ['Autoconf-2.71-Port-better-to-NVHPC.patch']
+patches = [
+    'Autoconf-2.71-Port-better-to-NVHPC.patch',
+    'Autoconf-2.72_ignore-target-feature-flags.patch'
+]
 checksums = [
-    '431075ad0bf529ef13cb41e9042c542381103e80015686222b8a9d4abef42a1c',  # autoconf-2.71.tar.gz
-    '157453a2f74821b06d3f7cd1ba8d2622f12d9e6d172a01e3ff8e8d32b3d7bfeb',  # Autoconf-2.71-Port-better-to-NVHPC.patch
+    {'autoconf-2.71.tar.gz': '431075ad0bf529ef13cb41e9042c542381103e80015686222b8a9d4abef42a1c'},
+    {'Autoconf-2.71-Port-better-to-NVHPC.patch': '157453a2f74821b06d3f7cd1ba8d2622f12d9e6d172a01e3ff8e8d32b3d7bfeb'},
+    {'Autoconf-2.72_ignore-target-feature-flags.patch':
+     'e18b8304def2cc4be56a85e4312f290f76d83e0c17654d4176a444df90eea267'},
 ]
 
 builddependencies = [


### PR DESCRIPTION
Apply same patch to `Autotools` as in

- #24669

edit: required to fix this error that pops up when building `ELPA`:
```
ld.lld: error: unable to find library -lwp
```