### PR TITLE
{bio} GROMACS 2026.2 with CP2K QM/MM support

### DIFF
--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2026.2-foss-2025b-CP2K.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2026.2-foss-2025b-CP2K.eb
@@ -57,17 +57,9 @@ builddependencies = [
     ('CMake', '4.0.3'),
     ('pkgconf', '2.4.3'),
     ('CP2K', local_cp2k_version),
-#    ('scikit-build-core', '0.11.5'),
-#    ('pybind11', '3.0.0'),
 ]
 
-dependencies = [
-#    ('CP2K', local_cp2k_version),
-#    ('Python', '3.13.5'),
-#    ('SciPy-bundle', '2025.07'),
-#    ('networkx', '3.5'),
-#    ('mpi4py', '4.1.0'),
-]
+dependencies = []
 
 cp2k = True
 build_shared_libs = False
@@ -81,25 +73,5 @@ python_pkg = False
 configopts = "-DGMX_TEST_TIMEOUT_FACTOR=3"
 
 skipsteps = ['test']
-
-# exts_defaultclass = 'PythonPackage'
-# 
-# _gmxapi_source_version = version
-# 
-# exts_list = [
-#     # gmxapi version can be found in python_packaging/gmxapi/src/gmxapi/version.py
-#     ('gmxapi', '0.5.0a1', {
-#         'patches': ['GROMACS-2024.1-fix-gmxapi-version.patch'],
-#         'preinstallopts': 'export CMAKE_ARGS="-Dgmxapi_ROOT=%(installdir)s ' +
-#                           '-C %(installdir)s/share/cmake/gromacs_mpi/gromacs-hints_mpi.cmake" && ',
-#         'source_tmpl': 'gromacs-%s.tar.gz' % _gmxapi_source_version,
-#         'start_dir': 'python_packaging/gmxapi',
-#         'checksums': [
-#             {'gromacs-2026.2.tar.gz': 'd27e4455e8246177952366798631a0dad9f2e1f567400a6cb854a168dcc050dd'},
-#             {'GROMACS-2024.1-fix-gmxapi-version.patch':
-#                 'df30b21352a26d8e01d693e2822db0ea45015c23f900a6ceb68522d44e6e790c'},
-#         ],
-#     }),
-# ]
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2026.2-foss-2025b-CP2K.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2026.2-foss-2025b-CP2K.eb
@@ -1,0 +1,105 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
+#                                 Ghent University / The Francis Crick Institute
+# Authors::
+# * Wiktor Jurkowski <wiktor.jurkowski@gmail.com>
+# * Fotis Georgatos <fotis@cern.ch>
+# * George Tsouloupas <g.tsouloupas@cyi.ac.cy>
+# * Kenneth Hoste <kenneth.hoste@ugent.be>
+# * Adam Huffman <adam.huffman@crick.ac.uk>
+# * Ake Sandgren <ake.sandgren@hpc2n.umu.se>
+# * J. Sassmannshausen <Crick HPC team>
+# * Dugan Witherick <dugan.witherick@warwick.ac.uk>
+# * Christoph Siegert <christoph.siegert@uni-leipzig.de>
+# License::   MIT/GPL
+
+name = 'GROMACS'
+version = '2026.2'
+versionsuffix = '-CP2K'
+
+modaltsoftname = 'GROMACS-CP2K'
+local_cp2k_version = '2025.2'
+
+homepage = 'https://www.gromacs.org'
+description = """
+GROMACS is a versatile package to perform molecular dynamics, i.e. simulate the
+Newtonian equations of motion for systems with hundreds to millions of
+particles.
+
+This is a CPU only build, containing both MPI and threadMPI binaries
+for both single and double precision.
+
+It also contains the gmxapi extension for the single precision MPI build.
+"""
+
+toolchain = {'name': 'foss', 'version': '2025b'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = [
+    'https://ftp.gromacs.org/pub/gromacs/',
+    'ftp://ftp.gromacs.org/pub/gromacs/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'GROMACS-2023.1_set_omp_num_threads_env_for_ntomp_tests.patch',
+    'GROMACS-2023.1_fix_tests_for_gmx_thread_mpi.patch',
+]
+checksums = [
+    {'gromacs-2026.2.tar.gz': 'd27e4455e8246177952366798631a0dad9f2e1f567400a6cb854a168dcc050dd'},
+    {'GROMACS-2023.1_set_omp_num_threads_env_for_ntomp_tests.patch':
+     '7f41bda16c9c2837624265dda4be252f655d1288ddc4486b1a2422af30d5d199'},
+    {'GROMACS-2023.1_fix_tests_for_gmx_thread_mpi.patch':
+     '6df844bb3bbc51180446a3595c61a4ef195e5f975533a04cef76841aa763aec1'},
+]
+
+builddependencies = [
+    ('CMake', '4.0.3'),
+    ('pkgconf', '2.4.3'),
+    ('CP2K', local_cp2k_version),
+#    ('scikit-build-core', '0.11.5'),
+#    ('pybind11', '3.0.0'),
+]
+
+dependencies = [
+#    ('CP2K', local_cp2k_version),
+#    ('Python', '3.13.5'),
+#    ('SciPy-bundle', '2025.07'),
+#    ('networkx', '3.5'),
+#    ('mpi4py', '4.1.0'),
+]
+
+cp2k = True
+build_shared_libs = False
+mpi_only = True
+plumed = 'native'
+python_pkg = False
+
+
+# be a bit more forgiving w.r.t. timeouts for GROMACS test suite,
+# see also https://gitlab.com/gromacs/gromacs/-/issues/5062
+configopts = "-DGMX_TEST_TIMEOUT_FACTOR=3"
+
+skipsteps = ['test']
+
+# exts_defaultclass = 'PythonPackage'
+# 
+# _gmxapi_source_version = version
+# 
+# exts_list = [
+#     # gmxapi version can be found in python_packaging/gmxapi/src/gmxapi/version.py
+#     ('gmxapi', '0.5.0a1', {
+#         'patches': ['GROMACS-2024.1-fix-gmxapi-version.patch'],
+#         'preinstallopts': 'export CMAKE_ARGS="-Dgmxapi_ROOT=%(installdir)s ' +
+#                           '-C %(installdir)s/share/cmake/gromacs_mpi/gromacs-hints_mpi.cmake" && ',
+#         'source_tmpl': 'gromacs-%s.tar.gz' % _gmxapi_source_version,
+#         'start_dir': 'python_packaging/gmxapi',
+#         'checksums': [
+#             {'gromacs-2026.2.tar.gz': 'd27e4455e8246177952366798631a0dad9f2e1f567400a6cb854a168dcc050dd'},
+#             {'GROMACS-2024.1-fix-gmxapi-version.patch':
+#                 'df30b21352a26d8e01d693e2822db0ea45015c23f900a6ceb68522d44e6e790c'},
+#         ],
+#     }),
+# ]
+
+moduleclass = 'bio'


### PR DESCRIPTION
GROMACS 2026.1 with CP2K QM/MM support

depends on: 
* #26754 (CP2K dependency) and
* easybuilders/easybuild-easyblocks#4211 (updated GROMACS easyblock)

Note that when enabling CP2K support makes binaries that are notably different from a "normal" GROMACS installation:

* has to be build statically (`build_shared_libs = False`), so no GMXAPI or Python bindings
* must build with the same MPI library as CP2K (`mpi_only = True`), so not with GROMACS' "thread-MPI"

This all builds correctly within EESSI/2025.06  & EasyBuild/5.4.0
