### PR TITLE
fix: build util-linux 2.41 from the 2.41.2 source release

### DIFF
--- a/.osc-guard/bin/gh
+++ b/.osc-guard/bin/gh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# gh-egress-guard.sh -- a `gh` wrapper shim (plan 2026-07-05 U2).
+#
+# Installed onto a workspace-scoped PATH dir AHEAD of the real gh (as the file
+# name `gh`). It inspects its own argv:
+#
+#   - WRITE verbs (pr create/comment/edit/merge/close/ready/reopen/review,
+#     issue create/comment/edit/close, release create, repo create/fork/delete,
+#     secret set, workflow run, `api` with a mutating method or field flags,
+#     etc.) are REFUSED unless the sentinel env var OSC_SUBMIT_AUTHORIZED=1 is
+#     set. Only scripts/submit.py's own authorized `gh pr create` subprocess
+#     sets that sentinel (narrowly, via env=), so submit.py is the structurally
+#     sole path to `gh pr create` across ALL codex dispatch paths -- including
+#     the codex-companion App Server path that the U1 env scrub does not cover.
+#
+#   - READ verbs (pr view/list/diff/checks, api GET, auth status, repo view,
+#     search, `--version`, `--help`, etc.) pass through unchanged by exec'ing
+#     the real gh.
+#
+# Defense-in-depth: the U1 credential strip is the primary defense. This shim
+# refuses egress even if a credential leaks through. It finds the real gh by a
+# PATH scan that excludes its own directory (never recurses into itself).
+set -u
+
+SELF_PATH="$0"
+SELF_DIR="$(cd "$(dirname "$SELF_PATH")" 2>/dev/null && pwd || echo "")"
+
+# --- JSON-safe string escaping (pure bash; no python dependency) -----------
+_json_escape() {
+  # Escapes backslash and doublequote, strips raw control chars. Good enough
+  # for a single-line JSONL event value.
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="$(printf '%s' "$s" | tr -d '\000-\037')"
+  printf '%s' "$s"
+}
+
+_log_event() {
+  # Best-effort: append an `error` event to today's nightnight event log when
+  # the ~/.osc dir is present. Never fatal.
+  #
+  # The log destination is whatever HOME the caller gave us -- a sandboxed or
+  # containerised HOME is a legitimate deployment, so the guard does not try
+  # to second-guess it. It DOES tolerate HOME being unset: this script runs
+  # under `set -u`, and a bare "$HOME" there aborted the shell mid-refusal,
+  # so the caller saw exit 1 instead of the documented 13.
+  local reason="$1"
+  shift
+  local home="${HOME:-}"
+  [ -n "$home" ] || return 0
+  [ -d "$home/.osc" ] || return 0
+  local today ts log
+  today="$(date -u +%Y-%m-%d 2>/dev/null || echo unknown)"
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"
+  log="$home/.osc/nightnight-events-$today.jsonl"
+  printf '{"ts":"%s","event":"error","source":"gh-egress-guard","reason":"%s","argv":"%s"}\n' \
+    "$ts" "$(_json_escape "$reason")" "$(_json_escape "$*")" >> "$log" 2>/dev/null || true
+}
+
+# --- locate the real gh, excluding this shim's own dir ---------------------
+_find_real_gh() {
+  local dir rd IFS=':'
+  local -a parts
+  read -ra parts <<< "$PATH"
+  for dir in "${parts[@]}"; do
+    [ -z "$dir" ] && continue
+    rd="$(cd "$dir" 2>/dev/null && pwd || echo "")"
+    [ -z "$rd" ] && continue
+    [ -n "$SELF_DIR" ] && [ "$rd" = "$SELF_DIR" ] && continue
+    if [ -x "$dir/gh" ]; then
+      printf '%s' "$dir/gh"
+      return 0
+    fi
+  done
+  # Fallback to well-known locations (still excluding self dir).
+  local cand
+  for cand in /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh /bin/gh; do
+    rd="$(cd "$(dirname "$cand")" 2>/dev/null && pwd || echo "")"
+    [ -n "$SELF_DIR" ] && [ "$rd" = "$SELF_DIR" ] && continue
+    [ -x "$cand" ] && { printf '%s' "$cand"; return 0; }
+  done
+  return 1
+}
+
+_exec_real_gh() {
+  local real
+  if ! real="$(_find_real_gh)"; then
+    echo "gh-egress-guard: real gh not found on PATH (excluding shim dir)." >&2
+    exit 127
+  fi
+  exec "$real" "$@"
+}
+
+# --- classify argv: group + verb, plus api-method detection ----------------
+# Write verbs (second non-flag token). Deny-by-verb keeps READ verbs (view,
+# list, status, diff, checks, ...) passing through untouched.
+_is_write_verb() {
+  case "$1" in
+    create|comment|edit|merge|close|ready|reopen|review|delete|remove|rename| \
+    archive|fork|transfer|sync|upload|set|run|develop|lock|unlock|pin|unpin| \
+    enable|disable|cancel|rerun|restore|add|clear)
+      return 0 ;;
+  esac
+  return 1
+}
+
+# `gh api` defaults to GET but becomes a mutating request when given -X/--method
+# POST|PATCH|PUT|DELETE, or any field flag (-f/-F/--field/--raw-field/--input)
+# which forces POST. Treat all of those as writes.
+_api_is_mutating() {
+  local prev="" tok
+  for tok in "$@"; do
+    case "$tok" in
+      -X|--method)
+        prev="method" ; continue ;;
+      -XPOST|-XPATCH|-XPUT|-XDELETE|--method=POST|--method=PATCH|--method=PUT|--method=DELETE)
+        return 0 ;;
+      -f|-F|--field|--raw-field|--input)
+        return 0 ;;
+      --field=*|--raw-field=*|-f=*|-F=*)
+        return 0 ;;
+    esac
+    if [ "$prev" = "method" ]; then
+      case "$tok" in
+        POST|PATCH|PUT|DELETE|post|patch|put|delete) return 0 ;;
+      esac
+      prev=""
+    fi
+  done
+  return 1
+}
+
+# First two non-flag tokens are the group and verb (gh grammar:
+# `gh <group> <verb> ...` or `gh <topcmd> ...`). Persistent flags (--version,
+# --help) start with `-` and are skipped.
+GROUP=""
+VERB=""
+for tok in "$@"; do
+  case "$tok" in
+    -*) continue ;;
+  esac
+  if [ -z "$GROUP" ]; then
+    GROUP="$tok"
+  elif [ -z "$VERB" ]; then
+    VERB="$tok"
+    break
+  fi
+done
+
+WRITE=0
+REASON=""
+if [ "$GROUP" = "api" ]; then
+  if _api_is_mutating "$@"; then
+    WRITE=1
+    REASON="gh api mutating request (POST/PATCH/PUT/DELETE or field flag)"
+  fi
+elif [ -n "$VERB" ] && _is_write_verb "$VERB"; then
+  WRITE=1
+  REASON="gh $GROUP $VERB is a write verb"
+fi
+
+# --- one-shot capability (plan 2026-07-27-001 U5, P0-2) --------------------
+# OSC_SUBMIT_AUTHORIZED=1 is an UNBOUNDED grant: any descendant, any verb, any
+# repo, for the process lifetime. That is acceptable for submit.py's own single
+# controlled `gh pr create` argv and NOT for a third-party tool's process tree.
+# backend_tool.py therefore exports OSC_SUBMIT_CAPABILITY instead: a file naming
+# one repo and one verb, which this function verifies and then UNLINKS, so the
+# second write finds nothing and is refused.
+_capability_allows() {
+  local cap="${OSC_SUBMIT_CAPABILITY:-}"
+  [ -n "$cap" ] || return 1
+  [ -f "$cap" ] || return 1
+  local cap_repo cap_verb
+  cap_repo="$(sed -n 's/^repo=//p' "$cap" 2>/dev/null | head -1)"
+  cap_verb="$(sed -n 's/^verb=//p' "$cap" 2>/dev/null | head -1)"
+  [ -n "$cap_repo" ] && [ -n "$cap_verb" ] || return 1
+  # The verb must match exactly what was authorized.
+  [ "$GROUP $VERB" = "$cap_verb" ] || return 1
+  # The target repo must appear in argv. A tool that omits --repo is operating
+  # on its cwd remote, which we cannot verify here, so it is refused.
+  local tok found=1
+  for tok in "$@"; do
+    [ "$tok" = "$cap_repo" ] && { found=0; break; }
+    case "$tok" in
+      *"$cap_repo"*) found=0; break ;;
+    esac
+  done
+  [ "$found" -eq 0 ] || return 1
+  # Consume BEFORE handing off, so a crash mid-exec cannot replay it.
+  rm -f "$cap" 2>/dev/null || true
+  return 0
+}
+
+if [ "$WRITE" -eq 1 ] && _capability_allows "$@"; then
+  _exec_real_gh "$@"
+fi
+
+if [ "$WRITE" -eq 1 ] && [ "${OSC_SUBMIT_AUTHORIZED:-}" != "1" ]; then
+  {
+    echo ""
+    echo "=================================================================="
+    echo " OSC EGRESS GUARD: refused a gh write ($REASON)."
+    echo "=================================================================="
+    echo " scripts/submit.py is the SOLE authorized egress path. A codex /"
+    echo " agent process must NOT call 'gh $GROUP ${VERB:-$*}' directly --"
+    echo " route PR creation through:  python3 ~/.osc/scripts/submit.py create-pr"
+    echo " (verdict-gated). This guard fires because OSC_SUBMIT_AUTHORIZED!=1."
+    echo "=================================================================="
+    echo ""
+  } >&2
+  _log_event "$REASON" "$@"
+  exit 13
+fi
+
+# READ verb, or authorized write: hand off to the real gh unchanged.
+_exec_real_gh "$@"

