### PR TITLE
Update Cbc-2.10.12-foss-2025b.eb   name 'VERSION_TAR_GZ' is not defined

### DIFF
--- a/easybuild/easyconfigs/c/Cbc/Cbc-2.10.12-foss-2025b.eb
+++ b/easybuild/easyconfigs/c/Cbc/Cbc-2.10.12-foss-2025b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'foss', 'version': '2025b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = ['https://github.com/coin-or/%(name)s/archive/refs/tags/releases']
-sources = [VERSION_TAR_GZ]
+sources = ['%(version)s.tar.gz']
 checksums = ['9ed71e4b61668462fc3794c102e26b4bb01a047efbbbcbd69ae7bde1f04f46a8']
 
 builddependencies = [


### PR DESCRIPTION
ERROR: Failed to process easyconfig /opt/easybuild/easybuild-easyconfigs/easybuild/easyconfigs/c/Cbc/Cbc-2.10.12-foss-2025b.eb: Parsing easyconfig file failed: name 'VERSION_TAR_GZ' is not defined (line 15)  Reverted to same of previous versions