### PR TITLE
install `graphviz` in CI workflow for easyconfigs test suite, required for `test_dep_graph`

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -49,7 +49,7 @@ jobs:
         # for testing OpenMPI-system*eb we need to have Open MPI installed
         sudo apt-get install libopenmpi-dev openmpi-bin
         # required for test_dep_graph
-        pip install pycodestyle python-graph-core python-graph-dot
+        pip install pycodestyle graphviz
 
     - name: install EasyBuild framework
       run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -49,6 +49,7 @@ jobs:
         # for testing OpenMPI-system*eb we need to have Open MPI installed
         sudo apt-get install libopenmpi-dev openmpi-bin
         # required for test_dep_graph
+        sudo apt-get install graphviz
         pip install pycodestyle graphviz
 
     - name: install EasyBuild framework


### PR DESCRIPTION
fix for broken `test_dep_graph` in easyconfigs test suite in CI:
```
ERROR: test_dep_graph (test.easyconfigs.easyconfigs.EasyConfigTest)
Unit test that builds a full dependency graph.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/easybuild-easyconfigs/easybuild-easyconfigs/test/easyconfigs/easyconfigs.py", line 320, in test_dep_graph
    dep_graph(fn, self.ordered_specs)
  File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/easybuild/tools/utilities.py", line 194, in error
    raise EasyBuildError("ImportError: %s", msg)
easybuild.tools.build_log.EasyBuildError: ImportError: None of the specified modules (graphviz) is available (provided by Python package graphviz, available from https://pypi.python.org/pypi/graphviz), yet one of them is required!

```

requires because of changes in:
- https://github.com/easybuilders/easybuild-framework/pull/5128