### PR TITLE
add  `--auto-servernum` to `preconfigopts` for `xvfb-run` in R-bundle-CRAN easyconfigs

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2023.12-foss-2023a.eb
+++ b/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2023.12-foss-2023a.eb
@@ -2624,7 +2624,7 @@ exts_list = [
         # need to run installation via xvfb-run to avoid problems on headless systems:
         # no DISPLAY variable so Tk is not available
         # [tcl] invalid command name "font"
-        'preinstallopts': "xvfb-run ",
+        'preinstallopts': "xvfb-run --auto-servernum ",
         # skip 'import' check with library(gWidgets2tcltk), since it also fails on headless systems...
         'modulename': False,
         'checksums': ['10399cc636eeeb5484c3379970c37c56df10d979bf866a35b66d0c75b7222c0a'],

--- a/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2024.06-foss-2023b.eb
+++ b/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2024.06-foss-2023b.eb
@@ -2639,7 +2639,7 @@ exts_list = [
         # need to run installation via xvfb-run to avoid problems on headless systems:
         # no DISPLAY variable so Tk is not available
         # [tcl] invalid command name "font"
-        'preinstallopts': "xvfb-run ",
+        'preinstallopts': "xvfb-run --auto-servernum ",
         'checksums': ['10399cc636eeeb5484c3379970c37c56df10d979bf866a35b66d0c75b7222c0a'],
         # skip 'import' check with library(gWidgets2tcltk), since it also fails on headless systems...
         'modulename': False,

--- a/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2024.11-foss-2024a.eb
+++ b/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2024.11-foss-2024a.eb
@@ -2672,7 +2672,7 @@ exts_list = [
         # need to run installation via xvfb-run to avoid problems on headless systems:
         # no DISPLAY variable so Tk is not available
         # [tcl] invalid command name "font"
-        'preinstallopts': "xvfb-run ",
+        'preinstallopts': "xvfb-run --auto-servernum ",
         # skip 'import' check with library(gWidgets2tcltk), since it also fails on headless systems...
         'modulename': False,
         'checksums': ['10399cc636eeeb5484c3379970c37c56df10d979bf866a35b66d0c75b7222c0a'],

--- a/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2025.10-foss-2025a.eb
+++ b/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2025.10-foss-2025a.eb
@@ -2642,7 +2642,7 @@ exts_list = [
     ('tcltk2', '1.6.1', {
         # need to run installation via xvfb-run to avoid problems on headless systems:
         # no DISPLAY variable so Tk is not available
-        'preinstallopts': "xvfb-run ",
+        'preinstallopts': "xvfb-run --auto-servernum ",
         'checksums': ['dc1cc00ce973df1ce98b830aa70998e455119d89961ce9a368e8a688e6845c6a'],
     }),
     ('minty', '0.0.5', {
@@ -2667,7 +2667,7 @@ exts_list = [
         # need to run installation via xvfb-run to avoid problems on headless systems:
         # no DISPLAY variable so Tk is not available
         # [tcl] invalid command name "font"
-        'preinstallopts': "xvfb-run ",
+        'preinstallopts': "xvfb-run --auto-servernum ",
         'checksums': ['5939ab6b0b40fa7dd55f190f8706f5b0d1d68bda411e4f90cd78004e470056ca'],
         # skip 'import' check with library(gWidgets2tcltk), since it also fails on headless systems...
         'modulename': False,

--- a/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2025.11-foss-2025b.eb
+++ b/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2025.11-foss-2025b.eb
@@ -2642,7 +2642,7 @@ exts_list = [
     ('tcltk2', '1.6.1', {
         # need to run installation via xvfb-run to avoid problems on headless systems:
         # no DISPLAY variable so Tk is not available
-        'preinstallopts': "xvfb-run ",
+        'preinstallopts': "xvfb-run --auto-servernum ",
         'checksums': ['dc1cc00ce973df1ce98b830aa70998e455119d89961ce9a368e8a688e6845c6a'],
     }),
     ('minty', '0.0.5', {
@@ -2667,7 +2667,7 @@ exts_list = [
         # need to run installation via xvfb-run to avoid problems on headless systems:
         # no DISPLAY variable so Tk is not available
         # [tcl] invalid command name "font"
-        'preinstallopts': "xvfb-run ",
+        'preinstallopts': "xvfb-run --auto-servernum ",
         'checksums': ['5939ab6b0b40fa7dd55f190f8706f5b0d1d68bda411e4f90cd78004e470056ca'],
         # skip 'import' check with library(gWidgets2tcltk), since it also fails on headless systems...
         'modulename': False,


### PR DESCRIPTION
This will avoid "xvfb failed to start" error in case there is another xvfb process running and claiming the default display port (99). Took me two failed 50-hour build of R-bundle-CRAN 2025a to figure this out. This should not affect most users, but hopefully would save all other from getting the same pain I got.