### PR TITLE
add patch for ncurses link issue to hwloc 2.13.0

### DIFF
--- a/easybuild/easyconfigs/h/hwloc/hwloc-2.13.0-GCCcore-15.2.0.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-2.13.0-GCCcore-15.2.0.eb
@@ -36,6 +36,7 @@ dependencies = [
     ('numactl', '2.0.19'),
     ('libxml2', '2.15.1'),
     ('libpciaccess', '0.19'),
+    ('ncurses', '6.6'),
 ]
 
 configopts = ' '.join([

--- a/easybuild/easyconfigs/h/hwloc/hwloc-2.13.0-GCCcore-15.2.0.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-2.13.0-GCCcore-15.2.0.eb
@@ -20,7 +20,12 @@ toolchain = {'name': 'GCCcore', 'version': '15.2.0'}
 
 source_urls = ['https://www.open-mpi.org/software/hwloc/v%(version_major_minor)s/downloads/']
 sources = [SOURCE_TAR_GZ]
-checksums = ['1514a5253f0a5c23bc006d3bdd30a6f6125c9a8dc9b5fa4984913d1fff45315d']
+patches = ['hwloc-2.13.0_lstopo-ascii-dont-call-refresh.patch']
+checksums = [
+    {'hwloc-2.13.0.tar.gz': '1514a5253f0a5c23bc006d3bdd30a6f6125c9a8dc9b5fa4984913d1fff45315d'},
+    {'hwloc-2.13.0_lstopo-ascii-dont-call-refresh.patch':
+     '0d8f7d16741301117a0eb71ce82a6a151b4b97c04ca59b8b20c08363e129739e'},
+]
 
 builddependencies = [
     ('binutils', '2.45'),

--- a/easybuild/easyconfigs/h/hwloc/hwloc-2.13.0_lstopo-ascii-dont-call-refresh.patch
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-2.13.0_lstopo-ascii-dont-call-refresh.patch
@@ -1,0 +1,28 @@
+From a79dc057444298405e2c21e7f9e3b24e16d94d11 Mon Sep 17 00:00:00 2001
+From: Samuel Thibault <samuel.thibault@ens-lyon.org>
+Date: Mon, 23 Feb 2026 19:32:07 +0100
+Subject: [PATCH] lstopo-ascii: Do not call refresh()
+
+This is not available when we link tinfo only, and apparently it is not
+actually needed.
+
+(cherry picked from commit f7f1f76573ce505dae73568c912d2b2efdbf0f71)
+---
+ utils/lstopo/lstopo-ascii.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/utils/lstopo/lstopo-ascii.c b/utils/lstopo/lstopo-ascii.c
+index d0dfb37312..4f270c3f6a 100644
+--- a/utils/lstopo/lstopo-ascii.c
++++ b/utils/lstopo/lstopo-ascii.c
+@@ -605,10 +605,6 @@ output_ascii(struct lstopo_output *loutput, const char *filename)
+ 
+ #if defined(HAVE_SYS_WAIT_H) && defined(HAVE_ISATTY)
+   if (use_pager) {
+-#ifdef HWLOC_HAVE_LIBTERMCAP
+-    /* Flush ncurses */
+-    refresh();
+-#endif
+     fflush(stdout);
+ 
+     /* Now that we have set up colors on the tty (which the pager doesn't


### PR DESCRIPTION
Ran into the following issue when installing hwloc 2.13.0 on top of a new EESSI (test) version:

```
/cvmfs/software.eessi.io/versions/2026.06/compat/linux/x86_64/usr/x86_64-pc-linux-gnu/binutils-bin/2.46.1/ld: lstopo_no_graphics-lstopo-ascii.o: in function `output_ascii':
lstopo-ascii.c:(.text+0xe38): undefined reference to `wrefresh'
```

`wrefresh` is from (n)curses. When checking hwloc 2.14.0 code, I found that they removed this call, see https://github.com/open-mpi/hwloc/commit/bc1531d216d9adba25325588d3db89f14cbee219, and that solves the issue.

edit: since it's still using ncurses, I've also added it as dependency.