### PR TITLE
{bio}[foss/2025b] GROMACS v2025.4 w/ CUDA 12.9.1 (and apply patch to retain letter suffix of CUDA compute capability to 2025.3)

### DIFF
--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2025.3-foss-2025b-CUDA-12.9.1.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2025.3-foss-2025b-CUDA-12.9.1.eb
@@ -41,6 +41,7 @@ patches = [
     'GROMACS-2023.1_set_omp_num_threads_env_for_ntomp_tests.patch',
     'GROMACS-2023.1_fix_tests_for_gmx_thread_mpi.patch',
     'GROMACS-2025.2_workaround-arm-sve512.patch',
+    'GROMACS-2025.3_retain_cuda_cc_suffix.patch',
 ]
 checksums = [
     {'gromacs-2025.3.tar.gz': '8bdfca0268f3f10a7ca3c06e59b62f73ea02420c67211c0ff3912f32d7833c65'},
@@ -50,6 +51,7 @@ checksums = [
      '6df844bb3bbc51180446a3595c61a4ef195e5f975533a04cef76841aa763aec1'},
     {'GROMACS-2025.2_workaround-arm-sve512.patch':
      'e62e075ee9328f647954365edd7979ea79e6f1d7a3b84834a2aae546cf74772c'},
+    {'GROMACS-2025.3_retain_cuda_cc_suffix.patch': '8f1ce3da8730f2af715fc6c9a4db3d99f73a5dbdd7d662b67c8ebc8b607ec641'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2025.3_retain_cuda_cc_suffix.patch
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2025.3_retain_cuda_cc_suffix.patch
@@ -1,0 +1,23 @@
+Recent CUDA versions introduced compute capabilities with a suffix (e.g. 12.0f),
+but these get removed by a quite brutal regular expression in the CMake code of GROMACS.
+This patch ensures that we use the CUDA compute capability specified with $GMX_CUDA_TARGET_SM (which is set by EB)
+without cutting off the suffix, and without relying on a regular expression.
+Note that the patch is no longer required for GROMACS 2026, as this code is completely removed.
+
+Author: Bob Dröge (University of Groningen)
+diff -ru gromacs-2025.3.orig/cmake/gmxManageNvccConfig.cmake gromacs-2025.3/cmake/gmxManageNvccConfig.cmake
+--- gromacs-2025.3.orig/cmake/gmxManageNvccConfig.cmake	2026-04-23 15:25:25.473457630 +0200
++++ gromacs-2025.3/cmake/gmxManageNvccConfig.cmake	2026-04-23 16:02:11.546551000 +0200
+@@ -233,6 +233,12 @@
+ # strip gencode/arch from GMX_CUDA_NVCC_GENCODE_FLAGS only keep the arch numbers
+ string(REGEX REPLACE "([A-Za-z=_-])" ""  GMX_CUDA_NVCC_GENCODE_FLAGS "${GMX_CUDA_NVCC_GENCODE_FLAGS}")
+ string(REGEX REPLACE "([0-9]+,)" ""  GMX_CUDA_NVCC_GENCODE_FLAGS "${GMX_CUDA_NVCC_GENCODE_FLAGS}")
++# Added by EasyBuild: if GMX_CUDA_TARGET_SM is set, we simply use that, since it already provides the arch numbers.
++# The regex used above would cut off compute capability suffixes that were introduced in recent CUDA versions
++# (e.g. 120f would result in 120).
++if (GMX_CUDA_TARGET_SM)
++    set(GMX_CUDA_NVCC_GENCODE_FLAGS ${GMX_CUDA_TARGET_SM})
++endif()
+ 
+ # Set the openmp host compilation flag if it has not been set automatically.
+ # Some other compilation flags, mostly warnings are not automatically

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2025.4-foss-2025b-CUDA-12.9.1.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2025.4-foss-2025b-CUDA-12.9.1.eb
@@ -1,0 +1,93 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
+#                                 Ghent University / The Francis Crick Institute
+# Authors::
+# * Wiktor Jurkowski <wiktor.jurkowski@gmail.com>
+# * Fotis Georgatos <fotis@cern.ch>
+# * George Tsouloupas <g.tsouloupas@cyi.ac.cy>
+# * Kenneth Hoste <kenneth.hoste@ugent.be>
+# * Adam Huffman <adam.huffman@crick.ac.uk>
+# * Ake Sandgren <ake.sandgren@hpc2n.umu.se>
+# * J. Sassmannshausen <Crick HPC team>
+# * Dugan Witherick <dugan.witherick@warwick.ac.uk>
+# * Christoph Siegert <christoph.siegert@uni-leipzig.de>
+# License::   MIT/GPL
+
+name = 'GROMACS'
+version = '2025.4'
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = 'https://www.gromacs.org'
+description = """
+GROMACS is a versatile package to perform molecular dynamics, i.e. simulate the
+Newtonian equations of motion for systems with hundreds to millions of
+particles.
+
+This is a GPU enabled build, containing both MPI and threadMPI binaries.
+
+It also contains the gmxapi extension for the single precision MPI build.
+"""
+
+toolchain = {'name': 'foss', 'version': '2025b'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = [
+    'https://ftp.gromacs.org/pub/gromacs/',
+    'ftp://ftp.gromacs.org/pub/gromacs/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'GROMACS-2023.1_set_omp_num_threads_env_for_ntomp_tests.patch',
+    'GROMACS-2023.1_fix_tests_for_gmx_thread_mpi.patch',
+    'GROMACS-2025.3_retain_cuda_cc_suffix.patch',
+]
+checksums = [
+    {'gromacs-2025.4.tar.gz': 'ca17720b4a260eb73649211e9f6a940ee7543452129844213c3accb0a927a5c3'},
+    {'GROMACS-2023.1_set_omp_num_threads_env_for_ntomp_tests.patch':
+     '7f41bda16c9c2837624265dda4be252f655d1288ddc4486b1a2422af30d5d199'},
+    {'GROMACS-2023.1_fix_tests_for_gmx_thread_mpi.patch':
+     '6df844bb3bbc51180446a3595c61a4ef195e5f975533a04cef76841aa763aec1'},
+    {'GROMACS-2025.3_retain_cuda_cc_suffix.patch': '8f1ce3da8730f2af715fc6c9a4db3d99f73a5dbdd7d662b67c8ebc8b607ec641'},
+]
+
+builddependencies = [
+    ('CMake', '4.0.3'),
+    ('scikit-build-core', '0.11.5'),
+    ('pybind11', '3.0.0'),
+]
+
+dependencies = [
+    ('CUDA', '12.9.1', '', SYSTEM),
+    ('UCX-CUDA', '1.19.0', versionsuffix),
+    ('Python', '3.13.5'),
+    ('SciPy-bundle', '2025.07'),
+    ('networkx', '3.5'),
+    ('mpi4py', '4.1.0'),
+]
+
+# be a bit more forgiving w.r.t. timeouts for GROMACS test suite,
+# see also https://gitlab.com/gromacs/gromacs/-/issues/5062
+configopts = "-DGMX_TEST_TIMEOUT_FACTOR=3"
+
+exts_defaultclass = 'PythonPackage'
+
+_gmxapi_source_version = version
+
+exts_list = [
+    # gmxapi version can be found in python_packaging/gmxapi/src/gmxapi/version.py
+    ('gmxapi', '0.5.0a1', {
+        'patches': ['GROMACS-2024.1-fix-gmxapi-version.patch'],
+        'preinstallopts': 'export CMAKE_ARGS="-Dgmxapi_ROOT=%(installdir)s ' +
+                          '-C %(installdir)s/share/cmake/gromacs_mpi/gromacs-hints_mpi.cmake" && ',
+        'source_tmpl': 'gromacs-%s.tar.gz' % _gmxapi_source_version,
+        'start_dir': 'python_packaging/gmxapi',
+        'checksums': [
+            {'gromacs-2025.4.tar.gz': 'ca17720b4a260eb73649211e9f6a940ee7543452129844213c3accb0a927a5c3'},
+            {'GROMACS-2024.1-fix-gmxapi-version.patch':
+                'df30b21352a26d8e01d693e2822db0ea45015c23f900a6ceb68522d44e6e790c'},
+        ],
+    }),
+]
+
+moduleclass = 'bio'


### PR DESCRIPTION
Also applies a new patch to 2025.3, which should ensure that suffixes in compute capabilities are not removed by CMake (otherwise `12.0f` would result in `12.0`).