### PR TITLE
{cae}[intel/2025a] SWASH v20260309

### DIFF
--- a/easybuild/easyconfigs/s/SWASH/SWASH-20260309-intel-2025a.eb
+++ b/easybuild/easyconfigs/s/SWASH/SWASH-20260309-intel-2025a.eb
@@ -1,0 +1,37 @@
+easyblock = 'CMakeNinja'
+name = 'SWASH'
+version = '20260309'
+_commit = 'c3a751a4b46471e9c21c65544df584946636529d'
+
+homepage = 'https://swash.sourceforge.net/'
+description = """SWASH is a general-purpose numerical tool for simulating unsteady, non-hydrostatic, free-surface,
+ rotational flow and transport phenomena in coastal waters as driven by waves, tides, buoyancy and wind forces."""
+
+toolchain = {'name': 'intel', 'version': '2025a'}
+
+source_urls = ['https://gitlab.tudelft.nl/citg/wavemodels/swash/-/archive/%s/' % _commit]
+sources = ['swash-%s.tar.gz' % _commit]
+patches = ['SWASH_fix-switch-option-parsing.patch']
+checksums = [
+    {'swash-c3a751a4b46471e9c21c65544df584946636529d.tar.gz':
+     'cd9b4f284f30cdb4de75199a164cc03b9f6edb942e3a4d7489ec103adc1e9015'},
+    {'SWASH_fix-switch-option-parsing.patch': '39212427ea2f936685f9649d3bd0daddb7c597178df7aaf950b4a333bab47959'},
+]
+
+builddependencies = [
+    ('CMake', '3.31.3'),
+    ('Ninja', '1.12.1'),
+    ('Perl', '5.40.0'),
+]
+
+configopts = (
+    '-DMPI=ON'
+    ' -DCMAKE_Fortran_COMPILER=mpif90'
+)
+
+sanity_check_paths = {
+    'files': ['bin/swashrun'],
+    'dirs': ['tools', 'mod'],
+}
+
+moduleclass = 'cae'

--- a/easybuild/easyconfigs/s/SWASH/SWASH_fix-switch-option-parsing.patch
+++ b/easybuild/easyconfigs/s/SWASH/SWASH_fix-switch-option-parsing.patch
@@ -1,0 +1,15 @@
+# The switch.pl script will enter an infinite loop when supplied with
+# filenames containing a dash. This patch makes sure only real options are
+# considered as options.
+# Author: steven.vandenbrande@kuleuven.be
+--- a/switch.pl	2026-03-27 11:07:00.433752000 +0100
++++ b/switch.pl	2026-03-27 11:06:35.722043000 +0100
+@@ -9,7 +9,7 @@
+ $imp = "FALSE";
+ $cvi = "FALSE";
+ $mv4 = "FALSE";
+-while ( $ARGV[0]=~/-.*/ )
++while ( $ARGV[0]=~/^-/ )
+    {
+    if ($ARGV[0]=~/-timg/) {$tim="TRUE";shift;}
+    if ($ARGV[0]=~/-mpi/) {$mpi="TRUE";shift;}


### PR DESCRIPTION
There are some very old easyconfigs for SWASH, but the build system has been modernized in the code base hosted at https://gitlab.tudelft.nl/citg/wavemodels/swash/-/tree/main. Unfortunately, it does not have releases as far as I can seem so this PR uses the latest version of the main branch at the time of creation.

(created using `eb --new-pr`)
