### PR TITLE
{chem}[foss/2026.1] QMCPACK v4.3.0

### DIFF
--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2025a-complex.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2025a-complex.eb
@@ -1,0 +1,66 @@
+easyblock = 'CMakeNinja'
+
+name = 'QMCPACK'
+version = '4.3.0'
+versionsuffix = '-complex'
+
+homepage = 'https://qmcpack.org'
+description = """QMCPACK is an open-source quantum Monte Carlo simulation code."""
+
+toolchain = {'name': 'foss', 'version': '2025a'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+github_account = 'QMCPACK'
+source_urls = [GITHUB_SOURCE]
+sources = [
+    {
+        'download_filename': 'v%(version)s.tar.gz',
+        'filename': SOURCELOWER_TAR_GZ,
+    },
+]
+checksums = [
+    '511d5f368db002f2f77504619e1ada8d4a3034200d25feef6773d12a6ed6d18e',
+]
+configopts = '-DCMAKE_BUILD_TYPE=Release -DQMC_MPI=ON -DQMC_OMP=ON -DQMC_MIXED_PRECISION=OFF -DQMC_COMPLEX=ON '
+configopts += '-DBUILD_AFQMC=OFF'
+modextrapaths = {
+    'PYTHONPATH': 'lib',
+}
+sanity_check_commands = [
+    "qmcpack_complex --version 2>&1 | grep -q 'QMCPACK version'",
+]
+sanity_check_paths = {
+    'dirs': [
+        'lib/nexus',
+    ],
+    'files': [
+        'bin/qmcpack_complex',
+        'bin/convert4qmc',
+        'bin/ppconvert',
+        'bin/qmcpack.settings',
+    ],
+}
+start_dir = '%(namelower)s-%(version)s'
+# Allow concurrent multi-rank mpiexec under ctest -j (netCDF/OTF-CPT pattern).
+pretestopts = 'export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe && '
+test_cmd = 'ctest'
+# Single-quoted -E pattern so shell does not treat | as a pipe.
+testopts = (
+    "-L deterministic -j %(parallel)s --output-on-failure "
+    "-E 'unit_test_message-r12|unit_test_new_drivers_mpi-r16'"
+)
+
+builddependencies = [
+    ('CMake', '3.31.3'),
+    ('Ninja', '1.12.1'),
+    ('pkgconf', '2.3.0'),
+]
+
+dependencies = [
+    ('Boost', '1.88.0'),
+    ('HDF5', '1.14.6'),
+    ('Python', '3.13.1'),
+    ('libxml2', '2.13.4'),
+]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2025a.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2025a.eb
@@ -1,0 +1,65 @@
+easyblock = 'CMakeNinja'
+
+name = 'QMCPACK'
+version = '4.3.0'
+
+homepage = 'https://qmcpack.org'
+description = """QMCPACK is an open-source quantum Monte Carlo simulation code."""
+
+toolchain = {'name': 'foss', 'version': '2025a'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+github_account = 'QMCPACK'
+source_urls = [GITHUB_SOURCE]
+sources = [
+    {
+        'download_filename': 'v%(version)s.tar.gz',
+        'filename': SOURCELOWER_TAR_GZ,
+    },
+]
+checksums = [
+    '511d5f368db002f2f77504619e1ada8d4a3034200d25feef6773d12a6ed6d18e',
+]
+configopts = '-DCMAKE_BUILD_TYPE=Release -DQMC_MPI=ON -DQMC_OMP=ON -DQMC_MIXED_PRECISION=OFF -DQMC_COMPLEX=OFF '
+configopts += '-DBUILD_AFQMC=OFF'
+modextrapaths = {
+    'PYTHONPATH': 'lib',
+}
+sanity_check_commands = [
+    "qmcpack --version 2>&1 | grep -q 'QMCPACK version'",
+]
+sanity_check_paths = {
+    'dirs': [
+        'lib/nexus',
+    ],
+    'files': [
+        'bin/qmcpack',
+        'bin/convert4qmc',
+        'bin/ppconvert',
+        'bin/qmcpack.settings',
+    ],
+}
+start_dir = '%(namelower)s-%(version)s'
+# Allow concurrent multi-rank mpiexec under ctest -j (netCDF/OTF-CPT pattern).
+pretestopts = 'export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe && '
+test_cmd = 'ctest'
+# Single-quoted -E pattern so shell does not treat | as a pipe.
+testopts = (
+    "-L deterministic -j %(parallel)s --output-on-failure "
+    "-E 'unit_test_message-r12|unit_test_new_drivers_mpi-r16'"
+)
+
+builddependencies = [
+    ('CMake', '3.31.3'),
+    ('Ninja', '1.12.1'),
+    ('pkgconf', '2.3.0'),
+]
+
+dependencies = [
+    ('Boost', '1.88.0'),
+    ('HDF5', '1.14.6'),
+    ('Python', '3.13.1'),
+    ('libxml2', '2.13.4'),
+]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2025b-complex.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2025b-complex.eb
@@ -1,0 +1,66 @@
+easyblock = 'CMakeNinja'
+
+name = 'QMCPACK'
+version = '4.3.0'
+versionsuffix = '-complex'
+
+homepage = 'https://qmcpack.org'
+description = """QMCPACK is an open-source quantum Monte Carlo simulation code."""
+
+toolchain = {'name': 'foss', 'version': '2025b'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+github_account = 'QMCPACK'
+source_urls = [GITHUB_SOURCE]
+sources = [
+    {
+        'download_filename': 'v%(version)s.tar.gz',
+        'filename': SOURCELOWER_TAR_GZ,
+    },
+]
+checksums = [
+    '511d5f368db002f2f77504619e1ada8d4a3034200d25feef6773d12a6ed6d18e',
+]
+configopts = '-DCMAKE_BUILD_TYPE=Release -DQMC_MPI=ON -DQMC_OMP=ON -DQMC_MIXED_PRECISION=OFF -DQMC_COMPLEX=ON '
+configopts += '-DBUILD_AFQMC=OFF'
+modextrapaths = {
+    'PYTHONPATH': 'lib',
+}
+sanity_check_commands = [
+    "qmcpack_complex --version 2>&1 | grep -q 'QMCPACK version'",
+]
+sanity_check_paths = {
+    'dirs': [
+        'lib/nexus',
+    ],
+    'files': [
+        'bin/qmcpack_complex',
+        'bin/convert4qmc',
+        'bin/ppconvert',
+        'bin/qmcpack.settings',
+    ],
+}
+start_dir = '%(namelower)s-%(version)s'
+# Allow concurrent multi-rank mpiexec under ctest -j (netCDF/OTF-CPT pattern).
+pretestopts = 'export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe && '
+test_cmd = 'ctest'
+# Single-quoted -E pattern so shell does not treat | as a pipe.
+testopts = (
+    "-L deterministic -j %(parallel)s --output-on-failure "
+    "-E 'unit_test_message-r12|unit_test_new_drivers_mpi-r16'"
+)
+
+builddependencies = [
+    ('CMake', '4.0.3'),
+    ('Ninja', '1.13.0'),
+    ('pkgconf', '2.4.3'),
+]
+
+dependencies = [
+    ('Boost', '1.88.0'),
+    ('HDF5', '1.14.6'),
+    ('Python', '3.13.5'),
+    ('libxml2', '2.14.3'),
+]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2025b.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2025b.eb
@@ -1,0 +1,65 @@
+easyblock = 'CMakeNinja'
+
+name = 'QMCPACK'
+version = '4.3.0'
+
+homepage = 'https://qmcpack.org'
+description = """QMCPACK is an open-source quantum Monte Carlo simulation code."""
+
+toolchain = {'name': 'foss', 'version': '2025b'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+github_account = 'QMCPACK'
+source_urls = [GITHUB_SOURCE]
+sources = [
+    {
+        'download_filename': 'v%(version)s.tar.gz',
+        'filename': SOURCELOWER_TAR_GZ,
+    },
+]
+checksums = [
+    '511d5f368db002f2f77504619e1ada8d4a3034200d25feef6773d12a6ed6d18e',
+]
+configopts = '-DCMAKE_BUILD_TYPE=Release -DQMC_MPI=ON -DQMC_OMP=ON -DQMC_MIXED_PRECISION=OFF -DQMC_COMPLEX=OFF '
+configopts += '-DBUILD_AFQMC=OFF'
+modextrapaths = {
+    'PYTHONPATH': 'lib',
+}
+sanity_check_commands = [
+    "qmcpack --version 2>&1 | grep -q 'QMCPACK version'",
+]
+sanity_check_paths = {
+    'dirs': [
+        'lib/nexus',
+    ],
+    'files': [
+        'bin/qmcpack',
+        'bin/convert4qmc',
+        'bin/ppconvert',
+        'bin/qmcpack.settings',
+    ],
+}
+start_dir = '%(namelower)s-%(version)s'
+# Allow concurrent multi-rank mpiexec under ctest -j (netCDF/OTF-CPT pattern).
+pretestopts = 'export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe && '
+test_cmd = 'ctest'
+# Single-quoted -E pattern so shell does not treat | as a pipe.
+testopts = (
+    "-L deterministic -j %(parallel)s --output-on-failure "
+    "-E 'unit_test_message-r12|unit_test_new_drivers_mpi-r16'"
+)
+
+builddependencies = [
+    ('CMake', '4.0.3'),
+    ('Ninja', '1.13.0'),
+    ('pkgconf', '2.4.3'),
+]
+
+dependencies = [
+    ('Boost', '1.88.0'),
+    ('HDF5', '1.14.6'),
+    ('Python', '3.13.5'),
+    ('libxml2', '2.14.3'),
+]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1-complex.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1-complex.eb
@@ -27,14 +27,14 @@ modextrapaths = {
     'PYTHONPATH': 'lib',
 }
 sanity_check_commands = [
-    'qmcpack --version 2>&1 | grep -q \'QMCPACK version\'',
+    'qmcpack_complex --version 2>&1 | grep -q \'QMCPACK version\'',
 ]
 sanity_check_paths = {
     'dirs': [
         'lib/nexus',
     ],
     'files': [
-        'bin/qmcpack',
+        'bin/qmcpack_complex',
         'bin/convert4qmc',
         'bin/ppconvert',
         'bin/qmcpack.settings',

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1-complex.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1-complex.eb
@@ -42,7 +42,7 @@ sanity_check_paths = {
 }
 start_dir = '%(namelower)s-%(version)s'
 test_cmd = 'ctest'
-testopts = '-j %(parallel)s --output-on-failure -E \'performance|long\''
+testopts = '-L deterministic -j %(parallel)s --output-on-failure'
 
 builddependencies = [
     ('CMake', '4.2.1'),

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1-complex.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1-complex.eb
@@ -41,8 +41,13 @@ sanity_check_paths = {
     ],
 }
 start_dir = '%(namelower)s-%(version)s'
+# Allow concurrent multi-rank mpiexec under ctest -j (netCDF/OTF-CPT pattern).
+pretestopts = 'export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe && '
 test_cmd = 'ctest'
-testopts = '-L deterministic -j %(parallel)s --output-on-failure -E \'unit_test_message-r12|unit_test_new_drivers_mpi-r16\''
+testopts = (
+    '-L deterministic -j %(parallel)s --output-on-failure '
+    '-E unit_test_message-r12|unit_test_new_drivers_mpi-r16'
+)
 
 builddependencies = [
     ('CMake', '4.2.1'),

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1-complex.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1-complex.eb
@@ -42,7 +42,7 @@ sanity_check_paths = {
 }
 start_dir = '%(namelower)s-%(version)s'
 test_cmd = 'ctest'
-testopts = '-L deterministic -j %(parallel)s --output-on-failure'
+testopts = '-L deterministic -j %(parallel)s --output-on-failure -E \'unit_test_message-r12|unit_test_new_drivers_mpi-r16\''
 
 builddependencies = [
     ('CMake', '4.2.1'),

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1-complex.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1-complex.eb
@@ -27,7 +27,7 @@ modextrapaths = {
     'PYTHONPATH': 'lib',
 }
 sanity_check_commands = [
-    'qmcpack_complex --version 2>&1 | grep -q \'QMCPACK version\'',
+    "qmcpack_complex --version 2>&1 | grep -q 'QMCPACK version'",
 ]
 sanity_check_paths = {
     'dirs': [
@@ -44,9 +44,10 @@ start_dir = '%(namelower)s-%(version)s'
 # Allow concurrent multi-rank mpiexec under ctest -j (netCDF/OTF-CPT pattern).
 pretestopts = 'export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe && '
 test_cmd = 'ctest'
+# Single-quoted -E pattern so shell does not treat | as a pipe.
 testopts = (
-    '-L deterministic -j %(parallel)s --output-on-failure '
-    '-E unit_test_message-r12|unit_test_new_drivers_mpi-r16'
+    "-L deterministic -j %(parallel)s --output-on-failure "
+    "-E 'unit_test_message-r12|unit_test_new_drivers_mpi-r16'"
 )
 
 builddependencies = [

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1-complex.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1-complex.eb
@@ -1,0 +1,60 @@
+easyblock = 'CMakeNinja'
+
+name = 'QMCPACK'
+version = '4.3.0'
+versionsuffix = '-complex'
+
+homepage = 'https://qmcpack.org'
+description = """QMCPACK is an open-source quantum Monte Carlo simulation code."""
+
+toolchain = {'name': 'foss', 'version': '2026.1'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+github_account = 'QMCPACK'
+source_urls = [GITHUB_SOURCE]
+sources = [
+    {
+        'download_filename': 'v%(version)s.tar.gz',
+        'filename': SOURCELOWER_TAR_GZ,
+    },
+]
+checksums = [
+    '511d5f368db002f2f77504619e1ada8d4a3034200d25feef6773d12a6ed6d18e',
+]
+configopts = '-DCMAKE_BUILD_TYPE=Release -DQMC_MPI=ON -DQMC_OMP=ON -DQMC_MIXED_PRECISION=OFF -DQMC_COMPLEX=ON '
+configopts += '-DBUILD_AFQMC=OFF'
+modextrapaths = {
+    'PYTHONPATH': 'lib',
+}
+sanity_check_commands = [
+    'qmcpack --version 2>&1 | grep -q \'QMCPACK version\'',
+]
+sanity_check_paths = {
+    'dirs': [
+        'lib/nexus',
+    ],
+    'files': [
+        'bin/qmcpack',
+        'bin/convert4qmc',
+        'bin/ppconvert',
+        'bin/qmcpack.settings',
+    ],
+}
+start_dir = '%(namelower)s-%(version)s'
+test_cmd = 'ctest'
+testopts = '-j %(parallel)s --output-on-failure -E \'performance|long\''
+
+builddependencies = [
+    ('CMake', '4.2.1'),
+    ('Ninja', '1.13.2'),
+    ('pkgconf', '2.5.1'),
+]
+
+dependencies = [
+    ('Boost', '1.90.0'),
+    ('HDF5', '2.1.1'),
+    ('Python', '3.14.2'),
+    ('libxml2', '2.15.1'),
+]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
@@ -70,9 +70,9 @@ sanity_check_paths = {
 }
 
 # Upstream qmcpack --version prints the banner then exits 1.
+# convert4qmc has no --help (prints "Unknown extension" and exits 0); path check only.
 sanity_check_commands = [
     "qmcpack --version 2>&1 | grep -q 'QMCPACK version'",
-    "convert4qmc --help 2>&1 | grep -qi convert",
 ]
 
 # Nexus lives under lib/nexus; put lib on PYTHONPATH for `import nexus`.

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
@@ -40,8 +40,13 @@ sanity_check_paths = {
     ],
 }
 start_dir = '%(namelower)s-%(version)s'
+# Allow concurrent multi-rank mpiexec under ctest -j (netCDF/OTF-CPT pattern).
+pretestopts = 'export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe && '
 test_cmd = 'ctest'
-testopts = '-L deterministic -j %(parallel)s --output-on-failure -E \'unit_test_message-r12|unit_test_new_drivers_mpi-r16\''
+testopts = (
+    '-L deterministic -j %(parallel)s --output-on-failure '
+    '-E unit_test_message-r12|unit_test_new_drivers_mpi-r16'
+)
 
 builddependencies = [
     ('CMake', '4.2.1'),

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
@@ -4,28 +4,44 @@ name = 'QMCPACK'
 version = '4.3.0'
 
 homepage = 'https://qmcpack.org'
-description = """
-QMCPACK is an open-source production-level many-body ab initio Quantum Monte
-Carlo code for computing the electronic structure of atoms, molecules, 2D
-nanomaterials and solids.
-
-This easyconfig builds the CPU real reference: MPI + OpenMP, full double
-precision (mixed precision off), no GPU offload.
-"""
+description = """QMCPACK is an open-source quantum Monte Carlo simulation code."""
 
 toolchain = {'name': 'foss', 'version': '2026.1'}
 toolchainopts = {'usempi': True, 'openmp': True}
 
 github_account = 'QMCPACK'
 source_urls = [GITHUB_SOURCE]
-sources = [{
-    'download_filename': 'v%(version)s.tar.gz',
-    'filename': SOURCELOWER_TAR_GZ,
-}]
-checksums = ['511d5f368db002f2f77504619e1ada8d4a3034200d25feef6773d12a6ed6d18e']
-
-# GitHub archive top-level is qmcpack-<ver>/ (repo name), not QMCPACK-<ver>/.
+sources = [
+    {
+        'download_filename': 'v%(version)s.tar.gz',
+        'filename': SOURCELOWER_TAR_GZ,
+    },
+]
+checksums = [
+    '511d5f368db002f2f77504619e1ada8d4a3034200d25feef6773d12a6ed6d18e',
+]
+configopts = '-DCMAKE_BUILD_TYPE=Release -DQMC_MPI=ON -DQMC_OMP=ON -DQMC_MIXED_PRECISION=OFF -DQMC_COMPLEX=OFF '
+configopts += '-DBUILD_AFQMC=OFF'
+modextrapaths = {
+    'PYTHONPATH': 'lib',
+}
+sanity_check_commands = [
+    'qmcpack --version 2>&1 | grep -q \'QMCPACK version\'',
+]
+sanity_check_paths = {
+    'dirs': [
+        'lib/nexus',
+    ],
+    'files': [
+        'bin/qmcpack',
+        'bin/convert4qmc',
+        'bin/ppconvert',
+        'bin/qmcpack.settings',
+    ],
+}
 start_dir = '%(namelower)s-%(version)s'
+test_cmd = 'ctest'
+testopts = '-j %(parallel)s --output-on-failure -E \'performance|long\''
 
 builddependencies = [
     ('CMake', '4.2.1'),
@@ -34,46 +50,10 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('HDF5', '2.1.1'),  # parallel (gompi) preferred with MPI builds
     ('Boost', '1.90.0'),
-    ('libxml2', '2.15.1'),
-    # Runtime for Nexus workflow package + converter scripts under bin/
+    ('HDF5', '2.1.1'),
     ('Python', '3.14.2'),
-    # FFTW / BLAS / LAPACK / MPI come from the foss toolchain
+    ('libxml2', '2.15.1'),
 ]
-
-# Pin the CPU-real product; defaults match today but must not drift silently.
-configopts = ' '.join([
-    '-DCMAKE_BUILD_TYPE=Release',
-    '-DQMC_MPI=ON',
-    '-DQMC_OMP=ON',
-    '-DQMC_MIXED_PRECISION=OFF',
-    '-DQMC_COMPLEX=OFF',
-    '-DBUILD_AFQMC=OFF',
-])
-
-# CMakeNinja defaults test_cmd to 'ninja', so runtest=True alone only re-invokes
-# ninja (no-op after a successful build). Drive ctest explicitly. Performance
-# suites need external QMC_DATA and are excluded.
-test_cmd = 'ctest'
-testopts = '-j %(parallel)s --output-on-failure -E performance'
-
-sanity_check_paths = {
-    'files': [
-        'bin/qmcpack',
-        'bin/convert4qmc',
-        'bin/ppconvert',
-        'bin/qmcpack.settings',
-    ],
-    'dirs': ['lib/nexus'],
-}
-
-# Upstream qmcpack --version prints the banner then exits 1.
-sanity_check_commands = [
-    "qmcpack --version 2>&1 | grep -q 'QMCPACK version'",
-]
-
-# Nexus lives under lib/nexus; put lib on PYTHONPATH for `import nexus`.
-modextrapaths = {'PYTHONPATH': 'lib'}
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
@@ -41,7 +41,7 @@ sanity_check_paths = {
 }
 start_dir = '%(namelower)s-%(version)s'
 test_cmd = 'ctest'
-testopts = '-j %(parallel)s --output-on-failure -E \'performance|long\''
+testopts = '-L deterministic -j %(parallel)s --output-on-failure'
 
 builddependencies = [
     ('CMake', '4.2.1'),

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
@@ -4,78 +4,51 @@ name = 'QMCPACK'
 version = '4.3.0'
 
 homepage = 'https://qmcpack.org'
-description = """
-QMCPACK is an open-source production-level many-body ab initio Quantum Monte
-Carlo code for computing the electronic structure of atoms, molecules, 2D
-nanomaterials and solids.
-
-This easyconfig builds the CPU real reference: MPI + OpenMP, full double
-precision (mixed precision off), no GPU offload.
-"""
+description = """QMCPACK is an open-source quantum Monte Carlo simulation code."""
 
 toolchain = {'name': 'foss', 'version': '2026.1'}
-toolchainopts = {'usempi': True, 'openmp': True}
+toolchainopts = {'openmp': True, 'usempi': True}
 
-github_account = 'QMCPACK'
-source_urls = [GITHUB_SOURCE]
-sources = [{
-    'download_filename': 'v%(version)s.tar.gz',
-    'filename': SOURCELOWER_TAR_GZ,
-}]
-checksums = ['511d5f368db002f2f77504619e1ada8d4a3034200d25feef6773d12a6ed6d18e']
-
-# GitHub archive top-level is qmcpack-<ver>/ (repo name), not QMCPACK-<ver>/.
-start_dir = '%(namelower)s-%(version)s'
-
-builddependencies = [
-    ('CMake', '4.2.1'),
-    ('Ninja', '1.13.2'),
-    ('pkgconf', '2.5.1'),
+sources = [
+    'https://github.com/QMCPACK/qmcpack/archive/refs/tags/v4.3.0.tar.gz',
 ]
-
-dependencies = [
-    ('HDF5', '2.1.1'),  # parallel (gompi) preferred with MPI builds
-    ('Boost', '1.90.0'),
-    ('libxml2', '2.15.1'),
-    # Runtime for Nexus workflow package + converter scripts under bin/
-    ('Python', '3.14.2'),
-    # FFTW / BLAS / LAPACK / MPI come from the foss toolchain
+checksums = [
+    '511d5f368db002f2f77504619e1ada8d4a3034200d25feef6773d12a6ed6d18e',
 ]
-
-# Pin the CPU-real product; defaults match today but must not drift silently.
-configopts = ' '.join([
-    '-DCMAKE_BUILD_TYPE=Release',
-    '-DQMC_MPI=ON',
-    '-DQMC_OMP=ON',
-    '-DQMC_MIXED_PRECISION=OFF',
-    '-DQMC_COMPLEX=OFF',
-    '-DBUILD_AFQMC=OFF',
-])
-
-# CMakeNinja defaults test_cmd to 'ninja', so runtest=True alone only re-invokes
-# ninja (no-op after a successful build). Drive ctest explicitly. Performance
-# suites need external QMC_DATA and are excluded; they skip cleanly without it
-# but still cost configure-time registration noise.
-test_cmd = 'ctest'
-testopts = '-j %(parallel)s --output-on-failure -E performance'
-
+configopts = '-DCMAKE_BUILD_TYPE=Release -DQMC_MPI=ON -DQMC_OMP=ON -DQMC_MIXED_PRECISION=OFF -DQMC_COMPLEX=OFF '
+configopts += '-DBUILD_AFQMC=OFF'
+modextrapaths = {
+    'PYTHONPATH': 'lib',
+}
+sanity_check_commands = [
+    'qmcpack --version 2>&1 | grep -q \'QMCPACK version\'',
+]
 sanity_check_paths = {
+    'dirs': [
+        'lib/nexus',
+    ],
     'files': [
         'bin/qmcpack',
         'bin/convert4qmc',
         'bin/ppconvert',
         'bin/qmcpack.settings',
     ],
-    'dirs': ['lib/nexus'],
 }
+start_dir = '%(namelower)s-%(version)s'
+test_cmd = 'ctest'
+testopts = '-j %(parallel)s --output-on-failure -E \'performance|long\''
 
-# Upstream qmcpack --version prints the banner then exits 1.
-# convert4qmc has no --help (prints "Unknown extension" and exits 0); path check only.
-sanity_check_commands = [
-    "qmcpack --version 2>&1 | grep -q 'QMCPACK version'",
+builddependencies = [
+    ('CMake', '4.2.1', '', ('GCCcore', '15.2.0')),
+    ('Ninja', '1.13.2', '', ('GCCcore', '15.2.0')),
+    ('pkgconf', '2.5.1', '', ('GCCcore', '15.2.0')),
 ]
 
-# Nexus lives under lib/nexus; put lib on PYTHONPATH for `import nexus`.
-modextrapaths = {'PYTHONPATH': 'lib'}
+dependencies = [
+    ('Boost', '1.90.0', '', ('GCCcore', '15.2.0')),
+    ('HDF5', '2.1.1', '', ('gompi', '2026.1')),
+    ('Python', '3.14.2', '', ('GCCcore', '15.2.0')),
+    ('libxml2', '2.15.1', '', ('GCCcore', '15.2.0')),
+]
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
@@ -41,7 +41,7 @@ sanity_check_paths = {
 }
 start_dir = '%(namelower)s-%(version)s'
 test_cmd = 'ctest'
-testopts = '-L deterministic -j %(parallel)s --output-on-failure'
+testopts = '-L deterministic -j %(parallel)s --output-on-failure -E \'unit_test_message-r12|unit_test_new_drivers_mpi-r16\''
 
 builddependencies = [
     ('CMake', '4.2.1'),

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
@@ -26,7 +26,7 @@ modextrapaths = {
     'PYTHONPATH': 'lib',
 }
 sanity_check_commands = [
-    'qmcpack --version 2>&1 | grep -q \'QMCPACK version\'',
+    "qmcpack --version 2>&1 | grep -q 'QMCPACK version'",
 ]
 sanity_check_paths = {
     'dirs': [
@@ -43,9 +43,10 @@ start_dir = '%(namelower)s-%(version)s'
 # Allow concurrent multi-rank mpiexec under ctest -j (netCDF/OTF-CPT pattern).
 pretestopts = 'export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe && '
 test_cmd = 'ctest'
+# Single-quoted -E pattern so shell does not treat | as a pipe.
 testopts = (
-    '-L deterministic -j %(parallel)s --output-on-failure '
-    '-E unit_test_message-r12|unit_test_new_drivers_mpi-r16'
+    "-L deterministic -j %(parallel)s --output-on-failure "
+    "-E 'unit_test_message-r12|unit_test_new_drivers_mpi-r16'"
 )
 
 builddependencies = [

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
@@ -1,7 +1,3 @@
-# EasyBuild recipe for QMCPACK 4.3.0 — CPU real (MPI+OpenMP), double precision.
-# Greenfield: no upstream QMCPACK easyconfig existed as of 2026-07-10.
-# Variant matrix note: GPU / complex / mixed-precision are separate recipes later.
-
 easyblock = 'CMakeNinja'
 
 name = 'QMCPACK'
@@ -10,9 +6,11 @@ version = '4.3.0'
 homepage = 'https://qmcpack.org'
 description = """
 QMCPACK is an open-source production-level many-body ab initio Quantum Monte
-Carlo code for electronic structure of atoms, molecules, 2D nanomaterials and
-solids. This recipe builds the CPU real reference: MPI+OpenMP, mixed precision
-OFF (full double), no GPU offload.
+Carlo code for computing the electronic structure of atoms, molecules, 2D
+nanomaterials and solids.
+
+This easyconfig builds the CPU real reference: MPI + OpenMP, full double
+precision (mixed precision off), no GPU offload.
 """
 
 toolchain = {'name': 'foss', 'version': '2026.1'}
@@ -20,15 +18,13 @@ toolchainopts = {'usempi': True, 'openmp': True}
 
 github_account = 'QMCPACK'
 source_urls = [GITHUB_SOURCE]
-sources = [
-    {
-        'download_filename': 'v%(version)s.tar.gz',
-        'filename': SOURCELOWER_TAR_GZ,
-    },
-]
+sources = [{
+    'download_filename': 'v%(version)s.tar.gz',
+    'filename': SOURCELOWER_TAR_GZ,
+}]
 checksums = ['511d5f368db002f2f77504619e1ada8d4a3034200d25feef6773d12a6ed6d18e']
 
-# GitHub archive unpacks to qmcpack-<ver>/ (repo name), not QMCPACK-<ver>/.
+# GitHub archive top-level is qmcpack-<ver>/ (repo name), not QMCPACK-<ver>/.
 start_dir = '%(namelower)s-%(version)s'
 
 builddependencies = [
@@ -38,17 +34,15 @@ builddependencies = [
 ]
 
 dependencies = [
-    # Parallel HDF5 under gompi (foss subtoolchain); robot has HDF5-2.1.1-gompi-2026.1
-    ('HDF5', '2.1.1'),
+    ('HDF5', '2.1.1'),  # parallel (gompi) preferred with MPI builds
     ('Boost', '1.90.0'),
     ('libxml2', '2.15.1'),
+    # Runtime for Nexus workflow package + converter scripts under bin/
     ('Python', '3.14.2'),
-    # FFTW / BLAS / LAPACK / OpenMPI come from the foss toolchain
+    # FFTW / BLAS / LAPACK / MPI come from the foss toolchain
 ]
 
-# Out-of-source is the CMake default. Explicit CPU-real reference flags.
-# Defaults already match (QMC_MPI=ON, QMC_OMP=ON, MIXED_PRECISION=OFF) but
-# pin them so a future upstream default flip cannot silently change the product.
+# Pin the CPU-real product; defaults match today but must not drift silently.
 configopts = ' '.join([
     '-DCMAKE_BUILD_TYPE=Release',
     '-DQMC_MPI=ON',
@@ -58,18 +52,30 @@ configopts = ' '.join([
     '-DBUILD_AFQMC=OFF',
 ])
 
-# CMakeNinja: runtest=True uses ctest via the ninja/ctest integration.
-runtest = True
+# CMakeNinja defaults test_cmd to 'ninja', so runtest=True alone only re-invokes
+# ninja (no-op after a successful build). Drive ctest explicitly. Performance
+# suites need external QMC_DATA and are excluded; they skip cleanly without it
+# but still cost configure-time registration noise.
+test_cmd = 'ctest'
+testopts = '-j %(parallel)s --output-on-failure -E performance'
 
 sanity_check_paths = {
-    'files': ['bin/qmcpack'],
-    'dirs': [],
+    'files': [
+        'bin/qmcpack',
+        'bin/convert4qmc',
+        'bin/ppconvert',
+        'bin/qmcpack.settings',
+    ],
+    'dirs': ['lib/nexus'],
 }
 
-# qmcpack --version prints the banner then exits 1 (upstream behaviour).
-# Grep for the banner so the sanity command returns 0.
+# Upstream qmcpack --version prints the banner then exits 1.
 sanity_check_commands = [
     "qmcpack --version 2>&1 | grep -q 'QMCPACK version'",
+    "convert4qmc --help 2>&1 | grep -qi convert",
 ]
+
+# Nexus lives under lib/nexus; put lib on PYTHONPATH for `import nexus`.
+modextrapaths = {'PYTHONPATH': 'lib'}
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
@@ -1,0 +1,75 @@
+# EasyBuild recipe for QMCPACK 4.3.0 — CPU real (MPI+OpenMP), double precision.
+# Greenfield: no upstream QMCPACK easyconfig existed as of 2026-07-10.
+# Variant matrix note: GPU / complex / mixed-precision are separate recipes later.
+
+easyblock = 'CMakeNinja'
+
+name = 'QMCPACK'
+version = '4.3.0'
+
+homepage = 'https://qmcpack.org'
+description = """
+QMCPACK is an open-source production-level many-body ab initio Quantum Monte
+Carlo code for electronic structure of atoms, molecules, 2D nanomaterials and
+solids. This recipe builds the CPU real reference: MPI+OpenMP, mixed precision
+OFF (full double), no GPU offload.
+"""
+
+toolchain = {'name': 'foss', 'version': '2026.1'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+github_account = 'QMCPACK'
+source_urls = [GITHUB_SOURCE]
+sources = [
+    {
+        'download_filename': 'v%(version)s.tar.gz',
+        'filename': SOURCELOWER_TAR_GZ,
+    },
+]
+checksums = ['511d5f368db002f2f77504619e1ada8d4a3034200d25feef6773d12a6ed6d18e']
+
+# GitHub archive unpacks to qmcpack-<ver>/ (repo name), not QMCPACK-<ver>/.
+start_dir = '%(namelower)s-%(version)s'
+
+builddependencies = [
+    ('CMake', '4.2.1'),
+    ('Ninja', '1.13.2'),
+    ('pkgconf', '2.5.1'),
+]
+
+dependencies = [
+    # Parallel HDF5 under gompi (foss subtoolchain); robot has HDF5-2.1.1-gompi-2026.1
+    ('HDF5', '2.1.1'),
+    ('Boost', '1.90.0'),
+    ('libxml2', '2.15.1'),
+    ('Python', '3.14.2'),
+    # FFTW / BLAS / LAPACK / OpenMPI come from the foss toolchain
+]
+
+# Out-of-source is the CMake default. Explicit CPU-real reference flags.
+# Defaults already match (QMC_MPI=ON, QMC_OMP=ON, MIXED_PRECISION=OFF) but
+# pin them so a future upstream default flip cannot silently change the product.
+configopts = ' '.join([
+    '-DCMAKE_BUILD_TYPE=Release',
+    '-DQMC_MPI=ON',
+    '-DQMC_OMP=ON',
+    '-DQMC_MIXED_PRECISION=OFF',
+    '-DQMC_COMPLEX=OFF',
+    '-DBUILD_AFQMC=OFF',
+])
+
+# CMakeNinja: runtest=True uses ctest via the ninja/ctest integration.
+runtest = True
+
+sanity_check_paths = {
+    'files': ['bin/qmcpack'],
+    'dirs': [],
+}
+
+# qmcpack --version prints the banner then exits 1 (upstream behaviour).
+# Grep for the banner so the sanity command returns 0.
+sanity_check_commands = [
+    "qmcpack --version 2>&1 | grep -q 'QMCPACK version'",
+]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
+++ b/easybuild/easyconfigs/q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb
@@ -4,51 +4,76 @@ name = 'QMCPACK'
 version = '4.3.0'
 
 homepage = 'https://qmcpack.org'
-description = """QMCPACK is an open-source quantum Monte Carlo simulation code."""
+description = """
+QMCPACK is an open-source production-level many-body ab initio Quantum Monte
+Carlo code for computing the electronic structure of atoms, molecules, 2D
+nanomaterials and solids.
+
+This easyconfig builds the CPU real reference: MPI + OpenMP, full double
+precision (mixed precision off), no GPU offload.
+"""
 
 toolchain = {'name': 'foss', 'version': '2026.1'}
-toolchainopts = {'openmp': True, 'usempi': True}
+toolchainopts = {'usempi': True, 'openmp': True}
 
-sources = [
-    'https://github.com/QMCPACK/qmcpack/archive/refs/tags/v4.3.0.tar.gz',
+github_account = 'QMCPACK'
+source_urls = [GITHUB_SOURCE]
+sources = [{
+    'download_filename': 'v%(version)s.tar.gz',
+    'filename': SOURCELOWER_TAR_GZ,
+}]
+checksums = ['511d5f368db002f2f77504619e1ada8d4a3034200d25feef6773d12a6ed6d18e']
+
+# GitHub archive top-level is qmcpack-<ver>/ (repo name), not QMCPACK-<ver>/.
+start_dir = '%(namelower)s-%(version)s'
+
+builddependencies = [
+    ('CMake', '4.2.1'),
+    ('Ninja', '1.13.2'),
+    ('pkgconf', '2.5.1'),
 ]
-checksums = [
-    '511d5f368db002f2f77504619e1ada8d4a3034200d25feef6773d12a6ed6d18e',
+
+dependencies = [
+    ('HDF5', '2.1.1'),  # parallel (gompi) preferred with MPI builds
+    ('Boost', '1.90.0'),
+    ('libxml2', '2.15.1'),
+    # Runtime for Nexus workflow package + converter scripts under bin/
+    ('Python', '3.14.2'),
+    # FFTW / BLAS / LAPACK / MPI come from the foss toolchain
 ]
-configopts = '-DCMAKE_BUILD_TYPE=Release -DQMC_MPI=ON -DQMC_OMP=ON -DQMC_MIXED_PRECISION=OFF -DQMC_COMPLEX=OFF '
-configopts += '-DBUILD_AFQMC=OFF'
-modextrapaths = {
-    'PYTHONPATH': 'lib',
-}
-sanity_check_commands = [
-    'qmcpack --version 2>&1 | grep -q \'QMCPACK version\'',
-]
+
+# Pin the CPU-real product; defaults match today but must not drift silently.
+configopts = ' '.join([
+    '-DCMAKE_BUILD_TYPE=Release',
+    '-DQMC_MPI=ON',
+    '-DQMC_OMP=ON',
+    '-DQMC_MIXED_PRECISION=OFF',
+    '-DQMC_COMPLEX=OFF',
+    '-DBUILD_AFQMC=OFF',
+])
+
+# CMakeNinja defaults test_cmd to 'ninja', so runtest=True alone only re-invokes
+# ninja (no-op after a successful build). Drive ctest explicitly. Performance
+# suites need external QMC_DATA and are excluded.
+test_cmd = 'ctest'
+testopts = '-j %(parallel)s --output-on-failure -E performance'
+
 sanity_check_paths = {
-    'dirs': [
-        'lib/nexus',
-    ],
     'files': [
         'bin/qmcpack',
         'bin/convert4qmc',
         'bin/ppconvert',
         'bin/qmcpack.settings',
     ],
+    'dirs': ['lib/nexus'],
 }
-start_dir = '%(namelower)s-%(version)s'
-test_cmd = 'ctest'
-testopts = '-j %(parallel)s --output-on-failure -E \'performance|long\''
 
-builddependencies = [
-    ('CMake', '4.2.1', '', ('GCCcore', '15.2.0')),
-    ('Ninja', '1.13.2', '', ('GCCcore', '15.2.0')),
-    ('pkgconf', '2.5.1', '', ('GCCcore', '15.2.0')),
+# Upstream qmcpack --version prints the banner then exits 1.
+sanity_check_commands = [
+    "qmcpack --version 2>&1 | grep -q 'QMCPACK version'",
 ]
 
-dependencies = [
-    ('Boost', '1.90.0', '', ('GCCcore', '15.2.0')),
-    ('HDF5', '2.1.1', '', ('gompi', '2026.1')),
-    ('Python', '3.14.2', '', ('GCCcore', '15.2.0')),
-    ('libxml2', '2.15.1', '', ('GCCcore', '15.2.0')),
-]
+# Nexus lives under lib/nexus; put lib on PYTHONPATH for `import nexus`.
+modextrapaths = {'PYTHONPATH': 'lib'}
 
 moduleclass = 'chem'


### PR DESCRIPTION
## Summary

First QMCPACK easyconfigs in the tree: 4.3.0 on foss/2026.1.

Two installable variants, same tarball and dependency set:

- `q/QMCPACK/QMCPACK-4.3.0-foss-2026.1.eb` — real-valued (`-DQMC_COMPLEX=OFF`), binary `qmcpack`
- `q/QMCPACK/QMCPACK-4.3.0-foss-2026.1-complex.eb` — complex (`-DQMC_COMPLEX=ON`, `versionsuffix = '-complex'`), binary `qmcpack_complex`

Shared config: MPI + OpenMP, full double precision, AFQMC off, no GPU. Parallel HDF5 under gompi; Boost, libxml2, Python for Nexus; FFTW/BLAS/MPI from foss.

Tests: `ctest -L deterministic`, excluding `unit_test_message-r12` and `unit_test_new_drivers_mpi-r16` (need 12/16 MPI slots under parallel ctest on typical build nodes).

GPU / mixed-precision / CUDA builds not included here.

## AI Disclosure

Build-eval facilitated by gpt-120b and eb-stack.