### PR TITLE
Use EasyBuild packages in venv for building pod5 wheel

### DIFF
--- a/easybuild/easyconfigs/p/pod5-file-format/pod5-file-format-0.3.10-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/pod5-file-format/pod5-file-format-0.3.10-foss-2023a.eb
@@ -12,7 +12,10 @@ toolchain = {'name': 'foss', 'version': '2023a'}
 
 source_urls = ['https://github.com/nanoporetech/%(name)s/archive/']
 sources = [{'download_filename': '%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
-patches = ['pod5-file-format-0.3.10_dep_fix.patch']
+patches = [
+    'pod5-file-format-0.3.10_dep_fix.patch',
+    'pod5-file-format-0.3.10_python_wheel_no_isolation.patch',
+]
 checksums = [
     {'pod5-file-format-0.3.10.tar.gz': 'eb177018b310e508f7ad6b5d486cc29166404dd5f82879d0c26aceaff51d3768'},
     {'pod5-file-format-0.3.10_dep_fix.patch': '20dc87ab82d4b52ff7fb769d17c2478daf95f787b2a184c9d985e33e03038e31'},
@@ -48,6 +51,13 @@ local_preinstallopts = (
     " pyproject.toml && "
 )
 
+
+local_lib_pod5_preinstall = (
+    "sed -i '/pbr/d' setup.cfg 2>/dev/null || true && "
+    "sed -i '/pbr/d' setup.py 2>/dev/null || true && "
+)
+
+
 exts_defaultclass = 'PythonPackage'
 exts_default_options = {
     'source_urls': [PYPI_SOURCE],
@@ -55,6 +65,7 @@ exts_default_options = {
 exts_list = [
     ('lib-pod5', version, {
         'nosource': True,
+        'preinstallopts': local_lib_pod5_preinstall,
         # Build and installed by CMake
         'install_src': '%(installdir)s/lib_pod5-%(version)s-*.whl',
         'modulename': 'lib_pod5',

--- a/easybuild/easyconfigs/p/pod5-file-format/pod5-file-format-0.3.10-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/pod5-file-format/pod5-file-format-0.3.10-foss-2023a.eb
@@ -51,13 +51,6 @@ local_preinstallopts = (
     " pyproject.toml && "
 )
 
-
-local_lib_pod5_preinstall = (
-    "sed -i '/pbr/d' setup.cfg 2>/dev/null || true && "
-    "sed -i '/pbr/d' setup.py 2>/dev/null || true && "
-)
-
-
 exts_defaultclass = 'PythonPackage'
 exts_default_options = {
     'source_urls': [PYPI_SOURCE],
@@ -65,7 +58,6 @@ exts_default_options = {
 exts_list = [
     ('lib-pod5', version, {
         'nosource': True,
-        'preinstallopts': local_lib_pod5_preinstall,
         # Build and installed by CMake
         'install_src': '%(installdir)s/lib_pod5-%(version)s-*.whl',
         'modulename': 'lib_pod5',

--- a/easybuild/easyconfigs/p/pod5-file-format/pod5-file-format-0.3.10-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/pod5-file-format/pod5-file-format-0.3.10-foss-2023a.eb
@@ -19,6 +19,8 @@ patches = [
 checksums = [
     {'pod5-file-format-0.3.10.tar.gz': 'eb177018b310e508f7ad6b5d486cc29166404dd5f82879d0c26aceaff51d3768'},
     {'pod5-file-format-0.3.10_dep_fix.patch': '20dc87ab82d4b52ff7fb769d17c2478daf95f787b2a184c9d985e33e03038e31'},
+    {'pod5-file-format-0.3.10_python_wheel_no_isolation.patch':
+     '5f33fbee877b7ca6b59000f3683f6786dbdbd47725e53ca23d709465b1bf5ba7'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/p/pod5-file-format/pod5-file-format-0.3.10_python_wheel_no_isolation.patch
+++ b/easybuild/easyconfigs/p/pod5-file-format/pod5-file-format-0.3.10_python_wheel_no_isolation.patch
@@ -1,0 +1,27 @@
+Patch pod5 wheel build to use system site packages instead of an isolated build environment.
+Author: Steven Vandenbrande (steven.vandenbrande@kuleuven.be)
+diff --git a/c++/pod5_format_pybind/build_wheel.cmake b/c++/pod5_format_pybind/build_wheel.cmake
+--- a/c++/pod5_format_pybind/build_wheel.cmake
++++ b/c++/pod5_format_pybind/build_wheel.cmake
+@@ -10,10 +10,10 @@
+
+ file(COPY "${PYBIND_INPUT_LIB}" DESTINATION "${PYTHON_PROJECT_DIR}/src/lib_pod5")
+
+-message("  using: ${PYTHON_EXECUTABLE} -m build --outdir ${WHEEL_OUTPUT_DIR}")
++message("  using: ${PYTHON_EXECUTABLE} -m build --no-isolation --outdir ${WHEEL_OUTPUT_DIR}")
+
+ execute_process(
+-    COMMAND ${PYTHON_EXECUTABLE} -m build --outdir ${WHEEL_OUTPUT_DIR}
++    COMMAND ${PYTHON_EXECUTABLE} -m build --no-isolation --outdir ${WHEEL_OUTPUT_DIR}
+     WORKING_DIRECTORY "${PYTHON_PROJECT_DIR}/"
+     RESULT_VARIABLE exit_code
+     OUTPUT_VARIABLE output
+--- a/python/lib_pod5/pyproject.toml	2026-03-24 08:32:14.511418000 +0100
++++ b/python/lib_pod5/pyproject.toml	2026-03-24 08:32:41.485544000 +0100
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["setuptools >= 61.0", "wheel", "pybind11~=2.10.0"]
++requires = ["setuptools >= 61.0", "wheel", "pybind11~=2.11.1"]
+ build-backend = "setuptools.build_meta"
+ 
+ 


### PR DESCRIPTION
This PR solves the same problem as https://github.com/easybuilders/easybuild-easyconfigs/pull/25127 (where it occurred for LAMMPS). When building a wheel for pod5, a temporary, isolated venv is created. This gives errors looking like
```
      import pkg_resources
  ModuleNotFoundError: No module named 'pkg_resources'
```
The solution proposed here is to add `--no-isolation` as an option when building the wheel. Additionally, the `pybind` version has to be pinned to the version provided by the EasyBuild dependency.

 (created using `eb --new-pr`)
