### PR TITLE
{tools}[GCC/14.3.0] Flux v0.80.0: use flux-pmix bugfix release

### DIFF
--- a/easybuild/easyconfigs/f/Flux/Flux-0.80.0-GCC-13.3.0.eb
+++ b/easybuild/easyconfigs/f/Flux/Flux-0.80.0-GCC-13.3.0.eb
@@ -69,9 +69,9 @@ components = [
         'checksums': ['8f8de89e445303e07b27912d4044862a8594d46b68d20dbb28b1e20bef198efe'],
         # 'runtest': True,
     }),
-    ('flux-pmix', '0.7.0', {
+    ('flux-pmix', '0.7.1', {
         'easyblock': 'ConfigureMake',
-        'checksums': ['0ad9fa0d76e8ffeaa4aa45bd39760b623219e8d3d2a66eb62e8832c2f7e3f47b'],
+        'checksums': ['0530d203370b13b63263ee48ecc829ab6bddadabf4e66ea470983f6f530a410f'],
         'configopts': '--without-openmpi',
         # 'runtest': 'check',
     }),
@@ -83,6 +83,8 @@ sanity_check_paths = {
 }
 
 sanity_check_commands = ['flux -h']
+
+modextravars = {'FLUX_PMI_CLIENT_METHODS': 'simple pmix libpmi2 libpmi single'}
 
 # Enable tab completion, and remove it upon unloading the module.
 modluafooter = """

--- a/easybuild/easyconfigs/f/Flux/Flux-0.80.0-GCC-14.3.0.eb
+++ b/easybuild/easyconfigs/f/Flux/Flux-0.80.0-GCC-14.3.0.eb
@@ -69,9 +69,9 @@ components = [
         'checksums': ['8f8de89e445303e07b27912d4044862a8594d46b68d20dbb28b1e20bef198efe'],
         # 'runtest': True,
     }),
-    ('flux-pmix', '0.7.0', {
+    ('flux-pmix', '0.7.1', {
         'easyblock': 'ConfigureMake',
-        'checksums': ['0ad9fa0d76e8ffeaa4aa45bd39760b623219e8d3d2a66eb62e8832c2f7e3f47b'],
+        'checksums': ['0530d203370b13b63263ee48ecc829ab6bddadabf4e66ea470983f6f530a410f'],
         'configopts': '--without-openmpi',
         # 'runtest': 'check',
     }),
@@ -83,6 +83,8 @@ sanity_check_paths = {
 }
 
 sanity_check_commands = ['flux -h']
+
+modextravars = {'FLUX_PMI_CLIENT_METHODS': 'simple pmix libpmi2 libpmi single'}
 
 # Enable tab completion, and remove it upon unloading the module.
 modluafooter = """


### PR DESCRIPTION
Update `flux-pmix` component of the Flux v0.80.0 Bundle to use an upstream bugfix release. Also adds an environment setting to add `pmix` to the list of PMI methods tried during bootstrap, with the default `simple` method left in first position (i.e. it will try `pmix` automatically but only if `simple` fails first).