### PR TITLE
Fix wrong extension name in error message on missing patch

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1881,7 +1881,7 @@ def template_easyconfig_test(self, spec):
         patch_checksums = checksums[src_cnt:]
 
         for idx, ext_patch in enumerate(ext.get('patches', [])):
-            failing_checks.extend(verify_patch(specdir, ext_patch, idx, patch_checksums, extension_name=ext_name))
+            failing_checks.extend(verify_patch(specdir, ext_patch, idx, patch_checksums, extension_name=ext['name']))
 
     # check whether all extra_options defined for used easyblock are defined
     extra_opts = app.extra_options()


### PR DESCRIPTION
This check (for a long time) uses `ext_name`, a variable from a previous loop. So it would have the value of the last extension instead of that from the current extension.


See https://github.com/easybuilders/easybuild-easyconfigs/actions/runs/25442431135/job/74637094906?pr=25924

> patch file torchaudio-2.3.0_remove-librosa-version-check.patch of extension torchtune is missing