### PR TITLE
{bio} Gblocks v1.0

### DIFF
--- a/easybuild/easyconfigs/g/Gblocks/Gblocks-1.0.eb
+++ b/easybuild/easyconfigs/g/Gblocks/Gblocks-1.0.eb
@@ -1,0 +1,29 @@
+easyblock = 'Tarball'
+
+name = 'Gblocks'
+version = '1.0'
+
+homepage = 'https://molevol-ibe.csic.es/Gblocks.html'
+description = "Selection of conserved blocks from multiple alignments for their use in phylogenetic analysis"
+
+toolchain = SYSTEM
+
+source_urls = ['https://molevol-ibe.csic.es/Gblocks/']
+sources = [{
+    'filename': 'Gblocks_%(version)s_Linux.tar.gz',
+    'extract_cmd': 'uncompress -c %s | tar zxf -'
+}]
+
+checksums = ['e899015c8c6583fd6c6799539af31d55a108d7d951c992930f8c452cca371c89']
+
+# fix exec permissions on both top-level installdir & 'more_alignments' subdir
+postinstallcmds = ["chmod a+x %(installdir)s %(installdir)s/more_alignments"]
+
+sanity_check_paths = {
+    'files': [name, 'nad3.fasta', 'paths.txt'],
+    'dirs': ['Documentation', 'more_alignments'],
+}
+
+modextrapaths = {'PATH': ''}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/Gblocks/Gblocks-1.0.eb
+++ b/easybuild/easyconfigs/g/Gblocks/Gblocks-1.0.eb
@@ -24,6 +24,8 @@ sanity_check_paths = {
     'dirs': ['Documentation', 'more_alignments'],
 }
 
+sanity_check_commands = ["Gblocks -h"]
+
 modextrapaths = {'PATH': ''}
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/Gblocks/Gblocks-1.0.eb
+++ b/easybuild/easyconfigs/g/Gblocks/Gblocks-1.0.eb
@@ -11,7 +11,7 @@ toolchain = SYSTEM
 source_urls = ['https://molevol-ibe.csic.es/Gblocks/']
 sources = [{
     'filename': 'Gblocks_%(version)s_Linux.tar.gz',
-    'extract_cmd': 'uncompress -c %s | tar zxf -'
+    'extract_cmd': 'gzip -dc %s | tar zxf -'
 }]
 
 checksums = ['e899015c8c6583fd6c6799539af31d55a108d7d951c992930f8c452cca371c89']


### PR DESCRIPTION
Updated the version to 1.0. Also, the download file (`Gblocks_1.0_Linux.tar.gz`) seems to be a .Z file so the `extract_cmd` was modified to make the uncompress just work.