### PR TITLE
OpenLB: Fix `CPU_SIMD` flag not supported for non x86 machines

### DIFF
--- a/easybuild/easyconfigs/o/OpenLB/OpenLB-1.8.1-foss-2023b.eb
+++ b/easybuild/easyconfigs/o/OpenLB/OpenLB-1.8.1-foss-2023b.eb
@@ -49,11 +49,13 @@ _features = ' '.join([
 ])
 
 # List of PLATFORMS that can be enabled
-_platforms = ' '.join([
+_platform_flags = [
     'CPU_SISD',
-    'CPU_SIMD',
     # 'GPU_CUDA',
-])
+]
+if ARCH == 'x86_64':
+    _platform_flags.append('CPU_SIMD')
+_platforms = ' '.join(_platform_flags)
 
 _config_mk = '\n'.join([
     'CC := $CC',


### PR DESCRIPTION
On non x86_64 archs, trying to include `CPU_SIMD` in the supported platforms when building code on top of OpenLB will result in errors like

```
/home/runner/eessi/versions/2023.06/software/linux/aarch64/nvidia/grace/software/OpenLB/1.8.1-foss-2023b/include/core/platform/cpu/simd/column.h:36:10: fatal error: asm/unistd_64.h: No such file or directory
   36 | #include <asm/unistd_64.h>
```

See https://github.com/AI-TranspWood/olb_permeability/actions/runs/34485218865/job/102897665861#step:4:4033

This flags acts as defaults for the makefile inherited by the project using OpenLB so it can technically be disabled for the project itself by setting `PLATFORMS` when building but i think it makes sense to start with the correct default

