### PR TITLE
Patch RStudio to correctly set `$R_HOME` when calculating `$LD_LIBRARY_PATH`

### DIFF
--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2024.09.0+375-foss-2023b-Java-11-R-4.4.1.eb
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2024.09.0+375-foss-2023b-Java-11-R-4.4.1.eb
@@ -22,10 +22,14 @@ toolchain = {'name': 'foss', 'version': '2023b'}
 
 source_urls = ['https://github.com/rstudio/rstudio/archive']
 sources = ['v%(version)s.tar.gz']
-patches = ['RStudio-Server-1.2.1335-fix_env.patch']
+patches = [
+    'RStudio-Server-1.2.1335-fix_env.patch',
+    'RStudio-Server-r_home-typo.patch',
+]
 checksums = [
     {'v2024.09.0+375.tar.gz': '8a29b77c53a3db8379d824a9f4a491843036003d105ed71981cd40fe39d2c8c8'},
     {'RStudio-Server-1.2.1335-fix_env.patch': 'a7b6edab4f5605f5695b5a987f2f1b229e90dbcfcb7a85cc2ea9341e8766941b'},
+    {'RStudio-Server-r_home-typo.patch': '642a298a9e7342fca0de8bde233f80bedc9e9524b2fc2553e859925b09c5513f'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2024.12.0+467-foss-2024a-R-4.4.2.eb
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2024.12.0+467-foss-2024a-R-4.4.2.eb
@@ -22,10 +22,14 @@ toolchain = {'name': 'foss', 'version': '2024a'}
 
 source_urls = ['https://github.com/rstudio/rstudio/archive']
 sources = ['v%(version)s.tar.gz']
-patches = ['RStudio-Server-1.2.1335-fix_env.patch']
+patches = [
+    'RStudio-Server-1.2.1335-fix_env.patch',
+    'RStudio-Server-r_home-typo.patch',
+]
 checksums = [
     {'v%(version)s.tar.gz': '4f976a3b77f1c3b6a61b8e1a1850aeba0e0a847efbfc17b03b2fcb19fce13d6a'},
     {'RStudio-Server-1.2.1335-fix_env.patch': 'a7b6edab4f5605f5695b5a987f2f1b229e90dbcfcb7a85cc2ea9341e8766941b'},
+    {'RStudio-Server-r_home-typo.patch': '642a298a9e7342fca0de8bde233f80bedc9e9524b2fc2553e859925b09c5513f'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2025.09.2+418-foss-2025a-R-4.5.1.eb
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2025.09.2+418-foss-2025a-R-4.5.1.eb
@@ -22,10 +22,14 @@ toolchain = {'name': 'foss', 'version': '2025a'}
 
 source_urls = ['https://github.com/rstudio/rstudio/archive']
 sources = ['v%(version)s.tar.gz']
-patches = ['RStudio-Server-1.2.1335-fix_env.patch']
+patches = [
+    'RStudio-Server-1.2.1335-fix_env.patch',
+    'RStudio-Server-r_home-typo.patch',
+]
 checksums = [
     {'v2025.09.2+418.tar.gz': '7e64e65bd3457855e981698dfb61f84e23de0d8bfcb2b1ffc28a38b5b964a769'},
     {'RStudio-Server-1.2.1335-fix_env.patch': 'a7b6edab4f5605f5695b5a987f2f1b229e90dbcfcb7a85cc2ea9341e8766941b'},
+    {'RStudio-Server-r_home-typo.patch': '642a298a9e7342fca0de8bde233f80bedc9e9524b2fc2553e859925b09c5513f'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-r_home-typo.patch
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-r_home-typo.patch
@@ -1,0 +1,26 @@
+From 1dd6cb14f9088c4d7fbb3bf76128bbd134c9d63b Mon Sep 17 00:00:00 2001
+From: ocaisa <alan.ocais@cecam.org>
+Date: Fri, 10 Apr 2026 14:01:24 +0200
+Subject: [PATCH] Suspected typo in `r-ldpath.in`
+
+At the least this would be unfortunate naming, but I believe this may actually be a typo.
+
+Without this change, it seems that `R_HOME` is not set when calling `$RHOME/etc/ldpaths` which means that the system path `/lib` (instead of `$R_HOME/lib`) gets included in `LD_LIBRARY_PATH` when opening a terminal. On most systems this probably has no impact, but we install RStudio under Gentoo Prefix which breaks in this case.
+---
+ src/cpp/session/r-ldpath.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/cpp/session/r-ldpath.in b/src/cpp/session/r-ldpath.in
+index 49816ce6b12..ca627c9de28 100755
+--- a/src/cpp/session/r-ldpath.in
++++ b/src/cpp/session/r-ldpath.in
+@@ -15,7 +15,7 @@
+ #
+ #
+ 
+-RHOME=$1
+-. $RHOME/etc/ldpaths
++R_HOME=$1
++. $R_HOME/etc/ldpaths
+ echo -n "${@LIBRARY_PATH_ENVVAR@}"
+ 


### PR DESCRIPTION
See https://github.com/rstudio/rstudio/pull/17390

I haven't gone too far back as I know these RStudio packages are brittle (some nodejs dependencies are not pinned)