### PR TITLE
add patch to deal with flaky test in LWP-Protocol-https extension in Perl-bundle-CPAN 5.42.0

### DIFF
--- a/easybuild/easyconfigs/p/Perl-bundle-CPAN/LWP-Protocol-https-6.15_fix-test-httpbin.patch
+++ b/easybuild/easyconfigs/p/Perl-bundle-CPAN/LWP-Protocol-https-6.15_fix-test-httpbin.patch
@@ -1,0 +1,44 @@
+Move live httpbin.org test to xt/ so outages can't fail installs
+
+see https://github.com/libwww-perl/LWP-Protocol-https/pull/100
+--- a/cpanfile
++++ b/cpanfile
+@@ -24,12 +24,12 @@ on 'test' => sub {
+     requires "Socket" => "0";
+     requires "Test::More" => "0.96";
+     requires "Test::Needs" => "0.002010";
+-    requires "Test::RequiresInternet" => "0";
+     requires "warnings" => "0";
+ };
+ 
+ on 'develop' => sub {
+     requires 'Capture::Tiny' => '0.48';
++    requires "Test::RequiresInternet" => "0";
+     requires 'Test::CheckManifest' => '1.29';
+     requires 'Test::CleanNamespaces';
+     requires "Test::CPAN::Changes" => "0.19";
+--- a/t/example.t
++++ b/xt/author/example.t
+@@ -8,10 +8,20 @@ use LWP::UserAgent ();
+ 
+ my $ua = LWP::UserAgent->new( ssl_opts => { verify_hostname => 0 } );
+ 
+-plan tests => 2;
+-
+ my $url = 'https://httpbin.org';
+ 
++# httpbin.org is a shared public service that intermittently returns 5xx or
++# times out. Test::RequiresInternet only proves the TCP port is reachable, so
++# an up-but-unhealthy service would otherwise fail this test even though there
++# is nothing wrong with the module. Probe once and skip if it is unhealthy.
++{
++    my $probe = $ua->simple_request( HTTP::Request->new( GET => $url ) );
++    plan skip_all => "$url unavailable: " . $probe->status_line
++        unless $probe->is_success;
++}
++
++plan tests => 2;
++
+ subtest "Request GET $url" => sub {
+     plan tests => 6;
+ 

--- a/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.42.0-GCCcore-15.2.0.eb
+++ b/easybuild/easyconfigs/p/Perl-bundle-CPAN/Perl-bundle-CPAN-5.42.0-GCCcore-15.2.0.eb
@@ -1923,7 +1923,12 @@ exts_list = [
     ('LWP::Protocol::https', '6.15', {
         'source_urls': ['https://cpan.metacpan.org/authors/id/O/OA/OALDERS'],
         'sources': ['LWP-Protocol-https-%(version)s.tar.gz'],
-        'checksums': ['44eec2da147ba0511090871b0ca82f69794376bc31e8c76d1040961ba57f59b8'],
+        'patches': ['LWP-Protocol-https-6.15_fix-test-httpbin.patch'],
+        'checksums': [
+            {'LWP-Protocol-https-6.15.tar.gz': '44eec2da147ba0511090871b0ca82f69794376bc31e8c76d1040961ba57f59b8'},
+            {'LWP-Protocol-https-6.15_fix-test-httpbin.patch':
+             '9daa98f29564969e794b3156ee6df131e8fc4708a7f810695de29cf296c59963'},
+        ],
     }),
     ('Module::Load', '0.36', {
         'source_tmpl': 'Module-Load-%(version)s.tar.gz',


### PR DESCRIPTION
fix for failing test for `` extension:
```
   #   Failed test 'success status'
    #   at t/example.t line 19.

    #   Failed test 'found expected document content'
    #   at t/example.t line 46.
    #                   '<html>^M
    # <head><title>503 Service Temporarily Unavailable</title></head>^M
    # <body>^M
    # <center><h1>503 Service Temporarily Unavailable</h1></center>^M
    # </body>^M
    # </html>^M
    # '
    #     doesn't match '(?^:httpbin\.org)'
    # Looks like you failed 2 tests of 6.

#   Failed test 'Request GET https://httpbin.org'
#   at t/example.t line 47.

    #   Failed test 'success status'
    #   at t/example.t line 54.
    # Looks like you failed 1 test of 2.

#   Failed test 'Check for warnings from GET https://httpbin.org (RT #81948)'
#   at t/example.t line 57.
# Looks like you failed 2 tests of 2.
t/example.t ............
Dubious, test returned 2 (wstat 512, 0x200)
Failed 2/2 subtests
```