### PR TITLE
remove M4 build in easyconfigs CI

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -152,10 +152,6 @@ jobs:
           eb --search '^foss-2023a.eb' | tee eb_search_foss.out
           grep '/foss-2023a.eb$' eb_search_foss.out
 
-          # try installing M4 with system toolchain (requires ConfigureMake easyblock + easyconfig)
-          # use /tmp/sources because that has cached downloads (see cache step above)
-          eb --prefix /tmp/$USER/$GITHUB_SHA --sourcepath /tmp/sources M4-1.4.18.eb
-
   test-sdist:
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -152,6 +152,10 @@ jobs:
           eb --search '^foss-2023a.eb' | tee eb_search_foss.out
           grep '/foss-2023a.eb$' eb_search_foss.out
 
+          # try installing M4 with system toolchain (requires ConfigureMake easyblock + easyconfig)
+          # use /tmp/sources because that has cached downloads (see cache step above)
+          # eb --prefix /tmp/$USER/$GITHUB_SHA --sourcepath /tmp/sources M4-1.4.18.eb
+
   test-sdist:
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
Remove this to reduce the number of times our CI processes try to download config.guess.