### PR TITLE
avoid test failures for netCDF with `iimpi` toolchain, by setting `$I_MPI_HYDRA_BOOTSTRAP` to `ssh`

### DIFF
--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.0-iimpi-2022a.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.0-iimpi-2022a.eb
@@ -47,6 +47,8 @@ configopts = [
 
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests
 pretestopts = "OMPI_MCA_rmaps_base_oversubscribe=1 "
+# Avoid failures with "unable to run bstrap_proxy on ..." when using the default "slurm"
+pretestopts += "I_MPI_HYDRA_BOOTSTRAP=ssh "
 
 runtest = 'test'
 

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.0-iimpi-2022b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.0-iimpi-2022b.eb
@@ -55,6 +55,8 @@ configopts = [
 
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests
 pretestopts = "OMPI_MCA_rmaps_base_oversubscribe=1 "
+# Avoid failures with "unable to run bstrap_proxy on ..." when using the default "slurm"
+pretestopts += "I_MPI_HYDRA_BOOTSTRAP=ssh "
 
 runtest = 'test'
 

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.2-iimpi-2023a.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.2-iimpi-2023a.eb
@@ -53,6 +53,8 @@ configopts = [
 
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests
 pretestopts = "OMPI_MCA_rmaps_base_oversubscribe=1 "
+# Avoid failures with "unable to run bstrap_proxy on ..." when using the default "slurm"
+pretestopts += "I_MPI_HYDRA_BOOTSTRAP=ssh "
 
 runtest = 'test'
 

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.2-iimpi-2023b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.2-iimpi-2023b.eb
@@ -53,6 +53,8 @@ configopts = [
 
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests
 pretestopts = "OMPI_MCA_rmaps_base_oversubscribe=1 "
+# Avoid failures with "unable to run bstrap_proxy on ..." when using the default "slurm"
+pretestopts += "I_MPI_HYDRA_BOOTSTRAP=ssh "
 
 runtest = 'test'
 

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-iimpi-2025a.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-iimpi-2025a.eb
@@ -54,6 +54,9 @@ configopts = [
 pretestopts = "unset $(env | grep '^SLURM_' | cut -d= -f1) && "
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests
 pretestopts += "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe "
+# Avoid failures with "unable to run bstrap_proxy on ..." when using the default "slurm"
+pretestopts += "I_MPI_HYDRA_BOOTSTRAP=ssh "
+
 runtest = 'test'
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-iimpi-2025b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-iimpi-2025b.eb
@@ -54,6 +54,9 @@ configopts = [
 pretestopts = "unset $(env | grep '^SLURM_' | cut -d= -f1) && "
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests
 pretestopts += "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe "
+# Avoid failures with "unable to run bstrap_proxy on ..." when using the default "slurm"
+pretestopts += "I_MPI_HYDRA_BOOTSTRAP=ssh "
+
 runtest = 'test'
 
 moduleclass = 'data'


### PR DESCRIPTION
Copied from https://github.com/easybuilders/easybuild-easyconfigs/commit/cb01b3517dd9e1b91d53b4b9a26dc95dfc1fed59

This happens when running EasyBuild inside a SLURM job which causes `I_MPI_HYDRA_BOOTSTRAP` and `HYDRA_BOOTSTRAP` to be set and also auto-detected by `mpirun` when `SLURM_JOBID` is set