### PR TITLE
add libiconv as direct dependency for R-bundle-CRAN + make sure that it's used for `haven` + `readxl` extensions

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2025.10-foss-2025a.eb
+++ b/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2025.10-foss-2025a.eb
@@ -32,7 +32,7 @@ dependencies = [
     ('GDAL', '3.11.1'),  # for sf
     ('MPFR', '4.2.2'),  # for Rmpfr
     ('PostgreSQL', '17.5'),  # for RPostgreSQL
-    ('libiconv', '1.18'),  # for haven
+    ('libiconv', '1.18'),  # for haven + readxl
 ]
 
 # Some R extensions (mclust, quantreg, waveslim for example) require the math library (-lm) to avoid undefined symbols.

--- a/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2025.10-foss-2025a.eb
+++ b/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2025.10-foss-2025a.eb
@@ -612,7 +612,7 @@ exts_list = [
     ('haven', '2.5.5', {
         'checksums': ['9482cd9c3760e1838acf687235317fed97fa6bf79219d3216f0ea447d4b1c9a5'],
         # explicitly link to libiconv by adding -liconv to PKG_LIBS,
-	# to ensure that libiconv dependency is picked up;
+        # to ensure that libiconv dependency is picked up;
         # we do this via the configure script,
         # which is used by haven to find zlib and generates src/Makevars;
         # fixes problems like "undefined symbol: libiconv",
@@ -1221,6 +1221,11 @@ exts_list = [
     }),
     ('readxl', '1.4.5', {
         'checksums': ['09d70d7bbafbe129ce687b8743dbf6b9d0f201205b30dc515a00b35fcc1bdedf'],
+        # explicitly link to libiconv by adding -liconv to PKG_LIBS
+        # to ensure that libiconv dependency is picked up;
+        # fixes problems like "undefined symbol: libiconv",
+        # see also https://github.com/tidyverse/readxl/issues/704
+        'preinstallopts': "PKG_LIBS='-liconv' ",
     }),
     ('writexl', '1.5.4', {
         'checksums': ['d0574a29ea22bd78785f50c7cd23c6e10036f65321e26d55a694e931467660d3'],

--- a/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2025.10-foss-2025a.eb
+++ b/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2025.10-foss-2025a.eb
@@ -32,6 +32,7 @@ dependencies = [
     ('GDAL', '3.11.1'),  # for sf
     ('MPFR', '4.2.2'),  # for Rmpfr
     ('PostgreSQL', '17.5'),  # for RPostgreSQL
+    ('libiconv', '1.18'),  # for haven
 ]
 
 # Some R extensions (mclust, quantreg, waveslim for example) require the math library (-lm) to avoid undefined symbols.
@@ -610,6 +611,13 @@ exts_list = [
     }),
     ('haven', '2.5.5', {
         'checksums': ['9482cd9c3760e1838acf687235317fed97fa6bf79219d3216f0ea447d4b1c9a5'],
+        # explicitly link to libiconv by adding -liconv to PKG_LIBS,
+	# to ensure that libiconv dependency is picked up;
+        # we do this via the configure script,
+        # which is used by haven to find zlib and generates src/Makevars;
+        # fixes problems like "undefined symbol: libiconv",
+        # see for example https://github.com/tidyverse/haven/issues/299
+        'preinstallopts': r"""sed -i 's/\(echo "Using PKG_LIBS\)/PKG_LIBS="$PKG_LIBS -liconv"; \1/g' configure && """,
     }),
     ('pan', '1.9', {
         'checksums': [


### PR DESCRIPTION
This should fix an "`undefined symbol: libiconv`" issue that pops up when installing `R-bundle-CRAN-2025.10-foss-2025a.eb` in EESSI:

```
Error: package or namespace load failed for ‘haven’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/cvmfs/software.eessi.io/versions/2025.06/software/linux/aarch64/nvidia/grace/software/R-bundle-CRAN/2025.10-foss-2025a/00LOCK-haven/00new/haven/libs/haven.so':
  /cvmfs/software.eessi.io/versions/2025.06/software/linux/aarch64/nvidia/grace/software/R-bundle-CRAN/2025.10-foss-2025a/00LOCK-haven/00new/haven/libs/haven.so: undefined symbol: libiconv
```

There a various reports of this problem upstream, see for example:
- https://github.com/tidyverse/haven/issues/299
- https://github.com/tidyverse/haven/issues/465

At some point, conda essentially made this change too (not anymore though, since `src/Makevars` does not exist anymore, it's not generated by the `configure` script in `haven` from `src/Makevars.in`):
- https://github.com/conda-forge/r-haven-feedstock/pull/12

WIP, TODOs:
- [x] verify whether the proposed change indeed fixes the problem observed in EESSI (via https://github.com/EESSI/software-layer/pull/1551): confirmed that this works
- ~~should make same change for newer `R-bundle-CRAN` easyconfigs, to be consistent~~ (same fix not needed for `2025b`, so not going there)
  - `R-bundle-CRAN-2025.11-foss-2025b.eb` (https://github.com/EESSI/software-layer/pull/1550 should tell if that's really required => nope);
  - `R-bundle-CRAN-2026.07-foss-2026.1.eb` (too early to test on top of EESSI 2026.06)