### PR TITLE
New checksum due to upstream changes by libcerf maintainer

### DIFF
--- a/easybuild/easyconfigs/l/libcerf/libcerf-2.4-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/l/libcerf/libcerf-2.4-GCCcore-13.2.0.eb
@@ -16,7 +16,8 @@ toolchainopts = {'pic': True}
 
 source_urls = ['https://jugit.fz-juelich.de/mlz/libcerf/-/archive/v%(version)s/']
 sources = ['libcerf-v%(version)s.tar.gz']
-checksums = ['080b30ae564c3dabe3b89264522adaf5647ec754021572bee54929697b276cdc']
+# Due to upstream changes by libcerf maintainer Joachim Wuttke <j.wuttke@fz-juelich.de>
+checksums = ['85c2f2c84a118f2f1714406d9251482e86ed4f15bac44f37888fa9d883fff04a']
 
 builddependencies = [
     ('binutils', '2.40'),


### PR DESCRIPTION
Checksums changed upstream. New checksum confirmed by libcerf maintainer <j.wuttke@fz-juelich.de> on 07/14/26.