### PR TITLE
add patch for OpenBLAS 0.3.32 to fix sdot/ddot issues on non-SVE Arm64

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.32-GCC-15.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.32-GCC-15.2.0.eb
@@ -18,6 +18,7 @@ patches = [
     'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch',
     'OpenBLAS-0.3.21_fix-order-vectorization.patch',
     'OpenBLAS-0.3.32_fix-non-sve-ddot-kernel-aarch64.patch',
+    'OpenBLAS-0.3.32_fix-non-sve-sdot-ddot-aarch64.patch',
 ]
 checksums = [
     {'v0.3.32.tar.gz': 'f8a1138e01fddca9e4c29f9684fd570ba39dedc9ca76055e1425d5d4b1a4a766'},
@@ -29,6 +30,8 @@ checksums = [
      '08af834e5d60441fd35c128758ed9c092ba6887c829e0471ecd489079539047d'},
     {'OpenBLAS-0.3.32_fix-non-sve-ddot-kernel-aarch64.patch':
      '19ca0ed7bc87f87cfca8418b1acf0ee9bbc3646b6bbac98d5d8ea2c07f981d2f'},
+    {'OpenBLAS-0.3.32_fix-non-sve-sdot-ddot-aarch64.patch':
+     '2b8cc1197aaaf7eab19f533909ac104517acc9baf77c3e36df319a6592e81df7'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.32-llvm-compilers-21.1.8.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.32-llvm-compilers-21.1.8.eb
@@ -18,6 +18,7 @@ patches = [
     'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch',
     'OpenBLAS-0.3.21_fix-order-vectorization.patch',
     'OpenBLAS-0.3.32_fix-non-sve-ddot-kernel-aarch64.patch',
+    'OpenBLAS-0.3.32_fix-non-sve-sdot-ddot-aarch64.patch',
 ]
 checksums = [
     {'v0.3.32.tar.gz': 'f8a1138e01fddca9e4c29f9684fd570ba39dedc9ca76055e1425d5d4b1a4a766'},
@@ -29,6 +30,8 @@ checksums = [
      '08af834e5d60441fd35c128758ed9c092ba6887c829e0471ecd489079539047d'},
     {'OpenBLAS-0.3.32_fix-non-sve-ddot-kernel-aarch64.patch':
      '19ca0ed7bc87f87cfca8418b1acf0ee9bbc3646b6bbac98d5d8ea2c07f981d2f'},
+    {'OpenBLAS-0.3.32_fix-non-sve-sdot-ddot-aarch64.patch':
+     '2b8cc1197aaaf7eab19f533909ac104517acc9baf77c3e36df319a6592e81df7'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.32_fix-non-sve-sdot-ddot-aarch64.patch
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.32_fix-non-sve-sdot-ddot-aarch64.patch
@@ -1,0 +1,59 @@
+Patch based on https://github.com/OpenMathLib/OpenBLAS/pull/5918,
+backported to 0.3.32.
+Another part of that PR was already part of OpenBLAS-0.3.32_fix-non-sve-ddot-kernel-aarch64.patch.
+diff -ru OpenBLAS-0.3.32.orig/kernel/arm64/dot_kernel_asimd.c OpenBLAS-0.3.32/kernel/arm64/dot_kernel_asimd.c
+--- OpenBLAS-0.3.32.orig/kernel/arm64/dot_kernel_asimd.c	2026-03-23 22:53:57.000000000 +0000
++++ OpenBLAS-0.3.32/kernel/arm64/dot_kernel_asimd.c	2026-08-31 07:51:59.136139567 +0000
+@@ -267,6 +267,7 @@
+ 
+ 	__asm__ __volatile__ (
+ 	"	fmov	"OUT", "REG0"			\n"
++	"	fmov	d0, xzr				\n"
+ 	"	fmov	d1, xzr				\n"
+ 	"	fmov	d2, xzr				\n"
+ 	"	fmov	d3, xzr				\n"
+@@ -339,7 +340,10 @@
+           [J_]    "r"   (j)
+ 	: "cc",
+ 	  "memory",
+-	  "d1", "d2", "d3", "d4", "d5", "d6", "d7"
++	  "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
++	  "v16", "v17", "v18", "v19", "v20", "v21", "v22",
++	  "v23", "v24", "v25", "v26", "v27", "v28", "v29",
++	  "v30", "v31"
+ 	);
+ 
+ 	return dot;
+diff -ru OpenBLAS-0.3.32.orig/utest/test_dsdot.c OpenBLAS-0.3.32/utest/test_dsdot.c
+--- OpenBLAS-0.3.32.orig/utest/test_dsdot.c	2026-03-23 22:53:57.000000000 +0000
++++ OpenBLAS-0.3.32/utest/test_dsdot.c	2026-08-31 07:52:38.111632299 +0000
+@@ -48,3 +48,29 @@
+ 
+ }
+ #endif
++#ifdef ARMV8
++#if defined(BUILD_SINGLE)
++CTEST(sdot,sdot_n_1)
++{
++    static float x[64], y[64];
++    for (int i = 0; i < 64; i++) { x[i] = 1.0f; y[i] = 1.0f; }
++    blasint n = 64, inc = 1;
++    float junk[4] = {1e6f, 1e6f, 1e6f, 1e6f};
++    __asm__ volatile("ld1 {v0.4s}, [%0]" :: "r"(junk) : "v0");
++    float r = BLASFUNC(sdot)(&n, x, &inc, y, &inc);
++    ASSERT_DBL_NEAR_TOL(64.,r, DOUBLE_EPS);
++}
++#endif
++#if defined(BUILD_DOUBLE)
++CTEST(ddot,ddot_n_1)
++{
++    static double x[64], y[64];
++    for (int i = 0; i < 64; i++) { x[i] = 1.0f; y[i] = 1.0f; }
++    blasint n = 64, inc = 1;
++    double junk[4] = {1e6f, 1e6f, 1e6f, 1e6f};
++    __asm__ volatile("ld1 {v0.4s}, [%0]" :: "r"(junk) : "v0");
++    double r = BLASFUNC(ddot)(&n, x, &inc, y, &inc);
++    ASSERT_DBL_NEAR_TOL(64.,r, DOUBLE_EPS);
++}
++#endif
++#endif


### PR DESCRIPTION
We ran into SciPy test failures on Neoverse N1 in https://github.com/EESSI/software-layer/pull/1585. That's a known and solved issue, see https://github.com/OpenMathLib/OpenBLAS/pull/5918 and https://github.com/scipy/scipy/issues/26074.