### PR TITLE
add KaHIP dependency for FEniCS-DOLFINx 0.9.0

### DIFF
--- a/easybuild/easyconfigs/f/FEniCS-DOLFINx/FEniCS-DOLFINx-0.9.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/f/FEniCS-DOLFINx/FEniCS-DOLFINx-0.9.0-foss-2023b.eb
@@ -37,9 +37,9 @@ configopts = (
     ' -DDOLFINX_UFCX_PYTHON=OFF '
     ' -DDOLFINX_BASIX_PYTHON=OFF '
     ' -DDOLFINX_ENABLE_KAHIP=ON '
-    ' -DDOLFINX_ENABLE_PARMETIS=ON '
     ' -DDOLFINX_ENABLE_PETSC=ON '
     ' -DDOLFINX_ENABLE_SLEPC=ON '
+    # ' -DDOLFINX_ENABLE_PARMETIS=ON ' # Strict check disabled to enable EESSI build.
 )
 
 sanity_check_paths = {


### PR DESCRIPTION
DOLFINx requires a partitioner, but Parmetis is problematic for EESSI as it is not released Open Source. This was raised at https://github.com/EESSI/software-layer/pull/1340.

This adds KaHIP as a dependency - I have not checked a successful build, please submit this to your test system.

Edit: Also adds cmake configure flags which trigger a failure if an expected optional dependency is not found during the build.