### PR TITLE
add patch for AmberTools 23.6 to fix infinite loop of for `mdgx` on aarch64

### DIFF
--- a/easybuild/easyconfigs/a/AmberTools/AmberTools-23.6-foss-2023a.eb
+++ b/easybuild/easyconfigs/a/AmberTools/AmberTools-23.6-foss-2023a.eb
@@ -32,6 +32,7 @@ patches = [
     'AmberTools-21_fix_rism_argument_mismatch.patch',
     'AmberTools-21_fix_xray_fftpack_arg_mismatch.patch',
     'AmberTools-22_fix_test_missing_cuda_dir.patch',
+    'AmberTools-23_fix-fgetc_arm_infiniteloop.patch',
 ]
 checksums = [
     {'AmberTools23.tar.bz2': 'debb52e6ef2e1b4eaa917a8b4d4934bd2388659c660501a81ea044903bf9ee9d'},
@@ -53,6 +54,8 @@ checksums = [
      '99c954e693659efc2a1d121f91510f56408006f0751d91595f45a34b03364e2f'},
     {'AmberTools-22_fix_test_missing_cuda_dir.patch':
      'fb1ab74314d7816169bb9f3f527b78085654aae2825c52cebf50a5760401b737'},
+    {'AmberTools-23_fix-fgetc_arm_infiniteloop.patch':
+     'dde9f8e7914c491f1e1c04171bbbbda371cb12403847fb15092d023fd28fb0f5'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/a/AmberTools/AmberTools-23_fix-fgetc_arm_infiniteloop.patch
+++ b/easybuild/easyconfigs/a/AmberTools/AmberTools-23_fix-fgetc_arm_infiniteloop.patch
@@ -1,0 +1,17 @@
+author: Davide Grassano (CECAM)
+Fixes an issue related to the use of casting fgetc() to a char before checking for EOF causing an infinite loop on ARM
+architectures when reading binary files.
+https://bugs.webkit.org/show_bug.cgi?id=144439
+See https://github.com/EESSI/software-layer/pull/1334 for more details.
+This was also patched in AmberTools-25 the same way 
+--- AmberTools/src/mdgx/Parse.c.orig	2026-01-30 17:45:10.130443999 +0100
++++ AmberTools/src/mdgx/Parse.c	2026-01-30 17:57:15.490587902 +0100
+@@ -2908,7 +2908,7 @@
+ {
+   int isbinary;
+   long long int il, fsize;
+-  char testchar;
++  int testchar;
+   FILE *finp;
+ 
+   // Detect binary files as those having any byte whose value is outside the


### PR DESCRIPTION
For a detailed description on the issue see:

- https://github.com/EESSI/software-layer/pull/1332