### PR TITLE
{cae,math}[foss/2023b,gompi/2023b] OpenFOAM vv2406, SCOTCH v7.0.4 w/ int64

### DIFF
--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2406-foss-2023b-int64.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2406-foss-2023b-int64.eb
@@ -51,7 +51,7 @@ dependencies = [
     ('GMP', '6.3.0'),
     ('MPFR', '4.2.1'),
     ('ParaView', '5.12.0'),
-    ('gnuplot', '6.0.0'),
+    ('gnuplot', '6.0.1'),
 ]
 
 moduleclass = 'cae'

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2406-foss-2023b-int64.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2406-foss-2023b-int64.eb
@@ -1,0 +1,57 @@
+name = 'OpenFOAM'
+version = 'v2406'
+_v = '64'
+versionsuffix = '-int%s' % _v
+
+homepage = 'https://www.openfoam.com/'
+description = """OpenFOAM is a free, open source CFD software package.
+ OpenFOAM has an extensive range of features to solve anything from complex fluid flows
+ involving chemical reactions, turbulence and heat transfer,
+ to solid dynamics and electromagnetics."""
+
+toolchain = {'name': 'foss', 'version': '2023b'}
+# Users have found that vectorizion caused OpenFOAM to produce some very incorrect results.
+# Disabling vectorize was confirmed to fix the the known issues.
+# With no test suite, sticking to known working toolchain options until proven otherwise.
+toolchainopts = {'cstd': 'c++14', 'vectorize': False, 'i8': True}
+
+source_urls = ['https://sourceforge.net/projects/openfoam/files/%(version)s/']
+sources = [
+    SOURCE_TGZ,
+    {
+        'filename': '%(name)s-plugins-%(version)s.tgz',
+        'extract_cmd': 'tar --strip-components=1 -C %(installdir)s/%(name)s-%(version)s/ -xzf %s'
+    }
+]
+patches = [
+    ('OpenFOAM-v2406-cleanup.patch', 1),
+    ('OpenFOAM-v2212-wmake-OpenMPI.patch', 1),
+]
+checksums = [
+    {'OpenFOAM-v2406.tgz': '8d1450fb89eec1e7cecc55c3bb7bc486ccbf63d069379d1d5d7518fa16a4686a'},
+    {'OpenFOAM-plugins-v2406.tgz': '1d008f86fad06a4a568d194c6e3d5ab52be2b20c83a3b9b1b0230e2de2d0558b'},
+    {'OpenFOAM-v2406-cleanup.patch': '3abff48a517fb63719ad57fa32af746bc379a1e80c72d3e5852aa17cd13cf03e'},
+    {'OpenFOAM-v2212-wmake-OpenMPI.patch': '241dc4898c22aab0cbd10c1ea931a07a786508ee03462d45dbc1c202fee3ebe8'},
+]
+
+builddependencies = [
+    ('Bison', '3.8.2'),
+    ('CMake', '3.27.6'),
+    ('flex', '2.6.4'),
+]
+
+dependencies = [
+    ('libreadline', '8.2'),
+    ('ncurses', '6.4'),
+    # OpenFOAM requires 64 bit METIS using 32 bit indexes (array indexes)
+    ('METIS', '5.1.0'),
+    ('SCOTCH', '7.0.4', versionsuffix),
+    ('KaHIP', '3.16'),
+    ('CGAL', '5.6.1'),
+    ('GMP', '6.3.0'),
+    ('MPFR', '4.2.1'),
+    ('ParaView', '5.12.0'),
+    ('gnuplot', '6.0.0'),
+]
+
+moduleclass = 'cae'

--- a/easybuild/easyconfigs/s/SCOTCH/SCOTCH-7.0.4-gompi-2023b-int64.eb
+++ b/easybuild/easyconfigs/s/SCOTCH/SCOTCH-7.0.4-gompi-2023b-int64.eb
@@ -1,0 +1,27 @@
+name = 'SCOTCH'
+version = '7.0.4'
+versionsuffix = '-int64'
+
+homepage = 'https://www.labri.fr/perso/pelegrin/scotch/'
+description = """Software package and libraries for sequential and parallel graph partitioning,
+static mapping, and sparse matrix block ordering, and sequential mesh and hypergraph partitioning."""
+
+toolchain = {'name': 'gompi', 'version': '2023b'}
+toolchainopts = {'pic': True, 'i8': True}
+
+source_urls = ['https://gitlab.inria.fr/scotch/scotch/-/archive/v%(version)s/']
+sources = ['%(namelower)s-v%(version)s.tar.gz']
+checksums = ['8ef4719d6a3356e9c4ca7fefd7e2ac40deb69779a5c116f44da75d13b3d2c2c3']
+
+threadedmpi = False
+
+builddependencies = [
+    ('Bison', '3.8.2'),
+    ('flex', '2.6.4'),
+]
+
+dependencies = [
+    ('zlib', '1.2.13'),
+]
+
+moduleclass = 'math'


### PR DESCRIPTION
No AI usage, based off previous recipes

Both recipes are `int64`