### PR TITLE
Change Rmath source url to cloud.r-project.org

### DIFF
--- a/easybuild/easyconfigs/r/Rmath/Rmath-4.3.2-foss-2023a.eb
+++ b/easybuild/easyconfigs/r/Rmath/Rmath-4.3.2-foss-2023a.eb
@@ -13,7 +13,7 @@ description = """Rmath is the standalone version of the R math library.
 
 toolchain = {'name': 'foss', 'version': '2023a'}
 
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s/']
+source_urls = ['https://cloud.r-project.org/src/base/R-%(version_major)s']
 sources = ['R-%(version)s.tar.gz']
 checksums = ['b3f5760ac2eee8026a3f0eefcb25b47723d978038eee8e844762094c860c452a']
 

--- a/easybuild/easyconfigs/r/Rmath/Rmath-4.4.1-foss-2023b.eb
+++ b/easybuild/easyconfigs/r/Rmath/Rmath-4.4.1-foss-2023b.eb
@@ -14,7 +14,7 @@ description = """Rmath is the standalone version of the R math library.
 
 toolchain = {'name': 'foss', 'version': '2023b'}
 
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s/']
+source_urls = ['https://cloud.r-project.org/src/base/R-%(version_major)s']
 sources = ['R-%(version)s.tar.gz']
 checksums = ['b4cb675deaaeb7299d3b265d218cde43f192951ce5b89b7bb1a5148a36b2d94d']
 

--- a/easybuild/easyconfigs/r/Rmath/Rmath-4.4.2-foss-2024a.eb
+++ b/easybuild/easyconfigs/r/Rmath/Rmath-4.4.2-foss-2024a.eb
@@ -14,7 +14,7 @@ description = """Rmath is the standalone version of the R math library.
 
 toolchain = {'name': 'foss', 'version': '2024a'}
 
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s/']
+source_urls = ['https://cloud.r-project.org/src/base/R-%(version_major)s']
 sources = ['R-%(version)s.tar.gz']
 checksums = ['1578cd603e8d866b58743e49d8bf99c569e81079b6a60cf33cdf7bdffeb817ec']
 

--- a/easybuild/easyconfigs/r/Rmath/Rmath-4.5.1-gompi-2025a.eb
+++ b/easybuild/easyconfigs/r/Rmath/Rmath-4.5.1-gompi-2025a.eb
@@ -14,7 +14,7 @@ description = """Rmath is the standalone version of the R math library.
 
 toolchain = {'name': 'gompi', 'version': '2025a'}
 
-source_urls = ['http://cran.us.r-project.org/src/base/R-%(version_major)s/']
+source_urls = ['https://cloud.r-project.org/src/base/R-%(version_major)s']
 sources = ['R-%(version)s.tar.gz']
 checksums = ['b42a7921400386645b10105b91c68728787db5c4c83c9f6c30acdce632e1bb70']
 


### PR DESCRIPTION
No AI used.

The existing source url for `Rmath` is giving HTTP issues and the EB installation is unable to find the package.

As an example:
```
curl -IL http://cran.us.r-project.org/src/base/R-4/R-4.5.2.tar.gz

HTTP/1.1 301 Moved Permanently
Date: Thu, 03 Sep 2026 08:31:45 GMT
Server: Apache/2.4
Location: http://lib.stat.cmu.edu/R/CRAN/src/base/R-4/R-4.5.2.tar.gz
Content-Type: text/html; charset=iso-8859-1

HTTP/1.1 301 Moved Permanently
Date: Thu, 03 Sep 2026 08:31:46 GMT
Server: Apache/2.4.58 (Ubuntu)
Location: https://lib.stat.cmu.edu/R/CRAN/src/base/R-4/R-4.5.2.tar.gz
Content-Type: text/html; charset=iso-8859-1

HTTP/1.1 403 Forbidden
Date: Thu, 03 Sep 2026 08:31:46 GMT
Server: Apache/2.4.58 (Ubuntu)
Content-Type: text/html; charset=iso-8859-1
```

Better change the url to https://cloud.r-project.org and make it consistent with the rest of the `R` related ECs.