### PR TITLE
Reduce combinations for CI unit tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         include:
           - python: '3.7'
-            module_syntax: Lua
             modules_tool: Lmod-8.6.8
-          - python: '3.11'
             module_syntax: Tcl
+          - python: '3.11'
             modules_tool: Lmod-8.6.8
+            module_syntax: Lua
       fail-fast: false
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,9 +13,13 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: ['3.7', '3.11']
-        modules_tool: [Lmod-8.6.8]
-        module_syntax: [Lua, Tcl]
+        include:
+          - python: '3.7'
+            module_syntax: Lua
+            modules_tool: Lmod-8.6.8
+          - python: '3.11'
+            module_syntax: Tcl
+            modules_tool: Lmod-8.6.8
       fail-fast: false
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2


### PR DESCRIPTION
As discussed on the meeting, this could speed up the CI a bit for us, essentially halving the CI time spent here.