### PR TITLE
fix various easyconfigs not using `python -s` in sanity check commands

### DIFF
--- a/easybuild/easyconfigs/c/Cantera/Cantera-2.6.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/c/Cantera/Cantera-2.6.0-foss-2022a.eb
@@ -45,6 +45,6 @@ sanity_check_paths = {
     'dirs': ['include/cantera', 'lib/pkgconfig', 'lib/python%(pyshortver)s/site-packages'],
 }
 
-sanity_check_commands = [('python', "-c 'import cantera'")]
+sanity_check_commands = [('python', "-s -c 'import cantera'")]
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-12.2.0-GCCcore-13.3.0-minimal.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-12.2.0-GCCcore-13.3.0-minimal.eb
@@ -77,7 +77,7 @@ sanity_check_paths = {
 sanity_check_commands = [
     ("test ! -d $EBROOTTCL/lib/*/graphviz", ''),
     ("test ! -d $EBROOTTCL/lib64/*/graphviz", ''),
-    ('python', '-c "import gv"'),
+    ('python', '-s -c "import gv"'),
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-12.2.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-12.2.0-GCCcore-13.3.0.eb
@@ -87,7 +87,7 @@ sanity_check_paths = {
 sanity_check_commands = [
     ("test ! -d $EBROOTTCL/lib/*/graphviz", ''),
     ("test ! -d $EBROOTTCL/lib64/*/graphviz", ''),
-    ('python', '-c "import gv"'),
+    ('python', '-s -c "import gv"'),
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-13.1.2-GCCcore-14.2.0-minimal.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-13.1.2-GCCcore-14.2.0-minimal.eb
@@ -76,7 +76,7 @@ sanity_check_paths = {
 sanity_check_commands = [
     ("test ! -d $EBROOTTCL/lib/*/graphviz", ''),
     ("test ! -d $EBROOTTCL/lib64/*/graphviz", ''),
-    ('python', '-c "import gv"'),
+    ('python', '-s -c "import gv"'),
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-13.1.2-GCCcore-14.3.0-minimal.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-13.1.2-GCCcore-14.3.0-minimal.eb
@@ -76,7 +76,7 @@ sanity_check_paths = {
 sanity_check_commands = [
     ("test ! -d $EBROOTTCL/lib/*/graphviz", ''),
     ("test ! -d $EBROOTTCL/lib64/*/graphviz", ''),
-    ('python', '-c "import gv"'),
+    ('python', '-s -c "import gv"'),
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-13.1.2-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-13.1.2-GCCcore-14.3.0.eb
@@ -85,7 +85,7 @@ sanity_check_paths = {
 sanity_check_commands = [
     ("test ! -d $EBROOTTCL/lib/*/graphviz", ''),
     ("test ! -d $EBROOTTCL/lib64/*/graphviz", ''),
-    ('python', '-c "import gv"'),
+    ('python', '-s -c "import gv"'),
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-2.50.0-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-2.50.0-GCCcore-11.2.0.eb
@@ -76,7 +76,7 @@ sanity_check_paths = {
 sanity_check_commands = [
     ("test ! -d $EBROOTTCL/lib/*/graphviz", ''),
     ("test ! -d $EBROOTTCL/lib64/*/graphviz", ''),
-    ('python', '-c "import gv"'),
+    ('python', '-s -c "import gv"'),
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-5.0.0-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-5.0.0-GCCcore-11.3.0.eb
@@ -86,7 +86,7 @@ sanity_check_paths = {
 sanity_check_commands = [
     ("test ! -d $EBROOTTCL/lib/*/graphviz", ''),
     ("test ! -d $EBROOTTCL/lib64/*/graphviz", ''),
-    ('python', '-c "import gv"'),
+    ('python', '-s -c "import gv"'),
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-8.1.0-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-8.1.0-GCCcore-12.2.0.eb
@@ -85,7 +85,7 @@ sanity_check_paths = {
 sanity_check_commands = [
     ("test ! -d $EBROOTTCL/lib/*/graphviz", ''),
     ("test ! -d $EBROOTTCL/lib64/*/graphviz", ''),
-    ('python', '-c "import gv"'),
+    ('python', '-s -c "import gv"'),
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-8.1.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-8.1.0-GCCcore-12.3.0.eb
@@ -85,7 +85,7 @@ sanity_check_paths = {
 sanity_check_commands = [
     ("test ! -d $EBROOTTCL/lib/*/graphviz", ''),
     ("test ! -d $EBROOTTCL/lib64/*/graphviz", ''),
-    ('python', '-c "import gv"'),
+    ('python', '-s -c "import gv"'),
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-9.0.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-9.0.0-GCCcore-13.2.0.eb
@@ -81,7 +81,7 @@ sanity_check_paths = {
 sanity_check_commands = [
     ("test ! -d $EBROOTTCL/lib/*/graphviz", ''),
     ("test ! -d $EBROOTTCL/lib64/*/graphviz", ''),
-    ('python', '-c "import gv"'),
+    ('python', '-s -c "import gv"'),
 ]
 
 modextrapaths = {

--- a/easybuild/easyconfigs/p/pypmt/pypmt-1.1.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/p/pypmt/pypmt-1.1.0-foss-2022a.eb
@@ -28,7 +28,7 @@ sanity_check_paths = {
         "lib/python",
         "include"],
 }
-sanity_check_commands = [('python', "-c 'import pmt'")]
+sanity_check_commands = [('python', "-s -c 'import pmt'")]
 
 modextrapaths = {
     'PYTHONPATH': ['lib/python']

--- a/easybuild/easyconfigs/p/pypmt/pypmt-1.1.0-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/p/pypmt/pypmt-1.1.0-gfbf-2023a.eb
@@ -28,7 +28,7 @@ sanity_check_paths = {
         "lib/python",
         "include"],
 }
-sanity_check_commands = [('python', "-c 'import pmt'")]
+sanity_check_commands = [('python', "-s -c 'import pmt'")]
 
 modextrapaths = {
     'PYTHONPATH': ['lib/python']

--- a/easybuild/easyconfigs/p/pypmt/pypmt-1.2.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/p/pypmt/pypmt-1.2.0-foss-2022a.eb
@@ -28,7 +28,7 @@ sanity_check_paths = {
         "lib/python",
         "include"],
 }
-sanity_check_commands = [('python', "-c 'import pmt'")]
+sanity_check_commands = [('python', "-s -c 'import pmt'")]
 
 modextrapaths = {
     'PYTHONPATH': ['lib/python']

--- a/easybuild/easyconfigs/p/pypmt/pypmt-1.2.0-gfbf-2023a.eb
+++ b/easybuild/easyconfigs/p/pypmt/pypmt-1.2.0-gfbf-2023a.eb
@@ -28,7 +28,7 @@ sanity_check_paths = {
         "lib/python",
         "include"],
 }
-sanity_check_commands = [('python', "-c 'import pmt'")]
+sanity_check_commands = [('python', "-s -c 'import pmt'")]
 
 modextrapaths = {
     'PYTHONPATH': ['lib/python']

--- a/easybuild/easyconfigs/p/python-casacore/python-casacore-3.5.2-foss-2023b.eb
+++ b/easybuild/easyconfigs/p/python-casacore/python-casacore-3.5.2-foss-2023b.eb
@@ -36,7 +36,7 @@ sanity_check_paths = {
 }
 
 sanity_check_commands = [
-    ('python', "-c 'import casacore'"),
+    ('python', "-s -c 'import casacore'"),
 ]
 
 moduleclass = 'astro'


### PR DESCRIPTION
we already have a CI check to catch any easyconfigs that use `python` without ignoring user site packages (`-s`), but this obviously doesn't catch cases where this isn't in a single string

