### PR TITLE
Add OpenSSL to RStudio-Server ECs to avoid mixing with system libraries

### DIFF
--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2022.07.2+576-foss-2022a-Java-11-R-4.2.1.eb
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2022.07.2+576-foss-2022a-Java-11-R-4.2.1.eb
@@ -50,6 +50,7 @@ dependencies = [
     ('R', '4.2.1'),
     ('SOCI', '4.0.3'),
     ('yaml-cpp', '0.7.0'),
+    ('OpenSSL', '1.1', '', SYSTEM),  # to avoid mixing with system libraries
 ]
 
 osdependencies = [

--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2023.09.1+494-foss-2023a-Java-11-R-4.3.2.eb
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2023.09.1+494-foss-2023a-Java-11-R-4.3.2.eb
@@ -60,6 +60,7 @@ dependencies = [
     ('R-bundle-CRAN', '2023.12'),
     ('SOCI', '4.0.3'),
     ('yaml-cpp', '0.7.0'),
+    ('OpenSSL', '1.1', '', SYSTEM),  # to avoid mixing with system libraries
 ]
 
 osdependencies = [

--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2023.12.1+402-gfbf-2023b-Java-11-R-4.3.3.eb
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2023.12.1+402-gfbf-2023b-Java-11-R-4.3.3.eb
@@ -38,6 +38,7 @@ dependencies = [
     ('R', '4.3.3'),
     ('SOCI', '4.0.3'),
     ('yaml-cpp', '0.8.0'),
+    ('OpenSSL', '1.1', '', SYSTEM),  # to avoid mixing with system libraries
 ]
 
 osdependencies = [

--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2024.09.0+375-foss-2023b-Java-11-R-4.4.1.eb
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2024.09.0+375-foss-2023b-Java-11-R-4.4.1.eb
@@ -47,6 +47,7 @@ dependencies = [
     ('R-bundle-CRAN', '2024.06'),
     ('SOCI', '4.0.3'),
     ('yaml-cpp', '0.8.0'),
+    ('OpenSSL', '1.1', '', SYSTEM),  # to avoid mixing with system libraries
 ]
 
 osdependencies = [

--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2024.12.0+467-foss-2024a-R-4.4.2.eb
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2024.12.0+467-foss-2024a-R-4.4.2.eb
@@ -47,6 +47,7 @@ dependencies = [
     ('R-bundle-CRAN', '2024.11'),
     ('SOCI', '4.0.3'),
     ('yaml-cpp', '0.8.0'),
+    ('OpenSSL', '3', '', SYSTEM),  # to avoid mixing with system libraries
 ]
 
 osdependencies = [

--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2025.09.2+418-foss-2025a-R-4.5.1.eb
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2025.09.2+418-foss-2025a-R-4.5.1.eb
@@ -47,6 +47,7 @@ dependencies = [
     ('R-bundle-CRAN', '2025.10'),
     ('SOCI', '4.1.2'),
     ('yaml-cpp', '0.8.0'),
+    ('OpenSSL', '3', '', SYSTEM),  # to avoid mixing with system libraries
 ]
 
 osdependencies = [

--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2026.01.2+418-foss-2025b-R-4.5.2.eb
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2026.01.2+418-foss-2025b-R-4.5.2.eb
@@ -47,6 +47,7 @@ dependencies = [
     ('R-bundle-CRAN', '2025.11'),
     ('SOCI', '4.1.2'),
     ('yaml-cpp', '0.8.0'),
+    ('OpenSSL', '3', '', SYSTEM),  # to avoid mixing with system libraries
 ]
 
 osdependencies = [

--- a/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2026.06.0+242-foss-2026.1-R-4.6.1.eb
+++ b/easybuild/easyconfigs/r/RStudio-Server/RStudio-Server-2026.06.0+242-foss-2026.1-R-4.6.1.eb
@@ -51,6 +51,7 @@ dependencies = [
     ('R-bundle-CRAN', '2026.07'),
     ('SOCI', '4.1.4'),
     ('yaml-cpp', '0.9.0'),
+    ('OpenSSL', '3', '', SYSTEM),  # to avoid mixing with system libraries
 ]
 
 osdependencies = [


### PR DESCRIPTION
No AI usage.

I just hit the following when trying to build `RStudio-Server-2026.01.2+418-foss-2025b-R-4.5.2.eb`:


```
FAILED: [code=1] src/cpp/session/postback/rpostback 
: && /eb_tmp/eb-nf30khp4/tmpjkr8gohq/rpath_wrappers/gxx_wrapper/g++ -O2 -ftree-vectFAILEDorize -march=native -fno-math-errno -std=c++17 -O3 -DNDEBUG -L/home/software/ScaLAPACK/2.2.2-gompi-2025b-fb/lib64 -L/home/software/ScaLAPACK/2.2.2-gompi-2025b-fb/lib -L/home/software/FFTW.MPI/3.3.10-gompi-2025b/lib64 -L/home/software/FFTW.MPI/3.3.10-gompi-2025b/lib -L/home/software/FFTW/3.3.10-GCC-14.3.0/lib64 -L/home/software/FFTW/3.3.10-GCC-14.3.0/lib -L/home/software/FlexiBLAS/3.4.5-GCC-14.3.0/lib64 -L/home/software/FlexiBLAS/3.4.5-GCC-14.3.0/lib -L/home/software/OpenMPI/5.0.8-GCC-14.3.0/lib64 -L/home/software/OpenMPI/5.0.8-GCC-14.3.0/lib -L/home/software/GCCcore/14.3.0/lib64 -L/home/software/GCCcore/14.3.0/lib -L/home/software/yaml-cpp/0.8.0-GCCcore-14.3.0/lib64 -L/home/software/yaml-cpp/0.8.0-GCCcore-14.3.0/lib -L/home/software/SOCI/4.1.2-GCC-14.3.0/lib64 -L/home/software/SOCI/4.1.2-GCC-14.3.0/lib -L/home/software/R/4.5.2-gfbf-2025b/lib64 -L/home/software/R/4.5.2-gfbf-2025b/lib -L/home/software/Java/21.0.2/lib64 -L/home/software/Java/21.0.2/lib -L/home/software/Boost/1.88.0-GCC-14.3.0/lib64 -L/home/software/Boost/1.88.0-GCC-14.3.0/lib -L/home/software/nodejs/22.17.1-GCCcore-14.3.0/lib64 -L/home/software/nodejs/22.17.1-GCCcore-14.3.0/lib -L/home/software/pkgconf/2.4.3-GCCcore-14.3.0/lib64 -L/home/software/pkgconf/2.4.3-GCCcore-14.3.0/lib -L/home/software/ant/1.10.15-Java-21/lib64 -L/home/software/ant/1.10.15-Java-21/lib -pie -Wl,-z,relro,-z,now -Wl,--dependency-file=src/cpp/session/postback/CMakeFiles/rpostback.dir/link.d src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackOptions.cpp.o -o src/cpp/session/postback/rpostback  src/cpp/core/librstudio-core.a  src/cpp/server_core/librstudio-server-core.a  src/cpp/core/librstudio-core.a  src/cpp/shared_core/librstudio-shared-core.a  src/cpp/ext/librstudio-hunspell.a  /home/software/Boost/1.88.0-GCC-14.3.0/lib/libboost_chrono-mt-x64.so.1.88.0  /home/software/Boost/1.88.0-GCC-14.3.0/lib/libboost_date_time-mt-x64.so.1.88.0  /home/software/Boost/1.88.0-GCC-14.3.0/lib/libboost_filesystem-mt-x64.so.1.88.0  /home/software/Boost/1.88.0-GCC-14.3.0/lib/libboost_atomic-mt-x64.so.1.88.0  /home/software/Boost/1.88.0-GCC-14.3.0/lib/libboost_iostreams-mt-x64.so.1.88.0  /home/software/Boost/1.88.0-GCC-14.3.0/lib/libboost_program_options-mt-x64.so.1.88.0  /home/software/Boost/1.88.0-GCC-14.3.0/lib/libboost_random-mt-x64.so.1.88.0  /home/software/Boost/1.88.0-GCC-14.3.0/lib/libboost_regex-mt-x64.so.1.88.0  /home/software/Boost/1.88.0-GCC-14.3.0/lib/libboost_thread-mt-x64.so.1.88.0  /home/software/Boost/1.88.0-GCC-14.3.0/lib/libboost_url-mt-x64.so.1.88.0  /home/software/Boost/1.88.0-GCC-14.3.0/lib/libboost_system-mt-x64.so.1.88.0  /home/software/SOCI/4.1.2-GCC-14.3.0/lib/libsoci_sqlite3.so  -lsqlite3  /home/software/SOCI/4.1.2-GCC-14.3.0/lib/libsoci_core.so  /usr/lib64/libdl.a  /usr/lib64/libutil.a  /home/software/util-linux/2.41-GCCcore-14.3.0/lib/libuuid.so  /usr/lib64/librt.a  /home/software/zlib/1.3.1-GCCcore-14.3.0/lib/libz.so  /home/software/NSS/3.114-GCCcore-14.3.0/lib/libssl.a  /home/software/OpenSSL/3/lib/libcrypto.so  /usr/lib64/libpam.so  /usr/lib64/libdl.a  /usr/lib64/libutil.a  /home/software/util-linux/2.41-GCCcore-14.3.0/lib/libuuid.so  /usr/lib64/librt.a  /home/software/zlib/1.3.1-GCCcore-14.3.0/lib/libz.so  /home/software/NSS/3.114-GCCcore-14.3.0/lib/libssl.a  /home/software/OpenSSL/3/lib/libcrypto.so  /usr/lib64/libpam.so  /usr/lib64/libpthread.a  _deps/fmt-build/libfmt.a  /home/software/yaml-cpp/0.8.0-GCCcore-14.3.0/lib/libyaml-cpp.a && :
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o: in function `boost::asio::ssl::detail::engine::do_read(void*, unsigned long)':
PostbackMain.cpp:(.text._ZN5boost4asio3ssl6detail6engine7do_readEPvm[_ZN5boost4asio3ssl6detail6engine7do_readEPvm]+0x10): undefined reference to `SSL_read'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o: in function `boost::asio::ssl::detail::engine::do_write(void*, unsigned long)':
PostbackMain.cpp:(.text._ZN5boost4asio3ssl6detail6engine8do_writeEPvm[_ZN5boost4asio3ssl6detail6engine8do_writeEPvm]+0x10): undefined reference to `SSL_write'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o: in function `boost::asio::ssl::detail::engine::do_accept(void*, unsigned long)':
PostbackMain.cpp:(.text._ZN5boost4asio3ssl6detail6engine9do_acceptEPvm[_ZN5boost4asio3ssl6detail6engine9do_acceptEPvm]+0x4): undefined reference to `SSL_accept'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o: in function `boost::asio::ssl::detail::engine::do_connect(void*, unsigned long)':
PostbackMain.cpp:(.text._ZN5boost4asio3ssl6detail6engine10do_connectEPvm[_ZN5boost4asio3ssl6detail6engine10do_connectEPvm]+0x4): undefined reference to `SSL_connect'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o: in function `boost::asio::ssl::detail::engine::verify_callback_function(int, x509_store_ctx_st*)':
PostbackMain.cpp:(.text._ZN5boost4asio3ssl6detail6engine24verify_callback_functionEiP17x509_store_ctx_st[_ZN5boost4asio3ssl6detail6engine24verify_callback_functionEiP17x509_store_ctx_st]+0x27): undefined reference to `SSL_get_ex_data_X509_STORE_CTX_idx'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN5boost4asio3ssl6detail6engine24verify_callback_functionEiP17x509_store_ctx_st[_ZN5boost4asio3ssl6detail6engine24verify_callback_functionEiP17x509_store_ctx_st]+0x43): undefined reference to `SSL_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN5boost4asio3ssl6detail6engine24verify_callback_functionEiP17x509_store_ctx_st[_ZN5boost4asio3ssl6detail6engine24verify_callback_functionEiP17x509_store_ctx_st]+0x52): undefined reference to `SSL_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o: in function `boost::asio::ssl::detail::engine::~engine()':
PostbackMain.cpp:(.text._ZN5boost4asio3ssl6detail6engineD2Ev[_ZN5boost4asio3ssl6detail6engineD5Ev]+0xf): undefined reference to `SSL_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN5boost4asio3ssl6detail6engineD2Ev[_ZN5boost4asio3ssl6detail6engineD5Ev]+0x1e): undefined reference to `SSL_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN5boost4asio3ssl6detail6engineD2Ev[_ZN5boost4asio3ssl6detail6engineD5Ev]+0x38): undefined reference to `SSL_set_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN5boost4asio3ssl6detail6engineD2Ev[_ZN5boost4asio3ssl6detail6engineD5Ev]+0x53): undefined reference to `SSL_free'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o: in function `boost::asio::ssl::detail::engine::map_error_code(boost::system::error_code&) const':
PostbackMain.cpp:(.text._ZNK5boost4asio3ssl6detail6engine14map_error_codeERNS_6system10error_codeE[_ZNK5boost4asio3ssl6detail6engine14map_error_codeERNS_6system10error_codeE]+0x7b): undefined reference to `SSL_get_shutdown'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o: in function `boost::asio::ssl::detail::engine::perform(int (boost::asio::ssl::detail::engine::*)(void*, unsigned long), void*, unsigned long, boost::system::error_code&, unsigned long*)':
PostbackMain.cpp:(.text._ZN5boost4asio3ssl6detail6engine7performEMS3_FiPvmES4_mRNS_6system10error_codeEPm[_ZN5boost4asio3ssl6detail6engine7performEMS3_FiPvmES4_mRNS_6system10error_codeEPm]+0x5a): undefined reference to `SSL_get_error'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o: in function `boost::asio::ssl::context::~context()':
PostbackMain.cpp:(.text._ZN5boost4asio3ssl7contextD2Ev[_ZN5boost4asio3ssl7contextD5Ev]+0xd): undefined reference to `SSL_CTX_get_default_passwd_cb_userdata'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN5boost4asio3ssl7contextD2Ev[_ZN5boost4asio3ssl7contextD5Ev]+0x25): undefined reference to `SSL_CTX_set_default_passwd_cb_userdata'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN5boost4asio3ssl7contextD2Ev[_ZN5boost4asio3ssl7contextD5Ev]+0x2f): undefined reference to `SSL_CTX_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN5boost4asio3ssl7contextD2Ev[_ZN5boost4asio3ssl7contextD5Ev]+0x3e): undefined reference to `SSL_CTX_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN5boost4asio3ssl7contextD2Ev[_ZN5boost4asio3ssl7contextD5Ev]+0x58): undefined reference to `SSL_CTX_set_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN5boost4asio3ssl7contextD2Ev[_ZN5boost4asio3ssl7contextD5Ev]+0x60): undefined reference to `SSL_CTX_free'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o: in function `void boost::checked_delete<boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor> > >(boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor> >*)':
PostbackMain.cpp:(.text._ZN5boost14checked_deleteINS_4asio3ssl6streamINS1_19basic_stream_socketINS1_2ip3tcpENS1_15any_io_executorEEEEEEEvPT_[_ZN5boost14checked_deleteINS_4asio3ssl6streamINS1_19basic_stream_socketINS1_2ip3tcpENS1_15any_io_executorEEEEEEEvPT_]+0xe0): undefined reference to `SSL_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN5boost14checked_deleteINS_4asio3ssl6streamINS1_19basic_stream_socketINS1_2ip3tcpENS1_15any_io_executorEEEEEEEvPT_[_ZN5boost14checked_deleteINS_4asio3ssl6streamINS1_19basic_stream_socketINS1_2ip3tcpENS1_15any_io_executorEEEEEEEvPT_]+0xf0): undefined reference to `SSL_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN5boost14checked_deleteINS_4asio3ssl6streamINS1_19basic_stream_socketINS1_2ip3tcpENS1_15any_io_executorEEEEEEEvPT_[_ZN5boost14checked_deleteINS_4asio3ssl6streamINS1_19basic_stream_socketINS1_2ip3tcpENS1_15any_io_executorEEEEEEEvPT_]+0x10b): undefined reference to `SSL_set_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN5boost14checked_deleteINS_4asio3ssl6streamINS1_19basic_stream_socketINS1_2ip3tcpENS1_15any_io_executorEEEEEEEvPT_[_ZN5boost14checked_deleteINS_4asio3ssl6streamINS1_19basic_stream_socketINS1_2ip3tcpENS1_15any_io_executorEEEEEEEvPT_]+0x127): undefined reference to `SSL_free'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o: in function `rstudio::core::http::TcpIpAsyncClientSsl::performHandshake()':
PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSsl16performHandshakeEv[_ZN7rstudio4core4http19TcpIpAsyncClientSsl16performHandshakeEv]+0x136): undefined reference to `SSL_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSsl16performHandshakeEv[_ZN7rstudio4core4http19TcpIpAsyncClientSsl16performHandshakeEv]+0x147): undefined reference to `SSL_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSsl16performHandshakeEv[_ZN7rstudio4core4http19TcpIpAsyncClientSsl16performHandshakeEv]+0x168): undefined reference to `SSL_set_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSsl16performHandshakeEv[_ZN7rstudio4core4http19TcpIpAsyncClientSsl16performHandshakeEv]+0x172): undefined reference to `SSL_get_verify_mode'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSsl16performHandshakeEv[_ZN7rstudio4core4http19TcpIpAsyncClientSsl16performHandshakeEv]+0x185): undefined reference to `SSL_set_verify'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o: in function `rstudio::core::http::TcpIpAsyncClientSsl::~TcpIpAsyncClientSsl()':
PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD2Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x180): undefined reference to `SSL_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD2Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x190): undefined reference to `SSL_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD2Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x1ab): undefined reference to `SSL_set_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD2Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x1c7): undefined reference to `SSL_free'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD2Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x2c8): undefined reference to `SSL_CTX_get_default_passwd_cb_userdata'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD2Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x2e4): undefined reference to `SSL_CTX_set_default_passwd_cb_userdata'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD2Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x2f2): undefined reference to `SSL_CTX_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD2Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x305): undefined reference to `SSL_CTX_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD2Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x323): undefined reference to `SSL_CTX_set_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD2Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x32f): undefined reference to `SSL_CTX_free'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o: in function `rstudio::core::http::sendSslRequest(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, boost::posix_time::time_duration const&, rstudio::core::http::Request const&, rstudio::core::http::Response*)':
PostbackMain.cpp:(.text._ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE[_ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE]+0x11c): undefined reference to `TLS_client_method'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE[_ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE]+0x124): undefined reference to `SSL_CTX_new'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE[_ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE]+0x141): undefined reference to `SSL_CTX_set_options'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE[_ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE]+0x3d0): undefined reference to `SSL_new'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE[_ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE]+0x3f2): undefined reference to `SSL_ctrl'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE[_ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE]+0x408): undefined reference to `SSL_ctrl'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE[_ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE]+0x41e): undefined reference to `SSL_ctrl'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE[_ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE]+0x44c): undefined reference to `SSL_set_bio'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE[_ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE]+0x823): undefined reference to `SSL_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE[_ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE]+0x833): undefined reference to `SSL_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE[_ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE]+0x84e): undefined reference to `SSL_set_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE[_ZN7rstudio4core4http14sendSslRequestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_bRKN5boost10posix_time13time_durationERKNS1_7RequestEPNS1_8ResponseE]+0x86a): undefined reference to `SSL_free'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/session/postback/CMakeFiles/rpostback.dir/PostbackMain.cpp.o: in function `rstudio::core::http::TcpIpAsyncClientSsl::~TcpIpAsyncClientSsl()':
PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD0Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x180): undefined reference to `SSL_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD0Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x190): undefined reference to `SSL_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD0Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x1ab): undefined reference to `SSL_set_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD0Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x1c7): undefined reference to `SSL_free'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD0Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x2c8): undefined reference to `SSL_CTX_get_default_passwd_cb_userdata'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD0Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x2e4): undefined reference to `SSL_CTX_set_default_passwd_cb_userdata'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD0Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x2f2): undefined reference to `SSL_CTX_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD0Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x305): undefined reference to `SSL_CTX_get_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD0Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x323): undefined reference to `SSL_CTX_set_ex_data'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: PostbackMain.cpp:(.text._ZN7rstudio4core4http19TcpIpAsyncClientSslD0Ev[_ZN7rstudio4core4http19TcpIpAsyncClientSslD5Ev]+0x32f): undefined reference to `SSL_CTX_free'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/core/librstudio-core.a(Ssl.cpp.o): in function `rstudio::core::http::ssl::initializeSslStream(boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
Ssl.cpp:(.text+0x27): undefined reference to `SSL_ctrl'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: src/cpp/core/librstudio-core.a(Ssl.cpp.o): in function `rstudio::core::http::ssl::initializeSslContext(boost::asio::ssl::context*, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
Ssl.cpp:(.text+0xf82): undefined reference to `SSL_CTX_get_verify_callback'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: Ssl.cpp:(.text+0xf92): undefined reference to `SSL_CTX_set_verify'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: Ssl.cpp:(.text+0xfc7): undefined reference to `SSL_CTX_set_default_verify_paths'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: Ssl.cpp:(.text+0x1001): undefined reference to `SSL_CTX_get_verify_callback'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: Ssl.cpp:(.text+0x1064): undefined reference to `SSL_CTX_get_cert_store'
/home/software/binutils/2.44-GCCcore-14.3.0/bin/ld: Ssl.cpp:(.text+0x1033): undefined reference to `SSL_CTX_set_verify'
collect2: error: ld returned 1 exit status
```

Which definitely looks like `Ninja` mixing up the system `OpenSSL` with the installation.

Adding the module `OpenSSL` explicitly to the EC fixes the error.

Initially I wasn't sure if that would apply only for this specific version of `RStudio-Server`, but I checked my previous (2-year old) `RStudio-Server-2023.12.1+402-gfbf-2023b-Java-11-R-4.3.3.eb` installation, and indeed I had had to add `OpenSSL-1.1` there explicitly to make it work.

Thus I'm proposing to change it everywhere.