### PR TITLE
Fix `cairo` - avoid using system `ttx` executable during build

### DIFF
--- a/easybuild/easyconfigs/c/cairo/cairo-1.17.8-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/c/cairo/cairo-1.17.8-GCCcore-12.3.0.eb
@@ -23,6 +23,7 @@ builddependencies = [
     ('pkgconf', '1.9.5'),
     ('Ninja', '1.11.1'),
     ('Meson', '1.1.1'),
+    ('fonttools', '4.53.1'),
 ]
 dependencies = [
     ('bzip2', '1.0.8'),

--- a/easybuild/easyconfigs/c/cairo/cairo-1.18.0-GCCcore-13.2.0.eb
+++ b/easybuild/easyconfigs/c/cairo/cairo-1.18.0-GCCcore-13.2.0.eb
@@ -23,6 +23,7 @@ builddependencies = [
     ('pkgconf', '2.0.3'),
     ('Ninja', '1.11.1'),
     ('Meson', '1.2.3'),
+    ('fonttools', '4.53.1'),
 ]
 dependencies = [
     ('bzip2', '1.0.8'),

--- a/easybuild/easyconfigs/c/cairo/cairo-1.18.0-GCCcore-13.3.0.eb
+++ b/easybuild/easyconfigs/c/cairo/cairo-1.18.0-GCCcore-13.3.0.eb
@@ -23,6 +23,7 @@ builddependencies = [
     ('pkgconf', '2.2.0'),
     ('Ninja', '1.12.1'),
     ('Meson', '1.4.0'),
+    ('fonttools', '4.53.1'),
 ]
 dependencies = [
     ('bzip2', '1.0.8'),

--- a/easybuild/easyconfigs/c/cairo/cairo-1.18.4-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/c/cairo/cairo-1.18.4-GCCcore-14.2.0.eb
@@ -23,6 +23,7 @@ builddependencies = [
     ('pkgconf', '2.3.0'),
     ('Ninja', '1.12.1'),
     ('Meson', '1.6.1'),
+    ('fonttools', '4.58.4'),
 ]
 dependencies = [
     ('bzip2', '1.0.8'),

--- a/easybuild/easyconfigs/c/cairo/cairo-1.18.4-GCCcore-14.3.0.eb
+++ b/easybuild/easyconfigs/c/cairo/cairo-1.18.4-GCCcore-14.3.0.eb
@@ -22,6 +22,7 @@ builddependencies = [
     ('pkgconf', '2.4.3'),
     ('Ninja', '1.13.0'),
     ('Meson', '1.8.2'),
+    ('fonttools', '4.58.5'),
 ]
 dependencies = [
     ('bzip2', '1.0.8'),

--- a/easybuild/easyconfigs/c/cairo/cairo-1.18.4-GCCcore-15.2.0.eb
+++ b/easybuild/easyconfigs/c/cairo/cairo-1.18.4-GCCcore-15.2.0.eb
@@ -22,6 +22,7 @@ builddependencies = [
     ('pkgconf', '2.5.1'),
     ('Ninja', '1.13.2'),
     ('Meson', '1.10.2'),
+    ('fonttools', '4.63.0'),
 ]
 dependencies = [
     ('bzip2', '1.0.8'),


### PR DESCRIPTION
Behavior observed with a system `ttx` executable found

configure step:
```
...
Run-time dependency libpng found: YES 1.6.56
Run-time dependency fontconfig found: YES 2.17.1
Program ttx found: YES (/home/crivella/.local/bin/ttx)
Run-time dependency freetype2 found: YES 26.6.20
Checking for type "FT_SVG_Document" with dependency freetype2: YES 
...
```

Can also end up in an error if the system ttx is non-functional:

```
...
[719/736] /home/crivella/.local/easybuild/software/Meson/1.10.2-GCCcore-15.2.0/bin/meson --internal copy ../cairo-1.18.4/test/view-test-results.py test/view-test-results.py
[720/736] /home/crivella/.local/bin/ttx -q -o test/cairo-logo-font.ttf ../cairo-1.18.4/test/cairo-logo-font.ttx
FAILED: [code=1] test/cairo-logo-font.ttf 
/home/crivella/.local/bin/ttx -q -o test/cairo-logo-font.ttf ../cairo-1.18.4/test/cairo-logo-font.ttx
Traceback (most recent call last):
  File "/home/crivella/.local/bin/ttx", line 5, in <module>
    from fontTools.ttx import main
ModuleNotFoundError: No module named 'fontTools'
[721/736] /home/crivella/.local/bin/ttx -q -o test/cairo-svg-test-color.ttf ../cairo-1.18.4/test/cairo-svg-test-color.ttx
FAILED: [code=1] test/cairo-svg-test-color.ttf 
/home/crivella/.local/bin/ttx -q -o test/cairo-svg-test-color.ttf ../cairo-1.18.4/test/cairo-svg-test-color.ttx
Traceback (most recent call last):
  File "/home/crivella/.local/bin/ttx", line 5, in <module>
    from fontTools.ttx import main
ModuleNotFoundError: No module named 'fontTools'
[722/736] /home/crivella/.local/bin/ttx -q -o test/cairo-svg-test-doc.ttf ../cairo-1.18.4/test/cairo-svg-test-doc.ttx
FAILED: [code=1] test/cairo-svg-test-doc.ttf 
/home/crivella/.local/bin/ttx -q -o test/cairo-svg-test-doc.ttf ../cairo-1.18.4/test/cairo-svg-test-doc.ttx
Traceback (most recent call last):
  File "/home/crivella/.local/bin/ttx", line 5, in <module>
    from fontTools.ttx import main
ModuleNotFoundError: No module named 'fontTools'
[723/736] gcc @test/cairo-test-suite.rsp
ninja: build stopped: subcommand failed.
...
```