### PR TITLE
Flux: adding binutils as build dependency for RiscV build

### DIFF
--- a/easybuild/easyconfigs/f/Flux/Flux-0.80.0-GCC-14.3.0.eb
+++ b/easybuild/easyconfigs/f/Flux/Flux-0.80.0-GCC-14.3.0.eb
@@ -25,6 +25,7 @@ builddependencies = [
     ('Python-bundle-PyPI', '2025.07'),
     ('jq', '1.8.1'),
     ('CMake', '4.0.3'),
+    ('binutils', '2.44'),
 ]
 
 dependencies = [


### PR DESCRIPTION
trying to build Flux:
$ eb Flux-0.80.0-GCC-14.3.0.eb --robot --optarch=-march=rv64imafdc

== 2026-06-01 05:49:08,381 build_log.py:233 ERROR EasyBuild encountered an error: get_software_root software root for binutils was not found in environment (at easybuild/tools/toolchain/toolchain.py:465 in _get_software_root)

but binutils is not listed as a dependency...