### PR TITLE
Improve python kernel's interoperability from EB to generic jupyter servers

### DIFF
--- a/easybuild/easyconfigs/j/jupyter-server/jupyter-server-2.17.0-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/j/jupyter-server/jupyter-server-2.17.0-GCCcore-14.3.0.eb
@@ -226,6 +226,17 @@ exts_list = [
     }),
 ]
 
+_python_bin = "${EBROOTPYTHON}/bin/python"
+_kernel_json = "%(installdir)s/share/jupyter/kernels/python3/kernel.json"
+_kernel_desc = "EasyBuild Python %(pyver)s (ipykernel)"
+
+postinstallcmds = [
+    # Hardcode the path to the python executable in the kernel.json file, so that it works even if another python
+    # takes precedence in the PATH
+    f'sed -i "/^ *\\\"python/ s|\\\"python\\\"|\\\"{_python_bin}\\\"|" {_kernel_json}',
+    f"sed -i 's|\"display_name\": .*|\"display_name\": \"{_kernel_desc}\",|' {_kernel_json}",
+]
+
 sanity_check_paths = {
     'files': ['bin/jupyter'],
     'dirs': ['share/jupyter', 'etc/jupyter'],
@@ -233,6 +244,11 @@ sanity_check_paths = {
 
 sanity_check_commands = ['jupyter --help']
 
-modextrapaths = {'EB_ENV_JUPYTER_ROOT': ''}
+modextrapaths = {
+    'EB_ENV_JUPYTER_ROOT': '',
+    # needed for kernelspecs to be dynamically found by jupyter, EG in a non-easybuild juypyter server loading EB
+    # modules through `jupyterlmod`
+    'JUPYTER_PATH': 'share/jupyter',
+}
 
 moduleclass = 'tools'


### PR DESCRIPTION
This is an improvement on the behavior of base python kernels that can be used in a generic jupyter server.

Currently the kernel installed with `jupyter-server` is only usable through a server started with EB's python/jupyter binaries.

It is also possible and i would say desirable to start a generic (non-tied to EB) jupyter server and allow to load the varius python kernels inside of it
[jupyterlmod](https://github.com/cmd-ntrf/jupyter-lmod) allows to dynamically load modules in a jupyter server allowing new kernels to be made available on-demand.

This PR address 2 main points:
- hardcodes the path to EB's python in the `kernel.json` file to ensure the correct python is used (maybe this could be improved in `jupyterlmod` but right now even if `PATH` is updated in the notebook, the server that starts the kernel still has the python from the `venv` and not the one from the loaded module)
- Ensure `JUPYTER_PATH` is also set as `EB_ENV_JUPYTER_ROOT` is only used at start-time and not dynamically by `KernelSpecManger` to find available kernels (the alternative would require us to patch also `KernelSpecManager`'s code but at this point i would prefer the alternative described below)

This has been tested by starting a server through a venv+pip installation of `jupyterlab` + `jupyterlmod` and than, loading the patched `jupyter-server` module makes the new kernel appear in the selection list

<img width="3153" height="1300" alt="image" src="https://github.com/user-attachments/assets/1649f671-98d0-4ef0-9f9f-ec16b25c6afe" />

The previous image shows a server started from a venv with only `jupyterlab` and `jupyterlmod` installed through pip 
Without these changes only the original kernel (the one from python used to start the server) would appear, even after loading the modules

## Possible improvements

- Allow the original kernel to still appear/be used with loaded modules
- Change approach entirely and ship an EB specific extension with a custom `KernelSpecManager` to allow finding and dynamically loading a kernel from all installed Python's (at-least the EB ones) that support it (similar to what VSCode does for starting kernels in a jupyter notebook, where any python that can load `ipykernel` can be used)