### PR TITLE
Remove unused configopt due to repetition in `Graphviz` easyconfigs

### DIFF
--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-12.2.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-12.2.0-GCCcore-13.3.0.eb
@@ -60,7 +60,7 @@ _copts = [
     '--enable-ltdl --without-included-ltdl --disable-ltdl-install',
     '--with-ltdl-include=$EBROOTLIBTOOL/include --with-ltdl-lib=$EBROOTLIBTOOL/lib',
     # Override the hardcoded paths to Java libraries
-    '--with-javaincludedir=$JAVA_HOME/include --with-javaincludedir=$JAVA_HOME/include/linux',
+    '--with-javaincludedir=$JAVA_HOME/include/linux',
     '--with-javalibdir=$JAVA_HOME/lib',
     '--with-expatincludedir=$EBROOTEXPAT/include --with-expatlibdir=$EBROOTEXPAT/lib',
     '--with-zincludedir=$EBROOTZLIB/include --with-zlibdir=$EBROOTZLIB/lib',

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-13.1.2-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-13.1.2-GCCcore-14.2.0.eb
@@ -58,7 +58,7 @@ _copts = [
     '--enable-ltdl --without-included-ltdl --disable-ltdl-install',
     '--with-ltdl-include=$EBROOTLIBTOOL/include --with-ltdl-lib=$EBROOTLIBTOOL/lib',
     # Override the hardcoded paths to Java libraries
-    '--with-javaincludedir=$JAVA_HOME/include --with-javaincludedir=$JAVA_HOME/include/linux',
+    '--with-javaincludedir=$JAVA_HOME/include/linux',
     '--with-javalibdir=$JAVA_HOME/lib',
     '--with-expatincludedir=$EBROOTEXPAT/include --with-expatlibdir=$EBROOTEXPAT/lib',
     '--with-zincludedir=$EBROOTZLIB/include --with-zlibdir=$EBROOTZLIB/lib',

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-13.1.2-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-13.1.2-GCCcore-14.3.0.eb
@@ -58,7 +58,7 @@ _copts = [
     '--enable-ltdl --without-included-ltdl --disable-ltdl-install',
     '--with-ltdl-include=$EBROOTLIBTOOL/include --with-ltdl-lib=$EBROOTLIBTOOL/lib',
     # Override the hardcoded paths to Java libraries
-    '--with-javaincludedir=$JAVA_HOME/include --with-javaincludedir=$JAVA_HOME/include/linux',
+    '--with-javaincludedir=$JAVA_HOME/include/linux',
     '--with-javalibdir=$JAVA_HOME/lib',
     '--with-expatincludedir=$EBROOTEXPAT/include --with-expatlibdir=$EBROOTEXPAT/lib',
     '--with-zincludedir=$EBROOTZLIB/include --with-zlibdir=$EBROOTZLIB/lib',

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-8.1.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-8.1.0-GCCcore-12.3.0.eb
@@ -58,7 +58,7 @@ _copts = [
     '--enable-ltdl --without-included-ltdl --disable-ltdl-install',
     '--with-ltdl-include=$EBROOTLIBTOOL/include --with-ltdl-lib=$EBROOTLIBTOOL/lib',
     # Override the hardcoded paths to Java libraries
-    '--with-javaincludedir=$JAVA_HOME/include --with-javaincludedir=$JAVA_HOME/include/linux',
+    '--with-javaincludedir=$JAVA_HOME/include/linux',
     '--with-javalibdir=$JAVA_HOME/lib',
     '--with-expatincludedir=$EBROOTEXPAT/include --with-expatlibdir=$EBROOTEXPAT/lib',
     '--with-zincludedir=$EBROOTZLIB/include --with-zlibdir=$EBROOTZLIB/lib',

--- a/easybuild/easyconfigs/g/Graphviz/Graphviz-9.0.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/g/Graphviz/Graphviz-9.0.0-GCCcore-13.2.0.eb
@@ -57,7 +57,7 @@ configopts += '--enable-r=no --enable-ruby=no --enable-php=no '
 configopts += '--enable-ltdl --without-included-ltdl --disable-ltdl-install '
 configopts += '--with-ltdl-include=$EBROOTLIBTOOL/include --with-ltdl-lib=$EBROOTLIBTOOL/lib '
 # Override the hardcoded paths to Java libraries
-configopts += '--with-javaincludedir=$JAVA_HOME/include --with-javaincludedir=$JAVA_HOME/include/linux '
+configopts += '--with-javaincludedir=$JAVA_HOME/include/linux '
 configopts += '--with-javalibdir=$JAVA_HOME/lib'
 configopts += '--with-expatincludedir=$EBROOTEXPAT/include --with-expatlibdir=$EBROOTEXPAT/lib'
 configopts += '--with-zincludedir=$EBROOTZLIB/include --with-zlibdir=$EBROOTZLIB/lib'


### PR DESCRIPTION
Only the last option is used by `./configure`.
Since the last one is the correct one, no failure is seen in the builds but this can mess up hooks that do stuff on the configopts without keeping order.

See for example

- https://github.com/EESSI/software-layer/pull/1334#issuecomment-3822941396