### PR TITLE
add googletest as build dependency for SPH-EXA

### DIFF
--- a/easybuild/easyconfigs/s/SPH-EXA/SPH-EXA-0.96.2-foss-2023b-CUDA-12.4.0.eb
+++ b/easybuild/easyconfigs/s/SPH-EXA/SPH-EXA-0.96.2-foss-2023b-CUDA-12.4.0.eb
@@ -26,6 +26,7 @@ checksums = [
 
 builddependencies = [
     ('CMake', '3.27.6'),
+    ('googletest', '1.14.0'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/s/SPH-EXA/SPH-EXA-0.96.2-foss-2025b-CUDA-12.9.1.eb
+++ b/easybuild/easyconfigs/s/SPH-EXA/SPH-EXA-0.96.2-foss-2025b-CUDA-12.9.1.eb
@@ -26,6 +26,7 @@ checksums = [
 
 builddependencies = [
     ('CMake', '4.0.3'),
+    ('googletest', '1.17.0'),
 ]
 
 dependencies = [


### PR DESCRIPTION
I found this in the log of an SPH-EXA build:
```
-- Could NOT find GTest (missing: GTEST_LIBRARY GTEST_INCLUDE_DIR GTEST_MAIN_LIBRARY) 
-- Configure GTest from github
-- Downloading GTest from github
```

Also see: https://github.com/sphexa-org/sphexa/blob/v0.96.2/cmake/setup_GTest.cmake.