### PR TITLE
fix pod5-file-format 0.3.x easyconfigs by avoiding that `preconfigopts` is inherited by extensions

### DIFF
--- a/easybuild/easyconfigs/p/pod5-file-format/pod5-file-format-0.3.10-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/pod5-file-format/pod5-file-format-0.3.10-foss-2023a.eb
@@ -52,6 +52,7 @@ local_preinstallopts = (
 exts_defaultclass = 'PythonPackage'
 exts_default_options = {
     'source_urls': [PYPI_SOURCE],
+    # avoid that preconfigopts of parent installation is picked up for extensions (where it makes no sense)
     'preconfigopts': '',
 }
 exts_list = [

--- a/easybuild/easyconfigs/p/pod5-file-format/pod5-file-format-0.3.10-foss-2023a.eb
+++ b/easybuild/easyconfigs/p/pod5-file-format/pod5-file-format-0.3.10-foss-2023a.eb
@@ -22,6 +22,7 @@ builddependencies = [
     ('poetry', '1.5.1'),
     ('CMake', '3.26.3'),
     ('pkgconfig', '1.5.5', '-python'),
+    ('setuptools', '80.9.0'),
 ]
 
 dependencies = [
@@ -51,6 +52,7 @@ local_preinstallopts = (
 exts_defaultclass = 'PythonPackage'
 exts_default_options = {
     'source_urls': [PYPI_SOURCE],
+    'preconfigopts': '',
 }
 exts_list = [
     ('lib-pod5', version, {

--- a/easybuild/easyconfigs/p/pod5-file-format/pod5-file-format-0.3.23-foss-2024a.eb
+++ b/easybuild/easyconfigs/p/pod5-file-format/pod5-file-format-0.3.23-foss-2024a.eb
@@ -60,6 +60,8 @@ local_preinstallopts = (
 exts_defaultclass = 'PythonPackage'
 exts_default_options = {
     'source_urls': [PYPI_SOURCE],
+    # avoid that preconfigopts of parent installation is picked up for extensions (where it makes no sense)
+    'preconfigopts': '',
 }
 exts_list = [
     ('lib-pod5', version, {


### PR DESCRIPTION
add missing builddependency setuptools and filter preconfigopts for extensions

edit: this fixes the following problem:
```
ERROR: Installation of pod5-file-format-0.3.23-foss-2024a.eb failed: Failed to resolve all templates in "cd %(start_dir)s/cmake && ...
```

This occurs because of a combination of things:
- the top-level `preconfigopts` is inherited by the extensions (but actually irrelevant there, because `preconfigopts` is totally ignored by the `PythonPackage` easyblock);
- the `start_dir` template can not be resolved for extensions;
- unresolved templates are no longer allowed since EasyBuild v5.0.0, see:
  - https://github.com/easybuilders/easybuild-framework/pull/4516
- `PythonPackage` used to *totally* ignore `preconfigopts`, but not anymore with the recent change made in:
  - https://github.com/easybuilders/easybuild-easyblocks/pull/4144/
  - in here, `preconfigopts` is updated by the `set_ulimit` method, and hence all template values must be resolvable...