### PR TITLE
Add PTX code for last/highest CUDA arch for easyconfigs using `TORCH_CUDA_ARCH_LIST`

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-1.12.1-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-1.12.1-foss-2022a-CUDA-11.7.0.eb
@@ -45,12 +45,12 @@ exts_list = [
     }),
     ('torchdata', '0.4.1', {
         'source_urls': ['https://github.com/pytorch/data/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': V_VERSION_TAR_GZ, 'filename': SOURCE_TAR_GZ}],
         'checksums': ['71c0aa3aca3b04a986a2cd4cc2e0be114984ca836dc4def2c700bf1bd1ff087e'],
     }),
     ('torchtext', '0.13.1', {
         'source_urls': ['https://github.com/pytorch/text/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': V_VERSION_TAR_GZ, 'filename': SOURCE_TAR_GZ}],
         'patches': [
             'torchtext-0.13.1_use-system-libs.patch',
             'torchtext-0.13.1_cxx_17.patch',
@@ -64,13 +64,13 @@ exts_list = [
     }),
     ('torchvision', '0.13.1', {
         'source_urls': ['https://github.com/pytorch/vision/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': V_VERSION_TAR_GZ, 'filename': SOURCE_TAR_GZ}],
         'checksums': ['c32fab734e62c7744dadeb82f7510ff58cc3bca1189d17b16aa99b08afc42249'],
     }),
     ('pytorch-ignite', '0.4.11', {
         'modulename': 'ignite',
         'source_urls': ['https://github.com/pytorch/ignite/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': V_VERSION_TAR_GZ, 'filename': SOURCE_TAR_GZ}],
         'checksums': ['33e7485cea3cac08d7a49a3a01d3013e1156128867602bff0a8e32b2c5ebd4e9'],
     }),
     ('torch-tb-profiler', '0.4.1', {

--- a/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-1.12.1-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-1.12.1-foss-2022a-CUDA-11.7.0.eb
@@ -29,7 +29,7 @@ dependencies = [
 local_preinstall_opts = ' '.join([
     'USE_SYSTEM_LIBS=1',
     'USE_OPENMP=1',
-    'USE_CUDA=1', 'TORCH_CUDA_ARCH_LIST="%(cuda_cc_semicolon_sep)s"',
+    'USE_CUDA=1', 'TORCH_CUDA_ARCH_LIST="%(cuda_cc_semicolon_sep)s+PTX"',
     'USE_CUDNN=1',
     'CMAKE_BUILD_PARALLEL_LEVEL=%(parallel)s',
 ]) + ' '

--- a/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-1.13.1-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-1.13.1-foss-2022a-CUDA-11.7.0.eb
@@ -29,7 +29,7 @@ dependencies = [
 local_preinstall_opts = ' '.join([
     'USE_SYSTEM_LIBS=1',
     'USE_OPENMP=1',
-    'USE_CUDA=1', 'TORCH_CUDA_ARCH_LIST="%(cuda_cc_semicolon_sep)s"',
+    'USE_CUDA=1', 'TORCH_CUDA_ARCH_LIST="%(cuda_cc_semicolon_sep)s+PTX"',
     'USE_CUDNN=1',
     'CMAKE_BUILD_PARALLEL_LEVEL=%(parallel)s',
 ]) + ' '

--- a/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-1.13.1-foss-2022a-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-1.13.1-foss-2022a-CUDA-11.7.0.eb
@@ -45,7 +45,7 @@ exts_list = [
     }),
     ('torchdata', '0.5.1', {
         'source_urls': ['https://github.com/pytorch/data/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}],
         'checksums': ['69d80bd33ce8f08e7cfeeb71cefddfc29cede25a85881e33dbae47576b96ed29'],
     }),
     ('torchtext', '0.14.1', {
@@ -54,7 +54,7 @@ exts_list = [
             'torchtext-0.13.1_cxx_17.patch',
         ],
         'source_urls': ['https://github.com/pytorch/text/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}],
         'checksums': [
             {'torchtext-0.14.1.tar.gz': 'fd1ef3da7d9c20408c740f7dc7d02ad52a6048b46368355a1a7326d3bc4f2e63'},
             {'torchtext-0.14.1_use-system-libs.patch':
@@ -64,13 +64,13 @@ exts_list = [
     }),
     ('torchvision', '0.14.1', {
         'source_urls': ['https://github.com/pytorch/vision/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}],
         'checksums': ['ced67e1cf1f97e168cdf271851a4d0b6d382ab7936e7bcbb39aaa87239c324b6'],
     }),
     ('pytorch-ignite', '0.4.12', {
         'modulename': 'ignite',
         'source_urls': ['https://github.com/pytorch/ignite/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}],
         'checksums': ['7d10fd40edc568bbda687151bb5b53b0d59a980cd6c25ec2b061e7f234aeab76'],
     }),
     ('torch-tb-profiler', '0.4.3', {

--- a/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a-CUDA-12.1.1.eb
@@ -58,7 +58,7 @@ exts_list = [
     }),
     ('torchdata', '0.7.1', {
         'source_urls': ['https://github.com/pytorch/data/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': V_VERSION_TAR_GZ, 'filename': SOURCE_TAR_GZ}],
         'checksums': ['ef9bbdcee759b53c3c9d99e76eb0a66da33d36bfb7f859a25a9b5e737a51fa23'],
         'runtest': False,  # circular test requirements
     }),
@@ -68,7 +68,7 @@ exts_list = [
             'torchtext-0.16.2_download-to-project-root.patch',
         ],
         'source_urls': ['https://github.com/pytorch/text/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': V_VERSION_TAR_GZ, 'filename': SOURCE_TAR_GZ}],
         'checksums': [
             {'torchtext-0.16.2.tar.gz': '6574b012804f65220329a2ad34a95c18e4df0d4cff2f862fb7862d57b374b013'},
             {'torchtext-0.14.1_use-system-libs.patch':
@@ -97,7 +97,7 @@ exts_list = [
             'torchvision-0.16.2_quantized_tol.patch',
         ],
         'source_urls': ['https://github.com/pytorch/vision/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': V_VERSION_TAR_GZ, 'filename': SOURCE_TAR_GZ}],
         'checksums': [
             {'torchvision-0.16.2.tar.gz': '8c1f2951e98d8ada6e5a468f179af4be9f56d2ebc3ab057af873da61669806d7'},
             {'torchvision-0.16.2_ffmpeg-6.0-fix.patch':
@@ -122,7 +122,7 @@ exts_list = [
                            'rm -r third_party/{sox,ffmpeg/multi}; '  # runs twice when testinstall
                            + local_preinstall_opts),
         'source_urls': ['https://github.com/pytorch/audio/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': V_VERSION_TAR_GZ, 'filename': SOURCE_TAR_GZ}],
         'checksums': [
             {'torchaudio-2.1.2.tar.gz': '82c2745a73172b495327ec36c6970ad5ad9d5d2ac44feeaea2617152f9393bf7'},
             {'torchaudio-2.1.2_use-external-sox.patch':
@@ -144,7 +144,7 @@ exts_list = [
     ('pytorch-ignite', '0.4.13', {
         'modulename': 'ignite',
         'source_urls': ['https://github.com/pytorch/ignite/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': V_VERSION_TAR_GZ, 'filename': SOURCE_TAR_GZ}],
         'patches': ['torch-ignite-0.4.13_dont_destroy_python_path_in_test_launcher.patch'],
         'checksums': [
             {'pytorch-ignite-0.4.13.tar.gz': 'bfe4b6f1cd96e78c021a65a0c51350cdb89d6ef5a8b9609638666ca95bae51d7'},
@@ -193,12 +193,12 @@ exts_list = [
     }),
     ('tensordict', '0.3.0', {
         'source_urls': ['https://github.com/pytorch/%(name)s/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': V_VERSION_TAR_GZ, 'filename': SOURCE_TAR_GZ}],
         'checksums': ['f0d95e8f055c3f82838fdbeb03c6a907f8786c1046791db7e39cdcd9cb8f1889'],
     }),
     ('torchrl', '0.3.0', {
         'source_urls': ['https://github.com/pytorch/rl/archive'],
-        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'sources': [{'download_filename': V_VERSION_TAR_GZ, 'filename': SOURCE_TAR_GZ}],
         'checksums': ['3ddb63dd33590c37f8edc9784cee718c20e2ced0c6bf0135600eb2dda7014814'],
     }),
 ]

--- a/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a-CUDA-12.1.1.eb
@@ -40,7 +40,7 @@ dependencies = [
 local_preinstall_opts = ' '.join([
     'USE_SYSTEM_LIBS=1',
     'USE_OPENMP=1',
-    'USE_CUDA=1', 'TORCH_CUDA_ARCH_LIST="%(cuda_cc_semicolon_sep)s"',
+    'USE_CUDA=1', 'TORCH_CUDA_ARCH_LIST="%(cuda_cc_semicolon_sep)s+PTX"',
     'USE_CUDNN=1',
     'USE_FFMPEG=1', 'FFMPEG_ROOT="$EBROOTFFMPEG"',
     'CMAKE_BUILD_PARALLEL_LEVEL=%(parallel)s',

--- a/easybuild/easyconfigs/x/xformers/xformers-0.0.23.post1-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/x/xformers/xformers-0.0.23.post1-foss-2023a-CUDA-12.1.1.eb
@@ -29,7 +29,7 @@ dependencies = [
 
 preinstallopts = 'export XFORMERS_MORE_DETAILS=1 && '
 preinstallopts += 'export XFORMERS_DISABLE_FLASH_ATTN=1 && '
-preinstallopts += 'export TORCH_CUDA_ARCH_LIST="5.2;6.0;7.0;7.5;8.0;8.6;9.0" && '
+preinstallopts += 'export TORCH_CUDA_ARCH_LIST="%(cuda_cc_semicolon_sep)s+PTX" && '
 preinstallopts += 'export MAX_JOBS=3 && '
 
 moduleclass = 'ai'


### PR DESCRIPTION
With https://github.com/easybuilders/easybuild-framework/pull/5144 it will add PTX code for the highest arch

See also https://github.com/easybuilders/easybuild-easyblocks/pull/4129

It avoids failures with the new CUDA sanity check checking for this.
No change to performance etc, it just causes slightly bigger binaries due to the addition (i.e. not replacement) of PTX code.

This assumes that `cuda_cc_semicolon_sep` is non-empty, which IMO is a safe assumption.