### PR TITLE
[GCCcore/14.3.0] Add astor-0.8.1, astunparse-1.6.3, tblib-3.1.0, termcolor-python-2.5.0

### DIFF
--- a/easybuild/easyconfigs/a/astor/astor-0.8.1-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/a/astor/astor-0.8.1-GCCcore-14.3.0.eb
@@ -1,0 +1,17 @@
+easyblock = 'PythonPackage'
+
+name = 'astor'
+version = '0.8.1'
+
+homepage = 'https://github.com/berkerpeksag/astor'
+description = """Read/rewrite/write Python ASTs"""
+
+toolchain = {'name': 'GCCcore', 'version': '14.3.0'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e']
+
+builddependencies = [('binutils', '2.44')]
+dependencies = [('Python', '3.13.5')]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/astunparse/astunparse-1.6.3-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/a/astunparse/astunparse-1.6.3-GCCcore-14.3.0.eb
@@ -1,0 +1,22 @@
+easyblock = 'PythonPackage'
+
+name = 'astunparse'
+version = '1.6.3'
+
+homepage = 'https://github.com/simonpercivall/astunparse'
+description = """An AST unparser for Python
+This is a factored out version of unparse found in the Python source distribution;
+under Demo/parser in Python 2 and under Tools/parser in Python 3."""
+
+toolchain = {'name': 'GCCcore', 'version': '14.3.0'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872']
+
+builddependencies = [('binutils', '2.44')]
+dependencies = [
+    ('Python', '3.13.5'),
+    ('Python-bundle-PyPI', '2025.07'),
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/d/dask/dask-2025.9.1-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/d/dask/dask-2025.9.1-gfbf-2025b.eb
@@ -15,6 +15,7 @@ dependencies = [
     ('SciPy-bundle', '2025.07'),
     ('PyYAML', '6.0.2'),
     ('bokeh', '3.7.3'),
+    ('tblib', '3.1.0'),
 ]
 
 exts_list = [
@@ -32,9 +33,6 @@ exts_list = [
     }),
     ('zict', '3.0.0', {
         'checksums': ['e321e263b6a97aafc0790c3cfb3c04656b7066e6738c37fffcca95d803c9fba5'],
-    }),
-    ('tblib', '3.1.0', {
-        'checksums': ['06404c2c9f07f66fee2d7d6ad43accc46f9c3361714d9b8426e7f47e595cd652'],
     }),
     (name, version, {
         # Patch fix for https://github.com/zarr-developers/zarr-python/issues/3514

--- a/easybuild/easyconfigs/t/tblib/tblib-3.1.0-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/t/tblib/tblib-3.1.0-GCCcore-14.3.0.eb
@@ -1,0 +1,17 @@
+easyblock = 'PythonPackage'
+
+name = 'tblib'
+version = '3.1.0'
+
+homepage = 'https://github.com/ionelmc/python-tblib'
+description = """Serialization library for Exceptions and Tracebacks."""
+
+toolchain = {'name': 'GCCcore', 'version': '14.3.0'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['06404c2c9f07f66fee2d7d6ad43accc46f9c3361714d9b8426e7f47e595cd652']
+
+builddependencies = [('binutils', '2.44')]
+dependencies = [('Python', '3.13.5')]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/termcolor-python/termcolor-python-2.5.0-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/t/termcolor-python/termcolor-python-2.5.0-GCCcore-14.3.0.eb
@@ -12,7 +12,10 @@ source_urls = ['https://pypi.python.org/packages/source/t/termcolor']
 sources = [{'download_filename': 'termcolor-%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
 checksums = ['998d8d27da6d48442e8e1f016119076b690d962507531df4890fcd2db2ef8a6f']
 
-builddependencies = [('binutils', '2.44')]
+builddependencies = [
+    ('binutils', '2.44'),
+    ('hatchling', '1.27.0'),
+]
 dependencies = [('Python', '3.13.5')]
 
 options = {'modulename': 'termcolor'}

--- a/easybuild/easyconfigs/t/termcolor-python/termcolor-python-2.5.0-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/t/termcolor-python/termcolor-python-2.5.0-GCCcore-14.3.0.eb
@@ -1,0 +1,20 @@
+easyblock = 'PythonPackage'
+
+name = 'termcolor-python'
+version = '2.5.0'
+
+homepage = 'https://github.com/termcolor/termcolor'
+description = """ANSI color formatting for output in terminal"""
+
+toolchain = {'name': 'GCCcore', 'version': '14.3.0'}
+
+source_urls = ['https://pypi.python.org/packages/source/t/termcolor']
+sources = [{'download_filename': 'termcolor-%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
+checksums = ['998d8d27da6d48442e8e1f016119076b690d962507531df4890fcd2db2ef8a6f']
+
+builddependencies = [('binutils', '2.44')]
+dependencies = [('Python', '3.13.5')]
+
+options = {'modulename': 'termcolor'}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Those are dependencies of TensorFlow 2.21.0 that are used elsewhere in previous toolchains so should have their own ECs to avoid duplication

Requires:
- https://github.com/easybuilders/easybuild-easyblocks/pull/4224