### PR TITLE
{chem}[system/system] Gaussian v16.C.02 w/ AVX2

### DIFF
--- a/easybuild/easyconfigs/g/Gaussian/Gaussian-16.C.02-AVX2.eb
+++ b/easybuild/easyconfigs/g/Gaussian/Gaussian-16.C.02-AVX2.eb
@@ -20,7 +20,7 @@ other than your computing resources and patience.
 toolchain = SYSTEM
 
 sources = [{
-    'filename': '%s.tbJ' %  _serial,
+    'filename': f'{_serial}.tbJ',
     'extract_cmd': 'tar xvfJ %s',
 }]
 checksums = ['df1e4e9c5429637e13c88659ae3ccb1c9cfdc344045ff26c3ab86a1077bf93c8']


### PR DESCRIPTION
note: easyconfigs for older versions were archived in https://github.com/easybuilders/easybuild-easyconfigs/pull/24945

afaik 16.C.02 is the latest release
(created using `eb --new-pr`)