### PR TITLE
add patch for XZ 5.8.1 to fix "`Failed to enable the sandbox`" on certain RHEL9 kernel versions

### DIFF
--- a/easybuild/easyconfigs/x/XZ/XZ-5.8.1-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.8.1-GCCcore-14.3.0.eb
@@ -10,7 +10,11 @@ toolchain = {'name': 'GCCcore', 'version': '14.3.0'}
 
 source_urls = ['https://tukaani.org/xz/']
 sources = [SOURCELOWER_TAR_BZ2]
-checksums = ['5965c692c4c8800cd4b33ce6d0f6ac9ac9d6ab227b17c512b6561bce4f08d47e']
+patches = ['XZ-5.8.1-RHEL9.patch']
+checksums = [
+    '5965c692c4c8800cd4b33ce6d0f6ac9ac9d6ab227b17c512b6561bce4f08d47e',
+    '02b00e89b0c18c9f42d4aeaf8ec29767c2a96b0cca505c6f1c5d40c7d9cda765',
+]
 
 builddependencies = [
     # use gettext built with system toolchain as build dep to avoid cyclic dependency (XZ -> gettext -> libxml2 -> XZ)

--- a/easybuild/easyconfigs/x/XZ/XZ-5.8.1-RHEL9.patch
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.8.1-RHEL9.patch
@@ -1,0 +1,192 @@
+# This patch fixes the "Failed to enable sandbox" error
+# Underlying issue is actually an issue with the RHEL 9 kernel, introduced
+# in 5.14.0-603.el9 and fixed in 5.14.0-648.el9.
+# Affected XZ versions are 5.8.0 and 5.8.1, a workaround was introduced in
+# 5.8.2. This patch implements that workaround.
+# Upstream issue: https://github.com/tukaani-project/xz/issues/199
+# Also see the 5.8.2 release notes: https://github.com/tukaani-project/xz/releases/tag/v5.8.2
+From e0c0c7eaa9f3e347c2e7431c2490264d52c6e7c0 Mon Sep 17 00:00:00 2001
+From: Lasse Collin <lasse.collin@tukaani.org>
+Date: Sun, 23 Nov 2025 20:13:37 +0200
+Subject: [PATCH 1/3] Landlock: Cache the ABI version
+
+In xz it can avoid up to two syscalls that query the ABI version.
+---
+ src/common/my_landlock.h | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/src/common/my_landlock.h b/src/common/my_landlock.h
+index e135d08c8..379d7bd4b 100644
+--- a/src/common/my_landlock.h
++++ b/src/common/my_landlock.h
+@@ -4,6 +4,10 @@
+ //
+ /// \file       my_landlock.h
+ /// \brief      Linux Landlock sandbox helper functions
++///
++/// \note       This uses static variables to cache the Landlock ABI version.
++///             Only one file in an application should include this header.
++///             Only one thread should call these functions.
+ //
+ //  Author:     Lasse Collin
+ //
+@@ -32,8 +36,16 @@ my_landlock_ruleset_attr_forbid_all(struct landlock_ruleset_attr *attr)
+ {
+ 	memzero(attr, sizeof(*attr));
+ 
+-	const int abi_version = syscall(SYS_landlock_create_ruleset,
++	// Cache the Landlock ABI version:
++	//  0 = not checked yet
++	// -1 = Landlock not supported
++	// >0 = Landlock ABI version
++	static int abi_version = 0;
++
++	if (abi_version == 0)
++		abi_version = syscall(SYS_landlock_create_ruleset,
+ 			(void *)NULL, 0, LANDLOCK_CREATE_RULESET_VERSION);
++
+ 	if (abi_version <= 0)
+ 		return -1;
+ 
+
+From d2e182b5acf0a2320cf44b7ec1b0803eda25824b Mon Sep 17 00:00:00 2001
+From: Lasse Collin <lasse.collin@tukaani.org>
+Date: Sun, 23 Nov 2025 20:13:49 +0200
+Subject: [PATCH 2/3] Landlock: Workaround a bug in RHEL 9 kernel
+
+If one runs xz 5.8.0 or 5.8.1 from some other distribution in a container
+on RHEL 9, xz will fail with the message "Failed to enable the sandbox".
+
+RHEL 9 kernel since 5.14.0-603.el9 (2025-07-30) claims to support
+Landlock ABI version 6, but it lacks support for LANDLOCK_SCOPE_SIGNAL.
+The issue is still present in 5.14.0-643.el9 (2025-11-22). Red Hat is
+aware of the issue, but I don't know when it will be fixed.
+
+The sandbox is meant to be transparent to users, thus there isn't and
+won't be a command line option to disable it. Instead, add a workaround
+to keep xz working on the buggy RHEL 9 kernels.
+
+Reported-by: Richard W.M. Jones
+Thanks-to: Pavel Raiskup
+Tested-by: Orgad Shaneh
+Tested-by: Richard W.M. Jones
+Fixes: https://github.com/tukaani-project/xz/issues/199
+Link: https://issues.redhat.com/browse/RHEL-125143
+Link: https://bugzilla.redhat.com/show_bug.cgi?id=2407105
+Link: https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/65BDSY56R5ZJRTUC4B6CIVCVLY4LG4ME/
+---
+ src/common/my_landlock.h | 27 ++++++++++++++++++++++++++-
+ 1 file changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/src/common/my_landlock.h b/src/common/my_landlock.h
+index 379d7bd4b..0f8e04e0a 100644
+--- a/src/common/my_landlock.h
++++ b/src/common/my_landlock.h
+@@ -21,6 +21,7 @@
+ #include <linux/landlock.h>
+ #include <sys/syscall.h>
+ #include <sys/prctl.h>
++#include <sys/utsname.h>
+ 
+ 
+ /// \brief      Initialize Landlock ruleset attributes to forbid everything
+@@ -42,10 +43,28 @@ my_landlock_ruleset_attr_forbid_all(struct landlock_ruleset_attr *attr)
+ 	// >0 = Landlock ABI version
+ 	static int abi_version = 0;
+ 
+-	if (abi_version == 0)
++	// Red Hat Enterprise Linux 9 kernel since 5.14.0-603.el9 (2025-07-30)
++	// claims ABI version 6 support, but as of 5.14.0-643.el9 (2025-11-22)
++	// it lacks LANDLOCK_SCOPE_SIGNAL. ABI version 6 was added in upstream
++	// Linux 6.12 while RHEL 9 has Linux 5.14 with lots of backports.
++	// We assume that any kernel version 5.14 with ABI version 6 is buggy.
++	static bool is_rhel9 = false;
++
++	if (abi_version == 0) {
+ 		abi_version = syscall(SYS_landlock_create_ruleset,
+ 			(void *)NULL, 0, LANDLOCK_CREATE_RULESET_VERSION);
+ 
++		if (abi_version == 6) {
++			static const char rel[] = "5.14.";
++			const size_t rel_len = sizeof(rel) - 1;
++
++			struct utsname un;
++			if (uname(&un) == 0 && strncmp(
++					un.release, rel, rel_len) == 0)
++				is_rhel9 = true;
++		}
++	}
++
+ 	if (abi_version <= 0)
+ 		return -1;
+ 
+@@ -121,6 +140,12 @@ my_landlock_ruleset_attr_forbid_all(struct landlock_ruleset_attr *attr)
+ #endif
+ 		FALLTHROUGH;
+ 
++	case 6:
++		if (is_rhel9)
++			attr->scoped &= ~LANDLOCK_SCOPE_SIGNAL;
++
++		FALLTHROUGH;
++
+ 	default:
+ 		// We only know about the features of the ABIs 1-6.
+ 		break;
+
+From 4f979cdaef7f945d9dabedbae56bd921bc62dc8c Mon Sep 17 00:00:00 2001
+From: Lasse Collin <lasse.collin@tukaani.org>
+Date: Sun, 23 Nov 2025 20:39:28 +0200
+Subject: [PATCH 3/3] Landlock: Add missing #ifdefs
+
+The build was broken on distros that have an old <sys/landlock.h>.
+
+Fixes: 2b2652e914b1 ("Landlock: Workaround a bug in RHEL 9 kernel")
+---
+ src/common/my_landlock.h | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/common/my_landlock.h b/src/common/my_landlock.h
+index 0f8e04e0a..5f761695b 100644
+--- a/src/common/my_landlock.h
++++ b/src/common/my_landlock.h
+@@ -43,17 +43,20 @@ my_landlock_ruleset_attr_forbid_all(struct landlock_ruleset_attr *attr)
+ 	// >0 = Landlock ABI version
+ 	static int abi_version = 0;
+ 
++#ifdef LANDLOCK_SCOPE_SIGNAL
+ 	// Red Hat Enterprise Linux 9 kernel since 5.14.0-603.el9 (2025-07-30)
+ 	// claims ABI version 6 support, but as of 5.14.0-643.el9 (2025-11-22)
+ 	// it lacks LANDLOCK_SCOPE_SIGNAL. ABI version 6 was added in upstream
+ 	// Linux 6.12 while RHEL 9 has Linux 5.14 with lots of backports.
+ 	// We assume that any kernel version 5.14 with ABI version 6 is buggy.
+ 	static bool is_rhel9 = false;
++#endif
+ 
+ 	if (abi_version == 0) {
+ 		abi_version = syscall(SYS_landlock_create_ruleset,
+ 			(void *)NULL, 0, LANDLOCK_CREATE_RULESET_VERSION);
+ 
++#ifdef LANDLOCK_SCOPE_SIGNAL
+ 		if (abi_version == 6) {
+ 			static const char rel[] = "5.14.";
+ 			const size_t rel_len = sizeof(rel) - 1;
+@@ -63,6 +66,7 @@ my_landlock_ruleset_attr_forbid_all(struct landlock_ruleset_attr *attr)
+ 					un.release, rel, rel_len) == 0)
+ 				is_rhel9 = true;
+ 		}
++#endif
+ 	}
+ 
+ 	if (abi_version <= 0)
+@@ -141,8 +145,10 @@ my_landlock_ruleset_attr_forbid_all(struct landlock_ruleset_attr *attr)
+ 		FALLTHROUGH;
+ 
+ 	case 6:
++#ifdef LANDLOCK_SCOPE_SIGNAL
+ 		if (is_rhel9)
+ 			attr->scoped &= ~LANDLOCK_SCOPE_SIGNAL;
++#endif
+ 
+ 		FALLTHROUGH;
+ 


### PR DESCRIPTION
Fix for "Failed to enable the sandbox" error on certain RHEL9 kernel versions, see https://github.com/tukaani-project/xz/issues/199

Note that this issue only occurs for RHEL9 kernel between 5.14.0-603.el9 and 5.14.0-648.el9. Tested the fix on Jureca, which runs a kernel version that is affected. Without the fix:

```
== FAILED: Installation ended unsuccessfully: Sanity check failed: sanity check command xz --help failed with exit code 1 (output: xz: Failed to enable the sandbox
)
```

With the fix, it installs succesfully.

(created using `eb --new-pr`)
