### PR TITLE
{chem}[GCC/13.2.0,foss/2023b,gompi/2023b] ESPResSo v5.0.1, Cabana v0.7.0, Kokkos v4.7.01, HighFive v3.3.0

### DIFF
--- a/easybuild/easyconfigs/c/Cabana/Cabana-0.7.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/c/Cabana/Cabana-0.7.0-foss-2023b.eb
@@ -1,0 +1,58 @@
+easyblock = 'CMakeMake'
+
+name = 'Cabana'
+version = '0.7.0'
+
+homepage = 'https://github.com/ECP-copa/Cabana'
+description = '''
+Cabana is a performance portable library for particle-based simulations. Applications include,
+but are not limited to, molecular dynamics (MD) with short- and/or long-range atomic
+interactions; various flavors of particle-in-cell (PIC) methods, including use within
+fluid/solid mechanics and plasma physics; N-body cosmology simulations; and peridynamics
+for fracture mechanics.
+
+Cabana provides particle data structures, algorithms, and communication, as well as
+structured grids, grid algorithms, and particle-grid interpolation to enable simulations
+on a variety of platforms including many-core CPU and GPU architectures. Cabana is built
+on Kokkos, with many additional optional library dependencies, including MPI for multi-node
+simulation.
+'''
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+toolchainopts = {'openmp': True}
+
+github_account = 'ECP-copa'
+source_urls = [GITHUB_SOURCE]
+sources = [{'download_filename': '%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
+checksums = [
+    # Cabana-0.7.0.tar.gz
+    '3d46532144ea9a3f36429a65cccb7562d1244f1389dd8aff0d253708d1ec9838',
+]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+]
+
+dependencies = [
+    ('HeFFTe', '2.4.1'),
+    ('Kokkos', '4.7.01'),
+    ('HDF5', '1.14.3'),
+]
+
+configopts = '-DCabana_ENABLE_TESTING=OFF '
+configopts += '-DCabana_REQUIRE_OPENMP=ON '
+configopts += '-DCabana_REQUIRE_HEFFTE=ON '
+configopts += '-DCabana_REQUIRE_HDF5=ON '
+configopts += '-DCabana_BUILD_MARCH="" '
+
+runtest = False
+
+sanity_check_paths = {
+    'files': [
+        'lib/cmake/Cabana/CabanaConfig.cmake',
+        'include/Cabana_Core.hpp',
+    ],
+    'dirs': ['include', 'lib']
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/c/Cabana/Cabana-0.7.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/c/Cabana/Cabana-0.7.0-foss-2023b.eb
@@ -24,10 +24,7 @@ toolchainopts = {'openmp': True}
 github_account = 'ECP-copa'
 source_urls = [GITHUB_SOURCE]
 sources = [{'download_filename': '%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
-checksums = [
-    # Cabana-0.7.0.tar.gz
-    '3d46532144ea9a3f36429a65cccb7562d1244f1389dd8aff0d253708d1ec9838',
-]
+checksums = ['3d46532144ea9a3f36429a65cccb7562d1244f1389dd8aff0d253708d1ec9838']
 
 builddependencies = [
     ('CMake', '3.27.6'),

--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-5.0.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-5.0.0-foss-2023b.eb
@@ -1,0 +1,100 @@
+easyblock = 'EB_ESPResSo'
+
+name = 'ESPResSo'
+version = '5.0.0'
+
+homepage = 'https://espressomd.org/wordpress'
+description = """A software package for Molecular Dynamics and Monte Carlo
+simulations of bead-spring models, with electrostatics, magnetostatics,
+hydrodynamics and reaction-diffusion-advection solvers."""
+
+source_urls = ['https://github.com/espressomd/espresso/archive/%(version)s.tar.gz']
+sources = [SOURCELOWER_TAR_GZ]
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+toolchainopts = {'openmp': True, 'usempi': True, 'pic': True}
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('Ninja', '1.11.1'),
+    ('Cython', '3.0.10'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.11'),
+    ('Boost.MPI', '1.83.0'),
+    ('HeFFTe', '2.4.1'),
+    ('Kokkos', '4.7.01'),
+    ('Cabana', '0.7.0'),
+    ('Mesa', '23.1.9'),
+    ('GSL', '2.7'),
+    ('NLopt', '2.7.1'),
+    ('IPython', '8.17.2'),
+    ('Pint', '0.24'),
+    ('HDF5', '1.14.3'),
+    ('h5py', '3.11.0'),
+    ('HighFive', '3.3.0'),
+    ('VTK', '9.3.0'),
+]
+
+sources = [
+    {
+        'source_urls': ['https://github.com/espressomd/espresso/archive/'],
+        'filename': 'espresso-%(version)s.tar.gz',
+        'download_filename': '%(version)s.tar.gz',
+    },
+    {
+        'source_urls': ['https://i10git.cs.fau.de/walberla/walberla/-/archive/'],
+        'filename': 'walberla-3247aa73.tar.gz',
+        'download_filename': '3247aa73.tar.gz',
+    },
+]
+checksums = [{
+    'espresso-%(version)s.tar.gz': '8b6a6ce62fa9358464c789ed200f72e19b6687f999dc95b20b407ee1274cdf4e',
+    'walberla-3247aa73.tar.gz': 'd297b462e9ad2107ee968439266855b97aafaef39ef0b82f72129630116db059',
+}]
+
+configopts = ' -DESPRESSO_BUILD_TESTS=ON '
+# make sure the right Python is used (note: -DPython3_EXECUTABLE or -DPython_EXECUTABLE does not work!)
+configopts += ' -DPYTHON_EXECUTABLE=$EBROOTPYTHON/bin/python '
+
+# build_cmd_targets does not work with CMakeNinja, use buildopts instead
+buildopts = 'espresso_packaging_dependencies'
+
+test_cmd = 'ctest'
+runtest = '-L "unit_test|python_test"'
+testopts = '--output-on-failure --no-tests=error'
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+_binaries = ['ipypresso',  'pypresso']
+_libs = [
+    'espresso_core', 'espresso_shapes', 'espresso_walberla',
+    'espresso_script_interface', 'script_interface', 'utils', '_init',
+]
+_python_modules = [
+    '__init__.py', 'system.py', 'version.py', 'collision_detection.py', 'lb.py',
+    'accumulators.py', 'constraints.py', 'observables.py', 'particle_data.py',
+]
+if any(x[0] == 'HDF5' for x in dependencies):
+    _libs.append('espresso_hdf5')
+    _python_modules.append('io/writer/h5md.py')
+if any(x[0] == 'CUDA' for x in dependencies):
+    _python_modules.append('cuda_init.py')
+
+_lib_path = 'lib/python%(pyshortver)s/site-packages/espressomd'
+sanity_check_paths = {
+    'files': [f'bin/{x}' for x in _binaries] +
+             [f'{_lib_path}/{x}.{SHLIB_EXT}' for x in _libs] +
+             [f'{_lib_path}/{x}' for x in _python_modules],
+    'dirs': ['bin', 'lib']
+}
+
+sanity_check_commands = [
+    'pypresso -h', 'ipypresso -h',
+    'pypresso -c "import espressomd.version;print(espressomd.version.friendly())"',
+    'python3 -c "import espressomd.version;print(espressomd.version.friendly())"',
+]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-5.0.1-foss-2023b.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-5.0.1-foss-2023b.eb
@@ -1,0 +1,55 @@
+name = 'ESPResSo'
+version = '5.0.1'
+
+homepage = 'https://espressomd.org/wordpress'
+description = """A software package for Molecular Dynamics and Monte Carlo
+simulations of bead-spring models, with electrostatics, magnetostatics,
+hydrodynamics and reaction-diffusion-advection solvers."""
+
+sources = [
+    {
+        'source_urls': ['https://github.com/espressomd/espresso/archive/'],
+        'filename': 'espresso-%(version)s.tar.gz',
+        'download_filename': '%(version)s.tar.gz',
+    },
+    {
+        'source_urls': ['https://i10git.cs.fau.de/walberla/walberla/-/archive/'],
+        # using specific waLBerla commit, because most recent release (v7.2) is missing bugfixes that prevent packaging
+        'filename': 'walberla-3247aa73.tar.gz',
+        'download_filename': '3247aa73.tar.gz',
+    },
+]
+
+checksums = [{
+    'espresso-%(version)s.tar.gz': '92b314c39e7715a9a8c347269bf2ffb8c85c23d6dfcadd3d81a7e04b67d89589',
+    'walberla-3247aa73.tar.gz': 'd297b462e9ad2107ee968439266855b97aafaef39ef0b82f72129630116db059',
+}]
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+toolchainopts = {'openmp': True, 'usempi': True, 'pic': True}
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('Ninja', '1.11.1'),
+    ('Cython', '3.0.10'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('SciPy-bundle', '2023.11'),
+    ('Boost.MPI', '1.83.0'),
+    ('HeFFTe', '2.4.1'),
+    ('Kokkos', '4.7.01'),
+    ('Cabana', '0.7.0'),
+    ('Mesa', '23.1.9'),
+    ('GSL', '2.7'),
+    ('NLopt', '2.7.1'),
+    ('IPython', '8.17.2'),
+    ('Pint', '0.24'),
+    ('HDF5', '1.14.3'),
+    ('h5py', '3.11.0'),
+    ('HighFive', '3.3.0'),
+    ('VTK', '9.3.0'),
+]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/e/ESPResSo/ESPResSo-5.0.1-foss-2023b.eb
+++ b/easybuild/easyconfigs/e/ESPResSo/ESPResSo-5.0.1-foss-2023b.eb
@@ -19,11 +19,10 @@ sources = [
         'download_filename': '3247aa73.tar.gz',
     },
 ]
-
-checksums = [{
-    'espresso-%(version)s.tar.gz': '92b314c39e7715a9a8c347269bf2ffb8c85c23d6dfcadd3d81a7e04b67d89589',
-    'walberla-3247aa73.tar.gz': 'd297b462e9ad2107ee968439266855b97aafaef39ef0b82f72129630116db059',
-}]
+checksums = [
+    {'espresso-5.0.1.tar.gz': '92b314c39e7715a9a8c347269bf2ffb8c85c23d6dfcadd3d81a7e04b67d89589'},
+    {'walberla-3247aa73.tar.gz': 'd297b462e9ad2107ee968439266855b97aafaef39ef0b82f72129630116db059'},
+]
 
 toolchain = {'name': 'foss', 'version': '2023b'}
 toolchainopts = {'openmp': True, 'usempi': True, 'pic': True}

--- a/easybuild/easyconfigs/h/HighFive/HighFive-3.3.0-gompi-2023b.eb
+++ b/easybuild/easyconfigs/h/HighFive/HighFive-3.3.0-gompi-2023b.eb
@@ -1,0 +1,38 @@
+easyblock = 'CMakeMake'
+
+name = 'HighFive'
+version = '3.3.0'
+
+homepage = 'https://github.com/highfive-devs/highfive'
+description = """HighFive is a modern, user-friendly, header-only, C++14 interface for libhdf5."""
+
+toolchain = {'name': 'gompi', 'version': '2023b'}
+
+github_account = 'highfive-devs'
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['325cfbcf0c0296a6dd26f3b088801b7ebb8d6f109c0565c11d2d8c4af3253bff']
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('binutils', '2.40'),
+]
+
+dependencies = [
+    ('HDF5', '1.14.3'),
+    ('Boost', '1.83.0'),
+    ('Eigen', '3.4.0'),
+]
+
+sanity_check_paths = {
+    'files': ['include/highfive/H5File.hpp'],
+    'dirs': [],
+}
+
+configopts = '-DHIGHFIVE_UNIT_TESTS=OFF '
+configopts += '-DHIGHFIVE_EXAMPLES=OFF '
+configopts += '-DHIGHFIVE_BUILD_DOCS=OFF'
+configopts += '-DHIGHFIVE_USE_EIGEN=ON '
+configopts += '-DHIGHFIVE_PARALLEL_HDF5=ON '
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/h/HighFive/HighFive-3.3.0-gompi-2023b.eb
+++ b/easybuild/easyconfigs/h/HighFive/HighFive-3.3.0-gompi-2023b.eb
@@ -31,7 +31,7 @@ sanity_check_paths = {
 
 configopts = '-DHIGHFIVE_UNIT_TESTS=OFF '
 configopts += '-DHIGHFIVE_EXAMPLES=OFF '
-configopts += '-DHIGHFIVE_BUILD_DOCS=OFF'
+configopts += '-DHIGHFIVE_BUILD_DOCS=OFF '
 configopts += '-DHIGHFIVE_USE_EIGEN=ON '
 configopts += '-DHIGHFIVE_PARALLEL_HDF5=ON '
 

--- a/easybuild/easyconfigs/k/Kokkos/Kokkos-4.7.01-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/k/Kokkos/Kokkos-4.7.01-GCC-13.2.0.eb
@@ -1,0 +1,36 @@
+name = 'Kokkos'
+version = '4.7.01'
+
+homepage = 'https://kokkos.org/'
+description = '''
+Kokkos Core implements a programming model in C++ for writing performance portable applications
+targeting all major HPC platforms. For that purpose it provides abstractions for both parallel
+execution of code and data management. Kokkos is designed to target complex node architectures
+with N-level memory hierarchies and multiple types of execution resources. It currently can use
+CUDA, HIP, SYCL, HPX, OpenMP and C++ threads as backend programming models with several other
+backends in development.
+'''
+
+toolchain = {'name': 'GCC', 'version': '13.2.0'}
+toolchainopts = {'openmp': True, 'pic': True}
+
+github_account = 'kokkos'
+source_urls = [GITHUB_SOURCE]
+sources = [{'download_filename': '%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
+patches = ['Kokkos-4.7.01_fix-missing-check-include-cxx.patch']
+checksums = [
+    # Kokkos-4.7.01.tar.gz
+    'cebf6daeb99c95e3d4116ea0d97c94b6a521c0cff1f5e613f127f6beea960ac7',
+    # Kokkos-4.7.01_fix-missing-check-include-cxx.patch
+    'ef8bb57088970fb765acd00bee6d9a07b52383b5e890feb7679bdff3cb1ad0db',
+]
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+]
+
+dependencies = [
+    ('hwloc', '2.9.2'),
+]
+
+moduleclass = 'lib'


### PR DESCRIPTION
requires:
- https://github.com/easybuilders/easybuild-easyblocks/pull/4066