### PR TITLE
OpenBLAS-0.3.30-GCC-14.3.0-x60.eb (SpaceMiT X60 / K1 RVV ZVL256B target)

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.30-GCC-14.3.0-x60.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.30-GCC-14.3.0-x60.eb
@@ -1,0 +1,70 @@
+name = 'OpenBLAS'
+version = '0.3.30'
+versionsuffix = '-x60'
+
+homepage = 'https://www.openblas.net/'
+description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.
+This variant targets the SpaceMiT X60 (SpaceMiT K1 SoC, RVV 1.0, VLEN=256 -- e.g. Orange Pi
+RV2, Banana Pi BPI-F3, Milk-V Jupiter) by building the UPSTREAM RISCV64_ZVL256B RVV kernels
+(the 8x8 vfmacc DGEMM kernel). No X60-specific source patch is required -- ZVL256B is already
+upstream; only the build TARGET is forced, because the stock riscv64 build auto-detects the
+X60 as RISCV64_GENERIC (scalar). Requires GCC >= 14 (the SGEMM RVV kernel fails to compile on
+GCC 13.x)."""
+
+toolchain = {'name': 'GCC', 'version': '14.3.0'}
+
+source_urls = [
+    # order matters, trying to download the large.tgz/timing.tgz LAPACK tarballs from GitHub causes trouble
+    'https://www.netlib.org/lapack/timing/',
+    'https://github.com/xianyi/OpenBLAS/archive/',
+]
+sources = ['v%(version)s.tar.gz']
+# NOTE: these are the STANDARD OpenBLAS build patches shipped with the stock easyconfig
+# (compiler/vectorization workarounds) -- NOT chip-specific. There is deliberately NO X60 patch.
+patches = [
+    ('large.tgz', '.'),
+    ('timing.tgz', '.'),
+    'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch',
+    'OpenBLAS-0.3.21_fix-order-vectorization.patch',
+    'OpenBLAS-0.3.30_revert-fix-out-of-bounds-access.patch',
+    # Backport of the upstream fix for the RISC-V RVV real-GEMV-N kernel. In v0.3.30,
+    # kernel/riscv64/gemv_n_vector.c zeroes its vector accumulator via `vfsub_vv` on an
+    # UNINITIALIZED vector register (VFILL_ZERO_FLOAT), so d/sgemv can emit NaN when that
+    # register holds NaN bits -> HPL fails with residual=nan (and -np 1 hangs). The kernel was
+    # rewritten upstream after v0.3.30 (clean f64m8 accumulation). REQUIRED for the RVV target:
+    # dgemv is exercised heavily by HPL's panel factorization. Verified: with this patch the
+    # eb-built 0.3.30 passes HPL (residual finite, PASSED); without it, dgemv is all-NaN.
+    'OpenBLAS-0.3.30_fix-riscv64-gemv_n-nan.patch',
+]
+checksums = [
+    {'v0.3.30.tar.gz': '27342cff518646afb4c2b976d809102e368957974c250a25ccc965e53063c95d'},
+    {'large.tgz': 'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1'},
+    {'timing.tgz': '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af'},
+    {'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch':
+     'e6b326fb8c4a8a6fd07741d9983c37a72c55c9ff9a4f74a80e1352ce5f975971'},
+    {'OpenBLAS-0.3.21_fix-order-vectorization.patch':
+     '08af834e5d60441fd35c128758ed9c092ba6887c829e0471ecd489079539047d'},
+    {'OpenBLAS-0.3.30_revert-fix-out-of-bounds-access.patch':
+     'c161fc0e2754c8ef073375138392a76ba9c4cb23f85d5d554051db4bc73ba6ae'},
+    {'OpenBLAS-0.3.30_fix-riscv64-gemv_n-nan.patch':
+     'e2360bb7a361391ec55ffc7682645c9932bb2c0d77c87eb6dc760a7ee86d04a6'},
+]
+
+builddependencies = [
+    ('make', '4.4.1'),
+    # required by LAPACK test suite
+    ('Python', '3.13.5'),
+]
+
+# Force the upstream RVV target for the X60/K1. Single-target (DYNAMIC_ARCH=0) => the ZVL256B
+# RVV kernels are ALWAYS used (guaranteed on the X60, no runtime detection needed).
+# Threading is left at the easyblock/toolchain default (OpenMP). It is NOT the source of any
+# HPL problem: the earlier residual=nan was the RVV gemv_n kernel bug (fixed by the patch
+# above), which is independent of OpenMP vs pthreads -- verified, the patched OpenMP build
+# passes HPL.
+buildopts = 'TARGET=RISCV64_ZVL256B DYNAMIC_ARCH=0'
+
+run_lapack_tests = True
+max_failing_lapack_tests_num_errors = 150
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.30_fix-riscv64-gemv_n-nan.patch
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.30_fix-riscv64-gemv_n-nan.patch
@@ -1,0 +1,340 @@
+# Backport of the upstream fix for the RISC-V RVV real-GEMV-N kernel NaN bug in OpenBLAS 0.3.30.
+#
+# In v0.3.30, kernel/riscv64/gemv_n_vector.c zeroes its vector accumulator via the VFILL_ZERO_FLOAT
+# macro (== vfsub_vv on an UNINITIALIZED vector register); NaN - NaN = NaN, so d/sgemv can return
+# all-NaN. This breaks HPL (residual = nan / FAILED; mpirun -np 1 hangs) because HPL's panel
+# factorization leans on dgemv. Standalone DGEMM is unaffected (it uses a different kernel).
+#
+# This patch brings 0.3.30's kernel to the fixed upstream (develop) state. Fixed upstream after
+# v0.3.30 (first released in v0.3.31) by:
+#   * PR #5408  "Fix bad vector zero initializer and other compiler warnings for RISC-V"
+#               Chip Kerchner, merged 2025-07-30, commit 72f082f31d191a2e4e6942530af873527c473004
+#               -- the direct NaN-init fix (proper vector zero, not a vfsub_vv self-subtract).
+#   * PR #5476  "Tranverse matrix data in a cache friendly manner for GEMV_N (RISCV)"
+#               Chip Kerchner, merged 2025-10-01, commits 2d82d144e2791e37d7a314237b638d85b156a2ec
+#               + 36f9cb85b15626fab48e15b7806444ace82f1206 -- kernel rewrite, LMUL f64m4 -> f64m8.
+#     https://github.com/OpenMathLib/OpenBLAS/pull/5408
+#     https://github.com/OpenMathLib/OpenBLAS/pull/5476
+#
+# Verified on Orange Pi RV2 (SpaceMiT X60, RVV 1.0): with this patch the eb-built 0.3.30 passes HPL
+# (residual finite, PASSED); without it dgemv is all-NaN. Single-variable proof -- swapping only
+# this one kernel into the otherwise byte-identical eb 0.3.30 build flips dgemv NaN -> correct.
+--- a/kernel/riscv64/gemv_n_vector.c
++++ b/kernel/riscv64/gemv_n_vector.c
+@@ -26,229 +26,106 @@
+ *****************************************************************************/
+ 
+ #include "common.h"
++
+ #if !defined(DOUBLE)
+-#define VSETVL(n) RISCV_RVV(vsetvl_e32m8)(n)
+-#define FLOAT_V_T vfloat32m8_t
+-#define VLEV_FLOAT RISCV_RVV(vle32_v_f32m8)
+-#define VLSEV_FLOAT RISCV_RVV(vlse32_v_f32m8)
+-#define VSEV_FLOAT RISCV_RVV(vse32_v_f32m8)
+-#define VSSEV_FLOAT RISCV_RVV(vsse32_v_f32m8)
+-#define VFMACCVF_FLOAT RISCV_RVV(vfmacc_vf_f32m8)
+-#define VFMUL_VF_FLOAT RISCV_RVV(vfmul_vf_f32m8)
+-#define VFILL_ZERO_FLOAT RISCV_RVV(vfsub_vv_f32m8)
++#define VSETVL(n)               RISCV_RVV(vsetvl_e32m8)(n)
++#define FLOAT_V_T               vfloat32m8_t
++#define VLEV_FLOAT              RISCV_RVV(vle32_v_f32m8)
++#define VLSEV_FLOAT             RISCV_RVV(vlse32_v_f32m8)
++#define VSEV_FLOAT              RISCV_RVV(vse32_v_f32m8)
++#define VSSEV_FLOAT             RISCV_RVV(vsse32_v_f32m8)
++#define VFMACCVF_FLOAT          RISCV_RVV(vfmacc_vf_f32m8)
+ #else
+-#define VSETVL(n) RISCV_RVV(vsetvl_e64m4)(n)
+-#define FLOAT_V_T vfloat64m4_t
+-#define VLEV_FLOAT RISCV_RVV(vle64_v_f64m4)
+-#define VLSEV_FLOAT RISCV_RVV(vlse64_v_f64m4)
+-#define VSEV_FLOAT RISCV_RVV(vse64_v_f64m4)
+-#define VSSEV_FLOAT RISCV_RVV(vsse64_v_f64m4)
+-#define VFMACCVF_FLOAT RISCV_RVV(vfmacc_vf_f64m4)
+-#define VFMUL_VF_FLOAT RISCV_RVV(vfmul_vf_f64m4)
+-#define VFILL_ZERO_FLOAT RISCV_RVV(vfsub_vv_f64m4)
++#define VSETVL(n)               RISCV_RVV(vsetvl_e64m8)(n)
++#define FLOAT_V_T               vfloat64m8_t
++#define VLEV_FLOAT              RISCV_RVV(vle64_v_f64m8)
++#define VLSEV_FLOAT             RISCV_RVV(vlse64_v_f64m8)
++#define VSEV_FLOAT              RISCV_RVV(vse64_v_f64m8)
++#define VSSEV_FLOAT             RISCV_RVV(vsse64_v_f64m8)
++#define VFMACCVF_FLOAT          RISCV_RVV(vfmacc_vf_f64m8)
+ #endif
+ 
+ int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y, FLOAT *buffer)
+ {
+-    BLASLONG i = 0, j = 0, k = 0;
+-    BLASLONG ix = 0, iy = 0;
+-
+-    if(n < 0)  return(0);
+-    FLOAT *a_ptr = a;
+-    FLOAT temp[4];
+-    FLOAT_V_T va0, va1, vy0, vy1,vy0_temp, vy1_temp , temp_v ,va0_0 , va0_1 , va1_0 ,va1_1 ,va2_0 ,va2_1 ,va3_0 ,va3_1 ;
+-    unsigned int gvl = 0;
+-    if(inc_y == 1 && inc_x == 1){
+-        gvl = VSETVL(m);
+-        if(gvl <= m/2){
+-            for(k=0,j=0; k<m/(2*gvl); k++){
+-                a_ptr = a;
+-                ix = 0;
+-                vy0_temp = VLEV_FLOAT(&y[j], gvl);
+-                vy1_temp = VLEV_FLOAT(&y[j+gvl], gvl);
+-                vy0 = VFILL_ZERO_FLOAT(vy0 , vy0 , gvl);
+-                vy1 = VFILL_ZERO_FLOAT(vy1 , vy1 , gvl);
+-                int i;
+-
+-                int remainder = n % 4;
+-                for(i = 0; i < remainder; i++){
+-                    temp[0] = x[ix];
+-                    va0 = VLEV_FLOAT(&a_ptr[j], gvl);
+-                    vy0 = VFMACCVF_FLOAT(vy0, temp[0], va0, gvl);
+-
+-                    va1 = VLEV_FLOAT(&a_ptr[j+gvl], gvl);
+-                    vy1 = VFMACCVF_FLOAT(vy1, temp[0], va1, gvl);
+-                    a_ptr += lda;
+-                    ix ++;
+-                }
+-
+-                for(i = remainder; i < n; i += 4){
+-                    va0_0 = VLEV_FLOAT(&(a_ptr)[j], gvl);
+-                    va0_1 = VLEV_FLOAT(&(a_ptr)[j+gvl], gvl);
+-                    va1_0 = VLEV_FLOAT(&(a_ptr+lda * 1)[j], gvl);
+-                    va1_1 = VLEV_FLOAT(&(a_ptr+lda * 1)[j+gvl], gvl);
+-                    va2_0 = VLEV_FLOAT(&(a_ptr+lda * 2)[j], gvl);
+-                    va2_1 = VLEV_FLOAT(&(a_ptr+lda * 2)[j+gvl], gvl);
+-                    va3_0 = VLEV_FLOAT(&(a_ptr+lda * 3)[j], gvl);
+-                    va3_1 = VLEV_FLOAT(&(a_ptr+lda * 3)[j+gvl], gvl);
+-
+-                    vy0 = VFMACCVF_FLOAT(vy0, x[ix], va0_0, gvl);
+-                    vy1 = VFMACCVF_FLOAT(vy1, x[ix], va0_1, gvl);
+-
+-                    vy0 = VFMACCVF_FLOAT(vy0, x[ix+1], va1_0, gvl);
+-                    vy1 = VFMACCVF_FLOAT(vy1, x[ix+1], va1_1, gvl);
+-
+-                    vy0 = VFMACCVF_FLOAT(vy0, x[ix+2], va2_0, gvl);
+-                    vy1 = VFMACCVF_FLOAT(vy1, x[ix+2], va2_1, gvl);
+-
+-                    vy0 = VFMACCVF_FLOAT(vy0, x[ix+3], va3_0, gvl);
+-                    vy1 = VFMACCVF_FLOAT(vy1, x[ix+3], va3_1, gvl);
+-                    a_ptr += 4 * lda;
+-                    ix +=4;
+-                }
+-                vy0 = VFMACCVF_FLOAT(vy0_temp, alpha, vy0, gvl);
+-                vy1 = VFMACCVF_FLOAT(vy1_temp, alpha, vy1, gvl);
+-                VSEV_FLOAT(&y[j], vy0, gvl);
+-                VSEV_FLOAT(&y[j+gvl], vy1, gvl);
+-                j += gvl * 2;
+-            }
+-        }
+-        //tail
+-		if(gvl <= m - j ){
+-			a_ptr = a;
+-			ix = 0;
+-			vy0_temp = VLEV_FLOAT(&y[j], gvl);
+-			vy0 = VFILL_ZERO_FLOAT(vy0 , vy0 , gvl);
+-			int i;
+-
+-			int remainder = n % 4;
+-			for(i = 0; i < remainder; i++){
+-				temp[0] = x[ix];
+-				va0 = VLEV_FLOAT(&a_ptr[j], gvl);
+-				vy0 = VFMACCVF_FLOAT(vy0, temp[0], va0, gvl);
+-				a_ptr += lda;
+-				ix ++;
+-			}
+-
+-			for(i = remainder; i < n; i += 4){
+-				va0_0 = VLEV_FLOAT(&(a_ptr)[j], gvl);			
+-				va1_0 = VLEV_FLOAT(&(a_ptr+lda * 1)[j], gvl);		
+-				va2_0 = VLEV_FLOAT(&(a_ptr+lda * 2)[j], gvl);	
+-				va3_0 = VLEV_FLOAT(&(a_ptr+lda * 3)[j], gvl);
+-				vy0 = VFMACCVF_FLOAT(vy0, x[ix], va0_0, gvl);
+-				vy0 = VFMACCVF_FLOAT(vy0, x[ix+1], va1_0, gvl);
+-				vy0 = VFMACCVF_FLOAT(vy0, x[ix+2], va2_0, gvl);
+-				vy0 = VFMACCVF_FLOAT(vy0, x[ix+3], va3_0, gvl);
+-				a_ptr += 4 * lda;
+-				ix +=4;
+-			}
+-			vy0 = VFMACCVF_FLOAT(vy0_temp, alpha, vy0, gvl);
+-		
+-			VSEV_FLOAT(&y[j], vy0, gvl);
+-			
+-			j += gvl ;
+-        }
+-		
++    if (n < 0) return(0);
+ 
+-        for(;j < m;){
+-            gvl = VSETVL(m-j);
++    FLOAT *a_ptr, *y_ptr, *a2_ptr, temp, temp2;
++    BLASLONG i, j, vl;
++    FLOAT_V_T va, vy, va2;
++
++    if (inc_y == 1) {
++        for (j = 0; j < (n >> 1); j++) {
++            temp = alpha * x[0];
++            temp2 = alpha * x[inc_x];
++            y_ptr = y;
+             a_ptr = a;
+-            ix = 0;
+-            vy0 = VLEV_FLOAT(&y[j], gvl);
+-            for(i = 0; i < n; i++){
+-                temp[0] = alpha * x[ix];
+-                va0 = VLEV_FLOAT(&a_ptr[j], gvl);
+-                vy0 = VFMACCVF_FLOAT(vy0, temp[0], va0, gvl);
+-
+-                a_ptr += lda;
+-                ix += inc_x;
+-            }
+-            VSEV_FLOAT(&y[j], vy0, gvl);
+-            j += gvl;
+-        }
+-    }else if (inc_y == 1 && inc_x !=1) {
+-        gvl = VSETVL(m);
+-        if(gvl <= m/2){
+-            for(k=0,j=0; k<m/(2*gvl); k++){
+-                a_ptr = a;
+-                ix = 0;
+-                vy0 = VLEV_FLOAT(&y[j], gvl);
+-                vy1 = VLEV_FLOAT(&y[j+gvl], gvl);
+-                for(i = 0; i < n; i++){
+-                    temp[0] = alpha * x[ix];
+-                    va0 = VLEV_FLOAT(&a_ptr[j], gvl);
+-                    vy0 = VFMACCVF_FLOAT(vy0, temp[0], va0, gvl);
+-
+-                    va1 = VLEV_FLOAT(&a_ptr[j+gvl], gvl);
+-                    vy1 = VFMACCVF_FLOAT(vy1, temp[0], va1, gvl);
+-                    a_ptr += lda;
+-                    ix += inc_x;
+-                }
+-                VSEV_FLOAT(&y[j], vy0, gvl);
+-                VSEV_FLOAT(&y[j+gvl], vy1, gvl);
+-                j += gvl * 2;
+-            }
+-        }
+-        //tail
+-        for(;j < m;){
+-            gvl = VSETVL(m-j);
++            a2_ptr = a + lda;
++            for (i = m; i > 0; i -= vl) {
++                vl = VSETVL(i);
++                vy = VLEV_FLOAT(y_ptr, vl);
++                va = VLEV_FLOAT(a_ptr, vl);
++                va2 = VLEV_FLOAT(a2_ptr, vl);
++                vy = VFMACCVF_FLOAT(vy, temp, va, vl);
++                vy = VFMACCVF_FLOAT(vy, temp2, va2, vl);
++                VSEV_FLOAT(y_ptr, vy, vl);
++                y_ptr += vl;
++                a_ptr += vl;
++                a2_ptr += vl;
++            }
++            x += inc_x * 2;
++            a += lda * 2;
++        }
++        if (n & 1) {
++            temp = alpha * x[0];
++            y_ptr = y;
+             a_ptr = a;
+-            ix = 0;
+-            vy0 = VLEV_FLOAT(&y[j], gvl);
+-            for(i = 0; i < n; i++){
+-                temp[0] = alpha * x[ix];
+-                va0 = VLEV_FLOAT(&a_ptr[j], gvl);
+-                vy0 = VFMACCVF_FLOAT(vy0, temp[0], va0, gvl);
+-
+-                a_ptr += lda;
+-                ix += inc_x;
++            for (i = m; i > 0; i -= vl) {
++                vl = VSETVL(i);
++                vy = VLEV_FLOAT(y_ptr, vl);
++                va = VLEV_FLOAT(a_ptr, vl);
++                vy = VFMACCVF_FLOAT(vy, temp, va, vl);
++                VSEV_FLOAT(y_ptr, vy, vl);
++                y_ptr += vl;
++                a_ptr += vl;
+             }
+-            VSEV_FLOAT(&y[j], vy0, gvl);
+-            j += gvl;
+         }
+-    }else{
++    } else {
+         BLASLONG stride_y = inc_y * sizeof(FLOAT);
+-        gvl = VSETVL(m);
+-        if(gvl <= m/2){
+-            BLASLONG inc_yv = inc_y * gvl;
+-            for(k=0,j=0; k<m/(2*gvl); k++){
+-                a_ptr = a;
+-                ix = 0;
+-                vy0 = VLSEV_FLOAT(&y[iy], stride_y, gvl);
+-                vy1 = VLSEV_FLOAT(&y[iy+inc_yv], stride_y, gvl);
+-                for(i = 0; i < n; i++){
+-                    temp[0] = alpha * x[ix];
+-                    va0 = VLEV_FLOAT(&a_ptr[j], gvl);
+-                    vy0 = VFMACCVF_FLOAT(vy0, temp[0], va0, gvl);
+-
+-                    va1 = VLEV_FLOAT(&a_ptr[j+gvl], gvl);
+-                    vy1 = VFMACCVF_FLOAT(vy1, temp[0], va1, gvl);
+-                    a_ptr += lda;
+-                    ix += inc_x;
+-                }
+-                VSSEV_FLOAT(&y[iy], stride_y, vy0, gvl);
+-                VSSEV_FLOAT(&y[iy+inc_yv], stride_y, vy1, gvl);
+-                j += gvl * 2;
+-                iy += inc_yv * 2;
+-            }
+-        }
+-        //tail
+-        for(;j < m;){
+-            gvl = VSETVL(m-j);
++        for (j = 0; j < (n >> 1); j++) {
++            temp = alpha * x[0];
++            temp2 = alpha * x[inc_x];
++            y_ptr = y;
+             a_ptr = a;
+-            ix = 0;
+-            vy0 = VLSEV_FLOAT(&y[j*inc_y], stride_y, gvl);
+-            for(i = 0; i < n; i++){
+-                temp[0] = alpha * x[ix];
+-                va0 = VLEV_FLOAT(&a_ptr[j], gvl);
+-                vy0 = VFMACCVF_FLOAT(vy0, temp[0], va0, gvl);
+-
+-                a_ptr += lda;
+-                ix += inc_x;
++            a2_ptr = a + lda;
++            for (i = m; i > 0; i -= vl) {
++                vl = VSETVL(i);
++                vy = VLSEV_FLOAT(y_ptr, stride_y, vl);
++                va = VLEV_FLOAT(a_ptr, vl);
++                va2 = VLEV_FLOAT(a2_ptr, vl);
++                vy = VFMACCVF_FLOAT(vy, temp, va, vl);
++                vy = VFMACCVF_FLOAT(vy, temp2, va2, vl);
++                VSSEV_FLOAT(y_ptr, stride_y, vy, vl);
++                y_ptr += vl * inc_y;
++                a_ptr += vl;
++                a2_ptr += vl;
++            }
++            x += inc_x * 2;
++            a += lda * 2;
++        }
++        if (n & 1) {
++            temp = alpha * x[0];
++            y_ptr = y;
++            a_ptr = a;
++            for (i = m; i > 0; i -= vl) {
++                vl = VSETVL(i);
++                vy = VLSEV_FLOAT(y_ptr, stride_y, vl);
++                va = VLEV_FLOAT(a_ptr, vl);
++                vy = VFMACCVF_FLOAT(vy, temp, va, vl);
++                VSSEV_FLOAT(y_ptr, stride_y, vy, vl);
++                y_ptr += vl * inc_y;
++                a_ptr += vl;
+             }
+-            VSSEV_FLOAT(&y[j*inc_y], stride_y, vy0, gvl);
+-            j += gvl;
+         }
+     }
+     return(0);
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
## OpenBLAS 0.3.30 for the SpaceMiT X60 (K1) — upstream RVV `RISCV64_ZVL256B` target

Companion to #26436 (SiFive U74). This adds an OpenBLAS easyconfig that builds the **already-upstream**
RVV kernels for the SpaceMiT X60 / K1 SoC (RVV 1.0, VLEN=256 — e.g. Orange Pi RV2, Banana Pi BPI-F3,
Milk-V Jupiter).

No custom target is added: `RISCV64_ZVL256B` is already in OpenBLAS. The stock riscv64 build simply
auto-detects the X60 as `RISCV64_GENERIC` (scalar), so this easyconfig forces
`buildopts = 'TARGET=RISCV64_ZVL256B DYNAMIC_ARCH=0'`. Requires GCC >= 14 (the SGEMM RVV kernel fails to
compile on GCC 13.x).

### Why the patch — `OpenBLAS-0.3.30_fix-riscv64-gemv_n-nan.patch`

OpenBLAS 0.3.30's RVV `kernel/riscv64/gemv_n_vector.c` zeroes its vector accumulator with `vfsub_vv`
applied to an **uninitialized** vector register (the `VFILL_ZERO_FLOAT` macro). When that register holds
NaN bit-patterns, `NaN - NaN = NaN`, so **`d/sgemv` can return all-NaN**. A standalone DGEMM benchmark
does not expose this (different kernel), but anything leaning on GEMV does — e.g. **HPL fails with
`residual = nan`** (and `mpirun -np 1` hangs), because HPL's panel factorization uses `dgemv` heavily.

Fixed upstream **after** v0.3.30 (first released in **v0.3.31**) by:
- OpenMathLib/OpenBLAS#5408 — the direct NaN-init fix (commit `72f082f31`)
- OpenMathLib/OpenBLAS#5476 — GEMV_N kernel rewrite, LMUL f64m4 -> f64m8 (commits `2d82d144e` + `36f9cb85b`)

The patch backports 0.3.30's `gemv_n_vector.c` to that fixed upstream state. The function signature is
unchanged, so it is a drop-in replacement.

### Validation — end-to-end, built from this PR (Orange Pi RV2 / SpaceMiT X60, 8 cores @ 1.6 GHz, GCC 14.3.0)

**The bug is live in the shipped EESSI stack — not only in custom builds.** The stock CVMFS
`OpenBLAS/0.3.30-GCC-14.3.0` (dev.eessi.io/riscv) is a `DYNAMIC_ARCH` build whose **LP64** library carries
the `ZVL256B` RVV kernels and dispatches them on the X60, so **stock EESSI HPL fails with `residual = nan`**
on this board — reproduced from a clean CVMFS-only shell (`module load HPL/2.3-foss-2025b`, N=8000, 1×8,
`-np 8`). The run even reports a healthy-looking ~8.5 GFLOP/s; only the residual check reveals the answer is
garbage. (Aside: the *ILP64* `libopenblas64_p` in that install is `RISCV64_GENERIC` — the vector cores are
in the LP64 lib, which is what HPL uses.)

**Built + tested straight from this PR.** `eb --from-pr 26444 --robot` on the board completed with **0
failures** in ~15.5 h — all three OpenBLAS interface iterations (LP64 + ILP64 + ILP64 symbol-suffix), each
running `make tests` (BLAS) **and** the full netlib LAPACK test suite (within
`max_failing_lapack_tests_num_errors`), then sanity check + module generation. The installed module loads
and its LP64 `libopenblas.so` resolves to the RVV `libopenblas_riscv64_zvl256bp`.

**HPL correctness.** With the installed module as the FlexiBLAS backend, HPL **PASSES** — scaled residual
`4.04e-03` (N=8000, 1×8) — versus `residual = nan` on the stock CVMFS backend, same HPL binary and input.
Single-variable proof: swapping **only** `gemv_n_vector.c` flips `dgemv` from all-NaN to correct and HPL
from FAILED to PASSED.

**Performance (this build).** Raw RVV `ZVL256B` DGEMM ~**16.8 GFLOP/s** 8-core (numerically correct). HPL
peaks at ~**10.5 GFLOP/s** (N=20000, NB=256, 2×4 grid; 9.7 at 1×8) — real double-precision vector
throughput in place of the scalar `RISCV64_GENERIC` fallback the X60 selects by default.

### Why 0.3.30 (and not a newer OpenBLAS)

0.3.30 matches the version EESSI currently ships, keeping this a minimal in-place fix. The `gemv_n` fix is
native in **≥ 0.3.31** — but **0.3.31–0.3.33 carry a *separate* RISC-V/K1 `ZVL256B` DGEMM regression**
(OpenMathLib/OpenBLAS#5811, non-PSD from AᵀA), fixed only in the **as-yet-unreleased 0.3.34**
(OpenMathLib/OpenBLAS#5815, merged to the 0.3.34 milestone). So **0.3.30 + this one backport is the correct
interim**; once EESSI moves to 0.3.34 both the version bump and dropping this patch become a clean
one-liner.

### Build notes

- Build with GCC >= 14. On EESSI / dev.eessi.io the C `-march` must be pinned to a value GCC 14.3.0
  accepts — the auto-optarch canonical expansion (`..._zaamo_zalrsc_...`) is rejected by GCC 14.3.0 and
  breaks `getarch`'s `Makefile.prebuild` c_check.
- `run_lapack_tests`/`max_failing_lapack_tests_num_errors` mirror the stock `OpenBLAS-0.3.30-GCC-14.3.0.eb`.

Opened as a **draft** alongside the U74 sibling (#26436); now validated end-to-end from this PR (see
Validation) — ready to flip to review.

## AI disclosure (per the [EasyBuild AI policy](https://docs.easybuild.io/policies/ai/))

This contribution was made with AI assistance.

- **Tool / model:** an OpenCode AI coding agent driving **Claude Opus 4.8** (model
  `claude-opus-4.8`, served via the GitHub Copilot model endpoint).
- **Extent:** the AI root-caused the RVV `gemv_n` NaN bug (via single-threaded differential BLAS
  testing), produced the backport patch (`OpenBLAS-0.3.30_fix-riscv64-gemv_n-nan.patch`, backporting
  upstream OpenMathLib/OpenBLAS#5408 + #5476), wrote this easyconfig, ran the end-to-end
  `eb --from-pr` build + HPL validation, and wrote this PR description.
- **Human in the loop:** a human directed the work, provided and operated the SpaceMiT X60 hardware
  (Orange Pi RV2), and reviewed/validated all results reported above (the from-PR build, the stock-CVMFS
  `residual = nan` reproduction, and the HPL residual `PASSED` checks).
