### PR TITLE
rename` NVHPC/22.7-CUDA-11.7.0` to `nvidia-compilers/22.7-CUDA-11.7.0` to fix nvompi/2022.07 + nvofbf/2022.07

### DIFF
--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.10-nvidia-compilers-22.7-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.10-nvidia-compilers-22.7-CUDA-11.7.0.eb
@@ -5,7 +5,7 @@ homepage = 'https://www.fftw.org'
 description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
 in one or more dimensions, of arbitrary input size, and of both real and complex data."""
 
-toolchain = {'name': 'NVHPC', 'version': '22.7-CUDA-11.7.0'}
+toolchain = {'name': 'nvidia-compilers', 'version': '22.7-CUDA-11.7.0'}
 toolchainopts = {'pic': True}
 
 source_urls = [homepage]

--- a/easybuild/easyconfigs/f/FlexiBLAS/FlexiBLAS-3.2.0-nvidia-compilers-22.7-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/f/FlexiBLAS/FlexiBLAS-3.2.0-nvidia-compilers-22.7-CUDA-11.7.0.eb
@@ -7,7 +7,7 @@ homepage = 'https://gitlab.mpi-magdeburg.mpg.de/software/flexiblas-release'
 description = """FlexiBLAS is a wrapper library that enables the exchange of the BLAS and LAPACK implementation
 used by a program without recompiling or relinking it."""
 
-toolchain = {'name': 'NVHPC', 'version': '22.7-CUDA-11.7.0'}
+toolchain = {'name': 'nvidia-compilers', 'version': '22.7-CUDA-11.7.0'}
 local_extra_flags = "-D__ELF__"
 toolchainopts = {'pic': True, 'extra_cflags': local_extra_flags, 'extra_fflags': local_extra_flags}
 

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.12.2-nvidia-compilers-22.7-CUDA-11.7.0-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.12.2-nvidia-compilers-22.7-CUDA-11.7.0-serial.eb
@@ -8,7 +8,7 @@ description = """HDF5 is a data model, library, and file format for storing and 
  It supports an unlimited variety of datatypes, and is designed for flexible
  and efficient I/O and for high volume and complex data."""
 
-toolchain = {'name': 'NVHPC', 'version': '22.7-CUDA-11.7.0'}
+toolchain = {'name': 'nvidia-compilers', 'version': '22.7-CUDA-11.7.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']

--- a/easybuild/easyconfigs/n/nvidia-compilers/nvidia-compilers-22.7-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/n/nvidia-compilers/nvidia-compilers-22.7-CUDA-11.7.0.eb
@@ -1,4 +1,4 @@
-name = 'NVHPC'
+name = 'nvidia-compilers'
 version = '22.7'
 versionsuffix = '-CUDA-%(cudaver)s'
 

--- a/easybuild/easyconfigs/n/nvofbf/nvofbf-2022.07.eb
+++ b/easybuild/easyconfigs/n/nvofbf/nvofbf-2022.07.eb
@@ -9,7 +9,7 @@ OpenBLAS (via FlexiBLAS for BLAS and LAPACK support), FFTW and ScaLAPACK."""
 
 toolchain = SYSTEM
 
-local_compiler = ('NVHPC', '22.7-CUDA-11.7.0')
+local_compiler = ('nvidia-compilers', '22.7-CUDA-11.7.0')
 
 local_comp_mpi_tc = ('nvompi', version)
 

--- a/easybuild/easyconfigs/n/nvompi/nvompi-2022.07.eb
+++ b/easybuild/easyconfigs/n/nvompi/nvompi-2022.07.eb
@@ -8,7 +8,7 @@ description = 'NVHPC based compiler toolchain, including OpenMPI for MPI support
 
 toolchain = SYSTEM
 
