### PR TITLE
{phys}[foss/2025b] SPH-EXA-0.96.1 CUDA-12.9.1

### DIFF
--- a/easybuild/easyconfigs/s/SPH-EXA/SPH-EXA-0.96.1-foss-2025b-CUDA-12.9.1.eb
+++ b/easybuild/easyconfigs/s/SPH-EXA/SPH-EXA-0.96.1-foss-2025b-CUDA-12.9.1.eb
@@ -22,6 +22,8 @@ builddependencies = [
 dependencies = [
     ('HDF5', '1.14.6'),
     ('CUDA', '12.9.1', '', SYSTEM),
+    ('UCX-CUDA', '1.19.0', versionsuffix),
+    ('UCC-CUDA', '1.4.4', versionsuffix),
 ]
 
 cuda_compute_capabilities = ['8.0', '8.6', '8.9', '9.0']

--- a/easybuild/easyconfigs/s/SPH-EXA/SPH-EXA-0.96.1-foss-2025b-CUDA-12.9.1.eb
+++ b/easybuild/easyconfigs/s/SPH-EXA/SPH-EXA-0.96.1-foss-2025b-CUDA-12.9.1.eb
@@ -1,0 +1,40 @@
+easyblock = 'CMakeMake'
+
+name = 'SPH-EXA'
+version = '0.96.1'
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = 'https://github.com/sphexa-org/sphexa'
+description = """ SPH-EXA is a C++20 simulation code for hydrodynamics simulations
+(with gravity and other physics), parallelized with MPI, OpenMP, CUDA, and HIP."""
+
+toolchain = {'name': 'foss', 'version': '2025b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/sphexa-org/sphexa/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['3b7bf2c2b24d5d00e1eb66d74820888a87a38e017272d2c5977c4aa82f16368e']
+
+builddependencies = [
+    ('CMake', '4.0.3'),
+]
+
+dependencies = [
+    ('HDF5', '1.14.6'),
+    ('CUDA', '12.9.1', '', SYSTEM),
+]
+
+cuda_compute_capabilities = ['8.0', '8.6', '8.9', '9.0']
+
+configopts = "-DCSTONE_WITH_GPU_AWARE_MPI=ON"
+
+buildopts = "sphexa-cuda"
+
+sanity_check_paths = {
+    'files': ['bin/sphexa', 'bin/sphexa-cuda'],
+    'dirs': [],
+}
+
+sanity_check_commands = ["sphexa --help"]
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/s/SPH-EXA/SPH-EXA-0.96.1-foss-2025b-CUDA-12.9.1.eb
+++ b/easybuild/easyconfigs/s/SPH-EXA/SPH-EXA-0.96.1-foss-2025b-CUDA-12.9.1.eb
@@ -1,3 +1,8 @@
+# This file is an EasyBuild reciPY as per https://easybuild.io/
+# Author: Pablo Escobar Lopez
+# sciCORE - University of Basel
+# SIB Swiss Institute of Bioinformatics
+
 easyblock = 'CMakeMake'
 
 name = 'SPH-EXA'


### PR DESCRIPTION
I would like to get this easyconfig into EESSI

@ocaisa when using EESSI 2025.6 I had to remove the deps for `UCX-CUDA` and `UCC-CUDA` . I guess that's expected?
