### PR TITLE
add Arm64 non-SVE DDOT kernel patch to OpenBLAS 0.3.32

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.32-GCC-15.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.32-GCC-15.2.0.eb
@@ -17,6 +17,7 @@ patches = [
     ('timing.tgz', '.'),
     'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch',
     'OpenBLAS-0.3.21_fix-order-vectorization.patch',
+    'OpenBLAS-0.3.32_fix-non-sve-ddot-kernel-aarch64.patch',
 ]
 checksums = [
     {'v0.3.32.tar.gz': 'f8a1138e01fddca9e4c29f9684fd570ba39dedc9ca76055e1425d5d4b1a4a766'},
@@ -26,6 +27,8 @@ checksums = [
      'e6b326fb8c4a8a6fd07741d9983c37a72c55c9ff9a4f74a80e1352ce5f975971'},
     {'OpenBLAS-0.3.21_fix-order-vectorization.patch':
      '08af834e5d60441fd35c128758ed9c092ba6887c829e0471ecd489079539047d'},
+    {'OpenBLAS-0.3.32_fix-non-sve-ddot-kernel-aarch64.patch':
+     '19ca0ed7bc87f87cfca8418b1acf0ee9bbc3646b6bbac98d5d8ea2c07f981d2f'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.32-llvm-compilers-21.1.8.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.32-llvm-compilers-21.1.8.eb
@@ -17,6 +17,7 @@ patches = [
     ('timing.tgz', '.'),
     'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch',
     'OpenBLAS-0.3.21_fix-order-vectorization.patch',
+    'OpenBLAS-0.3.32_fix-non-sve-ddot-kernel-aarch64.patch',
 ]
 checksums = [
     {'v0.3.32.tar.gz': 'f8a1138e01fddca9e4c29f9684fd570ba39dedc9ca76055e1425d5d4b1a4a766'},
@@ -26,6 +27,8 @@ checksums = [
      'e6b326fb8c4a8a6fd07741d9983c37a72c55c9ff9a4f74a80e1352ce5f975971'},
     {'OpenBLAS-0.3.21_fix-order-vectorization.patch':
      '08af834e5d60441fd35c128758ed9c092ba6887c829e0471ecd489079539047d'},
+    {'OpenBLAS-0.3.32_fix-non-sve-ddot-kernel-aarch64.patch':
+     '19ca0ed7bc87f87cfca8418b1acf0ee9bbc3646b6bbac98d5d8ea2c07f981d2f'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.32_fix-non-sve-ddot-kernel-aarch64.patch
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.32_fix-non-sve-ddot-kernel-aarch64.patch
@@ -1,0 +1,26 @@
+From e3ce4623c299068bbd47c35ee87aab334bac73b1 Mon Sep 17 00:00:00 2001
+From: Martin Kroeker <martin@ruby.chemie.uni-freiburg.de>
+Date: Tue, 24 Mar 2026 23:08:02 +0100
+Subject: [PATCH] Use volatile attribute for SDOT only, to avoid creating new
+ miscompilations
+
+---
+ kernel/arm64/dot_kernel_asimd.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/kernel/arm64/dot_kernel_asimd.c b/kernel/arm64/dot_kernel_asimd.c
+index 27f557c705..a1ae01f2d8 100644
+--- a/kernel/arm64/dot_kernel_asimd.c
++++ b/kernel/arm64/dot_kernel_asimd.c
+@@ -262,7 +262,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ static RETURN_TYPE dot_kernel_asimd(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y)
+ {
+-	volatile RETURN_TYPE  dot = 0.0;
++#ifndef DOUBLE
++    volatile
++#endif
++    RETURN_TYPE  dot = 0.0;
+ 	BLASLONG j = 0;
+ 
+ 	__asm__ __volatile__ (


### PR DESCRIPTION
We noticed that (some) Arm64 builds of OpenBLAS 0.3.32 are failing in https://github.com/EESSI/software-layer/pull/1561. This had already been reported in https://github.com/OpenMathLib/OpenBLAS/issues/5708 and fixed in https://github.com/OpenMathLib/OpenBLAS/pull/5710.

Tried this interactively, and it solved the issue. I'll also fire off some more test builds with the EESSI bot using the commit from this PR.