### PR TITLE
fix URL in comment to specific commit for ELPA eayconfigs using `lfoss` toolchain

### DIFF
--- a/easybuild/easyconfigs/e/ELPA/ELPA-2025.06.001-lfoss-2025b.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2025.06.001-lfoss-2025b.eb
@@ -36,7 +36,7 @@ builddependencies = [
 
 preconfigopts = './autogen.sh && export LDFLAGS="-lm $LDFLAGS" && autoreconf && '
 
-# See https://github.com/marekandreas/elpa/blob/master/documentation/INSTALL.md?plain=1#L600
+# See https://github.com/marekandreas/elpa/blob/2f09197d8342243f431025686ed59f7bb/documentation/INSTALL.md?plain=1#L603
 prebuildopts = 'sed -i \'s:\\\\$wl:-Wl,:g\' libtool && '
 
 # When building in parallel, the file test_setup_mpi.mod is sometimes

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2025.06.002-lfoss-2025b.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2025.06.002-lfoss-2025b.eb
@@ -37,7 +37,7 @@ builddependencies = [
 # need to autoreconf to avoid '-Wl' errors
 preconfigopts = 'autoreconf -fi && LDFLAGS="-fuse-ld=lld -lm $LDFLAGS" '
 
-# See https://github.com/marekandreas/elpa/blob/master/documentation/INSTALL.md?plain=1#L600
+# See https://github.com/marekandreas/elpa/blob/2f09197d8342243f431025686ed59f7bb/documentation/INSTALL.md?plain=1#L603
 prebuildopts = 'sed -i \'s:\\\\$wl:-Wl,:g\' libtool && '
 
 # When building in parallel, the file test_setup_mpi.mod is sometimes


### PR DESCRIPTION
The URL was pointing to the master branch but the mentioned part has been removed