### PR TITLE
add patch to fix build of OpenBLAS 0.3.23 + 0.3.24 on AMD Turin (Zen 5)

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.23-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.23-GCC-12.3.0.eb
@@ -22,6 +22,7 @@ patches = [
     'OpenBLAS-0.3.23_disable-xDRGES-LAPACK-test.patch',
     'OpenBLAS-0.3.23_fix-parallel-build.patch',
     'OpenBLAS-0.3.23_fix-tests-hang.patch',
+    'OpenBLAS-0.3.23_add_zen5_support.patch',
 ]
 checksums = [
     {'v0.3.23.tar.gz': '5d9491d07168a5d00116cdc068a40022c3455bf9293c7cb86a65b1054d7e5114'},
@@ -38,6 +39,7 @@ checksums = [
      'ab7e0af05f9b2a2ced32f3875e1e3767d9c3531a455421a38f7324350178a0ff'},
     {'OpenBLAS-0.3.23_fix-parallel-build.patch': 'abe10ba3b0ca54772dbf235596e35325a5159018f6a60cfc88824c2c220d99d9'},
     {'OpenBLAS-0.3.23_fix-tests-hang.patch': '9de1fdee6edf3b2bb55e4639fdd92d2877b5f0ac880f7df2cfea47ecebf16609'},
+    {'OpenBLAS-0.3.23_add_zen5_support.patch': '7a852f147b3b9d3f9b36e31a17a72d981e49e5d0b260f9207e5cfdd80aede40f'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.23_add_zen5_support.patch
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.23_add_zen5_support.patch
@@ -1,0 +1,23 @@
+see https://github.com/OpenMathLib/OpenBLAS/pull/4923
+backported to OpenBLAS 0.3.23
+--- OpenBLAS-0.3.23/cpuid_x86.c.orig	2026-02-10 22:33:00.863117376 +0100
++++ OpenBLAS-0.3.23/cpuid_x86.c	2026-02-10 22:40:04.381039301 +0100
+@@ -1657,7 +1657,8 @@
+ 	  else
+ 	    return CPUTYPE_BARCELONA;
+         }
+-      case 10: // Zen3		      
++      case 10: // Zen3/4		      
++      case 11: // Zen5
+ 	if(support_avx())
+ #ifndef NO_AVX2
+ 	    return CPUTYPE_ZEN;
+@@ -2424,7 +2425,7 @@
+ 	  }
+ 	  break;
+ 	}
+-      } else if (exfamily == 8 || exfamily == 10) {
++      } else if (exfamily == 8 || exfamily == 10 || exfamily == 11) {
+ 	switch (model) {
+ 	case 1:
+ 	  // AMD Ryzen

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.24-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.24-GCC-13.2.0.eb
@@ -21,6 +21,7 @@ patches = [
     'OpenBLAS-0.3.23_disable-xDRGES-LAPACK-test.patch',
     'OpenBLAS-0.3.24_fix-czasum.patch',
     'OpenBLAS-0.3.24_fix-A64FX.patch',
+    'OpenBLAS-0.3.23_add_zen5_support.patch',
 ]
 checksums = [
     {'v0.3.24.tar.gz': 'ceadc5065da97bd92404cac7254da66cc6eb192679cf1002098688978d4d5132'},
@@ -36,6 +37,7 @@ checksums = [
      'ab7e0af05f9b2a2ced32f3875e1e3767d9c3531a455421a38f7324350178a0ff'},
     {'OpenBLAS-0.3.24_fix-czasum.patch': '8132b87c519fb08caa3bd7291fe8a1d0e1afe6fcb667d16f3020b46122afe20c'},
     {'OpenBLAS-0.3.24_fix-A64FX.patch': '3712e8c3f0024c7bb327958779c388ad0234ad6d58b7b118e605256ec089964c'},
+    {'OpenBLAS-0.3.23_add_zen5_support.patch': '7a852f147b3b9d3f9b36e31a17a72d981e49e5d0b260f9207e5cfdd80aede40f'},
 ]
 
 builddependencies = [


### PR DESCRIPTION
fixes:
```
gemv.c: In function ‘sgemv_’:
gemv.c:229:29: error: ‘GEMM_MULTITHREAD_THRESHOLD’ undeclared (first use in this function)
  229 |   if ( 1L * m * n < 2304L * GEMM_MULTITHREAD_THRESHOLD )
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~
```

similar to:
* #22850
* #24027 (see #23041)

OpenBLAS 0.3.27+ builds fine