### PR TITLE
disable `opal_lifo` test for RISC-V in OpenMPI 5.0.8

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.8-llvm-compilers-20.1.8.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.8-llvm-compilers-20.1.8.eb
@@ -22,6 +22,15 @@ checksums = [
      '75d4417e35252ea3a19b2792f1b06e9aeb408c253aa4921d77226d57b71dee45'},
 ]
 
+if ARCH == 'riscv64':
+    patches.append(
+        'OpenMPI-5.0.8_disable_opal_lifo_test.patch',
+    )
+    checksums.append(
+        {'OpenMPI-5.0.8_disable_opal_lifo_test.patch': 
+         '7acc5056a1566e87e48bfc80671d2d5d54802434e89135cf164afeda229dfb5c'},
+    )
+
 builddependencies = [
     ('pkgconf', '2.4.3'),
     ('Perl', '5.40.2'),

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.8-llvm-compilers-20.1.8.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.8-llvm-compilers-20.1.8.eb
@@ -27,7 +27,7 @@ if ARCH == 'riscv64':
         'OpenMPI-5.0.8_disable_opal_lifo_test.patch',
     )
     checksums.append(
-        {'OpenMPI-5.0.8_disable_opal_lifo_test.patch': 
+        {'OpenMPI-5.0.8_disable_opal_lifo_test.patch':
          '7acc5056a1566e87e48bfc80671d2d5d54802434e89135cf164afeda229dfb5c'},
     )
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.8_disable_opal_lifo_test.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.8_disable_opal_lifo_test.patch
@@ -1,0 +1,30 @@
+Disable opal_lifo test in OpenMPI 5.0.8 for RISC-V as it is known to fail.
+See https://github.com/open-mpi/ompi/issues/13762
+Author: julianmorillo
+--- test/class/Makefile.am.ORIGINAL	2026-04-24 10:51:24.024105412 +0200
++++ test/class/Makefile.am	2026-04-24 10:52:52.894265019 +0200
+@@ -34,7 +34,6 @@
+ 	opal_list \
+ 	opal_value_array \
+ 	opal_pointer_array \
+-	opal_lifo \
+ 	opal_fifo \
+ 	opal_cstring
+ 
+@@ -83,11 +82,11 @@
+ 	$(top_builddir)/test/support/libsupport.a
+ ompi_rb_tree_DEPENDENCIES = $(ompi_rb_tree_LDADD)
+ 
+-opal_lifo_SOURCES = opal_lifo.c
+-opal_lifo_LDADD = \
+-        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
+-	$(top_builddir)/test/support/libsupport.a
+-opal_lifo_DEPENDENCIES = $(opal_lifo_LDADD)
++#opal_lifo_SOURCES = opal_lifo.c
++#opal_lifo_LDADD = \
++#        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
++#	$(top_builddir)/test/support/libsupport.a
++#opal_lifo_DEPENDENCIES = $(opal_lifo_LDADD)
+ 
+ opal_fifo_SOURCES = opal_fifo.c
+ opal_fifo_LDADD = \


### PR DESCRIPTION
This test is known to fail in RISC-V. See https://github.com/open-mpi/ompi/issues/13762