### PR TITLE
use `NETCDF_ENABLE_DAP_REMOTE_TESTS` instead of `ENABLE_DAP_REMOTE_TESTS` and prevent use of `srun` in netCDF 4.9.3 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-gompi-2025a.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-gompi-2025a.eb
@@ -50,8 +50,10 @@ configopts = [
     "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
 ]
 
+# unset SLURM_* environment variables to prevent that mpiexec (called by the MPI tests) tries to use srun
+pretestopts = "unset $(env | grep '^SLURM_' | cut -d= -f1) && "
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests
-pretestopts = "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe "
+pretestopts += "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe "
 runtest = 'test'
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-gompi-2025a.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-gompi-2025a.eb
@@ -46,8 +46,8 @@ preconfigopts = (
 # make sure both static and shared libs are built
 # and disable "remote" tests that access a unreliable external test server over internet
 configopts = [
-    "-DENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=OFF",
-    "-DENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
+    "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=OFF",
+    "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
 ]
 
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-gompi-2025b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-gompi-2025b.eb
@@ -50,8 +50,10 @@ configopts = [
     "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
 ]
 
+# unset SLURM_* environment variables to prevent that mpiexec (called by the MPI tests) tries to use srun
+pretestopts = "unset $(env | grep '^SLURM_' | cut -d= -f1) && "
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests
-pretestopts = "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe "
+pretestopts += "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe "
 runtest = 'test'
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-gompi-2025b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-gompi-2025b.eb
@@ -46,8 +46,8 @@ preconfigopts = (
 # make sure both static and shared libs are built
 # and disable "remote" tests that access a unreliable external test server over internet
 configopts = [
-    "-DENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=OFF",
-    "-DENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
+    "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=OFF",
+    "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
 ]
 
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-iimpi-2025a.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-iimpi-2025a.eb
@@ -50,8 +50,10 @@ configopts = [
     "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
 ]
 
+# unset SLURM_* environment variables to prevent that mpiexec (called by the MPI tests) tries to use srun
+pretestopts = "unset $(env | grep '^SLURM_' | cut -d= -f1) && "
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests
-pretestopts = "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe "
+pretestopts += "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe "
 runtest = 'test'
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-iimpi-2025a.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-iimpi-2025a.eb
@@ -46,8 +46,8 @@ preconfigopts = (
 # make sure both static and shared libs are built
 # and disable "remote" tests that access a unreliable external test server over internet
 configopts = [
-    "-DENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=OFF",
-    "-DENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
+    "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=OFF",
+    "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
 ]
 
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-iimpi-2025b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-iimpi-2025b.eb
@@ -50,8 +50,10 @@ configopts = [
     "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
 ]
 
+# unset SLURM_* environment variables to prevent that mpiexec (called by the MPI tests) tries to use srun
+pretestopts = "unset $(env | grep '^SLURM_' | cut -d= -f1) && "
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests
-pretestopts = "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe "
+pretestopts += "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe "
 runtest = 'test'
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-iimpi-2025b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-iimpi-2025b.eb
@@ -46,8 +46,8 @@ preconfigopts = (
 # make sure both static and shared libs are built
 # and disable "remote" tests that access a unreliable external test server over internet
 configopts = [
-    "-DENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=OFF",
-    "-DENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
+    "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=OFF",
+    "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
 ]
 
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-lompi-2025b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-lompi-2025b.eb
@@ -49,8 +49,8 @@ preconfigopts += (
 # make sure both static and shared libs are built
 # and disable "remote" tests that access a unreliable external test server over internet
 configopts = [
-    "-DENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=OFF",
-    "-DENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
+    "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=OFF",
+    "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
 ]
 
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-lompi-2025b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.9.3-lompi-2025b.eb
@@ -53,8 +53,10 @@ configopts = [
     "-DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
 ]
 
+# unset SLURM_* environment variables to prevent that mpiexec (called by the MPI tests) tries to use srun
+pretestopts = "unset $(env | grep '^SLURM_' | cut -d= -f1) && "
 # some tests try to start 16 MPI ranks, so we need to allow oversubscription to avoid failing tests
-pretestopts = "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe "
+pretestopts += "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe "
 runtest = 'test'
 
 moduleclass = 'data'


### PR DESCRIPTION
While debugging some weird netCDF test failures, I found that `ENABLE_DAP_REMOTE_TESTS` was renamed to `NETCDF_ENABLE_DAP_REMOTE_TESTS` in 4.9.3. See https://github.com/Unidata/netcdf-c/blob/v4.9.2/CMakeLists.txt#L1098 and 
https://github.com/Unidata/netcdf-c/blob/v4.9.3/CMakeLists.txt#L603.