### PR TITLE
{2024a} change version for cuDNN and NCCL dependencies in easyconfig for jax 0.6.2 w/ CUDA 12.6.0, to be compatible with easyconfig for PyTorch 2.7.1

### DIFF
--- a/easybuild/easyconfigs/j/jax/jax-0.6.2-gfbf-2024a-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/j/jax/jax-0.6.2-gfbf-2024a-CUDA-12.6.0.eb
@@ -23,8 +23,8 @@ builddependencies = [
 
 dependencies = [
     ('CUDA', '12.6.0', '', SYSTEM),
-    ('cuDNN', '9.5.0.50', versionsuffix, SYSTEM),
-    ('NCCL', '2.22.3', versionsuffix),
+    ('cuDNN', '9.5.1.17', versionsuffix, SYSTEM),
+    ('NCCL', '2.26.2', versionsuffix),
     ('Python', '3.12.3'),
     ('SciPy-bundle', '2024.05'),
     ('absl-py', '2.1.0'),
@@ -37,6 +37,7 @@ dependencies = [
 # downloading xla  tarball to avoid that Bazel downloads it during the build
 # note: following commits *must* be the exact same onces used upstream
 # XLA_COMMIT from jax-jaxlib: third_party/xla/workspace.bzl
+# also filename in /archives has to be {_xla_commit}.tar.gz
 _xla_commit = '3d5ece64321630dade7ff733ae1353fc3c83d9cc'
 # Use sources downloaded by EasyBuild
 _jaxlib_buildopts = '--bazel_options="--distdir=%(builddir)s/archives" '
@@ -59,15 +60,14 @@ components = [
             },
             {
                 'source_urls': ['https://github.com/openxla/xla/archive'],
-                'download_filename': f'{_xla_commit}.tar.gz',
-                'filename': f'xla-{_xla_commit[:8]}.tar.gz',
+                'filename': f'{_xla_commit}.tar.gz',
                 'extract_cmd': 'mkdir -p %(builddir)s/archives && cp %s %(builddir)s/archives',
             },
         ],
         'checksums': [
             {'jax-v0.6.2.tar.gz':
              'd46cb98795f2c1ccdf2b081e02d9d74b659063679a80beb001ad17d482a60e17'},
-            {'xla-3d5ece64.tar.gz':
+            {'3d5ece64321630dade7ff733ae1353fc3c83d9cc.tar.gz':
              'fbd20cf83bad78f66977fa7ff67a12e52964abae0b107ddd5486a0355643ec8a'},
         ],
         'start_dir': f'jax-jax-v{version}',


### PR DESCRIPTION
Update jax-0.6.2-gfbf-2024a-CUDA-12.6.0 to use the same cuDNN and NCCL versions as PyTorch-2.7.1-foss-2024a-CUDA-12.6.0, allowing both modules to be loaded together, for example as dependencies of the CUDA variant of Single-cell-python-bundle.

Also update the XLA source filename so that the pre-downloaded archive matches the filename expected by Bazel and can be reused via --distdir instead of being downloaded again during the build.