### PR TITLE
change version for SciPy-bundle with iimkl/2023b from 2023.12 to 2023.11 to align it with `gfbf/2023b` easyconfig

### DIFF
--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2023.11-iimkl-2023b.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2023.11-iimkl-2023b.eb
@@ -1,7 +1,8 @@
 easyblock = 'PythonBundle'
 
 name = 'SciPy-bundle'
-version = '2023.12'
+# using 2023.11 as version to keep it aligned with gfbf/2023b version
+version = '2023.11'
 
 homepage = 'https://python.org/'
 description = "Bundle of Python packages for scientific software"


### PR DESCRIPTION
follow-up for:
* #20262

Using the same version as for `SciPy-bundle-2023.11-gfbf-2023b.eb` will make this a whole lot less painful w.r.t. check for dependency variants in easyconfigs test suite...