### PR TITLE
{PETSc,petsc4Foam}: HIP (double-precision) OpenFOAM GPU-solver chain for foss/2025a

### DIFF
--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.23.5-foss-2025a-HIP.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.23.5-foss-2025a-HIP.eb
@@ -1,0 +1,128 @@
+# EasyBuild easyconfig: PETSc with AMD-GPU (HIP) backend
+#
+# =========================================================================
+#  Derived from the UPSTREAM easyconfig shipped in the EESSI 2025.06
+#  EasyBuild index:
+#      easybuild-easyconfigs/p/PETSc/PETSc-3.23.5-foss-2025a.eb
+#  (base CPU build) plus the AMD-GPU (HIP) additions transcribed from a
+#  WORKING manual PETSc build verified on phi-v710 (AMD Radeon Pro V710,
+#  gfx1101). Everything below the base build is the HIP delta.
+# =========================================================================
+#
+#  VERIFIED ON phi-v710 against EESSI 2025.06 (2026-07-28):
+#    * EasyBuild 5.3.1 in EESSI-extend/2025.06-easybuild defines the
+#      first-class `amdgcn_capabilities` param + `--amdgcn-capabilities`.
+#    * EESSI-extend maps EESSI_ACCELERATOR_TARGET=accel/amd/gfx1101 to
+#      EASYBUILD_AMDGCN_CAPABILITIES=gfx1101 (confirmed via `eb --show-config`
+#      -> amdgcn-capabilities = gfx1101). So the arch is driven entirely by
+#      the accel install path, NOT by anything hardcoded here.
+#    * The base (CPU) easyconfig parses + resolves the full foss-2025a
+#      dependency graph via `eb <ec> -D`.
+#
+#  GPU ARCH IS SPECIFIED AT THE RIGHT LEVEL:
+#    * Declared via the framework param `amdgcn_capabilities` (AMD analog of
+#      `cuda_compute_capabilities`), NOT a literal in configopts.
+#    * Fed into PETSc configure via the framework TEMPLATE
+#      `%(amdgcn_cc_space_sep)s` — required because the EB_PETSc easyblock has
+#      ZERO GPU handling, so arch must reach raw configopts, but via the
+#      template so an EESSI/CLI override (--amdgcn-capabilities) propagates.
+#    * Arch is deliberately NOT in the versionsuffix (just `-HIP`): it lives in
+#      the EESSI accel path (/accel/amd/gfxNNN), mirroring how EESSI keeps
+#      cc/gfx out of the module version for NVIDIA too.
+#
+#  ROCm DEPENDENCIES — reconciled against what EESSI 2025.06 actually ships
+#  (host is ROCm 6.3.1 but EESSI provides ROCm 6.4.1):
+#      HIP-6.4.1-rocm-compilers-19.0.0-ROCm-6.4.1
+#      hipBLAS-2.4.0-rocm-compilers-19.0.0-ROCm-6.4.1
+#      hipSPARSE-3.2.0-rocm-compilers-19.0.0-ROCm-6.4.1
+#  NOTE: these three have easyconfigs in the index but are NOT prebuilt as
+#  modules in EESSI 2025.06 — a from-source build (eb --robot) compiles the
+#  ROCm stack, which is heavy. See README for the build plan.
+
+easyblock = 'EB_PETSc'
+
+name = 'PETSc'
+version = '3.23.5'
+# Arch (gfxNNN) intentionally NOT in the versionsuffix — it lives in the EESSI
+# accel install path (/accel/amd/gfxNNN). This suffix only marks the HIP variant.
+versionsuffix = '-HIP'
+
+homepage = 'https://www.mcs.anl.gov/petsc'
+description = """PETSc, pronounced PET-see (the S is silent), is a suite of data structures and routines for the
+ scalable (parallel) solution of scientific applications modeled by partial differential equations.
+
+This variant enables the AMD-GPU (HIP) backend with hipBLAS and hipSPARSE, so GPU-accelerated
+Krylov solvers/preconditioners are available (e.g. to the petsc4Foam / OpenFOAM external-solver
+adapter). The target GPU architecture is taken from the amdgcn_capabilities parameter (default
+gfx1101, AMD Radeon Pro V710), overridable via --amdgcn-capabilities."""
+
+toolchain = {'name': 'foss', 'version': '2025a'}
+toolchainopts = {'openmp': True, 'usempi': True, 'pic': True}
+
+source_urls = [
+    'https://web.cels.anl.gov/projects/petsc/download/release-snapshots',
+]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['b0bb614dfbf36c286c8cad30912fe77359dccbf6b65a5edd1dde82af293f21fc']
+
+builddependencies = [('CMake', '3.31.3')]
+
+# --- GPU architecture (first-class framework param; NOT hardcoded) -------------
+# Default target is gfx1101 (V710). EESSI overrides per accel path via
+# --amdgcn-capabilities (EASYBUILD_AMDGCN_CAPABILITIES); the value flows into
+# configopts through the %(amdgcn_cc_space_sep)s template below.
+amdgcn_capabilities = ['gfx1101']
+
+dependencies = [
+    ('Python', '3.13.1'),
+    ('SciPy-bundle', '2025.06'),
+    ('Boost', '1.88.0'),
+    ('METIS', '5.1.0'),
+    ('SCOTCH', '7.0.8'),
+    ('MUMPS', '5.8.1', '-metis'),
+    ('SuiteSparse', '7.10.3'),
+    ('Hypre', '2.33.0'),
+    ('ParMETIS', '4.0.3'),
+    ('SuperLU_DIST', '9.1.0'),
+    ('mpi4py', '4.1.0'),
+    # --- AMD-GPU (HIP) stack, as shipped by EESSI 2025.06 ---
+    # These are built with the rocm-compilers/19.0.0 toolchain (NOT foss), so the
+    # dep toolchain MUST be given explicitly (4-element form), otherwise EasyBuild
+    # applies PETSc's foss-2025a toolchain and looks for a non-existent module.
+    # Resulting module names: HIP/6.4.1-rocm-compilers-19.0.0-ROCm-6.4.1, etc.
+    ('HIP', '6.4.1', '-ROCm-6.4.1', ('rocm-compilers', '19.0.0')),
+    ('hipBLAS', '2.4.0', '-ROCm-6.4.1', ('rocm-compilers', '19.0.0')),
+    ('hipSPARSE', '3.2.0', '-ROCm-6.4.1', ('rocm-compilers', '19.0.0')),
+    # PETSc's hip.py liblist requires libhipsolver (grouped with rocrand) whenever
+    # the HIP backend is on; without it configure fails at 'ld: cannot find -lhipsolver'.
+    ('hipSOLVER', '2.4.0', '-ROCm-6.4.1', ('rocm-compilers', '19.0.0')),
+    # rocRAND is grouped WITH hipsolver in PETSc's liblist; it must be a direct dep so
+    # its lib dir is on LIBRARY_PATH, else configure fails at 'ld: cannot find -lrocrand'.
+    ('rocRAND', '3.3.0', '-ROCm-6.4.1', ('rocm-compilers', '19.0.0')),
+    # rocm-core provides <rocm-core/rocm_version.h>, which PETSc's hip.py version
+    # conftest #includes to emit PETSC_PKG_HIP_VERSION_* macros. Without it on CPATH,
+    # version detection silently fails and petscdevice_hip.h errors on an undefined
+    # PETSC_PKG_HIP_VERSION_GE, falling through to a non-existent bare <hipblas.h>.
+    # NOTE: built with the GCCcore-14.2.0 subtoolchain (NOT rocm-compilers), so the
+    # 3-element form resolves rocm-core/6.4.1-GCCcore-14.2.0-ROCm-6.4.1.
+    ('rocm-core', '6.4.1', '-ROCm-6.4.1'),
+    # rocThrust provides <thrust/complex.h>, hard-required by petscsystypes.h when the
+    # HIP device backend is on (compiling src/sys/memory/hip/mhiphost for gfx1101).
+    # EESSI 2025.06 ships no rocThrust module, so we build it (header-only, deps rocPRIM).
+    ('rocThrust', '3.3.0', '-ROCm-6.4.1', ('rocm-compilers', '19.0.0')),
+]
+
+# Base (CPU) configure knobs from upstream PETSc-3.23.5-foss-2025a.eb ...
+configopts = '--LIBS="$LIBS -lrt" --with-mpi4py=0 '
+# ... plus the AMD-GPU (HIP) delta. --with-hip-arch is fed the framework template
+# so the EESSI/CLI amdgcn override propagates (expands to "gfx1101" here). PETSc
+# locates hipcc/ROCm from the loaded HIP module (ROCM_PATH/PATH), not /opt/rocm.
+configopts += '--with-hip=1 --with-hip-arch=%(amdgcn_cc_space_sep)s '
+configopts += '--with-hipblas=1 --with-hipsparse=1 '
+
+# Match the proven -O3, no-debugging production settings from the manual build.
+buildopts = 'COPTFLAGS="-O3" CXXOPTFLAGS="-O3" HIPOPTFLAGS="-O3"'
+
+shared_libs = 1
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/p/petsc4Foam/petsc4Foam-v2506-foss-2025a-HIP.eb
+++ b/easybuild/easyconfigs/p/petsc4Foam/petsc4Foam-v2506-foss-2025a-HIP.eb
@@ -1,0 +1,124 @@
+# EasyBuild easyconfig: petsc4Foam — OpenFOAM external-solver (PETSc) adapter, HIP
+#
+# =========================================================================
+#  STATUS: DESIGN ARTIFACT — NOT YET BUILT WITH EASYBUILD.
+#  Grounded in the WORKING manual build verified on phi-v710 (AMD Radeon
+#  Pro V710, gfx1101, host ROCm 6.3.1-48). Source tree on the VM:
+#      ~/external-solver-esi/            (ESI external-solver module)
+#      ~/external-solver-esi/src/petsc4Foam/Make/{files,options}
+#  The adapter builds one library, libpetscFoam.so, via OpenFOAM's wmake
+#  (Allwmake -> wmake libso). This .eb re-expresses that through a Bundle.
+#  It has NOT been run through EasyBuild — validate per README.
+# =========================================================================
+#
+#  VERIFIED FACTS (do NOT regress to hallucinated variants):
+#    * Library target is libpetscFoam  (Make/files: LIB = $(FOAM_MODULE_LIBBIN)/libpetscFoam)
+#      -> the built artifact is libpetscFoam.so   (NOT "libpetsc4foam.so")
+#    * PETSc version is 3.23.5           (NOT 3.24.0)
+#    * Built with plain wmake libso via Allwmake   (there is NO "ConfigOpts"
+#      easyblock and NO "wmake" module — those were hallucinations)
+#    * petsc4Foam is the ESI "external-solver (petsc)" module, GPL-3.0-or-later,
+#      requires OpenFOAM-v1912+ and PETSc 3.10+, and REQUIRES PETSC_ARCH_PATH set.
+#    * Upstream: https://develop.openfoam.com/modules/external-solver
+#      Versioned by the OpenFOAM release it targets (here: v2506), NOT an
+#      independent git tag.
+#
+#  ASSUMPTIONS & VALIDATION REQUIRED:
+#    1. Toolchain foss-2025a to match OpenFOAM-v2506-foss-2025a (the only
+#       upstream OpenFOAM-v2506 easyconfig) AND PETSc-3.23.5-foss-2025a-HIP.
+#       All three MUST share the toolchain (OpenFOAM's wmake links the adapter
+#       against both OpenFOAM libs and libpetsc).
+#    2. GPU ARCH is inherited, NOT declared here. The adapter compiles no GPU
+#       code itself (it only links -lpetsc), so it carries no amdgcn_capabilities
+#       and no gfxNNN in its versionsuffix. The GPU target comes entirely from
+#       the PETSc-HIP dependency + the EESSI accel install path (/accel/amd/gfxNNN).
+#    3. PETSC_ARCH_PATH: the adapter's Make/options pulls PETSc via
+#       PETSC_INC_DIR / PETSC_LIB_DIR derived from $PETSC_ARCH_PATH. The
+#       PETSc-HIP module must export it (or we set it here to $EBROOTPETSC).
+#    4. Source snapshot: pin the exact v2506 tarball/commit + checksum before
+#       contributing (placeholder below).
+
+easyblock = 'Bundle'
+
+name = 'petsc4Foam'
+version = 'v2506'
+# No gfxNNN here: arch differentiation lives in the accel path + the PETSc-HIP dep.
+versionsuffix = '-HIP'
+
+homepage = 'https://develop.openfoam.com/modules/external-solver'
+description = """petsc4Foam is the OpenFOAM 'external-solver' module (ESI), providing a
+PETSc linear-solver adapter (libpetscFoam) that lets OpenFOAM offload its linear systems
+to PETSc — here to a PETSc built with the AMD-GPU HIP backend (hipBLAS/hipSPARSE), by
+default for AMD Radeon Pro V710 (gfx1101). Built via OpenFOAM's wmake against
+OpenFOAM-v2506 and a GPU-enabled PETSc 3.23.5. Grounded in a working manual build
+verified on host ROCm 6.3.1."""
+
+toolchain = {'name': 'foss', 'version': '2025a'}
+
+dependencies = [
+    ('OpenFOAM', 'v2506'),                  # upstream: OpenFOAM-v2506-foss-2025a
+    ('PETSc', '3.23.5', '-HIP'),            # this repo's PETSc-HIP easyconfig
+]
+
+# The adapter ships inside the ESI external-solver module, versioned to the OpenFOAM
+# release. Pin the real snapshot + checksum before contributing.
+#
+# --- Build: OpenFOAM wmake (mirrors ~/external-solver-esi/Allwmake) -------------
+# We drive the build as a Bundle with a single component using the external-solver
+# source. Because OpenFOAM builds via wmake (not configure/make/cmake), the actual
+# compile is the Allwmake script, which honours FOAM_MODULE_LIBBIN.
+#
+# Required environment at build time (set by the OpenFOAM + PETSc-HIP modules,
+# asserted here for clarity):
+#   - OpenFOAM bashrc sourced (WM_PROJECT_DIR, wmake on PATH, WM_MPLIB=SYSTEMOPENMPI)
+#   - PETSC_ARCH_PATH  -> the PETSc-HIP install (EBROOTPETSC). Make/options reads
+#                         PETSC_INC_DIR / PETSC_LIB_DIR from it and links -lpetsc.
+#   - FOAM_MODULE_LIBBIN -> point at %(installdir)s/lib so libpetscFoam.so lands
+#                           in the module (default falls back to FOAM_USER_LIBBIN).
+
+# Upstream external-solver has NO 'v2506' tag (latest real tag is v2412; default
+# branch 'main' is byte-for-byte identical to v2412 in content). The adapter is
+# OpenFOAM-version-agnostic: it compiles against whatever OpenFOAM headers are
+# loaded ($LIB_SRC) and links -lpetsc, so v2412 sources build correctly against
+# the OpenFOAM/v2506 dependency. We keep the module identity at v2506 (aligned to
+# the targeted OpenFOAM release) but source the real, checksummed v2412 snapshot.
+local_es_source_ver = 'v2412'
+
+components = [
+    (name, version, {
+        'easyblock': 'MakeCp',
+        'source_urls': ['https://develop.openfoam.com/modules/external-solver/-/archive/%s/' % local_es_source_ver],
+        'sources': ['external-solver-%s.tar.gz' % local_es_source_ver],
+        'checksums': ['db6a161c68a2a0d3095c67bc82a9f3c84bd55dd72dcd2c57f6b847098b880ff6'],
+        'start_dir': 'external-solver-%s' % local_es_source_ver,
+        # Export PETSC_ARCH_PATH (ASSUMPTION 2) and target the module libdir,
+        # then run the upstream Allwmake. wmake libso produces libpetscFoam.so.
+        'prebuildopts': (
+            # Allwmake requires the full OpenFOAM shell environment (WM_PROJECT_DIR,
+            # wmake, $LIB_SRC, ...). The OpenFOAM module exports $FOAM_BASH (path to
+            # OpenFOAM/etc/bashrc); source it to populate that environment.
+            'source $FOAM_BASH && '
+            'export PETSC_ARCH_PATH=$EBROOTPETSC && '
+            'export FOAM_MODULE_LIBBIN=%(installdir)s/lib && '
+            'mkdir -p %(installdir)s/lib && '
+        ),
+        'build_cmd': './Allwmake',
+        'buildopts': '-j %(parallel)s',
+        # Allwmake already installs into FOAM_MODULE_LIBBIN; nothing extra to copy.
+        'files_to_copy': [],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['lib/libpetscFoam.so'],
+    'dirs': [],
+}
+
+# petsc4Foam is loaded by OpenFOAM at runtime via libs ("libpetscFoam.so"); make
+# the module's lib dir discoverable.
+modextrapaths = {
+    'LD_LIBRARY_PATH': ['lib'],
+    'FOAM_MODULE_LIBBIN': ['lib'],
+}
+
+moduleclass = 'cae'


### PR DESCRIPTION
## What

Adds the double-precision (HIP / AMD GPU) OpenFOAM external-solver chain for the `foss/2025a` toolchain:

- `PETSc-3.23.5-foss-2025a-HIP.eb` — PETSc built with `--with-hip` (AMD GPU offload), double precision.
- `petsc4Foam-v2506-foss-2025a-HIP.eb` — the `petsc4Foam` v2506 external-solver adapter (Bundle) that links OpenFOAM v2506 to PETSc, so OpenFOAM's linear solvers can be offloaded to the GPU.

`petsc4Foam` depends on the PETSc above and on the already-merged `OpenFOAM-v2506-foss-2025a`.

## Target

AMD gfx1101 (Radeon), ROCm base deps resolved from the EESSI index.

## Status

**Draft** — build/test reports still pending. Opening for early feedback on the packaging approach (PETSc-HIP + petsc4Foam Bundle) before attaching build logs.
