### PR TITLE
Add CI using Python 3.12

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,6 +20,9 @@ jobs:
           - python: '3.11'
             modules_tool: Lmod-8.6.8
             module_syntax: Lua
+          - python: '3.12'
+            modules_tool: Lmod-8.6.8
+            module_syntax: Lua
       fail-fast: false
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
@@ -48,6 +51,11 @@ jobs:
         sudo apt-get install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
         # for testing OpenMPI-system*eb we need to have Open MPI installed
         sudo apt-get install libopenmpi-dev openmpi-bin
+
+        # update to latest pip, check version
+        pip install --upgrade pip
+        pip --version
+        pip install setuptools
         # required for test_dep_graph
         pip install pycodestyle python-graph-core python-graph-dot
 

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -313,6 +313,14 @@ class EasyConfigTest(TestCase):
             print("(skipped dep graph test)")
             return
 
+        try:
+            # do specific import, since python-graph-dot is not compatible with setuptools >= 82.0.0
+            # in which pkg_resources was removed;
+            # see also https://github.com/easybuilders/easybuild-framework/issues/5110
+            import pygraph.classes.digraph  # noqa # pylint:disable=unused-import
+        except ImportError:
+            self.skipTest("Skipping test_dep_graph, since pygraph is not available")
+
         # temporary file for dep graph
         (hn, fn) = tempfile.mkstemp(suffix='.dot')
         os.close(hn)


### PR DESCRIPTION
Requires installing setuptools explicitely and skipping test_dep_graph similar to https://github.com/easybuilders/easybuild-framework/pull/5116