### PR TITLE
{bio}[foss/2024a] OrthoFinder v3.1.0, replace the bundled famsa

### DIFF
--- a/easybuild/easyconfigs/f/FAMSA/FAMSA-2.5.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/f/FAMSA/FAMSA-2.5.2-GCCcore-13.3.0.eb
@@ -10,7 +10,7 @@ sequence alignments"""
 toolchain = {"name": "GCCcore", "version": "13.3.0"}
 
 sources = [{
-    'filename': 'v2.5.2.tar.gz',
+    'filename': SOURCE_TAR_XZ,
     'git_config': {
         'url': 'https://github.com/refresh-bio',
         'repo_name': 'FAMSA',
@@ -18,8 +18,7 @@ sources = [{
         'clone_into': 'FAMSA-2.5.2',
     },
 }]
-# check sum of the gz file
-checksums = ['751d97c64524a38f2e3ded8c50a3a297fbe1c2dff0b2685e4bcedcf66d85687b']
+checksums = ['b00705aa660443b25421378a558defc05b2cf8a40657248348c372f469410335']
 
 builddependencies = [
     ('binutils', '2.42'),

--- a/easybuild/easyconfigs/f/FAMSA/FAMSA-2.5.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/f/FAMSA/FAMSA-2.5.2-GCCcore-13.3.0.eb
@@ -22,7 +22,8 @@ sources = [{
 checksums = ['751d97c64524a38f2e3ded8c50a3a297fbe1c2dff0b2685e4bcedcf66d85687b']
 
 builddependencies = [
-  ("CMake", "3.29.3"),
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
 ]
 
 files_to_copy = [

--- a/easybuild/easyconfigs/f/FAMSA/FAMSA-2.5.2-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/f/FAMSA/FAMSA-2.5.2-GCCcore-13.3.0.eb
@@ -1,0 +1,43 @@
+easyblock = 'MakeCp'
+
+name = 'FAMSA'
+version = '2.5.2'
+
+homepage = 'https://github.com/refresh-bio/FAMSA'
+description = """FAMSA2 is a progressive algorithm for large-scale multiple
+sequence alignments"""
+
+toolchain = {"name": "GCCcore", "version": "13.3.0"}
+
+sources = [{
+    'filename': 'v2.5.2.tar.gz',
+    'git_config': {
+        'url': 'https://github.com/refresh-bio',
+        'repo_name': 'FAMSA',
+        'commit': '2598410',
+        'clone_into': 'FAMSA-2.5.2',
+    },
+}]
+# check sum of the gz file
+checksums = ['751d97c64524a38f2e3ded8c50a3a297fbe1c2dff0b2685e4bcedcf66d85687b']
+
+builddependencies = [
+  ("CMake", "3.29.3"),
+]
+
+files_to_copy = [
+    (['bin/famsa'], 'bin'),
+    'LICENSE',
+    'README.md',
+]
+
+sanity_check_paths = {
+    'files': ['bin/famsa'],
+    'dirs': [],
+}
+
+sanity_check_commands = [
+    'famsa -h',
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/o/OrthoFinder/OrthoFinder-3.1.0-foss-2024a.eb
+++ b/easybuild/easyconfigs/o/OrthoFinder/OrthoFinder-3.1.0-foss-2024a.eb
@@ -16,6 +16,7 @@ dependencies = [
     ("BLAST+", "2.16.0"),
     ("DIAMOND", "2.1.11"),
     ("FastME", "2.1.6.3"),
+    ("FAMSA", "2.5.2"),
     ("MCL", "22.282"),
     ("MMseqs2", "17-b804f"),
 ]
@@ -46,6 +47,10 @@ exts_list = [
             ]
         },
     ),
+]
+
+postinstallcmds = [
+    'rm %(installdir)s/lib/python3.12/site-packages/orthofinder/bin/famsa',
 ]
 
 sanity_check_paths = {


### PR DESCRIPTION
The current config of OrthoFinder 3.1.0 would use the bundled famsa binary, which might cause problem as mentioned in https://github.com/OrthoFinder/OrthoFinder/issues/22 . This commit includes an EB file of FAMSA, adding dependency to FAMSA, and removing the bundled famsa (*).

*: it seems that OrthoFinder tries to use the bundled famsa first, no matter famsa is available in the environment or not.