### PR TITLE
{devel}[GCCcore/14.3.0] Bazel v7.7.0 

### DIFF
--- a/easybuild/easyconfigs/b/Bazel/Bazel-7.7.0-GCCcore-14.3.0-Java-21.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-7.7.0-GCCcore-14.3.0-Java-21.eb
@@ -13,7 +13,7 @@ sources = ['%(namelower)s-%(version)s-dist.zip']
 patches = [('bazel-7.7.0-bazel_features.patch', 1)]
 checksums = [
     '277946818c77fff70be442864cecc41faac862b6f2d0d37033e2da0b1fee7e0f',  # bazel-7.7.0-dist.zip
-    'fbd2b26fe849fd4453baf95665bc8754a5e3cb5e6e85e803efc7d9ba186a91bc',  # bazel-7.7.0-bazel_features.patch
+    '52f5999d6ab00a9d45d9b7734b4c6dc60e23362112195fc0425ecb44478067aa',  # bazel-7.7.0-bazel_features.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/b/Bazel/bazel-7.7.0-bazel_features.patch
+++ b/easybuild/easyconfigs/b/Bazel/bazel-7.7.0-bazel_features.patch
@@ -1,3 +1,5 @@
+# Author: Alvaro Huanay a.huanay.de.dios@fz-juelich.de
+# This patch solves the "name 'macro' is not defined" present in Bazel v7.7.0
 diff --git a/MODULE.bazel b/MODULE.bazel
 index 0a5ea5b..70aa431 100644
 --- a/MODULE.bazel


### PR DESCRIPTION
This PR is required for [Jax/0.8.1](https://github.com/easybuilders/easybuild-easyconfigs/pull/24675) which uses [Bazel 7.7.0](https://github.com/jax-ml/jax/blob/jax-v0.8.1/.bazelversion)

Bazel 7.7.0 has an issue with 'define macro'. Patch required to be able to install on systems.