### PR TITLE
Add mars-earth easyconfig

### DIFF
--- a/easybuild/easyconfigs/m/mars-earth/mars-earth-1.0.4-gfbf-2024a.eb
+++ b/easybuild/easyconfigs/m/mars-earth/mars-earth-1.0.4-gfbf-2024a.eb
@@ -1,0 +1,24 @@
+easyblock = 'PythonPackage'
+
+name = 'mars-earth'
+version = '1.0.4'
+
+homepage = 'https://github.com/edithatogo/mars'
+description = """Pure Python implementation of multivariate adaptive regression splines
+with a Rust-backed runtime core."""
+
+toolchain = {'name': 'gfbf', 'version': '2024a'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['0755aa79c879e06bb83d5e2811435c20e4f81623e1ddd8451b528cd8fe6d7972']
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('SciPy-bundle', '2024.05'),
+    ('scikit-learn', '1.5.2'),
+    ('matplotlib', '3.9.2'),
+]
+
+sanity_check_commands = ['python -c "import pymars"']
+
+moduleclass = 'math'


### PR DESCRIPTION
Add an H0-only `mars-earth` easyconfig to easybuild-easyconfigs.

The recipe is scoped to source installability and keeps higher-level accelerator, MPI, and distributed claims out of scope.

Validation:
- Python syntax check on the new easyconfig
- `git diff --check`
