### PR TITLE
Wrong source URL for python-parasail 1.3.4

### DIFF
--- a/easybuild/easyconfigs/p/python-parasail/python-parasail-1.3.4-foss-2023b.eb
+++ b/easybuild/easyconfigs/p/python-parasail/python-parasail-1.3.4-foss-2023b.eb
@@ -8,6 +8,7 @@ description = "Python Bindings for the Parasail C Library"
 
 toolchain = {'name': 'foss', 'version': '2023b'}
 
+source_urls = [PYPI_SOURCE.replace('%(name)s', 'parasail')]
 sources = ['parasail-%(version)s.tar.gz']
 checksums = ['d6a7035dfae3ef5aafdd7e6915711214c22b572ea059fa69d9d7ecbfb9b61b0f']
 

--- a/easybuild/easyconfigs/p/python-parasail/python-parasail-1.3.4-foss-2024a.eb
+++ b/easybuild/easyconfigs/p/python-parasail/python-parasail-1.3.4-foss-2024a.eb
@@ -8,6 +8,7 @@ description = "Python Bindings for the Parasail C Library"
 
 toolchain = {'name': 'foss', 'version': '2024a'}
 
+source_urls = [PYPI_SOURCE.replace('%(name)s', 'parasail')]
 sources = ['parasail-%(version)s.tar.gz']
 checksums = ['d6a7035dfae3ef5aafdd7e6915711214c22b572ea059fa69d9d7ecbfb9b61b0f']
 


### PR DESCRIPTION
Not sure how they managed to pass the builds in eg 

- #22896
- 
But the correct PyPI name has always been `parasail`

Fixes build failure in

- https://github.com/easybuilders/easybuild-easyconfigs/pull/25387#issuecomment-3950199262