### PR TITLE
fix failing build for tensorstore 0.1.72 when using RPATH by passing $TMPDIR from host into Bazel sandbox

### DIFF
--- a/easybuild/easyconfigs/t/tensorstore/tensorstore-0.1.72-gfbf-2024a.eb
+++ b/easybuild/easyconfigs/t/tensorstore/tensorstore-0.1.72-gfbf-2024a.eb
@@ -380,10 +380,10 @@ _preinstall_bazel_exports_buildopts += ' --subcommands --verbose_failures'
 _preinstall_bazel_exports_buildopts += '" &&'  # (end prebuild_bazel_exports_buildopts)
 
 # put all together:
-_preinstall_opts = _preinstall_use_invalid_proxy
-_preinstall_opts += _preinstall_bazel_exports_startup
-_preinstall_opts += _preinstall_bazel_exports_buildopts
-_preinstall_opts += _preinstall_bazel_exports_syslibs
+_preinstall_opts = _preinstall_use_invalid_proxy + ' '
+_preinstall_opts += _preinstall_bazel_exports_startup + ' '
+_preinstall_opts += _preinstall_bazel_exports_buildopts + ' '
+_preinstall_opts += _preinstall_bazel_exports_syslibs + ' '
 
 exts_list = [
     (name, version, {


### PR DESCRIPTION
fix for failing installation when using RPATH linking:

```
  Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
  src/main/tools/linux-sandbox-pid1.cc:548: "execvp(/tmp/eb-zilp5yc9/tmpr0fpmr63/rpath_wrappers/gcc_wrapper/gcc, 1d148c0)": No such file or directory
  Target //python/tensorstore:_tensorstore__shared_objects failed to build
```

Includes the missing `--host_copts/host_linkopts` that are required such that it finds dependencies for some targets

See https://github.com/easybuilders/easybuild-easyconfigs/pull/23139

Closes https://github.com/easybuilders/easybuild-easyconfigs/pull/23139