### PR TITLE
add patch for graniterapids support to OpenBLAS 0.3.27

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.27-GCC-13.3.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.27-GCC-13.3.0.eb
@@ -22,6 +22,7 @@ patches = [
     'OpenBLAS-0.3.27_riscv-drop-static-fortran-flag.patch',
     'OpenBLAS-0.3.27_add_zen5_support.patch',
     'OpenBLAS-0.3.27_add_new_intel_cpus_support.patch',
+    'OpenBLAS-0.3.27_add_graniterapids_support.patch',
 ]
 checksums = [
     {'v0.3.27.tar.gz': 'aa2d68b1564fe2b13bc292672608e9cdeeeb6dc34995512e65c3b10f4599e897'},
@@ -38,6 +39,8 @@ checksums = [
     {'OpenBLAS-0.3.27_add_zen5_support.patch': '218043f78c00a6418b5db059f9bf8cb067a7a1002c5f3d837069d89441db2d92'},
     {'OpenBLAS-0.3.27_add_new_intel_cpus_support.patch':
      '62698cbffb65dfd6632ac2cbd956adaa43bbbb8b607f71fabce40e9a49058c89'},
+    {'OpenBLAS-0.3.27_add_graniterapids_support.patch':
+     'd704b041e1111cd73923dafc360120e06eab085f41d02b3f509d7b19a1c9300d'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.27_add_graniterapids_support.patch
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.27_add_graniterapids_support.patch
@@ -1,0 +1,56 @@
+# Add autodetection support for Intel Granite Rapids as Sapphire Rapids
+# based on https://github.com/OpenMathLib/OpenBLAS/pull/4876
+# Author: martin-frbg
+--- a/cpuid_x86.c
++++ b/cpuid_x86.c
+@@ -1527,6 +1527,19 @@ int get_cpuname(void){
+       break;
+       case 10: //family 6 exmodel 10
+         switch (model) {
++	  case 13: // Granite Rapids
++	  if(support_amx_bf16())
++	    return CPUTYPE_SAPPHIRERAPIDS;
++	  if(support_avx512_bf16())
++            return CPUTYPE_COOPERLAKE;	
++          if(support_avx512())
++            return CPUTYPE_SKYLAKEX;
++          if(support_avx2())
++            return CPUTYPE_HASWELL;
++          if(support_avx())
++            return CPUTYPE_SANDYBRIDGE;
++          else
++          return CPUTYPE_NEHALEM;
+           case 5: // Comet Lake H and S
+           case 6: // Comet Lake U
+ 	  case 10: // Meteor Lake
+@@ -2352,8 +2365,22 @@ int get_coretype(void){
+ 
+       case 10:
+         switch (model) {
++	  case 13: // Granite Rapids
++	  if(support_amx_bf16())
++	    return CORE_SAPPHIRERAPIDS;
++	  if(support_avx512_bf16())
++            return CORE_COOPERLAKE;	
++          if(support_avx512())
++            return CORE_SKYLAKEX;
++          if(support_avx2())
++            return CORE_HASWELL;
++          if(support_avx())
++	    return CORE_SANDYBRIDGE;
++	  else
++	    return CORE_NEHALEM;
+ 	  case 5: // Comet Lake H and S
+     	  case 6: // Comet Lake U
++	  case 10: // Meteor Lake
+             if(support_avx())
+   #ifndef NO_AVX2
+               return CORE_HASWELL;
+@@ -2362,6 +2389,7 @@ int get_coretype(void){
+   #endif
+             else
+               return CORE_NEHALEM;
++	  case 0: // Meteor Lake
+ 	  case 7:// Rocket Lake
+ #ifndef NO_AVX512
+ 	  if(support_avx512())


### PR DESCRIPTION
OpenBLAS-0.3.27 can not detect the Intel GraniteRapids CPUs, this PR backports https://github.com/OpenMathLib/OpenBLAS/pull/4876 to fix build issues because of that.

(created using `eb --new-pr`)
