### PR TITLE
use `julia.wrapper` + don't set `$JULIA_DEPOT_PATH` in multi-arch in easyconfigs for Julia 1.11.x + 1.12.x

### DIFF
--- a/easybuild/easyconfigs/j/Julia/Julia-1.11.5.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.11.5.eb
@@ -11,6 +11,7 @@ toolchain = SYSTEM
 source_urls = ['https://julialang-s3.julialang.org/bin/linux/x64/%(version_major_minor)s/',
                'https://julialang-s3.julialang.org/bin/linux/%(arch)s/%(version_major_minor)s/']
 sources = ['%(namelower)s-%(version)s-linux-%(arch)s.tar.gz']
+patches = [('julia.wrapper', 'bin/')]
 checksums = [
     {
         'julia-1.11.5-linux-x86_64.tar.gz':
@@ -19,21 +20,20 @@ checksums = [
             'f63203574fba25c9bda5e98b2f87f985d4672109855633a46bae32bfba3cbc0d',
         'julia-1.11.5-linux-ppc64le.tar.gz':
             '11ae7f0b83663de35d9a30e916373378f7985424c030a4a5af96aecc9b6eaa66',
-    }
+    },
+    {
+        'julia.wrapper':
+            'd10aeaff53cca9875f7b0ce9218eae3bd21870b654e26c4c52aa8bfcc9da702d',
+    },
 ]
 
+# install wrapper with linking safeguards for Julia libraries
+postinstallcmds = ["cd %(installdir)s/bin && mv julia julia.bin && mv julia.wrapper julia"]
+
 sanity_check_paths = {
-    'files': ['bin/julia', 'include/julia/julia.h', 'lib/libjulia.%s' % SHLIB_EXT],
-    'dirs': ['bin', 'etc', 'include', 'lib', 'share']
+    'files': ['bin/julia', 'bin/julia.bin', 'include/julia/julia.h', 'lib/libjulia.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'etc', 'include', 'lib', 'lib/julia', 'share']
 }
-
 sanity_check_commands = ['julia --help']
-
-modextravars = {
-    # Use default DEPOT_PATH where first entry is user's depot
-    # JULIA_DEPOT_PATH must be set to be able to load other JuliaPackage modules and have
-    # those installations appended to DEPOT_PATH without disabling any of the default paths
-    'JULIA_DEPOT_PATH': ':',
-}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/j/Julia/Julia-1.11.7.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.11.7.eb
@@ -11,6 +11,7 @@ toolchain = SYSTEM
 source_urls = ['https://julialang-s3.julialang.org/bin/linux/x64/%(version_major_minor)s/',
                'https://julialang-s3.julialang.org/bin/linux/%(arch)s/%(version_major_minor)s/']
 sources = ['%(namelower)s-%(version)s-linux-%(arch)s.tar.gz']
+patches = [('julia.wrapper', 'bin/')]
 checksums = [
     {
         'julia-1.11.7-linux-x86_64.tar.gz':
@@ -19,20 +20,20 @@ checksums = [
             'f97f80b35c12bdaf40c26f6c55dbb7617441e49c9e6b842f65e8410a388ca6f4',
         'julia-1.11.7-linux-ppc64le.tar.gz':
             '68f1e3a7e530e97aabbe79edfcf38d219348ae5d065a19a7aa652ac57a940b85',
-    }
+    },
+    {
+        'julia.wrapper':
+            'd10aeaff53cca9875f7b0ce9218eae3bd21870b654e26c4c52aa8bfcc9da702d',
+    },
 ]
+
+# install wrapper with linking safeguards for Julia libraries
+postinstallcmds = ["cd %(installdir)s/bin && mv julia julia.bin && mv julia.wrapper julia"]
+
 sanity_check_paths = {
-    'files': ['bin/julia', 'include/julia/julia.h', 'lib/libjulia.%s' % SHLIB_EXT],
-    'dirs': ['bin', 'etc', 'include', 'lib', 'share']
+    'files': ['bin/julia', 'bin/julia.bin', 'include/julia/julia.h', 'lib/libjulia.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'etc', 'include', 'lib', 'lib/julia', 'share']
 }
-
 sanity_check_commands = ['julia --help']
-
-modextravars = {
-    # Use default DEPOT_PATH where first entry is user's depot
-    # JULIA_DEPOT_PATH must be set to be able to load other JuliaPackage modules and have
-    # those installations appended to DEPOT_PATH without disabling any of the default paths
-    'JULIA_DEPOT_PATH': ':',
-}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/j/Julia/Julia-1.12.2.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.12.2.eb
@@ -11,26 +11,27 @@ toolchain = SYSTEM
 source_urls = ['https://julialang-s3.julialang.org/bin/linux/x64/%(version_major_minor)s/',
                'https://julialang-s3.julialang.org/bin/linux/%(arch)s/%(version_major_minor)s/']
 sources = ['%(namelower)s-%(version)s-linux-%(arch)s.tar.gz']
+patches = [('julia.wrapper', 'bin/')]
 checksums = [
     {
         'julia-1.12.2-linux-x86_64.tar.gz':
             'a6d0c39ea57303ebcffa7a8d453429b86eb271e150c7cb0f5958fe65909b493a',
         'julia-1.12.2-linux-aarch64.tar.gz':
             '0383a2ce378b64356269f6f15e612f344523f507a9753f71a0b64ca02092445b',
-    }
+    },
+    {
+        'julia.wrapper':
+            'd10aeaff53cca9875f7b0ce9218eae3bd21870b654e26c4c52aa8bfcc9da702d',
+    },
 ]
+
+# install wrapper with linking safeguards for Julia libraries
+postinstallcmds = ["cd %(installdir)s/bin && mv julia julia.bin && mv julia.wrapper julia"]
+
 sanity_check_paths = {
-    'files': ['bin/julia', 'include/julia/julia.h', 'lib/libjulia.%s' % SHLIB_EXT],
-    'dirs': ['bin', 'etc', 'include', 'lib', 'share']
+    'files': ['bin/julia', 'bin/julia.bin', 'include/julia/julia.h', 'lib/libjulia.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'etc', 'include', 'lib', 'lib/julia', 'share']
 }
-
 sanity_check_commands = ['julia --help']
-
-modextravars = {
-    # Use default DEPOT_PATH where first entry is user's depot
-    # JULIA_DEPOT_PATH must be set to be able to load other JuliaPackage modules and have
-    # those installations appended to DEPOT_PATH without disabling any of the default paths
-    'JULIA_DEPOT_PATH': ':',
-}
 
 moduleclass = 'lang'


### PR DESCRIPTION
To make those easyconfigs more similar to the linux-x86_64 ones. Fixes #25835