### PR TITLE
Apply upstream patch to protobuf-python 6.31.1

### DIFF
--- a/easybuild/easyconfigs/p/protobuf-python/protobuf-python-6.31.1-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/p/protobuf-python/protobuf-python-6.31.1-GCCcore-14.2.0.eb
@@ -1,4 +1,4 @@
-easyblock = 'PythonPackage'
+easyblock = 'PythonBundle'
 
 name = 'protobuf-python'
 version = '6.31.1'
@@ -8,15 +8,6 @@ description = "Python Protocol Buffers runtime library."
 
 toolchain = {'name': 'GCCcore', 'version': '14.2.0'}
 
-source_urls = ['https://pypi.python.org/packages/source/p/protobuf']
-sources = ['protobuf-%(version)s.tar.gz']
-patches = ['protobuf-python-6.31.1-remove_pkg_resources.patch']
-checksums = [
-    {'protobuf-6.31.1.tar.gz': 'd8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a'},
-    {'protobuf-python-6.31.1-remove_pkg_resources.patch':
-     '83680b44574188a1924054a91a155a14b4934a05d77c8401d953f2e9f6d6f12f'},
-]
-
 builddependencies = [('binutils', '2.42')]
 
 dependencies = [
@@ -24,7 +15,17 @@ dependencies = [
     ('protobuf', version[2:]),  # Major version is only used for the Python bindings
 ]
 
-options = {'modulename': 'google.protobuf'}
+exts_list = [
+    ('protobuf', version, {
+        'modulename': 'google.protobuf',
+        'patches': ['protobuf-python-6.31.1-remove_pkg_resources.patch'],
+        'checksums': [
+            {'protobuf-6.31.1.tar.gz': 'd8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a'},
+            {'protobuf-python-6.31.1-remove_pkg_resources.patch':
+             '83680b44574188a1924054a91a155a14b4934a05d77c8401d953f2e9f6d6f12f'},
+        ],
+    })
+]
 
 # Make sure protobuf is installed as a regular folder or it will not be found if
 # other google packages are installed in other site-packages folders
@@ -32,7 +33,5 @@ sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/google/protobuf'],
 }
-
-sanity_check_pip_list = False
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/protobuf-python/protobuf-python-6.31.1-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/p/protobuf-python/protobuf-python-6.31.1-GCCcore-14.2.0.eb
@@ -10,7 +10,12 @@ toolchain = {'name': 'GCCcore', 'version': '14.2.0'}
 
 source_urls = ['https://pypi.python.org/packages/source/p/protobuf']
 sources = ['protobuf-%(version)s.tar.gz']
-checksums = ['d8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a']
+patches = ['protobuf-python-6.31.1-remove_pkg_resources.patch']
+checksums = [
+    {'protobuf-6.31.1.tar.gz': 'd8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a'},
+    {'protobuf-python-6.31.1-remove_pkg_resources.patch':
+     '83680b44574188a1924054a91a155a14b4934a05d77c8401d953f2e9f6d6f12f'},
+]
 
 builddependencies = [('binutils', '2.42')]
 

--- a/easybuild/easyconfigs/p/protobuf-python/protobuf-python-6.31.1-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/p/protobuf-python/protobuf-python-6.31.1-GCCcore-14.2.0.eb
@@ -33,4 +33,6 @@ sanity_check_paths = {
     'dirs': ['lib/python%(pyshortver)s/site-packages/google/protobuf'],
 }
 
+sanity_check_pip_list = False
+
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/protobuf-python/protobuf-python-6.31.1-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/p/protobuf-python/protobuf-python-6.31.1-GCCcore-14.3.0.eb
@@ -1,4 +1,4 @@
-easyblock = 'PythonPackage'
+easyblock = 'PythonBundle'
 
 name = 'protobuf-python'
 version = '6.31.1'
@@ -8,15 +8,6 @@ description = "Python Protocol Buffers runtime library."
 
 toolchain = {'name': 'GCCcore', 'version': '14.3.0'}
 
-source_urls = ['https://pypi.python.org/packages/source/p/protobuf']
-sources = ['protobuf-%(version)s.tar.gz']
-patches = ['protobuf-python-6.31.1-remove_pkg_resources.patch']
-checksums = [
-    {'protobuf-6.31.1.tar.gz': 'd8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a'},
-    {'protobuf-python-6.31.1-remove_pkg_resources.patch':
-     '83680b44574188a1924054a91a155a14b4934a05d77c8401d953f2e9f6d6f12f'},
-]
-
 builddependencies = [('binutils', '2.44')]
 
 dependencies = [
@@ -24,7 +15,17 @@ dependencies = [
     ('protobuf', version[2:]),  # Major version is only used for the Python bindings
 ]
 
-options = {'modulename': 'google.protobuf'}
+exts_list = [
+    ('protobuf', version, {
+        'modulename': 'google.protobuf',
+        'patches': ['protobuf-python-6.31.1-remove_pkg_resources.patch'],
+        'checksums': [
+            {'protobuf-6.31.1.tar.gz': 'd8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a'},
+            {'protobuf-python-6.31.1-remove_pkg_resources.patch':
+             '83680b44574188a1924054a91a155a14b4934a05d77c8401d953f2e9f6d6f12f'},
+        ],
+    })
+]
 
 # Make sure protobuf is installed as a regular folder or it will not be found if
 # other google packages are installed in other site-packages folders
@@ -32,7 +33,5 @@ sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages/google/protobuf'],
 }
