### PR TITLE
{lib} [GCCcore-13.2.0] python-irodsclient v3.2.0, mango-auth v0.0.11

### DIFF
--- a/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/m/mango-auth/mango-auth-0.0.11-GCCcore-13.2.0.eb
@@ -1,0 +1,40 @@
+# Author: Ehsan Moravveji (VSC - KU Leuven)
+
+easyblock = 'PythonBundle'
+
+name = 'mango-auth'
+version = '0.0.11'
+
+homepage = 'https://github.com/kuleuven/mango-auth'
+description = '''
+Mango Auth is a small python module to authenticate using interactive
+PAM authentication against an iRODS installation, opening web browser
+links as needed.
+'''
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+builddependencies = [
+    ('binutils', '2.40'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('python-irodsclient', '3.2.0'),
+]
+
+exts_list = [
+    (name, version, {
+        'modulename': 'mango_auth',
+        'checksums': ['6c2881e9be6e6f76dd1225ab561f07f145acddd74dd6aef4da8d4928a1377339'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/mango_auth'],
+    'dirs': [],
+}
+
+sanity_check_commands = ["mango_auth -h"]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/python-irodsclient/python-irodsclient-3.2.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/p/python-irodsclient/python-irodsclient-3.2.0-GCCcore-13.2.0.eb
@@ -1,0 +1,44 @@
+easyblock = 'PythonBundle'
+
+name = 'python-irodsclient'
+version = '3.2.0'
+
+homepage = 'https://github.com/irods/python-irodsclient'
+description = "A python API for iRODS"
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+builddependencies = [
+    ('binutils', '2.40'),
+]
+
+dependencies = [
+    ('Python', '3.11.5'),
+    ('Python-bundle-PyPI', '2023.10'),
+]
+
+exts_list = [
+    ('defusedxml', '0.7.1', {
+        'checksums': ['1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69'],
+    }),
+    ('prettytable', '3.17.0', {
+        'patches': ['prettytable-3.17.0-setutools-build-system.patch'],
+        'checksums': [
+            {'prettytable-3.17.0.tar.gz': '59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0'},
+            {'prettytable-3.17.0-setutools-build-system.patch':
+             '41398ba98428614e08f9060adbf2968184e570f87e7fa39625e210e491a4efec'},
+        ],
+    }),
+    ('jsonpatch', '1.33', {
+        'checksums': ['9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c'],
+    }),
+    ('jsonpointer', '3.0.0', {
+        'checksums': ['2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef'],
+    }),
+    (name, version, {
+        'modulename': 'irods',
+        'checksums': ['a7e1c765b5c24c7cc579334e06c32bc76bf4e9ffac3209abcea853f9440ff2e4'],
+    }),
+]
+
+moduleclass = 'lib'


### PR DESCRIPTION
PR for some irods-based tools for GCCcore 13.2.0:
- python-irods-client (PRC) 3.2.0
-  mango-auth 0.0.11