### PR TITLE
Add PostgreSQL as an EB dependency to GDAL 

### DIFF
--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.10.0-foss-2024a.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.10.0-foss-2024a.eb
@@ -57,6 +57,7 @@ dependencies = [
     ('OpenJPEG', '2.5.2'),
     ('SWIG', '4.2.1'),
     ('netCDF', '4.9.2'),
+    ('PostgreSQL', '16.4'),  # to avoid relying on system libs
 ]
 
 # iterative build for both static and shared libraries

--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.11.1-foss-2025a.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.11.1-foss-2025a.eb
@@ -57,6 +57,7 @@ dependencies = [
     ('OpenJPEG', '2.5.3'),
     ('SWIG', '4.3.1'),
     ('netCDF', '4.9.3'),
+    ('PostgreSQL', '17.5'),  # to avoid relying on system libs
 ]
 
 # iterative build for both static and shared libraries

--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.11.1-intel-2025a.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.11.1-intel-2025a.eb
@@ -57,6 +57,7 @@ dependencies = [
     ('OpenJPEG', '2.5.3'),
     ('SWIG', '4.3.1'),
     ('netCDF', '4.9.3'),
+    ('PostgreSQL', '17.5'),  # to avoid relying on system libs
 ]
 
 # iterative build for both static and shared libraries

--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.11.3-foss-2025b.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.11.3-foss-2025b.eb
@@ -57,6 +57,7 @@ dependencies = [
     ('OpenJPEG', '2.5.3'),
     ('SWIG', '4.3.1'),
     ('netCDF', '4.9.3'),
+    ('PostgreSQL', '17.5'),  # to avoid relying on system libs
 ]
 
 # iterative build for both static and shared libraries

--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.11.3-intel-2025b.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.11.3-intel-2025b.eb
@@ -57,6 +57,7 @@ dependencies = [
     ('OpenJPEG', '2.5.3'),
     ('SWIG', '4.3.1'),
     ('netCDF', '4.9.3'),
+    ('PostgreSQL', '17.5'),  # to avoid relying on system libs
 ]
 
 # iterative build for both static and shared libraries

--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.13.0-foss-2026.1.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.13.0-foss-2026.1.eb
@@ -58,7 +58,6 @@ dependencies = [
     ('LERC', '4.1.0'),
     ('OpenJPEG', '2.5.4'),
     ('SWIG', '4.4.1'),
-    ('netCDF', '4.10.0'),
     ('PostgreSQL', '18.4'),  # to avoid relying on system libs
 ]
 

--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.13.0-foss-2026.1.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.13.0-foss-2026.1.eb
@@ -58,6 +58,8 @@ dependencies = [
     ('LERC', '4.1.0'),
     ('OpenJPEG', '2.5.4'),
     ('SWIG', '4.4.1'),
+    ('netCDF', '4.10.0'),
+    ('PostgreSQL', '18.4'),  # to avoid relying on system libs
 ]
 
 # Iterative build for both static and shared libraries

--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.5.0-foss-2022a.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.5.0-foss-2022a.eb
@@ -43,6 +43,7 @@ dependencies = [
     ('HDF', '4.2.15'),
     ('OpenJPEG', '2.5.0'),
     ('netCDF', '4.9.0'),
+    ('PostgreSQL', '14.4'),  # to avoid relying on system libs
 ]
 
 preconfigopts = r"sed -e 's/-llapack/\$LIBLAPACK/g' -i.eb configure && "

--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.6.2-foss-2022b.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.6.2-foss-2022b.eb
@@ -56,6 +56,7 @@ dependencies = [
     ('LERC', '4.0.0'),
     ('OpenJPEG', '2.5.0'),
     ('netCDF', '4.9.0'),
+    ('PostgreSQL', '15.2'),  # to avoid relying on system libs
 ]
 
 # common configopts for static, shared library builds

--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.7.1-foss-2023a.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.7.1-foss-2023a.eb
@@ -58,6 +58,7 @@ dependencies = [
     ('OpenJPEG', '2.5.0'),
     ('SWIG', '4.1.1'),
     ('netCDF', '4.9.2'),
+    ('PostgreSQL', '16.1'),  # to avoid relying on system libs
 ]
 
 # iterative build for both static and shared libraries

--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.9.0-foss-2023b.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.9.0-foss-2023b.eb
@@ -57,6 +57,7 @@ dependencies = [
     ('OpenJPEG', '2.5.0'),
     ('SWIG', '4.1.1'),
     ('netCDF', '4.9.2'),
+    ('PostgreSQL', '16.1'),  # to avoid relying on system libs
 ]
 
 # iterative build for both static and shared libraries


### PR DESCRIPTION
Adding `PostgreSQL` as a direct dependency will prevent `GDAL` from linking to an existing system `libpq-devel`.
If linked to a system `PQ`, this can lead to future incompatibilities, for example with `R` package `terra`:

```
* installing *source* package ‘terra’ ...
** this is package ‘terra’ version ‘1.8-80’
** package ‘terra’ successfully unpacked and MD5 sums checked
** using staged installation
configure: CC: gcc
configure: CXX: g++ -std=gnu++17
checking for gdal-config... /home/software/GDAL/3.11.3-foss-2025b/bin/gdal-config
checking gdal-config usability... yes
configure: GDAL: 3.11.3
checking GDAL version >= 2.0.1... yes
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether gcc accepts -g... yes
checking for gcc option to enable C11 features... none needed
checking for stdio.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for strings.h... yes
checking for sys/stat.h... yes
checking for sys/types.h... yes
checking for unistd.h... yes
checking for gdal.h... yes
checking GDAL: linking with --libs only... no
checking GDAL: linking with --libs and --dep-libs... no
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQcmdStatus@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQfname@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQsetNoticeProcessor@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQftable@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQcancel@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQstatus@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQftablecol@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQconnectdb@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQescapeStringConn@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `lo_close@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQputCopyEnd@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQgetvalue@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQgetisnull@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQftype@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQfmod@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `lo_creat@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQresultStatus@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `lo_read@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQexec@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQsetClientEncoding@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQgetlength@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQputCopyData@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQgetResult@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `lo_write@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQfinish@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQclear@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQerrorMessage@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQnfields@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `lo_open@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQexecParams@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQgetCancel@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQntuples@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQresultErrorMessage@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQfreeCancel@RHPG_9.6'
collect2: error: ld returned 1 exit status
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQcmdStatus@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQfname@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQsetNoticeProcessor@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQftable@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQcancel@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQstatus@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQftablecol@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQconnectdb@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQescapeStringConn@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `lo_close@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQputCopyEnd@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQgetvalue@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQgetisnull@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQftype@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQfmod@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `lo_creat@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQresultStatus@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `lo_read@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQexec@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQsetClientEncoding@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQgetlength@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQputCopyData@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQgetResult@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `lo_write@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQfinish@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQclear@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQerrorMessage@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQnfields@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `lo_open@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQexecParams@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQgetCancel@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQntuples@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQresultErrorMessage@RHPG_9.6'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: /home/software/GDAL/3.11.3-foss-2025b/lib/libgdal.so: undefined reference to `PQfreeCancel@RHPG_9.6'
collect2: error: ld returned 1 exit status
configure: Install failure: compilation and/or linkage problems.
configure: error: GDALAllRegister not found in libgdal. 
*** Installing this package from source requires the prior
*** installation of external software, see for details
*** https://rspatial.github.io/terra/
ERROR: configuration failed for package ‘terra’
```