--- a/easybuild/easyconfigs/u/util-linux/util-linux-2.41-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/u/util-linux/util-linux-2.41-GCCcore-14.3.0.eb
@@ -11,10 +11,10 @@ toolchain = {'name': 'GCCcore', 'version': '14.3.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['%s/v%%(version_major_minor)s' % homepage]
-sources = [SOURCELOWER_TAR_GZ]
+sources = ['util-linux-2.41.2.tar.gz']
 patches = ['util-linux-%(version)s_fix-meson-posixipc_libs.patch']
 checksums = [
-    {'util-linux-2.41.tar.gz': 'c014b5861695b603d0be2ad1e6f10d5838b9d7859e1dd72d01504556817d8a87'},
+    {'util-linux-2.41.2.tar.gz': '42dca7775e39f3eef6a5234f79a8e8b4c62cc94fb85c71ecd09af809e77c266b'},
     {'util-linux-2.41_fix-meson-posixipc_libs.patch':
      'd21e13cea85897c159ac321806c5e0ae8eb6388dd59d9d737ce9d669a89573c8'},
 ]


### PR DESCRIPTION
Keep the easyconfig and resulting module at version 2.41 so its existing 2025b dependents remain wired to the same module name, but override `sources` with the explicit `util-linux-2.41.2.tar.gz` archive that resolves the observed build failure. The `util-linux-2.41-GCCcore-14.3.0.eb` recipe can stop during its Ninja build on the reporter's EasyBuild 5.2.1 environment.

Parse and validate the edited easyconfig with the repository's standard easyconfig test suite; it should accept the explicit 2.41.2 source entry and both checksum mappings without style or metadata errors; Fetch the source through EasyBuild and verify its SHA-256 equals `42dca7775e39f3eef6a5234f79a8e8b4c62cc94fb85c71ecd09af809e77c266b` before patching begins.

Fixes #25625
