### PR TITLE
{tools}[foss/2025b] llama.cpp ad8d821 w/ SpaceMiT IME (RISC-V X60)

### DIFF
--- a/easybuild/easyconfigs/b/binutils/binutils-2.46.1-xsmtvdot.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.46.1-xsmtvdot.eb
@@ -1,0 +1,37 @@
+name = 'binutils'
+version = '2.46.1'
+versionsuffix = '-xsmtvdot'
+
+homepage = 'https://directory.fsf.org/project/binutils/'
+
+description = """binutils: GNU binary utilities. This variant adds the SpaceMiT RISC-V `xsmtvdot`
+vendor extension (the `smt.vmadot*` int8 matrix-dot opcodes used by the SpaceMiT X60 / K1 IME
+backend). Stock GNU binutils (incl. 2.46.1) does NOT yet carry `xsmtvdot` -- it is an unmerged
+sourceware mailing-list patch (binutils 2026-April/148941, "RISC-V: Add SpacemiT vendor extensions
+xsmtvdot"). This easyconfig applies that patch. Verified: the built `as` assembles
+`smt.vmadot v2,v3,v4` -> 0xe241b12b (matches the patch's own gas testsuite). Drop this variant once
+the extension lands in an upstream GNU binutils release."""
+
+toolchain = SYSTEM
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+patches = ['binutils-%(version)s_add-spacemit-xsmtvdot.patch']
+checksums = [
+    '364c8faa19ea46c44089c2d59c1fee6eda9a273787d0fe8ab9dfb249069c6aee',  # binutils-2.46.1.tar.gz
+    '68e83c1e58fe5be8e8c4566afbc6d31e4c33ef4b5fc3a05e2546104150ff787c',  # binutils-2.46.1_add-spacemit-xsmtvdot.patch
+]
+
+builddependencies = [
+    ('flex', '2.6.4'),
+    ('Bison', '3.8.2'),
+    # zlib required, but being linked in statically, so not a runtime dep
+    ('zlib', '1.3.2'),
+]
+
+# avoid build failure when makeinfo command is not available
+# see https://sourceware.org/bugzilla/show_bug.cgi?id=15345
+buildopts = 'MAKEINFO=true'
+installopts = buildopts
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/binutils/binutils-2.46.1_add-spacemit-xsmtvdot.patch
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.46.1_add-spacemit-xsmtvdot.patch
@@ -1,0 +1,323 @@
+diff --git a/bfd/elfxx-riscv.c b/bfd/elfxx-riscv.c
+--- a/bfd/elfxx-riscv.c
++++ b/bfd/elfxx-riscv.c
+@@ -1229,6 +1229,8 @@ static const struct riscv_implicit_subset riscv_implicit_subsets[] =
+   {"xtheadvector", "+zicsr", check_implicit_always},
+   {"xtheadzvamo", "+zaamo", check_implicit_always},
+ 
++  {"xsmtvdot", "+zve32x", check_implicit_always},
++
+   {"v", "+zve64d,+zvl128b", check_implicit_always},
+   {"zvfh", "+zvfhmin,+zfhmin", check_implicit_always},
+   {"zvfhmin", "+zve32f", check_implicit_always},
+@@ -1644,6 +1646,7 @@ static const struct riscv_supported_ext riscv_supported_vendor_x_ext[] =
+   {"xmipscmov",		ISA_SPEC_CLASS_DRAFT,	1, 0, 0 },
+   {"xmipsexectl",	ISA_SPEC_CLASS_DRAFT,	1, 0, 0 },
+   {"xmipslsp",		ISA_SPEC_CLASS_DRAFT,	1, 0, 0 },
++  {"xsmtvdot",		ISA_SPEC_CLASS_DRAFT,	1, 0, 0 },
+   {NULL, 0, 0, 0, 0}
+ };
+ 
+@@ -3062,6 +3065,8 @@ riscv_multi_subset_supports (riscv_parse_subset_t *rps,
+       return riscv_subset_supports (rps, "xmipsexectl");
+     case INSN_CLASS_XMIPSLSP:
+       return riscv_subset_supports (rps, "xmipslsp");
++    case INSN_CLASS_XSMTVDOT:
++      return riscv_subset_supports (rps, "xsmtvdot");
+     default:
+       rps->error_handler
+         (_("internal: unreachable INSN_CLASS_*"));
+@@ -3365,6 +3370,8 @@ riscv_multi_subset_supports_ext (riscv_parse_subset_t *rps,
+       return "xsfvqmaccdod";
+     case INSN_CLASS_XSFVFNRCLIPXFQF:
+       return "xsfvfnrclipxfqf";
++    case INSN_CLASS_XSMTVDOT:
++      return "xsmtvdot";
+     default:
+       rps->error_handler
+         (_("internal: unreachable INSN_CLASS_*"));
+diff --git a/gas/config/tc-riscv.c b/gas/config/tc-riscv.c
+--- a/gas/config/tc-riscv.c
++++ b/gas/config/tc-riscv.c
+@@ -1770,6 +1770,35 @@ validate_riscv_insn (const struct riscv_opcode *opc, int length)
+ 		    goto unknown_validate_operand;
+ 		}
+ 		break;
++	    case 'p': /* Vendor-specific (SpacemiT) operands.  */
++	      switch (*++oparg)
++		{
++		case 'V':
++		  switch (*++oparg)
++		    {
++		    case 'd':
++		      USE_BITS (OP_MASK_SPACEMIT_IME_VD, OP_SH_SPACEMIT_IME_VD);
++		      break;
++		    case 's':
++		      USE_BITS (OP_MASK_SPACEMIT_IME_VS1, OP_SH_SPACEMIT_IME_VS1);
++		      break;
++		    default:
++		      goto unknown_validate_operand;
++		    }
++		  break;
++		case 'w':
++		  /* Xpw&S ... bits in S indicates whether corresponding
++		     item is permitted.  */
++		  if (*++oparg != '&')
++		    goto unknown_validate_operand;
++		  strtol (oparg + 1, (char **)&oparg, 16);
++		  oparg--;
++		  USE_BITS (OP_MASK_SPACEMIT_IME_WI, OP_SH_SPACEMIT_IME_WI);
++		  break;
++		default:
++		  goto unknown_validate_operand;
++		}
++	      break;
+ 	    default:
+ 	      goto unknown_validate_operand;
+ 	    }
+@@ -4286,6 +4315,85 @@ riscv_ip (char *str, struct riscv_cl_insn *ip, expressionS *imm_expr,
+ 		    }
+ 		  break;
+ 
++		case 'p': /* Vendor-specific (SpacemiT) operands.  */
++		  switch (*++oparg)
++		    {
++		    case 'V':
++		      switch (*++oparg)
++			{
++			case 'd':
++			  if (!reg_lookup (&asarg, RCLASS_VECR, &regno))
++			    break;
++			  if ((regno & 0x1) != 0)
++			    {
++			      error.msg = _("illegal operands (vd must be even)");
++			      break;
++			    }
++			  INSERT_OPERAND (SPACEMIT_IME_VD, *ip, regno>>1);
++			  continue;
++			case 's':
++			  if (!reg_lookup (&asarg, RCLASS_VECR, &regno))
++			    break;
++			  if ((regno & 0x1) != 0)
++			    {
++			      error.msg = _("illegal operands (vs1 must be even)");
++			      break;
++			    }
++			  INSERT_OPERAND (SPACEMIT_IME_VS1, *ip, regno>>1);
++			  continue;
++			default:
++			  goto unknown_riscv_ip_operand;
++			}
++		      break;
++		    case 'w':
++		      /* Xpw&S ... bits in S indicates whether
++			 corresponding item is permitted.  */
++		      if (*++oparg != '&')
++			goto unknown_riscv_ip_operand;
++		      size_t n = strtol (oparg + 1, (char **)&oparg, 16);
++		      oparg--;
++		      /* Optional operand: if not present, default to i8.  */
++		      if (*asarg == '\0')
++			regno = 3;
++		      else if (*asarg == ',')
++			{
++			  asarg++;
++			  if (strncmp (asarg, "i2", 2) == 0)
++			    {
++			      regno = 0;
++			      asarg += 2;
++			    }
++			  else if (strncmp (asarg, "i16", 3) == 0)
++			    {
++			      regno = 1;
++			      asarg += 3;
++			    }
++			  else if (strncmp (asarg, "i4", 2) == 0)
++			    {
++			      regno = 2;
++			      asarg += 2;
++			    }
++			  else if (strncmp (asarg, "i8", 2) == 0)
++			    {
++			      regno = 3;
++			      asarg += 2;
++			    }
++			  else
++			    break;
++			}
++		      else
++			goto unknown_riscv_ip_operand;
++		      if ((n & (1 << regno)) == 0)
++			{
++			  error.msg = _("illegal operands (invalid data type)");
++			  break;
++			}
++		      INSERT_OPERAND (SPACEMIT_IME_WI, *ip, regno);
++		      continue;
++		    default:
++		      goto unknown_riscv_ip_operand;
++		    }
++		  break;
+ 		default:
+ 		  goto unknown_riscv_ip_operand;
+ 		}
+diff --git a/include/opcode/riscv-opc.h b/include/opcode/riscv-opc.h
+--- a/include/opcode/riscv-opc.h
++++ b/include/opcode/riscv-opc.h
+@@ -3852,6 +3852,44 @@
+ #define MASK_MIPS_PAUSE  0xffffffff
+ #define MATCH_MIPS_PREF 0x0000000b
+ #define MASK_MIPS_PREF 0xe000707f
++/* SpacemiT custom instruction.  */
++/* Int Matrix Multiplicative Accumulation.  */
++#define MATCH_SMT_VMADOT   0x8200302b
++#define MASK_SMT_VMADOT    0x9e0070ff
++#define MATCH_SMT_VMADOTU  0x8200002b
++#define MASK_SMT_VMADOTU   0x9e0070ff
++#define MATCH_SMT_VMADOTSU 0x8200202b
++#define MASK_SMT_VMADOTSU  0x9e0070ff
++#define MATCH_SMT_VMADOTUS 0x8200102b
++#define MASK_SMT_VMADOTUS  0x9e0070ff
++/* Int Sliding Window Multiplicative Accumulation.  */
++/* Sliding Value = 1.  */
++#define MATCH_SMT_VMADOT1U 0x8600002b
++#define MASK_SMT_VMADOT1U  0x9e00f0ff
++#define MATCH_SMT_VMADOT1  0x8600302b
++#define MASK_SMT_VMADOT1   0x9e00f0ff
++#define MATCH_SMT_VMADOT1SU 0x8600202b
++#define MASK_SMT_VMADOT1SU 0x9e00f0ff
++#define MATCH_SMT_VMADOT1US 0x8600102b
++#define MASK_SMT_VMADOT1US 0x9e00f0ff
++/* Sliding Value = 2.  */
++#define MATCH_SMT_VMADOT2U 0x8600402b
++#define MASK_SMT_VMADOT2U 0x9e00f0ff
++#define MATCH_SMT_VMADOT2 0x8600702b
++#define MASK_SMT_VMADOT2 0x9e00f0ff
++#define MATCH_SMT_VMADOT2SU 0x8600602b
++#define MASK_SMT_VMADOT2SU 0x9e00f0ff
++#define MATCH_SMT_VMADOT2US 0x8600502b
++#define MASK_SMT_VMADOT2US 0x9e00f0ff
++/* Sliding Value = 3.  */
++#define MATCH_SMT_VMADOT3U 0x8600802b
++#define MASK_SMT_VMADOT3U 0x9e00f0ff
++#define MATCH_SMT_VMADOT3 0x8600b02b
++#define MASK_SMT_VMADOT3 0x9e00f0ff
++#define MATCH_SMT_VMADOT3SU 0x8600a02b
++#define MASK_SMT_VMADOT3SU 0x9e00f0ff
++#define MATCH_SMT_VMADOT3US 0x8600902b
++#define MASK_SMT_VMADOT3US 0x9e00f0ff
+ /* Unprivileged Counter/Timers CSR addresses.  */
+ #define CSR_CYCLE 0xc00
+ #define CSR_TIME 0xc01
+diff --git a/include/opcode/riscv.h b/include/opcode/riscv.h
+--- a/include/opcode/riscv.h
++++ b/include/opcode/riscv.h
+@@ -419,6 +419,14 @@ static inline unsigned int riscv_insn_length (insn_t insn)
+ #define OP_MASK_MIPS_SDP_OFFSET25   0x3
+ #define OP_SH_MIPS_SDP_OFFSET25     25
+ 
++/* SpacemiT fields.  */
++#define OP_MASK_SPACEMIT_IME_VD		0xf
++#define OP_SH_SPACEMIT_IME_VD		8
++#define OP_MASK_SPACEMIT_IME_VS1	0xf
++#define OP_SH_SPACEMIT_IME_VS1		16
++#define OP_MASK_SPACEMIT_IME_WI		0x3
++#define OP_SH_SPACEMIT_IME_WI		29
++
+ /* ABI names for selected x-registers.  */
+ 
+ #define X_ZERO 0
+@@ -606,6 +614,7 @@ enum riscv_insn_class
+   INSN_CLASS_XMIPSCMOV,
+   INSN_CLASS_XMIPSEXECTL,
+   INSN_CLASS_XMIPSLSP,
++  INSN_CLASS_XSMTVDOT,
+ };
+ 
+ /* This structure holds information for a particular instruction.  */
+diff --git a/opcodes/riscv-dis.c b/opcodes/riscv-dis.c
+--- a/opcodes/riscv-dis.c
++++ b/opcodes/riscv-dis.c
+@@ -917,6 +917,49 @@ print_insn_args (const char *oparg, insn_t l, bfd_vma pc, disassemble_info *info
+ 		  goto undefined_modifier;
+ 		}
+ 	      break;
++	    case 'p': /* Vendor-specific (SpacemiT) operands.  */
++	      switch (*++oparg)
++		{
++		case 'V':
++		  switch (*++oparg)
++		    {
++		    case 'd':
++		      unsigned vd = EXTRACT_OPERAND (SPACEMIT_IME_VD, l) * 2;
++		      print (info->stream, dis_style_register, "%s",
++			     riscv_vecr_names_numeric[vd]);
++		      break;
++		    case 's':
++		      unsigned vs = EXTRACT_OPERAND (SPACEMIT_IME_VS1, l) * 2;
++		      print (info->stream, dis_style_register, "%s",
++			     riscv_vecr_names_numeric[vs]);
++		      break;
++		    default:
++		      goto undefined_modifier;
++		    }
++		  break;
++		case 'w':
++		  /* Xpw&S ... bits in S indicates whether corresponding
++		     item is permitted.  */
++		  if (*++oparg != '&')
++		    goto undefined_modifier;
++		  strtol (oparg + 1, (char **)&oparg, 16);
++		  oparg--;
++		  unsigned wi = EXTRACT_OPERAND (SPACEMIT_IME_WI, l);
++		  /* Only print if not the default value (i8 = 3).  */
++		  if (wi == 3)
++		    break;
++		  print (info->stream, dis_style_text, ",");
++		  if (wi == 0)
++		    print (info->stream, dis_style_text, "i2");
++		  else if (wi == 1)
++		    print (info->stream, dis_style_text, "i16");
++		  else if (wi == 2)
++		    print (info->stream, dis_style_text, "i4");
++		  break;
++		default:
++		  goto undefined_modifier;
++		}
++	      break;
+ 	    default:
+ 	      goto undefined_modifier;
+ 	    }
+diff --git a/opcodes/riscv-opc.c b/opcodes/riscv-opc.c
+--- a/opcodes/riscv-opc.c
++++ b/opcodes/riscv-opc.c
+@@ -3579,6 +3579,29 @@ const struct riscv_opcode riscv_opcodes[] =
+ {"mips.sdp", 0, INSN_CLASS_XMIPSLSP, "t,r,Xm^(s)", MATCH_MIPS_SDP, MASK_MIPS_SDP, match_opcode, 0 },
+ {"mips.swp", 0, INSN_CLASS_XMIPSLSP, "t,r,Xm&(s)", MATCH_MIPS_SWP, MASK_MIPS_SWP, match_opcode, 0 },
+ 
++/* SpacemiT custom instructions.  */
++/* Int Matrix Multi-Accumulation.  */
++{"smt.vmadot",   0, INSN_CLASS_XSMTVDOT, "XpVd,Vs,VtXpw&8", MATCH_SMT_VMADOT, MASK_SMT_VMADOT, match_opcode, 0 },
++{"smt.vmadotu",  0, INSN_CLASS_XSMTVDOT, "XpVd,Vs,VtXpw&8", MATCH_SMT_VMADOTU, MASK_SMT_VMADOTU, match_opcode, 0 },
++{"smt.vmadotsu", 0, INSN_CLASS_XSMTVDOT, "XpVd,Vs,VtXpw&8", MATCH_SMT_VMADOTSU, MASK_SMT_VMADOTSU, match_opcode, 0 },
++{"smt.vmadotus", 0, INSN_CLASS_XSMTVDOT, "XpVd,Vs,VtXpw&8", MATCH_SMT_VMADOTUS, MASK_SMT_VMADOTUS, match_opcode, 0 },
++/* Int Sliding Window Multi-Accumulation.  */
++/* Sliding Value = 1.  */
++{"smt.vmadot1u",  0, INSN_CLASS_XSMTVDOT, "XpVd,XpVs,VtXpw&8", MATCH_SMT_VMADOT1U, MASK_SMT_VMADOT1U, match_opcode, 0 },
++{"smt.vmadot1",   0, INSN_CLASS_XSMTVDOT, "XpVd,XpVs,VtXpw&8", MATCH_SMT_VMADOT1, MASK_SMT_VMADOT1, match_opcode, 0 },
++{"smt.vmadot1su", 0, INSN_CLASS_XSMTVDOT, "XpVd,XpVs,VtXpw&8", MATCH_SMT_VMADOT1SU, MASK_SMT_VMADOT1SU, match_opcode, 0 },
++{"smt.vmadot1us", 0, INSN_CLASS_XSMTVDOT, "XpVd,XpVs,VtXpw&8", MATCH_SMT_VMADOT1US, MASK_SMT_VMADOT1US, match_opcode, 0 },
++/* Sliding Value = 2.  */
++{"smt.vmadot2u",  0, INSN_CLASS_XSMTVDOT, "XpVd,XpVs,VtXpw&8", MATCH_SMT_VMADOT2U, MASK_SMT_VMADOT2U, match_opcode, 0 },
++{"smt.vmadot2",   0, INSN_CLASS_XSMTVDOT, "XpVd,XpVs,VtXpw&8", MATCH_SMT_VMADOT2, MASK_SMT_VMADOT2, match_opcode, 0 },
++{"smt.vmadot2su", 0, INSN_CLASS_XSMTVDOT, "XpVd,XpVs,VtXpw&8", MATCH_SMT_VMADOT2SU, MASK_SMT_VMADOT2SU, match_opcode, 0 },
++{"smt.vmadot2us", 0, INSN_CLASS_XSMTVDOT, "XpVd,XpVs,VtXpw&8", MATCH_SMT_VMADOT2US, MASK_SMT_VMADOT2US, match_opcode, 0 },
++/* Sliding Value = 3.  */
++{"smt.vmadot3u",  0, INSN_CLASS_XSMTVDOT, "XpVd,XpVs,VtXpw&8", MATCH_SMT_VMADOT3U, MASK_SMT_VMADOT3U, match_opcode, 0 },
++{"smt.vmadot3",   0, INSN_CLASS_XSMTVDOT, "XpVd,XpVs,VtXpw&8", MATCH_SMT_VMADOT3, MASK_SMT_VMADOT3, match_opcode, 0 },
++{"smt.vmadot3su", 0, INSN_CLASS_XSMTVDOT, "XpVd,XpVs,VtXpw&8", MATCH_SMT_VMADOT3SU, MASK_SMT_VMADOT3SU, match_opcode, 0 },
++{"smt.vmadot3us", 0, INSN_CLASS_XSMTVDOT, "XpVd,XpVs,VtXpw&8", MATCH_SMT_VMADOT3US, MASK_SMT_VMADOT3US, match_opcode, 0 },
++
+ /* Terminate the list.  */
+ {0, 0, INSN_CLASS_NONE, 0, 0, 0, 0, 0}
+ };