-
-sanity_check_pip_list = False
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/protobuf-python/protobuf-python-6.31.1-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/p/protobuf-python/protobuf-python-6.31.1-GCCcore-14.3.0.eb
@@ -10,7 +10,12 @@ toolchain = {'name': 'GCCcore', 'version': '14.3.0'}
 
 source_urls = ['https://pypi.python.org/packages/source/p/protobuf']
 sources = ['protobuf-%(version)s.tar.gz']
-checksums = ['d8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a']
+patches = ['protobuf-python-6.31.1-remove_pkg_resources.patch']
+checksums = [
+    {'protobuf-6.31.1.tar.gz': 'd8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a'},
+    {'protobuf-python-6.31.1-remove_pkg_resources.patch':
+     '83680b44574188a1924054a91a155a14b4934a05d77c8401d953f2e9f6d6f12f'},
+]
 
 builddependencies = [('binutils', '2.44')]
 

--- a/easybuild/easyconfigs/p/protobuf-python/protobuf-python-6.31.1-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/p/protobuf-python/protobuf-python-6.31.1-GCCcore-14.3.0.eb
@@ -33,4 +33,6 @@ sanity_check_paths = {
     'dirs': ['lib/python%(pyshortver)s/site-packages/google/protobuf'],
 }
 
+sanity_check_pip_list = False
+
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/protobuf-python/protobuf-python-6.31.1-remove_pkg_resources.patch
+++ b/easybuild/easyconfigs/p/protobuf-python/protobuf-python-6.31.1-remove_pkg_resources.patch
@@ -1,0 +1,49 @@
+Remove deprecated usage of `pkg_resources` for the namespace packaging. See:
+- https://github.com/protocolbuffers/protobuf/pull/22447
+- https://github.com/easybuilders/easybuild-easyconfigs/pull/26051#issuecomment-4807848980
+
+From 8351926380c7cc91aae6df5695c91426e209f958 Mon Sep 17 00:00:00 2001
+From: Ge Yunxi <141423244+gyx47@users.noreply.github.com>
+Date: Fri, 11 Jul 2025 11:04:58 -0700
+Subject: [PATCH] drop-deprecated-pkg-resources-declare (#22442)
+
+# Description
+As of setuptools 81, pkg_resources.declare_namespace has been marked as deprecated (scheduled to be removed after 2025-11-30) so I remove it from init.py
+
+# Environment:
+a virtual machine of arch riscv64
+
+# procedure
+I got this problem when running a test that applied this package.
+```
+src/certbot_dns_google/_internal/tests/dns_google_test.py:9: in <module>
+    from google.auth import exceptions as googleauth_exceptions
+/usr/lib/python3.13/site-packages/google/__init__.py:2: in <module>
+    __import__('pkg_resources').declare_namespace(__name__)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/usr/lib/python3.13/site-packages/pkg_resources/__init__.py:98: in <module>
+    warnings.warn(
+E   UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
+```
+[certbot-dns-google-4.1.1-1-riscv64-check.log](https://github.com/user-attachments/files/20976539/certbot-dns-google-4.1.1-1-riscv64-check.log)
+
+Closes #22442
+
+COPYBARA_INTEGRATE_REVIEW=https://github.com/protocolbuffers/protobuf/pull/22442 from gyx47:patch-1 6aef5c9df150cce444910d224fe90b2a514c7868
+PiperOrigin-RevId: 782041935
+---
+ python/google/__init__.py | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/python/google/__init__.py b/python/google/__init__.py
+index 5585614122997..b36383a61027f 100644
+--- a/python/google/__init__.py
++++ b/python/google/__init__.py
+@@ -1,4 +1,3 @@
+-try:
+-  __import__('pkg_resources').declare_namespace(__name__)
+-except ImportError:
+-  __path__ = __import__('pkgutil').extend_path(__path__, __name__)
++from pkgutil import extend_path
++
++__path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
Apply upstream patch to remove usage of deprecated `pkg_resources` to resolve namespace packaging.

Fixes error encountered in:

- https://github.com/easybuilders/easybuild-easyconfigs/pull/26051