### PR TITLE
{devel}[GCC/14.3.0] texlive v20250308 w/ teTeX

### DIFF
--- a/easybuild/easyconfigs/t/texlive/texlive-20250308-GCC-14.3.0-teTeX.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20250308-GCC-14.3.0-teTeX.eb
@@ -1,0 +1,86 @@
+# Based off the 2017 version by John Dey jfdey@fredhutch.org
+# https://github.com/easybuilders/easybuild-easyconfigs/pull/5085
+easyblock = 'Tarball'
+
+name = 'texlive'
+version = '20250308'
+local_ver_year = version[:4]
+versionsuffix = '-teTeX'
+
+homepage = 'https://tug.org'
+description = """TeX is a typesetting language. Instead of visually formatting your text, you enter your manuscript
+ text intertwined with TeX commands in a plain text file. You then run TeX to produce formatted output, such as a
+ PDF file. Thus, in contrast to standard word processors, your document is a separate file that does not pretend to
+ be a representation of the final typeset output, and so can be easily edited and manipulated.
+
+ The teTeX scheme installs most standard packages and fonts, and it skips other less common ones, 
+ thus creating a lighter setup (close to 2GB, in comparison to the 7+GB for the Full scheme)."""
+
+toolchain = {'name': 'GCC', 'version': '14.3.0'}
+
+source_urls = [
+    'ftp://tug.org/texlive/historic/%s/' % local_ver_year,
+    'https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/%s/' % local_ver_year,
+    'https://texlive.info/historic/systems/texlive/%s/' % local_ver_year,
+]
+sources = [
+    {
+        'download_filename': 'install-tl-unx.tar.gz',
+        'filename': 'install-tl-unx-%(version)s.tar.gz'
+    }
+]
+checksums = ['9938f192af75f792e84282580cce6eedac32969e0e07b33cb39ca1b699e948b6']
+
+dependencies = [
+    ('X11', '20250608'),
+    ('libpng', '1.6.50'),
+    ('OpenGL', '2025.09'),
+    ('Perl', '5.40.2'),
+    ('HarfBuzz', '11.4.1'),
+    ('poppler', '25.12.0'),
+    ('cairo', '1.18.4'),
+    ('fontconfig', '2.17.0'),
+    ('zlib', '1.3.1'),
+    ('graphite2', '1.3.14'),
+]
+
+# For the latest release, the tlnet-final repository isn't available yet, so we use the default.
+# But the default can _not_ be used for historic releases: once the next TeX Live is released, the
+# default tlnet mirrors only serve the new year and install-tl refuses the version mismatch. So we
+# fall back to the frozen 'tlnet-final' historic archive, trying repositories one by one until one
+# works. ftp is not available on all HPC systems, and the primary historic mirror (ftp.math.utah.edu)
+# is not always reachable, hence several https historic mirrors are enumerated as extra fallbacks.
+# See https://github.com/easybuilders/easybuild-easyconfigs/issues/17871
+local_install_tl = "%%(builddir)s/install-tl-%%(version)s/install-tl -profile %%(installdir)s/texlive.profile %s"
+local_tlnet = 'systems/texlive/%s/tlnet-final' % local_ver_year
+local_repos = [
+    '',  # default (current) repository -- only valid while this is still the latest TeX Live release
+    '-repository ftp://ftp.math.utah.edu/pub/tex/historic/%s' % local_tlnet,
+    '-repository https://ftp.math.utah.edu/pub/tex/historic/%s' % local_tlnet,
+    '-repository https://texlive.info/historic/%s' % local_tlnet,
+    '-repository https://ftp.tu-chemnitz.de/pub/tug/historic/%s' % local_tlnet,
+]
+local_install_tl_or = ' || '.join(local_install_tl % r for r in local_repos)
+postinstallcmds = [
+    'echo "TEXDIR         %%(installdir)s/" > %%(installdir)s/texlive.profile && '
+    'echo "TEXMFLOCAL     %%(installdir)s/texmf-local" >> %%(installdir)s/texlive.profile && '
+    'echo "TEXMFSYSCONFIG %%(installdir)s/texmf-config" >> %%(installdir)s/texlive.profile && '
+    'echo "TEXMFSYSVAR    %%(installdir)s/texmf-var" >> %%(installdir)s/texlive.profile && '
+    'echo "selected_scheme scheme-tetex" >> %%(installdir)s/texlive.profile && '
+    '%s' % local_install_tl_or
+]
+
+sanity_check_paths = {
+    'files': ['bin/%(arch)s-linux/tex', 'bin/%(arch)s-linux/latex'],
+    'dirs': ['bin/%(arch)s-linux', 'texmf-dist'],
+}
+
+modextrapaths = {
+    'INFOPATH': 'texmf-dist/doc/info',
+    'MANPATH': 'texmf-dist/doc/man',
+    'PATH': 'bin/%(arch)s-linux',
+}
+
+modextravars = {'TEXMFHOME': '%(installdir)s/texmf-dist'}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/texlive/texlive-20250308-GCC-14.3.0-teTeX.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20250308-GCC-14.3.0-teTeX.eb
@@ -13,7 +13,7 @@ description = """TeX is a typesetting language. Instead of visually formatting y
  PDF file. Thus, in contrast to standard word processors, your document is a separate file that does not pretend to
  be a representation of the final typeset output, and so can be easily edited and manipulated.
 
- The teTeX scheme installs most standard packages and fonts, and it skips other less common ones, 
+ The teTeX scheme installs most standard packages and fonts, and it skips other less common ones,
  thus creating a lighter setup (close to 2GB, in comparison to the 7+GB for the Full scheme)."""
 
 toolchain = {'name': 'GCC', 'version': '14.3.0'}


### PR DESCRIPTION
Based on https://github.com/easybuilders/easybuild-easyconfigs/pull/25826

Thought of adding this one as well, since for me it's been a life-saver. The general `texlive` installation is done with the `full` scheme, which is around 7-8GB of downloads (could be more). That's quite massive because it usually ends up being treated as a "standalone" process and it hits certain limits on our clusters, making the whole `texlive` installation very troublesome to deal with.

The `teTeX` scheme comes to be I think the second most complete scheme after the `full` one, and it comprises some 1.5-2GB of packages and fonts, making it a lighter yet still an effective option for environments that won't hold the full `texlive`.