### PR TITLE
fix software name for CONCORD

### DIFF
--- a/easybuild/easyconfigs/c/CONCORD/CONCORD-1.0.13-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/c/CONCORD/CONCORD-1.0.13-foss-2023a-CUDA-12.1.1.eb
@@ -1,6 +1,6 @@
 easyblock = 'PythonBundle'
 
-name = 'Concord-sc'
+name = 'CONCORD'
 version = '1.0.13'
 versionsuffix = '-CUDA-%(cudaver)s'
 
@@ -100,7 +100,7 @@ exts_list = [
     ('plottable', '0.1.5', {
         'checksums': ['235d762a31c82129dc5bf74205c103a14b1e4393d0f921cc0231be5de884041d'],
     }),
-    ('%(namelower)s', version, {
+    ('concord-sc', version, {
         'modulename': 'concord',
         'sources': [{'download_filename': 'concord_sc-%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}],
         'checksums': ['96f5386128fd8256e9952e0689b47fcc22c0bba1f18a172f47ebaa728aa9f8c5'],


### PR DESCRIPTION
I noticed this merge seconds after merging #25216

`concord-sc` is the name on PyPI, but the official software name is clearly `CONCORD`