### PR TITLE
use binutils 2.46.1 + M4 1.4.21 as (build) dependency for GCC 16.1.0

### DIFF
--- a/easybuild/easyconfigs/b/Bison/Bison-3.8.2-GCCcore-16.1.0.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.8.2-GCCcore-16.1.0.eb
@@ -14,9 +14,9 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['06c9e13bdf7eb24d4ceb6b59205a4f67c2c7e7213119644430fe82fbd14a0abb']
 
 builddependencies = [
-    ('M4', '1.4.20'),
+    ('M4', '1.4.21'),
     # use same binutils version that was used when building GCCcore toolchain
-    ('binutils', '2.46.0', '', SYSTEM),
+    ('binutils', '2.46.1', '', SYSTEM),
 ]
 
 

--- a/easybuild/easyconfigs/b/binutils/binutils-2.46.1-GCCcore-16.1.0.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.46.1-GCCcore-16.1.0.eb
@@ -1,5 +1,5 @@
 name = 'binutils'
-version = '2.46.0'
+version = '2.46.1'
 
 homepage = 'https://directory.fsf.org/project/binutils/'
 description = "binutils: GNU binary utilities"
@@ -8,7 +8,7 @@ toolchain = {'name': 'GCCcore', 'version': '16.1.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
-checksums = ['8608fe44ab7de645f6ad0a898313b75338842490d609adb85c9fb2827c376af2']
+checksums = ['364c8faa19ea46c44089c2d59c1fee6eda9a273787d0fe8ab9dfb249069c6aee']
 
 builddependencies = [
     ('flex', '2.6.4'),

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-16.1.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-16.1.0.eb
@@ -20,11 +20,11 @@ builddependencies = [
     ('Bison', '3.8.2'),
     ('help2man', '1.49.3'),
     # use same binutils version that was used when building GCC toolchain
-    ('binutils', '2.46.0', '', SYSTEM),
+    ('binutils', '2.46.1', '', SYSTEM),
 ]
 
 dependencies = [
-    ('M4', '1.4.20'),
+    ('M4', '1.4.21'),
 ]
 
 # glibc 2.26 requires _GNU_SOURCE defined to expose reallocarray in the correct

--- a/easybuild/easyconfigs/g/GCC/GCC-16.1.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-16.1.0.eb
@@ -12,7 +12,7 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of binutils (built with system toolchain)
-    ('binutils', '2.46.0', '', ('GCCcore', version)),
+    ('binutils', '2.46.1', '', ('GCCcore', version)),
 ]
 
 altroot = 'GCCcore'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-16.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-16.1.0.eb
@@ -47,8 +47,8 @@ checksums = [
 ]
 
 builddependencies = [
-    ('M4', '1.4.20'),
-    ('binutils', '2.46.0'),
+    ('M4', '1.4.21'),
+    ('binutils', '2.46.1'),
 ]
 
 languages = ['c', 'c++', 'fortran']

--- a/easybuild/easyconfigs/h/help2man/help2man-1.49.3-GCCcore-16.1.0.eb
+++ b/easybuild/easyconfigs/h/help2man/help2man-1.49.3-GCCcore-16.1.0.eb
@@ -14,7 +14,7 @@ checksums = ['4d7e4fdef2eca6afe07a2682151cea78781e0a4e8f9622142d9f70c083a2fd4f']
 
 builddependencies = [
     # use same binutils version that was used when building GCC toolchain
-    ('binutils', '2.46.0', '', SYSTEM),
+    ('binutils', '2.46.1', '', SYSTEM),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.21-GCCcore-16.1.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.21-GCCcore-16.1.0.eb
@@ -1,7 +1,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'M4'
-version = '1.4.20'
+version = '1.4.21'
 
 homepage = 'https://www.gnu.org/software/m4/m4.html'
 description = """GNU M4 is an implementation of the traditional Unix macro processor. It is mostly SVR4 compatible
@@ -12,10 +12,10 @@ toolchain = {'name': 'GCCcore', 'version': '16.1.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['6ac4fc31ce440debe63987c2ebbf9d7b6634e67a7c3279257dc7361de8bdb3ef']
+checksums = ['38ae59f7a30bf9c108193cc5c25fbb06014f21e230c7ede2eff614f7b7c37ed8']
 
 # use same binutils version that was used when building GCC toolchain
-builddependencies = [('binutils', '2.46.0', '', SYSTEM)]
+builddependencies = [('binutils', '2.46.1', '', SYSTEM)]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/z/zlib/zlib-2.3.3-GCCcore-16.1.0.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-2.3.3-GCCcore-16.1.0.eb
@@ -15,7 +15,7 @@ sources = [{'download_filename': '%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ
 checksums = ['f9c65aa9c852eb8255b636fd9f07ce1c406f061ec19a2e7d508b318ca0c907d1']
 
 # use same binutils version that was used when building GCC toolchain
-builddependencies = [('binutils', '2.46.0', '', SYSTEM)]
+builddependencies = [('binutils', '2.46.1', '', SYSTEM)]
 
 configopts = '--zlib-compat'
 


### PR DESCRIPTION
follow-up for #26207 (which got merged 2 days ago), I should've used binutils 2.46.1 in there (likewise for M4 1.4.21).

In my defense, https://www.gnu.org/software/m4 still mentions "The latest stable version is 1.4.20", which is a lie (see also https://lists.gnu.org/archive/html/m4-announce/2026-02/msg00000.html)