### PR TITLE
in-place update for BBTools from v39.52 to v39.56

### DIFF
--- a/easybuild/easyconfigs/b/BBTools/BBTools-39.56-Java-17.eb
+++ b/easybuild/easyconfigs/b/BBTools/BBTools-39.56-Java-17.eb
@@ -1,7 +1,7 @@
 easyblock = 'PackedBinary'
 
 name = 'BBTools'
-version = '39.52'
+version = '39.56'
 versionsuffix = '-Java-%(javaver)s'
 
 homepage = 'https://bbmap.org/'
@@ -17,7 +17,7 @@ github_account = 'bbushnell'
 
 source_urls = [GITHUB_SOURCE]
 sources = ['v%(version)s.tar.gz']
-checksums = ['2530ff7b4f2632e1c27c967fc478b80f910f0fc2ef20936c23e634e8c006ee47']
+checksums = ['38ddc2ca996ad928a8efc9359cb17d6c9311587c5a1374be00147db9e6b5bb23']
 
 dependencies = [
     ('Java', '17'),


### PR DESCRIPTION
BBTools 39.52 contained a bug where due to race conditions when reading compressed files concurrently some threads would never get killed and Java would never exit properly. See bbushnell/BBTools#6. This was fixed in the latest version: 3.56 bbushnell/BBTools@75a7ccf

BBTools 39.52 is not yet in a release, so upgrading it seems best.