### PR TITLE
bump binutils in bzip2 v1.0.8 for GCCcore v16.1.0 to v2.46.1

### DIFF
--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.8-GCCcore-16.1.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.8-GCCcore-16.1.0.eb
@@ -21,7 +21,7 @@ checksums = [
 ]
 
 builddependencies = [
-    ('binutils', '2.46.0'),
+    ('binutils', '2.46.1'),
 ]
 
 moduleclass = 'tools'


### PR DESCRIPTION
Follow-up to:
- #26254
- #26213

Fixes failing CI, e.g., https://github.com/easybuilders/easybuild-easyconfigs/actions/runs/27452116109/job/81149381040