### PR TITLE
set `Tensile_CPU_THREADS` in rocBLAS 4.4.0 easyconfig

### DIFF
--- a/easybuild/easyconfigs/r/rocBLAS/rocBLAS-4.4.0-rocm-compilers-19.0.0-ROCm-6.4.1.eb
+++ b/easybuild/easyconfigs/r/rocBLAS/rocBLAS-4.4.0-rocm-compilers-19.0.0-ROCm-6.4.1.eb
@@ -40,6 +40,7 @@ configopts += '-DBUILD_CLIENTS_TESTS=OFF '
 configopts += '-DBUILD_CLIENTS_BENCHMARKS=OFF '
 configopts += '-DBUILD_CLIENTS_SAMPLES=OFF '
 configopts += '-DBUILD_CLIENTS=OFF '
+configopts += '-DTensile_CPU_THREADS=%(parallel)s '
 
 sanity_check_paths = {
     'files': ['lib/librocblas.so',


### PR DESCRIPTION
I'm having issues with the build getting stuck. Even when reducing the number of cores, I saw a lot of threads on the build machine. The hipBLASLt easyconfig already sets `Tensile_CPU_THREADS` (see https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/h/hipBLASLt/hipBLASLt-0.12.1-rocm-compilers-19.0.0-ROCm-6.4.1.eb#L66C1-L66C52), and adding this to the rocBLAS easyconfig seems to solve the issue for me (based on an interactive build, will do another one with the EESSI bot).