### PR TITLE
enable `BUILD_LLVM_DYLIB` configure option to easyconfig for ROCm-LLVM 19.0.0

### DIFF
--- a/easybuild/easyconfigs/r/ROCm-LLVM/ROCm-LLVM-19.0.0-GCCcore-14.2.0-ROCm-6.4.1.eb
+++ b/easybuild/easyconfigs/r/ROCm-LLVM/ROCm-LLVM-19.0.0-GCCcore-14.2.0-ROCm-6.4.1.eb
@@ -85,6 +85,7 @@ components = [
         'build_runtimes': True,
         'full_llvm': False,
         'skip_all_tests': True,
+        'build_shared_libs': True,
     }),
     ('ROCm-comgr', 'rocm-%s' % _rocm_version, {
         # sources are located in amd/comgr subdir of llvm-project component
@@ -136,6 +137,7 @@ components = [
         'build_runtimes': True,
         'full_llvm': False,
         'skip_all_tests': True,
+        'build_shared_libs': True,
     }),
     ('aomp-extras', 'rocm-%s' % _rocm_version, {
         'configopts':

--- a/easybuild/easyconfigs/r/ROCm-LLVM/ROCm-LLVM-19.0.0-GCCcore-14.2.0-ROCm-6.4.1.eb
+++ b/easybuild/easyconfigs/r/ROCm-LLVM/ROCm-LLVM-19.0.0-GCCcore-14.2.0-ROCm-6.4.1.eb
@@ -85,7 +85,7 @@ components = [
         'build_runtimes': True,
         'full_llvm': False,
         'skip_all_tests': True,
-        'build_shared_libs': True,
+        'configopts': '-DLLVM_BUILD_LLVM_DYLIB=ON ',
     }),
     ('ROCm-comgr', 'rocm-%s' % _rocm_version, {
         # sources are located in amd/comgr subdir of llvm-project component
@@ -137,7 +137,6 @@ components = [
         'build_runtimes': True,
         'full_llvm': False,
         'skip_all_tests': True,
-        'build_shared_libs': True,
     }),
     ('aomp-extras', 'rocm-%s' % _rocm_version, {
         'configopts':

--- a/easybuild/easyconfigs/r/ROCm-LLVM/ROCm-LLVM-19.0.0-GCCcore-14.2.0-ROCm-6.4.1.eb
+++ b/easybuild/easyconfigs/r/ROCm-LLVM/ROCm-LLVM-19.0.0-GCCcore-14.2.0-ROCm-6.4.1.eb
@@ -85,7 +85,6 @@ components = [
         'build_runtimes': True,
         'full_llvm': False,
         'skip_all_tests': True,
-        'configopts': '-DLLVM_BUILD_LLVM_DYLIB=ON ',
     }),
     ('ROCm-comgr', 'rocm-%s' % _rocm_version, {
         # sources are located in amd/comgr subdir of llvm-project component
@@ -137,6 +136,7 @@ components = [
         'build_runtimes': True,
         'full_llvm': False,
         'skip_all_tests': True,
+        'configopts': '-DLLVM_BUILD_LLVM_DYLIB=ON ',
     }),
     ('aomp-extras', 'rocm-%s' % _rocm_version, {
         'configopts':


### PR DESCRIPTION
Problems were encountered during building `AdaptiveCpp` will full support.

```
-- Found llc: /home/aayushj/eessi/versions/2025.06/software/linux/x86_64/intel/icelake/software/ROCm-LLVM/19.0.0-GCCcore-14.2.0-ROCm-6.4.1/bin/llc
-- Found ld.lld: /home/aayushj/eessi/versions/2025.06/software/linux/x86_64/intel/icelake/software/ROCm-LLVM/19.0.0-GCCcore-14.2.0-ROCm-6.4.1/bin/ld.lld
-- Found opt: /home/aayushj/eessi/versions/2025.06/software/linux/x86_64/intel/icelake/software/ROCm-LLVM/19.0.0-GCCcore-14.2.0-ROCm-6.4.1/bin/opt
CMake Error at src/compiler/llvm-to-backend/CMakeLists.txt:43 (message):
  LLVM at
  /home/aayushj/eessi/versions/2025.06/software/linux/x86_64/intel/icelake/software/ROCm-LLVM/19.0.0-GCCcore-14.2.0-ROCm-6.4.1/lib/cmake/llvm
  does not have libLLVM.so.  Disable advanced compiler-based functionality
  (-DACPP_COMPILER_FEATURE_PROFILE=minimal, not recommended for most use
  cases) or choose another LLVM installation
Call Stack (most recent call first):
  src/compiler/llvm-to-backend/CMakeLists.txt:146 (create_llvm_based_library)
```

These options will allow the build of `libLLVM.so`.

See: https://github.com/easybuilders/easybuild-easyconfigs/pull/25871#issuecomment-4338109403