### PR TITLE
Update patches for PyTorch 2.9.1

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1-foss-2024a-CUDA-12.6.0.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1-foss-2024a-CUDA-12.6.0.eb
@@ -64,6 +64,7 @@ patches = [
     'PyTorch-2.9.0_skip-test_unbacked_reduction.patch',
     'PyTorch-2.9.0_skip-unexpected-success-in-test_fake_export.patch',
     'PyTorch-2.9.0_update-exptected-output-for-z3-4.13.0.patch',
+    'PyTorch-2.9.1_add-ldl-to-test.patch',
     'PyTorch-2.9.1_avoid-multiprocess-tests-hanging-forever.patch',
     'PyTorch-2.9.1_avoid-using-wrong-libomp.patch',
     'PyTorch-2.9.1_check-device-avail-test_schedule.patch',
@@ -72,14 +73,20 @@ patches = [
     'PyTorch-2.9.1_fix-hypothesis-deadline.patch',
     'PyTorch-2.9.1_fix-iteration-in-fligh-reporter.patch',
     'PyTorch-2.9.1_fix-test_dist2-decorators.patch',
+    'PyTorch-2.9.1_fix-test_matmul_mv_cpu.patch',
+    'PyTorch-2.9.1_fix-test_memory_profiler.patch',
+    'PyTorch-2.9.1_fix-test_recursion_in_except_handler.patch',
     'PyTorch-2.9.1_fix-TestExportOpInfoCPU-with-single-GPU.patch',
     'PyTorch-2.9.1_GCC14-ARM-workaround.patch',
     'PyTorch-2.9.1_ignore-warning-incompatible-pointer-types.patch',
     'PyTorch-2.9.1_normalize_tree_output.patch',
     'PyTorch-2.9.1_set-test-timeout.patch',
+    'PyTorch-2.9.1_skip-bool-bessel-tests.patch',
     'PyTorch-2.9.1_skip-cutlass-addmm-test.patch',
     'PyTorch-2.9.1_skip-flex-attention-test_block_mask_non_divisible.patch',
     'PyTorch-2.9.1_skip-flex-attention-tests-on-unsupported-cpus.patch',
+    'PyTorch-2.9.1_skip-test_checkpoint_save_failure_continues_serving.patch',
+    'PyTorch-2.9.1_skip-test_norm_matrix_degenerate_shapes.patch',
     'PyTorch-2.9.1_skip-RingFlexAttentionTest.patch',
     'PyTorch-2.9.1_skip-test_dtensor_op_db_nn_functional_multi_head_attention_forward_cpu_float32.patch',
     'PyTorch-2.9.1_skip-tests-requiring-SM90.patch',
@@ -88,6 +95,9 @@ patches = [
     'PyTorch-2.9.1_skip-svd-pca-lowrank-tests-on-cpu.patch',
     'PyTorch-2.9.1_skip-test_optree_graph_break_message.patch',
     'PyTorch-2.9.1_skip-tests-requiring-MKLDNN.patch',
+    'PyTorch-2.9.1_skip-test_empty_batch.patch',
+    'PyTorch-2.9.1_skip-test_int8_woq_mm-with-acl.patch',
+    'PyTorch-2.9.1_skip-test_zero_redundancy_optimizer-without-gpu.patch',
 ]
 checksums = [
     {'pytorch-v2.9.1.tar.gz': 'e17504700ebc4c87f9b57059df1c4d790b769458c04db144c7a92aea90f2c92b'},
@@ -153,6 +163,7 @@ checksums = [
      '2e73f71ea0f09e613cc4a108893e7948b6daf239e3fe42fd2d3ae5d43c3cf9de'},
     {'PyTorch-2.9.0_update-exptected-output-for-z3-4.13.0.patch':
      '5c68e0de73212ed266879f4528a6041ef7ab2f1ac83c6cf7142c4baa78e7664c'},
+    {'PyTorch-2.9.1_add-ldl-to-test.patch': 'f311cb09018456682e982bddd368e3f9f811ba4c5ca005ef2efb07bba4b09bfe'},
     {'PyTorch-2.9.1_avoid-multiprocess-tests-hanging-forever.patch':
      '86ce380e69b3b20e010d817889cb1b825b05b4054a045b00f2ac12161b77d7e4'},
     {'PyTorch-2.9.1_avoid-using-wrong-libomp.patch':
@@ -166,6 +177,11 @@ checksums = [
      'ab408275ec66e836112a50054acc4e789ef38196efeb6137c6061d60d9ac9ead'},
     {'PyTorch-2.9.1_fix-test_dist2-decorators.patch':
      'bf4ed805f00775ed33351de7bce40ebf4eac16aff6c61d2e91790982bc43d73b'},
+    {'PyTorch-2.9.1_fix-test_matmul_mv_cpu.patch': 'e4c2a69557a0caefc7b46de2807453cf025a80b1a12c4fd9cbb632e6d83bef5d'},
+    {'PyTorch-2.9.1_fix-test_memory_profiler.patch':
+     '7370e0d0ec0affb6dea2fa87d2025639ee8f4f75fcccafbb00b999073757c119'},
+    {'PyTorch-2.9.1_fix-test_recursion_in_except_handler.patch':
+     'e7a64dbdc202151c5bff6aac86d77b0f6e7c52dc3117e3bfe9b57ec1371f87ad'},
     {'PyTorch-2.9.1_fix-TestExportOpInfoCPU-with-single-GPU.patch':
      'bdddf5a9ba47d57ec96f4bbefc3b85c4904e44de93dc5c7a65bc03e343035ae9'},
     {'PyTorch-2.9.1_GCC14-ARM-workaround.patch': 'ea8a8662e20fae2fb3a74c7f8bf390aba80a598ab37f9131c720d25ebb14965d'},
@@ -173,12 +189,17 @@ checksums = [
      'c4dad43a5d76e292bb0cada56ea05e8cbd522e3e83749cf3b2c15cd1e4ff6d7b'},
     {'PyTorch-2.9.1_normalize_tree_output.patch': '7d5994580339b73c28de595d9e5a0448db97b7d284f17efd18909e4613d170df'},
     {'PyTorch-2.9.1_set-test-timeout.patch': '15fa1149c250b1333b0bc491f659aaf89d5d6eaf6df5ebc81eea545478c1239c'},
+    {'PyTorch-2.9.1_skip-bool-bessel-tests.patch': '9c07cddaf4c1b17fe9a54874f10b8edbfb85785c40ac1e3aea11c7f4b5abca69'},
     {'PyTorch-2.9.1_skip-cutlass-addmm-test.patch':
      '1f81a8a9eea8eda51fc93dff84cd994772febf4fd05d77efbf21b8440dadfd4e'},
     {'PyTorch-2.9.1_skip-flex-attention-test_block_mask_non_divisible.patch':
      'd8489c192da549083569e09e5f94d2a83c9e41e111b1322f86512a9c5a58c0d9'},
     {'PyTorch-2.9.1_skip-flex-attention-tests-on-unsupported-cpus.patch':
      'e544f765beac7bdb3fc0ada98a3f92fd7e511ed8874de085aa2f213cca769d40'},
+    {'PyTorch-2.9.1_skip-test_checkpoint_save_failure_continues_serving.patch':
+     'fa22d7ed5bf20afa4798c8af3ec732b1a3f530ecc4be5c223b3796e839b0b812'},
+    {'PyTorch-2.9.1_skip-test_norm_matrix_degenerate_shapes.patch':
+     'd6082e62696a38dbfbc87c228f7ccb54dba4cfc615ce158f1f3bf77e6e30ff4f'},
     {'PyTorch-2.9.1_skip-RingFlexAttentionTest.patch':
      '3cf0b11136fb18c45072687eafd3024d91b504d231a4fa40e04bc62d8d6019c7'},
     {'PyTorch-2.9.1_skip-test_dtensor_op_db_nn_functional_multi_head_attention_forward_cpu_float32.patch':
@@ -195,6 +216,12 @@ checksums = [
      '2ef1ad424d5f12a4d0ae06938da623819596cee7c0fb4616008f27583c29494d'},
     {'PyTorch-2.9.1_skip-tests-requiring-MKLDNN.patch':
      '03756a8069bad01018f422f41aa24c7c543519fd857db88a0c6de661976c8859'},
+    {'PyTorch-2.9.1_skip-test_empty_batch.patch':
+     '696a07f9f88df9fb26a8847a00f28c2629cf4b58dac1eaf5a64ac793c1195cfb'},
+    {'PyTorch-2.9.1_skip-test_int8_woq_mm-with-acl.patch':
+     '78cc61098106f4720186f9927ac2b660b5c0db0a18ae94dee134089f23c49214'},
+    {'PyTorch-2.9.1_skip-test_zero_redundancy_optimizer-without-gpu.patch':
+     '25f0f0d3e9b9b140d4e4aee55eac810e8d63ed782168356fd3e43e5f4893a926'},
 ]
 
 osdependencies = [OS_PKG_IBVERBS_DEV]
@@ -278,7 +305,12 @@ excluded_tests = {
         # Occasional segfaults on CPU
         'inductor/test_flex_attention',
         'inductor/test_flex_decoding ',
-    ]
+    ],
+    'AArch64': [
+        # Not tested on upstream CI: See .ci/pytorch/test.sh & https://github.com/pytorch/pytorch/pull/146895
+        'nn/test_convolution',
+        'test_dataloader',
+    ],
 }
 
 runtest = (

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1-foss-2024a.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1-foss-2024a.eb
@@ -63,6 +63,7 @@ patches = [
     'PyTorch-2.9.0_skip-test_unbacked_reduction.patch',
     'PyTorch-2.9.0_skip-unexpected-success-in-test_fake_export.patch',
     'PyTorch-2.9.0_update-exptected-output-for-z3-4.13.0.patch',
+    'PyTorch-2.9.1_add-ldl-to-test.patch',
     'PyTorch-2.9.1_avoid-multiprocess-tests-hanging-forever.patch',
     'PyTorch-2.9.1_avoid-using-wrong-libomp.patch',
     'PyTorch-2.9.1_check-device-avail-test_schedule.patch',
@@ -71,14 +72,20 @@ patches = [
     'PyTorch-2.9.1_fix-hypothesis-deadline.patch',
     'PyTorch-2.9.1_fix-iteration-in-fligh-reporter.patch',
     'PyTorch-2.9.1_fix-test_dist2-decorators.patch',
+    'PyTorch-2.9.1_fix-test_matmul_mv_cpu.patch',
+    'PyTorch-2.9.1_fix-test_memory_profiler.patch',
+    'PyTorch-2.9.1_fix-test_recursion_in_except_handler.patch',
     'PyTorch-2.9.1_fix-TestExportOpInfoCPU-with-single-GPU.patch',
     'PyTorch-2.9.1_GCC14-ARM-workaround.patch',
     'PyTorch-2.9.1_ignore-warning-incompatible-pointer-types.patch',
     'PyTorch-2.9.1_normalize_tree_output.patch',
     'PyTorch-2.9.1_set-test-timeout.patch',
+    'PyTorch-2.9.1_skip-bool-bessel-tests.patch',
     'PyTorch-2.9.1_skip-cutlass-addmm-test.patch',
     'PyTorch-2.9.1_skip-flex-attention-test_block_mask_non_divisible.patch',
     'PyTorch-2.9.1_skip-flex-attention-tests-on-unsupported-cpus.patch',
+    'PyTorch-2.9.1_skip-test_checkpoint_save_failure_continues_serving.patch',
+    'PyTorch-2.9.1_skip-test_norm_matrix_degenerate_shapes.patch',
     'PyTorch-2.9.1_skip-RingFlexAttentionTest.patch',
     'PyTorch-2.9.1_skip-test_dtensor_op_db_nn_functional_multi_head_attention_forward_cpu_float32.patch',
     'PyTorch-2.9.1_skip-tests-requiring-SM90.patch',
@@ -87,6 +94,9 @@ patches = [
     'PyTorch-2.9.1_skip-svd-pca-lowrank-tests-on-cpu.patch',
     'PyTorch-2.9.1_skip-test_optree_graph_break_message.patch',
     'PyTorch-2.9.1_skip-tests-requiring-MKLDNN.patch',
+    'PyTorch-2.9.1_skip-test_empty_batch.patch',
+    'PyTorch-2.9.1_skip-test_int8_woq_mm-with-acl.patch',
+    'PyTorch-2.9.1_skip-test_zero_redundancy_optimizer-without-gpu.patch',
 ]
 checksums = [
     {'pytorch-v2.9.1.tar.gz': 'e17504700ebc4c87f9b57059df1c4d790b769458c04db144c7a92aea90f2c92b'},
@@ -152,6 +162,7 @@ checksums = [
      '2e73f71ea0f09e613cc4a108893e7948b6daf239e3fe42fd2d3ae5d43c3cf9de'},
     {'PyTorch-2.9.0_update-exptected-output-for-z3-4.13.0.patch':
      '5c68e0de73212ed266879f4528a6041ef7ab2f1ac83c6cf7142c4baa78e7664c'},
+    {'PyTorch-2.9.1_add-ldl-to-test.patch': 'f311cb09018456682e982bddd368e3f9f811ba4c5ca005ef2efb07bba4b09bfe'},
     {'PyTorch-2.9.1_avoid-multiprocess-tests-hanging-forever.patch':
      '86ce380e69b3b20e010d817889cb1b825b05b4054a045b00f2ac12161b77d7e4'},
     {'PyTorch-2.9.1_avoid-using-wrong-libomp.patch':
@@ -165,6 +176,11 @@ checksums = [
      'ab408275ec66e836112a50054acc4e789ef38196efeb6137c6061d60d9ac9ead'},
     {'PyTorch-2.9.1_fix-test_dist2-decorators.patch':
      'bf4ed805f00775ed33351de7bce40ebf4eac16aff6c61d2e91790982bc43d73b'},
+    {'PyTorch-2.9.1_fix-test_matmul_mv_cpu.patch': 'e4c2a69557a0caefc7b46de2807453cf025a80b1a12c4fd9cbb632e6d83bef5d'},
+    {'PyTorch-2.9.1_fix-test_memory_profiler.patch':
+     '7370e0d0ec0affb6dea2fa87d2025639ee8f4f75fcccafbb00b999073757c119'},
+    {'PyTorch-2.9.1_fix-test_recursion_in_except_handler.patch':
+     'e7a64dbdc202151c5bff6aac86d77b0f6e7c52dc3117e3bfe9b57ec1371f87ad'},
     {'PyTorch-2.9.1_fix-TestExportOpInfoCPU-with-single-GPU.patch':
      'bdddf5a9ba47d57ec96f4bbefc3b85c4904e44de93dc5c7a65bc03e343035ae9'},
     {'PyTorch-2.9.1_GCC14-ARM-workaround.patch': 'ea8a8662e20fae2fb3a74c7f8bf390aba80a598ab37f9131c720d25ebb14965d'},
@@ -172,12 +188,17 @@ checksums = [
      'c4dad43a5d76e292bb0cada56ea05e8cbd522e3e83749cf3b2c15cd1e4ff6d7b'},
     {'PyTorch-2.9.1_normalize_tree_output.patch': '7d5994580339b73c28de595d9e5a0448db97b7d284f17efd18909e4613d170df'},
     {'PyTorch-2.9.1_set-test-timeout.patch': '15fa1149c250b1333b0bc491f659aaf89d5d6eaf6df5ebc81eea545478c1239c'},
+    {'PyTorch-2.9.1_skip-bool-bessel-tests.patch': '9c07cddaf4c1b17fe9a54874f10b8edbfb85785c40ac1e3aea11c7f4b5abca69'},
     {'PyTorch-2.9.1_skip-cutlass-addmm-test.patch':
      '1f81a8a9eea8eda51fc93dff84cd994772febf4fd05d77efbf21b8440dadfd4e'},
     {'PyTorch-2.9.1_skip-flex-attention-test_block_mask_non_divisible.patch':
      'd8489c192da549083569e09e5f94d2a83c9e41e111b1322f86512a9c5a58c0d9'},
     {'PyTorch-2.9.1_skip-flex-attention-tests-on-unsupported-cpus.patch':
      'e544f765beac7bdb3fc0ada98a3f92fd7e511ed8874de085aa2f213cca769d40'},
+    {'PyTorch-2.9.1_skip-test_checkpoint_save_failure_continues_serving.patch':
+     'fa22d7ed5bf20afa4798c8af3ec732b1a3f530ecc4be5c223b3796e839b0b812'},
+    {'PyTorch-2.9.1_skip-test_norm_matrix_degenerate_shapes.patch':
+     'd6082e62696a38dbfbc87c228f7ccb54dba4cfc615ce158f1f3bf77e6e30ff4f'},
     {'PyTorch-2.9.1_skip-RingFlexAttentionTest.patch':
      '3cf0b11136fb18c45072687eafd3024d91b504d231a4fa40e04bc62d8d6019c7'},
     {'PyTorch-2.9.1_skip-test_dtensor_op_db_nn_functional_multi_head_attention_forward_cpu_float32.patch':
@@ -194,6 +215,12 @@ checksums = [
      '2ef1ad424d5f12a4d0ae06938da623819596cee7c0fb4616008f27583c29494d'},
     {'PyTorch-2.9.1_skip-tests-requiring-MKLDNN.patch':
      '03756a8069bad01018f422f41aa24c7c543519fd857db88a0c6de661976c8859'},
+    {'PyTorch-2.9.1_skip-test_empty_batch.patch':
+     '696a07f9f88df9fb26a8847a00f28c2629cf4b58dac1eaf5a64ac793c1195cfb'},
+    {'PyTorch-2.9.1_skip-test_int8_woq_mm-with-acl.patch':
+     '78cc61098106f4720186f9927ac2b660b5c0db0a18ae94dee134089f23c49214'},
+    {'PyTorch-2.9.1_skip-test_zero_redundancy_optimizer-without-gpu.patch':
+     '25f0f0d3e9b9b140d4e4aee55eac810e8d63ed782168356fd3e43e5f4893a926'},
 ]
 
 osdependencies = [OS_PKG_IBVERBS_DEV]
@@ -268,7 +295,12 @@ excluded_tests = {
         # Occasional segfaults on CPU
         'inductor/test_flex_attention',
         'inductor/test_flex_decoding ',
-    ]
+    ],
+    'AArch64': [
+        # Not tested on upstream CI: See .ci/pytorch/test.sh & https://github.com/pytorch/pytorch/pull/146895
+        'nn/test_convolution',
+        'test_dataloader',
+    ],
 }
 
 runtest = (

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1-foss-2025b-CUDA-12.9.1.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1-foss-2025b-CUDA-12.9.1.eb
@@ -64,6 +64,7 @@ patches = [
     'PyTorch-2.9.0_skip-test_unbacked_reduction.patch',
     'PyTorch-2.9.0_skip-tests-requiring-CUDA-12.8.patch',
     'PyTorch-2.9.0_skip-unexpected-success-in-test_fake_export.patch',
+    'PyTorch-2.9.1_add-ldl-to-test.patch',
     'PyTorch-2.9.1_avoid-multiprocess-tests-hanging-forever.patch',
     'PyTorch-2.9.1_avoid-using-wrong-libomp.patch',
     'PyTorch-2.9.1_check-device-avail-test_schedule.patch',
@@ -94,9 +95,12 @@ patches = [
     'PyTorch-2.9.1_skip-cpu_repro-tests-failing-on-ARM.patch',
     'PyTorch-2.9.1_skip-svd-pca-lowrank-tests-on-cpu.patch',
     'PyTorch-2.9.1_skip-test_optree_graph_break_message.patch',
-    'PyTorch-2.9.1_skip-test_zero_redundancy_optimizer-without-gpu.patch',
     'PyTorch-2.9.1_skip-tests-requiring-MKLDNN.patch',
+    'PyTorch-2.9.1_skip-test_empty_batch.patch',
+    'PyTorch-2.9.1_skip-test_int8_woq_mm-with-acl.patch',
+    'PyTorch-2.9.1_skip-test_zero_redundancy_optimizer-without-gpu.patch',
 ]
+
 checksums = [
     {'pytorch-v2.9.1.tar.gz': 'e17504700ebc4c87f9b57059df1c4d790b769458c04db144c7a92aea90f2c92b'},
     {'PyTorch-2.9.1-disabled-tests.json': '471f8aa36e056173d09ffd421ead45539a8d35fec6e61a8a0050d92a5fcd9f04'},
@@ -161,6 +165,7 @@ checksums = [
      '6d79aff5291627b86d8fea025bf2379e4065c7d9cbef5cf83452c35922848728'},
     {'PyTorch-2.9.0_skip-unexpected-success-in-test_fake_export.patch':
      '2e73f71ea0f09e613cc4a108893e7948b6daf239e3fe42fd2d3ae5d43c3cf9de'},
+    {'PyTorch-2.9.1_add-ldl-to-test.patch': 'f311cb09018456682e982bddd368e3f9f811ba4c5ca005ef2efb07bba4b09bfe'},
     {'PyTorch-2.9.1_avoid-multiprocess-tests-hanging-forever.patch':
      '86ce380e69b3b20e010d817889cb1b825b05b4054a045b00f2ac12161b77d7e4'},
     {'PyTorch-2.9.1_avoid-using-wrong-libomp.patch':
@@ -214,10 +219,14 @@ checksums = [
      '4fc772293047dc737b99e232b8a8db904aa8e88e3c8b2bcc3602fb723941fb89'},
     {'PyTorch-2.9.1_skip-test_optree_graph_break_message.patch':
      '2ef1ad424d5f12a4d0ae06938da623819596cee7c0fb4616008f27583c29494d'},
-    {'PyTorch-2.9.1_skip-test_zero_redundancy_optimizer-without-gpu.patch':
-     '25f0f0d3e9b9b140d4e4aee55eac810e8d63ed782168356fd3e43e5f4893a926'},
     {'PyTorch-2.9.1_skip-tests-requiring-MKLDNN.patch':
      '03756a8069bad01018f422f41aa24c7c543519fd857db88a0c6de661976c8859'},
+    {'PyTorch-2.9.1_skip-test_empty_batch.patch':
+     '696a07f9f88df9fb26a8847a00f28c2629cf4b58dac1eaf5a64ac793c1195cfb'},
+    {'PyTorch-2.9.1_skip-test_int8_woq_mm-with-acl.patch':
+     '78cc61098106f4720186f9927ac2b660b5c0db0a18ae94dee134089f23c49214'},
+    {'PyTorch-2.9.1_skip-test_zero_redundancy_optimizer-without-gpu.patch':
+     '25f0f0d3e9b9b140d4e4aee55eac810e8d63ed782168356fd3e43e5f4893a926'},
 ]
 
 osdependencies = [OS_PKG_IBVERBS_DEV]

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1_add-ldl-to-test.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1_add-ldl-to-test.patch
@@ -1,0 +1,20 @@
+Fix for
+undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
+
+.../ld: /lib64/libdl.so.2: error adding symbols: DSO missing from command line
+
+From 612cdc8f4868a405860ea5f08fb8b4e707327a1e Mon Sep 17 00:00:00 2001
+From: dolpm <34420038+dolpm@users.noreply.github.com>
+Pull Request resolved: https://github.com/pytorch/pytorch/pull/162643
+
+diff --git a/test/cpp/nativert/CMakeLists.txt b/test/cpp/nativert/CMakeLists.txt
+--- a/test/cpp/nativert/CMakeLists.txt
++++ b/test/cpp/nativert/CMakeLists.txt
+@@ -63,6 +63,7 @@ target_compile_definitions(test_nativert PRIVATE USE_GTEST)
+ 
+ set(NATIVERT_TEST_DEPENDENCIES torch gtest_main)
+ 
++target_link_libraries(test_nativert PRIVATE ${CMAKE_DL_LIBS})
+ target_link_libraries(test_nativert PRIVATE ${NATIVERT_TEST_DEPENDENCIES})
+ target_link_libraries(test_nativert PRIVATE fmt::fmt-header-only)
+ target_include_directories(test_nativert PRIVATE ${ATen_CPU_INCLUDE})

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1_skip-test_empty_batch.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1_skip-test_empty_batch.patch
@@ -1,0 +1,15 @@
+Skip TestQuantizedOps.test_empty_batch as it started to segfault when adding ACL on ARM,
+see https://github.com/EESSI/software-layer/pull/1389#issuecomment-4717026801
+
+Author: Alexander Grund (TU Dresden)
+diff --git a/test/quantization/core/test_quantized_op.py b/test/quantization/core/test_quantized_op.py
+--- a/test/quantization/core/test_quantized_op.py
++++ b/test/quantization/core/test_quantized_op.py
+@@ -2802,6 +2802,7 @@ class TestQuantizedOps(TestCase):
+                     qy.int_repr().numpy(), quantize_ref.int_repr().numpy(),
+                     msg=f"{qy} vs {quantize_ref}")
+ 
++    @unittest.skipIf(IS_ARM64, "Segfaults with ACL")
+     @override_qengines
+     def test_empty_batch(self):
+         scale = 1.0

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1_skip-test_int8_woq_mm-with-acl.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-2.9.1_skip-test_int8_woq_mm-with-acl.patch
@@ -1,0 +1,21 @@
+Skip test (all 54 variants) that fails when OneDNN and ACL is used on ARM,
+see https://github.com/pytorch/pytorch/pull/186935
+
+Failures are like:
+>	Absolute difference: 1
+and
+>	Greatest absolute difference: 0.03125 at index (12, 0, 548) (up to 1e-05 allowed)
+
+Author: Alexander Grund (TU Dresden)
+
+diff -ur a/test/inductor/test_cpu_select_algorithm.py b/test/inductor/test_cpu_select_algorithm.py
+--- a/test/inductor/test_cpu_select_algorithm.py	2026-06-10 16:41:59.438739668 +0200
++++ b/test/inductor/test_cpu_select_algorithm.py	2026-06-10 16:45:12.985918836 +0200
+@@ -1398,6 +1398,7 @@
+     )
+     @parametrize("in_features", (128, 144, 1024))
+     @parametrize("out_features", (64, 65, 1024))
++    @unittest.skipIf(torch.ops.mkldnn._is_mkldnn_acl_supported(), "OP fusion disabled with ACL")
+     def test_int8_woq_mm(self, dtype, batch_size, mid_dim, in_features, out_features):
+         def _convert_weight_to_int8pack(w):
+             scale, zp = _calculate_dynamic_per_channel_qparams(


### PR DESCRIPTION
I extracted the (very likely) harmless patches fixing some tests from the other Open PyTorch 2.9.1 (MKL/ACL) PRs included already in existing/merged 2.9.1 ECs similar to https://github.com/easybuilders/easybuild-easyconfigs/pull/26816

This also includes the patch I mentioned in https://github.com/easybuilders/easybuild-easyconfigs/pull/26839

Fixes #26826