### PR TITLE
fix InterProScan patches to properly pick up datasets

### DIFF
--- a/easybuild/easyconfigs/i/InterProScan/InterProScan-5.73-104.0-GCC-13.3.0.eb
+++ b/easybuild/easyconfigs/i/InterProScan/InterProScan-5.73-104.0-GCC-13.3.0.eb
@@ -18,7 +18,7 @@ patches = ['InterProScan-5.73-104.0_external-data-defines.patch']
 checksums = [
     {'interproscan-core-5.73-104.0.tar.gz': 'c659e92132fac59af8bcf198e1f27481506733e27420231a6b92380b1ee1e803'},
     {'InterProScan-5.73-104.0_external-data-defines.patch':
-     '60844e93e468b5fcc8b0b8e55e8df2e6f467dbcbb799d896d4c43f423bf7ef20'},
+     '0b2ce8c485eadfc50d48ee79c0fd371818454124e02adc56c846463f775a6460'},
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/i/InterProScan/InterProScan-5.73-104.0_external-data-defines.patch
+++ b/easybuild/easyconfigs/i/InterProScan/InterProScan-5.73-104.0_external-data-defines.patch
@@ -16,7 +16,7 @@ Update: Petr Král (INUITS)
 +    do
 +       var_name="${var#INTERPROSCAN_}"; var_name="${var_name%=*}"
 +    var_val="${var#*=}"
-+    EB_DEFINES="${EB_DEFINES} -D${var_name,,}.signature.libary.release=${var_val}"
++    EB_DEFINES="${EB_DEFINES} -D${var_name,,}.signature.library.release=${var_val}"
 +    done
 +fi
 +

--- a/easybuild/easyconfigs/i/InterProScan/InterProScan-5.73-104.0_external-data-defines.patch
+++ b/easybuild/easyconfigs/i/InterProScan/InterProScan-5.73-104.0_external-data-defines.patch
@@ -11,12 +11,12 @@ Update: Petr Král (INUITS)
 +EB_DEFINES=""
 +if [[ ! -z "${INTERPROSCAN_DATA_DIR}" ]];
 +then
-+    EB_DEFINES="${EB_DEFINES} -Ddata.directory=\"${INTERPROSCAN_DATA_DIR}\""
-+    for var in $(env | grep -P '^INTERPROSCAN_(?!DATA_DIR)[a-z0-9_]+');
++    EB_DEFINES="${EB_DEFINES} -Ddata.directory=${INTERPROSCAN_DATA_DIR}"
++    for var in $(env | grep -P '^INTERPROSCAN_(?!DATA_DIR)[A-Z0-9_]+');
 +    do
 +       var_name="${var#INTERPROSCAN_}"; var_name="${var_name%=*}"
 +    var_val="${var#*=}"
-+    EB_DEFINES="${EB_DEFINES} -D${var_name,,}.signature.libary.release=\"${var_val}\""
++    EB_DEFINES="${EB_DEFINES} -D${var_name,,}.signature.libary.release=${var_val}"
 +    done
 +fi
 +

--- a/easybuild/easyconfigs/i/InterProScan/InterProScan-5.77-108.0-GCC-14.2.0.eb
+++ b/easybuild/easyconfigs/i/InterProScan/InterProScan-5.77-108.0-GCC-14.2.0.eb
@@ -18,7 +18,7 @@ patches = ['InterProScan-5.77-108.0_external-data-defines.patch']
 checksums = [
     {'interproscan-core-5.77-108.0.tar.gz': '654507b6013e9d954530deef89b2e7bc2963c8d4c3233e45511cea4504b6d230'},
     {'InterProScan-5.77-108.0_external-data-defines.patch':
-     '110202dac825dcf0673f8a0f7f6417ae4da36ebe885748539209f6676d5bdd67'},
+     '317c099000862cfa8f61ae8755ad909521d3fc942d29c729b59a1003263e8877'},
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/i/InterProScan/InterProScan-5.77-108.0_external-data-defines.patch
+++ b/easybuild/easyconfigs/i/InterProScan/InterProScan-5.77-108.0_external-data-defines.patch
@@ -16,7 +16,7 @@ Update: Petr Král (INUITS)
 +    do
 +       var_name="${var#INTERPROSCAN_}"; var_name="${var_name%=*}"
 +    var_val="${var#*=}"
-+    EB_DEFINES="${EB_DEFINES} -D${var_name,,}.signature.libary.release=${var_val}"
++    EB_DEFINES="${EB_DEFINES} -D${var_name,,}.signature.library.release=${var_val}"
 +    done
 +fi
 +

--- a/easybuild/easyconfigs/i/InterProScan/InterProScan-5.77-108.0_external-data-defines.patch
+++ b/easybuild/easyconfigs/i/InterProScan/InterProScan-5.77-108.0_external-data-defines.patch
@@ -11,12 +11,12 @@ Update: Petr Král (INUITS)
 +EB_DEFINES=""
 +if [[ ! -z "${INTERPROSCAN_DATA_DIR}" ]];
 +then
-+    EB_DEFINES="${EB_DEFINES} -Ddata.directory=\"${INTERPROSCAN_DATA_DIR}\""
-+    for var in $(env | grep -P '^INTERPROSCAN_(?!DATA_DIR)[a-z0-9_]+');
++    EB_DEFINES="${EB_DEFINES} -Ddata.directory=${INTERPROSCAN_DATA_DIR}"
++    for var in $(env | grep -P '^INTERPROSCAN_(?!DATA_DIR)[A-Z0-9_]+');
 +    do
 +       var_name="${var#INTERPROSCAN_}"; var_name="${var_name%=*}"
 +    var_val="${var#*=}"
-+    EB_DEFINES="${EB_DEFINES} -D${var_name,,}.signature.libary.release=\"${var_val}\""
++    EB_DEFINES="${EB_DEFINES} -D${var_name,,}.signature.libary.release=${var_val}"
 +    done
 +fi
 +


### PR DESCRIPTION
- Fix regex not capturing the capital letters after `INTERPROSCAN_` in var names  e.g. `INTERPROSCAN_ANTIFAM`
- Fix typo in `signature.libary.release`
- Remove quotes around `INTERPROSCAN_DATA_DIR` and `var_val`, as they were showing up mid path e.g:
```
Error: File existence/permissions problem in trying to open HMM file "/opt/apps/eb/software/InterProScan_data/5.73-104.0"/ncbifam/"17.0"/ncbifam.hmm.
HMM file "/opt/apps/eb/software/InterProScan_data/5.73-104.0"/ncbifam/"17.0"/ncbifam.hmm not found (nor an .h3m binary of it)
```