### PR TITLE
add patch to tbb 2022.2.0 easyconfig to avoid the use of `-fcf-protection=full` for riscv64

### DIFF
--- a/easybuild/easyconfigs/t/tbb/tbb-2022.2.0-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/t/tbb/tbb-2022.2.0-GCCcore-14.3.0.eb
@@ -14,7 +14,11 @@ toolchainopts = {'extra_cxxflags': '-Wno-error=stringop-overflow'}
 
 source_urls = ['https://github.com/oneapi-src/oneTBB/archive/refs/tags/']
 sources = ['v%(version)s.tar.gz']
-checksums = ['f0f78001c8c8edb4bddc3d4c5ee7428d56ae313254158ad1eec49eced57f6a5b']
+patches = ['tbb-2022.2.0_fix_flag_riscv.patch']
+checksums = [
+    {'v%(version)s.tar.gz': 'f0f78001c8c8edb4bddc3d4c5ee7428d56ae313254158ad1eec49eced57f6a5b'},
+    {'tbb-2022.2.0_fix_flag_riscv.patch': '00c63199eabfac27bf2776941cf37da30d0a8d06a7e47d9d739e8a977f22d049'},
+]
 
 builddependencies = [
     ('binutils', '2.44'),

--- a/easybuild/easyconfigs/t/tbb/tbb-2022.2.0_fix_flag_riscv.patch
+++ b/easybuild/easyconfigs/t/tbb/tbb-2022.2.0_fix_flag_riscv.patch
@@ -1,0 +1,13 @@
+Add riscv64 to the list of architectures that do not support "-fcf-protection=full" flag
+Author: julianmorillo
+--- cmake/compilers/GNU.cmake.ORIG	2026-04-10 16:28:04.604671999 +0200
++++ cmake/compilers/GNU.cmake	2026-04-10 16:36:36.796584643 +0200
+@@ -107,7 +107,7 @@
+ set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -fno-strict-overflow -fno-delete-null-pointer-checks -fwrapv)
+ set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -Wformat -Wformat-security -Werror=format-security
+     -fstack-protector-strong )
+-if (NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" AND NOT EMSCRIPTEN)
++if (NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|riscv64" AND NOT EMSCRIPTEN)
+     set(TBB_LIB_COMPILE_FLAGS ${TBB_LIB_COMPILE_FLAGS} $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},8.0>>:-fcf-protection=full>)
+ endif ()
+ set(TBB_LIB_COMPILE_FLAGS ${TBB_LIB_COMPILE_FLAGS} $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},8.0>>:-fstack-clash-protection>)


### PR DESCRIPTION
This flag is not supported in both `aarch64` and `riscv64`. While there is a protection in the cmake file for aarch64, riscv64 is not considered.