### PR TITLE
{foss/2025b} Add OpenSSL explicitly to R-bundle-CRAN to avoid mixing with system libs

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2025.11-foss-2025b.eb
+++ b/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2025.11-foss-2025b.eb
@@ -32,6 +32,7 @@ dependencies = [
     ('GDAL', '3.11.3'),  # for sf
     ('MPFR', '4.2.2'),  # for Rmpfr
     ('PostgreSQL', '17.5'),  # for RPostgreSQL
+    ('OpenSSL', '3', '', SYSTEM),  # for PKI
 ]
 
 # Some R extensions (mclust, quantreg, waveslim for example) require the math library (-lm) to avoid undefined symbols.


### PR DESCRIPTION
No AI used.

Adding up `OpenSSL` as an explicit dependency to `R-bundle-CRAN`, because otherwise the system one gets linked when compiling extension `PKI` (781 for `foss-2025b`)

```
* installing *source* package 'PKI' ...
** this is package 'PKI' version '0.1-15'
** package 'PKI' successfully unpacked and MD5 sums checked
** using staged installation
checking for pkg-config... yes
checking whether it knows about openssl... yes
configure: CFLAGS:
configure: LIBS: -lssl -lcrypto
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether gcc accepts -g... yes
checking for gcc option to enable C11 features... none needed
checking for stdio.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for strings.h... yes
checking for sys/stat.h... yes
checking for sys/types.h... yes
checking for unistd.h... yes
checking for openssl/ssl.h... yes
checking for openssl/rsa.h... yes
checking for library containing RSA_generate_key_ex... none required
checking for openssl/ssl.h... (cached) yes
checking for library containing SSL_CTX_load_verify_locations... no
configure: error: Cannot find usable SSL library
ERROR: configuration failed for package 'PKI'
```

And a further inspection of the config.log for PKI gives:
```
configure:2302: CFLAGS: 
configure:2304: LIBS: -lssl -lcrypto
```
and
```
conftest.c:(.text.startup+0x5): undefined reference to `SSL_CTX_load_verify_locations'
collect2: error: ld returned 1 exit status
```
and also
```
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: cannot find -lopenssl: No such file or directory
```