### PR TITLE
disable `opal_lifo` test for RISC-V in OpenMPI 5.0.10 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.10-GCC-15.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.10-GCC-15.2.0.eb
@@ -20,6 +20,15 @@ checksums = [
      '75d4417e35252ea3a19b2792f1b06e9aeb408c253aa4921d77226d57b71dee45'},
 ]
 
+if ARCH == 'riscv64':
+    patches.append(
+        'OpenMPI-5.0.8_disable_opal_lifo_test.patch',
+    )
+    checksums.append(
+        {'OpenMPI-5.0.8_disable_opal_lifo_test.patch':
+         '7acc5056a1566e87e48bfc80671d2d5d54802434e89135cf164afeda229dfb5c'},
+    )
+
 builddependencies = [
     ('pkgconf', '2.5.1'),
     ('Perl', '5.42.0'),

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.10-llvm-compilers-21.1.8.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-5.0.10-llvm-compilers-21.1.8.eb
@@ -20,6 +20,15 @@ checksums = [
      '75d4417e35252ea3a19b2792f1b06e9aeb408c253aa4921d77226d57b71dee45'},
 ]
 
+if ARCH == 'riscv64':
+    patches.append(
+        'OpenMPI-5.0.8_disable_opal_lifo_test.patch',
+    )
+    checksums.append(
+        {'OpenMPI-5.0.8_disable_opal_lifo_test.patch':
+         '7acc5056a1566e87e48bfc80671d2d5d54802434e89135cf164afeda229dfb5c'},
+    )
+
 builddependencies = [
     ('pkgconf', '2.5.1'),
     ('Perl', '5.42.0'),


### PR DESCRIPTION
This was already done in 5.0.8, but the same thing still needs to be done for 5.0.10, see https://github.com/EESSI/software-layer/pull/1563#issuecomment-5263049592.