### PR TITLE
Fix CI tests when dependencies get removed on CI machine architecture

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -58,9 +58,10 @@ from easybuild.tools.filetools import change_dir, is_generic_easyblock, read_fil
 from easybuild.tools.filetools import verify_checksum, which, write_file
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.modules import modules_tool
+from easybuild.tools.options import set_tmpdir
 from easybuild.tools.robot import check_conflicts, resolve_dependencies
 from easybuild.tools.run import run_shell_cmd
-from easybuild.tools.options import set_tmpdir
+from easybuild.tools.systemtools import pick_dep_version
 from easybuild.tools.utilities import nub
 
 
@@ -1920,11 +1921,14 @@ def template_easyconfig_test(self, spec):
         # if no easyconfig was found for the dependency with the 'parent' toolchain,
         # if may get resolved using a subtoolchain, which is then hardcoded in the dumped easyconfig
         if key in DEPENDENCY_PARAMETERS:
-            # number of dependencies should remain the same
-            if len(orig_val) != len(dumped_val):
+            # dumped_val has no dependencies where the version resolves to None
+            # which can make the lists have different lengths
+            cleaned_orig_val = [val for val in orig_val if pick_dep_version(val[1]) is not False]
+            # number of dependencies should only be reduced and equal to the filtered ones
+            if len(orig_val) < len(dumped_val) or len(cleaned_orig_val) != len(dumped_val):
                 failing_checks.append("Length difference for %s: %s vs %s" % (key, orig_val, dumped_val))
                 continue
-            for orig_dep, dumped_dep in zip(orig_val, dumped_val):
+            for orig_dep, dumped_dep in zip(cleaned_orig_val, dumped_val):
                 # name should always match
                 if orig_dep[0] != dumped_dep[0]:
                     failing_checks.append("Different name in %s: %s vs %s" % (key, orig_dep[0], dumped_dep[0]))


### PR DESCRIPTION
The test checks that (raw) parsed and dumped dependencies are the same. However a dependency can get removed by setting the version to `False`, possibly depending on the current system architecture. This makes the list have different lengths and the test fails.

Fix by filtering the list first removing such `False`-entries. The original list should be at least as long as the dumped list and the dumped list should be equal to the filtered list.

This is required for the PRs adding ACL & IMKL to PyTorch, e.g. https://github.com/easybuilders/easybuild-easyconfigs/actions/runs/24199931920/job/70640443751?pr=25726


A more pressing issue: Our CI tests only test on a single architecture. So if e.g. the ACL easyconfig is missing, but only used on AArch then the CI check will not catch that.

Idea: Mock the `pick_system_specific_value` to never return `False`. This will still miss cases where a different version would be used and one is missing but at least catch those only present on some archs. But we could select a random version each time. See #25739 which is the alternative.

Closes #25739