### PR TITLE
[tools][GCCcore/14.3.0] ipympl v0.10.0

### DIFF
--- a/easybuild/easyconfigs/i/ipympl/ipympl-0.10.0-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/i/ipympl/ipympl-0.10.0-gfbf-2025b.eb
@@ -29,12 +29,7 @@ dependencies = [
 
 exts_list = [
     ('ipympl', version, {
-        'source_urls': ['https://github.com/matplotlib/ipympl/archive/refs/tags/'],
-        'source_tmpl': 'v%(version)s.tar.gz',
-        'checksums': [
-            {'v%(version)s.tar.gz':
-             '28b22ec30ceaddab2e929baa70d599e107579f90d9dc19be22c4650a763bbc22'},
-        ],
+        'checksums': ['eda69602a010af2a42e8ebd069b0ee0dbe8df7fc69d7c1e8b99fece0a2fe613f'],
     }),
 ]
 


### PR DESCRIPTION
This PR adds ipympl/0.10.0 for Stages/2026. Compiled and tested on x86_64 and aarch64.