### PR TITLE
QDirStat for 2024a

### DIFF
--- a/easybuild/easyconfigs/q/QDirStat/QDirStat-2.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/q/QDirStat/QDirStat-2.0-GCCcore-13.3.0.eb
@@ -49,7 +49,7 @@ files_to_copy = [
     (['%(start_dir)s/*.h'], 'include'),
 ]
 
-sanity_check_paths= {
+sanity_check_paths = {
     'files': ['bin/%(namelower)s'],
     'dirs': ['include'],
 }


### PR DESCRIPTION
In fact, `QDirStat` needs to be built with Qt6 (using `qtmake6`) first, before the `make` command, but I still picked the `MakeCp` easyblock for it, anyways.