### PR TITLE
fix value for `$HDF5_DIR` in easyconfigs for HDF5 1.14.6

### DIFF
--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.14.6-GCC-14.3.0-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.14.6-GCC-14.3.0-serial.eb
@@ -48,6 +48,6 @@ sanity_check_paths = {
     'dirs': ['include'],
 }
 
-modextravars = {'HDF5_DIR': ''}
+modextravars = {'HDF5_DIR': '%(installdir)s'}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.14.6-gompi-2025b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.14.6-gompi-2025b.eb
@@ -49,6 +49,6 @@ sanity_check_paths = {
     'dirs': ['include'],
 }
 
-modextravars = {'HDF5_DIR': ''}
+modextravars = {'HDF5_DIR': '%(installdir)s'}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.14.6-iimpi-2025b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.14.6-iimpi-2025b.eb
@@ -49,6 +49,6 @@ sanity_check_paths = {
     'dirs': ['include'],
 }
 
-modextravars = {'HDF5_DIR': ''}
+modextravars = {'HDF5_DIR': '%(installdir)s'}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.14.6-lompi-2025b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.14.6-lompi-2025b.eb
@@ -49,6 +49,6 @@ sanity_check_paths = {
     'dirs': ['include'],
 }
 
-modextravars = {'HDF5_DIR': ''}
+modextravars = {'HDF5_DIR': '%(installdir)s'}
 
 moduleclass = 'data'


### PR DESCRIPTION
`modextravars` does not automatically prepend `%(installdir)s` unlike `modextrapaths` so `HDF5_DIR` was empty.

In older HDF5 easyconfigs the HDF5 easyblock set it correctly, but 1.14.6 uses CMakeMake