### PR TITLE
explicit RPATH linking to libdeflate

### DIFF
--- a/easybuild/easyconfigs/m/medaka/medaka-1.12.1-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/m/medaka/medaka-1.12.1-foss-2023a-CUDA-12.1.1.eb
@@ -52,14 +52,13 @@ local_sed_commands = [
 ]
 
 exts_list = [
-    ('mappy', _minimap_ver, {
+    ('mappy', '2.26', {
         'checksums': ['e53fbe9a3ea8762a64b8103f4f779c9fb16d418eaa0a731f45cebc83867a9b71'],
     }),
     ('wurlitzer', '3.1.1', {
-        'source_tmpl': SOURCE_PY3_WHL,
+        'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl',
         'checksums': ['0b2749c2cde3ef640bf314a9f94b24d929fe1ca476974719a6909dfc568c3aac'],
     }),
-    # medaka 1.12.0 requires h5py ~=3.10.0
     ('h5py', '3.10.0', {
         'checksums': ['d93adc48ceeb33347eb24a634fb787efc7ae4644e6ea4ba733d099605045c049'],
     }),
@@ -67,10 +66,12 @@ exts_list = [
         'checksums': ['be39c83b12e923c9e47073cb8f0abc4c42f609fa2c0ec13d6f6a4f5a0537ee06'],
     }),
     (name, version, {
-        'checksums': ['df4baf7d1e9154de85229aef237919619ff6ae7f7d103abb0828e449ff977adf'],
-        # Some requirements are too strict.
-        'preinstallopts': " && ".join(local_sed_commands) + " && ",
-        'buildopts': 'LDFLAGS="$LDFLAGS -Wl,--no-as-needed -ldeflate"',
+        'patches': ['medaka-1.12.1-include-deflate.patch'],
+        'checksums': [
+            {'medaka-1.12.1.tar.gz': 'df4baf7d1e9154de85229aef237919619ff6ae7f7d103abb0828e449ff977adf'},
+            {'medaka-1.12.1-include-deflate.patch': '941e33a5040d6df2fb84cfaf818226a61462f20190eb34ad52b82f35fae99af9'},
+        ],
+        'preinstallopts': ' && '.join(local_sed_commands + ['']),
     }),
 ]
 

--- a/easybuild/easyconfigs/m/medaka/medaka-1.12.1-include-deflate.patch
+++ b/easybuild/easyconfigs/m/medaka/medaka-1.12.1-include-deflate.patch
@@ -1,0 +1,46 @@
+# Author: Ehsan Moravveji
+# Purpose: Making sure that libmedaka.abi3.so is linked against libdeflate
+
+diff -ruN medaka-orig/Makefile medaka/Makefile
+--- medaka-orig/Makefile	2026-01-05 11:30:22.867115000 +0100
++++ medaka/Makefile	2026-01-05 11:33:54.892672000 +0100
+@@ -44,7 +44,7 @@
+ # require setting LD_LIBRARY_PATH=submodules/libdeflate-<ver>/
+ # at runtime. This doesn't apply to wheel which will bundle
+ # the library (as curl, crypto, lzma, etc)
+-WITHDEFLATE ?= 
++WITHDEFLATE ?= 1
+ DEFLATEVER=$(shell sed -n 's/deflatever = "\(.*\)"/\1/p' build.py)
+ DEFLATE = $(PWD)/submodules/libdeflate-${DEFLATEVER}
+ DEFLATEREQ =
+@@ -53,7 +53,7 @@
+ LIBS += -ldeflate
+ HTS_CONF_ARGS += --with-libdeflate
+ HTS_CONF_ENV += LDFLAGS="-L$(DEFLATE)"
+-DEFLATEREQ = submodules/libdeflate-${DEFLATEVER}/libdeflate.so.0
++DEFLATEREQ = ${EBROOTLIBDEFLATE}/lib/libdeflate.so.0
+ endif
+ 
+ submodules/libdeflate-$(DEFLATEVER)/libdeflate.so.0:
+diff -ruN medaka-orig/build.py medaka/build.py
+--- medaka-orig/build.py	2026-01-05 11:30:22.871112000 +0100
++++ medaka/build.py	2026-01-05 13:59:22.955519000 +0100
+@@ -9,15 +9,10 @@
+ #samver is pulled from this file in the Makefile
+ samver = "1.14"
+ htslib_dir = os.path.join(dir_path, 'submodules', 'samtools-{}'.format(samver), 'htslib-{}'.format(samver))
+-deflatever = "1.10"
+-deflate_dir = os.path.join(dir_path, 'submodules', 'libdeflate-{}'.format(deflatever))
++deflate_dir = os.environ['EBROOTLIBDEFLATE']
+ 
+-libraries=['m', 'z', 'lzma', 'bz2', 'pthread', 'curl', 'crypto']
+-library_dirs=[htslib_dir]
+-if os.getenv('WITHDEFLATE') == "1":
+-    print("Using deflate")
+-    libraries.append('deflate')
+-    library_dirs.append(deflate_dir)
++libraries=['m', 'z', 'lzma', 'bz2', 'pthread', 'curl', 'crypto', 'deflate']
++library_dirs=[htslib_dir, deflate_dir]
+ src_dir='src'
+ 
+ extra_compile_args = ['-std=c99', '-O3']


### PR DESCRIPTION
I noticed that the sanity check failed when building `medaka/1.12.1-foss-2023a-CUDA-12.1.1`, because `medaka --help` gave the following error:

```python
$ medaka --help
Traceback (most recent call last):
  File "/apps/software/medaka/1.12.1-foss-2023a-CUDA-12.1.1/bin/./medaka", line 5, in <module>
    from medaka.medaka import main
  File "/apps/software/medaka/1.12.1-foss-2023a-CUDA-12.1.1/lib/python3.11/site-packages/medaka/medaka.py", line 7, in <module>
    import medaka.common
  File "/apps/software/medaka/1.12.1-foss-2023a-CUDA-12.1.1/lib/python3.11/site-packages/medaka/common.py", line 19, in <module>
    import libmedaka
ImportError: /apps/software/medaka/1.12.1-foss-2023a-CUDA-12.1.1/lib/python3.11/site-packages/libmedaka.abi3.so: undefined symbol: libdeflate_free_compressor
```
Enforcing `RPATH` and patching the `Makefile` and `build.py` seem like fixing the issue on our GPU P100/V100/A100 nodes.

If this issue is not reproducible on other platforms, this PR can be closed, but the proposed suggestion will stay here.