### PR TITLE
move netCDF to last dependency in GDAL 3.13.0 easyconfig, to make sure correct `netcdf.h` is picked up (not the one included in HDF dependency)

### DIFF
--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.13.0-foss-2026.1.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.13.0-foss-2026.1.eb
@@ -42,7 +42,6 @@ dependencies = [
     ('PCRE', '8.45'),
     ('PROJ', '9.8.1'),
     ('libgeotiff', '1.7.4'),
-    ('netCDF', '4.10.0'),
     ('HDF5', '2.1.1'),
     ('HDF', '4.3.1'),
     ('Armadillo', '15.2.7'),
@@ -58,6 +57,7 @@ dependencies = [
     ('LERC', '4.1.0'),
     ('OpenJPEG', '2.5.4'),
     ('SWIG', '4.4.1'),
+    ('netCDF', '4.10.0'),  # should be below HDF to make sure the correct netcdf.h is picked up
     ('PostgreSQL', '18.4'),  # to avoid relying on system libs
 ]
 


### PR DESCRIPTION
See:
- https://github.com/easybuilders/easybuild-easyconfigs/pull/24883