### PR TITLE
use `XORG_LIB_SOURCE` constant for libpciaccess and X11

### DIFF
--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.16-GCCcore-11.3.0.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.16-GCCcore-11.3.0.eb
@@ -8,7 +8,7 @@ description = """Generic PCI access library."""
 
 toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 
-source_urls = ['https://www.x.org/releases/individual/lib/']
+source_urls = [XORG_LIB_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['84413553994aef0070cf420050aa5c0a51b1956b404920e21b81e96db6a61a27']
 

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.17-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.17-GCCcore-12.2.0.eb
@@ -8,7 +8,7 @@ description = """Generic PCI access library."""
 
 toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
 
-source_urls = ['https://www.x.org/releases/individual/lib/']
+source_urls = [XORG_LIB_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['bf6985a77d2ecb00e2c79da3edfb26b909178ffca3f2e9d14ed0620259ab733b']
 

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.17-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.17-GCCcore-12.3.0.eb
@@ -8,7 +8,7 @@ description = """Generic PCI access library."""
 
 toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 
-source_urls = ['https://www.x.org/releases/individual/lib/']
+source_urls = [XORG_LIB_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['bf6985a77d2ecb00e2c79da3edfb26b909178ffca3f2e9d14ed0620259ab733b']
 

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.17-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.17-GCCcore-13.2.0.eb
@@ -8,7 +8,7 @@ description = """Generic PCI access library."""
 
 toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 
-source_urls = ['https://www.x.org/releases/individual/lib/']
+source_urls = [XORG_LIB_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['bf6985a77d2ecb00e2c79da3edfb26b909178ffca3f2e9d14ed0620259ab733b']
 

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.18.1-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.18.1-GCCcore-13.3.0.eb
@@ -8,7 +8,7 @@ description = """Generic PCI access library."""
 
 toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
 
-source_urls = ['https://www.x.org/releases/individual/lib/']
+source_urls = [XORG_LIB_SOURCE]
 sources = [SOURCE_TAR_XZ]
 checksums = ['4af43444b38adb5545d0ed1c2ce46d9608cc47b31c2387fc5181656765a6fa76']
 

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.18.1-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.18.1-GCCcore-14.2.0.eb
@@ -8,7 +8,7 @@ description = """Generic PCI access library."""
 
 toolchain = {'name': 'GCCcore', 'version': '14.2.0'}
 
-source_urls = ['https://www.x.org/releases/individual/lib/']
+source_urls = [XORG_LIB_SOURCE]
 sources = [SOURCE_TAR_XZ]
 checksums = ['4af43444b38adb5545d0ed1c2ce46d9608cc47b31c2387fc5181656765a6fa76']
 

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.18.1-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.18.1-GCCcore-14.3.0.eb
@@ -8,7 +8,7 @@ description = """Generic PCI access library."""
 
 toolchain = {'name': 'GCCcore', 'version': '14.3.0'}
 
-source_urls = ['https://www.x.org/releases/individual/lib/']
+source_urls = ['https://xorg.freedesktop.org/archive/individual/lib/']
 sources = [SOURCE_TAR_XZ]
 checksums = ['4af43444b38adb5545d0ed1c2ce46d9608cc47b31c2387fc5181656765a6fa76']
 

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.18.1-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.18.1-GCCcore-14.3.0.eb
@@ -8,7 +8,7 @@ description = """Generic PCI access library."""
 
 toolchain = {'name': 'GCCcore', 'version': '14.3.0'}
 
-source_urls = ['https://xorg.freedesktop.org/archive/individual/lib/']
+source_urls = [XORG_LIB_SOURCE]
 sources = [SOURCE_TAR_XZ]
 checksums = ['4af43444b38adb5545d0ed1c2ce46d9608cc47b31c2387fc5181656765a6fa76']
 

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.19-GCCcore-15.2.0.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.19-GCCcore-15.2.0.eb
@@ -8,7 +8,7 @@ description = """Generic PCI access library."""
 
 toolchain = {'name': 'GCCcore', 'version': '15.2.0'}
 
-source_urls = ['https://www.x.org/releases/individual/lib/']
+source_urls = [XORG_LIB_SOURCE]
 sources = [SOURCE_TAR_XZ]
 checksums = ['3c55aa86c82e54a4e3109786f0463530d53b36b6d1cfd14616454f985dd2aa43']
 

--- a/easybuild/easyconfigs/x/X11/X11-20250608-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20250608-GCCcore-14.3.0.eb
@@ -90,7 +90,6 @@ components = [
         'checksums': ['1da62f732f8679c20045708a29372b82dff9e7eceee543ed488b845002b3b0ff'],
     }),
     ('iceauth', '1.0.10', {  # 2024-03-10
-        'source_urls': ['https://xorg.freedesktop.org/archive/individual/app/'],
         'checksums': ['f17f373c6e7bfef9cfa4c688f165dfebec7642ad7c6304c5bb3c9bc2bfcde747'],
     }),
     ('libSM', '1.2.6', {  # 2025-03-09

--- a/easybuild/easyconfigs/x/X11/X11-20250608-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20250608-GCCcore-14.3.0.eb
@@ -32,7 +32,6 @@ dependencies = [
 source_urls = [
     XORG_LIB_SOURCE,
     XORG_PROTO_SOURCE,
-    'https://www.x.org/archive/individual/app/',
     'https://xcb.freedesktop.org/dist/',
     'https://xkbcommon.org/download/',
     'https://github.com/xkbcommon/libxkbcommon/archive/refs/tags/',
@@ -91,6 +90,7 @@ components = [
         'checksums': ['1da62f732f8679c20045708a29372b82dff9e7eceee543ed488b845002b3b0ff'],
     }),
     ('iceauth', '1.0.10', {  # 2024-03-10
+        'source_urls': ['https://xorg.freedesktop.org/archive/individual/app/'],
         'checksums': ['f17f373c6e7bfef9cfa4c688f165dfebec7642ad7c6304c5bb3c9bc2bfcde747'],
     }),
     ('libSM', '1.2.6', {  # 2025-03-09

--- a/easybuild/easyconfigs/x/X11/X11-20250608-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20250608-GCCcore-14.3.0.eb
@@ -32,6 +32,7 @@ dependencies = [
 source_urls = [
     XORG_LIB_SOURCE,
     XORG_PROTO_SOURCE,
+    'https://xorg.freedesktop.org/archive/individual/app/',
     'https://xcb.freedesktop.org/dist/',
     'https://xkbcommon.org/download/',
     'https://github.com/xkbcommon/libxkbcommon/archive/refs/tags/',

--- a/easybuild/easyconfigs/x/X11/X11-20260518-GCCcore-15.2.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20260518-GCCcore-15.2.0.eb
@@ -90,7 +90,6 @@ components = [
         'checksums': ['1da62f732f8679c20045708a29372b82dff9e7eceee543ed488b845002b3b0ff'],
     }),
     ('iceauth', '1.0.11', {  # 2026-04-18
-        'source_urls': ['https://xorg.freedesktop.org/archive/individual/app/'],
         'checksums': ['db417cae6d966e67892ebc3034ec92238af9733c53b5986e56cc8be7db540b3a'],
     }),
     ('libSM', '1.2.6', {  # 2025-03-09

--- a/easybuild/easyconfigs/x/X11/X11-20260518-GCCcore-15.2.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20260518-GCCcore-15.2.0.eb
@@ -32,6 +32,7 @@ dependencies = [
 source_urls = [
     XORG_LIB_SOURCE,
     XORG_PROTO_SOURCE,
+    'https://xorg.freedesktop.org/archive/individual/app/',
     'https://xcb.freedesktop.org/dist/',
     'https://xkbcommon.org/download/',
     'https://github.com/xkbcommon/libxkbcommon/archive/refs/tags/',

--- a/easybuild/easyconfigs/x/X11/X11-20260518-GCCcore-15.2.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20260518-GCCcore-15.2.0.eb
@@ -32,7 +32,6 @@ dependencies = [
 source_urls = [
     XORG_LIB_SOURCE,
     XORG_PROTO_SOURCE,
-    'https://www.x.org/archive/individual/app/',
     'https://xcb.freedesktop.org/dist/',
     'https://xkbcommon.org/download/',
     'https://github.com/xkbcommon/libxkbcommon/archive/refs/tags/',
@@ -91,6 +90,7 @@ components = [
         'checksums': ['1da62f732f8679c20045708a29372b82dff9e7eceee543ed488b845002b3b0ff'],
     }),
     ('iceauth', '1.0.11', {  # 2026-04-18
+        'source_urls': ['https://xorg.freedesktop.org/archive/individual/app/'],
         'checksums': ['db417cae6d966e67892ebc3034ec92238af9733c53b5986e56cc8be7db540b3a'],
     }),
     ('libSM', '1.2.6', {  # 2025-03-09


### PR DESCRIPTION
After getting 
```
== building and installing libpciaccess/0.18.1-GCCcore-14.3.0...
  >> installation prefix: /data/groups/technologies/data.core/bert.droesbeke/easybuild/software/libpciaccess/0.18.1-GCCcore-14.3.0
== fetching files and verifying checksums...
  >> download failed: https://www.x.org/releases/individual/lib/libpciaccess-0.18.1.tar.xz
  >> download failed: https://sources.easybuild.io/l/libpciaccess/libpciaccess-0.18.1.tar.xz
```

I discovered that the old url pattern doesn't work anymore. 