### PR TITLE
bump version for ml_types dependency to 0.5.4 for jax 0.8.1

### DIFF
--- a/easybuild/easyconfigs/j/jax/jax-0.8.1-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/j/jax/jax-0.8.1-gfbf-2025b.eb
@@ -24,7 +24,7 @@ dependencies = [
     ('SciPy-bundle', '2025.07'),
     ('absl-py', '2.3.1'),
     ('flatbuffers-python', '25.2.10'),
-    ('ml_dtypes', '0.5.3'),
+    ('ml_dtypes', '0.5.4'),
     ('hypothesis', '6.136.6'),
     ('zlib', '1.3.1'),
 ]

--- a/easybuild/easyconfigs/m/ml_dtypes/ml_dtypes-0.5.4-gfbf-2025b.eb
+++ b/easybuild/easyconfigs/m/ml_dtypes/ml_dtypes-0.5.4-gfbf-2025b.eb
@@ -1,0 +1,48 @@
+# Thomas Hoffmann, EMBL Heidelberg, structures-it@embl.de, 2024/11
+easyblock = 'PythonBundle'
+
+name = 'ml_dtypes'
+version = '0.5.4'
+
+homepage = 'https://github.com/jax-ml/ml_dtypes'
+description = """
+ml_dtypes is a stand-alone implementation of several NumPy dtype extensions used
+in machine learning libraries, including:
+
+bfloat16: an alternative to the standard float16 format
+float8_*: several experimental 8-bit floating point representations including:
+float8_e4m3b11fnuz
+float8_e4m3fn
+float8_e4m3fnuz
+float8_e5m2
+float8_e5m2fnuz
+"""
+
+toolchain = {'name': 'gfbf', 'version': '2025b'}
+
+builddependencies = [
+    ('poetry', '2.1.3'),
+]
+
+dependencies = [
+    ('Python', '3.13.5'),
+    ('SciPy-bundle', '2025.07'),
+    ('opt-einsum', '3.4.0'),
+]
+
+exts_list = [
+    (name, version, {
+        'patches': [
+            ('ml_dtypes-0.3.2_EigenAvx512.patch', 1),
+            {'name': 'ml_dtypes-0.5.0_fix-Eigen-Float16-support.patch', 'opts': '--binary'},
+        ],
+        'checksums': [
+            {'ml_dtypes-0.5.4.tar.gz': '8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453'},
+            {'ml_dtypes-0.3.2_EigenAvx512.patch': '197b05b0b7f611749824369f026099f6a172f9e8eab6ebb6504a16573746c892'},
+            {'ml_dtypes-0.5.0_fix-Eigen-Float16-support.patch':
+             '36261acfe8241481edfcca76a8452eb92da5f48e5ca0ea26d746f84654f2a4de'},
+        ],
+    }),
+]
+
+moduleclass = 'tools'


### PR DESCRIPTION
Fixes wrong bfloat16 byteswap results in ml_dtypes 0.5.3 (https://github.com/jax-ml/ml_dtypes/issues/308); also bumps the ml_dtypes dep of jax-0.8.1-gfbf-2025b accordingly. Split out of #25790.