### PR TITLE
Add openreg-test.patch to all PyTorch 2.9.1 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1-foss-2024a-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1-foss-2024a-CUDA-12.6.0.eb
@@ -88,6 +88,7 @@ patches = [
     'PyTorch-2.9.1_skip-svd-pca-lowrank-tests-on-cpu.patch',
     'PyTorch-2.9.1_skip-test_optree_graph_break_message.patch',
     'PyTorch-2.9.1_skip-tests-requiring-MKLDNN.patch',
+    'PyTorch-2.9.1_fix-openreg-test.patch',
 ]
 checksums = [
     {'pytorch-v2.9.1.tar.gz': 'e17504700ebc4c87f9b57059df1c4d790b769458c04db144c7a92aea90f2c92b'},
@@ -195,6 +196,8 @@ checksums = [
      '2ef1ad424d5f12a4d0ae06938da623819596cee7c0fb4616008f27583c29494d'},
     {'PyTorch-2.9.1_skip-tests-requiring-MKLDNN.patch':
      '03756a8069bad01018f422f41aa24c7c543519fd857db88a0c6de661976c8859'},
+    {'PyTorch-2.9.1_fix-openreg-test.patch':
+     'db47763fe16ed6e795268af2aef458c28d4ac8efdc0aa42588aaf111d2fcae76'},
 ]
 
 osdependencies = [OS_PKG_IBVERBS_DEV]

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1-foss-2024a.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1-foss-2024a.eb
@@ -87,6 +87,7 @@ patches = [
     'PyTorch-2.9.1_skip-svd-pca-lowrank-tests-on-cpu.patch',
     'PyTorch-2.9.1_skip-test_optree_graph_break_message.patch',
     'PyTorch-2.9.1_skip-tests-requiring-MKLDNN.patch',
+    'PyTorch-2.9.1_fix-openreg-test.patch',
 ]
 checksums = [
     {'pytorch-v2.9.1.tar.gz': 'e17504700ebc4c87f9b57059df1c4d790b769458c04db144c7a92aea90f2c92b'},
@@ -194,6 +195,8 @@ checksums = [
      '2ef1ad424d5f12a4d0ae06938da623819596cee7c0fb4616008f27583c29494d'},
     {'PyTorch-2.9.1_skip-tests-requiring-MKLDNN.patch':
      '03756a8069bad01018f422f41aa24c7c543519fd857db88a0c6de661976c8859'},
+    {'PyTorch-2.9.1_fix-openreg-test.patch':
+     'db47763fe16ed6e795268af2aef458c28d4ac8efdc0aa42588aaf111d2fcae76'},
 ]
 
 osdependencies = [OS_PKG_IBVERBS_DEV]

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1-foss-2025b-CUDA-12.9.1.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1-foss-2025b-CUDA-12.9.1.eb
@@ -96,6 +96,7 @@ patches = [
     'PyTorch-2.9.1_skip-test_optree_graph_break_message.patch',
     'PyTorch-2.9.1_skip-test_zero_redundancy_optimizer-without-gpu.patch',
     'PyTorch-2.9.1_skip-tests-requiring-MKLDNN.patch',
+    'PyTorch-2.9.1_fix-openreg-test.patch',
 ]
 checksums = [
     {'pytorch-v2.9.1.tar.gz': 'e17504700ebc4c87f9b57059df1c4d790b769458c04db144c7a92aea90f2c92b'},
@@ -218,6 +219,8 @@ checksums = [
      '25f0f0d3e9b9b140d4e4aee55eac810e8d63ed782168356fd3e43e5f4893a926'},
     {'PyTorch-2.9.1_skip-tests-requiring-MKLDNN.patch':
      '03756a8069bad01018f422f41aa24c7c543519fd857db88a0c6de661976c8859'},
+    {'PyTorch-2.9.1_fix-openreg-test.patch':
+     'db47763fe16ed6e795268af2aef458c28d4ac8efdc0aa42588aaf111d2fcae76'},
 ]
 
 osdependencies = [OS_PKG_IBVERBS_DEV]


### PR DESCRIPTION
requires:
- patch PyTorch-2.9.1_fix-openreg-test.patch from https://github.com/easybuilders/easybuild-easyconfigs/pull/26790