### PR TITLE
add Python as build dependency for recent QuantumESPRESSO easyconfigs, to ensure `pipes` Python module is available

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.4-foss-2024a-minimal.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.4-foss-2024a-minimal.eb
@@ -141,6 +141,7 @@ builddependencies = [
     ('M4', '1.4.19'),
     ('CMake', '3.29.3'),
     ('pkgconf', '2.2.0'),
+    ('Python', '3.12.3'),  # required for tests
 ]
 dependencies = [
     # ('HDF5', '1.14.5'),

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.4-foss-2024a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.4-foss-2024a.eb
@@ -135,6 +135,7 @@ builddependencies = [
     ('M4', '1.4.19'),
     ('CMake', '3.29.3'),
     ('pkgconf', '2.2.0'),
+    ('Python', '3.12.3'),  # required for tests
 ]
 dependencies = [
     ('HDF5', '1.14.5'),

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.5-foss-2025a.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.5-foss-2025a.eb
@@ -72,6 +72,7 @@ builddependencies = [
     ('M4', '1.4.19'),
     ('CMake', '3.31.3'),
     ('pkgconf', '2.3.0'),
+    ('Python', '3.13.1'),  # required for tests
 ]
 dependencies = [
     ('HDF5', '1.14.6'),

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.5-foss-2025b.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-7.5-foss-2025b.eb
@@ -72,6 +72,7 @@ builddependencies = [
     ('M4', '1.4.20'),
     ('CMake', '3.31.8'),
     ('pkgconf', '2.4.3'),
+    ('Python', '3.13.5'),  # required for tests
 ]
 dependencies = [
     ('HDF5', '1.14.6'),


### PR DESCRIPTION
An issue appears with QE 7.4 when the system python is 3.13 (https://gitlab.com/QEF/q-e/-/merge_requests/2559), best to be explicit
