### PR TITLE
{tools}[system/system] gocryptfs v2.6.1 w/ Go 1.25.7

### DIFF
--- a/easybuild/easyconfigs/g/gocryptfs/gocryptfs-2.6.1-Go-1.25.7.eb
+++ b/easybuild/easyconfigs/g/gocryptfs/gocryptfs-2.6.1-Go-1.25.7.eb
@@ -1,7 +1,7 @@
 name = 'gocryptfs'
 version = '2.6.1'
 _go_version = '1.25.7'
-versionsuffix='-Go-%s' % _go_version
+versionsuffix = '-Go-%s' % _go_version
 
 homepage = 'https://nuetzlich.net/gocryptfs/'
 description = """An encrypted overlay filesystem written in Go and built on top the go-fuse FUSE library."""

--- a/easybuild/easyconfigs/g/gocryptfs/gocryptfs-2.6.1-Go-1.25.7.eb
+++ b/easybuild/easyconfigs/g/gocryptfs/gocryptfs-2.6.1-Go-1.25.7.eb
@@ -1,5 +1,3 @@
-#easyblock = 'Bundle'
-
 name = 'gocryptfs'
 version = '2.6.1'
 _go_version = '1.25.7'

--- a/easybuild/easyconfigs/g/gocryptfs/gocryptfs-2.6.1-Go-1.25.7.eb
+++ b/easybuild/easyconfigs/g/gocryptfs/gocryptfs-2.6.1-Go-1.25.7.eb
@@ -21,10 +21,8 @@ dependencies = [
     ('OpenSSL', '3'),
 ]
 
-default_component_specs = {
-    'source_urls': ['https://github.com/rfjakob/gocryptfs/releases/download/v%(version)s/'],
-    'sources': ['%s_v%s_src-deps.tar.gz' % (name, version)],
-    'checksums': ['9a966c1340a1a1d92073091643687b1205c46b57017c5da2bf7e97e3f5729a5a'],
-}
+source_urls = ['https://github.com/rfjakob/gocryptfs/releases/download/v%(version)s/']
+sources = ['%s_v%s_src-deps.tar.gz' % (name, version)]
+checksums = ['9a966c1340a1a1d92073091643687b1205c46b57017c5da2bf7e97e3f5729a5a']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/g/gocryptfs/gocryptfs-2.6.1-Go-1.25.7.eb
+++ b/easybuild/easyconfigs/g/gocryptfs/gocryptfs-2.6.1-Go-1.25.7.eb
@@ -1,0 +1,32 @@
+#easyblock = 'Bundle'
+
+name = 'gocryptfs'
+version = '2.6.1'
+_go_version = '1.25.7'
+versionsuffix='-Go-%s' % _go_version
+
+homepage = 'https://nuetzlich.net/gocryptfs/'
+description = """An encrypted overlay filesystem written in Go and built on top the go-fuse FUSE library."""
+
+toolchain = SYSTEM
+
+builddependencies = [
+    ('Go', '%s' % _go_version),
+    ('Pandoc', '3.8.2.1'),
+]
+
+osdependencies = [
+    ('fuse')
+]
+
+dependencies = [
+    ('OpenSSL', '3'),
+]
+
+default_component_specs = {
+    'source_urls': ['https://github.com/rfjakob/gocryptfs/releases/download/v%(version)s/'],
+    'sources': ['%s_v%s_src-deps.tar.gz' % (name, version)],
+    'checksums': ['9a966c1340a1a1d92073091643687b1205c46b57017c5da2bf7e97e3f5729a5a'],
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
Requires easyblock PR:

- easybuilders/easybuild-easyblocks/pull/4131
