### PR TITLE
Precompiled binary for Github Copilot CLI

### DIFF
--- a/easybuild/easyconfigs/c/copilot-cli/copilot-cli-1.0.79.eb
+++ b/easybuild/easyconfigs/c/copilot-cli/copilot-cli-1.0.79.eb
@@ -1,0 +1,40 @@
+# Author: Ehsan Moravveji (VSC - KU Leuven)
+
+from easybuild.tools.systemtools import get_cpu_architecture as local_get_arch
+
+easyblock = 'Tarball'
+
+name = 'copilot-cli'
+version = '1.0.79'
+
+homepage = 'https://github.com/github/copilot-cli'
+description = '''
+GitHub Copilot CLI brings AI-powered coding assistance directly
+to your command line, enabling you to build, debug, and understand
+code through natural language conversations.
+'''
+
+toolchain = SYSTEM
+
+# Upstream release assets use x64/arm64 rather than EasyBuild's
+# x86_64/aarch64 architecture names
+local_arch = {
+    'x86_64': 'x64',
+    'aarch64': 'arm64',
+}[local_get_arch()]
+local_source_suffix = f'-linux-{local_arch}'
+
+source_urls = ['https://github.com/github/%(name)s/releases/download']
+sources = [f'v%(version)s/copilot{local_source_suffix}.tar.gz']
+checksums = ['9248d81ead3055c51e90067ae7adf0cfb84b2f8b456d8580f18705ae181ca624']
+
+sanity_check_paths = {
+    'files': ['copilot'],
+    'dirs': []
+}
+
+sanity_check_commands = ['copilot --version']
+
+modextrapaths = {'PATH': '.'}
+
+moduleclass = 'ai'

--- a/easybuild/easyconfigs/c/copilot-cli/copilot-cli-1.0.79.eb
+++ b/easybuild/easyconfigs/c/copilot-cli/copilot-cli-1.0.79.eb
@@ -26,7 +26,10 @@ local_source_suffix = f'-linux-{local_arch}'
 
 source_urls = ['https://github.com/github/%(name)s/releases/download']
 sources = [f'v%(version)s/copilot{local_source_suffix}.tar.gz']
-checksums = ['9248d81ead3055c51e90067ae7adf0cfb84b2f8b456d8580f18705ae181ca624']
+checksums = {
+    'v1.0.79-linux-x64.tar.gz': '9248d81ead3055c51e90067ae7adf0cfb84b2f8b456d8580f18705ae181ca624',
+    'v1.0.79-linux-arm64.tar.gz': 'c2181e3a597c7c9593b2a6d5d4e2e58b4e6a5ded12def8b74510869d3a3a977b',
+}
 
 sanity_check_paths = {
     'files': ['copilot'],

--- a/easybuild/easyconfigs/c/copilot-cli/copilot-cli-1.0.79.eb
+++ b/easybuild/easyconfigs/c/copilot-cli/copilot-cli-1.0.79.eb
@@ -26,10 +26,10 @@ local_source_suffix = f'-linux-{local_arch}'
 
 source_urls = ['https://github.com/github/%(name)s/releases/download']
 sources = [f'v%(version)s/copilot{local_source_suffix}.tar.gz']
-checksums = {
+checksums = [{
     'v1.0.79-linux-x64.tar.gz': '9248d81ead3055c51e90067ae7adf0cfb84b2f8b456d8580f18705ae181ca624',
     'v1.0.79-linux-arm64.tar.gz': 'c2181e3a597c7c9593b2a6d5d4e2e58b4e6a5ded12def8b74510869d3a3a977b',
-}
+},]
 
 sanity_check_paths = {
     'files': ['copilot'],

--- a/easybuild/easyconfigs/c/copilot-cli/copilot-cli-1.0.79.eb
+++ b/easybuild/easyconfigs/c/copilot-cli/copilot-cli-1.0.79.eb
@@ -1,7 +1,5 @@
 # Author: Ehsan Moravveji (VSC - KU Leuven)
 
-from easybuild.tools.systemtools import get_cpu_architecture as local_get_arch
-
 easyblock = 'Tarball'
 
 name = 'copilot-cli'
@@ -21,14 +19,12 @@ toolchain = SYSTEM
 local_arch = {
     'x86_64': 'x64',
     'aarch64': 'arm64',
-}[local_get_arch()]
-local_source_suffix = f'-linux-{local_arch}'
-
+}[ARCH]
 source_urls = ['https://github.com/github/%(name)s/releases/download']
-sources = [f'v%(version)s/copilot{local_source_suffix}.tar.gz']
+sources = [f'v%(version)s/copilot-linux-{local_arch}.tar.gz']
 checksums = [{
-    'v1.0.79-linux-x64.tar.gz': '9248d81ead3055c51e90067ae7adf0cfb84b2f8b456d8580f18705ae181ca624',
-    'v1.0.79-linux-arm64.tar.gz': 'c2181e3a597c7c9593b2a6d5d4e2e58b4e6a5ded12def8b74510869d3a3a977b',
+    'copilot-linux-x64.tar.gz': '9248d81ead3055c51e90067ae7adf0cfb84b2f8b456d8580f18705ae181ca624',
+    'copilot-linux-arm64.tar.gz': 'c2181e3a597c7c9593b2a6d5d4e2e58b4e6a5ded12def8b74510869d3a3a977b',
 },]
 
 sanity_check_paths = {


### PR DESCRIPTION
Instead of installing the `copilot-cli` using `npm` (which would tie this to a specific toolchain), I am opting for a toolchain-agnostic version for Linux x64 architecture, so that we can use this copilot CLI (in our OnDemand environment) with modules from different toolchains (well, to be tested soon).

For some minor fixes, I have used AI assistance with the 'GPT 5.4-mini' model.