### PR TITLE
Fix Triton test for CUDA families and CUDA CCs like `9.0a`

### DIFF
--- a/easybuild/easyconfigs/t/Triton/Triton-3.3.1-gfbf-2024a-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/t/Triton/Triton-3.3.1-gfbf-2024a-CUDA-12.6.0.eb
@@ -138,7 +138,7 @@ exts_list = [
 postinstallpatches = [('triton_test.py', 'test/triton_test.py')]
 
 checksums = [
-    {'triton_test.py': '0d8b4556a76268b000d6023a1abaee801d179db3aed51e781c06854858490cc8'},
+    {'triton_test.py': 'c5a4d75446f7bd277bb94a821d44671515c2d5641a3d279e03134d29ab964219'},
 ]
 
 sanity_check_commands = ['TRITON_HOME=$TMPDIR/eb-triton_home '

--- a/easybuild/easyconfigs/t/Triton/Triton-3.5.0-gfbf-2024a-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/t/Triton/Triton-3.5.0-gfbf-2024a-CUDA-12.6.0.eb
@@ -124,7 +124,7 @@ exts_list = [
 postinstallpatches = [('triton_test.py', 'test/triton_test.py')]
 
 checksums = [
-    {'triton_test.py': '0d8b4556a76268b000d6023a1abaee801d179db3aed51e781c06854858490cc8'},
+    {'triton_test.py': 'c5a4d75446f7bd277bb94a821d44671515c2d5641a3d279e03134d29ab964219'},
 ]
 
 sanity_check_commands = ['TRITON_HOME=$TMPDIR/eb-triton_home '

--- a/easybuild/easyconfigs/t/Triton/Triton-3.5.0-gfbf-2025b-CUDA-12.9.1.eb
+++ b/easybuild/easyconfigs/t/Triton/Triton-3.5.0-gfbf-2025b-CUDA-12.9.1.eb
@@ -120,7 +120,7 @@ exts_list = [
 postinstallpatches = [('triton_test.py', 'test/triton_test.py')]
 
 checksums = [
-    {'triton_test.py': '0d8b4556a76268b000d6023a1abaee801d179db3aed51e781c06854858490cc8'},
+    {'triton_test.py': 'c5a4d75446f7bd277bb94a821d44671515c2d5641a3d279e03134d29ab964219'},
 ]
 
 sanity_check_commands = ['TRITON_HOME=$TMPDIR/eb-triton_home '

--- a/easybuild/easyconfigs/t/Triton/triton_test.py
+++ b/easybuild/easyconfigs/t/Triton/triton_test.py
@@ -16,6 +16,7 @@ src = triton.compiler.ASTSource(
 )
 
 cuda_cc = sys.argv[1].split(',')[-1]
-target = GPUTarget("cuda", int(cuda_cc.replace('.', '')), 32)
+cuda_cc_digits = [d for d in cuda_cc if d.isdigit()]  # Strip dots and suffixes, e.g. from 9.0a
+target = GPUTarget("cuda", int(''.join(cuda_cc_digits)), 32)
 output = triton.compile(src, target=target)
 print(output)


### PR DESCRIPTION
Strip everything but digits from the passed CUDA CC