### PR TITLE
disable `test_dep_graph` for now, since it takes excessively long

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -306,7 +306,9 @@ class EasyConfigTest(TestCase):
             self._get_changed_patches()
         return EasyConfigTest._changed_patches
 
-    def test_dep_graph(self):
+    # dep_graph takes an excessive long time,
+    # due to changes in https://github.com/easybuilders/easybuild-framework/pull/5128
+    def _DISABLED_TOO_SLOW_test_dep_graph(self):
         """Unit test that builds a full dependency graph."""
 
         if not single_tests_ok:


### PR DESCRIPTION
The time required to run the easyconfigs test suite has suddenly become excessively long (4-5h), see:
- test suite run for [PR #25696](https://github.com/easybuilders/easybuild-easyconfigs/pull/25696): https://github.com/easybuilders/easybuild-easyconfigs/actions/runs/24161435256/job/70513455123
- post-merge test in `develop` branch: https://github.com/easybuilders/easybuild-easyconfigs/actions/runs/24169292277/job/70537409128

This is most likely caused by the changes to the `dep_graph` function in this framework PR:
- https://github.com/easybuilders/easybuild-framework/pull/5128

For normal use cases, like creating a dependency graph for `Single-cell-python-bundle-2024.02-foss-2023a.eb` (which involves 300+ easyconfigs), it works perfectly fine (and finishes in seconds).

However, it seems that when `dep_graph` is called on all (11.5k) easyconfigs we have, it takes an excessively long time.

For now, we can just disable this test until we figure this out, which shouldn't cause much trouble. This "global" test rarely fails (we detect missing easyconfigs for dependencies via `test_dep_versions_per_toolchain_generation`, not via `test_dep_graph`).