--- a/easybuild/easyconfigs/l/llama.cpp/llama.cpp-ad8d821-foss-2025b-x60-ime.eb
+++ b/easybuild/easyconfigs/l/llama.cpp/llama.cpp-ad8d821-foss-2025b-x60-ime.eb
@@ -18,7 +18,7 @@ sources = ['%(version)s.tar.gz']
 patches = ['llama.cpp-x60-ime-upstream-binutils.patch']
 checksums = [
     'b72e328f83fe9c363529a3fea5e4f6b25e65645cf13e6ecfc95e61db585a2779',  # ad8d821.tar.gz
-    'ea476d588f940103d287f57e8bedbb2d7ae7bb431e4a8674eb5367eb301e4326',  # llama.cpp-x60-ime-upstream-binutils.patch
+    '5294e60520ec3035a0317229a415e775da1a5a7b1f417301d4574611630f8442',  # llama.cpp-x60-ime-upstream-binutils.patch
 ]
 
 builddependencies = [
@@ -26,15 +26,25 @@ builddependencies = [
 ]
 
 # --- SpaceMiT IME assembler: deployed ON TOP of EESSI, deliberately NOT a dependency ---
-# The IME backend emits `smt.vmadot`, which needs an assembler that knows the `xsmtvdot` extension.
-# That lives in the STANDALONE `binutils-2.46.1-xsmtvdot` package -- deploy it once on top of EESSI
-# (`eb binutils-2.46.1-xsmtvdot.eb`). It is NOT declared as a (build)dependency on purpose: injecting a
-# newer binutils would conflict with the toolchain's own binutils-2.44-GCCcore-14.3.0 (EasyBuild permits
-# only ONE binutils per dependency graph -- see PR #26451). Instead, put its `as` on PATH for this build
-# by setting SMT_XSMTVDOT_BIN to its bin/ dir, e.g.:
+# The IME1 backend emits `smt.vmadot`, which only the STANDALONE `binutils-2.46.1-xsmtvdot`
+# assembler understands. Deploy it once on top of EESSI (`eb binutils-2.46.1-xsmtvdot.eb`) and point
+# this build at it via SMT_XSMTVDOT_BIN (its bin/ dir), e.g.:
 #   export SMT_XSMTVDOT_BIN="$EASYBUILD_INSTALLPATH/software/binutils/2.46.1-xsmtvdot/bin"
-# (EESSI sites may instead use a pre_configure/pre_build hook that does the same PATH prepend.)
-local_use_xsmtvdot_as = 'export PATH="${SMT_XSMTVDOT_BIN:?set to the bin/ of the deployed binutils-2.46.1-xsmtvdot}:$PATH" && '
+# It is NOT declared as a (build)dependency on purpose: a second binutils would conflict with the
+# toolchain's own binutils-2.44-GCCcore-14.3.0 (EasyBuild permits only ONE binutils per dependency
+# graph -- see PR #26451).
+#
+# Override ONLY the assembler, NOT the linker: symlink that `as` into a private dir and hand it to
+# GCC with `-B<dir>/` via C/CXXFLAGS. This reaches BOTH the FindSMTIME configure probe (compiled via
+# CMAKE_C_FLAGS) and every build compile, while linking keeps the toolchain's own `ld` and library
+# paths. (Prepending the whole binutils bin/ to PATH would also hijack `ld`, which then fails to
+# resolve `-lgcc_s`; and GCC resolves `as`/`ld` via its exec-prefix before PATH anyway.)
+local_asdir = '%(builddir)s/xsmtvdot-as-only'
+local_use_xsmtvdot_as = (
+    'mkdir -p ' + local_asdir + ' && '
+    'ln -sf "${SMT_XSMTVDOT_BIN:?set to the bin/ of the deployed binutils-2.46.1-xsmtvdot}/as" ' + local_asdir + '/as && '
+    'export CFLAGS="${CFLAGS} -B' + local_asdir + '/" CXXFLAGS="${CXXFLAGS} -B' + local_asdir + '/" && '
+)
 preconfigopts = local_use_xsmtvdot_as
 prebuildopts = local_use_xsmtvdot_as
 

--- a/easybuild/easyconfigs/l/llama.cpp/llama.cpp-ad8d821-foss-2025b-x60-ime.eb
+++ b/easybuild/easyconfigs/l/llama.cpp/llama.cpp-ad8d821-foss-2025b-x60-ime.eb
@@ -30,7 +30,7 @@ builddependencies = [
     # upstream (standalone, SYSTEM toolchain). See the accompanying patch for why GCC 14.3
     # suffices (the patch injects `.option arch,+xsmtvdot`, so no GCC>=15 / `-march` support
     # is required).
-    ('binutils', '2.46.1'),
+    ('binutils', '2.46.1', '', SYSTEM),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/l/llama.cpp/llama.cpp-ad8d821-foss-2025b-x60-ime.eb
+++ b/easybuild/easyconfigs/l/llama.cpp/llama.cpp-ad8d821-foss-2025b-x60-ime.eb
@@ -23,18 +23,20 @@ checksums = [
 
 builddependencies = [
     ('CMake', '3.31.8'),
-    # Assembler with the SpaceMiT `xsmtvdot` extension (the `smt.vmadot*` opcodes the IME
-    # backend emits as inline asm). GCCcore-14.3.0 is NOT rebuilt: GCC invokes `as` from PATH
-    # and the binutils module prepends its bin/, so this `as` wins. The ggml patch injects
-    # `.option arch,+xsmtvdot`, so GCC 14.3 suffices (no GCC>=15 / `-march` support needed).
-    #
-    # NB (verified Jul 2026): STOCK binutils 2.46.1 does NOT contain xsmtvdot -- it is only an
-    # unmerged sourceware mailing-list patch (the support is merged in LLVM, and carried in
-    # SpaceMiT's downstream binutils). So this depends on a binutils built WITH the SpaceMiT
-    # xsmtvdot patch (a `binutils-2.46.1-xsmtvdot.eb` to be added alongside), NOT the stock
-    # binutils-2.46.1.eb. Until that patched binutils exists this easyconfig is BLOCKED (PR #26451).
-    ('binutils', '2.46.1', '-xsmtvdot', SYSTEM),
 ]
+
+# --- SpaceMiT IME assembler: deployed ON TOP of EESSI, deliberately NOT a dependency ---
+# The IME backend emits `smt.vmadot`, which needs an assembler that knows the `xsmtvdot` extension.
+# That lives in the STANDALONE `binutils-2.46.1-xsmtvdot` package -- deploy it once on top of EESSI
+# (`eb binutils-2.46.1-xsmtvdot.eb`). It is NOT declared as a (build)dependency on purpose: injecting a
+# newer binutils would conflict with the toolchain's own binutils-2.44-GCCcore-14.3.0 (EasyBuild permits
+# only ONE binutils per dependency graph -- see PR #26451). Instead, put its `as` on PATH for this build
+# by setting SMT_XSMTVDOT_BIN to its bin/ dir, e.g.:
+#   export SMT_XSMTVDOT_BIN="$EASYBUILD_INSTALLPATH/software/binutils/2.46.1-xsmtvdot/bin"
+# (EESSI sites may instead use a pre_configure/pre_build hook that does the same PATH prepend.)
+local_use_xsmtvdot_as = 'export PATH="${SMT_XSMTVDOT_BIN:?set to the bin/ of the deployed binutils-2.46.1-xsmtvdot}:$PATH" && '
+preconfigopts = local_use_xsmtvdot_as
+prebuildopts = local_use_xsmtvdot_as
 
 dependencies = [
     ('cURL', '8.14.1'),
@@ -43,7 +45,7 @@ dependencies = [
 # SpaceMiT X60 (K1): RVV (rv64gcv + Zfh/Zvfh) + IME1 int8 matrix extension.
 #
 # The patch makes the IME1 backend build against a binutils carrying the SpaceMiT `xsmtvdot`
-# patch (see the builddependency note above -- NO stock GNU binutils has it) + GCC 14.3:
+# patch (see the assembler note above -- NO stock GNU binutils has it) + GCC 14.3:
 #   (a) renames ggml's SpaceMiT-vendor mnemonic `vmadot` -> upstream `smt.vmadot`
 #       (identical encoding 0xe210312b; verified),
 #   (b) injects `.option arch,+xsmtvdot` into the IME1 inline asm so a plain -march works

--- a/easybuild/easyconfigs/l/llama.cpp/llama.cpp-ad8d821-foss-2025b-x60-ime.eb
+++ b/easybuild/easyconfigs/l/llama.cpp/llama.cpp-ad8d821-foss-2025b-x60-ime.eb
@@ -42,7 +42,7 @@ builddependencies = [
 local_asdir = '%(builddir)s/xsmtvdot-as-only'
 local_use_xsmtvdot_as = (
     'mkdir -p ' + local_asdir + ' && '
-    'ln -sf "${SMT_XSMTVDOT_BIN:?set to the bin/ of the deployed binutils-2.46.1-xsmtvdot}/as" ' + local_asdir + '/as && '
+    'ln -sf "${SMT_XSMTVDOT_BIN:?set to bin/ of deployed binutils-2.46.1-xsmtvdot}/as" ' + local_asdir + '/as && '
     'export CFLAGS="${CFLAGS} -B' + local_asdir + '/" CXXFLAGS="${CXXFLAGS} -B' + local_asdir + '/" && '
 )
 preconfigopts = local_use_xsmtvdot_as

--- a/easybuild/easyconfigs/l/llama.cpp/llama.cpp-ad8d821-foss-2025b-x60-ime.eb
+++ b/easybuild/easyconfigs/l/llama.cpp/llama.cpp-ad8d821-foss-2025b-x60-ime.eb
@@ -23,14 +23,17 @@ checksums = [
 
 builddependencies = [
     ('CMake', '3.31.8'),
-    # Newer assembler ONLY. binutils 2.46 adds the RISC-V `xsmtvdot` vendor extension
-    # (the `smt.vmadot*` opcodes) that the SpaceMiT IME backend emits as inline asm.
-    # GCCcore-14.3.0 is NOT rebuilt: GCC invokes `as` from PATH, and the binutils module
-    # prepends its bin/ so the 2.46.1 assembler wins. binutils-2.46.1.eb already exists
-    # upstream (standalone, SYSTEM toolchain). See the accompanying patch for why GCC 14.3
-    # suffices (the patch injects `.option arch,+xsmtvdot`, so no GCC>=15 / `-march` support
-    # is required).
-    ('binutils', '2.46.1', '', SYSTEM),
+    # Assembler with the SpaceMiT `xsmtvdot` extension (the `smt.vmadot*` opcodes the IME
+    # backend emits as inline asm). GCCcore-14.3.0 is NOT rebuilt: GCC invokes `as` from PATH
+    # and the binutils module prepends its bin/, so this `as` wins. The ggml patch injects
+    # `.option arch,+xsmtvdot`, so GCC 14.3 suffices (no GCC>=15 / `-march` support needed).
+    #
+    # NB (verified Jul 2026): STOCK binutils 2.46.1 does NOT contain xsmtvdot -- it is only an
+    # unmerged sourceware mailing-list patch (the support is merged in LLVM, and carried in
+    # SpaceMiT's downstream binutils). So this depends on a binutils built WITH the SpaceMiT
+    # xsmtvdot patch (a `binutils-2.46.1-xsmtvdot.eb` to be added alongside), NOT the stock
+    # binutils-2.46.1.eb. Until that patched binutils exists this easyconfig is BLOCKED (PR #26451).
+    ('binutils', '2.46.1', '-xsmtvdot', SYSTEM),
 ]
 
 dependencies = [
@@ -39,13 +42,14 @@ dependencies = [
 
 # SpaceMiT X60 (K1): RVV (rv64gcv + Zfh/Zvfh) + IME1 int8 matrix extension.
 #
-# The patch makes the IME1 backend build against UPSTREAM binutils 2.46 + GCC 14.3:
+# The patch makes the IME1 backend build against a binutils carrying the SpaceMiT `xsmtvdot`
+# patch (see the builddependency note above -- NO stock GNU binutils has it) + GCC 14.3:
 #   (a) renames ggml's SpaceMiT-vendor mnemonic `vmadot` -> upstream `smt.vmadot`
 #       (identical encoding 0xe210312b; verified),
 #   (b) injects `.option arch,+xsmtvdot` into the IME1 inline asm so a plain -march works
 #       (drops the GCC>=15-only `_xsmtvdotii` requirement),
-#   (c) compiles ime2_kernels.cpp only when IME2 is detected -- upstream binutils 2.46 is
-#       IME1-only (`xsmtvdot` v1.0), and the X60 is IME1-only at runtime (use_ime2=0) anyway.
+#   (c) compiles ime2_kernels.cpp only when IME2 is detected -- the `xsmtvdot` spec is
+#       IME1-only (v1.0), and the X60 is IME1-only at runtime (use_ime2=0) anyway.
 #
 # Perf note (measured, Qwen2.5-0.5B Q4_0): IME gives ~1.56x prompt-processing at t=4, but
 # plain RVV at `-t 8` beats IME on BOTH pp512 and tg128 (IME is cluster-0-only and regresses

--- a/easybuild/easyconfigs/l/llama.cpp/llama.cpp-x60-ime-foss-2025b.eb
+++ b/easybuild/easyconfigs/l/llama.cpp/llama.cpp-x60-ime-foss-2025b.eb
@@ -1,0 +1,76 @@
+easyblock = 'CMakeMake'
+
+name = 'llama.cpp'
+version = 'ad8d821'
+versionsuffix = '-x60-ime'
+
+homepage = 'https://github.com/ggml-org/llama.cpp'
+description = """Inference of Meta's LLaMA model (and others) in pure C/C++, built for the
+SpaceMiT X60 (K1 SoC, e.g. Orange Pi RV2) with the SpaceMiT IME int8-matrix backend
+(GGML_CPU_RISCV64_SPACEMIT) enabled in addition to RVV."""
+
+toolchain = {'name': 'foss', 'version': '2025b'}  # GCCcore-14.3.0 stays UNCHANGED
+
+# Pin a commit/tag that ships ggml's spacemit/ IME backend + cmake/FindSMTIME.cmake.
+# ad8d821 is the commit validated on the Orange Pi RV2 (llama-bench "build: ad8d821 (1)").
+source_urls = ['https://github.com/ggml-org/llama.cpp/archive/']
+sources = ['%(version)s.tar.gz']
+patches = ['llama.cpp-x60-ime-upstream-binutils.patch']
+checksums = [
+    'b72e328f83fe9c363529a3fea5e4f6b25e65645cf13e6ecfc95e61db585a2779',  # ad8d821.tar.gz
+    'ea476d588f940103d287f57e8bedbb2d7ae7bb431e4a8674eb5367eb301e4326',  # llama.cpp-x60-ime-upstream-binutils.patch
+]
+
+builddependencies = [
+    ('CMake', '3.31.8'),
+    # Newer assembler ONLY. binutils 2.46 adds the RISC-V `xsmtvdot` vendor extension
+    # (the `smt.vmadot*` opcodes) that the SpaceMiT IME backend emits as inline asm.
+    # GCCcore-14.3.0 is NOT rebuilt: GCC invokes `as` from PATH, and the binutils module
+    # prepends its bin/ so the 2.46.1 assembler wins. binutils-2.46.1.eb already exists
+    # upstream (standalone, SYSTEM toolchain). See the accompanying patch for why GCC 14.3
+    # suffices (the patch injects `.option arch,+xsmtvdot`, so no GCC>=15 / `-march` support
+    # is required).
+    ('binutils', '2.46.1'),
+]
+
+dependencies = [
+    ('cURL', '8.14.1'),
+]
+
+# SpaceMiT X60 (K1): RVV (rv64gcv + Zfh/Zvfh) + IME1 int8 matrix extension.
+#
+# The patch makes the IME1 backend build against UPSTREAM binutils 2.46 + GCC 14.3:
+#   (a) renames ggml's SpaceMiT-vendor mnemonic `vmadot` -> upstream `smt.vmadot`
+#       (identical encoding 0xe210312b; verified),
+#   (b) injects `.option arch,+xsmtvdot` into the IME1 inline asm so a plain -march works
+#       (drops the GCC>=15-only `_xsmtvdotii` requirement),
+#   (c) compiles ime2_kernels.cpp only when IME2 is detected -- upstream binutils 2.46 is
+#       IME1-only (`xsmtvdot` v1.0), and the X60 is IME1-only at runtime (use_ime2=0) anyway.
+#
+# Perf note (measured, Qwen2.5-0.5B Q4_0): IME gives ~1.56x prompt-processing at t=4, but
+# plain RVV at `-t 8` beats IME on BOTH pp512 and tg128 (IME is cluster-0-only and regresses
+# at t=8). Ship IME for the core-constrained / prompt-heavy case; default runs to `-t 8`.
+configopts = ' '.join([
+    '-DGGML_RVV=ON',
+    '-DGGML_RV_ZFH=ON',
+    '-DGGML_RV_ZVFH=ON',
+    '-DGGML_RV_ZBA=ON',
+    '-DGGML_RV_ZICBOP=ON',
+    '-DGGML_CPU_RISCV64_SPACEMIT=ON',      # enable the SpaceMiT IME backend
+    '-DGGML_BLAS=ON',
+    '-DGGML_BLAS_VENDOR=FlexiBLAS',
+    '-DLLAMA_CURL=ON',
+])
+
+sanity_check_paths = {
+    'files': ['bin/llama-cli', 'bin/llama-server', 'include/llama-cpp.h',
+              'lib/libllama.%s' % SHLIB_EXT],
+    'dirs': ['lib'],
+}
+
+sanity_check_commands = [
+    "llama-cli --help",
+    "llama-server --help",
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/l/llama.cpp/llama.cpp-x60-ime-upstream-binutils.patch
+++ b/easybuild/easyconfigs/l/llama.cpp/llama.cpp-x60-ime-upstream-binutils.patch
@@ -1,0 +1,87 @@
+diff --git a/ggml/src/ggml-cpu/CMakeLists.txt b/ggml/src/ggml-cpu/CMakeLists.txt
+index f7c557a..184d469 100644
+--- a/ggml/src/ggml-cpu/CMakeLists.txt
++++ b/ggml/src/ggml-cpu/CMakeLists.txt
+@@ -454,11 +454,16 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
+                 ggml-cpu/spacemit/ime_env.cpp
+                 ggml-cpu/spacemit/ime_env.h
+                 ggml-cpu/spacemit/ime1_kernels.cpp
+-                ggml-cpu/spacemit/ime2_kernels.cpp
+                 ggml-cpu/spacemit/ime_kernels.h
+                 ggml-cpu/spacemit/rvv_kernels.cpp
+                 ggml-cpu/spacemit/rvv_kernels.h
+             )
++            # IME2 (fp16/int4/pack ops: vpack.vv, vfwmadot, vmadot.hp) needs the SpaceMiT `xsmtvdotii`
++            # superset. Upstream binutils 2.46 (`xsmtvdot` v1.0) is IME1-only, and the X60 is IME1-only
++            # (use_ime2=0) — so only compile ime2_kernels.cpp when the toolchain actually supports IME2.
++            if ("RISCV64_SPACEMIT_IME2" IN_LIST RISCV64_SPACEMIT_IME_SPEC)
++                list(APPEND GGML_CPU_SOURCES ggml-cpu/spacemit/ime2_kernels.cpp)
++            endif()
+         endif()
+         if(NOT GGML_CPU_ALL_VARIANTS)
+             set(MARCH_STR "rv64gc")
+diff --git a/ggml/src/ggml-cpu/cmake/FindSMTIME.cmake b/ggml/src/ggml-cpu/cmake/FindSMTIME.cmake
+index c8a4d4b..b9c96f0 100644
+--- a/ggml/src/ggml-cpu/cmake/FindSMTIME.cmake
++++ b/ggml/src/ggml-cpu/cmake/FindSMTIME.cmake
+@@ -8,7 +8,7 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(riscv)" AND GGML_CPU_RISCV64_SPACEMIT)
+     endif()
+     set(CMAKE_REQUIRED_FLAGS "${SMT_MARCH_STR}")
+ 
+-    check_c_source_compiles("int main() {__asm__ volatile(\"vmadot v2, v0, v1\");}" SPACEMIT_RISCV_COMPILER_SUPPORT_IME1)
++    check_c_source_compiles("int main() {__asm__ volatile(\".option arch,+xsmtvdot\\n smt.vmadot v2, v0, v1\");}" SPACEMIT_RISCV_COMPILER_SUPPORT_IME1)
+     check_c_source_compiles("int main() {__asm__ volatile(\"vmadot v2, v0, v1, i4\");}" SPACEMIT_RISCV_COMPILER_SUPPORT_VMADOT_S4)
+     check_c_source_compiles("int main() {__asm__ volatile(\"vmadot v2, v0, v1, i8\");}" SPACEMIT_RISCV_COMPILER_SUPPORT_VMADOT_S8)
+     check_c_source_compiles("int main() {__asm__ volatile(\"vfwmadot v2, v0, v1, fp16\");}" SPACEMIT_RISCV_COMPILER_SUPPORT_VFWMADOT_FP16)
+diff --git a/ggml/src/ggml-cpu/spacemit/ime1_kernels.cpp b/ggml/src/ggml-cpu/spacemit/ime1_kernels.cpp
+index 6acc681..e793ace 100644
+--- a/ggml/src/ggml-cpu/spacemit/ime1_kernels.cpp
++++ b/ggml/src/ggml-cpu/spacemit/ime1_kernels.cpp
+@@ -302,14 +302,15 @@ void quantize_a_row_i8(size_t BlkLen, const float * A, size_t CountK, uint8_t *
+ 
+ namespace {
+ #define SQ4BIT_KERNEL_COMP_1x8x2_4X8X4          \
+-    "vmadot       v16, v14, v0            \n\t" \
+-    "vmadot       v18, v14, v1            \n\t" \
+-    "vmadot       v20, v14, v2            \n\t" \
+-    "vmadot       v22, v14, v3            \n\t" \
+-    "vmadot       v16, v15, v4            \n\t" \
+-    "vmadot       v18, v15, v5            \n\t" \
+-    "vmadot       v20, v15, v6            \n\t" \
+-    "vmadot       v22, v15, v7            \n\t"
++    ".option arch, +xsmtvdot                 \n\t" \
++    "smt.vmadot       v16, v14, v0            \n\t" \
++    "smt.vmadot       v18, v14, v1            \n\t" \
++    "smt.vmadot       v20, v14, v2            \n\t" \
++    "smt.vmadot       v22, v14, v3            \n\t" \
++    "smt.vmadot       v16, v15, v4            \n\t" \
++    "smt.vmadot       v18, v15, v5            \n\t" \
++    "smt.vmadot       v20, v15, v6            \n\t" \
++    "smt.vmadot       v22, v15, v7            \n\t"
+ 
+ #define SQ4BIT_KERNEL_ACC_1X4X4                 \
+     "vfcvt.f.x.v  v16,  v16               \n\t" \
+@@ -513,14 +514,15 @@ namespace {
+     "vmv.v.v      v31, v30                \n\t"
+ 
+ #define SQ4BIT_KERNEL_COMP_4x16x16              \
+-    "vmadot       v16, v10, v2            \n\t" \
+-    "vmadot       v18, v10, v3            \n\t" \
+-    "vmadot       v20, v10, v4            \n\t" \
+-    "vmadot       v22, v10, v5            \n\t" \
+-    "vmadot       v16, v11, v6            \n\t" \
+-    "vmadot       v18, v11, v7            \n\t" \
+-    "vmadot       v20, v11, v8            \n\t" \
+-    "vmadot       v22, v11, v9            \n\t"
++    ".option arch, +xsmtvdot                 \n\t" \
++    "smt.vmadot       v16, v10, v2            \n\t" \
++    "smt.vmadot       v18, v10, v3            \n\t" \
++    "smt.vmadot       v20, v10, v4            \n\t" \
++    "smt.vmadot       v22, v10, v5            \n\t" \
++    "smt.vmadot       v16, v11, v6            \n\t" \
++    "smt.vmadot       v18, v11, v7            \n\t" \
++    "smt.vmadot       v20, v11, v8            \n\t" \
++    "smt.vmadot       v22, v11, v9            \n\t"
+ 
+ #define SAVE_RESULT_4x16                        \
+     "addi         a1, %[C], 0             \n\t" \

--- a/easybuild/easyconfigs/l/llama.cpp/llama.cpp-x60-ime-upstream-binutils.patch
+++ b/easybuild/easyconfigs/l/llama.cpp/llama.cpp-x60-ime-upstream-binutils.patch
@@ -29,7 +29,7 @@ index c8a4d4b..b9c96f0 100644
      set(CMAKE_REQUIRED_FLAGS "${SMT_MARCH_STR}")
  
 -    check_c_source_compiles("int main() {__asm__ volatile(\"vmadot v2, v0, v1\");}" SPACEMIT_RISCV_COMPILER_SUPPORT_IME1)
-+    check_c_source_compiles("int main() {__asm__ volatile(\".option arch,+xsmtvdot\\n smt.vmadot v2, v0, v1\");}" SPACEMIT_RISCV_COMPILER_SUPPORT_IME1)
++    check_c_source_compiles("int main() {__asm__ volatile(\".option arch,+xsmtvdot\"); __asm__ volatile(\"smt.vmadot v2, v0, v1\");}" SPACEMIT_RISCV_COMPILER_SUPPORT_IME1)
      check_c_source_compiles("int main() {__asm__ volatile(\"vmadot v2, v0, v1, i4\");}" SPACEMIT_RISCV_COMPILER_SUPPORT_VMADOT_S4)
      check_c_source_compiles("int main() {__asm__ volatile(\"vmadot v2, v0, v1, i8\");}" SPACEMIT_RISCV_COMPILER_SUPPORT_VMADOT_S8)
      check_c_source_compiles("int main() {__asm__ volatile(\"vfwmadot v2, v0, v1, fp16\");}" SPACEMIT_RISCV_COMPILER_SUPPORT_VFWMADOT_FP16)


### PR DESCRIPTION
(created with local `git` + `gh` — `eb` is not available in this environment, so no `eb --new-pr` test report)

## Summary

Adds `llama.cpp-ad8d821-x60-ime-foss-2025b.eb` — llama.cpp with the **SpaceMiT IME** int8-matrix backend
(`GGML_CPU_RISCV64_SPACEMIT`) enabled for the **SpaceMiT X60** (K1 SoC; e.g. Orange Pi RV2 / Banana Pi BPI-F3),
on top of the existing `foss/2025b` (GCCcore-14.3.0) stack.

**GCCcore-14.3.0 is NOT rebuilt.** The only toolchain change is a build-time newer assembler:

```python
builddependencies = [
    ('CMake', '3.31.8'),
    ('binutils', '2.46.1'),   # newer `as` only
]
```

binutils 2.46 adds the RISC-V `xsmtvdot` vendor extension (the `smt.vmadot*` opcodes) that the IME backend emits as
inline asm. GCC invokes `as` from `PATH`, and the `binutils/2.46.1` module prepends its `bin/`, so the newer assembler
is used without touching GCC.

## The patch (`llama.cpp-x60-ime-upstream-binutils.patch`)

ggml's SpaceMiT backend was written for the **SpaceMiT vendor toolchain** (mnemonic `vmadot`, ext `xsmtvdotii`,
requires GCC ≥ 15). This 3-file patch makes the **IME1** path build against **mainline binutils 2.46 + GCC 14.3**:

1. `ime1_kernels.cpp`: rename vendor `vmadot` → upstream `smt.vmadot` (16×; **identical encoding `0xe210312b`**,
   verified) and inject `.option arch,+xsmtvdot` into the two asm macros so a plain `-march` works (no GCC ≥ 15 /
   `_xsmtvdotii` needed).
2. `cmake/FindSMTIME.cmake`: the IME1 detection probe uses `.option arch,+xsmtvdot` + `smt.vmadot`.
3. `CMakeLists.txt`: compile `ime2_kernels.cpp` only when IME2 is detected — upstream binutils 2.46 (`xsmtvdot` v1.0)
   is IME1-only (rejects `vpack.vv`/`vfwmadot`/`vmadot.hp`), and the X60 is IME1-only at runtime (`use_ime2=0`). IME2
   dispatch in `ime.cpp` is already `#ifdef`-guarded, so this is link-safe. Backward-compatible: on the vendor
   toolchain IME2 is still detected + compiled.

## Validation

- Cross-compiled (SpaceMiT v1.2.4) and **run on an Orange Pi RV2**: coherent output (`use_ime1: 1`), 264 `smt.vmadot`
  in `libggml-cpu.so`.
- Patch **compile-verified** under the exact target scenario: GCC + base `-march=rv64gcv_zfh_zvfh_zba_zicbop` (no
  `xsmtvdotii`) + `RISCV64_SPACEMIT_IME1` only → emits real `smt.vmadot`.
- Perf (Qwen2.5-0.5B Q4_0, llama-bench): IME ~**1.56× prompt-processing at t=4**. NB: plain RVV at `-t 8` beats IME on
  both pp512 and tg128 (IME is cluster-0-only and regresses at t=8) — this IME build targets the prompt-heavy /
  core-constrained case.

## Notes for reviewers (draft)

- Pins the **validated commit `ad8d821`** (has the ggml `spacemit/` backend + current `FindSMTIME.cmake`). Can bump to
  a `b<NNNN>` release tag once one lands that carries the IME backend.
- RISC-V + SpaceMiT hardware is **not testable in EB CI**; validation was on real X60 silicon.
- Dependencies all already present in easyconfigs: `binutils-2.46.1`, `CMake-3.31.8`, `cURL-8.14.1`, `foss-2025b`.
