### PR TITLE
add pkconf build dependency to cargo-c 0.10.13

### DIFF
--- a/easybuild/easyconfigs/c/cargo-c/cargo-c-0.10.13-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/c/cargo-c/cargo-c-0.10.13-GCCcore-14.2.0.eb
@@ -798,6 +798,7 @@ checksums = [
 builddependencies = [
     ('binutils', '2.42'),
     ('Rust', '1.85.1'),
+    ('pkgconf', '2.3.0'),
 ]
 
 sanity_check_paths = {


### PR DESCRIPTION
cargo-c/0.10.13-GCCcore-14.2.0 build failure on Ubuntu Nobel without pkgconf
EB 5.2.0
