### PR TITLE
texlive-20230313: remove modextravars TEXMFHOME

### DIFF
--- a/easybuild/easyconfigs/t/texlive/texlive-20230313-GCC-11.3.0.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20230313-GCC-11.3.0.eb
@@ -73,6 +73,4 @@ modextrapaths = {
     'PATH': 'bin/%(arch)s-linux',
 }
 
-modextravars = {'TEXMFHOME': '%(installdir)s/texmf-dist'}
-
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/texlive/texlive-20230313-GCC-12.3.0.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20230313-GCC-12.3.0.eb
@@ -73,6 +73,4 @@ modextrapaths = {
     'PATH': 'bin/%(arch)s-linux',
 }
 
-modextravars = {'TEXMFHOME': '%(installdir)s/texmf-dist'}
-
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/texlive/texlive-20230313-GCC-13.2.0.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20230313-GCC-13.2.0.eb
@@ -73,6 +73,4 @@ modextrapaths = {
     'PATH': 'bin/%(arch)s-linux',
 }
 
-modextravars = {'TEXMFHOME': '%(installdir)s/texmf-dist'}
-
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/texlive/texlive-20230313-intel-compilers-2023.2.1.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20230313-intel-compilers-2023.2.1.eb
@@ -73,6 +73,4 @@ modextrapaths = {
     'PATH': 'bin/%(arch)s-linux',
 }
 
-modextravars = {'TEXMFHOME': '%(installdir)s/texmf-dist'}
-
 moduleclass = 'devel'


### PR DESCRIPTION
Setting `TEXMFHOME` equal to `TEXMFDIST` while both are set in the `TEXMF` search path is redundant, and extra slow as `TEXMFHOME` is a non-!! tree (unlike `TEXMFDIST`).

The non-!! trees in a TeX Live installation should typically be extremely small. See https://tug.org/texinfohtml/kpathsea.html#Subdirectory-expansion-1

(On a networked filesystem) this excessive searching of the entire `textmf-dist` tree made any `tex` command prohibitively slow.

Also see:
- https://github.com/easybuilders/easybuild-easyconfigs/issues/18717