### PR TITLE
Add MiXCR 4.7.0 and 4.7.0-254-develop (Java 17)

### DIFF
--- a/easybuild/easyconfigs/M/MiXCR/MiXCR-4.7.0-254-develop-Java-17.eb
+++ b/easybuild/easyconfigs/M/MiXCR/MiXCR-4.7.0-254-develop-Java-17.eb
@@ -1,0 +1,28 @@
+easyblock = 'Tarball'
+
+name = 'MiXCR'
+version = '4.7.0'
+versionsuffix = '-254-develop-Java-17'
+
+homepage = 'https://milaboratory.com/software/mixcr'
+description = """MiXCR is a universal software for fast and accurate extraction of T- and B- cell receptor repertoires
+from any type of sequencing data."""
+
+toolchain = SYSTEM
+
+source_urls = ['https://link.milaboratory.com/software/mixcr/']
+sources = ['mixcr-develop.zip']
+checksums = ['6bf8600d81df3b044df1043b937c03da9d30a04de55839faf466a704578c60be']
+
+dependencies = [('Java', '17')]
+
+sanity_check_paths = {
+    'files': ['mixcr', 'mixcr.jar'],
+    'dirs': [],
+}
+
+sanity_check_commands = ["mixcr -v"]
+
+modextrapaths = {'PATH': ''}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/M/MiXCR/MiXCR-4.7.0-Java-17.eb
+++ b/easybuild/easyconfigs/M/MiXCR/MiXCR-4.7.0-Java-17.eb
@@ -1,0 +1,28 @@
+easyblock = 'Tarball'
+
+name = 'MiXCR'
+version = '4.7.0'
+versionsuffix = '-Java-%(javaver)s'
+
+homepage = 'https://milaboratory.com/software/mixcr'
+description = """MiXCR is a universal software for fast and accurate extraction of T- and B- cell receptor repertoires
+from any type of sequencing data."""
+
+toolchain = SYSTEM
+
+source_urls = ['https://github.com/milaboratory/mixcr/releases/download/v%(version)s/']
+sources = [SOURCELOWER_ZIP]
+checksums = ['4fde83750f1d1308ba6b7431bcafe98297b361da7e17efc4d072ed935045cac7']
+
+dependencies = [('Java', '17')]
+
+sanity_check_paths = {
+    'files': ['mixcr', 'mixcr.jar'],
+    'dirs': [],
+}
+
+sanity_check_commands = ["mixcr -v"]
+
+modextrapaths = {'PATH': ''}
+
+moduleclass = 'bio'


### PR DESCRIPTION
This PR adds EasyBuild easyconfigs for MiXCR:

- MiXCR 4.7.0 (stable)
- MiXCR 4.7.0-254-develop

Both builds use Java 17.

The develop version is required to support newer presets that are not
available in the stable release.

Builds were tested successfully on an HPC environment.
No existing easyconfigs were modified.