### PR TITLE
Fix rocm-core version from 6.4.0 => 6.4.1

### DIFF
--- a/easybuild/easyconfigs/r/RCCL/RCCL-2.22.3-rocm-compilers-19.0.0-ROCm-6.4.1.eb
+++ b/easybuild/easyconfigs/r/RCCL/RCCL-2.22.3-rocm-compilers-19.0.0-ROCm-6.4.1.eb
@@ -41,7 +41,7 @@ dependencies = [
     ('googletest', '1.17.0'),
     ('rocm-smi', '7.6.0', f'-ROCm-{_rocm_version}'),
     ('rocprofiler-register', '0.4.0', f'-ROCm-{_rocm_version}'),
-    ('rocm-core', '6.4.0', f'-ROCm-{_rocm_version}'),
+    ('rocm-core', '6.4.1', f'-ROCm-{_rocm_version}'),
 ]
 
 # Ensure that full path of compilers is picked up, as rpath wrappers are not correctly used otherwise.

--- a/easybuild/easyconfigs/r/rocm-core/rocm-core-6.4.1-GCCcore-14.2.0-ROCm-6.4.1.eb
+++ b/easybuild/easyconfigs/r/rocm-core/rocm-core-6.4.1-GCCcore-14.2.0-ROCm-6.4.1.eb
@@ -3,7 +3,7 @@
 easyblock = 'CMakeMake'
 
 name = 'rocm-core'
-version = '6.4.0'
+version = '6.4.1'
 _rocm_version = '6.4.1'
 versionsuffix = f'-ROCm-{_rocm_version}'
 


### PR DESCRIPTION
rocm-core exposes ROCm release version at runtime via `getROCmVersion()`, so its version tracks the user-space ROCm release exactly. There is no hardcoded `6.4.1` in the source code; it picks up the version from the ROCm-LLVM at runtime, which led to the oversight.