### PR TITLE
fix source URL in git-annex easyconfigs

### DIFF
--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.2.0.eb
@@ -12,7 +12,9 @@ toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 
 sources = [{
     'git_config': {
-        'url': 'git://git-annex.branchable.com',
+        # main source https://git.joeyh.name/git/git-annex
+        # alternative source https://github.com/datalad/git-annex
+        'url': 'https://git.joeyh.name/git',
         'repo_name': '%(name)s',
         'tag': '%(version)s',
         'clone_into': '%(name)s-%(version)s',

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.2.0.eb
@@ -12,8 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 
 sources = [{
     'git_config': {
-        # main source https://git.joeyh.name/git/git-annex
-        # alternative source https://github.com/datalad/git-annex
+        # see https://git-annex.branchable.com/download/
         'url': 'https://git.joeyh.name/git',
         'repo_name': '%(name)s',
         'tag': '%(version)s',

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.3.0.eb
@@ -12,8 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 
 sources = [{
     'git_config': {
-        # main source https://git.joeyh.name/git/git-annex
-        # alternative source https://github.com/datalad/git-annex
+        # see https://git-annex.branchable.com/download/
         'url': 'https://git.joeyh.name/git',
         'repo_name': '%(name)s',
         'tag': '%(version)s',

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20230802-GCCcore-12.3.0.eb
@@ -12,7 +12,9 @@ toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 
 sources = [{
     'git_config': {
-        'url': 'git://git-annex.branchable.com',
+        # main source https://git.joeyh.name/git/git-annex
+        # alternative source https://github.com/datalad/git-annex
+        'url': 'https://git.joeyh.name/git',
         'repo_name': '%(name)s',
         'tag': '%(version)s',
         'clone_into': '%(name)s-%(version)s',

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20240531-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20240531-GCCcore-13.2.0.eb
@@ -12,7 +12,9 @@ toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 
 sources = [{
     'git_config': {
-        'url': 'git://git-annex.branchable.com',
+        # main source https://git.joeyh.name/git/git-annex
+        # alternative source https://github.com/datalad/git-annex
+        'url': 'https://git.joeyh.name/git',
         'repo_name': '%(name)s',
         'tag': '%(version)s',
         'clone_into': '%(name)s-%(version)s',

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20240531-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20240531-GCCcore-13.2.0.eb
@@ -12,8 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 
 sources = [{
     'git_config': {
-        # main source https://git.joeyh.name/git/git-annex
-        # alternative source https://github.com/datalad/git-annex
+        # see https://git-annex.branchable.com/download/
         'url': 'https://git.joeyh.name/git',
         'repo_name': '%(name)s',
         'tag': '%(version)s',

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20240731-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20240731-GCCcore-13.3.0.eb
@@ -12,7 +12,9 @@ toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
 
 sources = [{
     'git_config': {
-        'url': 'git://git-annex.branchable.com',
+        # main source https://git.joeyh.name/git/git-annex
+        # alternative source https://github.com/datalad/git-annex
+        'url': 'https://git.joeyh.name/git',
         'repo_name': '%(name)s',
         'tag': '%(version)s',
         'clone_into': '%(name)s-%(version)s',

--- a/easybuild/easyconfigs/g/git-annex/git-annex-10.20240731-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/g/git-annex/git-annex-10.20240731-GCCcore-13.3.0.eb
@@ -12,8 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
 
 sources = [{
     'git_config': {
-        # main source https://git.joeyh.name/git/git-annex
-        # alternative source https://github.com/datalad/git-annex
+        # see https://git-annex.branchable.com/download/
         'url': 'https://git.joeyh.name/git',
         'repo_name': '%(name)s',
         'tag': '%(version)s',


### PR DESCRIPTION
On some systems you are not able to git clone from `git://...git`. 
Now the sources are fetched from different official git repository that has `https://...git` available.