-local_compiler = ('NVHPC', '22.7-CUDA-11.7.0')
+local_compiler = ('nvidia-compilers', '22.7-CUDA-11.7.0')
 
 dependencies = [
     local_compiler,

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.20-nvidia-compilers-22.7-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.20-nvidia-compilers-22.7-CUDA-11.7.0.eb
@@ -4,7 +4,7 @@ version = '0.3.20'
 homepage = 'http://www.openblas.net/'
 description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
 
-toolchain = {'name': 'NVHPC', 'version': '22.7-CUDA-11.7.0'}
+toolchain = {'name': 'nvidia-compilers', 'version': '22.7-CUDA-11.7.0'}
 
 source_urls = [
     # order matters, trying to download the large.tgz/timing.tgz LAPACK tarballs from GitHub causes trouble

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.4-nvidia-compilers-22.7-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.4-nvidia-compilers-22.7-CUDA-11.7.0.eb
@@ -4,7 +4,7 @@ version = '4.1.4'
 homepage = 'https://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-3 implementation."""
 
-toolchain = {'name': 'NVHPC', 'version': '22.7-CUDA-11.7.0'}
+toolchain = {'name': 'nvidia-compilers', 'version': '22.7-CUDA-11.7.0'}
 
 source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_BZ2]


### PR DESCRIPTION
requires because of changes in:
- https://github.com/easybuilders/easybuild-framework/pull/4927

Main reason to make this change is to fix broken easyconfigs test suite:

```
easybuild.tools.build_log.EasyBuildError: Missing dependencies: FFTW/3.3.10-nvompi-2022.07, CMake/3.23.1-NVHPC-22.7-CUDA-11.7.0, zlib/1.2.12-NVHPC-22.7-CUDA-11.7.0, zlib/1.2.12-nvompi-2022.07, make/4.3-NVHPC-22.7-CUDA-11.7.0, pkgconf/1.8.0-NVHPC-22.7-CUDA-11.7.0, pkgconf/2.2.0-NVHPC-24.9-CUDA-12.6.0, CMake/3.23.1-nvompi-2022.07, Python/3.10.4-NVHPC-22.7-CUDA-11.7.0-bare, Szip/2.1.1-NVHPC-22.7-CUDA-11.7.0, Szip/2.1.1-nvompi-2022.07, Perl/5.34.1-NVHPC-22.7-CUDA-11.7.0, Perl/5.38.2-NVHPC-24.9-CUDA-12.6.0, FlexiBLAS/3.2.0-nvompi-2022.07, Autotools/20220317-NVHPC-22.7-CUDA-11.7.0, Autotools/20231222-NVHPC-24.9-CUDA-12.6.0, hwloc/2.7.1-NVHPC-22.7-CUDA-11.7.0, zlib/1.3.1-NVHPC-24.9-CUDA-12.6.0, libevent/2.1.12-NVHPC-22.7-CUDA-11.7.0, hwloc/2.10.0-NVHPC-24.9-CUDA-12.6.0, UCX/1.12.1-NVHPC-22.7-CUDA-11.7.0, libevent/2.1.12-NVHPC-24.9-CUDA-12.6.0, UCX-CUDA/1.12.1-NVHPC-22.7-CUDA-11.7.0-CUDA-11.7.0, UCX/1.16.0-NVHPC-24.9-CUDA-12.6.0, libfabric/1.15.1-NVHPC-22.7-CUDA-11.7.0, UCX-CUDA/1.16.0-NVHPC-24.9-CUDA-12.6.0-CUDA-12.6.0, PMIx/4.1.2-NVHPC-22.7-CUDA-11.7.0, libfabric/1.21.0-NVHPC-24.9-CUDA-12.6.0, UCC/1.0.0-NVHPC-22.7-CUDA-11.7.0, PMIx/5.0.2-NVHPC-24.9-CUDA-12.6.0, UCC-CUDA/1.0.0-NVHPC-22.7-CUDA-11.7.0-CUDA-11.7.0, PRRTE/3.0.5-NVHPC-24.9-CUDA-12.6.0, UCC/1.3.0-NVHPC-24.9-CUDA-12.6.0, UCC-CUDA/1.3.0-NVHPC-24.9-CUDA-12.6.0-CUDA-12.6.0 (no easyconfig file or existing module found)
```