### PR TITLE
{tools}[GCCcore/13.3.0,GCCcore/14.2.0] mango-auth v.0.0.11

### DIFF
--- a/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-13.3.0.eb
@@ -30,4 +30,9 @@ exts_list = [
     }),
 ]
 
+sanity_check_paths = {
+    'files': ['bin/mango_auth'],
+    'dirs': [],
+}
+
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-13.3.0.eb
@@ -35,4 +35,6 @@ sanity_check_paths = {
     'dirs': [],
 }
 
+sanity_check_commands = ["mango_auth -h"]
+
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-13.3.0.eb
@@ -14,6 +14,10 @@ links as needed.
 
 toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
 
+builddependencies = [
+    ('binutils', '2.42'),
+]
+
 dependencies = [
     ('Python', '3.12.3'),
     ('python-irodsclient', '3.2.0'),

--- a/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-13.3.0.eb
@@ -1,0 +1,29 @@
+# Author: Ehsan Moravveji (VSC - KU Leuven)
+
+easyblock = 'PythonBundle'
+
+name = 'mango-auth'
+version = '0.0.11'
+
+homepage = 'https://github.com/kuleuven/mango-auth'
+description = '''
+Mango Auth is a small python module to authenticate using interactive
+PAM authentication against an iRODS installation, opening web browser
+links as needed.
+'''
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('python-irodsclient', '3.2.0'),
+]
+
+exts_list = [
+    (name, version, {
+        'modulename': 'mango_auth',
+        'checksums': ['6c2881e9be6e6f76dd1225ab561f07f145acddd74dd6aef4da8d4928a1377339'],
+    }),
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-14.2.0.eb
@@ -1,0 +1,29 @@
+# Author: Ehsan Moravveji (VSC - KU Leuven)
+
+easyblock = 'PythonBundle'
+
+name = 'mango-auth'
+version = '0.0.11'
+
+homepage = 'https://github.com/kuleuven/mango-auth'
+description = '''
+Mango Auth is a small python module to authenticate using interactive
+PAM authentication against an iRODS installation, opening web browser
+links as needed.
+'''
+
+toolchain = {'name': 'GCCcore', 'version': '14.2.0'}
+
+dependencies = [
+    ('Python', '3.13.1'),
+    ('python-irodsclient', '3.2.0'),
+]
+
+exts_list = [
+    (name, version, {
+        'modulename': 'mango_auth',
+        'checksums': ['6c2881e9be6e6f76dd1225ab561f07f145acddd74dd6aef4da8d4928a1377339'],
+    }),
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-14.2.0.eb
@@ -30,4 +30,9 @@ exts_list = [
     }),
 ]
 
+sanity_check_paths = {
+    'files': ['bin/mango_auth'],
+    'dirs': [],
+}
+
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-14.2.0.eb
@@ -35,4 +35,6 @@ sanity_check_paths = {
     'dirs': [],
 }
 
+sanity_check_commands = ["mango_auth -h"]
+
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-14.2.0.eb
@@ -14,6 +14,10 @@ links as needed.
 
 toolchain = {'name': 'GCCcore', 'version': '14.2.0'}
 
+builddependencies = [
+    ('binutils', '2.42'),
+]
+
 dependencies = [
     ('Python', '3.13.1'),
     ('python-irodsclient', '3.2.0'),


### PR DESCRIPTION
In this PR:
- there are two easyconfig for a new `mango-auth` module for 2024a and 2025a
- the proposed modules depend on `python-irodsclient` (see below)

Requires:
- #25564 