### PR TITLE
add patch for Qt6 6.11.2 to fix a V8 build issue on systems with 64KiB pages

### DIFF
--- a/easybuild/easyconfigs/q/Qt6/Qt6-6.11.2-GCCcore-15.2.0.eb
+++ b/easybuild/easyconfigs/q/Qt6/Qt6-6.11.2-GCCcore-15.2.0.eb
@@ -20,7 +20,8 @@ patches = [
     'Qt6-6.6.3_fix_OF-Gentoo.patch',
     'Qt6-6.7.2_fix_cpu_features.patch',
     'Qt6-6.5.2_fix_too_long_filenames.patch',
-    'Qt6-6.11.2_gnu_source.patch'
+    'Qt6-6.11.2_gnu_source.patch',
+    'Qt6-6.11.2_fix-v8-segmented-table-64k-pages.patch',
 ]
 checksums = [
     {'qt-everywhere-src-6.11.2.tar.xz': '6dcfbca271d76a6502741a2c0dc6fc98ef7dd0b7b4cfd0abcebb285a86a26f33'},
@@ -28,6 +29,7 @@ checksums = [
     {'Qt6-6.7.2_fix_cpu_features.patch': '3f37e7a4e4ed38cc82037be9504bc644e48bf258555ffff848183142725c9dc8'},
     {'Qt6-6.5.2_fix_too_long_filenames.patch': 'b4a2aa3c72fe01d8b9cbab6da43cdbd968bd139f5dd9daba83181eb5d6125dac'},
     {'Qt6-6.11.2_gnu_source.patch': '4e36e7c91f568ebde5a7a6d7c3a32c6b1ef679912b1f8b15ff5abbf753032a01'},
+    {'Qt6-6.11.2_fix-v8-segmented-table-64k-pages.patch': 'dc091bad8ed216c451fd77626bb3e4600b502087209b793949ffd17e8c0aef5a'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/q/Qt6/Qt6-6.11.2-GCCcore-15.2.0.eb
+++ b/easybuild/easyconfigs/q/Qt6/Qt6-6.11.2-GCCcore-15.2.0.eb
@@ -29,7 +29,8 @@ checksums = [
     {'Qt6-6.7.2_fix_cpu_features.patch': '3f37e7a4e4ed38cc82037be9504bc644e48bf258555ffff848183142725c9dc8'},
     {'Qt6-6.5.2_fix_too_long_filenames.patch': 'b4a2aa3c72fe01d8b9cbab6da43cdbd968bd139f5dd9daba83181eb5d6125dac'},
     {'Qt6-6.11.2_gnu_source.patch': '4e36e7c91f568ebde5a7a6d7c3a32c6b1ef679912b1f8b15ff5abbf753032a01'},
-    {'Qt6-6.11.2_fix-v8-segmented-table-64k-pages.patch': 'dc091bad8ed216c451fd77626bb3e4600b502087209b793949ffd17e8c0aef5a'},
+    {'Qt6-6.11.2_fix-v8-segmented-table-64k-pages.patch':
+     'dc091bad8ed216c451fd77626bb3e4600b502087209b793949ffd17e8c0aef5a'},
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/q/Qt6/Qt6-6.11.2_fix-v8-segmented-table-64k-pages.patch
+++ b/easybuild/easyconfigs/q/Qt6/Qt6-6.11.2_fix-v8-segmented-table-64k-pages.patch
@@ -1,0 +1,31 @@
+Solves an issue for (Arm64) systems with 64 KiB pages where the build would fail with:
+FAILED: [code=251] gen/v8/embedded.S snapshot_blob.bin
+python ../../../../../../qt-everywhere-src-6.11.2/qtwebengine/src/3rdparty/chromium/v8/tools/run.py ./mksnapshot --turbo_instruction_scheduling --stress-turbo-late-spilling --target_os=linux --target_arch=arm64 --embedded_src gen/v8/embedded.S --predictable --no-use-ic --turbo-elide-frames --embedded_variant Default --random-seed 314159265 --startup_blob snapshot_blob.bin --no-native-code-counters --concurrent-builtin-generation --concurrent-turbofan-max-threads=0
+Return code is -5
+
+Solved upstream in:
+https://chromium.googlesource.com/v8/v8/+/1e190bbb0396f7228797bf9b74cf689e83c5354e%5E%21
+diff --git a/src/common/segmented-table.h b/src/common/segmented-table.h
+index b0e31c4..924398e 100644
+--- a/qt-everywhere-src-6.11.2/qtwebengine/src/3rdparty/chromium/v8/src/common/segmented-table.h
++++ b/qt-everywhere-src-6.11.2/qtwebengine/src/3rdparty/chromium/v8/src/common/segmented-table.h
+@@ -41,16 +41,14 @@
+   static constexpr bool kUseContiguousMemory = true;
+   static constexpr size_t kReservationSize = size;
+   static constexpr size_t kMaxCapacity = kReservationSize / kEntrySize;
+-#if defined(V8_TARGET_OS_WIN) || defined(V8_HOST_ARCH_PPC64)
++#if defined(V8_TARGET_OS_WIN)
+   // On windows the allocation granularity is 64KB and thus we cannot make a
+   // segment smaller than that.
+-  // PPC64 can utilize a 64KB page size.
+   static constexpr bool kUseSegmentPool = false;
+-  static constexpr size_t kSegmentSize = 64 * KB;
+ #else
+-  static constexpr bool kUseSegmentPool = true;
+-  static constexpr size_t kSegmentSize = 16 * KB;
++  static constexpr bool kUseSegmentPool = kMinimumOSPageSize <= 16 * KB;
+ #endif
++  static constexpr size_t kSegmentSize = kUseSegmentPool ? 16 * KB : 64 * KB;
+ #else
+   // On 32 bit, segments are individually mapped.
+   static constexpr bool kUseContiguousMemory = false;


### PR DESCRIPTION
We saw build failures on some Arm system in https://github.com/EESSI/software-layer/pull/1591#issuecomment-5497856263. After a long conversation with an AI friend and debugging it extensively with gdb, he found the issue, and pointed me to an upstream commit that fixes the issue (so the patch itself was not generated by AI). It's relevant for systems having 64KiB pages, which is indeed the case on our Neoverse N1 build host:
```
$ getconf PAGESIZE
65536
```